### PR TITLE
Remove strange self-initialization of object headers.

### DIFF
--- a/rosette/CMakeLists.txt
+++ b/rosette/CMakeLists.txt
@@ -32,7 +32,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-incomplete")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-init-self")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-int-to-pointer-cast")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shift-count-overflow")
 

--- a/rosette/h/Ob.h
+++ b/rosette/h/Ob.h
@@ -443,7 +443,7 @@ union HeaderBits {
     // NB(leaf): The heap allocation routines write information into the header
     // that need to be preserved, so any default ctor can't initialize any of
     // our variables. This needs to be fixed.
-    HeaderBits() {};
+    HeaderBits() {}
     HeaderBits(HeaderBits& hb) { all = hb.all; }
     HeaderBits(int sz) {
         all = 0;
@@ -541,7 +541,7 @@ class Ob : public Base {
     static char stringbuf[256];
 
     Ob(InPlace_Constructor*, int);
-    Ob(InPlace_Constructor*) {};
+    Ob(InPlace_Constructor*) {}
 
     Ob(InPlace_Constructor*, pOb meta, pOb parent) {
         ASSIGN(this, meta(), meta);

--- a/rosette/src/Heap.cc
+++ b/rosette/src/Heap.cc
@@ -245,6 +245,7 @@ void* Space::alloc(unsigned sz) {
         next = temp;
         return current;
     }
+
     return 0;
 }
 


### PR DESCRIPTION
I tried to leave a comment that was meaningful, but I'm not sure I succeeded. Here's what I think is happening. The Heap allocates memory and then wants to do in-place initialization of it. Rather than start by constructing the object in place and then setting some of its state and "remembering" the thing, the heap code first twiddles a bunch of bits in the object's memory and THEN does in-place initialization by way of calling `new (this) Something`. It's a really nasty hack.

If you try to write a good default constructor for `HeaderBits`, then `rosette` crashes because all the bits are fried when the `Ob` ctor fires. So, the only choice is to leave memory uninitialized by default.

This change passes my `(+ 1 1)` test, but I can't be sure everything else works correctly.

This PR also removes some more silly defines.