### PR TITLE
Add implementation for methods from ROS-183

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Actor.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Actor.scala
@@ -1,8 +1,8 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 trait Actor extends Ob {
   val extension: Ob
-  override val parent: Ob = null
-  override val meta: Ob = null
-  override val slot: Seq[Ob] = null
+  override val _slot: mutable.Seq[Ob] = null
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Code.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Code.scala
@@ -1,9 +1,8 @@
 package coop.rchain.rosette
 
-case class Code(litvec: Tuple,
-                override val parent: Ob,
-                override val meta: Ob,
-                override val slot: Seq[Ob])
+import scala.collection.mutable
+
+case class Code(litvec: Tuple, override val _slot: mutable.Seq[Ob])
     extends Ob {
   def lit(l: Int): Ob = litvec.elem(l)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
@@ -1,20 +1,20 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 case class Ctxt(argvec: Tuple,
                 code: Code,
                 ctxt: Ctxt,
                 env: Ob,
-                override val meta: Ob,
                 monitor: Monitor,
                 nargs: Int,
                 outstanding: Int,
-                override val parent: Ob,
                 pc: PC,
                 reg: Seq[Ob],
                 rslt: Ob,
                 trgt: Ob,
                 selfEnv: Ob,
-                override val slot: Seq[Ob],
+                override val _slot: mutable.Seq[Ob],
                 tag: Location)
     extends Ob {
   def arg(n: Int): Option[Ob] = argvec.elem.lift(n)
@@ -51,10 +51,8 @@ object Ctxt {
                    null,
                    null,
                    null,
-                   null,
                    0,
                    0,
-                   null,
                    null,
                    null,
                    null,
@@ -69,10 +67,8 @@ object Ctxt {
                    null,
                    null,
                    null,
-                   null,
                    0,
                    0,
-                   null,
                    null,
                    null,
                    null,

--- a/roscala/src/main/scala/coop/rchain/rosette/Instr.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Instr.scala
@@ -1,9 +1,9 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 // Covers 16-bit args; may want 64-bit ones eventually
 case class Instr(opcode: Op,
                  args: List[Int],
-                 override val parent: Ob,
-                 override val meta: Ob,
-                 override val slot: Seq[Ob])
+                 override val _slot: mutable.Seq[Ob])
     extends Ob

--- a/roscala/src/main/scala/coop/rchain/rosette/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Location.scala
@@ -5,6 +5,7 @@ case class LocationAtom(atom: Ob) extends Location
 case class LocationGT(genericType: Location.GenericType) extends Location
 
 object Location {
+  import utils.Instances.lgenTbl
   import Ob.Lenses._
 
   val AddrLevelSize = 5

--- a/roscala/src/main/scala/coop/rchain/rosette/Main.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Main.scala
@@ -16,7 +16,7 @@ object Main extends App {
   Parser.parse(bytes) match {
     case Right(opCodes) =>
       val initState = VMState(Map(),
-                              Code(null, null, null, null),
+                              Code(null, null),
                               Ctxt.PLACEHOLDER,
                               Location.PLACEHOLDER,
                               PC(0))

--- a/roscala/src/main/scala/coop/rchain/rosette/Monitor.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Monitor.scala
@@ -1,13 +1,13 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 case class Monitor(id: Ob,
                    timer: Timer,
                    opcodeCounts: Map[Op, Long],
                    obCounts: Long,
                    tracing: Boolean,
-                   override val parent: Ob,
-                   override val meta: Ob,
-                   override val slot: Seq[Ob])
+                   override val _slot: mutable.Seq[Ob])
     extends Ob {
   def reset(): Unit = {}
   def start(): Unit = timer.start()
@@ -17,5 +17,5 @@ case class Monitor(id: Ob,
 
 object Monitor {
   def apply(id: Ob): Monitor =
-    new Monitor(id, Timer(), Map(), 0, tracing = false, null, null, null)
+    new Monitor(id, Timer(), Map(), 0, tracing = false, null)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -25,16 +25,15 @@ trait Ob extends Base {
   def extendWith(keymeta: Ob): Ob = null
   def extendWith(keymeta: Ob, argvec: Tuple): Ob = null
 
-  def getAddr(ind: Int, level: Int, offset: Int): Ob = getLex(ind, level, offset) //TODO FIXNUM(ADDR_TO_PRE_FIXNUM _)
+  def getAddr(ind: Int, level: Int, offset: Int): Ob =
+    getLex(ind, level, offset)
 
   def getField(ind: Int,
                level: Int,
                offset: Int,
                spanSize: Int,
-               sign: Int): Ob = {
-
+               sign: Int): Ob =
     ??? //TODO
-  }
 
   def getLex(ind: Int, level: Int, offset: Int): Ob = {
     val p: Ob = nthParent(level)
@@ -52,21 +51,21 @@ trait Ob extends Base {
   def runtimeError(msg: String, state: VMState): (RblError, VMState) =
     (DeadThread, state)
 
-  def setAddr(ind: Int, level: Int, offset: Int, value: Ob): Ob = setLex(ind, level, offset, value) //TODO
+  def setAddr(ind: Int, level: Int, offset: Int, value: Ob): Ob =
+    setLex(ind, level, offset, value)
 
   def setField(ind: Int,
                level: Int,
                offset: Int,
                spanSize: Int,
-               value: Int): Ob = {
+               value: Int): Ob =
     ??? //TODO
-  }
 
   def setLex(ind: Int, level: Int, offset: Int, value: Ob): Ob = {
     val p: Ob = nthParent(level)
 
     actorExtensionFiltered(ind, p)
-      .filter { _ => offset < p.numberOfSlots() }
+      .filter(_ => offset < p.numberOfSlots())
       .map { ob =>
         ob.slot(offset) = value
         value
@@ -79,12 +78,14 @@ trait Ob extends Base {
   }
 
   def notImplemented(): Unit = {
-    val callingMethodName = Thread.currentThread.getStackTrace()(2).getMethodName
+    val callingMethodName =
+      Thread.currentThread.getStackTrace()(2).getMethodName
     notImplemented(callingMethodName)
   }
 
   def notImplementedOb(): Ob = {
-    val callingMethodName = Thread.currentThread.getStackTrace()(2).getMethodName
+    val callingMethodName =
+      Thread.currentThread.getStackTrace()(2).getMethodName
     notImplemented(callingMethodName)
     Ob.INVALID
   }
@@ -104,9 +105,9 @@ trait Ob extends Base {
   def setMailbox: Ob = self
 
   def rcons(ob: Ob): Ob =
-    copy(slot = slot :+ ob)
+    copyOb(slot = slot :+ ob)
 
-  def copy(parent: Ob = parent, meta: Ob = meta, slot: Seq[Ob] = slot): Ob = {
+  def copyOb(parent: Ob = parent, meta: Ob = meta, slot: Seq[Ob] = slot): Ob = {
     val values = (parent, meta, slot)
     new Ob {
       override val parent: Ob = values._1
@@ -124,27 +125,25 @@ trait Ob extends Base {
 
   def indexedSize: Ob = notImplementedOb()
 
-  def setNth(i: Int, v: Ob): Ob = notImplementedOb()
+  def setNth(i: Int, v: Ob): Option[Ob] = Some(notImplementedOb())
   def subObject(i1: Int, i2: Int): Ob = notImplementedOb()
   def asPathname: String = ""
-  def nth(i: Int): Ob = notImplementedOb()
+  def nth(i: Int): Option[Ob] = Some(notImplementedOb())
 
-  private def actorExtensionFiltered(ind: Int, p: Ob): Option[Ob] = {
+  private def actorExtensionFiltered(ind: Int, p: Ob): Option[Ob] =
     if (p.numberOfSlots() <= SLOT_NUM(Actor, extension)) { //TODO
       None
     } else {
       Some(actorExtension(ind, p))
     }
-  }
 
-  private def actorExtension(ind: Int, p: Ob): Ob = {
+  private def actorExtension(ind: Int, p: Ob): Ob =
     if (ind > 0) {
       p match {
         case a: Actor =>
           a.extension
       }
     } else p
-  }
 
   private def offsetOrInvalid(offset: Int, ob: Ob): Ob =
     if (offset < ob.numberOfSlots())
@@ -152,9 +151,7 @@ trait Ob extends Base {
     else
       Ob.INVALID
 
-  private def base(ob: Ob): Ob = ???
-
-  private def nthParent(level: Int): Ob = base(recMap(level, this)(_.parent))
+  private def nthParent(level: Int): Ob = recMap(level, this)(_.parent)
 }
 
 object Ob {
@@ -225,6 +222,7 @@ object Ob {
     }
   }
 
+  //TODO use logging framework
   def printOn[A <: Ob: Show](ob: A, file: File): Unit = {
     val str = Show[A].show(ob)
     printToFile(file)(_.print(str))

--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rosette
 
+import java.io.{File, PrintWriter}
+
 import coop.rchain.rosette.Ob.{ObTag, SysCode}
 import shapeless._
 import shapeless.OpticDefns.RootLens
@@ -10,24 +12,38 @@ case object Upcall extends LookupError
 
 trait Base
 
+//TODO change type of `indirect` argument to bool
 trait Ob extends Base {
   val meta: Ob
   val parent: Ob
   val slot: Seq[Ob]
   val obTag: ObTag = null
   val sysval: SysCode = null
+  val constantP = true
 
   def dispatch(ctxt: Ctxt): Ob = null
   def extendWith(keymeta: Ob): Ob = null
   def extendWith(keymeta: Ob, argvec: Tuple): Ob = null
-  def getAddr(ind: Int, level: Int, offset: Int): Ob = null
+
+  def getAddr(ind: Int, level: Int, offset: Int): Ob = getLex(ind, level, offset) //TODO FIXNUM(ADDR_TO_PRE_FIXNUM _)
+
   def getField(ind: Int,
                level: Int,
                offset: Int,
                spanSize: Int,
-               sign: Int): Ob =
-    null
-  def getLex(ind: Int, level: Int, offset: Int): Ob = null
+               sign: Int): Ob = {
+
+    ??? //TODO
+  }
+
+  def getLex(ind: Int, level: Int, offset: Int): Ob = {
+    val p: Ob = nthParent(level)
+
+    actorExtensionFiltered(ind, p)
+      .map(offsetOrInvalid(offset, _))
+      .getOrElse(Ob.INVALID)
+  }
+
   def is(value: Ob.ObTag): Boolean = true
   def lookupOBO(meta: Ob, ob: Ob, key: Ob): Either[LookupError, Ob] =
     Right(null)
@@ -35,22 +51,110 @@ trait Ob extends Base {
   def numberOfSlots(): Int = Math.max(0, slot.length - 2)
   def runtimeError(msg: String, state: VMState): (RblError, VMState) =
     (DeadThread, state)
-  def setAddr(ind: Int, level: Int, offset: Int, value: Ob): Ob = null
+
+  def setAddr(ind: Int, level: Int, offset: Int, value: Ob): Ob = setLex(ind, level, offset, value) //TODO
+
   def setField(ind: Int,
                level: Int,
                offset: Int,
                spanSize: Int,
-               value: Int): Ob = null
-  def setLex(ind: Int, level: Int, offset: Int, value: Ob): Ob = null
+               value: Int): Ob = {
+    ??? //TODO
+  }
+
+  def setLex(ind: Int, level: Int, offset: Int, value: Ob): Ob = {
+    val p: Ob = nthParent(level)
+
+    actorExtensionFiltered(ind, p)
+      .filter { _ => offset < p.numberOfSlots() }
+      .map { ob =>
+        ob.slot(offset) = value
+        value
+      } getOrElse Ob.INVALID
+  }
 
   def notImplemented(opName: String): Unit = {
     val className = this.getClass.getSimpleName
     System.err.println(s"$className#$opName is not implemented!")
   }
 
+  def notImplemented(): Unit = {
+    val callingMethodName = Thread.currentThread.getStackTrace()(2).getMethodName
+    notImplemented(callingMethodName)
+  }
+
+  def notImplementedOb(): Ob = {
+    val callingMethodName = Thread.currentThread.getStackTrace()(2).getMethodName
+    notImplemented(callingMethodName)
+    Ob.INVALID
+  }
+
   def forwardingAddress: Ob = meta
 
   def self: Ob = this
+
+  def inlineablePrimP: Prim = Prim.INVALID
+
+  def emptyMbox: Ob = Ob.INVALID
+
+  def container: Ob = this
+
+  def mailbox: Ob = emptyMbox
+
+  def setMailbox: Ob = self
+
+  def rcons(ob: Ob): Ob =
+    copy(slot = slot :+ ob)
+
+  def copy(parent: Ob = parent, meta: Ob = meta, slot: Seq[Ob] = slot): Ob = {
+    val values = (parent, meta, slot)
+    new Ob {
+      override val parent: Ob = values._1
+      override val meta: Ob = values._2
+      override val slot: Seq[Ob] = values._3
+    }
+  }
+
+  def addSlot(l: Ob, r: Ob): Int = {
+    notImplemented()
+    0
+  }
+
+  def dup: Ob = this
+
+  def indexedSize: Ob = notImplementedOb()
+
+  def setNth(i: Int, v: Ob): Ob = notImplementedOb()
+  def subObject(i1: Int, i2: Int): Ob = notImplementedOb()
+  def asPathname: String = ""
+  def nth(i: Int): Ob = notImplementedOb()
+
+  private def actorExtensionFiltered(ind: Int, p: Ob): Option[Ob] = {
+    if (p.numberOfSlots() <= SLOT_NUM(Actor, extension)) { //TODO
+      None
+    } else {
+      Some(actorExtension(ind, p))
+    }
+  }
+
+  private def actorExtension(ind: Int, p: Ob): Ob = {
+    if (ind > 0) {
+      p match {
+        case a: Actor =>
+          a.extension
+      }
+    } else p
+  }
+
+  private def offsetOrInvalid(offset: Int, ob: Ob): Ob =
+    if (offset < ob.numberOfSlots())
+      ob.slot(offset)
+    else
+      Ob.INVALID
+
+  private def base(ob: Ob): Ob = ???
+
+  private def nthParent(level: Int): Ob = base(recMap(level, this)(_.parent))
 }
 
 object Ob {
@@ -119,5 +223,22 @@ object Ob {
 
       def updateSelf[T](value: A => A): A = value(base)
     }
+  }
+
+  def printOn[A <: Ob: Show](ob: A, file: File): Unit = {
+    val str = Show[A].show(ob)
+    printToFile(file)(_.print(str))
+  }
+
+  def printQuotedOn[A <: Ob: Show](ob: A, file: File): Unit =
+    printOn(ob, file)
+
+  def displayOn[A <: Ob: Show](ob: A, file: File): Unit =
+    printOn(ob, file)
+
+  //TODO move to another class
+  private def printToFile(f: File)(op: PrintWriter => Unit) {
+    val p = new PrintWriter(f)
+    try { op(p) } finally { p.close() }
   }
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
@@ -1,9 +1,9 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 case class StdOprn(override val extension: Ob,
-                   override val parent: Ob,
-                   override val meta: Ob,
-                   override val slot: Seq[Ob])
+                   override val _slot: mutable.Seq[Ob])
     extends Actor
 
-object OprnVmError extends StdOprn(null, null, null, null)
+object OprnVmError extends StdOprn(null, null)

--- a/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
@@ -9,4 +9,6 @@ case class Prim(override val parent: Ob,
 
 object Prim {
   val nthPrim: Seq[Prim] = new Array[Prim](0)
+
+  case object INVALID extends Prim(null, null, null)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
@@ -1,14 +1,13 @@
 package coop.rchain.rosette
 
-abstract class Prim(override val parent: Ob,
-                    override val meta: Ob,
-                    override val slot: Seq[Ob])
-    extends Ob {
+import scala.collection.mutable
+
+case class Prim(override val _slot: mutable.Seq[Ob]) extends Ob {
   def dispatchHelper(ctxt: Ctxt): Either[RblError, Ob] = Right(null)
 }
 
 object Prim {
   val nthPrim: Seq[Prim] = new Array[Prim](0)
 
-  case object INVALID extends Prim(null, null, null)
+  object INVALID extends Prim(null)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Prim.scala
@@ -1,8 +1,8 @@
 package coop.rchain.rosette
 
-case class Prim(override val parent: Ob,
-                override val meta: Ob,
-                override val slot: Seq[Ob])
+abstract class Prim(override val parent: Ob,
+                    override val meta: Ob,
+                    override val slot: Seq[Ob])
     extends Ob {
   def dispatchHelper(ctxt: Ctxt): Either[RblError, Ob] = Right(null)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
@@ -1,10 +1,10 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 trait RblAtom extends Ob
 
 case class Fixnum(value: Int,
-                  override val parent: Ob = null,
-                  override val meta: Ob = null,
-                  override val slot: Seq[Ob] = null,
+                  override val _slot: mutable.Seq[Ob] = null,
                   override val obTag: Ob.ObTag = Ob.OTfixnum)
     extends RblAtom

--- a/roscala/src/main/scala/coop/rchain/rosette/TblObject.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/TblObject.scala
@@ -1,11 +1,10 @@
 package coop.rchain.rosette
 
-case class TblObject(entry: Seq[Ob],
-                     override val parent: Ob,
-                     override val meta: Ob,
-                     override val slot: Seq[Ob])
+import scala.collection.mutable
+
+case class TblObject(entry: Seq[Ob], override val _slot: mutable.Seq[Ob])
     extends Ob
 
 object TblObject {
-  object PLACEHOLDER extends TblObject(null, null, null, null)
+  object PLACEHOLDER extends TblObject(null, null)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rosette
 
+import scala.collection.mutable
+
 /** Tuple
   *
   *  Tuples are used to represent messages that convey information
@@ -11,10 +13,7 @@ sealed trait TupleError
 case object AbsentRest extends TupleError
 case object InvalidRest extends TupleError
 
-case class Tuple(elem: Seq[Ob],
-                 override val parent: Ob,
-                 override val meta: Ob,
-                 override val slot: Seq[Ob])
+case class Tuple(elem: mutable.Seq[Ob], override val _slot: mutable.Seq[Ob])
     extends Ob {
 
   def accepts(msg: Ctxt): Boolean =
@@ -106,7 +105,7 @@ case class Tuple(elem: Seq[Ob],
 
   override def setNth(n: Int, ob: Ob): Option[Tuple] =
     try {
-      Some(Tuple(this.elem.updated(n, ob), this.parent, this.meta, this.slot))
+      Some(Tuple(this.elem.updated(n, ob), this._slot))
     } catch {
       case _: IndexOutOfBoundsException => None
     }
@@ -117,14 +116,14 @@ case class Tuple(elem: Seq[Ob],
 
 object Tuple {
 
-  object NIL extends Tuple(null, null, null, null)
+  object NIL extends Tuple(null, null)
 
-  val PLACEHOLDER = new Tuple(Seq(), null, null, null)
+  val PLACEHOLDER = new Tuple(mutable.Seq(), null)
 
-  def apply(init: Ob) = new Tuple(Seq(init), null, null, null)
+  def apply(init: Ob) = new Tuple(mutable.Seq(init), null)
 
   def apply(t1: Tuple, t2: Tuple): Tuple =
-    new Tuple(t1.elem ++ t2.elem, null, null, null)
+    new Tuple(t1.elem ++ t2.elem, null)
 
   def apply(size: Int,
             master: Tuple,
@@ -139,17 +138,17 @@ object Tuple {
       Seq.empty
     }
 
-    new Tuple(slice ++ filling, null, null, null)
+    new Tuple(slice ++ filling, null)
   }
 
   def apply(a: Int, b: Option[Ob]): Tuple =
-    new Tuple(null, null, null, null)
+    new Tuple(null, null)
 
   def cons(ob: Ob, t: Tuple): Tuple =
-    new Tuple(ob +: t.elem, null, null, null)
+    new Tuple(ob +: t.elem, null)
 
   def rcons(t: Tuple, ob: Ob): Tuple =
-    new Tuple(t.elem :+ ob, null, null, null)
+    new Tuple(t.elem :+ ob, null)
 
   def concat(t1: Tuple, t2: Tuple): Tuple = apply(t1, t2)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
@@ -102,16 +102,16 @@ case class Tuple(elem: Seq[Ob],
       } else false
     }
 
-  def nth(n: Int): Option[Ob] = this.elem.lift(n)
+  override def nth(n: Int): Option[Ob] = this.elem.lift(n)
 
-  def setNth(n: Int, ob: Ob): Option[Tuple] =
+  override def setNth(n: Int, ob: Ob): Option[Tuple] =
     try {
       Some(Tuple(this.elem.updated(n, ob), this.parent, this.meta, this.slot))
     } catch {
       case _: IndexOutOfBoundsException => None
     }
 
-  def subObject(i: Int, n: Int): Tuple = makeSlice(i, n)
+  override def subObject(i: Int, n: Int): Tuple = makeSlice(i, n)
 
 }
 

--- a/roscala/src/main/scala/coop/rchain/rosette/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/package.scala
@@ -1,8 +1,10 @@
 package coop.rchain
 
 import coop.rchain.rosette.parser.bytecode.ParseError
+
 import reflect.runtime.universe._
 import reflect.runtime.currentMirror
+import scala.annotation.tailrec
 
 package object rosette {
   def suicide(msg: String): Unit = {
@@ -44,5 +46,10 @@ package object rosette {
         }
         .mkString("\n")
     }
+  }
+
+  @tailrec
+  def recMap[A](count: Int, l: A)(f: A => A): A = {
+    if (count == 0) l else recMap(count-1, f(l))(f)
   }
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/utils/Instances.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/utils/Instances.scala
@@ -1,0 +1,29 @@
+package coop.rchain.rosette.utils
+
+import coop.rchain.rosette.{Ob, TblObject}
+import shapeless._
+import record._
+import syntax.singleton._
+
+import scala.collection.mutable
+
+object Instances {
+
+  //TODO possibly we can make a generic derivation for any T <: Ob
+  implicit val lgenTbl = new LabelledGeneric[TblObject] {
+
+    type Repr =
+      Record.`'slot -> mutable.Seq[Ob], 'entry -> Seq[Ob], '_slot -> mutable.Seq[Ob]`.T
+
+    def to(a: TblObject): Repr =
+      ('slot ->> a.slot) :: ('entry ->> a.entry) :: ('_slot ->> a._slot) :: HNil
+
+    def from(r: Repr): TblObject = {
+      val slot = r('slot)
+      val _slot = r('_slot)
+      val entry = r('entry)
+      val newSlot = _slot(0) +: _slot(1) +: slot
+      TblObject(_slot = newSlot, entry = entry)
+    }
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/rosette/utils/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/utils/package.scala
@@ -1,0 +1,39 @@
+package coop.rchain.rosette
+
+import java.io.{File, PrintWriter}
+
+import scala.collection.mutable
+
+package object utils {
+
+  def printToFile(f: File)(op: PrintWriter => Unit) {
+    val p = new PrintWriter(f)
+    try { op(p) } finally { p.close() }
+  }
+
+  def pSlice[T](src: mutable.Seq[T], start: Int, end: => Int) =
+    new mutable.Seq[T] {
+      def checkBounds(idx: Int): Unit =
+        if (idx > end - start) {
+          throw new IndexOutOfBoundsException
+        }
+
+      override def update(idx: Int, elem: T): Unit = {
+        checkBounds(idx)
+
+        src(idx + start) = elem
+      }
+
+      override def length: Int =
+        math.min(src.size, end) - start
+
+      override def apply(idx: Int): T = {
+        checkBounds(idx)
+
+        src(idx + start)
+      }
+
+      override def iterator: Iterator[T] =
+        src.slice(start, end).iterator
+    }
+}

--- a/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
@@ -1,26 +1,89 @@
 package coop.rchain.rosette
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, WordSpec}
 
-class ObSpec extends FlatSpec with Matchers {
+import scala.collection.mutable
 
-  "forwardingAddress" should "return meta" in {
-    val newMeta = createOb()
-    val ob = createOb(meta = newMeta)
-    ob.forwardingAddress shouldBe newMeta
+class ObSpec extends WordSpec with Matchers {
+
+  "forwardingAddress" should {
+
+    "return meta" in {
+      val newMeta = createOb()
+      val ob = createOb(meta = newMeta)
+      ob.forwardingAddress shouldBe newMeta
+    }
   }
 
-  "self" should "return \"this\"" in {
-    val ob = createOb()
-    ob.self shouldEqual ob
+  "self" should {
+
+    "return \"this\"" in {
+      val ob = createOb()
+      ob.self shouldEqual ob
+    }
   }
 
-  def createOb(meta: Ob = null, parent: Ob = null, slot: Seq[Ob] = null): Ob = {
-    val values = (meta, parent, slot)
+  "getLex" should {
+
+    "return element by offset" in {
+      val third = createOb()
+      val parent = parentWithThreeSlots(third)
+
+      val ob = createOb(parent = parent)
+      val lex = ob.getLex(ind = 1, level = 1, offset = 2)
+
+      lex shouldEqual third
+    }
+
+    "return INVALID when offset is out of bounds" in {
+      val parent = parentWithThreeSlots()
+      val ob = createOb(parent = parent)
+      val lex =
+        ob.getLex(ind = 1, level = 1, offset = parent.numberOfSlots() + 1)
+
+      lex shouldEqual Ob.INVALID
+    }
+  }
+
+  "setLex" should {
+
+    "set an extension slot by offset" in {
+      val ext = createOb(slot = twoSlots)
+      val value = createOb()
+      val parent: Ob = parentWithThreeSlots(extension = Some(ext))
+      val ob = createOb(parent = parent)
+      val offset = 1
+      ob.setLex(ind = 1, level = 1, offset = offset, value = value)
+      ext.slot(offset) shouldEqual value
+    }
+  }
+
+  def parentWithThreeSlots(third: Ob = null,
+                           extension: Option[Ob] = None): Actor = {
+
+    val seq = twoSlots :+ third
+    val ext = extension.getOrElse(createOb(slot = seq))
+    createActor(ext, seq)
+  }
+
+  def twoSlots: mutable.Seq[Ob] = {
+    val first = createOb()
+    val second = createOb()
+    mutable.Seq(first, second)
+  }
+
+  def createActor(ext: Ob, slots: mutable.Seq[Ob]): Actor =
+    new Actor {
+      override val extension = ext
+      override val _slot = null +: null +: slots
+    }
+
+  def createOb(meta: Ob = null,
+               parent: Ob = null,
+               slot: mutable.Seq[Ob] = mutable.Seq.empty): Ob = {
+    val (m, p, s) = (meta, parent, slot)
     new Ob {
-      override val meta = values._1
-      override val parent = values._2
-      override val slot = values._3
+      override val _slot = m +: p +: s
     }
   }
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/UtilsSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/UtilsSpec.scala
@@ -1,0 +1,59 @@
+package coop.rchain.rosette
+
+import coop.rchain.rosette.utils.pSlice
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.mutable
+
+class UtilsSpec extends WordSpec with Matchers {
+  val seq = mutable.Seq(1, 2, 3, 4, 5)
+  val newValue = 1337
+  val start = 1
+  val end = 2
+
+  "A pSlice" should {
+
+    "return correct size" in {
+      pSlice(seq, start, end).length shouldEqual (end - start)
+    }
+
+    "return max size when end is out of bounds" in {
+      val outbound = seq.size + 3
+      val end = seq.size
+      pSlice(seq, start, outbound).length shouldEqual (end - start)
+    }
+
+    "mutate on origin seq" in {
+      val seq = mutable.Seq(1, 2, 3, 4)
+      val slice = pSlice(seq, 0, seq.size)
+      slice.update(0, newValue)
+      seq(0) shouldEqual newValue
+    }
+
+    "mutate on origin seq based on start index" in {
+      val seq = mutable.Seq(1, 2, 3, 4)
+      val slice = pSlice(seq, start, seq.size)
+      slice.update(0, newValue)
+      seq(start) shouldEqual newValue
+    }
+
+    "mutate on slice" in {
+      val seq = mutable.Seq(1, 2, 3, 4)
+      val slice = pSlice(seq, 0, seq.size)
+      slice.update(0, newValue)
+      slice(0) shouldEqual newValue
+    }
+
+    "mutate on slice when seq updated" in {
+      val seq = mutable.Seq(1, 2, 3, 4)
+      val slice = pSlice(seq, 0, seq.size)
+      seq.update(0, newValue)
+      slice(0) shouldEqual newValue
+    }
+
+    "should return element from origin seq based on start index" in {
+      val slice = pSlice(seq, start, end)
+      slice(0) shouldEqual seq(start)
+    }
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/package.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/package.scala
@@ -3,30 +3,31 @@ package coop.rchain.rosette.utils
 import coop.rchain.rosette.PC.PLACEHOLDER
 import coop.rchain.rosette._
 
+import scala.collection.mutable
+
 package object opcodes {
-  val someObs: Seq[Ob] = Seq(Ob.NIV, Ob.ABSENT)
-  val someTuple: Tuple = Tuple(someObs, Ob.NIV, Ob.NIV, Seq.empty)
+  val someObs: mutable.Seq[Ob] = mutable.Seq(Ob.NIV, Ob.ABSENT)
+  val someTuple: Tuple =
+    Tuple(someObs, Ob.NIV +: Ob.NIV +: mutable.Seq.empty[Ob])
 
   val ctxt = Ctxt(someTuple,
                   null,
                   null,
                   null,
                   null,
-                  null,
                   0,
                   0,
-                  Ob.NIV,
                   PC.PLACEHOLDER,
                   someObs,
                   Ob.NIV,
                   null,
                   null,
-                  someObs,
+                  null +: Ob.NIV +: someObs,
                   Location.LocTrgt)
 
   val testState = VMState(
     Map.empty,
-    Code(someTuple, Ob.NIV, Ob.NIV, someObs),
+    Code(someTuple, Ob.NIV +: Ob.NIV +: someObs),
     ctxt,
     Location.LocTrgt,
     PLACEHOLDER,
@@ -34,6 +35,6 @@ package object opcodes {
     null,
     systemMonitor = null,
     currentMonitor = null,
-    globalEnv = TblObject(someObs, Ob.NIV, Ob.NIV, Seq.empty)
+    globalEnv = TblObject(someObs, Ob.NIV +: Ob.NIV +: mutable.Seq.empty)
   )
 }


### PR DESCRIPTION
The implementation for methods from https://rchain.atlassian.net/browse/ROS-183

There are few methods replaced:
- `asCString` replaced in favour to `Show` typeclass;
- `printOn`, `printQuotedOn`, `displayOn` now depends on `Show` typeclass;
- `clone`, `cloneTo` methods are replaced in favour to new `copy` method;

This PR is little bit messy because this branch contains commit from #34 
I'll add tests a bit later.

I still have problems with implementations for following:
- Methods “getAddr” and “setAddr” methods look exactly the same like “getLex” and “setLex”, except that given values are wrapped in “FIXNUM(ADDR_TO_PRE_FIXNUM(_))” and PRE_FIXNUM_TO_ADDR(FIXVAL(_))”. I’m not sure that this difference should be reflected in Scala implementation.
- Not sure that I can provide a correct implementation for "getField” and “setField” methods. Any help would be appreciated!