### PR TITLE
Add getter functions to Kademlia table.

### DIFF
--- a/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
@@ -214,7 +214,7 @@ case class PeerTable[A <: Peer](home: A,
   def find(key: Seq[Byte]): Option[A] =
     for {
       d <- distance(key)
-      e <- table(d) synchronized { table(d).find(_.entry.key == key) } 
+      e <- table(d) synchronized { table(d).find(_.entry.key == key) }
     } yield e.entry
 
 

--- a/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
@@ -110,9 +110,7 @@ case class PeerTable[A <: Peer](home: A,
   def distance(other: A): Option[Int] = distance(other.key)
 
   private val pool = Executors.newFixedThreadPool(alpha)
-  private def ping(ps: mutable.ListBuffer[Entry],
-                   older: Entry,
-                   newer: A): Unit =
+  private def ping(ps: mutable.ListBuffer[Entry], older: Entry, newer: A): Unit =
     pool.execute(new Runnable {
       def run = {
         val winner =
@@ -216,7 +214,6 @@ case class PeerTable[A <: Peer](home: A,
       d <- distance(key)
       e <- table(d) synchronized { table(d).find(_.entry.key == key) }
     } yield e.entry
-
 
   /**
     * Return a sequence of all the `A`s in the table.

--- a/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
@@ -207,4 +207,20 @@ case class PeerTable[A <: Peer](home: A,
       case None => Vector.empty
     }
   }
+
+  /**
+    * Return `Some[A]` if `key` names an entry in the table.
+    */
+  def find(key: Seq[Byte]): Option[A] =
+    for {
+      d <- distance(key)
+      e <- table(d) synchronized { table(d).find(_.entry.key == key) } 
+    } yield e.entry
+
+
+  /**
+    * Return a sequence of all the `A`s in the table.
+    */
+  def peers: Seq[A] =
+    table.flatMap(l => l synchronized { l.map(_.entry) })
 }

--- a/comm/src/test/scala/coop/rchain/kademlia/distance.scala
+++ b/comm/src/test/scala/coop/rchain/kademlia/distance.scala
@@ -29,7 +29,7 @@ object b {
 }
 
 class DistanceSpec extends FlatSpec with Matchers {
-  "A PeerNode of width n byte" should "have distance to itself equal to 8n" in {
+  "A PeerNode of width n bytes" should "have distance to itself equal to 8n" in {
     for (i <- 1 to 64) {
       val home = PeerNode(b.rand(i))
       val nt = PeerTable(home)
@@ -78,12 +78,17 @@ class DistanceSpec extends FlatSpec with Matchers {
     assert(table.table.forall(_.size == 0))
   }
 
+  it should "return no peers" in {
+    val table = PeerTable(PeerNode(kr))
+    table.peers.size should be (0)
+  }
+
   it should "return no values on lookup" in {
     val table = PeerTable(PeerNode(kr))
     table.lookup(b.rand(width)).size should be (0)
   }
 
-  it should "add any key at most once" in {
+  "A table" should "add a key at most once" in {
     val table = PeerTable(PeerNode(kr))
     val toAdd = oneOffs(kr).head
     val dist = table.distance(toAdd).get
@@ -93,7 +98,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
   }
 
-  "A table with peers at all distances" should "have no empty slots" in {
+  "A table with peers at all distances" should "have no empty buckets" in {
     val table = PeerTable(PeerNode(kr))
     for (k <- oneOffs(kr.toArray)) {
       table.observe(PeerNode(k))
@@ -117,5 +122,23 @@ class DistanceSpec extends FlatSpec with Matchers {
     val target = table.table(table.width*4)(0)
     val resp = table.lookup(target.key)
     assert(resp.forall(_.key != target.key))
+  }
+
+  it should "return 8n peers when sequenced" in {
+    val table = PeerTable(PeerNode(kr))
+    for (k <- oneOffs(kr.toArray)) {
+      table.observe(PeerNode(k))
+    }
+    table.peers.size should be (8*width)
+  }
+
+  it should "find each added peer" in {
+    val table = PeerTable(PeerNode(kr))
+    for (k <- oneOffs(kr.toArray)) {
+      table.observe(PeerNode(k))
+    }
+    for (k <- oneOffs(kr.toArray)) {
+      table.find(k) should be (Some(PeerNode(k)))
+    }
   }
 }


### PR DESCRIPTION
Added a `find` method to locate a node with a particular key in the table. This is useful for implementing protocols, not for querying by remote nodes (see `lookup` for that). Also added the `peers` method to produce a `Seq` of all nodes in the table. This is used to generate targets for broadcast messages, for example.

Added a few tests to sanity-check these functions. Also, `scalafmt` did some adjusting of spacing.

Meting out changes in digestible chunks for CORE-43 and CORE-29.

CORE-29 CORE-43 #comment Preparatory commit