### PR TITLE
Remove internal scalar typdefs Byte, Word16, Word32

### DIFF
--- a/rosette/h/Addr.h
+++ b/rosette/h/Addr.h
@@ -30,7 +30,7 @@
 #pragma interface
 #endif
 
-Word32 pre_fixnum_to_addr(int x);
+uint32_t pre_fixnum_to_addr(int x);
 int addr_to_pre_fixnum(Ob *);
 
 #ifndef ADDR_TO_PRE_FIXNUM
@@ -38,7 +38,7 @@ int addr_to_pre_fixnum(Ob *);
 #define ADDR_TO_PRE_FIXNUM(x) nontrivial_addr_to_pre_fixnum(x)
 #define PRE_FIXNUM_TO_ADDR(x) nontrivial_pre_fixnum_to_addr(x)
 #else
-#define ADDR_TO_PRE_FIXNUM(x) ((Word32)(int)(x))
+#define ADDR_TO_PRE_FIXNUM(x) ((uint32_t)(int)(x))
 #define PRE_FIXNUM_TO_ADDR(x) ((int)(Ob *)(x))
 #endif
 #endif
@@ -46,7 +46,7 @@ int addr_to_pre_fixnum(Ob *);
 #define CHECK_ADDR(n, var)                    \
     if (!IS_FIXNUM(ARG(n)))                   \
         return PRIM_MISMATCH((n), "Address"); \
-    Word32 var = PRE_FIXNUM_TO_ADDR(FIXVAL(ARG(n)));
+    uint32_t var = PRE_FIXNUM_TO_ADDR(FIXVAL(ARG(n)));
 
 #define ADDR_TO_FIXNUM(x) FIXNUM(ADDR_TO_PRE_FIXNUM((Ob *)(void *)(x)))
 

--- a/rosette/h/BinaryOb.h
+++ b/rosette/h/BinaryOb.h
@@ -78,7 +78,7 @@ class ByteVec : public BinaryOb {
     static ByteVec* create(int);
     static ByteVec* create(ByteVec*, int);
 
-    Byte& byte(int);
+    uint8_t& byte(int);
     int numberOfBytes(EMPTY);
     void reset(EMPTY);
     unsigned long sum(EMPTY);
@@ -94,9 +94,9 @@ inline ByteVec::ByteVec(int sz, pOb meta, pOb parent, int numberOfBytes)
     byteCount = numberOfBytes;
 }
 
-inline Byte& ByteVec::byte(int n) {
+inline uint8_t& ByteVec::byte(int n) {
     // WTH????
-    Byte* p = (Byte*)(((char*)&byteCount) + sizeof(byteCount));
+    uint8_t* p = (uint8_t*)(((char*)&byteCount) + sizeof(byteCount));
     return p[n];
 }
 
@@ -125,7 +125,7 @@ class Word16Vec : public BinaryOb {
     static Word16Vec* create(pOb, pOb, int);
     static Word16Vec* create(Word16Vec*, int);
 
-    Word16& word(int);
+    uint16_t& word(int);
     int numberOfWords(EMPTY);
     void reset(EMPTY);
     unsigned long sum(EMPTY);
@@ -141,8 +141,8 @@ inline Word16Vec::Word16Vec(int sz, pOb meta, pOb parent, int cnt)
     wordCount = cnt;
 }
 
-inline Word16& Word16Vec::word(int n) {
-    Word16* p = (Word16*)(((char*)&wordCount) + sizeof(wordCount));
+inline uint16_t& Word16Vec::word(int n) {
+    uint16_t* p = (uint16_t*)(((char*)&wordCount) + sizeof(wordCount));
     return p[n];
 }
 
@@ -161,7 +161,7 @@ class Word32Vec : public BinaryOb {
     static Word32Vec* create(int);
     static Word32Vec* create(Word32Vec*, int);
 
-    Word32& word(int);
+    uint32_t& word(int);
     int numberOfWords(EMPTY);
     void reset(EMPTY);
     unsigned long sum(EMPTY);
@@ -175,13 +175,13 @@ class Word32Vec : public BinaryOb {
 inline Word32Vec::Word32Vec(int sz, pOb meta, pOb parent)
     : BinaryOb(sz, meta, parent) {}
 
-inline Word32& Word32Vec::word(int n) {
-    Word32* p = (Word32*)&slot(0);
+inline uint32_t& Word32Vec::word(int n) {
+    uint32_t* p = (uint32_t*)&slot(0);
     return p[n];
 }
 
 inline int Word32Vec::numberOfWords(EMPTY) {
-    return (SIZE(this) - sizeof(Word32Vec)) / sizeof(Word32);
+    return (SIZE(this) - sizeof(Word32Vec)) / sizeof(uint32_t);
 }
 
 #endif

--- a/rosette/h/BuiltinClass.h
+++ b/rosette/h/BuiltinClass.h
@@ -46,7 +46,7 @@ static const int INDIRECT = 1;
 class BuiltinClass {
     static int nClasses;
     static BuiltinClass* root;
-    static Word32* counts;
+    static uint32_t* counts;
     static char** names;
 
 

--- a/rosette/h/Code.h
+++ b/rosette/h/Code.h
@@ -67,7 +67,7 @@ class CodeBuf : public Ob {
     void emitE1(unsigned);
     void emitE2(unsigned, unsigned);
 
-    void patchAddress(int, Word16);
+    void patchAddress(int, uint16_t);
 
     int size();
     void clear();

--- a/rosette/h/Compile.h
+++ b/rosette/h/Compile.h
@@ -112,7 +112,7 @@ enum NodeFlag {
    * graph.  It is useful for suppressing certain warnings that are a
    * nuisance for top-level expressions.
    */
-    f_topLevel = BITS(Ob*) - (2 * BITS(Byte) + 6) + 1,
+    f_topLevel = BITS(Ob*) - (2 * BITS(uint8_t) + 6) + 1,
     /*
      * valueContext is true if the expression represented by this node is
      * in a position where it is expected to produce a value.
@@ -153,14 +153,14 @@ class AttrNode : public BinaryOb {
      * subexpressions.
      */
 
-    Byte av_size;
+    uint8_t av_size;
 
     /*
      * outstanding is a count of the number suspending (not inlineable)
      * sub-expressions contained by this expression.
      */
 
-    Byte outstanding;
+    uint8_t outstanding;
 
     unsigned short word;
 
@@ -196,9 +196,9 @@ class AttrNode : public BinaryOb {
     void emitLit(Ob*);
     void emitLookup(Ob*);
     void emitOpAndLabel(Opcode, Label);
-    void emitOpAndLabel(Opcode, Byte, Label);
+    void emitOpAndLabel(Opcode, uint8_t, Label);
     void emitOpAndLabel(Opcode, Ob*);
-    void emitOpAndLabel(Opcode, Byte, Ob*);
+    void emitOpAndLabel(Opcode, uint8_t, Ob*);
     void emitOutstanding();
     void emitPush(int);
     void emitStore(Label);
@@ -591,7 +591,7 @@ class GotoNode : public AttrNode {
     STD_DECLS(GotoNode);
 
    protected:
-    enum CompilerFakery { MaximumCut = (1 << BITS(Byte)) - 1 };
+    enum CompilerFakery { MaximumCut = (1 << BITS(uint8_t)) - 1 };
 
     Ob* labelName;
     LabelNode* labelNode;

--- a/rosette/h/Cstruct.h
+++ b/rosette/h/Cstruct.h
@@ -58,7 +58,7 @@ class GenericDescriptor : public Actor {
      *
      */
 
-    Word32 _offset, _align_to, _size; /* memory map */
+    uint32_t _offset, _align_to, _size; /* memory map */
     Ob* mnemonic;                     /* was consed up from rosette heap */
     Ob* imported;
     /* was returned by a foreign function or is a */
@@ -70,32 +70,32 @@ class GenericDescriptor : public Actor {
 
     virtual ~GenericDescriptor();
 
-    virtual Ob* sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sDesc(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sDeref(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sDesc(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sDeref(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
-    virtual Ob* sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
+    virtual Ob* sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val, Tuple* path,
                           int pindex = 0);
-    virtual Ob* nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
+    virtual Ob* nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path,
                         int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
 
     Ob* nullDescriptor(Ctxt*);
 
-    virtual Ob* oprnSwitch(Ctxt* ctxt, Word32 base, Tuple* path,
+    virtual Ob* oprnSwitch(Ctxt* ctxt, uint32_t base, Tuple* path,
                            int pindex = 0);
-    Ob* sBox(Word32);
+    Ob* sBox(uint32_t);
 
-    virtual Word32 absoluteAddress(Word32 base);
-    void setAddrContents(Word32 base, Word32 val);
+    virtual uint32_t absoluteAddress(uint32_t base);
+    void setAddrContents(uint32_t base, uint32_t val);
 };
 
-inline Ob* GenericDescriptor::sBox(Word32 off) {
+inline Ob* GenericDescriptor::sBox(uint32_t off) {
     GenericDescriptor* rslt = (GenericDescriptor*)cloneTo(meta(), parent());
     rslt->mbox = emptyMbox;
     rslt->_offset = off;
@@ -115,19 +115,19 @@ class NullDescriptor : public GenericDescriptor {
    public:
     static NullDescriptor* create();
 
-    virtual Ob* sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sDesc(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sDeref(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sDesc(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sDeref(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
-    virtual Ob* nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
+    virtual Ob* nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path,
                         int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 
     virtual Ob* isNullP();
 
-    virtual Word32 absoluteAddress(Word32 base);
+    virtual uint32_t absoluteAddress(uint32_t base);
 };
 
 class AtomicDescriptor : public GenericDescriptor {
@@ -147,14 +147,14 @@ class AtomicDescriptor : public GenericDescriptor {
     static AtomicDescriptor* create(RblBool*);
     static AtomicDescriptor* create();
 
-    virtual Ob* sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
-    virtual Word32 absoluteAddress(Word32 base);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
+    virtual uint32_t absoluteAddress(uint32_t base);
 };
 
 class CStructure : public GenericDescriptor {
@@ -174,65 +174,65 @@ class CStructure : public GenericDescriptor {
     static CStructure* create(RblTable*, Tuple*);
     static CStructure* create();
 
-    virtual Ob* select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
+    virtual Ob* select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val, Tuple* path,
                           int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 class CArray : public GenericDescriptor {
     STD_DECLS(CArray);
 
    protected:
-    CArray(Word16, GenericDescriptor*, pExt);
-    CArray(int s, pOb m, pOb p, pOb mbx, pExt, Word16, GenericDescriptor*);
+    CArray(uint16_t, GenericDescriptor*, pExt);
+    CArray(int s, pOb m, pOb p, pOb mbx, pExt, uint16_t, GenericDescriptor*);
 
     virtual int traversePtrs(PSOb__PSOb);
     virtual int traversePtrs(SI__PSOb);
     virtual void traversePtrs(V__PSOb);
 
    public:
-    Word16 _numElems;
-    Word16 filler_up_please;
+    uint16_t _numElems;
+    uint16_t filler_up_please;
     GenericDescriptor* _elemDesc;
 
-    static CArray* create(Word16, GenericDescriptor*);
+    static CArray* create(uint16_t, GenericDescriptor*);
     static CArray* create();
 
-    virtual Ob* sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
+    virtual Ob* sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val, Tuple* path,
                           int pindex = 0);
-    virtual Ob* nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
+    virtual Ob* nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path,
                         int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 class CharArray : public CArray {
     STD_DECLS(CharArray);
 
    protected:
-    CharArray(Word16, GenericDescriptor*, pExt);
-    CharArray(int s, pOb m, pOb p, pOb mbx, pExt, Word16, GenericDescriptor*);
+    CharArray(uint16_t, GenericDescriptor*, pExt);
+    CharArray(int s, pOb m, pOb p, pOb mbx, pExt, uint16_t, GenericDescriptor*);
 
    public:
-    static CharArray* create(Word16, GenericDescriptor*);
+    static CharArray* create(uint16_t, GenericDescriptor*);
     static CharArray* create();
 
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 class CharArray0 : public CharArray {
     STD_DECLS(CharArray0);
 
    protected:
-    CharArray0(Word16, GenericDescriptor*, pExt);
+    CharArray0(uint16_t, GenericDescriptor*, pExt);
 
    public:
-    static CharArray0* create(Word16, GenericDescriptor*);
+    static CharArray0* create(uint16_t, GenericDescriptor*);
     static CharArray0* create();
 
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 class CRef : public GenericDescriptor {
@@ -252,15 +252,15 @@ class CRef : public GenericDescriptor {
     static CRef* create(GenericDescriptor*);
     static CRef* create();
 
-    virtual Ob* sDeref(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sDeref(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
-    virtual Ob* nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
+    virtual Ob* nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path,
                         int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
 };
 
 class CharRef : public CRef {
@@ -274,7 +274,7 @@ class CharRef : public CRef {
     static CharRef* create(GenericDescriptor*);
     static CharRef* create();
 
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
@@ -291,8 +291,8 @@ class CRef0 : public CRef {
     static CRef0* create();
     static CRef0* create(GenericDescriptor*);
 
-    virtual Ob* sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 
@@ -305,8 +305,8 @@ class CharRef0 : public CRef0 {
    public:
     static CharRef0* create();
 
-    virtual Ob* flatten(Ctxt*, Word32, RblTable*);
-    virtual Ob* sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+    virtual Ob* flatten(Ctxt*, uint32_t, RblTable*);
+    virtual Ob* sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                      int pindex = 0);
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
 };
@@ -328,8 +328,8 @@ class CUnion : public GenericDescriptor {
     static CUnion* create(RblTable*, Tuple*);
     static CUnion* create();
 
-    virtual Ob* select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex = 0);
-    virtual Ob* flatten(Ctxt* ctxt, Word32 base, RblTable*);
+    virtual Ob* select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex = 0);
+    virtual Ob* flatten(Ctxt* ctxt, uint32_t base, RblTable*);
 };
 
 #endif

--- a/rosette/h/Ctxt.h
+++ b/rosette/h/Ctxt.h
@@ -53,9 +53,9 @@ class Ctxt : public MboxOb {
 
    public:
     Location tag;
-    Byte nargs;
-    Byte outstanding;
-    Word16 pc;
+    uint8_t nargs;
+    uint8_t outstanding;
+    uint16_t pc;
 
     // Additions to or deletions from the following list must
     // be reflected in the definition of NumberOfCtxtRegs.

--- a/rosette/h/Ob.h
+++ b/rosette/h/Ob.h
@@ -52,16 +52,7 @@
 #endif
 #endif
 
-#ifdef __GNUG__
-#include <stdint.h>
-typedef uint8_t Byte;
-typedef uint16_t Word16;
-typedef uint32_t Word32;
-#else
-typedef unsigned char Byte;
-typedef unsigned short Word16;
-typedef unsigned long Word32;
-#endif
+ #include <stdint.h>
 
 #if !defined(HAS_BOOL)
 typedef int bool;
@@ -480,7 +471,7 @@ inline HeaderBits::HeaderBits(int sz) {
 }
 
 struct convertArgReturnPair {
-    Word32 val;
+    uint32_t val;
     int failp;
 };
 
@@ -535,7 +526,7 @@ extern convertArgReturnPair cnvArgRetPair;
 class Base {
    public:
     static char** classNames;
-    static Word32* obCounts;
+    static uint32_t* obCounts;
     static int nClasses;
 
     Base(EMPTY);
@@ -651,7 +642,7 @@ class Ob : public Base {
     virtual pOb getAddr(int, int, int);
     virtual pOb setAddr(int, int, int, pOb);
     virtual pOb getField(int, int, int, int, int);
-    virtual pOb setField(int, int, int, int, Word32);
+    virtual pOb setField(int, int, int, int, uint32_t);
     virtual pOb indexedSize(EMPTY);
     virtual pOb nth(int);
     virtual pOb setNth(int, pOb);
@@ -678,7 +669,7 @@ class Ob : public Base {
     virtual bool matches(pCtxt);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
 
     virtual pOb isNullP(EMPTY);
 

--- a/rosette/h/Opcode.h
+++ b/rosette/h/Opcode.h
@@ -312,7 +312,7 @@ enum Opcode {
 #define SET_OP_e1_op0(x, val) SET_FW(x, 0, 16, val)
 
 union Instr {
-    Word16 word;
+    uint16_t word;
     operator int();
 };
 

--- a/rosette/h/RBLstring.h
+++ b/rosette/h/RBLstring.h
@@ -56,7 +56,7 @@ class RBLstring : public ByteVec {
     Ob* subObject(int, int);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
 };
 
 #endif

--- a/rosette/h/RblAtom.h
+++ b/rosette/h/RblAtom.h
@@ -83,7 +83,7 @@ class RblBool : public RblAtom {
     const char* asCstring();
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    // virtual Ob*         convertActualRslt(Ctxt*, Word32);
+    // virtual Ob*         convertActualRslt(Ctxt*, uint32_t);
 };
 
 class Char : public RblAtom {
@@ -116,7 +116,7 @@ class Fixnum : public RblAtom {
     const char* asCstring();
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
-    virtual Ob* convertActualRslt(Ctxt*, Word32);
+    virtual Ob* convertActualRslt(Ctxt*, uint32_t);
 };
 
 

--- a/rosette/h/Vm.h
+++ b/rosette/h/Vm.h
@@ -62,7 +62,7 @@ class VirtualMachine : public RootSet {
     ObStk* sleeperPool;
     Ctxt* upcallCtxt;
 
-    Word32* bytecodes;
+    uint32_t* bytecodes;
 
     static Ob* vmLiterals[16];
 

--- a/rosette/src/BaseSupp.cc
+++ b/rosette/src/BaseSupp.cc
@@ -80,7 +80,7 @@ extern "C" {
 #endif
 
 #ifdef MAP_BACK_ADDRESS
-extern Word32 nontrivial_pre_fixnum_to_addr(int);
+extern uint32_t nontrivial_pre_fixnum_to_addr(int);
 extern int nontrivial_addr_to_pre_fixnum(Ob*);
 #endif
 
@@ -269,8 +269,8 @@ DEF("prim-gen-actor", obGenActor, 3, 3) {
     return rslt;
 }
 
-Word32 mem_get_field(Word32* addr, int offset, int span, int sign) {
-    static const int WordSize = BITS(Word32);
+uint32_t mem_get_field(uint32_t* addr, int offset, int span, int sign) {
+    static const int WordSize = BITS(uint32_t);
 
     long ans;
 
@@ -302,8 +302,8 @@ Word32 mem_get_field(Word32* addr, int offset, int span, int sign) {
         int bitOffset = offset % WordSize;
 
         if (bitOffset + span > WordSize) {
-            Word32 loBucket = *(addr + wordOffset);
-            Word32 hiBucket = *(addr + wordOffset + 1);
+            uint32_t loBucket = *(addr + wordOffset);
+            uint32_t hiBucket = *(addr + wordOffset + 1);
             int loSpan = WordSize - bitOffset;
             int hiSpan = span - loSpan;
 
@@ -315,9 +315,9 @@ Word32 mem_get_field(Word32* addr, int offset, int span, int sign) {
             ans = ((loBucket << hiSpan) | (hiBucket >> (WordSize - hiSpan)));
         }
         else {
-            Word32 bucket = *(addr + wordOffset);
-            Word32 mask = (span == 32) ? -1 : (1L << span) - 1;
-            Word32 bits = (bucket >> (WordSize - (bitOffset + span))) & mask;
+            uint32_t bucket = *(addr + wordOffset);
+            uint32_t mask = (span == 32) ? -1 : (1L << span) - 1;
+            uint32_t bits = (bucket >> (WordSize - (bitOffset + span))) & mask;
             if (sign && (bits & (1L << (span - 1))))
                 bits |= (span == 32) ? 0 : (~0L) << span;
 
@@ -328,8 +328,8 @@ Word32 mem_get_field(Word32* addr, int offset, int span, int sign) {
     return ans;
 }
 
-Word32* mem_set_field(Word32* addr, int offset, int span, Word32 bits) {
-    static const int WordSize = BITS(Word32);
+uint32_t* mem_set_field(uint32_t* addr, int offset, int span, uint32_t bits) {
+    static const int WordSize = BITS(uint32_t);
 
     switch (span) {
     case 8:
@@ -353,21 +353,21 @@ Word32* mem_set_field(Word32* addr, int offset, int span, Word32 bits) {
         int bitOffset = offset % WordSize;
 
         if (bitOffset + span > WordSize) {
-            Word32* loBucketAddr = addr + wordOffset;
-            Word32* hiBucketAddr = loBucketAddr + 1;
+            uint32_t* loBucketAddr = addr + wordOffset;
+            uint32_t* hiBucketAddr = loBucketAddr + 1;
             int loSpan = WordSize - bitOffset;
             int hiSpan = span - loSpan;
-            Word32 loMask = (1L << loSpan) - 1;
-            Word32 hiMask = ~((1L << (WordSize - hiSpan)) - 1);
+            uint32_t loMask = (1L << loSpan) - 1;
+            uint32_t hiMask = ~((1L << (WordSize - hiSpan)) - 1);
             *loBucketAddr =
                 (*loBucketAddr & ~loMask) | ((bits >> hiSpan) & loMask);
             *hiBucketAddr =
                 (*hiBucketAddr & ~hiMask) | (bits << (WordSize - hiSpan));
         }
         else {
-            Word32* bucketAddr = addr + wordOffset;
+            uint32_t* bucketAddr = addr + wordOffset;
             int shift = WordSize - (bitOffset + span);
-            Word32 mask = ((span == 32) ? -1 : (1L << span) - 1) << shift;
+            uint32_t mask = ((span == 32) ? -1 : (1L << span) - 1) << shift;
             *bucketAddr = (*bucketAddr & ~mask) | ((bits << shift) & mask);
         }
     }
@@ -481,12 +481,12 @@ DEF("M-get", addressGetField, 3, 3) {
     CHECK(2, RblBool, sign);
 
     int offset = (int)base % 4;
-    Word32* addr = (Word32*)(base - offset);
+    uint32_t* addr = (uint32_t*)(base - offset);
 
     if (base < local_page_size)
         return PRIM_ERROR("invalid address");
     else if ((span >= 1) && (span <= 4)) {
-        Word32 rslt = mem_get_field(addr, offset * 8, span * 8, BOOLVAL(sign));
+        uint32_t rslt = mem_get_field(addr, offset * 8, span * 8, BOOLVAL(sign));
 
         return FIXNUM((int)rslt);
     }
@@ -501,12 +501,12 @@ DEF("M-set", addressSetField, 3, 3) {
     CHECK_FIXNUM(2, val);
 
     int offset = (int)base % 4;
-    Word32* addr = (Word32*)(base - offset);
+    uint32_t* addr = (uint32_t*)(base - offset);
 
     if (base < local_page_size)
         return PRIM_ERROR("invalid address");
     else if ((span >= 1) && (span <= 4)) {
-        Word32* rslt = mem_set_field(addr, offset * 8, span * 8, (Word32)val);
+        uint32_t* rslt = mem_set_field(addr, offset * 8, span * 8, (uint32_t)val);
 
         return ADDR_TO_FIXNUM((int)addr);
     }

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -107,7 +107,7 @@ CUnion* obCUnion = (CUnion*)INVALID;
 
 int BuiltinClass::nClasses = 0;
 BuiltinClass* BuiltinClass::root = 0;
-Word32* BuiltinClass::counts = 0;
+uint32_t* BuiltinClass::counts = 0;
 char** BuiltinClass::names = 0;
 
 
@@ -121,10 +121,10 @@ BuiltinClass::BuiltinClass(char* nm, pMeta* cmeta, pSBO* csbo, FIELD_FN ffn)
     root = this;
 }
 
-Word32* Base::obCounts = 0;
+uint32_t* Base::obCounts = 0;
 char** Base::classNames = {0};
 void BuiltinClass::allocBuiltinClasses() {
-    counts = new Word32[nClasses];
+    counts = new uint32_t[nClasses];
     names = new char*[nClasses];
     for (int i = 0; i < nClasses; i++) {
         counts[i] = 0;

--- a/rosette/src/BinaryOb.cc
+++ b/rosette/src/BinaryOb.cc
@@ -68,35 +68,35 @@ void BinaryOb::traversePtrs(V__PSOb f) {
 
 
 ByteVec::ByteVec(int sz)
-    : BinaryOb(sizeof(ByteVec) + align(sz * sizeof(Byte)), CLASS_META(ByteVec),
+    : BinaryOb(sizeof(ByteVec) + align(sz * sizeof(uint8_t)), CLASS_META(ByteVec),
                CLASS_SBO(ByteVec)),
       byteCount(sz) {
-    memset((char*)&this->byte(0), 0, align(sz * sizeof(Byte)));
+    memset((char*)&this->byte(0), 0, align(sz * sizeof(uint8_t)));
     ByteVec::updateCnt();
 }
 
 
 ByteVec::ByteVec(ByteVec* old, int newsize)
-    : BinaryOb(sizeof(ByteVec) + align(newsize * sizeof(Byte)), old->meta(),
+    : BinaryOb(sizeof(ByteVec) + align(newsize * sizeof(uint8_t)), old->meta(),
                old->parent()),
       byteCount(newsize) {
     int oldsize = old->numberOfBytes();
     memcpy((char*)&this->byte(0), (char*)&old->byte(0),
-           min(oldsize, newsize) * sizeof(Byte));
+           min(oldsize, newsize) * sizeof(uint8_t));
     if (newsize > oldsize)
-        memset(&this->byte(0), 0, (newsize - oldsize) * sizeof(Byte));
+        memset(&this->byte(0), 0, (newsize - oldsize) * sizeof(uint8_t));
     ByteVec::updateCnt();
 }
 
 
 ByteVec* ByteVec::create(int n) {
-    void* loc = PALLOC(sizeof(ByteVec) + align(n * sizeof(Byte)));
+    void* loc = PALLOC(sizeof(ByteVec) + align(n * sizeof(uint8_t)));
     return NEW(loc) ByteVec(n);
 }
 
 
 ByteVec* ByteVec::create(ByteVec* old, int newsize) {
-    void* loc = PALLOC1(sizeof(ByteVec) + align(newsize * sizeof(Byte)), old);
+    void* loc = PALLOC1(sizeof(ByteVec) + align(newsize * sizeof(uint8_t)), old);
     return NEW(loc) ByteVec(old, newsize);
 }
 
@@ -128,13 +128,13 @@ Ob* ByteVec::subObject(int start, int n) {
     PROTECT_THIS(ByteVec);
     ByteVec* result = ByteVec::create(n);
     memcpy((char*)&result->byte(0), (char*)&SELF->byte(start),
-           n * sizeof(Byte));
+           n * sizeof(uint8_t));
     return result;
 }
 
 
 Word16Vec::Word16Vec(int n)
-    : BinaryOb(sizeof(Word16Vec) + align(n * sizeof(Word16)),
+    : BinaryOb(sizeof(Word16Vec) + align(n * sizeof(uint16_t)),
                CLASS_META(Word16Vec), CLASS_SBO(Word16Vec)),
       wordCount(n) {
     while (n--)
@@ -144,7 +144,7 @@ Word16Vec::Word16Vec(int n)
 
 
 Word16Vec::Word16Vec(Ob* meta, Ob* parent, int n)
-    : BinaryOb(sizeof(Word16Vec) + align(n * sizeof(Word16)), meta, parent),
+    : BinaryOb(sizeof(Word16Vec) + align(n * sizeof(uint16_t)), meta, parent),
       wordCount(n) {
     while (n--)
         this->word(n) = 0;
@@ -153,34 +153,34 @@ Word16Vec::Word16Vec(Ob* meta, Ob* parent, int n)
 
 
 Word16Vec::Word16Vec(Word16Vec* old, int newsize)
-    : BinaryOb(sizeof(Word16Vec) + align(newsize * sizeof(Word16)), old->meta(),
+    : BinaryOb(sizeof(Word16Vec) + align(newsize * sizeof(uint16_t)), old->meta(),
                old->parent()),
       wordCount(newsize) {
     int oldsize = old->numberOfWords();
     memcpy(&this->word(0), &old->word(0),
-           min(oldsize, newsize) * sizeof(Word16));
+           min(oldsize, newsize) * sizeof(uint16_t));
     if (newsize > oldsize)
-        memset(&this->word(oldsize), 0, (newsize - oldsize) * sizeof(Word16));
+        memset(&this->word(oldsize), 0, (newsize - oldsize) * sizeof(uint16_t));
     Word16Vec::updateCnt();
 }
 
 
 Word16Vec* Word16Vec::create(int n) {
-    void* loc = PALLOC(sizeof(Word16Vec) + align(n * sizeof(Word16)));
+    void* loc = PALLOC(sizeof(Word16Vec) + align(n * sizeof(uint16_t)));
     return NEW(loc) Word16Vec(n);
 }
 
 
 Word16Vec* Word16Vec::create(Ob* meta, Ob* parent, int n) {
     void* loc =
-        PALLOC2(sizeof(Word16Vec) + align(n * sizeof(Word16)), meta, parent);
+        PALLOC2(sizeof(Word16Vec) + align(n * sizeof(uint16_t)), meta, parent);
     return NEW(loc) Word16Vec(meta, parent, n);
 }
 
 
 Word16Vec* Word16Vec::create(Word16Vec* old, int newsize) {
     void* loc =
-        PALLOC1(sizeof(Word16Vec) + align(newsize * sizeof(Word16)), old);
+        PALLOC1(sizeof(Word16Vec) + align(newsize * sizeof(uint16_t)), old);
     return NEW(loc) Word16Vec(old, newsize);
 }
 
@@ -214,13 +214,13 @@ Ob* Word16Vec::setNth(int n, Ob* v) {
 Ob* Word16Vec::subObject(int start, int n) {
     PROTECT_THIS(Word16Vec);
     Word16Vec* result = Word16Vec::create(n);
-    memcpy(&result->word(0), &SELF->word(start), n * sizeof(Word16));
+    memcpy(&result->word(0), &SELF->word(start), n * sizeof(uint16_t));
     return result;
 }
 
 
 Word32Vec::Word32Vec(int n)
-    : BinaryOb(sizeof(Word32Vec) + n * sizeof(Word32), CLASS_META(Word32Vec),
+    : BinaryOb(sizeof(Word32Vec) + n * sizeof(uint32_t), CLASS_META(Word32Vec),
                CLASS_SBO(Word32Vec)) {
     while (n--)
         this->word(n) = 0;
@@ -229,25 +229,25 @@ Word32Vec::Word32Vec(int n)
 
 
 Word32Vec::Word32Vec(Word32Vec* old, int newsize)
-    : BinaryOb(sizeof(Word32Vec) + newsize * sizeof(Word32), old->meta(),
+    : BinaryOb(sizeof(Word32Vec) + newsize * sizeof(uint32_t), old->meta(),
                old->parent()) {
     int oldsize = old->numberOfWords();
     memcpy(&this->word(0), &old->word(0),
-           min(oldsize, newsize) * sizeof(Word32));
+           min(oldsize, newsize) * sizeof(uint32_t));
     if (newsize > oldsize)
-        memset(&this->word(oldsize), 0, (newsize - oldsize) * sizeof(Word32));
+        memset(&this->word(oldsize), 0, (newsize - oldsize) * sizeof(uint32_t));
     Word32Vec::updateCnt();
 }
 
 
 Word32Vec* Word32Vec::create(int n) {
-    void* loc = PALLOC(sizeof(Word32Vec) + n * sizeof(Word32));
+    void* loc = PALLOC(sizeof(Word32Vec) + n * sizeof(uint32_t));
     return NEW(loc) Word32Vec(n);
 }
 
 
 Word32Vec* Word32Vec::create(Word32Vec* old, int newsize) {
-    void* loc = PALLOC1(sizeof(Word32Vec) + newsize * sizeof(Word32), old);
+    void* loc = PALLOC1(sizeof(Word32Vec) + newsize * sizeof(uint32_t), old);
     return NEW(loc) Word32Vec(old, newsize);
 }
 
@@ -281,7 +281,7 @@ Ob* Word32Vec::setNth(int n, Ob* v) {
 Ob* Word32Vec::subObject(int start, int n) {
     PROTECT_THIS(Word32Vec);
     Word32Vec* result = Word32Vec::create(n);
-    memcpy(&result->word(0), &SELF->word(start), n * sizeof(Word32));
+    memcpy(&result->word(0), &SELF->word(start), n * sizeof(uint32_t));
     return result;
 }
 

--- a/rosette/src/Code.cc
+++ b/rosette/src/Code.cc
@@ -201,7 +201,7 @@ void CodeBuf::emitE2(unsigned op0, unsigned op1) {
     }
 }
 
-void CodeBuf::patchAddress(int wordAddress, Word16 realAddress) {
+void CodeBuf::patchAddress(int wordAddress, uint16_t realAddress) {
     Instr* pc = codevec->absolutize(wordAddress);
     SET_OP_f6_pc((*pc), realAddress);
 }
@@ -370,7 +370,7 @@ Instr* CodeVec::dumpInstr(Instr* pc, char* buf, Code* code) {
     case opApplyPrimTag | NextOff | UnwindOn:
     case opApplyPrimTag | NextOn | UnwindOff:
     case opApplyPrimTag | NextOn | UnwindOn: {
-        Word16 extension = (*pc++).word;
+        uint16_t extension = (*pc++).word;
         unsigned prim_num = WORD_OP_e0_op0(extension);
         if (prim_num == 255)
             prim_num = OP_e1_op0((*pc++));
@@ -387,7 +387,7 @@ Instr* CodeVec::dumpInstr(Instr* pc, char* buf, Code* code) {
     case opApplyPrimArg | NextOff | UnwindOn:
     case opApplyPrimArg | NextOn | UnwindOff:
     case opApplyPrimArg | NextOn | UnwindOn: {
-        Word16 extension = (*pc++).word;
+        uint16_t extension = (*pc++).word;
         unsigned prim_num = WORD_OP_e0_op0(extension);
         if (prim_num == 255)
             prim_num = OP_e1_op0((*pc++));
@@ -404,7 +404,7 @@ Instr* CodeVec::dumpInstr(Instr* pc, char* buf, Code* code) {
     case opApplyPrimReg | NextOff | UnwindOn:
     case opApplyPrimReg | NextOn | UnwindOff:
     case opApplyPrimReg | NextOn | UnwindOn: {
-        Word16 extension = (*pc++).word;
+        uint16_t extension = (*pc++).word;
         unsigned prim_num = WORD_OP_e0_op0(extension);
         if (prim_num == 255)
             prim_num = OP_e1_op0((*pc++));
@@ -421,7 +421,7 @@ Instr* CodeVec::dumpInstr(Instr* pc, char* buf, Code* code) {
     case opApplyCmd | NextOff | UnwindOn:
     case opApplyCmd | NextOn | UnwindOff:
     case opApplyCmd | NextOn | UnwindOn: {
-        Word16 extension = (*pc++).word;
+        uint16_t extension = (*pc++).word;
         unsigned prim_num = WORD_OP_e0_op0(extension);
         if (prim_num == 255)
             prim_num = OP_e1_op0((*pc++));

--- a/rosette/src/Cstruct.cc
+++ b/rosette/src/Cstruct.cc
@@ -55,7 +55,7 @@
 #include "ModuleInit.h"
 
 #ifdef MAP_BACK_ADDRESS
-extern Word32 nontrivial_pre_fixnum_to_addr(int);
+extern uint32_t nontrivial_pre_fixnum_to_addr(int);
 extern int nontrivial_addr_to_pre_fixnum(Ob*);
 #endif
 
@@ -86,8 +86,8 @@ extern AtomicDescriptor* obChar;
 // these live in Basic-support.cc
 extern Ob* newSBO(Ob* proto_sbo, Ob* id, Ob* prnt, Ob* ctxt);
 extern Ob* genActor(Ob* proto, Ob* sbo);
-extern Word32 mem_get_field(Word32* addr, int offset, int span, int sign);
-extern Word32* mem_set_field(Word32* addr, int offset, int span, Word32 bits);
+extern uint32_t mem_get_field(uint32_t* addr, int offset, int span, int sign);
+extern uint32_t* mem_set_field(uint32_t* addr, int offset, int span, uint32_t bits);
 
 // some useful defines so i don't have to remember the accessors
 
@@ -114,7 +114,7 @@ static int local_page_size = getpagesize();
 
 #define OCTAGCOUNT 4
 
-Tuple* makeOCTag(Ob* self, Word32 nid) {
+Tuple* makeOCTag(Ob* self, uint32_t nid) {
     PROTECT(self);
     Tuple* OCTag = Tuple::create(OCTAGCOUNT, INVALID);
     OCTag->setNth(0, FIXNUM(nid));
@@ -127,7 +127,7 @@ Tuple* makeOCTag(Ob* self, Word32 nid) {
 
 /*
 Ob*
-makeOCTag(GenericDescriptor* self, Word32 base)
+makeOCTag(GenericDescriptor* self, uint32_t base)
 {
   return( FIXNUM(self->absoluteAddress(base)) );
 }
@@ -268,8 +268,8 @@ DEF_OPRN(Std, "nth", oprnCSNth, obCSNth);
 
 BUILTIN_CLASS(GenericDescriptor) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", GenericDescriptor, imported);
     OB_FIELD("free-on-gc", GenericDescriptor, freeStructOnGC);
@@ -357,7 +357,7 @@ void GenericDescriptor::traversePtrs(V__PSOb f) {
     useIfPtr(freeStructOnGC, f);
 }
 
-Ob* GenericDescriptor::oprnSwitch(Ctxt* ctxt, Word32 base, Tuple* path,
+Ob* GenericDescriptor::oprnSwitch(Ctxt* ctxt, uint32_t base, Tuple* path,
                                   int pindex) {
     PROTECT_THIS(GenericDescriptor);
     PROTECT(ctxt);
@@ -434,12 +434,12 @@ Ob* GenericDescriptor::nullDescriptor(Ctxt* ctxt) {
 }
 
 convertArgReturnPair GenericDescriptor::convertActualArg(Ctxt* ctxt, Ob* obj) {
-    cnvArgRetPair.val = (Word32)-1;
+    cnvArgRetPair.val = (uint32_t)-1;
     cnvArgRetPair.failp = 1;
     return cnvArgRetPair;
 }
 
-Ob* GenericDescriptor::convertActualRslt(Ctxt* ctxt, Word32 obj) {
+Ob* GenericDescriptor::convertActualRslt(Ctxt* ctxt, uint32_t obj) {
     if (obj == 0)
         return nullDescriptor(ctxt);
     else {
@@ -451,7 +451,7 @@ Ob* GenericDescriptor::convertActualRslt(Ctxt* ctxt, Word32 obj) {
     }
 }
 
-Ob* GenericDescriptor::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* GenericDescriptor::sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     if (NULLP(path, pindex)) {
         return sBox(base + _offset);
     }
@@ -459,7 +459,7 @@ Ob* GenericDescriptor::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
         return oprnSwitch(ctxt, base, path, pindex);
 }
 
-Ob* GenericDescriptor::sDesc(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* GenericDescriptor::sDesc(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     /* remember to ask about gc protection */
     if (NULLP(path, pindex)) {
         return sBox(base + _offset);
@@ -468,15 +468,15 @@ Ob* GenericDescriptor::sDesc(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
         return oprnSwitch(ctxt, base, path, pindex);
 }
 
-Ob* GenericDescriptor::sDeref(Ctxt* ctxt, Word32, Tuple* path, int) {
+Ob* GenericDescriptor::sDeref(Ctxt* ctxt, uint32_t, Tuple* path, int) {
     return runtimeError(ctxt, "Cannot de-reference ", path);
 }
 
-Ob* GenericDescriptor::select(Ctxt* ctxt, Word32, Tuple* path, int) {
+Ob* GenericDescriptor::select(Ctxt* ctxt, uint32_t, Tuple* path, int) {
     return runtimeError(ctxt, "Cannot select with: ", path);
 }
 
-Ob* GenericDescriptor::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+Ob* GenericDescriptor::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                             int pindex) {
     if (TYPEP(this, val)) {
         memcpy((void*)(base + _offset),
@@ -494,7 +494,7 @@ Ob* GenericDescriptor::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
     return runtimeError(ctxt, "S-set type-mismatch ", val);
 }
 
-Ob* GenericDescriptor::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val,
+Ob* GenericDescriptor::sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val,
                                  Tuple* path, int pindex) {
     // Needs protection code.
     PROTECT_THIS(GenericDescriptor);
@@ -505,7 +505,7 @@ Ob* GenericDescriptor::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val,
     Ob* tupHead = INVALID;
     PROTECT(tupHead);
 
-    for (Word32 addr = base; !(NULLP(val, vindex)); addr = addr + SELF->_size) {
+    for (uint32_t addr = base; !(NULLP(val, vindex)); addr = addr + SELF->_size) {
         tupHead = TUPLE_HEAD(val, vindex);
         TUPLE_TAIL(val, vindex);
         (void)(SELF->sSet(ctxt, addr, tupHead, NIL));
@@ -519,12 +519,12 @@ Ob* GenericDescriptor::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val,
     }
 }
 
-Ob* GenericDescriptor::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
+Ob* GenericDescriptor::nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path,
                                int pindex) {
     PROTECT_THIS(GenericDescriptor);
     PROTECT(ctxt);
     PROTECT(path);
-    Word32 newBase = (base + (i * SELF->_size));
+    uint32_t newBase = (base + (i * SELF->_size));
     if (NULLP(path, pindex)) {
         return SELF->sBox(newBase + SELF->_offset);
     }
@@ -534,24 +534,24 @@ Ob* GenericDescriptor::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path,
     }
 }
 
-Ob* GenericDescriptor::flatten(Ctxt* ctxt, Word32, RblTable*) {
+Ob* GenericDescriptor::flatten(Ctxt* ctxt, uint32_t, RblTable*) {
     return runtimeError(ctxt, "method undefined for ", this);
 }
 
-Word32 GenericDescriptor::absoluteAddress(Word32 base) {
-    Word32 newbase = (base + _offset);
-    Word32 newoff = newbase % 4;
-    return (Word32)(mem_get_field((Word32*)(newbase - newoff),
+uint32_t GenericDescriptor::absoluteAddress(uint32_t base) {
+    uint32_t newbase = (base + _offset);
+    uint32_t newoff = newbase % 4;
+    return (uint32_t)(mem_get_field((uint32_t*)(newbase - newoff),
                                   (int)(newoff * 8), (int)(_size * 8),
                                   BOOLVAL(RBLFALSE)));
 }
 
-void GenericDescriptor::setAddrContents(Word32 base, Word32 val) {
-    Word32 newbase, offset, *addr;
+void GenericDescriptor::setAddrContents(uint32_t base, uint32_t val) {
+    uint32_t newbase, offset, *addr;
     newbase = base + _offset;
     offset = newbase % 4;
 
-    mem_set_field((Word32*)(newbase - offset), (int)(offset * 8),
+    mem_set_field((uint32_t*)(newbase - offset), (int)(offset * 8),
                   (int)(_size * 8), val);
 }
 
@@ -575,39 +575,39 @@ NullDescriptor* NullDescriptor::create() {
     return NEW(loc) NullDescriptor(ext);
 }
 
-Ob* NullDescriptor::sGet(Ctxt*, Word32, Tuple*, int) {
+Ob* NullDescriptor::sGet(Ctxt*, uint32_t, Tuple*, int) {
     //(pure (S-get & r) (self))
     return this;
 }
 
-Ob* NullDescriptor::sDesc(Ctxt*, Word32, Tuple*, int) {
+Ob* NullDescriptor::sDesc(Ctxt*, uint32_t, Tuple*, int) {
     //(pure (S-desc & r) (self))
     return this;
 }
 
-Ob* NullDescriptor::sDeref(Ctxt* ctxt, Word32, Tuple* path, int) {
+Ob* NullDescriptor::sDeref(Ctxt* ctxt, uint32_t, Tuple* path, int) {
     //(pure (S-deref & r) (RuntimeError (self) "Cannot deref(^) " r))
     return runtimeError(ctxt, "Cannot deref(^) ", path);
 }
 
-Ob* NullDescriptor::select(Ctxt* ctxt, Word32, Tuple* path, int) {
+Ob* NullDescriptor::select(Ctxt* ctxt, uint32_t, Tuple* path, int) {
     //(pure (select & r) (RuntimeError (self) "Cannot select " r))
     return runtimeError(ctxt, "Cannot select ", path);
 }
 
-Ob* NullDescriptor::sSet(Ctxt* ctxt, Word32, Ob*, Tuple* path, int) {
+Ob* NullDescriptor::sSet(Ctxt* ctxt, uint32_t, Ob*, Tuple* path, int) {
     //(pure (S-set & r) (RuntimeError (self) "Cannot set(:=) " r))
     return runtimeError(ctxt, "Cannot set(:=) ", path);
 }
 
-Ob* NullDescriptor::nthBase(Ctxt* ctxt, Word32, int, Tuple* path, int) {
+Ob* NullDescriptor::nthBase(Ctxt* ctxt, uint32_t, int, Tuple* path, int) {
     //(pure (nth & r) (RuntimeError (self) "Cannot index " r))
     return runtimeError(ctxt, "Cannot index ", path);
 }
 
-Ob* NullDescriptor::flatten(Ctxt*, Word32, RblTable*) { return this; }
+Ob* NullDescriptor::flatten(Ctxt*, uint32_t, RblTable*) { return this; }
 
-Word32 NullDescriptor::absoluteAddress(Word32 base) { return (Word32)0; }
+uint32_t NullDescriptor::absoluteAddress(uint32_t base) { return (uint32_t)0; }
 
 pOb NullDescriptor::isNullP() { return RBLTRUE; }
 
@@ -619,8 +619,8 @@ pOb NullDescriptor::isNullP() { return RBLTRUE; }
 
 BUILTIN_CLASS(AtomicDescriptor) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", NullDescriptor, imported);
     OB_FIELD("free-on-gc", NullDescriptor, freeStructOnGC);
@@ -669,23 +669,23 @@ void AtomicDescriptor::traversePtrs(V__PSOb f) {
 convertArgReturnPair AtomicDescriptor::convertActualArg(Ctxt* ctxt, Ob* obj) {
     cnvArgRetPair.failp = 0;
     if (IS_FIXNUM(obj)) {
-        cnvArgRetPair.val = (Word32)FIXVAL(obj);
+        cnvArgRetPair.val = (uint32_t)FIXVAL(obj);
     }
     else if (TYPEP(this, obj)) {
-        cnvArgRetPair.val = (Word32)FIXVAL(sGet(ctxt, 0, NIL));
+        cnvArgRetPair.val = (uint32_t)FIXVAL(sGet(ctxt, 0, NIL));
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 1;
     }
     return cnvArgRetPair;
 }
 
-Ob* AtomicDescriptor::convertActualRslt(Ctxt*, Word32 obj) {
+Ob* AtomicDescriptor::convertActualRslt(Ctxt*, uint32_t obj) {
     return FIXNUM(obj);
 }
 
-Ob* AtomicDescriptor::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* AtomicDescriptor::sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     // Needs protection code.
 
     PROTECT_THIS(AtomicDescriptor);
@@ -699,7 +699,7 @@ Ob* AtomicDescriptor::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
         return (SELF->oprnSwitch(ctxt, base, path, pindex));
 }
 
-Ob* AtomicDescriptor::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
+Ob* AtomicDescriptor::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
                            int pindex) {
     // Needs protection code.
     PROTECT_THIS(AtomicDescriptor);
@@ -708,7 +708,7 @@ Ob* AtomicDescriptor::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
     PROTECT(path);
 
     if (IS_FIXNUM(val)) {
-        SELF->setAddrContents(base, (Word32)FIXVAL(val));
+        SELF->setAddrContents(base, (uint32_t)FIXVAL(val));
         if (!NULLP(path, pindex))
             return (SELF->oprnSwitch(ctxt, base, path, pindex));
         else
@@ -721,14 +721,14 @@ Ob* AtomicDescriptor::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path,
         return runtimeError(ctxt, "S-set type-mismatch ", val);
 }
 
-Ob* AtomicDescriptor::flatten(Ctxt* ctxt, Word32 base, RblTable*) {
+Ob* AtomicDescriptor::flatten(Ctxt* ctxt, uint32_t base, RblTable*) {
     return sGet(ctxt, base, NIL);
 }
 
-Word32 AtomicDescriptor::absoluteAddress(Word32 base) {
-    Word32 newbase = (base + _offset);
-    Word32 newoff = newbase % 4;
-    return (Word32)(mem_get_field((Word32*)(newbase - newoff),
+uint32_t AtomicDescriptor::absoluteAddress(uint32_t base) {
+    uint32_t newbase = (base + _offset);
+    uint32_t newoff = newbase % 4;
+    return (uint32_t)(mem_get_field((uint32_t*)(newbase - newoff),
                                   (int)(newoff * 8), (int)(_size * 8),
                                   BOOLVAL(_signed)));
 }
@@ -741,8 +741,8 @@ Word32 AtomicDescriptor::absoluteAddress(Word32 base) {
 
 BUILTIN_CLASS(CStructure) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CStructure, imported);
     OB_FIELD("free-on-gc", CStructure, freeStructOnGC);
@@ -795,7 +795,7 @@ void CStructure::traversePtrs(V__PSOb f) {
     useIfPtr(_fieldNames, f);
 }
 
-Ob* CStructure::select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* CStructure::select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     // Needs protection code.
     PROTECT_THIS(CStructure);
     PROTECT(ctxt);
@@ -821,7 +821,7 @@ Ob* CStructure::select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
     }
 }
 
-Ob* CStructure::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
+Ob* CStructure::sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val, Tuple* path,
                           int pindex) {
     // Needs protection code.
 
@@ -851,7 +851,7 @@ Ob* CStructure::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
         return runtimeError(ctxt, "S-tupleSet too many elements ", val);
 }
 
-Ob* CStructure::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CStructure::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CStructure);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -901,16 +901,16 @@ Ob* CStructure::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CArray) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CArray, imported);
     OB_FIELD("free-on-gc", CArray, freeStructOnGC);
-    BIT_FIELD("numElems", CArray, _numElems, BITS(Word16));
+    BIT_FIELD("numElems", CArray, _numElems, BITS(uint16_t));
     OB_FIELD("elemDesc", CArray, _elemDesc);
 }
 
-CArray::CArray(Word16 cnt, GenericDescriptor* elemd, pExt ext)
+CArray::CArray(uint16_t cnt, GenericDescriptor* elemd, pExt ext)
     : GenericDescriptor(sizeof(CArray), CLASS_META(CArray), CLASS_SBO(CArray),
                         emptyMbox, ext),
       _numElems(cnt),
@@ -918,13 +918,13 @@ CArray::CArray(Word16 cnt, GenericDescriptor* elemd, pExt ext)
     CArray::updateCnt();
 }
 
-CArray::CArray(int s, pOb m, pOb p, pOb mbx, pExt ext, Word16 cnt,
+CArray::CArray(int s, pOb m, pOb p, pOb mbx, pExt ext, uint16_t cnt,
                GenericDescriptor* elemd)
     : GenericDescriptor(s, m, p, mbx, ext), _numElems(cnt), _elemDesc(elemd) {
     CArray::updateCnt();
 }
 
-CArray* CArray::create(Word16 cnt, GenericDescriptor* elmd) {
+CArray* CArray::create(uint16_t cnt, GenericDescriptor* elmd) {
     PROTECT(elmd);
     StdExtension* ext = StdExtension::create(0);
     void* loc = PALLOC1(sizeof(CArray), ext);
@@ -952,18 +952,18 @@ void CArray::traversePtrs(V__PSOb f) {
     useIfPtr(_elemDesc, f);
 }
 
-Ob* CArray::sTupleSet(Ctxt* ctxt, Word32 base, Tuple* val, Tuple* path,
+Ob* CArray::sTupleSet(Ctxt* ctxt, uint32_t base, Tuple* val, Tuple* path,
                       int pindex) {
     if (val->numberOfElements() <= _numElems)
         return (_elemDesc->sTupleSet(ctxt, base + _offset, val, path, pindex));
     return (runtimeError(ctxt, "S-tupleSet too many elements ", val));
 }
 
-Ob* CArray::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path, int pindex) {
+Ob* CArray::nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path, int pindex) {
     // Needs protection code.
 
     if ((i >= 0) && (i <= _numElems)) {
-        Word32 addr = (base + _offset + (i * _elemDesc->_size));
+        uint32_t addr = (base + _offset + (i * _elemDesc->_size));
 
         if (NULLP(path, pindex))
             return (_elemDesc->sBox(addr));
@@ -976,7 +976,7 @@ Ob* CArray::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path, int pindex) {
         return runtimeError(ctxt, "Index out of bounds ", path);
 }
 
-Ob* CArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CArray::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CArray);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -990,7 +990,7 @@ Ob* CArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
         PROTECT(rslt);
         occtxt->addKey(selfTag, rslt);
         for (int i = 0; i < SELF->_numElems; i++) {
-            Word32 addrKey =
+            uint32_t addrKey =
                 base + SELF->_offset + (i * sizeof(SELF->_elemDesc));
             rslt->setNth(i, SELF->_elemDesc->flatten(ctxt, addrKey, occtxt));
         }
@@ -1009,28 +1009,28 @@ Ob* CArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CharArray) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CharArray, imported);
     OB_FIELD("free-on-gc", CharArray, freeStructOnGC);
-    BIT_FIELD("numElems", CArray, _numElems, BITS(Word16));
+    BIT_FIELD("numElems", CArray, _numElems, BITS(uint16_t));
     OB_FIELD("elemDesc", CArray, _elemDesc);
 }
 
-CharArray::CharArray(Word16 cnt, GenericDescriptor* elemd, pExt ext)
+CharArray::CharArray(uint16_t cnt, GenericDescriptor* elemd, pExt ext)
     : CArray(sizeof(CharArray), CLASS_META(CharArray), CLASS_SBO(CharArray),
              emptyMbox, ext, cnt, elemd) {
     CharArray::updateCnt();
 }
 
-CharArray::CharArray(int s, pOb m, pOb p, pOb mbx, pExt ext, Word16 cnt,
+CharArray::CharArray(int s, pOb m, pOb p, pOb mbx, pExt ext, uint16_t cnt,
                      GenericDescriptor* elemd)
     : CArray(s, m, p, mbx, ext, cnt, elemd) {
     CharArray::updateCnt();
 }
 
-CharArray* CharArray::create(Word16 cnt, GenericDescriptor* elmd) {
+CharArray* CharArray::create(uint16_t cnt, GenericDescriptor* elmd) {
     PROTECT(elmd);
     StdExtension* ext = StdExtension::create(0);
     void* loc = PALLOC1(sizeof(CharArray), ext);
@@ -1045,9 +1045,9 @@ CharArray* CharArray::create() {
     return NEW(loc) CharArray(0, tmp, ext);
 }
 
-Ob* CharArray::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
+Ob* CharArray::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
     if (STRINGP(val)) {
-        Word32 addr = base + _offset;
+        uint32_t addr = base + _offset;
         if (VALID_ADDR(addr)) {
             char* tmp = (char*)GET_STRING(val);
             (void)strncpy((char*)addr, tmp, _numElems);
@@ -1060,7 +1060,7 @@ Ob* CharArray::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
         return CArray::sSet(ctxt, base, val, path, pindex);
 }
 
-Ob* CharArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CharArray::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CharArray);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -1070,7 +1070,7 @@ Ob* CharArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
     PROTECT(selfTag);
 
     if ((chck = occtxt->getKey(selfTag)) == ABSENT) {
-        Word32 addr = base + _offset;
+        uint32_t addr = base + _offset;
         if (VALID_ADDR(addr)) {
             Ob* rslt = RBLstring::create((int)_size, (char*)addr);
             PROTECT(rslt);
@@ -1092,22 +1092,22 @@ Ob* CharArray::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CharArray0) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CharArray, imported);
     OB_FIELD("free-on-gc", CharArray, freeStructOnGC);
-    BIT_FIELD("numElems", CArray, _numElems, BITS(Word16));
+    BIT_FIELD("numElems", CArray, _numElems, BITS(uint16_t));
     OB_FIELD("elemDesc", CArray, _elemDesc);
 }
 
-CharArray0::CharArray0(Word16 cnt, GenericDescriptor* elemd, pExt ext)
+CharArray0::CharArray0(uint16_t cnt, GenericDescriptor* elemd, pExt ext)
     : CharArray(sizeof(CharArray0), CLASS_META(CharArray0),
                 CLASS_SBO(CharArray0), emptyMbox, ext, cnt, elemd) {
     CharArray0::updateCnt();
 }
 
-CharArray0* CharArray0::create(Word16 cnt, GenericDescriptor* elmd) {
+CharArray0* CharArray0::create(uint16_t cnt, GenericDescriptor* elmd) {
     PROTECT(elmd);
     StdExtension* ext = StdExtension::create(0);
     void* loc = PALLOC1(sizeof(CharArray0), ext);
@@ -1122,7 +1122,7 @@ CharArray0* CharArray0::create() {
     return NEW(loc) CharArray0(0, tmp, ext);
 }
 
-Ob* CharArray0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CharArray0::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CharArray);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -1132,7 +1132,7 @@ Ob* CharArray0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
     PROTECT(selfTag);
 
     if ((chck = occtxt->getKey(selfTag)) == ABSENT) {
-        Word32 addr = base + _offset;
+        uint32_t addr = base + _offset;
         if (VALID_ADDR(addr)) {
             Ob* rslt = RBLstring::create((char*)addr);
             PROTECT(rslt);
@@ -1154,8 +1154,8 @@ Ob* CharArray0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CRef) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CRef, imported);
     OB_FIELD("free-on-gc", CRef, freeStructOnGC);
@@ -1211,16 +1211,16 @@ convertArgReturnPair CRef::convertActualArg(Ctxt* ctxt, Ob* obj) {
     GenericDescriptor* gobj = (GenericDescriptor*)obj;
     if (TYPEP(SELF, obj)) {
         if (VALID_ADDR(gobj->_offset)) {
-            Word32 addr = gobj->absoluteAddress(0);
+            uint32_t addr = gobj->absoluteAddress(0);
             if (VALID_ADDR(addr))
                 cnvArgRetPair.val = addr;
             else {
-                cnvArgRetPair.val = (Word32)-1;
+                cnvArgRetPair.val = (uint32_t)-1;
                 cnvArgRetPair.failp = 1;
             }
         }
         else {
-            cnvArgRetPair.val = (Word32)-1;
+            cnvArgRetPair.val = (uint32_t)-1;
             cnvArgRetPair.failp = 1;
         }
     }
@@ -1229,7 +1229,7 @@ convertArgReturnPair CRef::convertActualArg(Ctxt* ctxt, Ob* obj) {
             VALID_ADDR(gobj->_offset)
         cnvArgRetPair.val = gobj->_offset;
         else {
-            cnvArgRetPair.val = (Word32)-1;
+            cnvArgRetPair.val = (uint32_t)-1;
             cnvArgRetPair.failp = 1;
         }
     }
@@ -1237,14 +1237,14 @@ convertArgReturnPair CRef::convertActualArg(Ctxt* ctxt, Ob* obj) {
         cnvArgRetPair.val = 0;
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 1;
     }
 
     return cnvArgRetPair;
 }
 
-Ob* CRef::convertActualRslt(Ctxt* ctxt, Word32 obj) {
+Ob* CRef::convertActualRslt(Ctxt* ctxt, uint32_t obj) {
     if (obj == 0)
         return _desc->nullDescriptor(ctxt);
     else {
@@ -1256,10 +1256,10 @@ Ob* CRef::convertActualRslt(Ctxt* ctxt, Word32 obj) {
     }
 }
 
-Ob* CRef::sDeref(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* CRef::sDeref(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     PROTECT(ctxt);
     PROTECT(path);
-    Word32 bddr = absoluteAddress(base);
+    uint32_t bddr = absoluteAddress(base);
     GenericDescriptor* d =
         ((bddr == 0) ? (GenericDescriptor*)(_desc->nullDescriptor(ctxt))
                      : _desc);
@@ -1270,15 +1270,15 @@ Ob* CRef::sDeref(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
         return (d->oprnSwitch(ctxt, bddr, path, pindex));
 }
 
-Ob* CRef::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
+Ob* CRef::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
     if (TUPLEP(val)) {
         return sTupleSet(ctxt, base, (Tuple*)val, path, pindex);
     }
     else {
-        Word32 msetval;
+        uint32_t msetval;
 
         if (TYPEP(this, val)) {
-            Word32 msetval = ((GenericDescriptor*)val)->absoluteAddress(0);
+            uint32_t msetval = ((GenericDescriptor*)val)->absoluteAddress(0);
         }
         else if (TYPEP(_desc, val)) {
             msetval = ((GenericDescriptor*)val)->_offset;
@@ -1302,8 +1302,8 @@ Ob* CRef::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
     }
 }
 
-Ob* CRef::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path, int pindex) {
-    Word32 newbase = base + (i * _size);
+Ob* CRef::nthBase(Ctxt* ctxt, uint32_t base, int i, Tuple* path, int pindex) {
+    uint32_t newbase = base + (i * _size);
     if (NULLP(path, pindex)) {
         return sBox(newbase + _offset);
     }
@@ -1313,7 +1313,7 @@ Ob* CRef::nthBase(Ctxt* ctxt, Word32 base, int i, Tuple* path, int pindex) {
     }
 }
 
-Ob* CRef::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CRef::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CRef);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -1322,7 +1322,7 @@ Ob* CRef::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
     Ob* selfTag = makeOCTag(SELF, base + SELF->_offset);
     PROTECT(selfTag);
 
-    Word32 addr = SELF->absoluteAddress(base);
+    uint32_t addr = SELF->absoluteAddress(base);
 
     // Note: must check for nullness first.
 
@@ -1353,8 +1353,8 @@ Ob* CRef::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CharRef) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CharRef, imported);
     OB_FIELD("free-on-gc", CharRef, freeStructOnGC);
@@ -1388,7 +1388,7 @@ CharRef* CharRef::create() {
     return NEW(loc) CharRef(tmp, ext);
 }
 
-Ob* CharRef::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
+Ob* CharRef::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
     PROTECT_THIS(CharRef);
     PROTECT(ctxt);
     PROTECT(val);
@@ -1396,7 +1396,7 @@ Ob* CharRef::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
     if (STRINGP(val)) {
         RBLstring* stmp = (RBLstring*)val;
         char* saddr = new char[stmp->numberOfBytes()];
-        Word32 prev = SELF->absoluteAddress(base);
+        uint32_t prev = SELF->absoluteAddress(base);
 
 #ifdef MEMORYCAUTIOUS
         if (VALID_ADDR(prev))
@@ -1404,7 +1404,7 @@ Ob* CharRef::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
 #endif
 
         (void)strcpy((char*)saddr, (GET_STRING(val)));
-        SELF->setAddrContents(base, (Word32)saddr);
+        SELF->setAddrContents(base, (uint32_t)saddr);
         return NIV;
     }
     else
@@ -1424,24 +1424,24 @@ convertArgReturnPair CharRef::convertActualArg(Ctxt* ctxt, Ob* arg) {
             cnvArgRetPair.val = obj->_offset;
         }
         else {
-            cnvArgRetPair.val = (Word32)-1;
+            cnvArgRetPair.val = (uint32_t)-1;
             cnvArgRetPair.failp = 1;
         }
     }
     else if (STRINGP(obj)) {
-        cnvArgRetPair.val = (Word32)(GET_STRING(obj));
+        cnvArgRetPair.val = (uint32_t)(GET_STRING(obj));
     }
     else if (IS_FIXNUM(obj)) {
-        cnvArgRetPair.val = (Word32)(PRE_FIXNUM_TO_ADDR((FIXVAL(obj))));
+        cnvArgRetPair.val = (uint32_t)(PRE_FIXNUM_TO_ADDR((FIXVAL(obj))));
     }
     else if (IS_A(obj, ByteVec)) {
-        cnvArgRetPair.val = (Word32)((char*)&(((ByteVec*)obj)->byte(0)));
+        cnvArgRetPair.val = (uint32_t)((char*)&(((ByteVec*)obj)->byte(0)));
     }
     else if (obj->isNullP()) {
         cnvArgRetPair.val = 0;
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 1;
     }
 
@@ -1456,8 +1456,8 @@ convertArgReturnPair CharRef::convertActualArg(Ctxt* ctxt, Ob* arg) {
 
 BUILTIN_CLASS(CRef0) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CRef0, imported);
     OB_FIELD("free-on-gc", CRef0, freeStructOnGC);
@@ -1492,7 +1492,7 @@ CRef0* CRef0::create() {
     return NEW(loc) CRef0(tmp, ext);
 }
 
-Ob* CRef0::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* CRef0::sGet(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     if (NULLP(path, pindex)) {
         return flatten(ctxt, base, makeOccursCheckTable());
     }
@@ -1500,7 +1500,7 @@ Ob* CRef0::sGet(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
         return runtimeError(ctxt, "cannot access ", path);
 }
 
-Ob* CRef0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CRef0::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CRef0);
     PROTECT(ctxt);
     PROTECT(occtxt);
@@ -1510,20 +1510,20 @@ Ob* CRef0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
     // Ob* selfTag = makeOCTag( SELF, base );
     PROTECT(selfTag);
     if ((chck = occtxt->getKey(selfTag)) == ABSENT) {
-        Word32 addr = SELF->absoluteAddress(base);
+        uint32_t addr = SELF->absoluteAddress(base);
         if (addr == 0) {
             Ob* rslt = SELF->_desc->nullDescriptor(ctxt);
             PROTECT(rslt);
             occtxt->addKey(selfTag, rslt);
         }
         else {
-            Word32 skip = sizeof(SELF->_desc);
+            uint32_t skip = sizeof(SELF->_desc);
             Tuple* rslt = NIL;
             PROTECT(rslt);
             occtxt->addKey(selfTag, rslt);
             GenericDescriptor* itr = SELF->_desc;
             Ob* tmp = itr->flatten(ctxt, addr, occtxt);
-            Word32 iddr = addr + skip;
+            uint32_t iddr = addr + skip;
             PROTECT(tmp);
             for (; !(ISNULLP(tmp)); iddr = iddr + skip) {
                 rslt = ::rcons(rslt, tmp);
@@ -1545,8 +1545,8 @@ Ob* CRef0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
 
 BUILTIN_CLASS(CharRef0) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CharRef0, imported);
     OB_FIELD("free-on-gc", CharRef0, freeStructOnGC);
@@ -1565,12 +1565,12 @@ CharRef0* CharRef0::create() {
     return NEW(loc) CharRef0(ext);
 }
 
-Ob* CharRef0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CharRef0::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CharRef0);
     PROTECT(ctxt);
     PROTECT(occtxt);
 
-    Word32 addr = SELF->absoluteAddress(base);
+    uint32_t addr = SELF->absoluteAddress(base);
     if (addr == 0) {
         return (obChar->nullDescriptor(ctxt));
     }
@@ -1583,19 +1583,19 @@ Ob* CharRef0::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
     }
 }
 
-Ob* CharRef0::sSet(Ctxt* ctxt, Word32 base, Ob* val, Tuple* path, int pindex) {
+Ob* CharRef0::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
     if (STRINGP(val)) {
         int valsize = strlen(GET_STRING(val));
         char* tmp = new char[valsize];
 
-        Word32 addr = absoluteAddress(base);
+        uint32_t addr = absoluteAddress(base);
 #ifdef MEMORYCAUTIOUS
         (void)free((char*)addr);
 #endif
 
         (void)strcpy(tmp, GET_STRING(val));
 
-        setAddrContents(base, (Word32)tmp);
+        setAddrContents(base, (uint32_t)tmp);
 
         return NIV;
     }
@@ -1608,7 +1608,7 @@ convertArgReturnPair CharRef0::convertActualArg(Ctxt* ctxt, Ob* arg) {
     cnvArgRetPair.failp = 0;
 
     if (STRINGP(obj)) {
-        cnvArgRetPair.val = (Word32)(GET_STRING(obj));
+        cnvArgRetPair.val = (uint32_t)(GET_STRING(obj));
     }
     else
         return CRef::convertActualArg(ctxt, arg);
@@ -1624,8 +1624,8 @@ convertArgReturnPair CharRef0::convertActualArg(Ctxt* ctxt, Ob* arg) {
 
 BUILTIN_CLASS(CUnion) {
     ADDR_FIELD("offset!", GenericDescriptor, _offset);
-    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(Word32));
-    BIT_FIELD("size!", GenericDescriptor, _size, BITS(Word32));
+    BIT_FIELD("align-to!", GenericDescriptor, _align_to, BITS(uint32_t));
+    BIT_FIELD("size!", GenericDescriptor, _size, BITS(uint32_t));
     OB_FIELD("mnemonic", GenericDescriptor, mnemonic);
     OB_FIELD("imported", CUnion, imported);
     OB_FIELD("free-on-gc", CUnion, freeStructOnGC);
@@ -1677,7 +1677,7 @@ void CUnion::traversePtrs(V__PSOb f) {
     useIfPtr(_fieldNames, f);
 }
 
-Ob* CUnion::select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
+Ob* CUnion::select(Ctxt* ctxt, uint32_t base, Tuple* path, int pindex) {
     // Needs protection code.
     PROTECT_THIS(CUnion);
     PROTECT(ctxt);
@@ -1703,7 +1703,7 @@ Ob* CUnion::select(Ctxt* ctxt, Word32 base, Tuple* path, int pindex) {
     }
 }
 
-Ob* CUnion::flatten(Ctxt* ctxt, Word32 base, RblTable* occtxt) {
+Ob* CUnion::flatten(Ctxt* ctxt, uint32_t base, RblTable* occtxt) {
     PROTECT_THIS(CUnion);
     PROTECT(ctxt);
     PROTECT(occtxt);

--- a/rosette/src/Ctxt.cc
+++ b/rosette/src/Ctxt.cc
@@ -48,9 +48,9 @@ extern Ob* lockedMbox;
 BUILTIN_CLASS(Ctxt) {
     OB_FIELD("mbox", Ctxt, mbox);
     OB_FIELD("tag", Ctxt, tag);
-    BIT_FIELD("nargs", Ctxt, nargs, BITS(Byte));
-    BIT_FIELD("outstanding", Ctxt, outstanding, BITS(Byte));
-    BIT_FIELD("pc", Ctxt, pc, BITS(Word16));
+    BIT_FIELD("nargs", Ctxt, nargs, BITS(uint8_t));
+    BIT_FIELD("outstanding", Ctxt, outstanding, BITS(uint8_t));
+    BIT_FIELD("pc", Ctxt, pc, BITS(uint16_t));
     OB_FIELD("rslt", Ctxt, rslt);
     OB_FIELD("trgt", Ctxt, trgt);
     OB_FIELD("argvec", Ctxt, argvec);
@@ -66,9 +66,9 @@ BUILTIN_CLASS(Ctxt) {
 BUILTIN_CLASS(UpcallCtxt) {
     OB_FIELD("mbox", Ctxt, mbox);
     OB_FIELD("tag", Ctxt, tag);
-    BIT_FIELD("nargs", Ctxt, nargs, BITS(Byte));
-    BIT_FIELD("outstanding", Ctxt, outstanding, BITS(Byte));
-    BIT_FIELD("pc", Ctxt, pc, BITS(Word16));
+    BIT_FIELD("nargs", Ctxt, nargs, BITS(uint8_t));
+    BIT_FIELD("outstanding", Ctxt, outstanding, BITS(uint8_t));
+    BIT_FIELD("pc", Ctxt, pc, BITS(uint16_t));
     OB_FIELD("rslt", Ctxt, rslt);
     OB_FIELD("trgt", Ctxt, trgt);
     OB_FIELD("argvec", Ctxt, argvec);

--- a/rosette/src/ForeignFun.cc
+++ b/rosette/src/ForeignFun.cc
@@ -177,7 +177,7 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
     PROTECT(ctxt);
     ForeignFunction* KONST __PRIM__ = this;
     Ctxt* KONST __CTXT__ = ctxt;
-    Word32 x[32];
+    uint32_t x[32];
     KONST int n = argConverters->numberOfElements();
     int i = 0;
     long res;

--- a/rosette/src/InetSupp.cc
+++ b/rosette/src/InetSupp.cc
@@ -83,7 +83,7 @@ extern "C" {
 #include "Vm.h"
 
 #ifdef MAP_BACK_ADDRESS
-extern Word32 nontrivial_pre_fixnum_to_addr(int);
+extern uint32_t nontrivial_pre_fixnum_to_addr(int);
 extern int nontrivial_addr_to_pre_fixnum(Ob*);
 #endif
 /*  */

--- a/rosette/src/Location.cc
+++ b/rosette/src/Location.cc
@@ -39,8 +39,8 @@
 #define SPANSIZE00(n) ((n) == 0 ? (1 << BitField00SpanSize) : (n))
 
 #ifdef MAP_BACK_ADDRESS
-Word32 nontrivial_pre_fixnum_to_addr(int x) {
-    Word32 y = x;
+uint32_t nontrivial_pre_fixnum_to_addr(int x) {
+    uint32_t y = x;
     if (x < END_SMALL_ADDR)
         return y;
     if (x >= END_SMALL_ADDR)
@@ -253,7 +253,7 @@ Ob* setValWrt(Location loc, Ob* v, Ob* val) {
                                 GET_ADDRVAR_OFFSET(loc), val);
     case LT_BitField:
         if (IS_FIXNUM(val)) {
-            Word32 bits = (Word32)FIXVAL(val);
+            uint32_t bits = (uint32_t)FIXVAL(val);
             return BASE(v)->setField(GET_BITFIELD_IND(loc),
                                      GET_BITFIELD_LEVEL(loc),
                                      GET_BITFIELD_OFFSET(loc),
@@ -265,7 +265,7 @@ Ob* setValWrt(Location loc, Ob* v, Ob* val) {
         }
     case LT_BitField00:
         if (IS_FIXNUM(val)) {
-            Word32 bits = (Word32)FIXVAL(val);
+            uint32_t bits = (uint32_t)FIXVAL(val);
             return BASE(v)->setField(0, 0, GET_BITFIELD00_OFFSET(loc),
                                      SPANSIZE(GET_BITFIELD00_SPAN(loc)), bits);
         }

--- a/rosette/src/Monitor.cc
+++ b/rosette/src/Monitor.cc
@@ -87,14 +87,14 @@ void Monitor::start() { timer->start(); }
 void Monitor::stop() { timer->stop(); }
 
 
-static void prettyPrint(Word32 n, char* name, FILE* f) {
+static void prettyPrint(uint32_t n, char* name, FILE* f) {
     if (n != 0)
         fprintf(f, "%8ul %s%s\n", n, name, plural((int)n));
 }
 
 
 void Monitor::printStats(FILE* f) {
-    Word32 total = 0;
+    uint32_t total = 0;
 
     fprintf(f, "%s:\n", BASE(id)->asCstring());
 
@@ -102,7 +102,7 @@ void Monitor::printStats(FILE* f) {
     int n = obCounts->numberOfWords();
     int i = 0;
     for (i = 0; i < n; i++) {
-        Word32 count = (int)obCounts->word(i);
+        uint32_t count = (int)obCounts->word(i);
         prettyPrint(count, Base::classNames[i], f);
         total += count;
     }
@@ -111,7 +111,7 @@ void Monitor::printStats(FILE* f) {
     fprintf(f, "bytecodes:\n");
     total = 0;
     for (i = 0; i < 256; i++) {
-        Word32 n = opcodeCounts->word(i);
+        uint32_t n = opcodeCounts->word(i);
         if (n > 0) {
             total += n;
             char* str = opcodeStrings[i];

--- a/rosette/src/Ob.cc
+++ b/rosette/src/Ob.cc
@@ -53,7 +53,7 @@
 #include <ctime>
 
 #ifdef MAP_BACK_ADDRESS
-extern Word32 nontrivial_pre_fixnum_to_addr(int);
+extern uint32_t nontrivial_pre_fixnum_to_addr(int);
 extern int nontrivial_addr_to_pre_fixnum(Ob*);
 #endif
 
@@ -460,7 +460,7 @@ pOb Ob::getAddr(int indirect, int level, int offset) {
 
 
 pOb Ob::setAddr(int indirect, int level, int offset, pOb val) {
-    Word32 addr;
+    uint32_t addr;
     if (!IS_FIXNUM(val))
         return INVALID;
     addr = PRE_FIXNUM_TO_ADDR(FIXVAL(val));
@@ -482,7 +482,7 @@ pOb Ob::setAddr(int indirect, int level, int offset, pOb val) {
 
 
 pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
-    static const int WordSize = BITS(Word32);
+    static const int WordSize = BITS(uint32_t);
 
     long ans;
     pOb p = this;
@@ -520,8 +520,8 @@ pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
 
         warning("%s suspect span in getField", span);
         if (bitOffset + span > WordSize) {
-            Word32 loBucket = *((Word32*)p + wordOffset);
-            Word32 hiBucket = *((Word32*)p + wordOffset + 1);
+            uint32_t loBucket = *((uint32_t*)p + wordOffset);
+            uint32_t hiBucket = *((uint32_t*)p + wordOffset + 1);
             int loSpan = WordSize - bitOffset;
             int hiSpan = span - loSpan;
 
@@ -533,9 +533,9 @@ pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
             ans = ((loBucket << hiSpan) | (hiBucket >> (WordSize - hiSpan)));
         }
         else {
-            Word32 bucket = *((Word32*)p + wordOffset);
-            Word32 mask = (span == 32) ? -1 : (1L << span) - 1;
-            Word32 bits = (bucket >> (WordSize - (bitOffset + span))) & mask;
+            uint32_t bucket = *((uint32_t*)p + wordOffset);
+            uint32_t mask = (span == 32) ? -1 : (1L << span) - 1;
+            uint32_t bits = (bucket >> (WordSize - (bitOffset + span))) & mask;
             if (sign && (bits & (1L << (span - 1))))
                 bits |= (span == 32) ? 0 : (~0L) << span;
 
@@ -546,8 +546,8 @@ pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
     return FIXNUM(ans);
 }
 
-pOb Ob::setField(int indirect, int level, int offset, int span, Word32 bits) {
-    static const int WordSize = BITS(Word32);
+pOb Ob::setField(int indirect, int level, int offset, int span, uint32_t bits) {
+    static const int WordSize = BITS(uint32_t);
 
     pOb p = this;
     while (level--)
@@ -578,21 +578,21 @@ pOb Ob::setField(int indirect, int level, int offset, int span, Word32 bits) {
 
         warning("%s suspect span in setField", span);
         if (bitOffset + span > WordSize) {
-            Word32* loBucketAddr = (Word32*)p + wordOffset;
-            Word32* hiBucketAddr = loBucketAddr + 1;
+            uint32_t* loBucketAddr = (uint32_t*)p + wordOffset;
+            uint32_t* hiBucketAddr = loBucketAddr + 1;
             int loSpan = WordSize - bitOffset;
             int hiSpan = span - loSpan;
-            Word32 loMask = (1L << loSpan) - 1;
-            Word32 hiMask = ~((1L << (WordSize - hiSpan)) - 1);
+            uint32_t loMask = (1L << loSpan) - 1;
+            uint32_t hiMask = ~((1L << (WordSize - hiSpan)) - 1);
             *loBucketAddr =
                 (*loBucketAddr & ~loMask) | ((bits >> hiSpan) & loMask);
             *hiBucketAddr =
                 (*hiBucketAddr & ~hiMask) | (bits << (WordSize - hiSpan));
         }
         else {
-            Word32* bucketAddr = (Word32*)p + wordOffset;
+            uint32_t* bucketAddr = (uint32_t*)p + wordOffset;
             int shift = WordSize - (bitOffset + span);
-            Word32 mask = ((span == 32) ? -1 : (1L << span) - 1) << shift;
+            uint32_t mask = ((span == 32) ? -1 : (1L << span) - 1) << shift;
             *bucketAddr = (*bucketAddr & ~mask) | ((bits << shift) & mask);
         }
     }
@@ -759,12 +759,12 @@ pOb Ob::becomeNew(pOb, Ctxt* ctxt) {
 }
 
 convertArgReturnPair Ob::convertActualArg(Ctxt*, Ob* actual) {
-    cnvArgRetPair.val = (Word32)actual;
+    cnvArgRetPair.val = (uint32_t)actual;
     cnvArgRetPair.failp = 0;
     return cnvArgRetPair;
 }
 
-Ob* Ob::convertActualRslt(Ctxt*, Word32 rslt) { return ((Ob*)rslt); }
+Ob* Ob::convertActualRslt(Ctxt*, uint32_t rslt) { return ((Ob*)rslt); }
 
 pOb Ob::isNullP() { return RBLFALSE; }
 
@@ -1187,7 +1187,7 @@ DEF("set-field", objectSetField, 5, 5) {
     CHECK(3, RblBool, indirect);
     CHECK_FIXNUM(4, bits);
     pOb rslt =
-        BASE(ARG(0))->setField(BOOLVAL(indirect), 0, start, span, (Word32)bits);
+        BASE(ARG(0))->setField(BOOLVAL(indirect), 0, start, span, (uint32_t)bits);
 
     return (rslt == INVALID ? PRIM_ERROR("invalid bit range") : rslt);
 }

--- a/rosette/src/RBLstring.cc
+++ b/rosette/src/RBLstring.cc
@@ -157,7 +157,7 @@ const char* RBLstring::asCstring() {
 Ob* RBLstring::subObject(int start, int n) {
     PROTECT_THIS(RBLstring);
     RBLstring* result = RBLstring::create(n + 1);
-    memcpy(&result->byte(0), &SELF->byte(start), n * sizeof(Byte));
+    memcpy(&result->byte(0), &SELF->byte(start), n * sizeof(uint8_t));
     result->byte(n) = 0;
     return result;
 }
@@ -487,16 +487,16 @@ DEF("string-split", stringSplit, 2, 3) {
 
 convertArgReturnPair RBLstring::convertActualArg(Ctxt* ctxt, Ob* obj) {
     if (typep(obj) == RBLTRUE) {
-        cnvArgRetPair.val = (Word32)(&((RBLstring*)obj)->byte(0));
+        cnvArgRetPair.val = (uint32_t)(&((RBLstring*)obj)->byte(0));
         cnvArgRetPair.failp = 0;
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 1;
     }
     return cnvArgRetPair;
 }
 
-Ob* RBLstring::convertActualRslt(Ctxt*, Word32 obj) {
+Ob* RBLstring::convertActualRslt(Ctxt*, uint32_t obj) {
     return (RBLstring::create((char*)obj));
 }

--- a/rosette/src/RblAtom.cc
+++ b/rosette/src/RblAtom.cc
@@ -174,11 +174,11 @@ const char* RblBool::asCstring() { return BOOLVAL(atom) ? "#t" : "#f"; }
 
 convertArgReturnPair RblBool::convertActualArg(Ctxt* ctxt, Ob* obj) {
     if (typep(obj)) {
-        cnvArgRetPair.val = (Word32)BOOLVAL(obj);
+        cnvArgRetPair.val = (uint32_t)BOOLVAL(obj);
         cnvArgRetPair.failp = 0;
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 1;
     }
     return cnvArgRetPair;
@@ -238,13 +238,13 @@ convertArgReturnPair Fixnum::convertActualArg(Ctxt* ctxt, Ob* obj) {
         cnvArgRetPair.failp = 0;
     }
     else {
-        cnvArgRetPair.val = (Word32)-1;
+        cnvArgRetPair.val = (uint32_t)-1;
         cnvArgRetPair.failp = 0;
     }
     return cnvArgRetPair;
 }
 
-Ob* Fixnum::convertActualRslt(Ctxt*, Word32 obj) { return FIXNUM(obj); }
+Ob* Fixnum::convertActualRslt(Ctxt*, uint32_t obj) { return FIXNUM(obj); }
 
 
 DEF("fxFormat:", fxFormat, 1, 1) {

--- a/rosette/src/Vm.cc
+++ b/rosette/src/Vm.cc
@@ -866,10 +866,10 @@ nextop:
     case opApplyPrimTag | NextOff | UnwindOn:
     case opApplyPrimTag | NextOn | UnwindOff:
     case opApplyPrimTag | NextOn | UnwindOn: {
-        Word16 ext = FETCH.word;
+        uint16_t ext = FETCH.word;
         unsigned p_num = WORD_OP_e0_op0(ext);
         if (p_num == 255) {
-            const Word16 ext1 = FETCH.word;
+            const uint16_t ext1 = FETCH.word;
             p_num = ext1;
         }
 
@@ -896,10 +896,10 @@ nextop:
     case opApplyPrimArg | NextOff | UnwindOn:
     case opApplyPrimArg | NextOn | UnwindOff:
     case opApplyPrimArg | NextOn | UnwindOn: {
-        Word16 ext = FETCH.word;
+        uint16_t ext = FETCH.word;
         unsigned p_num = WORD_OP_e0_op0(ext);
         if (p_num == 255) {
-            const Word16 ext1 = FETCH.word;
+            const uint16_t ext1 = FETCH.word;
             p_num = ext1;
         }
 
@@ -927,10 +927,10 @@ nextop:
     case opApplyPrimReg | NextOff | UnwindOn:
     case opApplyPrimReg | NextOn | UnwindOff:
     case opApplyPrimReg | NextOn | UnwindOn: {
-        Word16 ext = FETCH.word;
+        uint16_t ext = FETCH.word;
         unsigned p_num = WORD_OP_e0_op0(ext);
         if (p_num == 255) {
-            const Word16 ext1 = FETCH.word;
+            const uint16_t ext1 = FETCH.word;
             p_num = ext1;
         }
 
@@ -956,10 +956,10 @@ nextop:
     case opApplyCmd | NextOff | UnwindOn:
     case opApplyCmd | NextOn | UnwindOff:
     case opApplyCmd | NextOn | UnwindOn: {
-        Word16 ext = FETCH.word;
+        uint16_t ext = FETCH.word;
         unsigned p_num = WORD_OP_e0_op0(ext);
         if (p_num == 255) {
-            const Word16 ext1 = FETCH.word;
+            const uint16_t ext1 = FETCH.word;
             p_num = ext1;
         }
 
@@ -1577,8 +1577,8 @@ void VirtualMachine::initVmTables() {
         ASSIGN(litvec, elem(1), templat);
     }
 
-    static const Word16 StartLabel = 0;
-    static const Word16 ResumeLabel = 8;
+    static const uint16_t StartLabel = 0;
+    static const uint16_t ResumeLabel = 8;
     int dummy = 0;
 
     /*  0 */ cb->emitF6(opOutstanding, ResumeLabel);

--- a/rosette/src/rbl-rosy.cc
+++ b/rosette/src/rbl-rosy.cc
@@ -478,7 +478,7 @@ DEF("M-set", addressSetField, 3, 3) {
     if (base < local_page_size)
         PRIM_ERROR("invalid address");
     else {
-        pOb rslt = BASE((pOb)addr)->setField(0, 0, offset, span, (Word32)val);
+        pOb rslt = BASE((pOb)addr)->setField(0, 0, offset, span, (uint32_t)val);
 
         return (rslt == INVALID ? PRIM_ERROR("invalid bit range") : rslt);
     }


### PR DESCRIPTION
... in favor of c++11 standard types uint8_t, uint16_t, and uint32_t.

https://rchain.atlassian.net/browse/ROS-298
