### PR TITLE
Add implementation for methods from ROS-182

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -11,8 +11,8 @@ case object Upcall extends LookupError
 trait Base
 
 trait Ob extends Base {
-  val parent: Ob
   val meta: Ob
+  val parent: Ob
   val slot: Seq[Ob]
   val obTag: ObTag = null
   val sysval: SysCode = null
@@ -42,6 +42,15 @@ trait Ob extends Base {
                spanSize: Int,
                value: Int): Ob = null
   def setLex(ind: Int, level: Int, offset: Int, value: Ob): Ob = null
+
+  def notImplemented(opName: String): Unit = {
+    val className = this.getClass.getSimpleName
+    System.err.println(s"$className#$opName is not implemented!")
+  }
+
+  def forwardingAddress: Ob = meta
+
+  def self: Ob = this
 }
 
 object Ob {

--- a/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
@@ -1,0 +1,26 @@
+package coop.rchain.rosette
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ObSpec extends FlatSpec with Matchers {
+
+  "forwardingAddress" should "return meta" in {
+    val newMeta = createOb()
+    val ob = createOb(meta = newMeta)
+    ob.forwardingAddress shouldBe newMeta
+  }
+
+  "self" should "return \"this\"" in {
+    val ob = createOb()
+    ob.self shouldEqual ob
+  }
+
+  def createOb(meta: Ob = null, parent: Ob = null, slot: Seq[Ob] = null): Ob = {
+    val values = (meta, parent, slot)
+    new Ob {
+      override val meta = values._1
+      override val parent = values._2
+      override val slot = values._3
+    }
+  }
+}


### PR DESCRIPTION
The implementation for methods from https://rchain.atlassian.net/browse/ROS-182

Other methods are discarded because they do not seem relevant for Scala.
I'll add tests a bit later.