### PR TITLE
Add OpFork

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -226,6 +226,7 @@ object VirtualMachine {
       if (currentState.exitFlag) exit = true
     }
 
+    loggerOpcode.info("Exiting")
     currentState
   }
 
@@ -234,7 +235,7 @@ object VirtualMachine {
 
     if (mState.doXmitFlag) {
       // may set doNextThreadFlag
-      mState = doXmit(mState)
+      mState = doXmit(mState).set(_ >> 'doXmitFlag)(false)
     }
 
     if (mState.doRtnFlag) {
@@ -249,8 +250,9 @@ object VirtualMachine {
     }
 
     if (mState.doNextThreadFlag) {
-      val (isEmpty, newState) = getNextStrand(mState)
-      mState = newState.set(_ >> 'doNextThreadFlag)(false)
+      val (isEmpty, tmpState) = getNextStrand(mState)
+      // TODO: Probably should move that into getNextStrand
+      mState = tmpState.set(_ >> 'doNextThreadFlag)(false)
 
       if (isEmpty) {
         mState = mState.set(_ >> 'exitFlag)(true)
@@ -290,13 +292,17 @@ object VirtualMachine {
       newState
   }
 
-  def doXmit(state: VMState): VMState =
-    state.ctxt.trgt match {
+  def doXmit(state: VMState): VMState = {
+    val newState = state.ctxt.trgt match {
       case ob: StdOprn => ob.dispatch(state)._2
 
       // TODO: Add other cases
       case _ => state
     }
+
+    // TODO: Add logic
+    newState.set(_ >> 'doNextThreadFlag)(true)
+  }
 
   def executeDispatch(op: Op, state: VMState): VMState =
     op match {
@@ -403,9 +409,10 @@ object VirtualMachine {
       .set(_ >> 'ctxt >> 'pc)(PC.fromInt(op.p))
       .set(_ >> 'ctxt >> 'outstanding)(op.n)
 
-  def execute(op: OpFork, state: VMState): VMState =
-    state.set(_ >> 'strandPool)(
-      state.ctxt.copy(pc = PC.fromInt(op.p)) +: state.strandPool)
+  def execute(op: OpFork, state: VMState): VMState = {
+    val newCtxt = state.ctxt.copy(pc = PC(op.p))
+    state.update(_ >> 'strandPool)(newCtxt +: _)
+  }
 
   def execute(op: OpXmitTag, state: VMState): VMState =
     state

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -190,7 +190,6 @@ class TransitionSpec extends FlatSpec with Matchers {
       *  10:  xfer global[+],trgt
       *  12:  xmit/nxt 2
       */
-    // b src/Vm.cc if code->codevec->instr(0)->word == 3079
     val start =
       testState
         .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)

--- a/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
@@ -34,8 +34,8 @@ class VirtualMachineSpec extends WordSpec with Matchers {
     }
 
     (theState >> 'strandPool on OpFork(n)) {
-      val newCtxt = testState.ctxt.copy(pc = PC.fromInt(n)) +: testState.strandPool
-      _ shouldBe newCtxt
+      val newCtxt = testState.ctxt.copy(pc = PC(n))
+      _ shouldBe newCtxt +: testState.strandPool
     }
 
     (theState >> 'exitFlag on OpHalt()) {


### PR DESCRIPTION
In Rosette compiling the expression `(block (+ 1 2) (+ 3 4))` results in the following Code object:
```
litvec:
  0:   {BlockExpr}
codevec:
  0:   fork 7
  1:   alloc 2
  2:   lit 1,arg[0]
  3:   lit 2,arg[1]
  4:   xfer global[+],trgt
  6:   xmit/nxt 2
  7:   alloc 2
  8:   lit 3,arg[0]
  9:   lit 4,arg[1]
  10:  xfer global[+],trgt
  12:  xmit/nxt 2
```

When the VM starts to execute the above `codevec`, the following is happening when it comes to the execution of `OpFork(7)`:
1.  Copy the current `state.ctxt` and change the instruction pointer to `7` for the copy. Then push the result to `state.strandPool`.

After that the VM continues with the remaining opcodes. When it hits the `OpXmit` opcode, the `ctxt` with the changed instruction pointer will be scheduled and run.

One important observation from the above example is that Rosette calculates offsets to positions in the `codevec` in bytes (see: `fork 7`) and not in number of opcodes. In Roscala we probably want to offset by number of opcodes. Therefore for the above example `fork 7` becomes `OpFork(6)`.

### How to observe the above with gdb
Set this breakpoint in gdb: `b src/Vm.cc if code->codevec->instr(0)->word == 3079`.
Then go back to the Rosette REPL and execute `(block (+ 1 2) (+ 3 4))` which will jump to the beginning of the execution of the codevec we are interested in.