### PR TITLE
say something about Node.Hello in the top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 The open-source RChain project is building a decentralized, economic, censorship-resistant, public compute infrastructure and blockchain. It will host and execute programs popularly referred to as “smart contracts”. It will be trustworthy, scalable, concurrent, with proof-of-stake consensus and content delivery.
 
+### Communication
+
+The `comm` subproject contains code for network related operations for RChain.
+
+The network layer is the lowest level component in the architecture and it
+is featured in our **Node.Hello (v0.1) release**. The simplest way to get
+started is with docker: `docker run -ti rchain/rchain-comm`. For other options,
+see `README.md` under `comm`.
+
 ### Rholang
 
 The `rholang` subproject contains compiler related code for the Rholang language.
@@ -15,10 +24,6 @@ The `roscala` subproject contains a Scala translation of the Rosette VM.
 ### Rosette
 
 The `rosette` subproject contains code for a low level virtual machine for RChain.
-
-### Communication
-
-The `comm` subproject contains code for network related operations for RChain.
 
 ### Storage
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ The `comm` subproject contains code for network related operations for RChain.
 
 The network layer is the lowest level component in the architecture and it
 is featured in our **Node.Hello (v0.1) release**. The simplest way to get
-started is with docker: `docker run -ti rchain/rchain-comm`. For other options,
-see `README.md` under `comm`.
+started is with [docker][]: `docker run -ti rchain/rchain-comm`. For other options,
+see [comm/README.md][cr].
+
+[docker]: https://store.docker.com/community/images/rchain/rchain-comm
+[cr]: https://github.com/rchain/rchain/tree/master/comm
 
 ### Rholang
 


### PR DESCRIPTION
The Node.Hello functionality is documented under `comm` but there was nothing at the top level to help people find it.