### PR TITLE
Dev remove redundant code

### DIFF
--- a/rholang/src/main/scala/README.md
+++ b/rholang/src/main/scala/README.md
@@ -1,0 +1,19 @@
+# Scala Code Organization
+## Lib
+Within the lib are the zipper and term libraries. These libraries are used
+solely for producing RBL, and not for any of the Rholang parsing/compilation.
+### Zipper
+The zipper library is basically straight out of the (original zipper
+paper)[https://www.st.cs.uni-saarland.de/edu/seminare/2005/advanced-fp/docs/huet-zipper.pdf]
+### Term
+Specializations of the zipper for the Roselang compiler. The only function of
+note is TermZipperComposition.compose in Rewrite.scala, which composes two
+contexts. Since a context is a data
+structure with a hole, Composing two contexts proceeds by placing the inner
+context in the hole of the outer context, leaving a larger context with a single
+hole.
+## Rholang / Rosette
+This is where the main compiler lives.
+Most of the compiler is a visitor for the AST that produces RBL directly.
+An important part of the compilation logic lives in combine(), which I don't
+currently understand.

--- a/rholang/src/main/scala/lib/term/Rewrite.scala
+++ b/rholang/src/main/scala/lib/term/Rewrite.scala
@@ -1,9 +1,9 @@
-// -*- mode: Scala;-*- 
-// Filename:    Rewrite.scala 
-// Authors:     luciusmeredith                                                    
-// Creation:    Thu Feb  2 12:35:45 2017 
-// Copyright:   See site license 
-// Description: 
+// -*- mode: Scala;-*-
+// Filename:    Rewrite.scala
+// Authors:     luciusmeredith
+// Creation:    Thu Feb  2 12:35:45 2017
+// Copyright:   See site license
+// Description:
 // ------------------------------------------------------------------------
 
 package coop.rchain.lib.term
@@ -11,262 +11,23 @@ package coop.rchain.lib.term
 import coop.rchain.lib.zipper._
 import coop.rchain.lib.navigation.{ Right => _, Left => _, _ }
 
-trait TermNavigation[L,V,T] extends ZipperNavigation[Either[T,V]] {
-  override def left [A1 >: Either[T,V]] ( location : Location[A1] ) : Location[A1] = {
-    location match {
-      case Location( _, Top( ) ) => {
-        throw new Exception( "left of top" )
-      }
-      case Location(t, LabeledTreeContext(lbl: L @unchecked, l :: left, up, right)) => {
-        Location( l, LabeledTreeContext[L,A1]( lbl, left, up, t :: right ) )
-      }
-      case Location(t, LabeledTreeContext(lbl: L @unchecked, Nil, up, right)) => {
-        throw new Exception( "left of first" )
-      }
-    }
-  }
-  override def right [A1 >: Either[T,V]] ( location : Location[A1] ) : Location[A1] = {
-    location match {
-      case Location( _, Top( ) ) => {
-        throw new Exception( "right of top" )
-      }
-      case Location(t, LabeledTreeContext(lbl: L @unchecked, left, up, r :: right)) => {
-        Location( r, LabeledTreeContext[L, A1]( lbl, t :: left, up, right ) )
-      }
-      case Location( t, _ ) => {
-        throw new Exception( "right of last" )
-      }
-    }
-  }
-  override def up [A1 >: Either[T,V]]( location : Location[A1] ) : Location[A1] = {
-    location match {
-      case Location( _, Top( ) ) => {
-        throw new Exception( "up of top" )
-      }   
-      case Location( t : TermCtxt[L, V, T] with Factual, LabeledTreeContext(lbl: L @unchecked, left, up, right)) => {
-	( left, right ) match {
-	  case (lTerms: List[TermCtxt[L, V, T] with Factual] @unchecked, rTerms: List[TermCtxt[L, V, T] with Factual] @unchecked) => {
-	    val rvrsLTerms : List[TermCtxt[L,V,T] with Factual] = lTerms.reverse
-            Location[A1]( new TermCtxtBranch[L,V,T]( lbl, rvrsLTerms ::: ( t :: rTerms ) ), up )
-	  }
-	  case _ => throw new Exception( "unexpected location shape: " + location )
-	}
-      }
-      case Location( t, ctxt ) => {
-	/*
-	 println(
-	  (
-	    "/* ------------------------------------------------------- */\n"
-	    + "/* method: " + "up" + " */\n"
-	    + "/* location: " + location + " */\n"
-	    + "/* location.tree: " + location.tree + "; class: " + location.tree.getClass + " */\n"
-	    + "/* location.ctxt: " + location.ctxt + "; class: " + location.ctxt.getClass +" */\n"
-	    + "/* ------------------------------------------------------- */\n"
-	  )
-	)
-	*/
-	throw new Exception( "unmatched location shape: " + location )
-      }
-    }
-  }
-  override def down [A1 >: Either[T,V]]( location : Location[A1] ) : Location[A1] = {
-    location match {
-      case Location( TreeItem( _ ), _ ) => {
-        throw new Exception( "down of item" )
-      }
-      case Location( TreeSection( Nil ), ctxt ) => {
-        throw new Exception( "down of empty" )
-      }
-      case Location(TermCtxtBranch(lbl: L @unchecked, u :: trees), ctxt) => {
-        Location( u, LabeledTreeContext[L, A1]( lbl, List[TermCtxt[L,V,T] with Factual](), ctxt, trees ) )
-      }
-    }
-  }
-}
-
-trait TermMutation[L,V,T] extends ZipperMutation[Either[T,V]] {
-  def update(
-    location : Location[Either[T,V]],
-    tree : TermCtxt[L,V,T]
-  ) : Location[Either[T,V]] = {
-    location match {
-      case Location( _, ctxt ) =>
-	Location( tree, ctxt )
-    }
-  }
-  def insertRight(
-    location : Location[Either[T,V]],
-    tree : TermCtxt[L,V,T]
-  ) : Location[Either[T,V]] = {
-    location match {
-      case Location( _, Top( ) ) => {
-	throw new Exception( "insert of top" )
-      }
-      case Location(
-	curr,
-	LabeledTreeContext(lbl: L @unchecked, left, up, right)
-      ) => {
-	Location(
-	  curr,
-	  LabeledTreeContext[L,Either[T,V]]( lbl, left, up, tree :: right )
-	)	
-      }
-    }    
-  }
-  def insertLeft(
-    location : Location[Either[T,V]], tree : TermCtxt[L,V,T]
-  ) : Location[Either[T,V]] = {
-    location match {
-      case Location( _, Top( ) ) => {
-	throw new Exception( "insert of top" )
-      }
-      case Location(
-	curr,
-	LabeledTreeContext(lbl: L @unchecked, left, up, right)
-      ) => {
-	Location(
-	  curr,
-	  LabeledTreeContext[L,Either[T,V]]( lbl, tree :: left, up, right )
-	)	
-      }
-    }    
-  }
-  def insertDown(
-    location : Location[Either[T,V]], tree : TermCtxt[L,V,T]
-  ) : Location[Either[T,V]] = {
-    location match {
-      case Location( TreeItem( _ ), _ ) => {
-	throw new Exception( "down of item" )
-      }
-      case Location(
-	TermCtxtBranch(lbl: L @unchecked, progeny),
-	ctxt@Top()
-      ) => {
-	Location(
-	  tree,
-	  LabeledTreeContext[L,Either[T,V]]( lbl, List[TermCtxt[L,V,T] with Factual](), ctxt, progeny )
-	)
-      }
-      case Location(
-	TermCtxtBranch(lbl: L @unchecked, progeny),
-	ctxt : LabeledTreeContext[L,Either[T,V]] @unchecked
-      ) => {
-	Location(
-	  tree,
-	  LabeledTreeContext[L,Either[T,V]]( lbl, List[TermCtxt[L,V,T] with Factual](), ctxt, progeny )
-	)
-      }
-      case Location(
-	t,
-	ctxt
-      ) => {
-	/*
-	 println(
-	  (
-	    "/* ------------------------------------------------------- */\n"
-	    + "/* method: " + "insertDown" + " */\n"
-	    + "/* location: " + location + " */\n"
-	    + "/* location.tree: " + location.tree + "; class: " + location.tree.getClass + " */\n"
-	    + "/* location.ctxt: " + location.ctxt + "; class: " + location.ctxt.getClass +" */\n"
-	    + "/* tree: " + tree + "; class: " + location.ctxt.getClass + " */\n"
-	    + "/* ------------------------------------------------------- */\n"
-	  )
-	)
-	*/
-	throw new Exception( "unmatched location shape: " + location )
-      }
-    }
-  }
-  def delete(
-    location : Location[Either[T,V]], tree : TermCtxt[L,V,T]
-  ) : Location[Either[T,V]] = {
-    location match {
-      case Location( _, Top( ) ) => {
-	throw new Exception( "delete of top" )
-      }
-      case Location(
-	_,
-	LabeledTreeContext(lbl: L @unchecked, left, up, r :: right)
-      ) => {
-	Location(
-	  r,
-	  LabeledTreeContext[L, Either[T,V]]( lbl, left, up, right )
-	)
-      }
-      case Location(
-	_,
-	LabeledTreeContext(lbl: L @unchecked, l :: left, up, Nil)
-      ) => {
-	Location(
-	  l,
-	  LabeledTreeContext[L, Either[T,V]]( lbl, left, up, Nil )
-	)
-      }
-      case Location(
-	_,
-	LabeledTreeContext(lbl : L @unchecked, Nil, up, Nil)
-      ) => {
-	Location( new TermCtxtBranch[L,V,T]( lbl, List[TermCtxt[L,V,T] with Factual]() ), up )
-      }
-    }
-  }
-}
+trait TermNavigation[L,V,T] extends ZipperNavigation[Either[T,V]]
+trait TermMutation[L,V,T] extends ZipperMutation[Either[T,V]]
 
 trait TermZipperComposition[L,V,T] {
+  // Composing a context places the inner context in the hole of the outer
+  // context, leaving a larger context with a single hole.
   def compose(
-    ctxtL : Context[Either[T,V]],
-    ctxtR : Context[Either[T,V]]
+    ctxtInner : Context[Either[T,V]],
+    ctxtOuter : Context[Either[T,V]]
   ) : Context[Either[T,V]] = {
-    ctxtL match {
-      case Top() => ctxtR
+    ctxtInner match {
+      case Top() => ctxtOuter
       case LabeledTreeContext(lbl: L @unchecked, left: List[TermCtxt[L, V, T] with Factual] @unchecked, ctxt: LabeledTreeContext[L, Either[T, V]] @unchecked, right: List[TermCtxt[L, V, T] with Factual] @unchecked) => {
 	LabeledTreeContext[L,Either[T,V]](
-	  lbl, left, compose( ctxt, ctxtR ), right 
+	  lbl, left, compose( ctxt, ctxtOuter ), right
 	)
       }
     }
   }
-  def compose(
-    ctxt : Context[Either[T,V]],
-    tree : TermCtxt[L,V,T] with Factual
-  ) : TermCtxt[L,V,T] with Factual = {
-    ctxt match {
-      case Top() => tree
-      case LabeledTreeContext(lbl: L @unchecked, left: List[TermCtxt[L, V, T] with Factual] @unchecked, ctxt: LabeledTreeContext[L, Either[T, V]] @unchecked, right: List[TermCtxt[L, V, T] with Factual] @unchecked) => {
-	new TermCtxtBranch[L,V,T](
-	  lbl, 
-	  left.reverse ++ ( compose( ctxt, tree ) :: right )
-	)
-      }
-    }
-  }
-  def decontextualize( location : Location[Either[T,V]] ) : TermCtxt[L,V,T] with Factual = {
-    location match {
-      case Location( tree : TermCtxt[L,V,T] with Factual, ctxt ) => {
-	compose( ctxt, tree )
-      }
-      case _ => throw new Exception( "unexpected location shape: " + location )
-    }
-    
-  }
 }
-
-trait TermSubstitution[L,V,T] {
-  def substitute( term : TermCtxt[L,V,T] )(
-    bindings : scala.collection.Map[V,TermCtxt[L,V,T] with Factual]
-  ) : TermCtxt[L,V,T] with Factual = {
-    term match {
-      case tLeaf@TermCtxtLeaf( Left( _ ) ) => {
-        tLeaf
-      }
-      case vLeaf@TermCtxtLeaf(Right(v: V @unchecked)) => {
-        bindings.get( v ).getOrElse( vLeaf )
-      }
-      case TermCtxtBranch(fnctr: L @unchecked, actls: List[TermCtxt[L, V, T] with Factual]) => {
-        new TermCtxtBranch( fnctr, actls.map( substitute( _ )( bindings ) ) )
-      }
-    }
-  }
-}
-
-

--- a/rholang/src/main/scala/lib/term/Term.scala
+++ b/rholang/src/main/scala/lib/term/Term.scala
@@ -14,7 +14,8 @@ import scala.collection.SeqProxy
 trait Term[Namespace, /*+*/Tag]
 extends Tree[Tag] with SeqProxy[Term[Namespace,Tag]]
   with Serializable {
-  def up /* [Tag1 >: Tag] */ ( term : Term[Namespace,Tag] )
+  // Collects a list of all the tags in the tree.
+  def collectTags /* [Tag1 >: Tag] */ ( term : Term[Namespace,Tag] )
    : List[Tag] = {
     term match {
       case TermLeaf( t ) => List( t )
@@ -22,7 +23,7 @@ extends Tree[Tag] with SeqProxy[Term[Namespace,Tag]]
 	( List[Tag]() /: lbls.flatMap( _.self ) )(
 	  {
 	    ( acc, e ) => {
-	      acc ++ up/*[Tag1]*/( e )
+	      acc ++ collectTags/*[Tag1]*/( e )
 	    }
 	  }
 	)
@@ -30,7 +31,7 @@ extends Tree[Tag] with SeqProxy[Term[Namespace,Tag]]
     }
   }
 
-  def atoms : Seq[Tag] = { this flatMap( up ) }
+  def atoms : Seq[Tag] = { this flatMap( collectTags ) }
   def self : List[Term[Namespace,Tag]]
 }
 
@@ -114,6 +115,7 @@ class TermCtxtLeaf[Namespace,Var,Tag]( val tag : Either[Tag,Var] )
 extends TreeItem[Either[Tag,Var]]( tag )
 with TermCtxt[Namespace,Var,Tag]
 with Factual {
+  override def self = List( this )
   override def toString = {
     tag match {
       case Left( t ) => "" + t + ""
@@ -141,6 +143,7 @@ trait AbstractTermCtxtBranch[Namespace,Var,Tag]
 extends TermCtxt[Namespace,Var,Tag] {  
   def nameSpace : Namespace
   def labels : List[TermCtxt[Namespace,Var,Tag]]
+  override def self = labels
   override def toString = {
     val lblStr =
       labels match {

--- a/rholang/src/main/scala/lib/term/Term.scala
+++ b/rholang/src/main/scala/lib/term/Term.scala
@@ -85,23 +85,6 @@ trait TermCtxt[Namespace,Var,/*+*/Tag]
 extends Term[Either[Namespace,Var],Either[Tag,Var]] {
   type U/*[Tag1]*/ =
     Term[Either[Namespace,Var],Either[Tag,Var]]
-  override def up /*[Tag1 >: Tag]*/ ( term : U/*[Tag1]*/ )
-   : List[Either[Tag,Var]] = {
-    term match {
-      case TermLeaf( t ) => List( t )
-      case TermCtxtLeaf( tOrV ) => List( tOrV )
-      case TermCtxtBranch( ns, lbls ) => {
-	val selves : List[U/*[Tag1]*/] = lbls.flatMap( _.self )
-	( List[Either[Tag,Var]]() /: selves )(
-	  {
-	    ( acc, e ) => {
-	      acc ++ up/*[Tag1]*/( e )
-	    }
-	  }
-	)
-      }
-    }
-  }  
 
   def names : Seq[Either[Tag,Var]] = {
     atoms filter(
@@ -131,7 +114,6 @@ class TermCtxtLeaf[Namespace,Var,Tag]( val tag : Either[Tag,Var] )
 extends TreeItem[Either[Tag,Var]]( tag )
 with TermCtxt[Namespace,Var,Tag]
 with Factual {
-  override def self = List( this )
   override def toString = {
     tag match {
       case Left( t ) => "" + t + ""
@@ -157,7 +139,6 @@ object TermCtxtLeaf extends Serializable {
 
 trait AbstractTermCtxtBranch[Namespace,Var,Tag]
 extends TermCtxt[Namespace,Var,Tag] {  
-  override def self = labels
   def nameSpace : Namespace
   def labels : List[TermCtxt[Namespace,Var,Tag]]
   override def toString = {
@@ -257,30 +238,6 @@ trait TermCtxtInjector[Namespace,Var,Tag] {
       cLabel.factuals.map( injectLabel( _ ) )
     )
   }
-}
-
-trait TwoCell[Src,+Label,Trgt] {
-  def src   : Src
-  def label : Label
-  def trgt  : Trgt
-}
-class CTwoCell[Src,+Label,Trgt](
-  override val src : Src,
-  override val label : Label,
-  override val trgt : Trgt
-) extends TwoCell[Src,Label,Trgt]
-
-object CTwoCell extends Serializable {
-  def apply[Src,Label,Trgt](
-    src : Src, lbl : Label, trgt : Trgt 
-  ) : CTwoCell[Src,Label,Trgt] = {
-    new CTwoCell[Src,Label,Trgt]( src, lbl, trgt )
-  }
-  def unapply[Src,Label,Trgt](
-    cnxn : CTwoCell[Src,Label,Trgt]
-  ) : Option[(Src,Label,Trgt)] = {
-    Some( ( cnxn.src, cnxn.label, cnxn.trgt ) )
-  }  
 }
 
 case class StrTermLf( override val tag : String )

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -44,11 +44,15 @@ object StrZipAbbrevs {
 }
 
 object VisitorTypes {
+  // Arg Type
   type A = Option[StrZipAbbrevs.LocVorV]
+  // Return Type
   type R = Option[StrZipAbbrevs.LocVorV]    
 }
 
 object S2SImplicits {
+  // A term may implicitly be converted to a location by placing it at the top
+  // context.
   implicit def asLoc( 
     term : StrTermCtorAbbrevs.StrTermCtxt
   ) : StrZipAbbrevs.LocVorV = StrZipAbbrevs.L( term, StrZipAbbrevs.T() )
@@ -124,13 +128,13 @@ extends FoldVisitor[VisitorTypes.R,VisitorTypes.A] {
   def zipr : StrTermNavigation with StrTermMutation with StrTermZipperComposition
   def theCtxtVar : String
 
-  def wrap( context : VisitorTypes.R ) : VisitorTypes.R = context
-  def leaf( context : VisitorTypes.R ) : VisitorTypes.R = wrap( context )    
+  def wrap( context : VisitorTypes.A ) : VisitorTypes.R = context
+  def leaf( context : VisitorTypes.A ) : VisitorTypes.R = wrap( context )
 
   override def combine(
     y : VisitorTypes.R,
     x : VisitorTypes.R,
-    context : VisitorTypes.R
+    context : VisitorTypes.A
   ) : VisitorTypes.R = {
     /*
      println(
@@ -392,7 +396,7 @@ extends StrFoldCtxtVisitor {
   /* Contr */
   def visit( p : Contr, arg : A ) : R = {
     p match {
-      case dcontr : DContr => visitDispatch( dcontr.proc_, arg )
+      case dcontr : DContr => dcontr.proc_.accept(this, arg)
       case _ => throw new UnexpectedContractType( p )
     }
   }
@@ -410,7 +414,7 @@ extends StrFoldCtxtVisitor {
      */
     combine(
       arg,
-      (for( Location( pTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.proc_, Here() ) )
+      (for( Location( pTerm : StrTermCtxt @unchecked, _ ) <- p.proc_.accept(this, Here() ) )
       yield {
 
         def toListOfTuples(bindingsComponents: List[Option[List[StrTermCtxt]]]) = {
@@ -425,7 +429,7 @@ extends StrFoldCtxtVisitor {
         val bindingsComponents = ptrnTermList map {
           case ptrn: CPattern => {
             for (
-              Location(ptrnTerm: StrTermCtxt @unchecked, _) <- visitDispatch(ptrn, Here())
+              Location(ptrnTerm: StrTermCtxt @unchecked, _) <- ptrn.accept(this, Here())
             ) yield {
               val productFresh = V(Fresh())
               val quotedPtrnTerm = (for (Location(q: StrTermCtxt @unchecked, _) <- doQuote(ptrnTerm)) yield {
@@ -458,30 +462,11 @@ extends StrFoldCtxtVisitor {
   }
 
   /* Proc */
-  def visitDispatch( p : Proc, arg : A ) : R = {
-    p match {
-      case pNil : PNil => visit( pNil, arg )
-      case pVal : PValue => visit( pVal, arg )
-      case pDrop : PDrop => visit( pDrop, arg )
-      case pInject : PInject => visit( pInject, arg )
-      case pLift : PLift => visit( pLift, arg )
-      case pFoldL : PFoldL => visit( pFoldL, arg )
-      case pFoldR : PFoldR => visit( pFoldR, arg )
-      case pInput : PInput => visit( pInput, arg )
-      case pChoice : PChoice => visit( pChoice, arg )
-      case pMatch : PMatch => visit( pMatch, arg )
-      case pNew : PNew => visit( pNew, arg )
-      case pConstr : PConstr => visit( pConstr, arg )
-      case pContr : PContr => visit (pContr, arg)
-      case pPrint : PPrint => visit (pPrint, arg)
-      case pPar : PPar => visit( pPar, arg )
-    }
-  }
   override def visit(  p : PPrint, arg : A ) : R = {
     combine(
       arg,
       for(
-        Location( pTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.proc_, Here() )
+        Location( pTerm : StrTermCtxt @unchecked, _ ) <- p.proc_.accept(this, Here() )
       ) yield {
         val printTerm = B("print")(pTerm)
         val displayTerm = B("display")(G( "#\\\\n"))
@@ -493,7 +478,7 @@ extends StrFoldCtxtVisitor {
     combine( arg, Some( L( G( "#niv" ), T() ) ) )
   }
   override def visit(  p : PValue, arg : A ) : R = {
-    combine( arg, visitDispatch( p.value_, Here() ) )
+    combine( arg, p.value_.accept(this, Here() ) )
   }
   override def visit(  p : PDrop, arg : A ) : R = {
     /*
@@ -513,7 +498,7 @@ extends StrFoldCtxtVisitor {
     combine( arg, 
       ( p.chan_ match {
         case quote : CQuote => {
-          visitDispatch( quote.proc_, Here() )
+          quote.proc_.accept(this, Here() )
         }
         case v : CVar => {
           Some( L( B( _run )( B( _compile )( V( v.var_ ) ) ), Top() ) )
@@ -535,7 +520,7 @@ extends StrFoldCtxtVisitor {
       ( List[StrTermCtxt]() /: p.listproc_.asScala.toList )(
         {
           ( acc, e ) => {
-            visitDispatch( e, Here() ) match {
+            e.accept(this, Here() ) match {
               case Some( Location( pTerm : StrTermCtxt @unchecked, _ ) ) => {
                 acc ++ List( pTerm )
               }
@@ -547,7 +532,7 @@ extends StrFoldCtxtVisitor {
 
     combine(
       arg,
-      for( Location( cTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.chan_, Here() ) ) yield {
+      for( Location( cTerm : StrTermCtxt @unchecked, _ ) <- p.chan_.accept(this, Here() ) ) yield {
         L( B( _produce )( (List( TS ) ++ List(cTerm) ++ List(V("**wildcard**")) ++ actls):_* ), Top() )
       }
     )
@@ -566,13 +551,13 @@ extends StrFoldCtxtVisitor {
       }
 
       for (
-        Location(procTerm: StrTermCtxt @unchecked, _) <- visitDispatch(p.proc_, Here())
+        Location(procTerm: StrTermCtxt @unchecked, _) <- p.proc_.accept(this, Here())
       ) yield {
         val bindingsComponents = bindings map {
           case inBind: InputBind => {
             for (
-              Location(chanTerm: StrTermCtxt @unchecked, _) <- visitDispatch(inBind.chan_, Here());
-              Location(ptrnTerm: StrTermCtxt @unchecked, _) <- visitDispatch(inBind.cpattern_, Here())
+              Location(chanTerm: StrTermCtxt @unchecked, _) <- inBind.chan_.accept(this, Here());
+              Location(ptrnTerm: StrTermCtxt @unchecked, _) <- inBind.cpattern_.accept(this, Here())
             ) yield {
               val productFresh = V(Fresh())
               val unificationBindingFresh = V(Fresh())
@@ -631,7 +616,7 @@ extends StrFoldCtxtVisitor {
     val newVars = p.listvar_.asScala.toList
     combine( 
       arg,
-      (for( Location( pTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.proc_, Here() ) )
+      (for( Location( pTerm : StrTermCtxt @unchecked, _ ) <- p.proc_.accept(this, Here() ) )
       yield {
         val newBindings = newVars.map( { ( v ) => {
           val fresh = V(FreshSymbol(v))
@@ -772,15 +757,15 @@ extends StrFoldCtxtVisitor {
     def nonExhaustiveMatch: R = L(G("#niv"), Top())
 
     def patternMatchVisitAux: R = {
-      val result = for (Location(pTerm: StrTermCtxt @unchecked, _) <- visitDispatch(p.proc_, Here())) yield {
+      val result = for (Location(pTerm: StrTermCtxt @unchecked, _) <- p.proc_.accept(this, Here())) yield {
         val reverseListPMBranch = p.listpmbranch_.asScala.toList.reverse
         (nonExhaustiveMatch /: reverseListPMBranch) {
           (acc, e) => {
             e match {
               case pm: PatternMatch => {
                 for (
-                  Location(pattern: StrTermCtxt @unchecked, _) <- visitDispatch(pm.ppattern_, Here());
-                  Location(continuation: StrTermCtxt @unchecked, _) <- visitDispatch(pm.proc_, Here());
+                  Location(pattern: StrTermCtxt @unchecked, _) <- pm.ppattern_.accept(this, Here());
+                  Location(continuation: StrTermCtxt @unchecked, _) <- pm.proc_.accept(this, Here());
                   Location(remainder: StrTermCtxt @unchecked, _) <- acc
                 ) yield {
                   if (isWild(pm.ppattern_)) {
@@ -861,7 +846,7 @@ extends StrFoldCtxtVisitor {
       ( List[StrTermCtxt]() /: p.listproc_.asScala.toList )(
         {
           ( acc, e ) => {
-            visitDispatch( e, Here() ) match {
+            e.accept(this, Here() ) match {
               case Some( Location( pTerm : StrTermCtxt @unchecked, _ ) ) => acc ++ List( pTerm )
               case None => acc
             }
@@ -883,8 +868,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for( 
-        Location( pTerm1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.proc_1, Here() );
-        Location( pTerm2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.proc_2, Here() )
+        Location( pTerm1 : StrTermCtxt @unchecked, _ ) <- p.proc_1.accept(this, Here() );
+        Location( pTerm2 : StrTermCtxt @unchecked, _ ) <- p.proc_2.accept(this, Here() )
       ) yield {
         L( B( _block )( pTerm1, pTerm2 ), Top() )
       }
@@ -892,18 +877,12 @@ extends StrFoldCtxtVisitor {
   }
 
   /* Chan */
-  def visitDispatch(  p : Chan, arg : A ) : R = {
-    p match {
-      case cVar : CVar => visit( cVar, arg )
-      case cQuote : CQuote => visit( cQuote, arg )
-    }
-  }
   override def visit(  p : CVar, arg : A ) : R = {
     combine( arg, Some( L( V( p.var_ ), T() ) ) )
   }
   override def visit(  p : CQuote, arg : A ) : R = {
     // TODO: Handle quoting and unquoting
-    combine( arg, visitDispatch( p.proc_, Here() ) )
+    combine( arg, p.proc_.accept(this, Here() ) )
   }
   /* Bind */
   def visit( b : Bind, arg : A ) : R
@@ -913,9 +892,9 @@ extends StrFoldCtxtVisitor {
       case Some( Location( proc : StrTermCtxt @unchecked, Top() ) ) => {
         for(
           // [[ chan ]] is chanTerm
-          Location( chanTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.chan_, Here() );
+          Location( chanTerm : StrTermCtxt @unchecked, _ ) <- p.chan_.accept(this, Here() );
           // [[ ptrn ]] is ptrnTerm
-          Location( ptrnTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.cpattern_, Here() )
+          Location( ptrnTerm : StrTermCtxt @unchecked, _ ) <- p.cpattern_.accept(this, Here() )
         ) yield {
           // ( map [[ chan ]] proc [[ ptrn ]] [[ P ]] )
           L( B( _map )( chanTerm, B( _abs )( B(_list)(ptrnTerm), proc ) ), T() )
@@ -925,9 +904,9 @@ extends StrFoldCtxtVisitor {
         // should ensure that arg is a reasonable context to be really safe
         for(
           // [[ chan ]] is chanTerm
-          Location( chanTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.chan_, Here() );
+          Location( chanTerm : StrTermCtxt @unchecked, _ ) <- p.chan_.accept(this, Here() );
           // [[ ptrn ]] is ptrnTerm
-          Location( ptrnTerm : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.cpattern_, Here() );
+          Location( ptrnTerm : StrTermCtxt @unchecked, _ ) <- p.cpattern_.accept(this, Here() );
           Location( rbindingsTerm : StrTermCtxt @unchecked, _ ) <- arg
         ) yield {
           // ( flatMap [[ chan ]] proc [[ ptrn ]] [[ for( bindings )P ]] )
@@ -940,50 +919,12 @@ extends StrFoldCtxtVisitor {
   override def visit(  p : Choice, arg : A ) : R
 
   /* Value */
-  def visitDispatch( p : Value, arg : A ) : R = {
-    p match {
-      case quant : VQuant => visit( quant, arg )
-      case char : EChar => visit( char, arg )
-      case tuple : ETuple => visit( tuple, arg )
-    }
-  }
   override def visit(  p : VQuant, arg : A ) : R = {
-    combine( arg, visitDispatch( p.quantity_, Here() ) )
+    combine( arg, p.quantity_.accept(this, Here() ) )
   }
   /* Quantity */
-  def visitDispatch( p : Quantity, arg : A ) : R = {
-    p match {
-      case qVar : QVar => visit( qVar, arg )
-      case bool : QBool => visitDispatch( bool.rhobool_, arg )
-      case int : QInt => visit( int, arg )
-      case double : QDouble => visit( double, arg )
-      case string : QString => visit( string, arg )
-      case map : QMap => visit( map, arg )
-
-      case method : QDot => visit( method, arg )
-
-      case neg : QNeg => visit(neg, arg)
-      case mult : QMult => visit(mult, arg)
-      case div : QDiv => visit(div, arg)
-      case add : QAdd => visit(add, arg)
-      case minus : QMinus => visit(minus, arg)
-
-      case lt : QLt => visit(lt, arg)
-      case lte : QLte => visit(lte, arg)
-      case gt : QGt => visit(gt, arg)
-      case gte : QGte => visit(gte, arg)
-      case eq : QEq => visit(eq, arg)
-      case neq : QNeq => visit(neq, arg)
-    }
-  }
   override def visit(  p : QVar, arg : A ) : R = {
     combine( arg, L(V(p.var_), Top()) )
-  }
-  def visitDispatch( p : RhoBool, arg : A ) : R = {
-    p match {
-      case qTrue : QTrue => visit( qTrue, arg )
-      case qFalse : QFalse => visit( qFalse, arg )
-    }
   }
   override def visit(  p : QInt, arg : A ) : R = {
     combine(
@@ -1030,12 +971,12 @@ extends StrFoldCtxtVisitor {
      */
     combine(
       arg,
-      for (Location( q : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_, Here() )) yield {
+      for (Location( q : StrTermCtxt @unchecked, _ ) <- p.quantity_.accept(this, Here() )) yield {
         val qArgs =
           ( List[StrTermCtxt]() /: p.listquantity_.asScala.toList )(
             {
               ( acc, e ) => {
-                visitDispatch( e, Here() ) match {
+                e.accept(this, Here() ) match {
                   case Some( Location( frml : StrTermCtxt @unchecked, _ ) ) => {
                     acc ++ List( frml )
                   }
@@ -1053,7 +994,7 @@ extends StrFoldCtxtVisitor {
   override def visit( p : QNeg, arg : A) : R = {
     combine(
       arg,
-      for( Location( q : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_, Here() ) ) yield {
+      for( Location( q : StrTermCtxt @unchecked, _ ) <- p.quantity_.accept(this, Here() ) ) yield {
         L( B("-")(q), Top() )
       }
     )
@@ -1062,8 +1003,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("*")(q1,q2), Top() )
       }
@@ -1073,8 +1014,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("/")(q1,q2), Top() )
       }
@@ -1084,8 +1025,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("+")(q1,q2), Top() )
       }
@@ -1095,8 +1036,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("<")(q1,q2), Top() )
       }
@@ -1106,8 +1047,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("<=")(q1,q2), Top() )
       }
@@ -1117,8 +1058,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B(">")(q1,q2), Top() )
       }
@@ -1128,8 +1069,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B(">=")(q1,q2), Top() )
       }
@@ -1139,8 +1080,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("==")(q1,q2), Top() )
       }
@@ -1150,8 +1091,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("!=")(q1,q2), Top() )
       }
@@ -1163,8 +1104,8 @@ extends StrFoldCtxtVisitor {
     combine(
       arg,
       for(
-        Location( q1 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_1, Here() );
-        Location( q2 : StrTermCtxt @unchecked, _ ) <- visitDispatch( p.quantity_2, Here() )
+        Location( q1 : StrTermCtxt @unchecked, _ ) <- p.quantity_1.accept(this, Here() );
+        Location( q2 : StrTermCtxt @unchecked, _ ) <- p.quantity_2.accept(this, Here() )
       ) yield {
         L( B("-")(q1,q2), Top() )
       }
@@ -1184,7 +1125,7 @@ extends StrFoldCtxtVisitor {
       ( List[StrTermCtxt]() /: p.listproc_.asScala.toList )(
         {
           ( acc, e ) => {
-            visitDispatch( e, Here() ) match {
+            e.accept(this, Here() ) match {
               case Some( Location( frml : StrTermCtxt @unchecked, _ ) ) => {
                 acc ++ List( frml )
               }
@@ -1202,40 +1143,18 @@ extends StrFoldCtxtVisitor {
   }
 
   /* Pattern */
-  def visitDispatch( p : CPattern, arg : A ) : R = {
-    p match {
-      case cPtVar : CPtVar => visit( cPtVar, arg )
-      case cPtQuote : CPtQuote => visit( cPtQuote, arg )
-      case cValPtrn : CValPtrn => visit( cValPtrn, arg )
-    }
-  }
-  /* VarPattern */
-  def visitDispatch( p : VarPattern, arg : A ) : R = {
-    p match {
-      case regular: VarPtVar => visit(regular, Here())
-      case wild: VarPtWild => visit(wild, Here())
-    }
-  }
   override def visit(p: VarPtVar, arg: A): R = {
     combine( arg, L(V(p.var_), Top()) )
   }
   override def visit(  p : VarPtWild, arg : A ) : R
 
   /* PPattern */
-  def visitDispatch( p : PPattern, arg : A ) : R = {
-    // TODO: Fill in rest of PPattern subclasses
-    p match {
-      case pPtVar : PPtVar => visit( pPtVar, arg )
-      case pPtNil : PPtNil => visit( pPtNil, arg )
-      case pPtVal : PPtVal => visit( pPtVal, arg )
-    }
-  }
   override def visit(  p : PPtVar, arg : A ) : R = {
-    combine(arg, visitDispatch(p.varpattern_, Here()))
+    combine(arg, p.varpattern_.accept(this, Here()))
   }
   override def visit(  p : PPtNil, arg : A ) : R
   override def visit(  p : PPtVal, arg : A ) : R = {
-    combine(arg, visitDispatch(p.valpattern_, Here()))
+    combine(arg, p.valpattern_.accept(this, Here()))
   }
 
   override def visit(  p : PPtDrop, arg : A ) : R
@@ -1251,7 +1170,7 @@ extends StrFoldCtxtVisitor {
 
   /* CPattern */
   override def visit(p: CPtVar, arg: A): R = {
-    combine(arg, visitDispatch(p.varpattern_, Here()))
+    combine(arg, p.varpattern_.accept(this, Here()))
   }
   override def visit(  p : CPtQuote, arg : A ) : R
   /* PatternBind */
@@ -1259,19 +1178,6 @@ extends StrFoldCtxtVisitor {
   /* PatternPatternMatch */
   override def visit(  p : PtBranch, arg : A ) : R
   /* ValPattern */
-  def visitDispatch( p : ValPattern, arg : A ) : R = {
-    // TODO: Fill in rest of ValPattern subclasses
-    p match {
-      case vPtStruct : VPtStruct => visit( vPtStruct, arg )
-      case vPtTuple : VPtTuple => visit (vPtTuple, arg)
-      case vPtTrue : VPtTrue => visit( vPtTrue, arg )
-      case vPtFalse : VPtFalse => visit( vPtFalse, arg )
-      case vPtInt : VPtInt => visit( vPtInt, arg )
-      case vPtDbl : VPtDbl => visit( vPtDbl, arg )
-      case vPtNegInt : VPtNegInt => visit( vPtNegInt, arg )
-      case vPtNegDbl : VPtNegDbl => visit( vPtNegDbl, arg )
-    }
-  }
   override def visit(  p : VPtStruct, arg : A ) : R = {
     import scala.collection.JavaConverters._
     
@@ -1279,7 +1185,7 @@ extends StrFoldCtxtVisitor {
       ( List[StrTermCtxt]() /: p.listppattern_.asScala.toList )(
         {
           ( acc, e ) => {
-            visitDispatch( e, Here() ) match {
+            e.accept(this, Here() ) match {
               case Some( Location( frml : StrTermCtxt @unchecked, _ ) ) => {
                 acc ++ List( frml )
               }
@@ -1303,7 +1209,7 @@ extends StrFoldCtxtVisitor {
       ( List[StrTermCtxt]() /: p.listppattern_.asScala.toList )(
         {
           ( acc, e ) => {
-            visitDispatch( e, Here() ) match {
+            e.accept(this, Here() ) match {
               case Some( Location( frml : StrTermCtxt @unchecked, _ ) ) => {
                 acc ++ List( frml )
               }

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -22,7 +22,6 @@ import scala.language.postfixOps
 trait StrTermNavigation extends TermNavigation[String,Either[String,String],String]
 trait StrTermMutation extends TermMutation [String,Either[String,String],String]
 trait StrTermZipperComposition extends TermZipperComposition[String,Either[String,String],String]
-trait StrTermSubstitution extends TermSubstitution[String,Either[String,String],String]
 
 // V for language variable
 // K for "context" variable


### PR DESCRIPTION
Some commits that should make it easier to follow the compiler code.

More planned for the next sprint, but these reduce the number of lines that need to be read, and they contained bugs. (The decontextualize was broken, for example)