### PR TITLE
Stop suppressing unused variable warning.

### DIFF
--- a/rosette/CMakeLists.txt
+++ b/rosette/CMakeLists.txt
@@ -32,7 +32,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-incomplete")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-init-self")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-int-to-pointer-cast")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shift-count-overflow")
 

--- a/rosette/CMakeLists.txt
+++ b/rosette/CMakeLists.txt
@@ -30,12 +30,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-write-strings")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-delete-incomplete")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sign-compare")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-int-to-pointer-cast")
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-shift-count-overflow")
-
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DARCH_INC=linux.h")
 
 include_directories("${PROJECT_SOURCE_DIR}/h")
 include_directories("${PROJECT_SOURCE_DIR}/h/sys")

--- a/rosette/h/Ob.h
+++ b/rosette/h/Ob.h
@@ -443,7 +443,7 @@ union HeaderBits {
     // NB(leaf): The heap allocation routines write information into the header
     // that need to be preserved, so any default ctor can't initialize any of
     // our variables. This needs to be fixed.
-    HeaderBits() {};
+    HeaderBits(){};
     HeaderBits(HeaderBits& hb) { all = hb.all; }
     HeaderBits(int sz) {
         all = 0;
@@ -541,7 +541,7 @@ class Ob : public Base {
     static char stringbuf[256];
 
     Ob(InPlace_Constructor*, int);
-    Ob(InPlace_Constructor*) {};
+    Ob(InPlace_Constructor*){};
 
     Ob(InPlace_Constructor*, pOb meta, pOb parent) {
         ASSIGN(this, meta(), meta);

--- a/rosette/h/Prim.h
+++ b/rosette/h/Prim.h
@@ -119,34 +119,44 @@ class BuiltinPrim {
     BUILTIN_PRIM(int_name)
 #endif
 
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
 #define CHECK(n, type, var)                       \
     if (!IS_A(ARG(n), type))                      \
         return PRIM_MISMATCH((n), _STRING(type)); \
     type* var = (type*)ARG(n);
 
-#define CHECK_NOVAR(n, type)                      \
-    if (!IS_A(ARG(n), type))                      \
-        return PRIM_MISMATCH((n), _STRING(type)); \
+#define CHECK_NOVAR(n, type)                            \
+    do {                                                \
+        decltype(n) __n = (n);                          \
+        if (!IS_A(ARG(__n), type)) {                    \
+            return PRIM_MISMATCH((__n), _STRING(type)); \
+        }                                               \
+    } while (0)
 
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
 #define CHECK_FIXNUM(n, var)                 \
     if (!IS_FIXNUM(ARG(n)))                  \
         return PRIM_MISMATCH((n), "Fixnum"); \
     int var = FIXVAL(ARG(n));
 
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
 #define CHECK_SYM(n, var)                    \
     if (!IS_SYM(ARG(n)))                     \
         return PRIM_MISMATCH((n), "Symbol"); \
     Ob* var = ARG(n);
 
-#define CHECK_SYM_NOVAR(n)                   \
-    if (!IS_SYM(ARG(n)))                     \
-        return PRIM_MISMATCH((n), "Symbol"); \
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
+#define CHECK_SYM_NOVAR(n) \
+    if (!IS_SYM(ARG(n)))   \
+        return PRIM_MISMATCH((n), "Symbol");
 
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
 #define CHECK_TYPE(n, typ, var)                   \
     if (!(typeGreaterEq(CLASS_SBO(typ), ARG(n)))) \
         return PRIM_MISMATCH((n), _STRING(typ));  \
     typ* var = (typ*)(ARG(n));
 
+// TODO(leaf): Someone should rewrite this similarly to CHECK_NOVAR.
 #define CHECK_TYPE_BASE(n, typ, var)              \
     if (!(typeGreaterEq(CLASS_SBO(typ), ARG(n)))) \
         return PRIM_MISMATCH((n), _STRING(typ));  \

--- a/rosette/h/Prim.h
+++ b/rosette/h/Prim.h
@@ -124,6 +124,10 @@ class BuiltinPrim {
         return PRIM_MISMATCH((n), _STRING(type)); \
     type* var = (type*)ARG(n);
 
+#define CHECK_NOVAR(n, type)                      \
+    if (!IS_A(ARG(n), type))                      \
+        return PRIM_MISMATCH((n), _STRING(type)); \
+
 #define CHECK_FIXNUM(n, var)                 \
     if (!IS_FIXNUM(ARG(n)))                  \
         return PRIM_MISMATCH((n), "Fixnum"); \
@@ -133,6 +137,10 @@ class BuiltinPrim {
     if (!IS_SYM(ARG(n)))                     \
         return PRIM_MISMATCH((n), "Symbol"); \
     Ob* var = ARG(n);
+
+#define CHECK_SYM_NOVAR(n)                   \
+    if (!IS_SYM(ARG(n)))                     \
+        return PRIM_MISMATCH((n), "Symbol"); \
 
 #define CHECK_TYPE(n, typ, var)                   \
     if (!(typeGreaterEq(CLASS_SBO(typ), ARG(n)))) \

--- a/rosette/src/BaseSupp.cc
+++ b/rosette/src/BaseSupp.cc
@@ -254,8 +254,6 @@ DEF("prim-gen-actor", obGenActor, 3, 3) {
 }
 
 uint32_t mem_get_field(uint32_t* addr, int offset, int span, int sign) {
-    static const int WordSize = BITS(uint32_t);
-
     uint32_t ans = 0;
 
     switch (span) {
@@ -293,8 +291,6 @@ uint32_t mem_get_field(uint32_t* addr, int offset, int span, int sign) {
 }
 
 uint32_t* mem_set_field(uint32_t* addr, int offset, int span, uint32_t bits) {
-    static const int WordSize = BITS(uint32_t);
-
     switch (span) {
     case 8:
         *(uint8_t*)((int8_t*)addr + (offset / BITS(int8_t))) = (uint8_t)bits;
@@ -464,9 +460,7 @@ DEF("M-set", addressSetField, 3, 3) {
     if (base < local_page_size) {
         return PRIM_ERROR("invalid address");
     } else if ((span >= 1) && (span <= 4)) {
-        uint32_t* rslt =
-            mem_set_field(addr, offset * 8, span * 8, (uint32_t)val);
-
+        mem_set_field(addr, offset * 8, span * 8, (uint32_t)val);
         return ADDR_TO_FIXNUM((int)addr);
     }
 

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -545,13 +545,13 @@ int BigBang(int argc, char** argv, char** envp) {
         *stderr = *fdopen(2, "w");
     }
 
-    /**
-     * Always reset the malloc_verify stuff to current settings,
-     * regardless of whether we are restoring an image.  This permits us
-     * maximum checking while building an image, but allows the built
-     * image to run with no checking unless specifically overridden with
-     * a command-line option.
-     */
+/**
+ * Always reset the malloc_verify stuff to current settings,
+ * regardless of whether we are restoring an image.  This permits us
+ * maximum checking while building an image, but allows the built
+ * image to run with no checking unless specifically overridden with
+ * a command-line option.
+ */
 
 #if defined(MALLOC_DEBUGGING)
     malloc_debug(ParanoidAboutGC);
@@ -625,7 +625,7 @@ int asyncHelper(int fd, int desiredState) {
     DO_BLOCKING
 #endif
 
-        result = fcntl(fd, F_SETFL, flags);
+    result = fcntl(fd, F_SETFL, flags);
 #else
     flags = (desiredState ? 1 : 0);
     result = ioctl(fd, FIOSNBIO, &flags);

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -510,39 +510,28 @@ int malloc_debug(int);
 #endif
 
 extern int restore(const char*, char*);
-#if defined(DYNAMIC_LOADING)
-extern DynamicLoader* loader;
-#endif
-
 
 int InBigBang = 0;
 
 int BigBang(int argc, char** argv, char** envp) {
-    const char* cmdName = argv[0];
-
     argc = ParseCommandLine(argc, argv);
-
     InBigBang = true;
-
     setsid();
 
     if (RestoringImage) {
-/*
- * This stuff must be (re-)initialized *after* the restore, since
- * restore will return them to their values at the time that the
- * image file was created.  This also assumes that the strings in
- * argv actually reside on the stack and are not clobbered by the
- * restore.
- */
+        /**
+         * This stuff must be (re-)initialized *after* the restore, since
+         * restore will return them to their values at the time that the
+         * image file was created.  This also assumes that the strings in
+         * argv actually reside on the stack and are not clobbered by the
+         * restore.
+         */
 
-#if defined(DYNAMIC_LOADING)
-        delete loader;
-#endif
         Define("argv", GetArgv(argc, argv));
         Define("envp", GetEnvp(envp));
         vm->resetSignals();
 
-        /*
+        /**
          * This bit of stream manipulation is necessary to reset the
          * stdin and stdout streams to the values appropriate for this
          * particular run, rather than the ones inherited from the image
@@ -556,27 +545,23 @@ int BigBang(int argc, char** argv, char** envp) {
         *stderr = *fdopen(2, "w");
     }
 
-/*
- * Always reset the malloc_verify stuff to current settings,
- * regardless of whether we are restoring an image.  This permits us
- * maximum checking while building an image, but allows the built
- * image to run with no checking unless specifically overridden with
- * a command-line option.
- */
+    /**
+     * Always reset the malloc_verify stuff to current settings,
+     * regardless of whether we are restoring an image.  This permits us
+     * maximum checking while building an image, but allows the built
+     * image to run with no checking unless specifically overridden with
+     * a command-line option.
+     */
 
 #if defined(MALLOC_DEBUGGING)
     malloc_debug(ParanoidAboutGC);
 #endif
 
-/*
- * Always rebuild the loader so that it gets the current command
- * path, just in case the image has been moved from its birthplace in
- * the file system.
- */
-
-#if defined(DYNAMIC_LOADING)
-    loader = new DynamicLoader(cmdName);
-#endif
+    /*
+     * Always rebuild the loader so that it gets the current command
+     * path, just in case the image has been moved from its birthplace in
+     * the file system.
+     */
 
     if (!RestoringImage) {
         heap = new Heap(InfantSpaceSize, SurvivorSpaceSize, OldSpaceChunkSize);
@@ -603,9 +588,6 @@ int BigBang(int argc, char** argv, char** envp) {
 void BigCrunch() {
     delete vm;
     delete heap;
-#if defined(DYNAMIC_LOADING)
-    delete loader;
-#endif
 }
 
 
@@ -643,7 +625,7 @@ int asyncHelper(int fd, int desiredState) {
     DO_BLOCKING
 #endif
 
-    result = fcntl(fd, F_SETFL, flags);
+        result = fcntl(fd, F_SETFL, flags);
 #else
     flags = (desiredState ? 1 : 0);
     result = ioctl(fd, FIOSNBIO, &flags);
@@ -670,7 +652,7 @@ int asyncHelper(int fd, int desiredState) {
 DEF("async", asyncify, 1, 2) {
     FILE* f = stdin;
 
-    CHECK(NARGS - 1, RblBool, b);
+    CHECK_NOVAR(NARGS - 1, RblBool);
     int desiredState = BOOLVAL(ARG(NARGS - 1));
     if (NARGS == 2) {
         CHECK(0, Istream, stream);

--- a/rosette/src/Compile.cc
+++ b/rosette/src/Compile.cc
@@ -686,8 +686,6 @@ SymbolNode* SymbolNode::create(pOb symbol, bool valueCtxt) {
 
 void SymbolNode::initialize(pOb ctEnv, pOb freeEnv, Location dest,
                             CompilationUnit* cu) {
-    extern pOb Qid;
-
     AttrNode::initialize(ctEnv, freeEnv, dest, cu);
     SET_FLAG(word, f_inlineableNode);
     SET_FLAG(word, f_simpleNode);

--- a/rosette/src/Cstruct.cc
+++ b/rosette/src/Cstruct.cc
@@ -538,7 +538,7 @@ uint32_t GenericDescriptor::absoluteAddress(uint32_t base) {
 }
 
 void GenericDescriptor::setAddrContents(uint32_t base, uint32_t val) {
-    uint32_t newbase, offset, *addr;
+    uint32_t newbase, offset;
     newbase = base + _offset;
     offset = newbase % 4;
 
@@ -1267,7 +1267,7 @@ Ob* CRef::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
         uint32_t msetval;
 
         if (TYPEP(this, val)) {
-            uint32_t msetval = ((GenericDescriptor*)val)->absoluteAddress(0);
+            msetval = ((GenericDescriptor*)val)->absoluteAddress(0);
         } else if (TYPEP(_desc, val)) {
             msetval = ((GenericDescriptor*)val)->_offset;
         } else if ((val == this->nullDescriptor(ctxt)) ||
@@ -1381,7 +1381,6 @@ Ob* CharRef::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path, int pindex) {
     if (STRINGP(val)) {
         RBLstring* stmp = (RBLstring*)val;
         char* saddr = new char[stmp->numberOfBytes()];
-        uint32_t prev = SELF->absoluteAddress(base);
 
 #ifdef MEMORYCAUTIOUS
         if (VALID_ADDR(prev)) {
@@ -1568,7 +1567,6 @@ Ob* CharRef0::sSet(Ctxt* ctxt, uint32_t base, Ob* val, Tuple* path,
         int valsize = strlen(GET_STRING(val));
         char* tmp = new char[valsize];
 
-        uint32_t addr = absoluteAddress(base);
 #ifdef MEMORYCAUTIOUS
         (void)free((char*)addr);
 #endif

--- a/rosette/src/Dump-world.cc
+++ b/rosette/src/Dump-world.cc
@@ -27,10 +27,6 @@
 #include "Prim.h"
 #include "Tuple.h"
 
-#if defined(DYNAMIC_LOADING)
-DynamicLoader* loader; /* initialized in BigBang.cc */
-#endif
-
 extern int RestoringImage;
 
 
@@ -41,12 +37,7 @@ DEF("image-dump", imageDump, 1, 1) {
     }
 
     RestoringImage = true;
-    char msg_buf[BUFSIZ];
-#if defined(DYNAMIC_LOADING)
-    return (loader->dump(path, msg_buf) ? PRIM_ERROR(msg_buf) : RBLFALSE);
-#else
     return RBLFALSE;
-#endif
 }
 
 

--- a/rosette/src/ForeignFun.cc
+++ b/rosette/src/ForeignFun.cc
@@ -29,10 +29,6 @@
 
 #include "BuiltinClass.h"
 
-#if defined(DYNAMIC_LOADING)
-extern DynamicLoader* loader;
-#endif
-
 // abstract class
 
 BUILTIN_CLASS(AbstractForeignFunction) {
@@ -119,22 +115,18 @@ Ob* ForeignFunction::typecheckActuals(Ctxt* ctxt) {
 }
 
 convertArgReturnPair ForeignFunction::convertActual(Ctxt* ctxt, int argpos) {
-    ForeignFunction* const __PRIM__ = this;
     Ctxt* const __CTXT__ = ctxt;
-
     Ob* argCnv = argConverters->elem(argpos);
     Ob* arg = ARG(argpos);
-
     return BASE(argCnv)->convertActualArg(ctxt, arg);
 }
 
 Ob* ForeignFunction::convertResult(Ctxt* ctxt, long rslt) {
-    ForeignFunction* const __PRIM__ = this;
-    Ctxt* const __CTXT__ = ctxt;
+    if (NIV == rsltConverter) {
+        return NIV; 
+    }
 
-    return (rsltConverter == NIV)
-               ? NIV
-               : BASE(rsltConverter)->convertActualRslt(ctxt, rslt);
+    return BASE(rsltConverter)->convertActualRslt(ctxt, rslt);
 }
 
 #define CNVARG(i) this->convertActual(ctxt, i)
@@ -145,20 +137,18 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
     }
 
     /*
-      * Check all of the arguments for type conformance, and compute how
-        * much space will be required to pass them.  (We also give
-                                                      * definitions of
+     * Check all of the arguments for type conformance, and compute how
+     * much space will be required to pass them.  (We also give
+     * definitions of
      * "__CTXT__" and "__PRIM__" to keep the CHECK macros
-                                                      * happy.)
-          */
+     * happy.)
+     */
     PROTECT(ctxt);
     ForeignFunction* const __PRIM__ = this;
     Ctxt* const __CTXT__ = ctxt;
     uint32_t x[32];
     const int n = argConverters->numberOfElements();
-    int i = 0;
     long res;
-    int nChars = 0;
     Incantation the_real_fn = (Incantation)(FIXVAL(Caddr));
 
     if (n != NARGS) {
@@ -183,8 +173,8 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
         }
 
 #define CAS(i) \
-    case i:    \
-        res = (*the_real_fn)
+        case i:    \
+                   res = (*the_real_fn)
 #define BR break
         switch (m) {
             CAS(0)();
@@ -210,112 +200,112 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
             CAS(10)(x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9]);
             BR;
             CAS(11)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]);
             BR;
             CAS(12)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11]);
             BR;
             CAS(13)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12]);
             BR;
             CAS(14)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13]);
             BR;
             CAS(15)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14]);
             BR;
             CAS(16)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15]);
             BR;
             CAS(17)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16]);
             BR;
             CAS(18)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17]);
             BR;
             CAS(19)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18]);
             BR;
             CAS(20)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19]);
             BR;
             CAS(21)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20]);
             BR;
             CAS(22)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21]);
             BR;
             CAS(23)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22]);
             BR;
             CAS(24)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23]);
             BR;
             CAS(25)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24]);
             BR;
             CAS(26)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25]);
             BR;
             CAS(27)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26]);
             BR;
             CAS(28)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27]);
             BR;
             CAS(29)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28]);
             BR;
             CAS(30)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-             x[29]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+                 x[29]);
             BR;
             CAS(31)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-             x[29], x[30]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+                 x[29], x[30]);
             BR;
             CAS(32)
-            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-             x[29], x[30], x[31]);
+                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+                 x[29], x[30], x[31]);
             BR;
-        default: {
-            runtimeError(ctxt, "Exceeded arg limit");
-            ctxt->ret(result);
-            return result;
-        }
+            default: {
+                         runtimeError(ctxt, "Exceeded arg limit");
+                         ctxt->ret(result);
+                         return result;
+                     }
         }
         result = convertResult(ctxt, res);
         ctxt->ret(result);
@@ -361,17 +351,17 @@ BUILTIN_CLASS(ForeignFunction) {
 }
 
 ForeignFunction::ForeignFunction(Ob* Cname, Tuple* argConverters,
-                                 Ob* rsltConverter, void* Caddr)
+        Ob* rsltConverter, void* Caddr)
     : AbstractForeignFunction(
-          Cname, argConverters, rsltConverter, Caddr, sizeof(ForeignFunction),
-          CLASS_META(ForeignFunction), CLASS_SBO(ForeignFunction)) {
-    // ForeignFunction is already calling it's version of updateCnt.
-    // Should we call this???
-    ForeignFunction::updateCnt();
-}
+            Cname, argConverters, rsltConverter, Caddr, sizeof(ForeignFunction),
+            CLASS_META(ForeignFunction), CLASS_SBO(ForeignFunction)) {
+        // ForeignFunction is already calling it's version of updateCnt.
+        // Should we call this???
+        ForeignFunction::updateCnt();
+    }
 
 ForeignFunction* ForeignFunction::create(Ob* Cname, Tuple* argConverters,
-                                         Ob* rsltConverter, void* Caddr) {
+        Ob* rsltConverter, void* Caddr) {
     void* loc =
         PALLOC3(sizeof(ForeignFunction), Cname, argConverters, rsltConverter);
     return new (loc)
@@ -465,36 +455,36 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
 
     for (i = 0; i < n; i++) {
         switch ((ArgConverter)FIXVAL(argConverters->elem(i))) {
-        case AC_FixnumToUnsignedLong:
-        case AC_FixnumToLong:
-        case AC_FixnumToInt:
-        case AC_FixnumToUnsignedShort:
-        case AC_FixnumToShort:
-        case AC_FixnumToUnsignedChar:
-        case AC_FixnumToChar:
-        case AC_FixnumToFloat:
-        case AC_FixnumToDouble:
-        case AC_FixnumToVoidStar:
-            CHECK_FIXNUM(i, dummyint);
-            break;
-        case AC_FloatToFloat:
-        case AC_FloatToDouble:
-            CHECK(i, Float, dummyfloat);
-            break;
-        case AC_BoolToInt:
-            CHECK(i, RblBool, dummyBool);
-            break;
-        case AC_StringToCharStar:
-            CHECK(i, RBLstring, dummystr);
-            break;
-        case AC_ByteVecToVoidStar:
-            /* pray a lot */
-            break;
-        case AC_Rosette:
-            break;
-        case nArgConverters:
-        default:
-            return runtimeError(ctxt, "unknown argument type");
+            case AC_FixnumToUnsignedLong:
+            case AC_FixnumToLong:
+            case AC_FixnumToInt:
+            case AC_FixnumToUnsignedShort:
+            case AC_FixnumToShort:
+            case AC_FixnumToUnsignedChar:
+            case AC_FixnumToChar:
+            case AC_FixnumToFloat:
+            case AC_FixnumToDouble:
+            case AC_FixnumToVoidStar:
+                CHECK_FIXNUM(i, dummyint);
+                break;
+            case AC_FloatToFloat:
+            case AC_FloatToDouble:
+                CHECK(i, Float, dummyfloat);
+                break;
+            case AC_BoolToInt:
+                CHECK(i, RblBool, dummyBool);
+                break;
+            case AC_StringToCharStar:
+                CHECK(i, RBLstring, dummystr);
+                break;
+            case AC_ByteVecToVoidStar:
+                /* pray a lot */
+                break;
+            case AC_Rosette:
+                break;
+            case nArgConverters:
+            default:
+                return runtimeError(ctxt, "unknown argument type");
         }
         nChars += argsize[FIXVAL(argConverters->elem(i))];
     }
@@ -521,105 +511,105 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
 
     for (i = 0; i < n; i++) {
         switch ((ArgConverter)FIXVAL(argConverters->elem(i))) {
-        case AC_FixnumToUnsignedLong: {
-            LONG_ARG* p = (LONG_ARG*)argp;
-            *p = (LONG_ARG)(unsigned long)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToLong: {
-            LONG_ARG* p = (LONG_ARG*)argp;
-            *p = (LONG_ARG)(long)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToInt: {
-            INT_ARG* p = (INT_ARG*)argp;
-            *p = (INT_ARG)(int)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToUnsignedShort: {
-            SHORT_ARG* p = (SHORT_ARG*)argp;
-            *p = (SHORT_ARG)(unsigned short)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToShort: {
-            SHORT_ARG* p = (SHORT_ARG*)argp;
-            *p = (SHORT_ARG)(short)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToUnsignedChar: {
-            CHAR_ARG* p = (CHAR_ARG*)argp;
-            *p = (CHAR_ARG)(unsigned char)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToChar: {
-            CHAR_ARG* p = (CHAR_ARG*)argp;
-            *p = (CHAR_ARG)(char)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToFloat: {
-            FLOAT_ARG* p = (FLOAT_ARG*)argp;
-            *p = (FLOAT_ARG)(float)FIXVAL(ARG(i));
-            break;
-        }
-        case AC_FixnumToDouble: {
-            /* Watch out for alignment problems here. */
-            LONG_ARG* p = (LONG_ARG*)argp;
-            union {
-                double f;
-                LONG_ARG ul[2];
-            } tmp;
-            tmp.f = (double)FIXVAL(ARG(i));
-            p[0] = tmp.ul[0];
-            p[1] = tmp.ul[1];
-            break;
-        }
-        case AC_FloatToFloat: {
-            FLOAT_ARG* p = (FLOAT_ARG*)argp;
-            *p = (FLOAT_ARG)(float)((Float*)ARG(i))->val;
-            break;
-        }
-        case AC_FloatToDouble: {
-            LONG_ARG* p = (LONG_ARG*)argp;
-            union {
-                double f;
-                LONG_ARG ul[2];
-            } tmp;
-            tmp.f = (double)((Float*)ARG(i))->val;
-            p[0] = tmp.ul[0];
-            p[1] = tmp.ul[1];
-            break;
-        }
-        case AC_BoolToInt: {
-            INT_ARG* p = (INT_ARG*)argp;
-            *p = (INT_ARG)(int)BOOLVAL(ARG(i));
-            break;
-        }
-        case AC_StringToCharStar: {
-            PTR_ARG* p = (PTR_ARG*)argp;
-            *p = (PTR_ARG) & ((RBLstring*)ARG(i))->byte(0);
-            break;
-        }
-        case AC_ByteVecToVoidStar: {
-            PTR_ARG* p = (PTR_ARG*)argp;
-            *p = (PTR_ARG) & ((ByteVec*)ARG(i))->byte(0);
-            break;
-        }
-        case AC_Rosette: {
-            PTR_ARG* p = (PTR_ARG*)argp;
-            *p = (PTR_ARG)ARG(i);
-            break;
-        }
-        case AC_FixnumToVoidStar: {
-            PTR_ARG* p = (PTR_ARG*)argp;
-            *p = (PTR_ARG)(void*)FIXVAL(ARG(i));
-            break;
-        }
-        case nArgConverters:
-            /*
-              * To silence the compiler while still allowing it to make
-                * sure that we have covered all cases.
-                  */
-            break;
+            case AC_FixnumToUnsignedLong: {
+                                              LONG_ARG* p = (LONG_ARG*)argp;
+                                              *p = (LONG_ARG)(unsigned long)FIXVAL(ARG(i));
+                                              break;
+                                          }
+            case AC_FixnumToLong: {
+                                      LONG_ARG* p = (LONG_ARG*)argp;
+                                      *p = (LONG_ARG)(long)FIXVAL(ARG(i));
+                                      break;
+                                  }
+            case AC_FixnumToInt: {
+                                     INT_ARG* p = (INT_ARG*)argp;
+                                     *p = (INT_ARG)(int)FIXVAL(ARG(i));
+                                     break;
+                                 }
+            case AC_FixnumToUnsignedShort: {
+                                               SHORT_ARG* p = (SHORT_ARG*)argp;
+                                               *p = (SHORT_ARG)(unsigned short)FIXVAL(ARG(i));
+                                               break;
+                                           }
+            case AC_FixnumToShort: {
+                                       SHORT_ARG* p = (SHORT_ARG*)argp;
+                                       *p = (SHORT_ARG)(short)FIXVAL(ARG(i));
+                                       break;
+                                   }
+            case AC_FixnumToUnsignedChar: {
+                                              CHAR_ARG* p = (CHAR_ARG*)argp;
+                                              *p = (CHAR_ARG)(unsigned char)FIXVAL(ARG(i));
+                                              break;
+                                          }
+            case AC_FixnumToChar: {
+                                      CHAR_ARG* p = (CHAR_ARG*)argp;
+                                      *p = (CHAR_ARG)(char)FIXVAL(ARG(i));
+                                      break;
+                                  }
+            case AC_FixnumToFloat: {
+                                       FLOAT_ARG* p = (FLOAT_ARG*)argp;
+                                       *p = (FLOAT_ARG)(float)FIXVAL(ARG(i));
+                                       break;
+                                   }
+            case AC_FixnumToDouble: {
+                                        /* Watch out for alignment problems here. */
+                                        LONG_ARG* p = (LONG_ARG*)argp;
+                                        union {
+                                            double f;
+                                            LONG_ARG ul[2];
+                                        } tmp;
+                                        tmp.f = (double)FIXVAL(ARG(i));
+                                        p[0] = tmp.ul[0];
+                                        p[1] = tmp.ul[1];
+                                        break;
+                                    }
+            case AC_FloatToFloat: {
+                                      FLOAT_ARG* p = (FLOAT_ARG*)argp;
+                                      *p = (FLOAT_ARG)(float)((Float*)ARG(i))->val;
+                                      break;
+                                  }
+            case AC_FloatToDouble: {
+                                       LONG_ARG* p = (LONG_ARG*)argp;
+                                       union {
+                                           double f;
+                                           LONG_ARG ul[2];
+                                       } tmp;
+                                       tmp.f = (double)((Float*)ARG(i))->val;
+                                       p[0] = tmp.ul[0];
+                                       p[1] = tmp.ul[1];
+                                       break;
+                                   }
+            case AC_BoolToInt: {
+                                   INT_ARG* p = (INT_ARG*)argp;
+                                   *p = (INT_ARG)(int)BOOLVAL(ARG(i));
+                                   break;
+                               }
+            case AC_StringToCharStar: {
+                                          PTR_ARG* p = (PTR_ARG*)argp;
+                                          *p = (PTR_ARG) & ((RBLstring*)ARG(i))->byte(0);
+                                          break;
+                                      }
+            case AC_ByteVecToVoidStar: {
+                                           PTR_ARG* p = (PTR_ARG*)argp;
+                                           *p = (PTR_ARG) & ((ByteVec*)ARG(i))->byte(0);
+                                           break;
+                                       }
+            case AC_Rosette: {
+                                 PTR_ARG* p = (PTR_ARG*)argp;
+                                 *p = (PTR_ARG)ARG(i);
+                                 break;
+                             }
+            case AC_FixnumToVoidStar: {
+                                          PTR_ARG* p = (PTR_ARG*)argp;
+                                          *p = (PTR_ARG)(void*)FIXVAL(ARG(i));
+                                          break;
+                                      }
+            case nArgConverters:
+                                      /*
+                                       * To silence the compiler while still allowing it to make
+                                       * sure that we have covered all cases.
+                                       */
+                                      break;
         }
 
         argp += argsize[FIXVAL(argConverters->elem(i))];
@@ -637,48 +627,48 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
         LONG_ARG rslt = ff_single_helper(fn, marshallingArea, nChars);
 
         switch ((RsltConverter)FIXVAL(rsltConverter)) {
-        case RC_Void:
-            result = NIV;
-            break;
+            case RC_Void:
+                result = NIV;
+                break;
 
-        case RC_UnsignedLong:
-        case RC_Long:
-        case RC_Int:
-        case RC_UnsignedShort:
-        case RC_Short:
-        case RC_UnsignedChar:
-        case RC_Char:
-            result = FIXNUM(rslt);
-            break;
-
-        case RC_Float:
-            result = Float::create((double)rslt);
-            break;
-
-        case RC_Double:
-            suicide("unreachable case in ForeignFunction::dispatch");
-            break;
-
-        case RC_CharStar:
-            result = RBLstring::create((char*)rslt);
-            break;
-
-        case RC_Rosette:
-            result = (Ob*)rslt;
-            break;
-
-        case RC_VoidStar:
-            if (rslt & 0xc0000000L) {
-                return PRIM_ERROR("unrepresentable address");
-            } else {
+            case RC_UnsignedLong:
+            case RC_Long:
+            case RC_Int:
+            case RC_UnsignedShort:
+            case RC_Short:
+            case RC_UnsignedChar:
+            case RC_Char:
                 result = FIXNUM(rslt);
-            }
-            break;
+                break;
 
-        case RC_ByteVec:
-        case nRsltConverters:
-        default:
-            return PRIM_ERROR("unknown result type");
+            case RC_Float:
+                result = Float::create((double)rslt);
+                break;
+
+            case RC_Double:
+                suicide("unreachable case in ForeignFunction::dispatch");
+                break;
+
+            case RC_CharStar:
+                result = RBLstring::create((char*)rslt);
+                break;
+
+            case RC_Rosette:
+                result = (Ob*)rslt;
+                break;
+
+            case RC_VoidStar:
+                if (rslt & 0xc0000000L) {
+                    return PRIM_ERROR("unrepresentable address");
+                } else {
+                    result = FIXNUM(rslt);
+                }
+                break;
+
+            case RC_ByteVec:
+            case nRsltConverters:
+            default:
+                return PRIM_ERROR("unknown result type");
         }
     }
 
@@ -707,23 +697,16 @@ DEF("unix-load", unixLoad, 1, 3) {
     }
 
     switch (NARGS) {
-    case 3:
-        otherStr = BASE(ARG(2))->asPathname();
-        if (!otherStr)
-            return PRIM_MISMATCH(2, "String or Symbol");
+        case 3:
+            otherStr = BASE(ARG(2))->asPathname();
+            if (!otherStr)
+                return PRIM_MISMATCH(2, "String or Symbol");
 
-    case 2:
-        libStr = BASE(ARG(1))->asPathname();
-        if (!libStr)
-            return PRIM_MISMATCH(1, "String");
+        case 2:
+            libStr = BASE(ARG(1))->asPathname();
+            if (!libStr)
+                return PRIM_MISMATCH(1, "String");
     }
-
-    char buf[BUFSIZ];
-#if defined(DYNAMIC_LOADING)
-    if (loader->load(path, buf, libStr, otherStr)) {
-        return PRIM_ERROR(buf);
-    }
-#endif
 
     return NIV;
 }
@@ -749,13 +732,6 @@ DEF("wizard-load", unixWizardLoad, 1, 1) {
         return PRIM_MISMATCH(0, "String or Symbol");
     }
 
-    char buf[BUFSIZ];
-#if defined(DYNAMIC_LOADING)
-    if (loader->loadhelp(cmd, buf)) {
-        return PRIM_ERROR(buf);
-    }
-#endif
-
     return NIV;
 }
 
@@ -765,38 +741,18 @@ DEF("unix-resolve", unixResolve, 1, 1) {
     if (!name) {
         return PRIM_MISMATCH(0, "String or Symbol");
     }
-
-#if defined(DYNAMIC_LOADING)
-    void* addr = loader->resolve(name);
-#else
-    void* addr = 0;
-#endif
-
-    if (addr == 0) {
-        return ABSENT;
-    }
-
-    return FIXNUM((int)addr);
+    // NB(leaf): No dynamic loading support.
+    return ABSENT;
 }
 
 
 DEF("ff-new", ffNew, 3, 3) {
-    CHECK_SYM(0, Cname);
-    CHECK(1, Tuple, argConverters);
+    CHECK_SYM_NOVAR(0);
+    CHECK_NOVAR(1, Tuple);
 
-    const char* name = BASE(Cname)->asCstring();
     char buf[BUFSIZ];
-#if defined(DYNAMIC_LOADING)
-    void* addr = loader->resolve(name, buf);
-#else
-    void* addr = 0;
-#endif
-
-    if (0 == addr) {
-        return PRIM_ERROR(buf);
-    }
-
-    return ForeignFunction::create(Cname, argConverters, ARG(2), addr);
+    // NB(leaf): No dynamic loading support.
+    return PRIM_ERROR(buf);
 }
 
 DEF("ff-create", ffCreate, 4, 4) {

--- a/rosette/src/ForeignFun.cc
+++ b/rosette/src/ForeignFun.cc
@@ -123,7 +123,7 @@ convertArgReturnPair ForeignFunction::convertActual(Ctxt* ctxt, int argpos) {
 
 Ob* ForeignFunction::convertResult(Ctxt* ctxt, long rslt) {
     if (NIV == rsltConverter) {
-        return NIV; 
+        return NIV;
     }
 
     return BASE(rsltConverter)->convertActualRslt(ctxt, rslt);
@@ -173,8 +173,8 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
         }
 
 #define CAS(i) \
-        case i:    \
-                   res = (*the_real_fn)
+    case i:    \
+        res = (*the_real_fn)
 #define BR break
         switch (m) {
             CAS(0)();
@@ -200,112 +200,112 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
             CAS(10)(x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9]);
             BR;
             CAS(11)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10]);
             BR;
             CAS(12)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11]);
             BR;
             CAS(13)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12]);
             BR;
             CAS(14)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13]);
             BR;
             CAS(15)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14]);
             BR;
             CAS(16)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15]);
             BR;
             CAS(17)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16]);
             BR;
             CAS(18)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17]);
             BR;
             CAS(19)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18]);
             BR;
             CAS(20)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19]);
             BR;
             CAS(21)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20]);
             BR;
             CAS(22)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21]);
             BR;
             CAS(23)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22]);
             BR;
             CAS(24)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23]);
             BR;
             CAS(25)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24]);
             BR;
             CAS(26)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25]);
             BR;
             CAS(27)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26]);
             BR;
             CAS(28)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27]);
             BR;
             CAS(29)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28]);
             BR;
             CAS(30)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-                 x[29]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+             x[29]);
             BR;
             CAS(31)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-                 x[29], x[30]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+             x[29], x[30]);
             BR;
             CAS(32)
-                (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
-                 x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
-                 x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
-                 x[29], x[30], x[31]);
+            (x[0], x[1], x[2], x[3], x[4], x[5], x[6], x[7], x[8], x[9], x[10],
+             x[11], x[12], x[13], x[14], x[15], x[16], x[17], x[18], x[19],
+             x[20], x[21], x[22], x[23], x[24], x[25], x[26], x[27], x[28],
+             x[29], x[30], x[31]);
             BR;
-            default: {
-                         runtimeError(ctxt, "Exceeded arg limit");
-                         ctxt->ret(result);
-                         return result;
-                     }
+        default: {
+            runtimeError(ctxt, "Exceeded arg limit");
+            ctxt->ret(result);
+            return result;
+        }
         }
         result = convertResult(ctxt, res);
         ctxt->ret(result);
@@ -351,17 +351,17 @@ BUILTIN_CLASS(ForeignFunction) {
 }
 
 ForeignFunction::ForeignFunction(Ob* Cname, Tuple* argConverters,
-        Ob* rsltConverter, void* Caddr)
+                                 Ob* rsltConverter, void* Caddr)
     : AbstractForeignFunction(
-            Cname, argConverters, rsltConverter, Caddr, sizeof(ForeignFunction),
-            CLASS_META(ForeignFunction), CLASS_SBO(ForeignFunction)) {
-        // ForeignFunction is already calling it's version of updateCnt.
-        // Should we call this???
-        ForeignFunction::updateCnt();
-    }
+          Cname, argConverters, rsltConverter, Caddr, sizeof(ForeignFunction),
+          CLASS_META(ForeignFunction), CLASS_SBO(ForeignFunction)) {
+    // ForeignFunction is already calling it's version of updateCnt.
+    // Should we call this???
+    ForeignFunction::updateCnt();
+}
 
 ForeignFunction* ForeignFunction::create(Ob* Cname, Tuple* argConverters,
-        Ob* rsltConverter, void* Caddr) {
+                                         Ob* rsltConverter, void* Caddr) {
     void* loc =
         PALLOC3(sizeof(ForeignFunction), Cname, argConverters, rsltConverter);
     return new (loc)
@@ -455,36 +455,36 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
 
     for (i = 0; i < n; i++) {
         switch ((ArgConverter)FIXVAL(argConverters->elem(i))) {
-            case AC_FixnumToUnsignedLong:
-            case AC_FixnumToLong:
-            case AC_FixnumToInt:
-            case AC_FixnumToUnsignedShort:
-            case AC_FixnumToShort:
-            case AC_FixnumToUnsignedChar:
-            case AC_FixnumToChar:
-            case AC_FixnumToFloat:
-            case AC_FixnumToDouble:
-            case AC_FixnumToVoidStar:
-                CHECK_FIXNUM(i, dummyint);
-                break;
-            case AC_FloatToFloat:
-            case AC_FloatToDouble:
-                CHECK(i, Float, dummyfloat);
-                break;
-            case AC_BoolToInt:
-                CHECK(i, RblBool, dummyBool);
-                break;
-            case AC_StringToCharStar:
-                CHECK(i, RBLstring, dummystr);
-                break;
-            case AC_ByteVecToVoidStar:
-                /* pray a lot */
-                break;
-            case AC_Rosette:
-                break;
-            case nArgConverters:
-            default:
-                return runtimeError(ctxt, "unknown argument type");
+        case AC_FixnumToUnsignedLong:
+        case AC_FixnumToLong:
+        case AC_FixnumToInt:
+        case AC_FixnumToUnsignedShort:
+        case AC_FixnumToShort:
+        case AC_FixnumToUnsignedChar:
+        case AC_FixnumToChar:
+        case AC_FixnumToFloat:
+        case AC_FixnumToDouble:
+        case AC_FixnumToVoidStar:
+            CHECK_FIXNUM(i, dummyint);
+            break;
+        case AC_FloatToFloat:
+        case AC_FloatToDouble:
+            CHECK(i, Float, dummyfloat);
+            break;
+        case AC_BoolToInt:
+            CHECK(i, RblBool, dummyBool);
+            break;
+        case AC_StringToCharStar:
+            CHECK(i, RBLstring, dummystr);
+            break;
+        case AC_ByteVecToVoidStar:
+            /* pray a lot */
+            break;
+        case AC_Rosette:
+            break;
+        case nArgConverters:
+        default:
+            return runtimeError(ctxt, "unknown argument type");
         }
         nChars += argsize[FIXVAL(argConverters->elem(i))];
     }
@@ -511,105 +511,105 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
 
     for (i = 0; i < n; i++) {
         switch ((ArgConverter)FIXVAL(argConverters->elem(i))) {
-            case AC_FixnumToUnsignedLong: {
-                                              LONG_ARG* p = (LONG_ARG*)argp;
-                                              *p = (LONG_ARG)(unsigned long)FIXVAL(ARG(i));
-                                              break;
-                                          }
-            case AC_FixnumToLong: {
-                                      LONG_ARG* p = (LONG_ARG*)argp;
-                                      *p = (LONG_ARG)(long)FIXVAL(ARG(i));
-                                      break;
-                                  }
-            case AC_FixnumToInt: {
-                                     INT_ARG* p = (INT_ARG*)argp;
-                                     *p = (INT_ARG)(int)FIXVAL(ARG(i));
-                                     break;
-                                 }
-            case AC_FixnumToUnsignedShort: {
-                                               SHORT_ARG* p = (SHORT_ARG*)argp;
-                                               *p = (SHORT_ARG)(unsigned short)FIXVAL(ARG(i));
-                                               break;
-                                           }
-            case AC_FixnumToShort: {
-                                       SHORT_ARG* p = (SHORT_ARG*)argp;
-                                       *p = (SHORT_ARG)(short)FIXVAL(ARG(i));
-                                       break;
-                                   }
-            case AC_FixnumToUnsignedChar: {
-                                              CHAR_ARG* p = (CHAR_ARG*)argp;
-                                              *p = (CHAR_ARG)(unsigned char)FIXVAL(ARG(i));
-                                              break;
-                                          }
-            case AC_FixnumToChar: {
-                                      CHAR_ARG* p = (CHAR_ARG*)argp;
-                                      *p = (CHAR_ARG)(char)FIXVAL(ARG(i));
-                                      break;
-                                  }
-            case AC_FixnumToFloat: {
-                                       FLOAT_ARG* p = (FLOAT_ARG*)argp;
-                                       *p = (FLOAT_ARG)(float)FIXVAL(ARG(i));
-                                       break;
-                                   }
-            case AC_FixnumToDouble: {
-                                        /* Watch out for alignment problems here. */
-                                        LONG_ARG* p = (LONG_ARG*)argp;
-                                        union {
-                                            double f;
-                                            LONG_ARG ul[2];
-                                        } tmp;
-                                        tmp.f = (double)FIXVAL(ARG(i));
-                                        p[0] = tmp.ul[0];
-                                        p[1] = tmp.ul[1];
-                                        break;
-                                    }
-            case AC_FloatToFloat: {
-                                      FLOAT_ARG* p = (FLOAT_ARG*)argp;
-                                      *p = (FLOAT_ARG)(float)((Float*)ARG(i))->val;
-                                      break;
-                                  }
-            case AC_FloatToDouble: {
-                                       LONG_ARG* p = (LONG_ARG*)argp;
-                                       union {
-                                           double f;
-                                           LONG_ARG ul[2];
-                                       } tmp;
-                                       tmp.f = (double)((Float*)ARG(i))->val;
-                                       p[0] = tmp.ul[0];
-                                       p[1] = tmp.ul[1];
-                                       break;
-                                   }
-            case AC_BoolToInt: {
-                                   INT_ARG* p = (INT_ARG*)argp;
-                                   *p = (INT_ARG)(int)BOOLVAL(ARG(i));
-                                   break;
-                               }
-            case AC_StringToCharStar: {
-                                          PTR_ARG* p = (PTR_ARG*)argp;
-                                          *p = (PTR_ARG) & ((RBLstring*)ARG(i))->byte(0);
-                                          break;
-                                      }
-            case AC_ByteVecToVoidStar: {
-                                           PTR_ARG* p = (PTR_ARG*)argp;
-                                           *p = (PTR_ARG) & ((ByteVec*)ARG(i))->byte(0);
-                                           break;
-                                       }
-            case AC_Rosette: {
-                                 PTR_ARG* p = (PTR_ARG*)argp;
-                                 *p = (PTR_ARG)ARG(i);
-                                 break;
-                             }
-            case AC_FixnumToVoidStar: {
-                                          PTR_ARG* p = (PTR_ARG*)argp;
-                                          *p = (PTR_ARG)(void*)FIXVAL(ARG(i));
-                                          break;
-                                      }
-            case nArgConverters:
-                                      /*
-                                       * To silence the compiler while still allowing it to make
-                                       * sure that we have covered all cases.
-                                       */
-                                      break;
+        case AC_FixnumToUnsignedLong: {
+            LONG_ARG* p = (LONG_ARG*)argp;
+            *p = (LONG_ARG)(unsigned long)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToLong: {
+            LONG_ARG* p = (LONG_ARG*)argp;
+            *p = (LONG_ARG)(long)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToInt: {
+            INT_ARG* p = (INT_ARG*)argp;
+            *p = (INT_ARG)(int)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToUnsignedShort: {
+            SHORT_ARG* p = (SHORT_ARG*)argp;
+            *p = (SHORT_ARG)(unsigned short)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToShort: {
+            SHORT_ARG* p = (SHORT_ARG*)argp;
+            *p = (SHORT_ARG)(short)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToUnsignedChar: {
+            CHAR_ARG* p = (CHAR_ARG*)argp;
+            *p = (CHAR_ARG)(unsigned char)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToChar: {
+            CHAR_ARG* p = (CHAR_ARG*)argp;
+            *p = (CHAR_ARG)(char)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToFloat: {
+            FLOAT_ARG* p = (FLOAT_ARG*)argp;
+            *p = (FLOAT_ARG)(float)FIXVAL(ARG(i));
+            break;
+        }
+        case AC_FixnumToDouble: {
+            /* Watch out for alignment problems here. */
+            LONG_ARG* p = (LONG_ARG*)argp;
+            union {
+                double f;
+                LONG_ARG ul[2];
+            } tmp;
+            tmp.f = (double)FIXVAL(ARG(i));
+            p[0] = tmp.ul[0];
+            p[1] = tmp.ul[1];
+            break;
+        }
+        case AC_FloatToFloat: {
+            FLOAT_ARG* p = (FLOAT_ARG*)argp;
+            *p = (FLOAT_ARG)(float)((Float*)ARG(i))->val;
+            break;
+        }
+        case AC_FloatToDouble: {
+            LONG_ARG* p = (LONG_ARG*)argp;
+            union {
+                double f;
+                LONG_ARG ul[2];
+            } tmp;
+            tmp.f = (double)((Float*)ARG(i))->val;
+            p[0] = tmp.ul[0];
+            p[1] = tmp.ul[1];
+            break;
+        }
+        case AC_BoolToInt: {
+            INT_ARG* p = (INT_ARG*)argp;
+            *p = (INT_ARG)(int)BOOLVAL(ARG(i));
+            break;
+        }
+        case AC_StringToCharStar: {
+            PTR_ARG* p = (PTR_ARG*)argp;
+            *p = (PTR_ARG) & ((RBLstring*)ARG(i))->byte(0);
+            break;
+        }
+        case AC_ByteVecToVoidStar: {
+            PTR_ARG* p = (PTR_ARG*)argp;
+            *p = (PTR_ARG) & ((ByteVec*)ARG(i))->byte(0);
+            break;
+        }
+        case AC_Rosette: {
+            PTR_ARG* p = (PTR_ARG*)argp;
+            *p = (PTR_ARG)ARG(i);
+            break;
+        }
+        case AC_FixnumToVoidStar: {
+            PTR_ARG* p = (PTR_ARG*)argp;
+            *p = (PTR_ARG)(void*)FIXVAL(ARG(i));
+            break;
+        }
+        case nArgConverters:
+            /*
+             * To silence the compiler while still allowing it to make
+             * sure that we have covered all cases.
+             */
+            break;
         }
 
         argp += argsize[FIXVAL(argConverters->elem(i))];
@@ -627,48 +627,48 @@ Ob* ForeignFunction::dispatch(Ctxt* ctxt) {
         LONG_ARG rslt = ff_single_helper(fn, marshallingArea, nChars);
 
         switch ((RsltConverter)FIXVAL(rsltConverter)) {
-            case RC_Void:
-                result = NIV;
-                break;
+        case RC_Void:
+            result = NIV;
+            break;
 
-            case RC_UnsignedLong:
-            case RC_Long:
-            case RC_Int:
-            case RC_UnsignedShort:
-            case RC_Short:
-            case RC_UnsignedChar:
-            case RC_Char:
+        case RC_UnsignedLong:
+        case RC_Long:
+        case RC_Int:
+        case RC_UnsignedShort:
+        case RC_Short:
+        case RC_UnsignedChar:
+        case RC_Char:
+            result = FIXNUM(rslt);
+            break;
+
+        case RC_Float:
+            result = Float::create((double)rslt);
+            break;
+
+        case RC_Double:
+            suicide("unreachable case in ForeignFunction::dispatch");
+            break;
+
+        case RC_CharStar:
+            result = RBLstring::create((char*)rslt);
+            break;
+
+        case RC_Rosette:
+            result = (Ob*)rslt;
+            break;
+
+        case RC_VoidStar:
+            if (rslt & 0xc0000000L) {
+                return PRIM_ERROR("unrepresentable address");
+            } else {
                 result = FIXNUM(rslt);
-                break;
+            }
+            break;
 
-            case RC_Float:
-                result = Float::create((double)rslt);
-                break;
-
-            case RC_Double:
-                suicide("unreachable case in ForeignFunction::dispatch");
-                break;
-
-            case RC_CharStar:
-                result = RBLstring::create((char*)rslt);
-                break;
-
-            case RC_Rosette:
-                result = (Ob*)rslt;
-                break;
-
-            case RC_VoidStar:
-                if (rslt & 0xc0000000L) {
-                    return PRIM_ERROR("unrepresentable address");
-                } else {
-                    result = FIXNUM(rslt);
-                }
-                break;
-
-            case RC_ByteVec:
-            case nRsltConverters:
-            default:
-                return PRIM_ERROR("unknown result type");
+        case RC_ByteVec:
+        case nRsltConverters:
+        default:
+            return PRIM_ERROR("unknown result type");
         }
     }
 
@@ -697,15 +697,15 @@ DEF("unix-load", unixLoad, 1, 3) {
     }
 
     switch (NARGS) {
-        case 3:
-            otherStr = BASE(ARG(2))->asPathname();
-            if (!otherStr)
-                return PRIM_MISMATCH(2, "String or Symbol");
+    case 3:
+        otherStr = BASE(ARG(2))->asPathname();
+        if (!otherStr)
+            return PRIM_MISMATCH(2, "String or Symbol");
 
-        case 2:
-            libStr = BASE(ARG(1))->asPathname();
-            if (!libStr)
-                return PRIM_MISMATCH(1, "String");
+    case 2:
+        libStr = BASE(ARG(1))->asPathname();
+        if (!libStr)
+            return PRIM_MISMATCH(1, "String");
     }
 
     return NIV;

--- a/rosette/src/Heap.cc
+++ b/rosette/src/Heap.cc
@@ -884,9 +884,6 @@ int Heap::size() { return newSpace->size() + oldSpace->size(); }
 static void catchMagic() {}
 #endif
 
-static void* magicLoc = 0;
-
-
 void* Heap::alloc(unsigned sz) {
     void* loc = newSpace->alloc(sz);
 #ifdef DEBUG

--- a/rosette/src/Heap.cc
+++ b/rosette/src/Heap.cc
@@ -245,6 +245,7 @@ void* Space::alloc(unsigned sz) {
         next = temp;
         return current;
     }
+
     return 0;
 }
 

--- a/rosette/src/Meta.cc
+++ b/rosette/src/Meta.cc
@@ -393,7 +393,7 @@ DEF("set-obo", metaSetOBO, 4, 4) {
 DEF("lexvar", locLexvar, 3, 3) {
     CHECK_FIXNUM(0, level);
     CHECK_FIXNUM(1, offset);
-    CHECK(2, RblBool, indirect);
+    CHECK_NOVAR(2, RblBool);
     return LexVar(level, offset, ARG(2) == RBLTRUE).atom;
 }
 
@@ -402,8 +402,8 @@ DEF("bitfield", locBitfield, 5, 5) {
     CHECK_FIXNUM(0, level);
     CHECK_FIXNUM(1, offset);
     CHECK_FIXNUM(2, span);
-    CHECK(3, RblBool, indirect);
-    CHECK(4, RblBool, sign);
+    CHECK_NOVAR(3, RblBool);
+    CHECK_NOVAR(4, RblBool);
     return BitField(level, offset, span, ARG(3) == RBLTRUE, ARG(4) == RBLTRUE)
         .atom;
 }

--- a/rosette/src/Ob.cc
+++ b/rosette/src/Ob.cc
@@ -539,8 +539,6 @@ pOb Ob::setAddr(int indirect, int level, int offset, pOb val) {
 
 
 pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
-    static const int WordSize = BITS(uint32_t);
-
     long ans;
     pOb p = this;
     while (level--) {
@@ -582,8 +580,6 @@ pOb Ob::getField(int indirect, int level, int offset, int span, int sign) {
 }
 
 pOb Ob::setField(int indirect, int level, int offset, int span, uint32_t bits) {
-    static const int WordSize = BITS(uint32_t);
-
     pOb p = this;
     while (level--) {
         p = BASE(p->parent());
@@ -1214,8 +1210,8 @@ DEF("object->symbol", objectToSymbol, 1, MaxArgs) {
 DEF("get-field", objectGetField, 5, 5) {
     CHECK_FIXNUM(1, start);
     CHECK_FIXNUM(2, span);
-    CHECK(3, RblBool, indirect);
-    CHECK(4, RblBool, sign);
+    CHECK_NOVAR(3, RblBool);
+    CHECK_NOVAR(4, RblBool);
     pOb rslt = BASE(ARG(0))->getField(ARG(3) == RBLTRUE, 0, start, span,
                                       ARG(4) == RBLTRUE);
 

--- a/rosette/src/Queue.cc
+++ b/rosette/src/Queue.cc
@@ -136,7 +136,8 @@ Ob* Queue::setNth(int n, Ob* val) {
 Ob* Queue::subObject(int start, int size) {
     PROTECT_THIS(Queue);
     Queue* new_queue = Queue::create();
-    Tuple* new_elems = Tuple::create(SELF->elems->numberOfElements(), NIV);
+    Tuple::create(SELF->elems->numberOfElements(), NIV);
+
     while (size--) {
         new_queue->enqueue(SELF->nth(start++));
     }

--- a/rosette/src/RBLstream.cc
+++ b/rosette/src/RBLstream.cc
@@ -201,7 +201,7 @@ DEF("istream-clear", istreamClear, 1, 2) {
 
 
 DEF("istream-rdstate", istreamRdState, 1, 1) {
-    CHECK(0, Istream, stream);
+    CHECK_NOVAR(0, Istream);
     return PRIM_ERROR("de-implemented");
 }
 
@@ -223,7 +223,6 @@ DEF("istream-close", istreamClose, 1, 1) {
 
 DEF("ostream-new", makeOstream, 1, 2) {
     char* path = BASE(ARG(0))->asPathname();
-    char* reason = "problem opening ostream";
     const char* mode = "a";
 
     if (!path) {

--- a/rosette/src/StreamUtils.cc
+++ b/rosette/src/StreamUtils.cc
@@ -45,7 +45,6 @@ int eofError(FILE* f) { return readError(f, "unexpected eof"); }
 
 
 char getEscapedChar(FILE* f) {
-    char buf[4];
     int c;
 
     if ((c = getc(f)) == EOF)

--- a/rosette/src/Vm.cc
+++ b/rosette/src/Vm.cc
@@ -366,8 +366,6 @@ void VirtualMachine::check() { traversePtrs(MF_ADDR(Ob::checkOb)); }
 
 
 void VirtualMachine::handleException(Ob* v, Instr instr, Location tag) {
-    static const int XmitFamily = opXmitTag & 0xf0;
-    static const int XmitXtndFamily = opXmitTagXtnd & 0xf0;
     static const int ApplyPrimFamily = opApplyPrimTag & 0xf0;
 
     int family = OP_f0_opcode(instr) & 0xf0;
@@ -703,7 +701,6 @@ Ob* VirtualMachine::vmLiterals[16] = {0};
 void VirtualMachine::execute() {
     Instr instr;
     Location loc;
-    pOb temp = INVALID;
     pOb result = INVALID;
 
 nextop:
@@ -1624,7 +1621,6 @@ void VirtualMachine::initVmTables() {
 
     static const uint16_t StartLabel = 0;
     static const uint16_t ResumeLabel = 8;
-    int dummy = 0;
 
     /*  0 */ cb->emitF6(opOutstanding, ResumeLabel);
     cb->emitE0(1, 0);


### PR DESCRIPTION
This PR comes after: https://github.com/rchain/rchain/pull/118 Until that PR is merged, this one will include its diffs.

This pull request removes `-Wno-unused-variable` from the list of suppressed warnings. In general this should be safe, unless some serious hackery has been going on (possible). However, it passes by `(+ 1 1)` test.
