### PR TITLE
Remove redundant Either from Term types.

### DIFF
--- a/rholang/src/main/scala/lib/term/Rewrite.scala
+++ b/rholang/src/main/scala/lib/term/Rewrite.scala
@@ -235,7 +235,7 @@ trait TermZipperComposition[L,V,T] {
       case LabeledTreeContext(lbl: L @unchecked, left: List[TermCtxt[L, V, T] with Factual] @unchecked, ctxt: LabeledTreeContext[L, Either[T, V]] @unchecked, right: List[TermCtxt[L, V, T] with Factual] @unchecked) => {
 	new TermCtxtBranch[L,V,T](
 	  lbl, 
-	  left ++ ( compose( ctxt, tree ) :: right )
+	  left.reverse ++ ( compose( ctxt, tree ) :: right )
 	)
       }
     }

--- a/rholang/src/main/scala/lib/term/Term.scala
+++ b/rholang/src/main/scala/lib/term/Term.scala
@@ -131,7 +131,6 @@ class TermCtxtLeaf[Namespace,Var,Tag]( val tag : Either[Tag,Var] )
 extends TreeItem[Either[Tag,Var]]( tag )
 with TermCtxt[Namespace,Var,Tag]
 with Factual {
-  def this() = { this( null.asInstanceOf[Either[Tag,Var]] ) }
   override def self = List( this )
   override def toString = {
     tag match {
@@ -201,7 +200,6 @@ class TermCtxtBranch[Namespace,Var,Tag](
 ) extends TreeSection[Either[Tag,Var]]( factuals )
 with AbstractTermCtxtBranch[Namespace,Var,Tag]
 with Factual {
-  def this() = { this( null.asInstanceOf[Namespace], Nil ) }
   override def labels : List[TermCtxt[Namespace,Var,Tag]] = {
     factuals
   }


### PR DESCRIPTION
The code was wrapping was using Either to distinguish values when the Term types
were sufficient to distinguish. As an added bonus, the reader now longer has to
ask why the Right match is incomplete.