### PR TITLE
Add math primitive examples

### DIFF
--- a/roscala/build.sbt
+++ b/roscala/build.sbt
@@ -1,21 +1,27 @@
 import Dependencies._
 
+lazy val macros = project
+
 lazy val root = (project in file("."))
   .settings(
+    name := "Rosette",
     mainClass in assembly := Some("coop.rchain.rosette.Main"),
+    assemblyJarName in assembly := "rosette.jar",
     inThisBuild(List(
-      assemblyJarName in assembly := "rosette.jar",
       organization := "coop.rchain",
       scalaVersion := "2.12.3",
       version      := "0.1.0-SNAPSHOT",
-      scalafmtOnCompile in Compile := true
+      scalafmtOnCompile in Compile := true,
+      addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
     )),
-    name := "Rosette",
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.2.3",
       "com.chuusai" %% "shapeless" % "2.3.2",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
       "org.typelevel" %% "cats" % "0.9.0",
-      scalaTest % Test
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+      scalaTest % Test,
+      "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
     )
-  )
+  ).dependsOn(macros)
+

--- a/roscala/macros/build.sbt
+++ b/roscala/macros/build.sbt
@@ -1,0 +1,6 @@
+name := "macros"
+
+libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
+)
+

--- a/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
+++ b/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
@@ -1,0 +1,74 @@
+package coop.rchain.rosette.macros
+
+import scala.language.experimental.macros
+import scala.annotation.{compileTimeOnly, StaticAnnotation}
+import scala.reflect.macros.whitebox
+
+@compileTimeOnly("enable macro paradise to expand macro annotations")
+class checkArgumentMismatch extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro ArgumentMismatchMacro.impl
+}
+
+@compileTimeOnly("enable macro paradise to expand macro annotations")
+class checkTypeMismatch[A] extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro TypeMismatchMacro.impl[A]
+}
+
+object ArgumentMismatchMacro {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+
+    val result =
+      annottees.map(_.tree).toList match {
+        case q"$mods def fn(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
+          q"""$mods def fn(ctxt: Ctxt): $returnType =  {
+              if(ctxt.nargs < minArgs || ctxt.nargs > maxArgs)
+                Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs)))
+              else
+                {..$body}
+          }"""
+
+        case _ =>
+          c.abort(
+            c.enclosingPosition,
+            "Annotation @checkArgumentMismatch can only be used on Prim.fn")
+      }
+
+    c.Expr[Any](result)
+  }
+}
+
+object TypeMismatchMacro {
+  def impl[A](c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+
+    object findTypeParam extends Traverser {
+      var idents = List[NameApi]()
+
+      override def traverse(tree: c.universe.Tree): Unit = tree match {
+        case Ident(tpe) => idents = idents :+ tpe
+        case _ => super.traverse(tree)
+      }
+    }
+
+    val result =
+      annottees.map(_.tree).toList match {
+        case q"$mods def fn(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
+          findTypeParam.traverse(c.macroApplication)
+          val param = findTypeParam.idents(1)
+
+          q"""$mods def fn(ctxt: Ctxt): $returnType =  {
+              mismatchType[${param.toTypeName}](ctxt) match {
+                case Some(typeMismatch) => Left(PrimErrorWrapper(typeMismatch))
+                case None => {..$body}
+              }
+          }"""
+
+        case _ =>
+          c.abort(c.enclosingPosition,
+                  "Annotation @checkTypeMismatch can only be used on Prim.fn")
+      }
+
+    c.Expr[Any](result)
+  }
+}

--- a/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
+++ b/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
@@ -23,7 +23,7 @@ object ArgumentMismatchMacro {
         case q"$mods def fn(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
           q"""$mods def fn(ctxt: Ctxt): $returnType =  {
               if(ctxt.nargs < minArgs || ctxt.nargs > maxArgs)
-                Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs)))
+                Left(mismatchArgs(ctxt, minArgs, maxArgs))
               else
                 {..$body}
           }"""
@@ -59,7 +59,7 @@ object TypeMismatchMacro {
 
           q"""$mods def fn(ctxt: Ctxt): $returnType =  {
               mismatchType[${param.toTypeName}](ctxt) match {
-                case Some(typeMismatch) => Left(PrimErrorWrapper(typeMismatch))
+                case Some(typeMismatch) => Left(typeMismatch)
                 case None => {..$body}
               }
           }"""

--- a/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
@@ -20,7 +20,8 @@ case class Ctxt(tag: Location,
                 monitor: Monitor, // reg[9]
                 override val _slot: mutable.Seq[Ob])
     extends Ob {
-  private val regs = Vector(rslt, trgt, argvec, env, code, ctxt, self2, selfEnv, rcvr, monitor)
+  private val regs =
+    Vector(rslt, trgt, argvec, env, code, ctxt, self2, selfEnv, rcvr, monitor)
 
   def applyK(result: Ob, tag: Location)(state: VMState): (Boolean, VMState) =
     ctxt.rcv(result, tag)(state)

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -4,15 +4,6 @@ import com.typesafe.scalalogging.Logger
 import coop.rchain.rosette.Ob._
 import coop.rchain.rosette.prim.Prim
 
-sealed trait RblError
-case object DeadThread extends RblError
-case object Invalid extends RblError
-case object Suspend extends RblError
-case object Absent extends RblError
-case object Upcall extends RblError
-case class PrimMismatch(msg: String) extends RblError
-case class RuntimeError(msg: String) extends RblError
-
 sealed trait Work
 case object NoWorkLeft extends Work
 case object WaitForAsync extends Work

--- a/roscala/src/main/scala/coop/rchain/rosette/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/package.scala
@@ -1,11 +1,22 @@
 package coop.rchain
 
 import coop.rchain.rosette.parser.bytecode.ParseError
+import coop.rchain.rosette.prim.PrimError
+
 import reflect.runtime.universe._
 import reflect.runtime.currentMirror
 import scala.annotation.tailrec
 
 package object rosette {
+  sealed trait RblError
+  case object DeadThread extends RblError
+  case object Invalid extends RblError
+  case object Suspend extends RblError
+  case object Absent extends RblError
+  case object Upcall extends RblError
+  case class PrimErrorWrapper(value: PrimError) extends RblError
+  case class RuntimeError(msg: String) extends RblError
+
   type Result = Either[RblError, Ob]
 
   def suicide(msg: String): Unit = {

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
@@ -1,23 +1,97 @@
 package coop.rchain.rosette.prim
-import coop.rchain.rosette.{Ctxt, Fixnum, PrimMismatch}
+import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
+import coop.rchain.rosette.{Ctxt, Fixnum, PrimErrorWrapper}
+import coop.rchain.rosette.prim.Prim._
 
 object Number {
   object fxPlus extends Prim {
-    override val externalName: String = "fx+"
+    override val name: String = "fx+"
     override val minArgs: Int = 0
-    override val maxArgs: Int = 255
+    override val maxArgs: Int = MaxArgs
 
-    override def fn(ctxt: Ctxt): Either[PrimMismatch, Fixnum] = {
+    @checkTypeMismatch[Fixnum]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
       val n = ctxt.nargs
-      val isArgsFixnum =
-        ctxt.argvec.elem.take(n).forall(_.isInstanceOf[Fixnum])
 
-      if (isArgsFixnum) {
-        Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
-          case (accum, fixnum: Fixnum) => accum + fixnum
-        })
-      } else {
-        Left(PrimMismatch("no fixnum arguments"))
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
+        case (accum, fixnum: Fixnum) => accum + fixnum
+      })
+    }
+  }
+
+  object fxMinus extends Prim {
+    override val name: String = "fx-"
+    override val minArgs: Int = 1
+    override val maxArgs: Int = 2
+
+    @checkTypeMismatch[Fixnum]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] =
+      ctxt.nargs match {
+        case 1 =>
+          val fixval = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+          Right(Fixnum(-fixval))
+
+        case 2 =>
+          val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+          val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
+          Right(Fixnum(m - n))
+      }
+  }
+
+  object fxTimes extends Prim {
+    override val name: String = "fx*"
+    override val minArgs: Int = 0
+    override val maxArgs: Int = MaxArgs
+
+    @checkTypeMismatch[Fixnum]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+      val n = ctxt.nargs
+
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(1)) {
+        case (accum, fixnum: Fixnum) => accum * fixnum
+      })
+    }
+  }
+
+  object fxDiv extends Prim {
+    override val name: String = "fx/"
+    override val minArgs: Int = 2
+    override val maxArgs: Int = 2
+
+    @checkTypeMismatch[Fixnum]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
+
+      try {
+        Right(Fixnum(m / n))
+      } catch {
+        case e: ArithmeticException =>
+          Left(PrimErrorWrapper(ArithmeticError))
+      }
+    }
+  }
+
+  object fxMod extends Prim {
+    override val name: String = "fx%"
+    override val minArgs: Int = 2
+    override val maxArgs: Int = 2
+
+    @checkTypeMismatch[Fixnum]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
+
+      try {
+        Right(Fixnum(m % n))
+      } catch {
+        case e: ArithmeticException =>
+          Left(PrimErrorWrapper(ArithmeticError))
       }
     }
   }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
@@ -11,7 +11,7 @@ object Number {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
@@ -27,7 +27,7 @@ object Number {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] =
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] =
       ctxt.nargs match {
         case 1 =>
           val fixval = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
@@ -47,7 +47,7 @@ object Number {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(1)) {
@@ -63,7 +63,7 @@ object Number {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
 
@@ -71,7 +71,7 @@ object Number {
         Right(Fixnum(m / n))
       } catch {
         case e: ArithmeticException =>
-          Left(PrimErrorWrapper(ArithmeticError))
+          Left(ArithmeticError)
       }
     }
   }
@@ -83,7 +83,7 @@ object Number {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Fixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
 
@@ -91,7 +91,7 @@ object Number {
         Right(Fixnum(m % n))
       } catch {
         case e: ArithmeticException =>
-          Left(PrimErrorWrapper(ArithmeticError))
+          Left(ArithmeticError)
       }
     }
   }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
@@ -17,7 +17,7 @@ abstract class Prim extends Ob {
   val minArgs: Int
   val maxArgs: Int
 
-  def fn(ctxt: Ctxt): Either[PrimErrorWrapper, Ob]
+  def fn(ctxt: Ctxt): Either[PrimError, Ob]
 
   /** Dispatch primitive
     *
@@ -28,7 +28,7 @@ abstract class Prim extends Ob {
     val n = ctxt.nargs
 
     if (minArgs <= n && n <= maxArgs) {
-      fn(ctxt)
+      fn(ctxt).left.map(PrimErrorWrapper)
     } else {
       Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs)))
     }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
@@ -2,11 +2,10 @@ package coop.rchain.rosette
 
 package object prim {
   // For now keys in Prims correspond to Prim::primnum in Rosette
-  // TODO:
-  val Prims = Map[Int, Prim](226 -> Number.fxPlus,
-                             1 -> Number.fxDiv,
-                             2 -> Number.fxMinus,
-                             3 -> Number.fxTimes,
-                             4 -> Number.fxMod)
+  val Prims = Map[Int, Prim](222 -> Number.fxMod,
+                             223 -> Number.fxDiv,
+                             224 -> Number.fxTimes,
+                             225 -> Number.fxMinus,
+                             226 -> Number.fxPlus)
 
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
@@ -2,5 +2,11 @@ package coop.rchain.rosette
 
 package object prim {
   // For now keys in Prims correspond to Prim::primnum in Rosette
-  val Prims = Map[Int, Prim](226 -> Number.fxPlus)
+  // TODO:
+  val Prims = Map[Int, Prim](226 -> Number.fxPlus,
+                             1 -> Number.fxDiv,
+                             2 -> Number.fxMinus,
+                             3 -> Number.fxTimes,
+                             4 -> Number.fxMod)
+
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/HelloSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/HelloSpec.scala
@@ -1,9 +1,0 @@
-package coop.rchain.rosette
-
-import org.scalatest._
-
-class HelloSpec extends FlatSpec with Matchers {
-  "The Hello object" should "say hello" in {
-    "hello" shouldEqual "hello"
-  }
-}

--- a/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
@@ -1,0 +1,23 @@
+package coop.rchain.rosette
+
+import org.scalacheck.Gen
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+class PrimPropertySpec extends PropSpec with PropertyChecks with Matchers {
+  property("Primitives should return error for illegal number of arguments") {
+    val nargsGen = Gen.choose(0, 1000)
+    val primitives = prim.Prims.values
+
+    primitives.foreach { prim =>
+      forAll(nargsGen) { i: Int =>
+        whenever(i < prim.minArgs || i > prim.maxArgs) {
+          val ctxt =
+            utils.opcodes.ctxt.copy(nargs = i, argvec = Tuple(i, Fixnum(1)))
+
+          prim.fn(ctxt) should be('left)
+        }
+      }
+    }
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/rosette/PrimSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/PrimSpec.scala
@@ -1,0 +1,75 @@
+package coop.rchain.rosette
+
+import coop.rchain.rosette.prim.Number._
+
+import org.scalatest._
+
+class PrimSpec extends FlatSpec with Matchers {
+  val ctxt = Ctxt(
+    tag = null,
+    nargs = 1,
+    outstanding = 0,
+    pc = PC.PLACEHOLDER,
+    rslt = null,
+    trgt = null,
+    argvec = Tuple(1, Fixnum(1)),
+    env = null,
+    code = null,
+    ctxt = null,
+    self2 = null,
+    selfEnv = null,
+    rcvr = null,
+    monitor = null,
+    _slot = null
+  )
+
+  "fxPlus" should "correctly add numbers" in {
+    val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Fixnum(1)))
+    fxPlus.fn(newCtxt) should be(Right(Fixnum(5)))
+  }
+
+  it should "fail for non-fixnum arguments" in {
+    val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
+    fxPlus.fn(newCtxt) should be('left)
+  }
+
+  "fxMinus" should "correctly subtract numbers" in {
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(1)))
+    fxMinus.fn(newCtxt) should be(Right(Fixnum(0)))
+  }
+
+  it should "fail for non-fixnum arguments" in {
+    val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
+    fxMinus.fn(newCtxt) should be('left)
+  }
+
+  "fxTimes" should "correctly multiply numbers" in {
+    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Fixnum(5)))
+    fxTimes.fn(newCtxt) should be(Right(Fixnum(125)))
+  }
+
+  it should "fail for non-fixnum arguments" in {
+    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Ob.NIV))
+    fxTimes.fn(newCtxt) should be('left)
+  }
+
+  "fxDiv" should "correctly divide numbers" in {
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
+    fxDiv.fn(newCtxt) should be(Right(Fixnum(1)))
+  }
+
+  it should "fail for non-fixnum arguments" in {
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
+    fxDiv.fn(newCtxt) should be('left)
+  }
+
+  "fxMod" should "correctly return the remainder" in {
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
+    fxMod.fn(newCtxt) should be(Right(Fixnum(0)))
+  }
+
+  it should "fail for non-fixnum arguments" in {
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
+    fxMod.fn(newCtxt) should be('left)
+  }
+}


### PR DESCRIPTION
Rewrote `fx+` and added `fx-`, `fx*`, `fx/` and `fx%` (see: `prim/Number.scala`).
Also created macros to make creating primitives easier and less redundant.

Please have an extra close look on how primitives are defined since we want to create a bounty program for the translation of primitives.

I'm still not quite happy about error types: I want to have a single error ADT (currently that is `PrimError`) for everything that can go wrong in the `Prim.fn` method.

However in `Prim.dispatchHelper` we have to return an error type which includes `Invalid`, `Upcall` and `DeadThread` (these error types are currently included in the top level `RblError` ADT).
Therefore we have to decide if we want to embed the `PrimError` into the `RblError` ADT (currently that is what I do by introducing `PrimErrorWrapper extends RblError`) or use union types with coproducts from shapeless (`PrimError :+: RblError :+: CNil`).
Using coproducts from shapeless is kind of ugly and could bloat the code at some point. Therefore I went with the first option. I'm very open to other opinions on this one though.
