### PR TITLE
Add uPnP port mapping.

### DIFF
--- a/comm/Dockerfile
+++ b/comm/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:17.04
+from ubuntu:16.04
 
 run apt update && apt install -y dirmngr apt-transport-https openjdk-8-jdk bc
 run echo "deb https://dl.bintray.com/sbt/debian /" > /etc/apt/sources.list.d/sbt.list && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 
@@ -8,12 +8,13 @@ copy . /src
 workdir /src
 run rm ensime.sbt
 
-env JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true
+env JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 
 run sbt assembly
 
 COPY main.sh /bin
-run mv /src/target/scala-2.12/comm-assembly-0.1-SNAPSHOT.jar /
+run mv /src/target/scala-2.12/comm-assembly-0.1.jar /
 run rm -rf /src
 
+env RCHAIN_TARGET_JAR /comm-assembly-0.1.jar
 entrypoint [ "/bin/main.sh" ]

--- a/comm/README.md
+++ b/comm/README.md
@@ -103,7 +103,7 @@ Status: Downloaded newer image for rchain/rchain-comm:latest
 The fat jar built above may be run with Java like so:
 
 ```
-$ java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/comm-assembly-0.1.jar
+$ java -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/comm-assembly-0.1.jar
 07:57:16.465 [main] INFO main - uPnP: Some(/10.0.0.3) -> Some(192.168.1.1)
 07:57:16.584 [main] INFO main - Listening for traffic on #{Network rnode://f869a0d0a21744e1807b4176b0217e56@10.0.0.3:30304}.
 07:57:16.585 [main] INFO main - Bootstrapping from rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012.
@@ -116,7 +116,6 @@ If you built a docker image called `rchain-comm:latest`, you can run that with
 
 ```
 $ docker run -ti rchain-comm
-Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
 16:42:48.310 [main] INFO main - uPnP: None -> None
 16:42:48.414 [main] INFO main - Listening for traffic on #{Network rnode://0acfd966f69a412ebd8c0b267c9817dc@172.17.0.2:30304}.
 16:42:48.415 [main] INFO main - Bootstrapping from rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012.
@@ -141,77 +140,102 @@ However it gets run, it responds to the following arguments:
       --version            Show version of this program
 ```
 
-#### Bootstrapping
+#### Bootstrapping a Private Network
 
-By default, the node will not attempt to bootstrap into any other network and so will create a brand new network with
-only the one node sitting there, waiting for other nodes to contact it. Giving the argument
+It is possible to set up a private RChain network by running a standalone node and using it for bootstrapping other nodes. Here we
+run one on port 40000:
 
 ```
---bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
+$ java -Djava.net.preferIPv4Stack=true -jar target/scala-2.12/comm-assembly-0.1.jar --standalone --port 40000
+08:51:46.823 [main] INFO main - uPnP: Some(/10.0.0.3) -> Some(192.168.1.1)
+08:51:46.926 [main] INFO main - Listening for traffic on #{Network rnode://142acf0737fd4f2ab030150723ef5dea@10.0.0.3:40000}.
+08:51:46.927 [main] INFO main - Starting stand-alone node.
 ```
 
-will cause the new node to attempt to attach to the test net. There is nothing special about this node beyond the name:
-any node in the network can be used for bootstrapping, but the above node is the most likely to be up.
+Now bootstrapping the other node just means giving the argument
+
+```
+--bootstrap rnode://142acf0737fd4f2ab030150723ef5dea@10.0.0.3:40000
+```
+
+For example:
+
+```
+$ docker run -ti rchain-comm --bootstrap rnode://142acf0737fd4f2ab030150723ef5dea@10.0.0.3:40000 --port 40001            
+16:52:37.517 [main] INFO main - uPnP: None -> None
+16:52:37.624 [main] INFO main - Listening for traffic on #{Network rnode://5fb160c772ea40a89567ce83733a9d05@172.17.0.2:40001}.
+16:52:37.625 [main] INFO main - Bootstrapping from rnode://142acf0737fd4f2ab030150723ef5dea@10.0.0.3:40000.
+16:52:37.626 [main] DEBUG p2p - connect(): Connecting to #{PeerNode 142acf0737fd4f2ab030150723ef5dea}
+16:52:38.035 [main] DEBUG p2p - connect(): Received encryption handshake response from #{PeerNode 142acf0737fd4f2ab030150723ef5dea}.
+16:52:38.044 [main] DEBUG p2p - connect(): Received protocol handshake response from #{PeerNode 142acf0737fd4f2ab030150723ef5dea}.
+16:52:43.100 [main] INFO main - Peers: 1.
+```
 
 #### Host and Port
 
-The system tries to guess a good IP address and a reasonable UDP port that other nodes can use to communicate with this
-one. If it does not guess a usable pair, they may be specified on the command line using the `--host` and `--port`
-options:
+The system attempts to find a gateway device with Universal Plug-and-Play enabled. If that fails, the system tries to guess a good
+IP address and a reasonable UDP port that other nodes can use to communicate with this one. If it does not guess a usable pair, they
+may be specified on the command line using the `--host` and `--port` options:
 
 ```
---host 1.2.3.4 --port 30304 --bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
+--host 1.2.3.4 --port 30304
 ```
 
-By default it uses UDP port 30304. This is also how more than one node may be run on a single machine: just pick
-different ports. Remember that if using Docker, ports have to be properly mapped and forwarded. For example, if we want
-to connect on the test net on UDP port 12345 and our machine's public IP address is 1.2.3.4, we could do it like
-so:
+By default it uses UDP port 30304. This is also how more than one node may be run on a single machine: just pick different
+ports. Remember that if using Docker, ports may have to be properly mapped and forwarded. For example, if we want to connect on the
+test net on UDP port 12345 and our machine's public IP address is 1.2.3.4, we could do it like so:
 
 ```
-$ docker run -ti -p 12345:12345/udp rchain-comm:latest -p 12345 --host 1.2.3.4 --bootstrap rnode://RChainAuthoritativeBootstrapNode@216.83.154.106:30012
+$ docker run -ti -p 12345:12345/udp rchain/rchain-comm:latest -p 12345 --host 1.2.3.4
 ```
+
+or perhaps by causing docker to use the host network and not its own bridge:
+
+```
+$ docker run -ti --network=host rchain/rchain-comm:latest -p 12345
+```
+
+This may take some experimentation to find combinations of arguments that work for any given setup.
 
 Read more than you want to know about Docker networking starting about
-[here](https://docs.docker.com/engine/userguide/networking/work-with-networks/), but honestly, it's featureful and
-powerful enough that you need a [cheatsheet](https://github.com/wsargent/docker-cheat-sheet#exposing-ports).
+[here](https://docs.docker.com/engine/userguide/networking/work-with-networks/), but honestly, it's featureful and powerful enough
+that you need a [cheatsheet](https://github.com/wsargent/docker-cheat-sheet#exposing-ports).
 
 ## Notes
 
 ### Caveats
 
-This is very much a work in progress. The networking overlay is only known to work when it can avail itself of visible
-IP addresses, either public or all contained within the same network. It does not yet include any special code for
-getting around a home firewall or a closed router, including uPNP handling. Any port used must be open. Additionally, it
-might be necessary to configure port-forwarding on your router. In some cases, it might even be necessary to specify
+This is very much a work in progress. The networking overlay is only known to work when it can avail itself of visible IP addresses,
+either public or all contained within the same network. It does not yet include any special code for getting around a home firewall
+or a closed router, though it does contain some uPNP handling. Any port used must be open or mapped through the router. Depending on
+your setup, it might be necessary to configure port-forwarding on your router. In some cases, it might even be necessary to specify
 your router's public IP address as the node address if your router's port-forwarding requires it.
 
 ### Dependency list
 
 The list of dependencies that sbt downloads and packages with the system is currently
- * lenses_2.12-0.4.12.jar
- * fastparse-utils_2.12-0.4.4.jar
- * macro-compat_2.12-1.1.1.jar
- * slf4j-api-1.7.25.jar
- * logback-classic-1.2.3.jar
- * scala-logging_2.12-3.7.2.jar
- * scala-uri_2.12-0.5.0.jar
- * sourcecode_2.12-0.1.4.jar
- * fastparse_2.12-0.4.4.jar
- * protobuf-java-3.4.0.jar
- * parboiled_2.12-2.1.4.jar
+ * bcprov-jdk15on-1.58.jar
  * curve25519-java-0.4.1.jar
- * spray-json_2.12-1.3.2.jar
- * scala-library.jar
- * scalactic_2.12-3.0.1.jar
+ * fastparse-utils_2.12-0.4.4.jar
+ * fastparse_2.12-0.4.4.jar
+ * guava-19.0.jar
+ * lenses_2.12-0.4.12.jar
+ * logback-classic-1.2.3.jar
  * logback-core-1.2.3.jar
- * shapeless_2.12-2.3.2.jar
+ * macro-compat_2.12-1.1.1.jar
+ * parboiled_2.12-2.1.4.jar
+ * protobuf-java-3.4.0.jar
+ * scala-library.jar
+ * scala-logging_2.12-3.7.2.jar
+ * scala-reflect.jar
+ * scala-uri_2.12-0.5.0.jar
+ * scalactic_2.12-3.0.1.jar
+ * scalapb-runtime_2.12-0.6.6.jar
  * scallop_2.12-3.0.3.jar
  * scrypto_2.12-2.0.0.jar
+ * shapeless_2.12-2.3.2.jar
+ * slf4j-api-1.7.25.jar
+ * sourcecode_2.12-0.1.4.jar
+ * spray-json_2.12-1.3.2.jar
  * supertagged_2.12-1.3.jar
- * scalapb-runtime_2.12-0.6.6.jar
- * bcprov-jdk15on-1.58.jar
- * guava-19.0.jar
-
-And for testing, add to that
- * scala-reflect.jar
+ * weupnp-0.1.4.jar

--- a/comm/build.sbt
+++ b/comm/build.sbt
@@ -1,4 +1,5 @@
 scalaVersion := "2.12.4"
+organization := "coop.rchain"
 version      := "0.0.1"
 
 PB.targets in Compile := Seq(
@@ -22,6 +23,9 @@ libraryDependencies ++= Seq(
 
   // Hashing
   "org.scorexfoundation" %% "scrypto" % "2.0.0",
+
+  // uPNP library
+  "org.bitlet" % "weupnp" % "0.1.+",
 
   // Logging
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",

--- a/comm/build.sbt
+++ b/comm/build.sbt
@@ -1,5 +1,5 @@
 scalaVersion := "2.12.4"
-organization := "coop.rchain"
+organization := "rchain"
 version      := "0.1"
 
 PB.targets in Compile := Seq(
@@ -14,10 +14,13 @@ libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.truea
 libraryDependencies ++= Seq(
   "org.scalactic" %% "scalactic" % "3.0.1",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+
   // URI Parsing
   "io.lemonlabs" %% "scala-uri" % "0.5.0",
+
   // Command-line parsing
   "org.rogach" %% "scallop" % "3.0.3",
+
   // Hashing
   "org.scorexfoundation" %% "scrypto" % "2.0.0",
 
@@ -74,6 +77,6 @@ dockerfile in docker := {
 }
 
 imageNames in docker := Seq(
-  ImageName(s"rchain/rchain-${name.value}:latest"),
-  ImageName(s"rchain/rchain-${name.value}:v${version.value}")
+  ImageName(s"${organization.value}/${organization.value}-${name.value}:latest"),
+  ImageName(s"${organization.value}/${organization.value}-${name.value}:v${version.value}")
 )

--- a/comm/build.sbt
+++ b/comm/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.12.4"
 organization := "coop.rchain"
-version      := "0.0.1"
+version      := "0.1"
 
 PB.targets in Compile := Seq(
   PB.gens.java -> (sourceManaged in Compile).value,
@@ -74,6 +74,6 @@ dockerfile in docker := {
 }
 
 imageNames in docker := Seq(
-  ImageName(s"rchain-${name.value}:latest"),
-  ImageName(s"rchain-${name.value}:v${version.value}")
+  ImageName(s"rchain/rchain-${name.value}:latest"),
+  ImageName(s"rchain/rchain-${name.value}:v${version.value}")
 )

--- a/comm/main.sh
+++ b/comm/main.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-java -jar $RCHAIN_TARGET_JAR "$@"
+java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar $RCHAIN_TARGET_JAR "$@"

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -27,6 +27,14 @@ message ReturnHeader {
     uint64 seq            = 2;
 }
 
+message Whoami {
+}
+
+message WhoamiResponse {
+    bytes  host = 1;
+    uint32 port = 2;
+}
+
 message Ping {
 }
 
@@ -56,5 +64,7 @@ message Protocol {
         Lookup              lookup          = 6;
         LookupResponse      lookup_response = 7;
         Disconnect          disconnect      = 8;
+        Whoami              whoami          = 9;
+        WhoamiResponse      whoami_response = 10;
     }
 }

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -27,14 +27,6 @@ message ReturnHeader {
     uint64 seq            = 2;
 }
 
-message Whoami {
-}
-
-message WhoamiResponse {
-    bytes  host = 1;
-    uint32 port = 2;
-}
-
 message Ping {
 }
 
@@ -64,7 +56,5 @@ message Protocol {
         Lookup              lookup          = 6;
         LookupResponse      lookup_response = 7;
         Disconnect          disconnect      = 8;
-        Whoami              whoami          = 9;
-        WhoamiResponse      whoami_response = 10;
     }
 }

--- a/comm/src/main/scala/coop/rchain/comm/comm.scala
+++ b/comm/src/main/scala/coop/rchain/comm/comm.scala
@@ -1,8 +1,10 @@
 package coop.rchain.comm
 
-trait Comm {
+import java.net.InetSocketAddress
+
+trait Comm[A] {
   def send(data: Seq[Byte], p: PeerNode): Either[CommError, Unit]
-  def recv: Either[CommError, Seq[Byte]]
+  def recv: Either[CommError, (A, Seq[Byte])]
 }
 
 case class NodeIdentifier(pKey: Seq[Byte]) {
@@ -16,8 +18,11 @@ case class NodeIdentifier(pKey: Seq[Byte]) {
 }
 
 case class Endpoint(host: String, tcpPort: Int, udpPort: Int) {
-  val tcpSocketAddress = new java.net.InetSocketAddress(host, tcpPort)
-  val udpSocketAddress = new java.net.InetSocketAddress(host, udpPort)
+  val tcpSocketAddress = new InetSocketAddress(host, tcpPort)
+  val udpSocketAddress = new InetSocketAddress(host, udpPort)
+
+  def withUdp(udp: java.net.InetSocketAddress): Endpoint =
+    Endpoint(udp.getHostString, tcpPort, udp.getPort)
 }
 
 /**
@@ -33,6 +38,9 @@ case class PeerNode(id: NodeIdentifier, endpoint: Endpoint) {
 
   def toAddress: String =
     s"rnode://$sKey@${endpoint.host}:${endpoint.udpPort}"
+
+  def withUdpSocket(udp: java.net.InetSocketAddress): PeerNode =
+    PeerNode(id, endpoint.withUdp(udp))
 }
 
 trait Notary {

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -35,27 +35,37 @@ object Main {
   val pauseTime = 5000L
 
   def whoami: Option[InetAddress] = {
-    val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
-    val addresses = ifaces
-      .flatMap(_.asScala)
-      .map(_.getAddress)
-      .toList
-      .groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress || x.isSiteLocalAddress)
-    if (addresses.contains(false)) {
-      Some(addresses(false).head)
-    } else {
-      val locals = addresses(true).groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress)
-      if (addresses.contains(false)) {
-        Some(addresses(false).head)
-      } else if (addresses.contains(true)) {
-        Some(addresses(true).head)
-      } else {
-        None
+    val upnp = new UPnP
+
+    logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
+
+    upnp.localAddress match {
+      case Some(addy) => Some(addy)
+      case None => {
+        val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
+        val addresses = ifaces
+          .flatMap(_.asScala)
+          .map(_.getAddress)
+          .toList
+          .groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress || x.isSiteLocalAddress)
+        if (addresses.contains(false)) {
+          Some(addresses(false).head)
+        } else {
+          val locals = addresses(true).groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress)
+          if (addresses.contains(false)) {
+            Some(addresses(false).head)
+          } else if (addresses.contains(true)) {
+            Some(addresses(true).head)
+          } else {
+            None
+          }
+        }
       }
     }
   }
 
   def main(args: Array[String]): Unit = {
+
     val conf = Conf(args)
 
     val name = conf.name.toOption match {

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -34,9 +34,10 @@ object Main {
    */
   val pauseTime = 5000L
 
-  def whoami: Option[InetAddress] = {
-    val upnp = new UPnP
+  def whoami(port: Int): Option[InetAddress] = {
 
+    val upnp = new UPnP(port)
+ 
     logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
 
     upnp.localAddress match {
@@ -76,7 +77,7 @@ object Main {
     val host = conf.host.toOption match {
       case Some(host) => host
       case None =>
-        whoami match {
+        whoami(conf.port()) match {
           case Some(addy) => addy.getHostAddress
           case None       => "localhost"
         }

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -37,7 +37,7 @@ object Main {
   def whoami(port: Int): Option[InetAddress] = {
 
     val upnp = new UPnP(port)
- 
+
     logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
 
     upnp.localAddress match {

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -10,7 +10,7 @@ import coop.rchain.p2p
 import com.typesafe.scalalogging.Logger
 
 case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  version("0.0.1 RChain Communications Library")
+  version("RChain Communications Library version 0.1")
 
   val name =
     opt[String](default = None, short = 'n', descr = "Node name or key.")

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -1,6 +1,6 @@
 package coop.rchain.comm
 
-import java.net.SocketTimeoutException
+import java.net.{SocketAddress, SocketTimeoutException}
 import scala.collection.concurrent
 import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.{Duration, MILLISECONDS}
@@ -14,13 +14,13 @@ import scala.util.{Failure, Success}
   */
 case class UnicastNetwork(id: NodeIdentifier,
                           endpoint: Endpoint,
-                          next: Option[ProtocolDispatcher] = None)
+                          next: Option[ProtocolDispatcher[SocketAddress]] = None)
     extends ProtocolHandler
-    with ProtocolDispatcher {
+    with ProtocolDispatcher[SocketAddress] {
 
   val logger = Logger("network-overlay")
 
-  def this(peer: PeerNode, next: Option[ProtocolDispatcher]) =
+  def this(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddress]]) =
     this(peer.id, peer.endpoint, next)
 
   case class PendingKey(remote: Seq[Byte], timestamp: Long, seq: Long)
@@ -36,10 +36,10 @@ case class UnicastNetwork(id: NodeIdentifier,
     override def run =
       while (true) {
         comm.recv match {
-          case Right(res) =>
+          case Right((sock, res)) =>
             for {
               msg <- ProtocolMessage.parse(res)
-            } dispatch(msg)
+            } dispatch(sock, msg)
           case Left(err: CommError) =>
             err match {
               case DatagramException(ex: SocketTimeoutException) => ()
@@ -95,19 +95,26 @@ case class UnicastNetwork(id: NodeIdentifier,
     potentials.toSeq
   }
 
-  def dispatch(msg: ProtocolMessage): Unit =
+  def dispatch(sock: SocketAddress, msg: ProtocolMessage): Unit =
     for {
-      sender <- msg.sender
+      sndr <- msg.sender
     } {
+      val sender =
+        sock match {
+          case (s: java.net.InetSocketAddress) =>
+            sndr.withUdpSocket(s)
+          case _ => sndr
+        }
       // Update sender's last-seen time, adding it if there are no
       // higher-level protocols.
       table.observe(new ProtocolNode(sender, this), next == None)
       msg match {
+        case whoami @ WhoamiMessage(_, _)         => handleWhoami(sender, whoami)
         case ping @ PingMessage(_, _)             => handlePing(sender, ping)
         case lookup @ LookupMessage(_, _)         => handleLookup(sender, lookup)
         case disconnect @ DisconnectMessage(_, _) => handleDisconnect(sender, disconnect)
-        case resp: ProtocolResponse               => handleResponse(sender, resp)
-        case _                                    => next.foreach(_.dispatch(msg))
+        case resp: ProtocolResponse               => handleResponse(sock, sender, resp)
+        case _                                    => next.foreach(_.dispatch(sock, msg))
       }
     }
 
@@ -117,14 +124,24 @@ case class UnicastNetwork(id: NodeIdentifier,
    * Handle a response to a message. If this message isn't one we were
    * expecting, propagate it to the next dispatcher.
    */
-  private def handleResponse(sender: PeerNode, msg: ProtocolResponse): Unit =
+  private def handleResponse(sock: SocketAddress, sender: PeerNode, msg: ProtocolResponse): Unit =
     for {
       ret <- msg.returnHeader
     } {
       pending.get(PendingKey(sender.key, ret.timestamp, ret.seq)) match {
         case Some(promise) => promise.success(Right(msg))
-        case None          => next.foreach(_.dispatch(msg))
+        case None          => next.foreach(_.dispatch(sock, msg))
       }
+    }
+
+  /**
+    * Clue the requester in as to its public host and port as observed at this node.
+    */
+  private def handleWhoami(sender: PeerNode, whoami: WhoamiMessage): Unit =
+    for {
+      resp <- whoami.response(local)
+    } {
+      comm.send(resp.toByteSeq, sender)
     }
 
   /**

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -109,7 +109,6 @@ case class UnicastNetwork(id: NodeIdentifier,
       // higher-level protocols.
       table.observe(new ProtocolNode(sender, this), next == None)
       msg match {
-        case whoami @ WhoamiMessage(_, _)         => handleWhoami(sender, whoami)
         case ping @ PingMessage(_, _)             => handlePing(sender, ping)
         case lookup @ LookupMessage(_, _)         => handleLookup(sender, lookup)
         case disconnect @ DisconnectMessage(_, _) => handleDisconnect(sender, disconnect)
@@ -132,16 +131,6 @@ case class UnicastNetwork(id: NodeIdentifier,
         case Some(promise) => promise.success(Right(msg))
         case None          => next.foreach(_.dispatch(sock, msg))
       }
-    }
-
-  /**
-    * Clue the requester in as to its public host and port as observed at this node.
-    */
-  private def handleWhoami(sender: PeerNode, whoami: WhoamiMessage): Unit =
-    for {
-      resp <- whoami.response(local)
-    } {
-      comm.send(resp.toByteSeq, sender)
     }
 
   /**

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -9,14 +9,14 @@ import com.google.protobuf.any.{Any => AnyProto}
 // TODO: In message construction, the system clock is used for nonce
 // generation. For reproducibility, this should be a passed-in value.
 
-trait ProtocolDispatcher {
+trait ProtocolDispatcher[A] {
 
   /**
     * Handle an incoming message. This function is intended to thread
     * levels of protocol together, such that inner protocols can
     * bubble unhandled messages up to outer levels.
     */
-  def dispatch(msg: ProtocolMessage): Unit
+  def dispatch(extra: A, msg: ProtocolMessage): Unit
 }
 
 /**
@@ -128,6 +128,15 @@ trait ProtocolResponse extends ProtocolMessage {
   def returnHeader: Option[ReturnHeader] = proto.returnHeader
 }
 
+case class WhoamiMessage(proto: Protocol, timestamp: Long) extends ProtocolMessage {
+  def response(src: ProtocolNode): Option[ProtocolMessage] =
+    for {
+      h <- header
+    } yield WhoamiResponseMessage(ProtocolMessage.whoamiResponse(src, h, "foo", 23), System.currentTimeMillis)
+}
+
+case class WhoamiResponseMessage(proto: Protocol, timestamp: Long) extends ProtocolResponse
+
 /**
   * A ping is a simple are-you-there? message.
   */
@@ -210,6 +219,19 @@ object ProtocolMessage {
       .withTimestamp(h.timestamp)
       .withSeq(h.seq)
 
+  def whoami(src: ProtocolNode): Protocol =
+    Protocol()
+      .withHeader(header(src))
+      .withWhoami(Whoami())
+
+  def whoamiResponse(src: ProtocolNode, h: Header, host: String, port: Int): Protocol =
+    Protocol()
+      .withHeader(header(src))
+      .withReturnHeader(returnHeader(h))
+      .withWhoamiResponse(WhoamiResponse()
+        .withHost(host)
+        .withPort(port))
+
   def ping(src: ProtocolNode): Protocol =
     Protocol()
       .withHeader(header(src))
@@ -254,6 +276,9 @@ object ProtocolMessage {
     Protocol.parseFrom(bytes.toArray) match {
       case msg: Protocol =>
         msg.message match {
+          case Protocol.Message.Whoami(_) => Some(WhoamiMessage(msg, System.currentTimeMillis))
+          case Protocol.Message.WhoamiResponse(_) =>
+            Some(WhoamiResponseMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Ping(_)   => Some(PingMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Pong(_)   => Some(PongMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Lookup(_) => Some(LookupMessage(msg, System.currentTimeMillis))

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -128,15 +128,6 @@ trait ProtocolResponse extends ProtocolMessage {
   def returnHeader: Option[ReturnHeader] = proto.returnHeader
 }
 
-case class WhoamiMessage(proto: Protocol, timestamp: Long) extends ProtocolMessage {
-  def response(src: ProtocolNode): Option[ProtocolMessage] =
-    for {
-      h <- header
-    } yield WhoamiResponseMessage(ProtocolMessage.whoamiResponse(src, h, "foo", 23), System.currentTimeMillis)
-}
-
-case class WhoamiResponseMessage(proto: Protocol, timestamp: Long) extends ProtocolResponse
-
 /**
   * A ping is a simple are-you-there? message.
   */
@@ -219,19 +210,6 @@ object ProtocolMessage {
       .withTimestamp(h.timestamp)
       .withSeq(h.seq)
 
-  def whoami(src: ProtocolNode): Protocol =
-    Protocol()
-      .withHeader(header(src))
-      .withWhoami(Whoami())
-
-  def whoamiResponse(src: ProtocolNode, h: Header, host: String, port: Int): Protocol =
-    Protocol()
-      .withHeader(header(src))
-      .withReturnHeader(returnHeader(h))
-      .withWhoamiResponse(WhoamiResponse()
-        .withHost(host)
-        .withPort(port))
-
   def ping(src: ProtocolNode): Protocol =
     Protocol()
       .withHeader(header(src))
@@ -276,9 +254,6 @@ object ProtocolMessage {
     Protocol.parseFrom(bytes.toArray) match {
       case msg: Protocol =>
         msg.message match {
-          case Protocol.Message.Whoami(_) => Some(WhoamiMessage(msg, System.currentTimeMillis))
-          case Protocol.Message.WhoamiResponse(_) =>
-            Some(WhoamiResponseMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Ping(_)   => Some(PingMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Pong(_)   => Some(PongMessage(msg, System.currentTimeMillis))
           case Protocol.Message.Lookup(_) => Some(LookupMessage(msg, System.currentTimeMillis))

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -19,8 +19,6 @@ import scala.util.control.NonFatal
   * sends.
   */
 case class UnicastComm(local: PeerNode) extends Comm[SocketAddress] {
-  println(s"LOCAL: ${local.endpoint.udpSocketAddress}")
-
   val socket = new DatagramSocket(local.endpoint.udpPort)
 
   /*

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -1,0 +1,73 @@
+package coop.rchain.comm
+
+import java.net.InetAddress
+
+import org.bitlet.weupnp.{GatewayDevice, GatewayDiscover}
+// import scorex.core.settings.NetworkSettings
+// import scorex.core.utils.ScorexLogging
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+import com.typesafe.scalalogging.Logger
+
+class UPnP// (settings: NetworkSettings) extends ScorexLogging
+{
+  val logger = Logger("upnp")
+
+  private var gateway: Option[GatewayDevice] = None
+
+  lazy val localAddress = gateway.map(_.getLocalAddress)
+  lazy val externalAddress = gateway.map(_.getExternalIPAddress).map(InetAddress.getByName)
+
+  Try {
+    logger.info("Looking for UPnP gateway device...")
+    val defaultHttpReadTimeout = 5000 // settings.upnpGatewayTimeout.map(_.toMillis.toInt).getOrElse(GatewayDevice.getHttpReadTimeout)
+    GatewayDevice.setHttpReadTimeout(defaultHttpReadTimeout)
+    val discover = new GatewayDiscover()
+    val defaultDiscoverTimeout = 5000 // settings.upnpDiscoverTimeout.map(_.toMillis.toInt).getOrElse(discover.getTimeout)
+    discover.setTimeout(defaultDiscoverTimeout)
+
+    logger.info(s"${discover.discover}")
+
+    val gatewayMap = Option(discover.discover).map(_.asScala).map(_.toMap).getOrElse(Map())
+    if (gatewayMap.isEmpty) {
+      logger.debug("There are no UPnP gateway devices")
+    } else {
+      gatewayMap.foreach { case (addr, _) =>
+        logger.debug("UPnP gateway device found on " + addr.getHostAddress)
+      }
+      Option(discover.getValidGateway) match {
+        case None => logger.debug("There is no connected UPnP gateway device")
+        case Some(device) =>
+          gateway = Some(device)
+          logger.debug("Using UPnP gateway device on " + localAddress.map(_.getHostAddress).getOrElse("err"))
+          logger.info("External IP address is " + externalAddress.map(_.getHostAddress).getOrElse("err"))
+      }
+    }
+  }.recover { case t: Throwable =>
+    logger.error("Unable to discover UPnP gateway devices: " + t.toString)
+  }
+
+  addPort(30304)
+  // if (settings.upnpEnabled) addPort(settings.port)
+
+  def addPort(port: Int): Try[Unit] = Try {
+    if (gateway.get.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain")) {
+      logger.debug("Mapped port [" + externalAddress.get.getHostAddress + "]:" + port)
+    } else {
+      logger.debug("Unable to map port " + port)
+    }
+  }.recover { case t: Throwable =>
+    logger.error("Unable to map port " + port + ": " + t.toString)
+  }
+
+  def deletePort(port: Int): Try[Unit] = Try {
+    if (gateway.get.deletePortMapping(port, "TCP")) {
+      logger.debug("Mapping deleted for port " + port)
+    } else {
+      logger.debug("Unable to delete mapping for port " + port)
+    }
+  }.recover { case t: Throwable =>
+    logger.error("Unable to delete mapping for port " + port + ": " + t.toString)
+  }
+}

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -38,7 +38,8 @@ class UPnP(port: Int) {
     try {
       gateway match {
         case Some(device) =>
-          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
+          Right(
+            device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
         case None => Left(UnknownCommError("no gateway"))
       }
     } catch {

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -3,71 +3,50 @@ package coop.rchain.comm
 import java.net.InetAddress
 
 import org.bitlet.weupnp.{GatewayDevice, GatewayDiscover}
-// import scorex.core.settings.NetworkSettings
-// import scorex.core.utils.ScorexLogging
 
+import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 import scala.util.Try
 import com.typesafe.scalalogging.Logger
 
-class UPnP// (settings: NetworkSettings) extends ScorexLogging
-{
+class UPnP(port: Int) {
   val logger = Logger("upnp")
 
-  private var gateway: Option[GatewayDevice] = None
+  val gateway: Option[GatewayDevice] = {
+    GatewayDevice.setHttpReadTimeout(5000)
+    val discover = new GatewayDiscover
+    discover.setTimeout(5000)
 
-  lazy val localAddress = gateway.map(_.getLocalAddress)
-  lazy val externalAddress = gateway.map(_.getExternalIPAddress).map(InetAddress.getByName)
+    discover.discover
 
-  Try {
-    logger.info("Looking for UPnP gateway device...")
-    val defaultHttpReadTimeout = 5000 // settings.upnpGatewayTimeout.map(_.toMillis.toInt).getOrElse(GatewayDevice.getHttpReadTimeout)
-    GatewayDevice.setHttpReadTimeout(defaultHttpReadTimeout)
-    val discover = new GatewayDiscover()
-    val defaultDiscoverTimeout = 5000 // settings.upnpDiscoverTimeout.map(_.toMillis.toInt).getOrElse(discover.getTimeout)
-    discover.setTimeout(defaultDiscoverTimeout)
+    Option(discover.getValidGateway)
+  }
 
-    logger.info(s"${discover.discover}")
+  def localAddress: Option[InetAddress] = gateway.map(_.getLocalAddress)
+  def externalAddress: Option[String] = gateway.map(_.getExternalIPAddress)
 
-    val gatewayMap = Option(discover.discover).map(_.asScala).map(_.toMap).getOrElse(Map())
-    if (gatewayMap.isEmpty) {
-      logger.debug("There are no UPnP gateway devices")
-    } else {
-      gatewayMap.foreach { case (addr, _) =>
-        logger.debug("UPnP gateway device found on " + addr.getHostAddress)
-      }
-      Option(discover.getValidGateway) match {
-        case None => logger.debug("There is no connected UPnP gateway device")
+  addPort(port)
+
+  def addPort(port: Int): Either[CommError, Boolean] =
+    try {
+      gateway match {
         case Some(device) =>
-          gateway = Some(device)
-          logger.debug("Using UPnP gateway device on " + localAddress.map(_.getHostAddress).getOrElse("err"))
-          logger.info("External IP address is " + externalAddress.map(_.getHostAddress).getOrElse("err"))
+          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
+        case None => Left(UnknownCommError("no gateway"))
       }
+    } catch {
+      case NonFatal(ex: Exception) => Left(UnknownCommError(ex.toString))
     }
-  }.recover { case t: Throwable =>
-    logger.error("Unable to discover UPnP gateway devices: " + t.toString)
-  }
 
-  addPort(30304)
-  // if (settings.upnpEnabled) addPort(settings.port)
-
-  def addPort(port: Int): Try[Unit] = Try {
-    if (gateway.get.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain")) {
-      logger.debug("Mapped port [" + externalAddress.get.getHostAddress + "]:" + port)
-    } else {
-      logger.debug("Unable to map port " + port)
+  def removePort(port: Int): Either[CommError, Unit] =
+    try {
+      gateway match {
+        case Some(device) =>
+          device.deletePortMapping(port, "UDP")
+          Right(())
+        case None => Left(UnknownCommError("no gateway"))
+      }
+    } catch {
+      case NonFatal(ex: Exception) => Left(UnknownCommError(ex.toString))
     }
-  }.recover { case t: Throwable =>
-    logger.error("Unable to map port " + port + ": " + t.toString)
-  }
-
-  def deletePort(port: Int): Try[Unit] = Try {
-    if (gateway.get.deletePortMapping(port, "TCP")) {
-      logger.debug("Mapping deleted for port " + port)
-    } else {
-      logger.debug("Unable to delete mapping for port " + port)
-    }
-  }.recover { case t: Throwable =>
-    logger.error("Unable to delete mapping for port " + port + ": " + t.toString)
-  }
 }

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -9,6 +9,13 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 import com.typesafe.scalalogging.Logger
 
+/**
+  * Simple class that attempts to find and use a uPnP router for networking.
+  *
+  * Registers the given port for UDP transmission through a NAT.
+  *
+  * Cribbed from https://github.com/ScorexFoundation/Scorex/blob/503fda982d96707db8731f954ac6428b1d17e4e8/src/main/scala/scorex/core/network/UPnP.scala.
+  */
 class UPnP(port: Int) {
   val logger = Logger("upnp")
 


### PR DESCRIPTION
This is probably 40% of the story and needs to be cleaned up. This does the following:
* looks for a uPnP router it can use and registers the udp port with it
* records and propagates incoming source data (host:port information) for each received datagram through each protocol layer, updating peer node routing data (ignoring transmitted host:port if necessary)

This all allows connectivity from behind a router that implements uPnP, if uPnP is turned on. uPnP support is provided by org.bitlet.weupnp, which seems pretty widely used.

Also, the docker image name is changed to include our repository (rchain) at hub.docker.com, so that `sbt dockerBuildAndPush` can be used.