### PR TITLE
Rholang: Reduce compiler warnings. No Functional changes.

### DIFF
--- a/rholang/src/main/scala/lib/term/Rewrite.scala
+++ b/rholang/src/main/scala/lib/term/Rewrite.scala
@@ -9,7 +9,7 @@
 package coop.rchain.lib.term
 
 import coop.rchain.lib.zipper._
-import coop.rchain.lib.navigation.{ Right => R, Left => L,_ }
+import coop.rchain.lib.navigation.{ Right => _, Left => _, _ }
 
 trait TermNavigation[L,V,T] extends ZipperNavigation[Either[T,V]] {
   override def left [A1 >: Either[T,V]] ( location : Location[A1] ) : Location[A1] = {
@@ -149,7 +149,7 @@ trait TermMutation[L,V,T] extends ZipperMutation[Either[T,V]] {
       }
       case Location(
 	TermCtxtBranch(lbl: L @unchecked, progeny),
-	ctxt : LabeledTreeContext[L,Either[T,V]]
+	ctxt : LabeledTreeContext[L,Either[T,V]] @unchecked
       ) => {
 	Location(
 	  tree,

--- a/rholang/src/main/scala/rholang/rosette/Compiler.scala
+++ b/rholang/src/main/scala/rholang/rosette/Compiler.scala
@@ -9,12 +9,10 @@
 
 package coop.rchain.rho2rose
 
-import coop.rchain.lib.term._
 import coop.rchain.lib.zipper._
 import coop.rchain.syntax.rholang._
 import coop.rchain.syntax.rholang.Absyn._
 
-import java_cup.runtime._
 import java.io._
 
 trait Rholang2RosetteCompilerT {
@@ -51,7 +49,7 @@ object Rholang2RosetteCompiler extends RholangASTToTerm
   override def parser( lexer : Yylex ) : parser = { new parser( lexer ) }
   override def serialize( ast : VisitorTypes.R ) : String = {
     ast match {
-      case Some(Location(term: StrTermCtorAbbrevs.StrTermCtxt, _)) =>
+      case Some(Location(term: StrTermCtorAbbrevs.StrTermCtxt @unchecked, _)) =>
         term.rosetteSerializeOperation + term.rosetteSerialize
       case _ => "Not a StrTermCtxt"
     }


### PR DESCRIPTION
The majority of the warnings required @unchecked annotations due to type
erasure. A few more were var's that were never re-written. A couple of unused
imports, and then magic imports for implicits and postfix.

There are 4 more warnings, but they'll take a little more work to clean up.