### PR TITLE
Add kademlia table and PING/PONG.

### DIFF
--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -8,12 +8,6 @@ option (scalapb.options) = {
   flat_package: true
 };
 
-message Header {
-    bytes  id        = 1;
-    uint64 timestamp = 2;
-    uint64 seq       = 3;
-}
-
 message Node {
     bytes  id       = 1;
     bytes  host     = 2;
@@ -21,17 +15,28 @@ message Node {
     uint32 udp_port = 4;
 }
 
+message Header {
+    Node   sender         = 1;
+    uint64 timestamp      = 2;
+    uint64 seq            = 3;
+}
+
+message ReturnHeader {
+    uint64 timestamp      = 1;
+    uint64 seq            = 2;
+}
+
 message Disconnect {
 }
 
 message Hello {
-    Node node = 1;
 }
 
 message Ping {
 }
 
 message Pong {
+    ReturnHeader return_header = 1;
 }
 
 message Lookup {
@@ -43,7 +48,7 @@ message LookupResponse {
 }
 
 message Protocol {
-    Header header             =  1;
+    Header header                      = 1;
 
     oneof message {
         Hello          hello           = 2;

--- a/comm/src/main/scala/coop/rchain/comm/comm.scala
+++ b/comm/src/main/scala/coop/rchain/comm/comm.scala
@@ -16,8 +16,8 @@ case class NodeIdentifier(pKey: Seq[Byte]) {
 }
 
 case class Endpoint(host: String, tcpPort: Int, udpPort: Int) {
-  lazy val tcpSocketAddress = new java.net.InetSocketAddress(host, tcpPort)
-  lazy val udpSocketAddress = new java.net.InetSocketAddress(host, udpPort)
+  val tcpSocketAddress = new java.net.InetSocketAddress(host, tcpPort)
+  val udpSocketAddress = new java.net.InetSocketAddress(host, udpPort)
 }
 
 /**

--- a/comm/src/main/scala/coop/rchain/comm/comm.scala
+++ b/comm/src/main/scala/coop/rchain/comm/comm.scala
@@ -3,7 +3,7 @@ package coop.rchain.comm
 import scala.util.Try
 
 trait Comm {
-  def send(data: Seq[Byte], p: PeerNode): Try[Boolean]
+  def send(data: Seq[Byte], p: PeerNode): Try[Unit]
   def recv: Try[Seq[Byte]]
 }
 

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -105,7 +105,8 @@ case class UnicastNetwork(id: NodeIdentifier, endpoint: Endpoint) extends Protoc
         } catch {
           case ex: Throwable => Failure(ex)
         } finally {
-          val _ = pending.remove(pend)
+          pending.remove(pend)
+          ()
         }
       }
       case None => Failure(new Exception("malformed message"))

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -1,0 +1,115 @@
+package coop.rchain.comm
+
+import java.net.SocketTimeoutException
+import scala.util.{Failure, Success, Try}
+import scala.collection.concurrent
+import scala.concurrent.{Await, Promise}
+import scala.concurrent.duration.{Duration, MILLISECONDS}
+import coop.rchain.kademlia.PeerTable
+
+/**
+  * Implements the lower levels of the network protocol.
+  */
+case class UnicastNetwork(id: NodeIdentifier, endpoint: Endpoint) extends ProtocolHandler {
+
+  case class PendingKey(remote: Seq[Byte], timestamp: Long, seq: Long)
+
+  val pending =
+    new concurrent.TrieMap[PendingKey, Promise[Try[ProtocolMessage]]]
+
+  val local = new ProtocolNode(id, endpoint, this)
+  val comm = UnicastComm(local)
+  val table = PeerTable(local)
+
+  private val receiver = new Thread {
+    override def run =
+      while (true) {
+        comm.recv match {
+          case Success(res) =>
+            for {
+              msg <- ProtocolMessage.parse(res)
+            } dispatch(msg)
+          case Failure(ex: SocketTimeoutException) => ()
+          case Failure(ex)                         => ex.printStackTrace
+        }
+      }
+  }.start
+
+  private def dispatch(msg: ProtocolMessage) =
+    for {
+      sender <- ProtocolMessage.sender(msg)
+    } {
+      table.observe(new ProtocolNode(sender, this))
+      msg match {
+        case ping@PingMessage(_, _) => handlePing(sender, ping)
+        case pong@PongMessage(_, _) => handlePong(sender, pong)
+        case _ => ???
+      }
+    }
+
+  /**
+    * Validate incoming PING and send responding PONG.
+    */
+  private def handlePing(sender: PeerNode, ping: PingMessage) =
+    for {
+      pong <- ProtocolMessage.pong(local, ping)
+    } {
+      comm.send(ProtocolMessage.toBytes(pong), sender)
+    }
+
+  /**
+    * Validate incoming PONG and complete its pending promise.
+    */
+  private def handlePong(sender: PeerNode, pong: PongMessage) =
+    for {
+      ret <- ProtocolMessage.returnHeader(pong)
+      promise <- pending.get(PendingKey(sender.key, ret.timestamp, ret.seq))
+    } {
+      try {
+        promise.success(Success(pong))
+      } catch {
+        case ex: java.lang.IllegalStateException => () // Future already completed
+      }
+    }
+
+  /**
+    * Broadcast a message to all peers in the Kademlia table.
+    */
+  override def broadcast(msg: ProtocolMessage): Seq[Try[Boolean]] = {
+    val bytes = ProtocolMessage.toBytes(msg)
+    table.peers.par.map { p =>
+      comm.send(bytes, p)
+    }.toList
+  }
+
+  /**
+    * Send a message to a single, identified peer and return any
+    * response that arrives within `timeout`. Receipt of messages is
+    * asynchronous in this protocol, so create a promise and await its
+    * completion.
+    *
+    * This method should be called in its own thread.
+    */
+  override def roundTrip(msg: ProtocolMessage,
+                         remote: ProtocolNode,
+                         timeout: Duration = Duration(500, MILLISECONDS)): Try[ProtocolMessage] =
+    ProtocolMessage.header(msg) match {
+      case Some(header) => {
+        val bytes = ProtocolMessage.toBytes(msg)
+        val pend = PendingKey(remote.key, header.timestamp, header.seq)
+        val promise = Promise[Try[ProtocolMessage]]
+        pending.put(pend, promise)
+        try {
+          comm.send(bytes, remote)
+          Await.result(promise.future, timeout)
+        } catch {
+          case ex: Throwable => Failure(ex)
+        } finally {
+          val _ = pending.remove(pend)
+        }
+      }
+      case None => Failure(new Exception("malformed message"))
+    }
+
+  override def toString = s"#{Network $local ${local.endpoint.udpSocketAddress}}"
+}

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -35,22 +35,22 @@ case class UnicastNetwork(id: NodeIdentifier, endpoint: Endpoint) extends Protoc
       }
   }.start
 
-  private def dispatch(msg: ProtocolMessage) =
+  private def dispatch(msg: ProtocolMessage): Unit =
     for {
       sender <- ProtocolMessage.sender(msg)
     } {
       table.observe(new ProtocolNode(sender, this))
       msg match {
-        case ping@PingMessage(_, _) => handlePing(sender, ping)
-        case pong@PongMessage(_, _) => handlePong(sender, pong)
-        case _ => ???
+        case ping @ PingMessage(_, _) => handlePing(sender, ping)
+        case pong @ PongMessage(_, _) => handlePong(sender, pong)
+        case _                        => ???
       }
     }
 
   /**
     * Validate incoming PING and send responding PONG.
     */
-  private def handlePing(sender: PeerNode, ping: PingMessage) =
+  private def handlePing(sender: PeerNode, ping: PingMessage): Unit =
     for {
       pong <- ProtocolMessage.pong(local, ping)
     } {
@@ -60,7 +60,7 @@ case class UnicastNetwork(id: NodeIdentifier, endpoint: Endpoint) extends Protoc
   /**
     * Validate incoming PONG and complete its pending promise.
     */
-  private def handlePong(sender: PeerNode, pong: PongMessage) =
+  private def handlePong(sender: PeerNode, pong: PongMessage): Unit =
     for {
       ret <- ProtocolMessage.returnHeader(pong)
       promise <- pending.get(PendingKey(sender.key, ret.timestamp, ret.seq))

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -75,7 +75,7 @@ case class UnicastNetwork(id: NodeIdentifier, endpoint: Endpoint) extends Protoc
   /**
     * Broadcast a message to all peers in the Kademlia table.
     */
-  override def broadcast(msg: ProtocolMessage): Seq[Try[Boolean]] = {
+  override def broadcast(msg: ProtocolMessage): Seq[Try[Unit]] = {
     val bytes = ProtocolMessage.toBytes(msg)
     table.peers.par.map { p =>
       comm.send(bytes, p)

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -27,7 +27,7 @@ trait ProtocolHandler {
   /**
     * Asynchronously broadcast a message to all known peers.
     */
-  def broadcast(msg: ProtocolMessage): Seq[Try[Boolean]]
+  def broadcast(msg: ProtocolMessage): Seq[Try[Unit]]
 }
 
 /**

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -88,10 +88,9 @@ object ProtocolMessage {
   implicit def toProtocolBytes(x: Seq[Byte]) =
     com.google.protobuf.ByteString.copyFrom(x.toArray)
 
-  def toPeer(header: Option[Header]): Option[PeerNode] =
+  def toPeer(header: Header): Option[PeerNode] =
     for {
-      h <- header
-      node <- h.sender
+      node <- header.sender
     } yield
       PeerNode(NodeIdentifier(node.id.toByteArray),
                Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
@@ -99,10 +98,8 @@ object ProtocolMessage {
   def sender(msg: ProtocolMessage): Option[PeerNode] =
     for {
       header <- msg.proto.header
-      node <- header.sender
-    } yield
-      PeerNode(NodeIdentifier(node.id.toByteArray),
-               Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
+      sender <- toPeer(header)
+    } yield sender
 
   def header(src: ProtocolNode) =
     Header()

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -1,0 +1,163 @@
+package coop.rchain.comm
+
+import coop.rchain.kademlia
+import coop.rchain.comm.protocol.routing._
+import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration.{Duration, MILLISECONDS}
+
+/**
+  * Implements broadcasting and round-trip (request-response) messaging
+  * for higher level protocols.
+  */
+trait ProtocolHandler {
+  /**
+    * The node that anchors this handler; `local` becomes the source
+    * for outgoing communications.
+    */
+  def local: ProtocolNode
+
+  /**
+    * Send a message to a single, remote node, and wait up to the
+    * specified duration for a response.
+    */
+  def roundTrip(msg: ProtocolMessage,
+                remote: ProtocolNode,
+                timeout: Duration = Duration(500, MILLISECONDS)): Try[ProtocolMessage]
+
+  /**
+    * Asynchronously broadcast a message to all known peers.
+    */
+  def broadcast(msg: ProtocolMessage): Seq[Try[Boolean]]
+}
+
+/**
+  * A `PeerNode` that knows how to send and receive messages. The
+  * `ping` method for Kademlia is here.
+  */
+class ProtocolNode(id: NodeIdentifier, endpoint: Endpoint, handler: ProtocolHandler)
+    extends PeerNode(id, endpoint)
+    with kademlia.Peer {
+
+  def this(peer: PeerNode, handler: ProtocolHandler) =
+    this(peer.id, peer.endpoint, handler)
+
+  private var _seq = 0L
+  def seq: Long = _seq synchronized {
+    _seq += 1
+    _seq
+  }
+
+  override def ping: Try[Duration] =
+    ProtocolMessage.ping(handler.local) match {
+      case Some(ping) =>
+        handler.roundTrip(PingMessage(ping, System.currentTimeMillis), this) match {
+          case Success(pong) =>
+            ping.header match {
+              case Some(incoming) =>
+                Success(Duration(pong.timestamp - incoming.timestamp, MILLISECONDS))
+              case _ => Failure(new Exception("ping failed"))
+            }
+          case Failure(ex) => Failure(ex)
+        }
+      case None => Failure(new Exception("ping failed"))
+    }
+}
+
+/**
+  * `ProtocolMessage` insulates protocol handlers from protocol buffer
+  * clutter.
+  */
+trait ProtocolMessage {
+  val proto: Protocol
+  val timestamp: Long
+}
+
+case class PingMessage(proto: Protocol, timestamp: Long) extends ProtocolMessage
+case class PongMessage(proto: Protocol, timestamp: Long) extends ProtocolMessage
+
+/**
+  * Utility functions for working with protocol buffers.
+  */
+object ProtocolMessage {
+
+  implicit def toProtocolBytes(x: String) =
+    com.google.protobuf.ByteString.copyFromUtf8(x)
+  implicit def toProtocolBytes(x: Array[Byte]) =
+    com.google.protobuf.ByteString.copyFrom(x)
+  implicit def toProtocolBytes(x: Seq[Byte]) =
+    com.google.protobuf.ByteString.copyFrom(x.toArray)
+
+  def toPeer(h: Option[Header]): Option[PeerNode] =
+    for {
+      h <- h
+      node <- h.sender
+    } yield
+      PeerNode(NodeIdentifier(node.id.toByteArray),
+               Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
+
+  def sender(msg: ProtocolMessage): Option[PeerNode] =
+  for {
+    header <- msg.proto.header
+    node <- header.sender
+  } yield
+      PeerNode(NodeIdentifier(node.id.toByteArray),
+        Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
+
+  def header(src: ProtocolNode) =
+    Header()
+      .withSender(node(src))
+      .withTimestamp(System.currentTimeMillis)
+      .withSeq(src.seq)
+
+  def header(msg: ProtocolMessage): Option[Header] = msg.proto.header
+
+  def returnHeader(msg: ProtocolMessage): Option[ReturnHeader] =
+    for {
+      proto <- msg.proto.message.pong
+      ret <- proto.returnHeader
+    } yield ret
+
+  def node(n: ProtocolNode) =
+    Node()
+      .withId(n.key)
+      .withHost(n.endpoint.host)
+      .withUdpPort(n.endpoint.udpPort)
+      .withTcpPort(n.endpoint.tcpPort)
+
+  def returnHeader(h: Header) =
+    ReturnHeader()
+      .withTimestamp(h.timestamp)
+      .withSeq(h.seq)
+
+  def ping(src: ProtocolNode): Option[Protocol] =
+    Some(Protocol().withHeader(header(src)).withPing(Ping()))
+
+  def pong(src: ProtocolNode, h: Header): Protocol =
+    Protocol()
+      .withHeader(header(src))
+      .withPong(Pong()
+        .withReturnHeader(returnHeader(h)))
+
+  def pong(src: ProtocolNode, ping: PingMessage): Option[Protocol] =
+    for {
+      h <- ping.proto.header
+    } yield pong(src, h)
+
+  def toBytes(proto: Protocol): Array[Byte] = {
+    val buf = new java.io.ByteArrayOutputStream
+    proto.writeTo(buf)
+    buf.toByteArray
+  }
+
+  def toBytes(msg: ProtocolMessage): Array[Byte] = toBytes(msg.proto)
+
+  def parse(bytes: Seq[Byte]): Option[ProtocolMessage] =
+    Protocol.parseFrom(bytes.toArray) match {
+      case msg: Protocol =>
+        msg.message match {
+          case Protocol.Message.Ping(p) => Some(PingMessage(msg, System.currentTimeMillis))
+          case Protocol.Message.Pong(p) => Some(PongMessage(msg, System.currentTimeMillis))
+          case _                        => None
+        }
+    }
+}

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration.{Duration, MILLISECONDS}
   * for higher level protocols.
   */
 trait ProtocolHandler {
+
   /**
     * The node that anchors this handler; `local` becomes the source
     * for outgoing communications.
@@ -87,21 +88,21 @@ object ProtocolMessage {
   implicit def toProtocolBytes(x: Seq[Byte]) =
     com.google.protobuf.ByteString.copyFrom(x.toArray)
 
-  def toPeer(h: Option[Header]): Option[PeerNode] =
+  def toPeer(header: Option[Header]): Option[PeerNode] =
     for {
-      h <- h
+      h <- header
       node <- h.sender
     } yield
       PeerNode(NodeIdentifier(node.id.toByteArray),
                Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
 
   def sender(msg: ProtocolMessage): Option[PeerNode] =
-  for {
-    header <- msg.proto.header
-    node <- header.sender
-  } yield
+    for {
+      header <- msg.proto.header
+      node <- header.sender
+    } yield
       PeerNode(NodeIdentifier(node.id.toByteArray),
-        Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
+               Endpoint(node.host.toStringUtf8, node.tcpPort, node.udpPort))
 
   def header(src: ProtocolNode) =
     Header()

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -92,7 +92,7 @@ case class UnicastComm(local: PeerNode) extends Comm {
         println(s"COMM Sending to ${peer.endpoint.udpSocketAddress}")
         val dgram = new DatagramPacket(payload, 0, payload.size, peer.endpoint.udpSocketAddress)
         sender.send(dgram)
-        return Success(true)
+        Success(true)
       }
       case Failure(ex) => Failure(ex)
     }

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try}
   * (`local`) be given; this supplies the source data for datagrams it
   * sends.
   */
-case class UnicastComm(val local: PeerNode) extends Comm {
+case class UnicastComm(local: PeerNode) extends Comm {
   lazy val receiver = new DatagramSocket(local.endpoint.udpPort)
   lazy val sender = new DatagramSocket()
 

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -19,8 +19,8 @@ import scala.util.{Failure, Success, Try}
   * sends.
   */
 case class UnicastComm(local: PeerNode) extends Comm {
-  lazy val receiver = new DatagramSocket(local.endpoint.udpPort)
-  lazy val sender = new DatagramSocket()
+  val receiver = new DatagramSocket(local.endpoint.udpPort)
+  val sender = new DatagramSocket()
 
   /*
    * Timeout for recv() calls; might need to be adjusted lower. This

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -86,13 +86,12 @@ case class UnicastComm(local: PeerNode) extends Comm {
     * the exception in a @scala.util.Try. See
     * @java.net.DatagramSocket.send for a list of possible exceptions.
     */
-  override def send(data: Seq[Byte], peer: PeerNode): Try[Boolean] =
+  override def send(data: Seq[Byte], peer: PeerNode): Try[Unit] =
     encode(data) match {
       case Success(payload) => {
         println(s"COMM Sending to ${peer.endpoint.udpSocketAddress}")
         val dgram = new DatagramPacket(payload, 0, payload.size, peer.endpoint.udpSocketAddress)
-        sender.send(dgram)
-        Success(true)
+        Try(sender.send(dgram))
       }
       case Failure(ex) => Failure(ex)
     }

--- a/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/kademlia/kademlia.scala
@@ -32,7 +32,7 @@ object ReputationOrder extends Ordering[Reputable] {
   def compare(a: Reputable, b: Reputable) = a.reputation compare b.reputation
 }
 
-case class PeerTableEntry[A <: Keyed](val entry: A) extends Keyed {
+case class PeerTableEntry[A <: Keyed](entry: A) extends Keyed {
   var pinging = false
   override def key = entry.key
   override def toString = s"#{PeerTableEntry $entry}"
@@ -167,6 +167,7 @@ case class PeerTable[A <: Peer](home: A,
                   }
                 }
             }
+            ()
           }
         }
       case None => ()


### PR DESCRIPTION
This PR builds on the `UnicastComm` object to enable overlaying a simple network via UDP. Overlaying network `net` and attaching to a remote node `remote` can be as simple as:
```
import coop.rchain.comm._
val net = UnicastNetwork(NodeIdentifier("local node".getBytes), Endpoint("localhost", 33313, 33313))
val remote = new ProtocolNode(NodeIdentifier("alien node".getBytes), Endpoint("localhost", 33314, 33314), net)
remote.ping
```
which "homes" this view of the network at udp://localhost:33313 and pings the node at udp://localhost:33314.

The `UnicastNetwork` class builds a kademlia routing table using only PING and PONG messages. It extends the `ProtocolHandler` trait with UDP transport versions of the slightly higher-than-base-level comms functions for request-response (`roundTrip`) and `broadcast` (though this PR doesn't use `broadcast`). A `UnicastNetwork` continually receives network traffic in a dedicated thread. The tightness of the receive loop is a constant 500ms currently, controlled by a socket timeout down in the `Comm` object, and it should be parameterized in the future. Messages are handled in the order received.

Since UDP is (for all intents and purposes) connectionless, the `UnicastNetwork` handler class simulates synchronous request-response by blocking in `roundTrip` on a promise of a response. These promises are stored in a `pending` map, keyed by some information in the original message. There is a timeout in `roundTrip`, distinct from the receive timeout above, that can be tailored per call. After the timeout tolls, the promise is failed. The promise succeeds when the receiving thread is able to match an incoming message with one in the pending map.

A node's Kademlia table in this version of the protocol simply includes every remote node it learns of (because that remote node has sent it a PING).

Ultimately, all messages are serialized protocol buffers on the wire. The protocol classes are insulated from this by the `ProtocolMessage` object, which is responsible for parsing arrays of bytes into Scala objects and thereby for some measure of syntactic validation of messages. This object is pretty messy right now, and it will need a good going-over when it does more than PING and PONG; I think something more elegant will fall out of it when there's more to it. If anyone has a suggestion for how to structure it at this point, I'm all ears.

CORE-29 CORE-23 #comment Higher-level Kademlia-lite protocol