### PR TITLE
Update arithmetic_test.rho to be unit test-like

### DIFF
--- a/rholang/examples/arithmetic_test.rho
+++ b/rholang/examples/arithmetic_test.rho
@@ -1,14 +1,52 @@
-// -25, false, true, -0.4
+// This is a will-be-unit-test for the arithmetic operations in Rholang.
+// Note that the currently outputted values are simply based on
+// Rosette's output. We probably want to change a lot of behavior
+// in the reimplementation.
 
-new arithmetic_test in {
-    contract arithmetic_test(rtn) = {
-        { (5+(-5))*5/1+6+9-40 } |
-        { true * true * false } |
-        { true + (false + false) } |
-        { (5.0/2.5)-2.4 } // This may not be exactly -0.4 due to the nature of floating point arithmetic
-    } |
-    new rtn in {
-        arithmetic_test!(rtn)
-    }
+match [
+    // Addition
+
+    2+8,                        // 10
+    1+2+3+4+5+6+7+8+9+10,       // 55
+    2147483647+2147483647,      // -2
+    2.5+7.5,                    // 10.0
+    3.1415926535897932384626+3.1415926535897932384626, // 6.283185307179586
+
+    // Subtraction
+
+    47-37,                      // 10
+    -2147483647-1,              // 0
+
+    // Interestingly enough -2147483648 can't be parsed even though
+    // in theory it is the minimum 32-bit signed integer because
+    // the parser treats it as -1*2147483648
+
+    // Multiplication
+
+    2*5,                        // 10
+    -5*-2,                      // 10
+    2147483647*2147483647,      // 1
+
+    // -1.5*-1 fails *** 2nd argument is not a Float: ((FO Prim fl*) -1.5 -1)
+
+    // Division
+
+    120/12,                     // 10
+    2147483647/-1,              // 1
+
+    // 14/0 fails with Program received signal SIGFPE, Arithmetic exception.
+
+    // Mix
+
+    -10+4*5-(30/10)-2+5,        // 10
+    10+(10-10)*10,              // 10
+    10.5-0.5+2.5/2.5-1.0        // 10.0
+
+    ] with
+
+< 10, 55, -2, 10.0, 6.283185307179586, 10, 0, 10, 10, 1, 10, 1, 10, 10, 10.0 > => {
+    print("Pass")
 }
-
+_ => {
+    print("Fail")
+}

--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -120,12 +120,17 @@ PtBranch. PatternPatternMatch ::= PPattern "=>" "{" PPattern "}" ;
 separator nonempty PatternPatternMatch "" ;
 
 -- Value patterns
+
+-- We only allow for constants in pattern matches
+-- unlike for Procs which can have arbitrary operations
 VPtStruct. ValPattern ::= Var "{" [PPattern] "}" ;
 VPtTuple. ValPattern ::= "<" [PPattern] ">" ;
 VPtTrue. ValPattern ::= "true" ;
 VPtFalse. ValPattern ::= "false" ;
 VPtInt. ValPattern ::= Integer ;
 VPtDbl. ValPattern ::= Double ;
+VPtNegInt. ValPattern ::= "-" Integer;
+VPtNegDbl. ValPattern ::= "-" Double;
 VPtStr. ValPattern ::= String ;
 --VPtString. ValPattern ::=  ;
 --VPtArray.  ValPattern ::=  ;

--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -91,9 +91,9 @@ VarPtWild. VarPattern ::= "_" ;
 separator VarPattern "," ;
 
 -- Process patterns
+PPtVal.    PPattern4 ::= ValPattern ;
 PPtVar.    PPattern4 ::= VarPattern ;
 PPtNil.    PPattern4 ::= "Nil" ;
-PPtVal.    PPattern4 ::= ValPattern ;
 PPtDrop.   PPattern3 ::= "*" CPattern ;
 PPtInject. PPattern3 ::= "#" CPattern ;
 PPtOutput. PPattern2 ::= CPattern "!" "(" [PPattern] ")" ;

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -1265,6 +1265,9 @@ extends StrFoldCtxtVisitor {
       case vPtTrue : VPtTrue => visit( vPtTrue, arg )
       case vPtFalse : VPtFalse => visit( vPtFalse, arg )
       case vPtInt : VPtInt => visit( vPtInt, arg )
+      case vPtDbl : VPtDbl => visit( vPtDbl, arg )
+      case vPtNegInt : VPtNegInt => visit( vPtNegInt, arg )
+      case vPtNegDbl : VPtNegDbl => visit( vPtNegDbl, arg )
     }
   }
   override def visit(  p : VPtStruct, arg : A ) : R = {
@@ -1331,6 +1334,24 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       L( G( s"""${p.integer_}"""), Top() )
+    )
+  }
+  override def visit(  p : VPtDbl, arg: A ): R = {
+    combine(
+      arg,
+      L( G( s"""${p.double_}"""), Top() )
+    )
+  }
+  override def visit(  p : VPtNegInt, arg: A ): R = {
+    combine(
+      arg,
+      L( G( s"""-${p.integer_}"""), Top() )
+    )
+  }
+  override def visit(  p : VPtNegDbl, arg: A ): R = {
+    combine(
+      arg,
+      L( G( s"""-${p.double_}"""), Top() )
     )
   }
 }


### PR DESCRIPTION
This PR modifies the arithemtic_test.rho to be more unit test-like and makes the necessary changes on the compiler to ensure it compiles.

As written in a commit message, this has been tested to pass on the Rosette C++ implementation.

```
(if (match? [(+ 2 8) (+ (+ (+ (+ (+ (+ (+ (+ (+ 1 2) 3) 4) 5) 6) 7) 8)
9) 10) (+ 2147483647 2147483647) (+ 2.5 7.5) (+ 3.141592653589793
3.141592653589793) (- 47 37) (- (- 2147483647) 1) (* 2 5) (* (- 5) (-
2)) (* 2147483647 2147483647) (/ 120 12) (/ 2147483647 (- 1)) (+ (- (-
(+ (- 10) (* 4 5)) (/ 30 10)) 2) 5) (+ 10 (* (- 10 10) 10)) (- (+ (-
10.5 0.5) (/ 2.5 2.5)) 1.0)] [10 55 -2 10.0 6.283185307179586 10 0 10 10
1 10 1 10 10 10.0]) (seq (print "Pass") (display #\\n)) (seq (print
"Fail") (display #\\n)))
"Pass"
(FO Printer -511084772)
```

Note the values that I'm matching to patterns to are the outputs of
Rosette and if we want to perform arithmetic computations differently,
we will have to modify the behavior in the reimplementation.