### PR TITLE
ROS-305 Fix crash with extended ASCII characters.

### DIFF
--- a/rosette/src/Reader.cc
+++ b/rosette/src/Reader.cc
@@ -82,7 +82,7 @@ class ReadMacro {
 };
 
 
-static const int NCHARS = 255;
+static const int NCHARS = 256;
 static const int _DELIMITER = 0x1;
 
 

--- a/rosette/src/Reader.cc
+++ b/rosette/src/Reader.cc
@@ -82,7 +82,7 @@ class ReadMacro {
 };
 
 
-static const int NCHARS = 128;
+static const int NCHARS = 255;
 static const int _DELIMITER = 0x1;
 
 


### PR DESCRIPTION
https://rchain.atlassian.net/browse/ROS-305

The ReadTable class builds an array of ReadMacro objects based on whether the char position is whitespace or not. It later indexes into this table using the read character and calls a method in the object. This table was only sized to allow the traditional 128 ASCII characters. A character greater than 127 would index off the end of the table and attempt to call through a garbage object pointer.

This extends the table for the extended ASCII character set. 
 
edit: typo 