### PR TITLE
Rholang: Unbreak BNFC sbt rules.

### DIFF
--- a/rholang/project/BNFC.scala
+++ b/rholang/project/BNFC.scala
@@ -29,10 +29,9 @@ object BNFC {
     val targPath: String  = makeOutputPath(grammarFile, outputDir, namespace)
     val bnfcCmd: String   = s"bnfc --java -o ${outputDir.getAbsolutePath} -p $namespace $grammarFile"
     val jlexCmd: String   = s"java -cp $classpath JLex.Main $targPath/Yylex"
-    val renameDefaultCmd: String = s"mv $targPath/_cup.cup $targPath/${stripSuffix(grammarFile.getName)}.cup"
-    val cupCmd: String    = s"java -cp $classpath java_cup.Main -nopositions -expect 100 $targPath/${stripSuffix(grammarFile.getName)}.cup" // TODO: Figure out naming behind _cup.cup
+    val cupCmd: String    = s"java -cp $classpath java_cup.Main -nopositions -expect 100 $targPath/${stripSuffix(grammarFile.getName)}.cup"
     val mvCmd: String     = s"mv sym.java parser.java $targPath"
-    Process(bnfcCmd) #&& Process(jlexCmd) #&& Process(renameDefaultCmd) #&& Process(cupCmd) #&& Process(mvCmd) !
+    Process(bnfcCmd) #&& Process(jlexCmd) #&& Process(cupCmd) #&& Process(mvCmd) !
   }
 
   def bnfcGenerateLaTeX(grammarFile: File, outputDir: File): Unit = {


### PR DESCRIPTION
The sbt BNFC rules were accidentally broken by:
eebbdd8425e53fe558323e7071d7a39bb660b73b
Revert the specific portion of the change that broke the Rholang compiler,
leaving the TODO in place.