### PR TITLE
Don't fail if ensime.sbt isn't present.

### DIFF
--- a/comm/Dockerfile
+++ b/comm/Dockerfile
@@ -6,7 +6,7 @@ run apt update && apt dist-upgrade -y && apt install -y sbt
 
 copy . /src
 workdir /src
-run rm ensime.sbt
+run rm -f ensime.sbt
 
 env JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 


### PR DESCRIPTION
Super quick fix for intrepid folk who are trying to use the included Dockerfile. That file will go away soon, but I think this'll fix their issue.

That `ensime.sbt` file is an Emacs remnant, and most people won't have it. It's not something that belongs in git, either, so this line of the Dockerfile is just cleanup for _my_ environment.