### PR TITLE
Add execution of bytecode derived from if expression

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rosette
 
 import coop.rchain.rosette.Location.StoreCtxt
+import coop.rchain.rosette.VirtualMachine.loggerStrand
 import Location._
 import scala.collection.mutable
 
@@ -23,7 +24,7 @@ case class Ctxt(tag: Location,
   private val regs = Vector(rslt, trgt, argvec, env, code, ctxt, self2, selfEnv, rcvr, monitor)
 
   def applyK(result: Ob, tag: Location)(state: VMState): (Boolean, VMState) =
-    ctxt.rcv(result, tag)(state)
+    this.ctxt.rcv(result, tag)(state)
 
   def arg(n: Int): Option[Ob] = argvec.elem.lift(n)
 
@@ -62,8 +63,10 @@ case class Ctxt(tag: Location,
       (false, state)
     }
 
-  def scheduleStrand(state: VMState): VMState =
-    state.update(_ >> 'strandPool)(_ :+ this)
+  def scheduleStrand(state: VMState): VMState = {
+    loggerStrand.info(s"Schedule strand ${state.ctxt.ctxt.hashCode()}")
+    state.update(_ >> 'strandPool)(_ :+ state.ctxt.ctxt)
+  }
 
   def setReg(r: Int, ob: Ob): Option[Ctxt] =
     r match {

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -20,7 +20,8 @@ case class StrandsScheduled(state: VMState) extends Work
 
 object VirtualMachine {
 
-  val logger = Logger("opcode")
+  val loggerOpcode = Logger("opcode")
+  val loggerStrand = Logger("strand")
 
   val vmLiterals: Seq[Ob] = Seq(
     Fixnum(0),
@@ -113,7 +114,9 @@ object VirtualMachine {
       case _ => suicide(s"unknown SysCode value (${v.sysval})")
     }
 
-  def getNextStrand(state: VMState): (Boolean, VMState) =
+  def getNextStrand(state: VMState): (Boolean, VMState) = {
+    loggerStrand.info("Try to get next strand")
+
     if (state.strandPool.isEmpty) {
       tryAwakeSleepingStrand(state) match {
         case WaitForAsync =>
@@ -140,6 +143,7 @@ object VirtualMachine {
 
       (false, installStrand(strand, newState))
     }
+  }
 
   def tryAwakeSleepingStrand(state: VMState): Work =
     if (state.sleeperPool.isEmpty) {
@@ -171,6 +175,7 @@ object VirtualMachine {
         installMonitor(strand.monitor, state)
       else state
 
+    loggerStrand.info(s"Install strand ${strand.hashCode()}")
     installCtxt(strand, stateInstallMonitor)
   }
 
@@ -209,18 +214,20 @@ object VirtualMachine {
   }
 
   def executeSeq(opCodes: Seq[Op], state: VMState): VMState = {
-    var pc = 0
+    var pc = state.pc.relative
     var exit = false
     var currentState = state
 
     while (pc < opCodes.size && !exit) {
       val op = opCodes(pc)
-      logger.info("PC: " + pc + " Opcode: " + op)
+      loggerOpcode.info("PC: " + pc + " Opcode: " + op)
 
-      currentState = modifyFlags(executeDispatch(op, currentState))
+      currentState = currentState
+        .update(_ >> 'pc >> 'relative)(_ + 1)
         .update(_ >> 'bytecodes)(
           _.updated(op, currentState.bytecodes.getOrElse(op, 0.toLong) + 1))
-        .update(_ >> 'pc >> 'relative)(_ + 1)
+
+      currentState = runFlags(executeDispatch(op, currentState))
 
       pc = currentState.pc.relative
 
@@ -230,7 +237,7 @@ object VirtualMachine {
     currentState
   }
 
-  def modifyFlags(state: VMState): VMState = {
+  def runFlags(state: VMState): VMState = {
     var mState = state
 
     if (mState.doXmitFlag) {
@@ -239,25 +246,36 @@ object VirtualMachine {
     }
 
     if (mState.doRtnFlag) {
-      //if (mState.ctxt.ret(mState.ctxt.rslt)) {
-      //  mState = mState.set(_ >> 'vmErrorFlag)(true)
-      //} else if (mState.doRtnFlag) {
-      //  mState = mState.set(_ >> 'doNextThreadFlag)(true)
-      //}
+      // may set doNextThreadFlag
+      mState = doRtn(mState).set(_ >> 'doRtnFlag)(false)
     }
 
     if (mState.vmErrorFlag) {
-      handleVirtualMachineError(mState)
+      //handleVirtualMachineError(mState)
       mState = mState.set(_ >> 'doNextThreadFlag)(true)
     }
 
     if (mState.doNextThreadFlag) {
-      //if (getNextStrand()) {
-      //  tmpState = tmpState.set(_ >> 'nextOpFlag)(false)
-      //}
+      val (isEmpty, newState) = getNextStrand(mState)
+      mState = newState.set(_ >> 'doNextThreadFlag)(false)
+
+      if (isEmpty) {
+        mState = mState.set(_ >> 'exitFlag)(true)
+      }
     }
 
     mState
+  }
+
+  def doRtn(state: VMState): VMState = {
+    val (isError, newState) = state.ctxt.ret(state.ctxt.rslt)(state)
+
+    if (isError)
+      newState.set(_ >> 'vmErrorFlag)(true)
+    else if (newState.doRtnFlag)
+      newState.set(_ >> 'doNextThreadFlag)(true)
+    else
+      newState
   }
 
   def doXmit(state: VMState): VMState =

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -251,6 +251,7 @@ object VirtualMachine {
     }
 
     if (mState.vmErrorFlag) {
+      // TODO: Revisit once OprnVmError works
       //handleVirtualMachineError(mState)
       mState = mState.set(_ >> 'doNextThreadFlag)(true)
     }

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -5,6 +5,74 @@ import org.scalatest._
 import coop.rchain.rosette.utils.opcodes._
 
 class TransitionSpec extends FlatSpec with Matchers {
+  "Executing bytecode from expression \"(if #t 1 2)\"" should "result in state.ctxt.rslt == Fixnum(1)" in {
+
+    /**
+      * litvec:
+      *  0:   {IfExpr}
+      * codevec:
+      *  0:   lit #t,rslt
+      *  1:   jf 4
+      *  2:   lit 1,rslt
+      *  3:   rtn/nxt
+      *  4:   lit 2,rslt
+      *  5:   rtn/nxt
+      */
+    val start =
+      testState
+        .set(_ >> 'pc >> 'relative)(0)
+        .set(_ >> 'ctxt >> 'tag)(LocationGT(Location.LTCtxtRegister(0)))
+        .set(_ >> 'ctxt >> 'pc)(PC(0))
+        .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
+        .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
+        .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
+        .set(_ >> 'sleeperPool)(Seq())
+
+    val codevec = Seq(OpImmediateLitToReg(v = 8, r = 0),
+                      OpJmpFalse(4),
+                      OpImmediateLitToReg(v = 1, r = 0),
+                      OpRtn(n = true),
+                      OpImmediateLitToReg(v = 2, r = 0),
+                      OpRtn(n = true))
+
+    val end = VirtualMachine.executeSeq(codevec, start)
+    end.ctxt.rslt shouldBe Fixnum(1)
+  }
+
+  "Executing bytecode from expression \"(if #f 1 2)\"" should "result in state.ctxt.rslt == Fixnum(2)" in {
+
+    /**
+      * litvec:
+      *  0:   {IfExpr}
+      * codevec:
+      *  0:   lit #f,rslt
+      *  1:   jf 4
+      *  2:   lit 1,rslt
+      *  3:   rtn/nxt
+      *  4:   lit 2,rslt
+      *  5:   rtn/nxt
+      */
+    val start =
+      testState
+        .set(_ >> 'pc >> 'relative)(0)
+        .set(_ >> 'ctxt >> 'tag)(LocationGT(Location.LTCtxtRegister(0)))
+        .set(_ >> 'ctxt >> 'pc)(PC(0))
+        .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
+        .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
+        .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
+        .set(_ >> 'sleeperPool)(Seq())
+
+    val codevec = Seq(OpImmediateLitToReg(v = 9, r = 0),
+                      OpJmpFalse(4),
+                      OpImmediateLitToReg(v = 1, r = 0),
+                      OpRtn(n = true),
+                      OpImmediateLitToReg(v = 2, r = 0),
+                      OpRtn(n = true))
+
+    val end = VirtualMachine.executeSeq(codevec, start)
+    end.ctxt.rslt shouldBe Fixnum(2)
+  }
+
   "Executing bytecode from expression \"(+ 1 2)\"" should "result in Fixnum(3)" in {
 
     /**
@@ -27,9 +95,9 @@ class TransitionSpec extends FlatSpec with Matchers {
         .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
 
     val codevec = Seq(OpAlloc(2),
-                      OpImmediateLitToArg(1, 0),
-                      OpImmediateLitToArg(2, 1),
-                      OpXferGlobalToReg(1, 668),
+                      OpImmediateLitToArg(v = 1, a = 0),
+                      OpImmediateLitToArg(v = 2, a = 1),
+                      OpXferGlobalToReg(r = 1, g = 668),
                       OpXmit(u = false, n = true, 2))
 
     val end = VirtualMachine.executeSeq(codevec, start)


### PR DESCRIPTION
In Rosette compiling the expression `(if #f 1 2)` results in the following `Code` object:

```
  litvec:
    0:   {IfExpr}
  codevec:
    0:   lit #f,rslt
    1:   jf 4
    2:   lit 1,rslt
    3:   rtn/nxt
    4:   lit 2,rslt
    5:   rtn/nxt
```

Before the execution of the `codevec`, the VM is in a state where the following assertions hold:
* `state.ctxt.outstanding == 0`
* `state.ctxt.ctxt.outstanding == 1`
* `state.pc.relative == 0`
* `state.ctxt.tag == LocationGT(Location.LTCtxtRegister(0)) `
* `state.ctxt.pc = 0`
* `state.ctxt.ctxt.pc = 0`

After the execution of the `codevec`, the VM should be in a state where `state.ctxt.rslt == Fixnum(2)` holds.

When it comes to the execution of the above `codevec`, the following list describes the transitions taken in the VM.

1. Set `state.ctxt.rslt` to `RBLFALSE`
2. Set the instruction counter (`state.pc.relative`) to `4` (because `state.ctxt.rslt == RBLFALSE`)
3. Jump ahead and set `state.ctxt.rslt` to `Fixnum(2)`
4. Set `state.doRtnFlag` to `true` which results in running `doRtn`
   1. In `doRtn` set `state.ctxt.ctxt.rslt` to the value of `state.ctxt.rslt`
   2. In `Ctxt.rcv(...)` decrease `state.ctxt.ctxt.outstanding` to `0` and afterwards schedule `state.ctxt.ctxt` (adding `state.ctxt.ctxt` to `state.strandPool`)
   3. Set `state.doNextThreadFlag` to `true`
5. `getNextStrand(state)` installs `state.strandPool.head` (sets `state.ctxt` to the value of `state.strandPool.head`) from which follows that `state.ctxt.rslt == Fixnum(2)`

### How to observe the above with gdb
Set this breakpoint in gdb: `b src/Vm.cc:1382 if code->codevec->instr(0)->word == 55296`.
Then go back to the Rosette REPL and execute `(if #f 1 2)` which brings you to the beginning of the execution of the `codevec` we are interested in.