### PR TITLE
Add OpIndLitToArg

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
@@ -15,7 +15,8 @@ object Meta {
         result.left.flatMap {
           // TODO:
           // BASE(BASE(client)->parent())->lookup(key, ctxt)
-          case Absent if client.isInstanceOf[RoFloat] => Right(prim.Prims(197))
+          case Absent if client.isInstanceOf[RblFloat] =>
+            Right(prim.Prims(197))
           case Absent => Right(prim.Prims(226))
         }
       }

--- a/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
@@ -15,6 +15,7 @@ object Meta {
         result.left.flatMap {
           // TODO:
           // BASE(BASE(client)->parent())->lookup(key, ctxt)
+          case Absent if client.isInstanceOf[RoFloat] => Right(prim.Prims(197))
           case Absent => Right(prim.Prims(226))
         }
       }

--- a/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
@@ -17,15 +17,15 @@ case class Fixnum(value: Int, override val slot: Seq[Ob] = Seq(StdMeta()))
   def /(that: Fixnum) = Fixnum(this.value / that.value)
 }
 
-case class RoFloat(value: Double, override val slot: Seq[Ob] = Seq(StdMeta()))
+case class RblFloat(value: Double, override val slot: Seq[Ob] = Seq(StdMeta()))
     extends RblAtom {
   override def toString: String = s"Float($value)"
 
-  def +(that: RoFloat) = RoFloat(this.value + that.value)
+  def +(that: RblFloat) = RblFloat(this.value + that.value)
 
-  def -(that: RoFloat) = RoFloat(this.value - that.value)
+  def -(that: RblFloat) = RblFloat(this.value - that.value)
 
-  def *(that: RoFloat) = RoFloat(this.value * that.value)
+  def *(that: RblFloat) = RblFloat(this.value * that.value)
 
-  def /(that: RoFloat) = RoFloat(this.value / that.value)
+  def /(that: RblFloat) = RblFloat(this.value / that.value)
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
@@ -16,3 +16,16 @@ case class Fixnum(value: Int, override val slot: Seq[Ob] = Seq(StdMeta()))
 
   def /(that: Fixnum) = Fixnum(this.value / that.value)
 }
+
+case class RoFloat(value: Double, override val slot: Seq[Ob] = Seq(StdMeta()))
+    extends RblAtom {
+  override def toString: String = s"Float($value)"
+
+  def +(that: RoFloat) = RoFloat(this.value + that.value)
+
+  def -(that: RoFloat) = RoFloat(this.value - that.value)
+
+  def *(that: RoFloat) = RoFloat(this.value * that.value)
+
+  def /(that: RoFloat) = RoFloat(this.value / that.value)
+}

--- a/roscala/src/main/scala/coop/rchain/rosette/expr/LetExpr.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/expr/LetExpr.scala
@@ -1,3 +1,4 @@
 package coop.rchain.rosette.expr
 
 case class LetExpr() extends Expr
+case object RequestExpr extends Expr

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
-import coop.rchain.rosette.{Ctxt, Fixnum, RoFloat}
+import coop.rchain.rosette.{Ctxt, Fixnum, RblFloat}
 import coop.rchain.rosette.prim.Prim._
 
 object Number {
@@ -101,13 +101,13 @@ object Number {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RoFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RoFloat] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RoFloat(0)) {
-        case (accum, float: RoFloat) => accum + float
+      Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(0)) {
+        case (accum, float: RblFloat) => accum + float
       })
     }
   }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Number.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
-import coop.rchain.rosette.{Ctxt, Fixnum}
+import coop.rchain.rosette.{Ctxt, Fixnum, RoFloat}
 import coop.rchain.rosette.prim.Prim._
 
 object Number {
@@ -93,6 +93,22 @@ object Number {
         case e: ArithmeticException =>
           Left(ArithmeticError)
       }
+    }
+  }
+
+  object flPlus extends Prim {
+    override val name: String = "fl+"
+    override val minArgs: Int = 0
+    override val maxArgs: Int = MaxArgs
+
+    @checkTypeMismatch[RoFloat]
+    @checkArgumentMismatch
+    override def fn(ctxt: Ctxt): Either[PrimError, RoFloat] = {
+      val n = ctxt.nargs
+
+      Right(ctxt.argvec.elem.take(n).foldLeft(RoFloat(0)) {
+        case (accum, float: RoFloat) => accum + float
+      })
     }
   }
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
@@ -2,7 +2,8 @@ package coop.rchain.rosette
 
 package object prim {
   // For now keys in Prims correspond to Prim::primnum in Rosette
-  val Prims = Map[Int, Prim](222 -> Number.fxMod,
+  val Prims = Map[Int, Prim](197 -> Number.flPlus,
+                             222 -> Number.fxMod,
                              223 -> Number.fxDiv,
                              224 -> Number.fxTimes,
                              225 -> Number.fxMinus,

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -311,23 +311,22 @@ class TransitionSpec extends FlatSpec with Matchers {
 
     /**
       * litvec:
-      &   0:   {RequestExpr}
-      &   1:   1.1
-      &   2:   2.2
-      & odevec:
-      &   0:   alloc 2
-      &   1:   liti 1,arg[0]
-      &   2:   liti 2,arg[1]
-      &   3:   xfer global[+],trgt
-      &   5:   xmit/nxt 2
+      *   0:   {RequestExpr}
+      *   1:   1.1
+      *   2:   2.2
+      * codevec:
+      *   0:   alloc 2
+      *   1:   liti 1,arg[0]
+      *   2:   liti 2,arg[1]
+      *   3:   xfer global[+],trgt
+      *   5:   xmit/nxt 2
       */
-
     val start =
       testState
         .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
         .set(_ >> 'globalEnv)(TblObject(globalEnv))
         .update(_ >> 'code >> 'litvec)(_ =>
-          Tuple(Seq(RequestExpr, RoFloat(1.2), RoFloat(2.3))))
+          Tuple(Seq(RequestExpr, RblFloat(1.2), RblFloat(2.3))))
 
     val codevec = Seq(
       OpAlloc(2),
@@ -338,6 +337,6 @@ class TransitionSpec extends FlatSpec with Matchers {
     )
 
     val end = VirtualMachine.executeSeq(codevec, start)
-    end.ctxt.ctxt.rslt shouldBe RoFloat(3.5)
+    end.ctxt.ctxt.rslt shouldBe RblFloat(3.5)
   }
 }


### PR DESCRIPTION
In Rosette compiling the expression `(+ 1.2 2.3)` results in the following Code object:
```
litvec:
   0:   {RequestExpr}
   1:   1.2
   2:   2.3
codevec:
   0:   alloc 2
   1:   liti 1,arg[0]
   2:   liti 2,arg[1]
   3:   xfer global[+],trgt
   5:   xmit/nxt 2
```
When it comes to the execution of `liti 1,arg[0]` the specified element is loaded from `code.litvec` (in this case `1.2` is loaded to `ctxt.argvec.elem[0]`).

**How to observe the above with gdb**
Run REPL in GDB, then hit Ctrl+C, set this breakpoint:
`b src/Vm.cc:796 if code->codevec->instr(0)->word == 1026`;
return to REPL with c and execute `(+ 1.2 2.3)` which will jump to the beginning of the execution of the first opcode (`alloc`).