### PR TITLE
Fix boot.rbl getFd warning.

### DIFF
--- a/rosette/src/RBLstream.cc
+++ b/rosette/src/RBLstream.cc
@@ -385,25 +385,15 @@ DEF("prim-flush", obFlush, 0, 1) {
     return NIV;
 }
 
-#if !defined(LINUX)
 DEF("getFd", obGetFd, 1, 1) {
     if (IS_A(ARG(0), Istream)) {
-#ifdef HPUX
-        return FIXNUM(((Istream*)ARG(0))->reader->file->__fileL);
-#else
-        return FIXNUM(((Istream*)ARG(0))->reader->file->_file);
-#endif
+        return FIXNUM(fileno(((Istream*)ARG(0))->reader->file));
     } else if (IS_A(ARG(0), Ostream)) {
-#ifdef HPUX
-        return FIXNUM(((Ostream*)ARG(0))->stream->__fileL);
-#else
-        return FIXNUM(((Ostream*)ARG(0))->stream->_file);
-#endif
+        return FIXNUM(fileno(((Ostream*)ARG(0))->stream));
     } else {
         return FIXNUM(-1);
     }
 }
-#endif /* ! LINUX */
 
 DEF_OPRN(Sync, "print", oprnPrint, obPrint);
 DEF_OPRN(Sync, "display", oprnDisplay, obDisplay);


### PR DESCRIPTION
The primitive getFd was explicitly commented out with "#if !defined(LINUX)".

During our cleanup we defined "LINUX" and caused this code to go away.

I've removed the HPUX specific code and replaced it with code that will return the file descriptor using Linux friendly code.

https://rchain.atlassian.net/browse/ROS-303

