### PR TITLE
Make bootstrap address stable

### DIFF
--- a/comm/README.md
+++ b/comm/README.md
@@ -21,7 +21,7 @@ Clone (or download and unpack) the master branch of the source.
 ### Building with `sbt`
 
 The only up-front build-time requirement is [sbt](http://www.scala-sbt.org/download.html), which should be installed
-according to your platform. It, in turn, will download and include all depedencies for the system.
+according to your platform. It, in turn, will download and include all dependencies for the system.
 
 To build once `sbt` is installed, issue:
 
@@ -55,7 +55,7 @@ The fat jar built above may be run with Java like so:
 
 ```
 $ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/src-assembly-0.0.1.jar
-17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012}.
+17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://ace40ebca0924eb797bb69dfda04f5d9@1.2.3.4:30304}.
 ```
 
 ### Running via Docker
@@ -65,7 +65,7 @@ If you built a docker image called `rchain-comm:latest`, you can run that with
 ```
 $ docker run -ti -p 30304:30304/udp rchain-comm:latest
 Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true
-04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012}.
+04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://ace40ebca0924eb797bb69dfda04f5d9@172.17.0.3:30304}.
 ```
 
 Note that the port used has to be mapped to the proper host port for the node to be able to advertise itself to the
@@ -88,19 +88,23 @@ However it gets run, it responds to the following arguments:
 #### Bootstrapping
 
 By default, the node will not attempt to bootstrap into any other network and so will create a brand new network with
-only the one
+only the one node sitting there, waiting for other nodes to contact it. Giving the argument
 
 ```
 --bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
 ```
 
+will cause the new node to attempt to attach to the test net. There is nothing special about this node beyond the name:
+any node in the network can be used for bootstrapping, but the above node is the most likely to be up.
+
 #### Host and Port
 
-The system attempts to guess an good IP address and UDP port that other nodes can use to communicate with this one. If
-it does not guess a usable pair, they may be specified on the command line using the `--host` and `--port` options:
+The system tries to guess a good IP address and a reasonable UDP port that other nodes can use to communicate with this
+one. If it does not guess a usable pair, they may be specified on the command line using the `--host` and `--port`
+options:
 
 ```
---host 1.2.3.4 --port 30304 --bootstrap rnode://ace40ebca0924eb797bb69dfda04f5d9@216.83.154.106:30012
+--host 1.2.3.4 --port 30304 --bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
 ```
 
 By default it uses UDP port 30304. This is also how more than one node may be run on a single machine: just pick

--- a/comm/README.md
+++ b/comm/README.md
@@ -55,7 +55,7 @@ The fat jar built above may be run with Java like so:
 
 ```
 $ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/src-assembly-0.0.1.jar
-17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012}.
+17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012}.
 ```
 
 ### Running via Docker
@@ -65,7 +65,7 @@ If you built a docker image called `rchain-comm:latest`, you can run that with
 ```
 $ docker run -ti -p 30304:30304/udp rchain-comm:latest
 Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true
-04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012}.
+04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012}.
 ```
 
 Note that the port used has to be mapped to the proper host port for the node to be able to advertise itself to the
@@ -79,6 +79,7 @@ However it gets run, it responds to the following arguments:
 ```
   -b, --bootstrap  <arg>   Bootstrap rnode address for initial seed.
   -h, --host  <arg>        Hostname or IP of this node.
+  -n, --name  <arg>        Node name or key.
   -p, --port  <arg>        Network port to use.
       --help               Show help message
       --version            Show version of this program
@@ -90,7 +91,7 @@ By default, the node will not attempt to bootstrap into any other network and so
 only the one
 
 ```
---bootstrap rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012
+--bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
 ```
 
 #### Host and Port
@@ -108,7 +109,7 @@ to connect on the test net on UDP port 12345 and our machine's public IP address
 so:
 
 ```
-$ docker run -ti -p 12345:12345/udp rchain-comm:latest -p 12345 --host 1.2.3.4 --bootstrap rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012
+$ docker run -ti -p 12345:12345/udp rchain-comm:latest -p 12345 --host 1.2.3.4 --bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
 ```
 
 Read more than you want to know about Docker networking starting about

--- a/comm/README.md
+++ b/comm/README.md
@@ -55,7 +55,7 @@ The fat jar built above may be run with Java like so:
 
 ```
 $ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/src-assembly-0.0.1.jar
-17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://ac4b1fdee5a947e8a511383e698df99d@63.224.55.75:30304}.
+17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012}.
 ```
 
 ### Running via Docker
@@ -65,7 +65,7 @@ If you built a docker image called `rchain-comm:latest`, you can run that with
 ```
 $ docker run -ti -p 30304:30304/udp rchain-comm:latest
 Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true
-04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://c75981a613b547d7bd7e127c543e4d31@172.17.0.6:30304}.
+04:20:56.910 [main] INFO main - Listening for traffic on #{Network rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012}.
 ```
 
 Note that the port used has to be mapped to the proper host port for the node to be able to advertise itself to the
@@ -90,7 +90,7 @@ By default, the node will not attempt to bootstrap into any other network and so
 only the one
 
 ```
---bootstrap rnode://ace40ebca0924eb797bb69dfda04f5d9@216.83.154.106:30012
+--bootstrap rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012
 ```
 
 #### Host and Port
@@ -104,11 +104,11 @@ it does not guess a usable pair, they may be specified on the command line using
 
 By default it uses UDP port 30304. This is also how more than one node may be run on a single machine: just pick
 different ports. Remember that if using Docker, ports have to be properly mapped and forwarded. For example, if we want
-to connect on the test net on UDP port 12345 and our machine's public IP address is 63.224.55.75, we could do it like
+to connect on the test net on UDP port 12345 and our machine's public IP address is 1.2.3.4, we could do it like
 so:
 
 ```
-$ docker run -ti -p 12345:12345/udp rchain-comm:latest -p 12345 --host 63.224.55.75 --bootstrap rnode://ace40ebca0924eb797bb69dfda04f5d9@216.83.154.106:30012
+$ docker run -ti -p 12345:12345/udp rchain-comm:latest -p 12345 --host 1.2.3.4 --bootstrap rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012
 ```
 
 Read more than you want to know about Docker networking starting about

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -12,6 +12,9 @@ import com.typesafe.scalalogging.Logger
 case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   version("0.0.1 RChain Communications Library")
 
+  val name =
+    opt[String](default = None, short = 'n', descr = "Node name or key")
+
   val port =
     opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")
 
@@ -54,7 +57,12 @@ object Main {
 
   def main(args: Array[String]): Unit = {
     val conf = Conf(args)
-    val name = UUID.randomUUID.toString.replaceAll("-", "")
+
+    val name = conf.name.toOption match {
+      case Some(key) => key
+      case None => UUID.randomUUID.toString.replaceAll("-", "")
+    }
+
     val host = conf.host.toOption match {
       case Some(host) => host
       case None =>

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -13,7 +13,7 @@ case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   version("0.0.1 RChain Communications Library")
 
   val name =
-    opt[String](default = None, short = 'n', descr = "Node name or key")
+    opt[String](default = None, short = 'n', descr = "Node name or key.")
 
   val port =
     opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")


### PR DESCRIPTION
This adds a `--name` option, so the bootstrap node can be started with a consistent name. It's also a bit more memorable and possible for humans to type. Of course, it has to be 32 characters (I guess I could have automatically padded something shorter), so it's a bit unwieldy.

I'll be changing the bootstrap node name if this gets pushed to master.