### PR TITLE
Add sbt docker target.

### DIFF
--- a/comm/README.md
+++ b/comm/README.md
@@ -54,7 +54,7 @@ program with no arguments.
 The fat jar built above may be run with Java like so:
 
 ```
-$ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/src-assembly-0.0.1.jar
+$ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/comm-assembly-0.0.1.jar
 17:34:52.110 [main] INFO main - Listening for traffic on #{Network rnode://ace40ebca0924eb797bb69dfda04f5d9@1.2.3.4:30304}.
 ```
 

--- a/comm/build.sbt
+++ b/comm/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.12.4"
-version      := "0.0.1"
+version := "0.0.1"
 
 PB.targets in Compile := Seq(
   PB.gens.java -> (sourceManaged in Compile).value,
@@ -13,22 +13,16 @@ libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.truea
 libraryDependencies ++= Seq(
   "org.scalactic" %% "scalactic" % "3.0.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-
   // URI Parsing
   "io.lemonlabs" %% "scala-uri" % "0.5.0",
-
   // Command-line parsing
   "org.rogach" %% "scallop" % "3.0.3",
-
   // Hashing
   "org.scorexfoundation" %% "scrypto" % "2.0.0",
-
   // Logging
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "ch.qos.logback" % "logback-classic" % "1.2.3"
 )
-
-
 
 addCompilerPlugin(
   "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full
@@ -45,10 +39,36 @@ lazy val commonOptions = Seq(
   "-Ywarn-numeric-widen",
   "-Ywarn-value-discard",
   "-deprecation",
-  "-encoding", "UTF-8",
+  "-encoding",
+  "UTF-8",
   "-feature",
-  "-unchecked")
+  "-unchecked"
+)
 
 scalacOptions ++= commonOptions
 
 logBuffered in Test := false
+
+/*
+ * Dockerization via sbt-docker
+ */
+enablePlugins(DockerPlugin)
+
+dockerfile in docker := {
+  val artifact: File = assembly.value
+  val artifactTargetPath = s"/${artifact.name}"
+  val entry: File = baseDirectory(_ / "main.sh").value
+  val entryTargetPath = "/bin"
+  new Dockerfile {
+    from("openjdk:8u151-jre-alpine")
+    add(artifact, artifactTargetPath)
+    env("RCHAIN_TARGET_JAR", artifactTargetPath)
+    add(entry, entryTargetPath)
+    entryPoint("/bin/main.sh")
+  }
+}
+
+imageNames in docker := Seq(
+  ImageName(s"rchain-${name.value}:latest"),
+  ImageName(s"rchain-${name.value}:v${version.value}")
+)

--- a/comm/main.sh
+++ b/comm/main.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-java -jar /comm-assembly-0.1-SNAPSHOT.jar "$@"
+java -jar $RCHAIN_TARGET_JAR "$@"

--- a/comm/project/plugins.sbt
+++ b/comm/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")


### PR DESCRIPTION
Adds `sbt docker` which CI can use to produce a docker image. The target jar file is passed via environment variable to the docker entrypoint. Entrypoint file `main.sh` is updated accordingly.

Also fix README.md mistake.

Also ran scalafmt on build.sbt, which I might never do again.