### PR TITLE
Add OpOutstanding

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
@@ -92,7 +92,25 @@ case class Ctxt(tag: Location,
 }
 
 object Ctxt {
-  def apply(tuple: Option[Tuple], ctxt: Ctxt): Ctxt = PLACEHOLDER
+  def apply(tuple: Option[Tuple], ctxt: Ctxt): Ctxt = {
+    val t = tuple.getOrElse(Tuple.Placeholder)
+    Ctxt(
+      tag = LocRslt,
+      nargs = t.elem.size,
+      outstanding = 0,
+      pc = PC(0),
+      rslt = Ob.NIV,
+      trgt = Ob.NIV,
+      argvec = t,
+      env = ctxt.env,
+      code = ctxt.code,
+      ctxt = ctxt,
+      self2 = ctxt.self2,
+      selfEnv = ctxt.selfEnv,
+      rcvr = ctxt.rcvr,
+      monitor = ctxt.monitor
+    )
+  }
 
   def apply(trgt: Ob, argvec: Tuple): Ctxt = PLACEHOLDER
 

--- a/roscala/src/main/scala/coop/rchain/rosette/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Location.scala
@@ -320,7 +320,6 @@ object Location {
   def ArgReg(n: Int): Location = {
     if (n > MaxArgs) {
       suicide(s"Location.ArgReg: invalid arg register index ($n)")
-      null
     }
 
     LocationGT(LTArgRegister(n))

--- a/roscala/src/main/scala/coop/rchain/rosette/Op.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Op.scala
@@ -4,13 +4,13 @@ sealed trait Op
 case class OpHalt() extends Op
 case class OpPush() extends Op
 case class OpPop() extends Op
-case class OpNargs(n: Int) extends Op
+case class OpNargs(nargs: Int) extends Op
 case class OpAlloc(n: Int) extends Op
 case class OpPushAlloc(n: Int) extends Op
-case class OpExtend(v: Int) extends Op
+case class OpExtend(lit: Int) extends Op
 case class OpOutstanding(pc: Int, n: Int) extends Op
 case class OpFork(pc: Int) extends Op
-case class OpXmitTag(unwind: Boolean, next: Boolean, nargs: Int, v: Int)
+case class OpXmitTag(unwind: Boolean, next: Boolean, nargs: Int, lit: Int)
     extends Op
 case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)
     extends Op
@@ -44,32 +44,34 @@ case class OpApplyPrimReg(unwind: Boolean,
     extends Op
 case class OpApplyCmd(unwind: Boolean, next: Boolean, nargs: Int, primNum: Int)
     extends Op
-case class OpRtnTag(n: Boolean, v: Int) extends Op
-case class OpRtnArg(n: Boolean, arg: Int) extends Op
-case class OpRtnReg(n: Boolean, reg: Int) extends Op
-case class OpRtn(n: Boolean) extends Op
-case class OpUpcallRtn(n: Boolean, v: Int) extends Op
+case class OpRtnTag(next: Boolean, lit: Int) extends Op
+case class OpRtnArg(next: Boolean, arg: Int) extends Op
+case class OpRtnReg(next: Boolean, reg: Int) extends Op
+case class OpRtn(next: Boolean) extends Op
+case class OpUpcallRtn(next: Boolean, lit: Int) extends Op
 case class OpUpcallResume() extends Op
 case class OpNxt() extends Op
 case class OpJmp(pc: Int) extends Op
 case class OpJmpFalse(pc: Int) extends Op
-case class OpJmpCut(pc: Int, m: Int) extends Op
-case class OpLookupToArg(arg: Int, v: Int) extends Op
-case class OpLookupToReg(reg: Int, v: Int) extends Op
-case class OpXferLexToArg(i: Boolean, l: Int, o: Int, arg: Int) extends Op
-case class OpXferLexToReg(i: Boolean, l: Int, o: Int, reg: Int) extends Op
-case class OpXferGlobalToArg(arg: Int, g: Int) extends Op
-case class OpXferGlobalToReg(reg: Int, g: Int) extends Op
+case class OpJmpCut(pc: Int, cut: Int) extends Op
+case class OpLookupToArg(arg: Int, lit: Int) extends Op
+case class OpLookupToReg(reg: Int, lit: Int) extends Op
+case class OpXferLexToArg(indirect: Boolean, level: Int, offset: Int, arg: Int)
+    extends Op
+case class OpXferLexToReg(indirect: Boolean, level: Int, offset: Int, reg: Int)
+    extends Op
+case class OpXferGlobalToArg(arg: Int, global: Int) extends Op
+case class OpXferGlobalToReg(reg: Int, global: Int) extends Op
 case class OpXferArgToArg(dest: Int, src: Int) extends Op
 case class OpXferRsltToArg(arg: Int) extends Op
 case class OpXferArgToRslt(arg: Int) extends Op
 case class OpXferRsltToReg(reg: Int) extends Op
 case class OpXferRegToRslt(reg: Int) extends Op
-case class OpXferRsltToDest(v: Int) extends Op
-case class OpXferSrcToRslt(v: Int) extends Op
+case class OpXferRsltToDest(lit: Int) extends Op
+case class OpXferSrcToRslt(lit: Int) extends Op
 case class OpIndLitToArg(arg: Int, lit: Int) extends Op
-case class OpIndLitToReg(r: Int, lit: Int) extends Op
-case class OpIndLitToRslt(v: Int) extends Op
+case class OpIndLitToReg(reg: Int, lit: Int) extends Op
+case class OpIndLitToRslt(lit: Int) extends Op
 case class OpImmediateLitToArg(value: Int, arg: Int) extends Op
 case class OpImmediateLitToReg(lit: Int, reg: Int) extends Op
 case class OpUnknown() extends Op

--- a/roscala/src/main/scala/coop/rchain/rosette/Op.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Op.scala
@@ -11,9 +11,9 @@ case class OpExtend(v: Int) extends Op
 case class OpOutstanding(pc: Int, n: Int) extends Op
 case class OpFork(p: Int) extends Op
 case class OpXmitTag(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
-case class OpXmitArg(u: Boolean, n: Boolean, m: Int, arg: Int) extends Op
+case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int) extends Op
 case class OpXmitReg(u: Boolean, n: Boolean, m: Int, r: Int) extends Op
-case class OpXmit(u: Boolean, n: Boolean, m: Int) extends Op
+case class OpXmit(unwind: Boolean, next: Boolean, nargs: Int) extends Op
 case class OpXmitTagXtnd(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
 case class OpXmitArgXtnd(u: Boolean, n: Boolean, m: Int, a: Int) extends Op
 case class OpXmitRegXtnd(u: Boolean, n: Boolean, m: Int, r: Int) extends Op

--- a/roscala/src/main/scala/coop/rchain/rosette/Op.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Op.scala
@@ -4,59 +4,60 @@ sealed trait Op
 case class OpHalt() extends Op
 case class OpPush() extends Op
 case class OpPop() extends Op
-case class OpNargs(next: Int) extends Op
-case class OpAlloc(next: Int) extends Op
-case class OpPushAlloc(next: Int) extends Op
+case class OpNargs(n: Int) extends Op
+case class OpAlloc(n: Int) extends Op
+case class OpPushAlloc(n: Int) extends Op
 case class OpExtend(v: Int) extends Op
 case class OpOutstanding(pc: Int, n: Int) extends Op
 case class OpFork(pc: Int) extends Op
-case class OpXmitTag(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
+case class OpXmitTag(unwind: Boolean, next: Boolean, nargs: Int, v: Int)
+    extends Op
 case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)
     extends Op
 case class OpXmitReg(unwind: Boolean, next: Boolean, nargs: Int, reg: Int)
     extends Op
 case class OpXmit(unwind: Boolean, next: Boolean, nargs: Int) extends Op
-case class OpXmitTagXtnd(unwind: Boolean, next: Boolean, nargs: Int, v: Int)
+case class OpXmitTagXtnd(unwind: Boolean, next: Boolean, nargs: Int, lit: Int)
     extends Op
 case class OpXmitArgXtnd(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)
     extends Op
 case class OpXmitRegXtnd(unwind: Boolean, next: Boolean, nargs: Int, reg: Int)
     extends Op
-case class OpSend(u: Boolean, n: Boolean, m: Int) extends Op
+case class OpSend(unwind: Boolean, next: Boolean, nargs: Int) extends Op
 case class OpApplyPrimTag(unwind: Boolean,
                           next: Boolean,
                           nargs: Int,
-                          k: Int,
-                          v: Int)
+                          primNum: Int,
+                          lit: Int)
     extends Op
 case class OpApplyPrimArg(unwind: Boolean,
                           next: Boolean,
                           nargs: Int,
-                          k: Int,
-                          a: Int)
+                          primNum: Int,
+                          arg: Int)
     extends Op
 case class OpApplyPrimReg(unwind: Boolean,
                           next: Boolean,
                           nargs: Int,
-                          k: Int,
-                          r: Int)
+                          primNum: Int,
+                          reg: Int)
     extends Op
-case class OpApplyCmd(unwind: Boolean, next: Boolean, nargs: Int, k: Int)
+case class OpApplyCmd(unwind: Boolean, next: Boolean, nargs: Int, primNum: Int)
     extends Op
-case class OpRtnTag(next: Boolean, v: Int) extends Op
-case class OpRtnArg(next: Boolean, arg: Int) extends Op
-case class OpRtnReg(next: Boolean, reg: Int) extends Op
-case class OpRtn(next: Boolean) extends Op
-case class OpUpcallRtn(next: Boolean, v: Int) extends Op
+case class OpRtnTag(n: Boolean, v: Int) extends Op
+case class OpRtnArg(n: Boolean, arg: Int) extends Op
+case class OpRtnReg(n: Boolean, reg: Int) extends Op
+case class OpRtn(n: Boolean) extends Op
+case class OpUpcallRtn(n: Boolean, v: Int) extends Op
 case class OpUpcallResume() extends Op
 case class OpNxt() extends Op
-case class OpJmp(next: Int) extends Op
-case class OpJmpFalse(next: Int) extends Op
-case class OpJmpCut(next: Int, m: Int) extends Op
+case class OpJmp(pc: Int) extends Op
+case class OpJmpFalse(pc: Int) extends Op
+case class OpJmpCut(pc: Int, m: Int) extends Op
 case class OpLookupToArg(arg: Int, v: Int) extends Op
 case class OpLookupToReg(reg: Int, v: Int) extends Op
-case class OpXferLexToArg(i: Boolean, l: Int, o: Int, a: Int) extends Op
-case class OpXferLexToReg(i: Boolean, l: Int, o: Int, r: Int) extends Op
+case class OpXferLexToArg(i: Boolean, l: Int, o: Int, arg: Int) extends Op
+case class OpXferLexToReg(i: Boolean, l: Int, o: Int, reg: Int) extends Op
 case class OpXferGlobalToArg(arg: Int, g: Int) extends Op
 case class OpXferGlobalToReg(reg: Int, g: Int) extends Op
 case class OpXferArgToArg(dest: Int, src: Int) extends Op
@@ -66,9 +67,9 @@ case class OpXferRsltToReg(reg: Int) extends Op
 case class OpXferRegToRslt(reg: Int) extends Op
 case class OpXferRsltToDest(v: Int) extends Op
 case class OpXferSrcToRslt(v: Int) extends Op
-case class OpIndLitToArg(arg: Int, v: Int) extends Op
-case class OpIndLitToReg(r: Int, v: Int) extends Op
+case class OpIndLitToArg(arg: Int, lit: Int) extends Op
+case class OpIndLitToReg(r: Int, lit: Int) extends Op
 case class OpIndLitToRslt(v: Int) extends Op
 case class OpImmediateLitToArg(value: Int, arg: Int) extends Op
-case class OpImmediateLitToReg(v: Int, reg: Int) extends Op
+case class OpImmediateLitToReg(lit: Int, reg: Int) extends Op
 case class OpUnknown() extends Op

--- a/roscala/src/main/scala/coop/rchain/rosette/Op.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Op.scala
@@ -8,10 +8,10 @@ case class OpNargs(n: Int) extends Op
 case class OpAlloc(n: Int) extends Op
 case class OpPushAlloc(n: Int) extends Op
 case class OpExtend(v: Int) extends Op
-case class OpOutstanding(p: Int, n: Int) extends Op
+case class OpOutstanding(pc: Int, n: Int) extends Op
 case class OpFork(p: Int) extends Op
 case class OpXmitTag(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
-case class OpXmitArg(u: Boolean, n: Boolean, m: Int, a: Int) extends Op
+case class OpXmitArg(u: Boolean, n: Boolean, m: Int, arg: Int) extends Op
 case class OpXmitReg(u: Boolean, n: Boolean, m: Int, r: Int) extends Op
 case class OpXmit(u: Boolean, n: Boolean, m: Int) extends Op
 case class OpXmitTagXtnd(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
@@ -51,6 +51,6 @@ case class OpXferSrcToRslt(v: Int) extends Op
 case class OpIndLitToArg(a: Int, v: Int) extends Op
 case class OpIndLitToReg(r: Int, v: Int) extends Op
 case class OpIndLitToRslt(v: Int) extends Op
-case class OpImmediateLitToArg(v: Int, a: Int) extends Op
+case class OpImmediateLitToArg(value: Int, arg: Int) extends Op
 case class OpImmediateLitToReg(v: Int, r: Int) extends Op
 case class OpUnknown() extends Op

--- a/roscala/src/main/scala/coop/rchain/rosette/Op.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Op.scala
@@ -4,53 +4,71 @@ sealed trait Op
 case class OpHalt() extends Op
 case class OpPush() extends Op
 case class OpPop() extends Op
-case class OpNargs(n: Int) extends Op
-case class OpAlloc(n: Int) extends Op
-case class OpPushAlloc(n: Int) extends Op
+case class OpNargs(next: Int) extends Op
+case class OpAlloc(next: Int) extends Op
+case class OpPushAlloc(next: Int) extends Op
 case class OpExtend(v: Int) extends Op
 case class OpOutstanding(pc: Int, n: Int) extends Op
-case class OpFork(p: Int) extends Op
+case class OpFork(pc: Int) extends Op
 case class OpXmitTag(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
-case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int) extends Op
-case class OpXmitReg(u: Boolean, n: Boolean, m: Int, r: Int) extends Op
+case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)
+    extends Op
+case class OpXmitReg(unwind: Boolean, next: Boolean, nargs: Int, reg: Int)
+    extends Op
 case class OpXmit(unwind: Boolean, next: Boolean, nargs: Int) extends Op
-case class OpXmitTagXtnd(u: Boolean, n: Boolean, m: Int, v: Int) extends Op
-case class OpXmitArgXtnd(u: Boolean, n: Boolean, m: Int, a: Int) extends Op
-case class OpXmitRegXtnd(u: Boolean, n: Boolean, m: Int, r: Int) extends Op
+case class OpXmitTagXtnd(unwind: Boolean, next: Boolean, nargs: Int, v: Int)
+    extends Op
+case class OpXmitArgXtnd(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)
+    extends Op
+case class OpXmitRegXtnd(unwind: Boolean, next: Boolean, nargs: Int, reg: Int)
+    extends Op
 case class OpSend(u: Boolean, n: Boolean, m: Int) extends Op
-case class OpApplyPrimTag(u: Boolean, n: Boolean, m: Int, k: Int, v: Int)
+case class OpApplyPrimTag(unwind: Boolean,
+                          next: Boolean,
+                          nargs: Int,
+                          k: Int,
+                          v: Int)
     extends Op
-case class OpApplyPrimArg(u: Boolean, n: Boolean, m: Int, k: Int, a: Int)
+case class OpApplyPrimArg(unwind: Boolean,
+                          next: Boolean,
+                          nargs: Int,
+                          k: Int,
+                          a: Int)
     extends Op
-case class OpApplyPrimReg(u: Boolean, n: Boolean, m: Int, k: Int, r: Int)
+case class OpApplyPrimReg(unwind: Boolean,
+                          next: Boolean,
+                          nargs: Int,
+                          k: Int,
+                          r: Int)
     extends Op
-case class OpApplyCmd(u: Boolean, n: Boolean, m: Int, k: Int) extends Op
-case class OpRtnTag(n: Boolean, v: Int) extends Op
-case class OpRtnArg(n: Boolean, a: Int) extends Op
-case class OpRtnReg(n: Boolean, r: Int) extends Op
-case class OpRtn(n: Boolean) extends Op
-case class OpUpcallRtn(n: Boolean, v: Int) extends Op
+case class OpApplyCmd(unwind: Boolean, next: Boolean, nargs: Int, k: Int)
+    extends Op
+case class OpRtnTag(next: Boolean, v: Int) extends Op
+case class OpRtnArg(next: Boolean, arg: Int) extends Op
+case class OpRtnReg(next: Boolean, reg: Int) extends Op
+case class OpRtn(next: Boolean) extends Op
+case class OpUpcallRtn(next: Boolean, v: Int) extends Op
 case class OpUpcallResume() extends Op
 case class OpNxt() extends Op
-case class OpJmp(n: Int) extends Op
-case class OpJmpFalse(n: Int) extends Op
-case class OpJmpCut(n: Int, m: Int) extends Op
-case class OpLookupToArg(a: Int, v: Int) extends Op
-case class OpLookupToReg(r: Int, v: Int) extends Op
+case class OpJmp(next: Int) extends Op
+case class OpJmpFalse(next: Int) extends Op
+case class OpJmpCut(next: Int, m: Int) extends Op
+case class OpLookupToArg(arg: Int, v: Int) extends Op
+case class OpLookupToReg(reg: Int, v: Int) extends Op
 case class OpXferLexToArg(i: Boolean, l: Int, o: Int, a: Int) extends Op
 case class OpXferLexToReg(i: Boolean, l: Int, o: Int, r: Int) extends Op
-case class OpXferGlobalToArg(a: Int, g: Int) extends Op
-case class OpXferGlobalToReg(r: Int, g: Int) extends Op
-case class OpXferArgToArg(d: Int, s: Int) extends Op
-case class OpXferRsltToArg(a: Int) extends Op
-case class OpXferArgToRslt(a: Int) extends Op
-case class OpXferRsltToReg(r: Int) extends Op
-case class OpXferRegToRslt(r: Int) extends Op
+case class OpXferGlobalToArg(arg: Int, g: Int) extends Op
+case class OpXferGlobalToReg(reg: Int, g: Int) extends Op
+case class OpXferArgToArg(dest: Int, src: Int) extends Op
+case class OpXferRsltToArg(arg: Int) extends Op
+case class OpXferArgToRslt(arg: Int) extends Op
+case class OpXferRsltToReg(reg: Int) extends Op
+case class OpXferRegToRslt(reg: Int) extends Op
 case class OpXferRsltToDest(v: Int) extends Op
 case class OpXferSrcToRslt(v: Int) extends Op
-case class OpIndLitToArg(a: Int, v: Int) extends Op
+case class OpIndLitToArg(arg: Int, v: Int) extends Op
 case class OpIndLitToReg(r: Int, v: Int) extends Op
 case class OpIndLitToRslt(v: Int) extends Op
 case class OpImmediateLitToArg(value: Int, arg: Int) extends Op
-case class OpImmediateLitToReg(v: Int, r: Int) extends Op
+case class OpImmediateLitToReg(v: Int, reg: Int) extends Op
 case class OpUnknown() extends Op

--- a/roscala/src/main/scala/coop/rchain/rosette/PC.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/PC.scala
@@ -6,5 +6,4 @@ case class PC(relative: Int) {
 
 object PC {
   object PLACEHOLDER extends PC(0)
-  def fromInt(i: Int): PC = PLACEHOLDER
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
@@ -12,6 +12,12 @@ case object AbsentRest extends TupleError
 case object InvalidRest extends TupleError
 
 case class Tuple(elem: Seq[Ob]) extends Ob {
+  //TODO revisit
+  val metaTup: Ob = Ob.INVALID
+  val sboTup: Ob = Ob.INVALID
+
+  override val slot: Seq[Ob] = metaTup +: sboTup +: elem
+
   def accepts(msg: Ctxt): Boolean =
     if (this == Tuple.NIL) {
       true
@@ -116,11 +122,12 @@ case class Tuple(elem: Seq[Ob]) extends Ob {
 
 object Tuple {
 
-  object NIL extends Tuple(null)
+  object NIL extends Tuple(Seq.empty)
 
-  val Placeholder = new Tuple(Seq())
+  val Placeholder = Tuple(Seq.empty)
 
-  def apply(init: Ob) = new Tuple(Seq(init))
+  def apply(init: Ob): Tuple =
+    Tuple(Seq(init))
 
   def apply(t1: Tuple, t2: Tuple): Tuple =
     new Tuple(t1.elem ++ t2.elem)
@@ -144,7 +151,7 @@ object Tuple {
   def apply(a: Int, b: Ob): Tuple = new Tuple(Seq.fill(a)(b))
 
   def apply(a: Int, b: Option[Ob]): Tuple =
-    new Tuple(null)
+    Tuple(Seq.fill(a)(b getOrElse Ob.INVALID))
 
   def cons(ob: Ob, t: Tuple): Tuple =
     new Tuple(ob +: t.elem)

--- a/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Tuple.scala
@@ -12,11 +12,6 @@ case object AbsentRest extends TupleError
 case object InvalidRest extends TupleError
 
 case class Tuple(elem: Seq[Ob]) extends Ob {
-  //TODO revisit
-  val metaTup: Ob = Ob.INVALID
-  val sboTup: Ob = Ob.INVALID
-
-  override val slot: Seq[Ob] = metaTup +: sboTup +: elem
 
   def accepts(msg: Ctxt): Boolean =
     if (this == Tuple.NIL) {

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -427,9 +427,9 @@ object VirtualMachine {
 
   def execute(op: OpXmitArg, state: VMState): VMState =
     state
-      .set(_ >> 'ctxt >> 'nargs)(op.m)
+      .set(_ >> 'ctxt >> 'nargs)(op.nargs)
       .set(_ >> 'ctxt >> 'tag)(Location.ArgReg(op.arg))
-      .set(_ >> 'xmitData)((op.u, op.n))
+      .set(_ >> 'xmitData)((op.unwind, op.next))
       .set(_ >> 'doXmitFlag)(true)
 
   def execute(op: OpXmitReg, state: VMState): VMState =
@@ -441,8 +441,8 @@ object VirtualMachine {
 
   def execute(op: OpXmit, state: VMState): VMState =
     state
-      .set(_ >> 'ctxt >> 'nargs)(op.m)
-      .set(_ >> 'xmitData)((op.u, op.n))
+      .set(_ >> 'ctxt >> 'nargs)(op.nargs)
+      .set(_ >> 'xmitData)((op.unwind, op.next))
       .set(_ >> 'doXmitFlag)(true)
 
   def execute(op: OpXmitTagXtnd, state: VMState): VMState =

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -410,7 +410,7 @@ object VirtualMachine {
 
   def execute(op: OpOutstanding, state: VMState): VMState =
     state
-      .set(_ >> 'ctxt >> 'pc)(PC.fromInt(op.p))
+      .set(_ >> 'ctxt >> 'pc)(PC(op.pc))
       .set(_ >> 'ctxt >> 'outstanding)(op.n)
 
   def execute(op: OpFork, state: VMState): VMState = {
@@ -428,7 +428,7 @@ object VirtualMachine {
   def execute(op: OpXmitArg, state: VMState): VMState =
     state
       .set(_ >> 'ctxt >> 'nargs)(op.m)
-      .set(_ >> 'ctxt >> 'tag)(Location.ArgReg(op.a))
+      .set(_ >> 'ctxt >> 'tag)(Location.ArgReg(op.arg))
       .set(_ >> 'xmitData)((op.u, op.n))
       .set(_ >> 'doXmitFlag)(true)
 
@@ -814,7 +814,7 @@ object VirtualMachine {
 
   def execute(op: OpImmediateLitToArg, state: VMState): VMState =
     state.update(_ >> 'ctxt >> 'argvec >> 'elem)(
-      _.updated(op.a, vmLiterals(op.v)))
+      _.updated(op.arg, vmLiterals(op.value)))
 
   def execute(op: OpImmediateLitToReg, state: VMState): VMState =
     setCtxtReg(op.r, vmLiterals(op.v))(state)

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -6,7 +6,6 @@ import coop.rchain.rosette.expr.{LetExpr, TupleExpr}
 import org.scalatest._
 
 class TransitionSpec extends FlatSpec with Matchers {
-  val t = Tuple.apply(Ob.NIV)
   val testCtxt = Ctxt(
     tag = LocationGT(Location.LTCtxtRegister(0)),
     nargs = 1,
@@ -40,8 +39,6 @@ class TransitionSpec extends FlatSpec with Matchers {
 
   val globalEnv = Seq.fill(669)(Ob.NIV).updated(668, stdOprnPlus)
 
-  val xferGlobalToReg_plus = OpXferGlobalToReg(r = 1, g = 668)
-
   "Executing bytecode from expression \"(if #t 1 2)\"" should "result in state.ctxt.rslt == Fixnum(1)" in {
 
     /**
@@ -61,12 +58,12 @@ class TransitionSpec extends FlatSpec with Matchers {
         .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
         .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
 
-    val codevec = Seq(OpImmediateLitToReg(v = 8, r = 0),
+    val codevec = Seq(OpImmediateLitToReg(v = 8, reg = 0),
                       OpJmpFalse(4),
-                      OpImmediateLitToReg(v = 1, r = 0),
-                      OpRtn(n = true),
-                      OpImmediateLitToReg(v = 2, r = 0),
-                      OpRtn(n = true))
+                      OpImmediateLitToReg(v = 1, reg = 0),
+                      OpRtn(next = true),
+                      OpImmediateLitToReg(v = 2, reg = 0),
+                      OpRtn(next = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(1)
@@ -91,12 +88,12 @@ class TransitionSpec extends FlatSpec with Matchers {
         .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
         .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
 
-    val codevec = Seq(OpImmediateLitToReg(v = 9, r = 0),
+    val codevec = Seq(OpImmediateLitToReg(v = 9, reg = 0),
                       OpJmpFalse(4),
-                      OpImmediateLitToReg(v = 1, r = 0),
-                      OpRtn(n = true),
-                      OpImmediateLitToReg(v = 2, r = 0),
-                      OpRtn(n = true))
+                      OpImmediateLitToReg(v = 1, reg = 0),
+                      OpRtn(next = true),
+                      OpImmediateLitToReg(v = 2, reg = 0),
+                      OpRtn(next = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(2)
@@ -122,7 +119,7 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(OpAlloc(2),
                       OpImmediateLitToArg(value = 1, arg = 0),
                       OpImmediateLitToArg(value = 2, arg = 1),
-                      xferGlobalToReg_plus,
+                      OpXferGlobalToReg(reg = 1, g = 668),
                       OpXmit(unwind = false, next = true, 2))
 
     val end = VirtualMachine.executeSeq(codevec, start)
@@ -155,12 +152,12 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 9, n = 1),
-      OpPushAlloc(n = 2),
+      OpPushAlloc(next = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
       OpImmediateLitToArg(value = 3, arg = 1),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmit(unwind = false, next = true, nargs = 2)
     )
@@ -199,16 +196,16 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 14, n = 1),
-      OpPushAlloc(n = 2),
+      OpPushAlloc(next = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 13, n = 1),
-      OpPushAlloc(n = 2),
+      OpPushAlloc(next = 2),
       OpImmediateLitToArg(value = 3, arg = 0),
       OpImmediateLitToArg(value = 4, arg = 1),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmit(unwind = false, next = true, nargs = 2)
@@ -257,7 +254,7 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpAlloc(2),
       OpXferLexToArg(i = false, l = 0, o = 0, a = 0),
       OpXferLexToArg(i = false, l = 0, o = 1, a = 1),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpXmit(unwind = false, next = true, 2)
     )
 
@@ -293,12 +290,12 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
       OpImmediateLitToArg(value = 2, arg = 1),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpXmit(unwind = false, next = true, 2),
       OpAlloc(2),
       OpImmediateLitToArg(value = 3, arg = 0),
       OpImmediateLitToArg(value = 4, arg = 1),
-      xferGlobalToReg_plus,
+      OpXferGlobalToReg(reg = 1, g = 668),
       OpXmit(unwind = false, next = true, 2)
     )
 

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -5,6 +5,11 @@ import coop.rchain.rosette.Meta.StdMeta
 import coop.rchain.rosette.expr.{LetExpr, TupleExpr}
 import org.scalatest._
 
+/**
+  * NOTE that in Roscala we are using one-byte offset for every opcode,
+  * so PC will change per unit for every opcode
+  *
+ */
 class TransitionSpec extends FlatSpec with Matchers {
   val testCtxt = Ctxt(
     tag = LocationGT(Location.LTCtxtRegister(0)),
@@ -129,20 +134,19 @@ class TransitionSpec extends FlatSpec with Matchers {
   "Executing bytecode from expression \"(+ 1 (+ 2 3))\"" should "result in Fixnum(6)" in {
 
     /**
-      *
       * litvec:
       *  0:   {RequestExpr}
       * codevec:
       *  0:   alloc 2
       *  1:   lit 1,arg[0]
       *  2:   xfer global[+],trgt
-      *  3:   outstanding 12,1
-      *  4:   push/alloc 2
-      *  5:   lit 2,arg[0]
-      *  6:   lit 3,arg[1]
-      *  7:   xfer global[+],trgt
-      *  8:   xmit/nxt 2,arg[1]
-      *  9:   xmit/nxt 2
+      *  4:   outstanding 12,1
+      *  6:   push/alloc 2
+      *  7:   lit 2,arg[0]
+      *  8:   lit 3,arg[1]
+      *  9:   xfer global[+],trgt
+      *  11:  xmit/nxt 2,arg[1]
+      *  12:  xmit/nxt 2
       */
     val start =
       testState
@@ -175,18 +179,18 @@ class TransitionSpec extends FlatSpec with Matchers {
       *  0:   alloc 2
       *  1:   lit 1,arg[0]
       *  2:   xfer global[+],trgt
-      *  3:   outstanding 14,1
-      *  4:   push/alloc 2
-      *  5:   lit 2,arg[0]
-      *  6:   xfer global[+],trgt
-      *  7:   outstanding 13,1
-      *  8:   push/alloc 2
-      *  9:   lit 3,arg[0]
-      * 10:   lit 4,arg[1]
-      * 11:   xfer global[+],trgt
-      * 12:   xmit/nxt 2,arg[1]
-      * 13:   xmit/nxt 2,arg[1]
-      * 14:   xmit/nxt 2
+      *  4:   outstanding 14,1
+      *  6:   push/alloc 2
+      *  7:   lit 2,arg[0]
+      *  8:   xfer global[+],trgt
+      * 10:   outstanding 13,1
+      * 12:   push/alloc 2
+      * 13:   lit 3,arg[0]
+      * 14:   lit 4,arg[1]
+      * 15:   xfer global[+],trgt
+      * 17:   xmit/nxt 2,arg[1]
+      * 18:   xmit/nxt 2,arg[1]
+      * 19:   xmit/nxt 2
       */
     val start =
       testState

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -58,12 +58,12 @@ class TransitionSpec extends FlatSpec with Matchers {
         .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
         .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
 
-    val codevec = Seq(OpImmediateLitToReg(v = 8, reg = 0),
+    val codevec = Seq(OpImmediateLitToReg(lit = 8, reg = 0),
                       OpJmpFalse(4),
-                      OpImmediateLitToReg(v = 1, reg = 0),
-                      OpRtn(next = true),
-                      OpImmediateLitToReg(v = 2, reg = 0),
-                      OpRtn(next = true))
+                      OpImmediateLitToReg(lit = 1, reg = 0),
+                      OpRtn(n = true),
+                      OpImmediateLitToReg(lit = 2, reg = 0),
+                      OpRtn(n = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(1)
@@ -88,12 +88,12 @@ class TransitionSpec extends FlatSpec with Matchers {
         .set(_ >> 'ctxt >> 'ctxt >> 'outstanding)(1)
         .set(_ >> 'ctxt >> 'ctxt >> 'pc)(PC(6)) // Setting pc to 6 so that the VM halts after strand is installed
 
-    val codevec = Seq(OpImmediateLitToReg(v = 9, reg = 0),
+    val codevec = Seq(OpImmediateLitToReg(lit = 9, reg = 0),
                       OpJmpFalse(4),
-                      OpImmediateLitToReg(v = 1, reg = 0),
-                      OpRtn(next = true),
-                      OpImmediateLitToReg(v = 2, reg = 0),
-                      OpRtn(next = true))
+                      OpImmediateLitToReg(lit = 1, reg = 0),
+                      OpRtn(n = true),
+                      OpImmediateLitToReg(lit = 2, reg = 0),
+                      OpRtn(n = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(2)
@@ -154,7 +154,7 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpImmediateLitToArg(value = 1, arg = 0),
       OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 9, n = 1),
-      OpPushAlloc(next = 2),
+      OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
       OpImmediateLitToArg(value = 3, arg = 1),
       OpXferGlobalToReg(reg = 1, g = 668),
@@ -198,11 +198,11 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpImmediateLitToArg(value = 1, arg = 0),
       OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 14, n = 1),
-      OpPushAlloc(next = 2),
+      OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
       OpXferGlobalToReg(reg = 1, g = 668),
       OpOutstanding(pc = 13, n = 1),
-      OpPushAlloc(next = 2),
+      OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 3, arg = 0),
       OpImmediateLitToArg(value = 4, arg = 1),
       OpXferGlobalToReg(reg = 1, g = 668),
@@ -252,8 +252,8 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpNargs(2),
       OpExtend(1),
       OpAlloc(2),
-      OpXferLexToArg(i = false, l = 0, o = 0, a = 0),
-      OpXferLexToArg(i = false, l = 0, o = 1, a = 1),
+      OpXferLexToArg(i = false, l = 0, o = 0, arg = 0),
+      OpXferLexToArg(i = false, l = 0, o = 1, arg = 1),
       OpXferGlobalToReg(reg = 1, g = 668),
       OpXmit(unwind = false, next = true, 2)
     )

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -61,9 +61,9 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(OpImmediateLitToReg(lit = 8, reg = 0),
                       OpJmpFalse(4),
                       OpImmediateLitToReg(lit = 1, reg = 0),
-                      OpRtn(n = true),
+                      OpRtn(next = true),
                       OpImmediateLitToReg(lit = 2, reg = 0),
-                      OpRtn(n = true))
+                      OpRtn(next = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(1)
@@ -91,9 +91,9 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(OpImmediateLitToReg(lit = 9, reg = 0),
                       OpJmpFalse(4),
                       OpImmediateLitToReg(lit = 1, reg = 0),
-                      OpRtn(n = true),
+                      OpRtn(next = true),
                       OpImmediateLitToReg(lit = 2, reg = 0),
-                      OpRtn(n = true))
+                      OpRtn(next = true))
 
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.rslt shouldBe Fixnum(2)
@@ -119,7 +119,7 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(OpAlloc(2),
                       OpImmediateLitToArg(value = 1, arg = 0),
                       OpImmediateLitToArg(value = 2, arg = 1),
-                      OpXferGlobalToReg(reg = 1, g = 668),
+                      OpXferGlobalToReg(reg = 1, global = 668),
                       OpXmit(unwind = false, next = true, 2))
 
     val end = VirtualMachine.executeSeq(codevec, start)
@@ -152,12 +152,12 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpOutstanding(pc = 9, n = 1),
       OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
       OpImmediateLitToArg(value = 3, arg = 1),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmit(unwind = false, next = true, nargs = 2)
     )
@@ -196,16 +196,16 @@ class TransitionSpec extends FlatSpec with Matchers {
     val codevec = Seq(
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpOutstanding(pc = 14, n = 1),
       OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 2, arg = 0),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpOutstanding(pc = 13, n = 1),
       OpPushAlloc(n = 2),
       OpImmediateLitToArg(value = 3, arg = 0),
       OpImmediateLitToArg(value = 4, arg = 1),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmitArg(unwind = false, next = true, nargs = 2, arg = 1),
       OpXmit(unwind = false, next = true, nargs = 2)
@@ -252,9 +252,9 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpNargs(2),
       OpExtend(1),
       OpAlloc(2),
-      OpXferLexToArg(i = false, l = 0, o = 0, arg = 0),
-      OpXferLexToArg(i = false, l = 0, o = 1, arg = 1),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferLexToArg(indirect = false, level = 0, offset = 0, arg = 0),
+      OpXferLexToArg(indirect = false, level = 0, offset = 1, arg = 1),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpXmit(unwind = false, next = true, 2)
     )
 
@@ -290,12 +290,12 @@ class TransitionSpec extends FlatSpec with Matchers {
       OpAlloc(2),
       OpImmediateLitToArg(value = 1, arg = 0),
       OpImmediateLitToArg(value = 2, arg = 1),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpXmit(unwind = false, next = true, 2),
       OpAlloc(2),
       OpImmediateLitToArg(value = 3, arg = 0),
       OpImmediateLitToArg(value = 4, arg = 1),
-      OpXferGlobalToReg(reg = 1, g = 668),
+      OpXferGlobalToReg(reg = 1, global = 668),
       OpXmit(unwind = false, next = true, 2)
     )
 

--- a/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
@@ -144,7 +144,7 @@ class VirtualMachineSpec extends WordSpec with Matchers {
 
     (theState >> 'ctxt >> 'argvec >> 'elem on OpXferGlobalToArg(
       arg = someObsInd,
-      g = someObsInd)) {
+      global = someObsInd)) {
       val elem = testState.globalEnv.entry(someObsInd)
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated

--- a/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
@@ -129,8 +129,9 @@ class VirtualMachineSpec extends WordSpec with Matchers {
       _ shouldBe 1
     }
 
-    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferArgToArg(d = someObsInd,
-                                                             s = someObsInd)) {
+    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferArgToArg(
+      dest = someObsInd,
+      src = someObsInd)) {
       val elem = testState.ctxt.argvec.elem(someObsInd)
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated
@@ -142,14 +143,14 @@ class VirtualMachineSpec extends WordSpec with Matchers {
     }
 
     (theState >> 'ctxt >> 'argvec >> 'elem on OpXferGlobalToArg(
-      a = someObsInd,
+      arg = someObsInd,
       g = someObsInd)) {
       val elem = testState.globalEnv.entry(someObsInd)
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated
     }
 
-    (theState >> 'ctxt >> 'rslt on OpXferRegToRslt(r = someObsInd)) {
+    (theState >> 'ctxt >> 'rslt on OpXferRegToRslt(reg = someObsInd)) {
       val elem = testState.ctxt.getReg(someObsInd)
       Some(_) shouldBe elem
     }

--- a/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
@@ -47,8 +47,8 @@ class VirtualMachineSpec extends WordSpec with Matchers {
     }
 
     (theState >> 'ctxt >> 'argvec >> 'elem on OpImmediateLitToArg(
-      v = m,
-      a = someObsInd)) {
+      value = m,
+      arg = someObsInd)) {
       val updatedElem =
         testState.ctxt.argvec.elem
           .updated(someObsInd, VirtualMachine.vmLiterals(m))
@@ -80,7 +80,7 @@ class VirtualMachineSpec extends WordSpec with Matchers {
     }
 
     (theState >> 'ctxt >> 'pc on OpOutstanding(m, n)) {
-      _ shouldBe PC.fromInt(m)
+      _ shouldBe PC(m)
     }
 
     (theState >> 'ctxt >> 'outstanding on OpOutstanding(m, n)) {


### PR DESCRIPTION
In Rosette compiling the expression `(+ 1 (+ 2 3))` results in the following Code object:
```
litvec:
   0:   {RequestExpr}
codevec:
   0:   alloc 2
   1:   lit 1,arg[0]
   2:   xfer global[+],trgt
   4:   outstanding 12,1
   6:   push/alloc 2
   7:   lit 2,arg[0]
   8:   lit 3,arg[1]
   9:   xfer global[+],trgt
  11:   xmit/nxt 2,arg[1]
  12:   xmit/nxt 2
```
When it comes to the execution of `outstanding 12,1`, the specified pc and number of "outstanding" arguments is stored to `state.ctxt.pc` and `state.ctxt.oustanding` respectively.

`xmit` opcodes are set the `doXmitFlag` that may force "outstanding" values to evaluate, so when the execution comes to `12` in specified codevec, the "outstanding" values should be evaluated in order to continue evaluating the outer expression.

In `OpXmitArg` the VM writes `5` to `state.ctxt.ctxt.argvec.elem(1)`.

Note that this PR relies on the fact that for each opcode we using one byte. That means that the `PC` is depended on the position of the executing opcode only.

**How to observe the above with gdb**

Set this breakpoint in gdb: 
`b src/Vm.cc:796 if code->codevec->instr(0)->word == 1026 && code->codevec->instr(1)->word == 49408 && code->codevec->instr(2)->word == 45313`.
Run the Rosette REPL and execute (+ 1 (+ 2 3 )) which will jump to the beginning of the execution of the first opcode (`alloc`).
