### PR TITLE
Hacks to try to add regression tests for segfaults.

### DIFF
--- a/rosette/cmaketest.sh
+++ b/rosette/cmaketest.sh
@@ -1,35 +1,60 @@
 #!/usr/bin/env bash
 
-
-
-# Create file for printing results
-touch rbl/rosette/results.txt
+# Create/clear file for printing results
+RESULTS=rbl/rosette/results.txt
+cat > "${RESULTS}" < /dev/null
 
 # Build Rosette
 ./clean.sh
 ./build.sh
+if [ $? -ne 0 ]
+then
+    echo Build failed. >&2
+    exit 1
+fi
 
-# Increase stack limit so that Rosette can load all files
-ulimit -s unlimited
+{
+    # Increase stack limit so that Rosette can load all files
+    ulimit -s unlimited
 
-# Execute Rosette instance
-./build.out/src/rosette -boot rbl/rosette/boot.rbl \
-    -run rbl/rosette/hello_world.rbl <<EOF
+    export ESS_SYSDIR=$PWD/rbl/rosette
+    ROSETTE="./build.out/src/rosette -boot rbl/rosette/boot.rbl"
+
+    # Execute Rosette instance
+    ${ROSETTE} -run rbl/rosette/hello_world.rbl <<EOF
 (exit)
 EOF
 
-./build.out/src/rosette -boot rbl/rosette/boot.rbl <<EOF
+    ${ROSETTE} <<EOF
 (seq
   (display "\n")		; (terpri)
   (load "tests/run-tests.ros" 'silent))
 EOF
 
+    # Segfault regression test hacks
+
+    for f in rbl/rosette/tests/segfaults/*.rbl
+    do
+	${ROSETTE} < $f
+	res=$?
+	if [ ${res} -ne 0 ]
+	then
+	    echo -e "\033[31mRegression failure (exit code ${res}) on $f\033[39m"
+	else
+	    echo -e "\033[32mRegression success (exit code ${res}) on $f\033[39m"
+	fi
+    done
+} 2>&1 | tee -a "${RESULTS}"
+
+echo
+echo Summary:
+
 # Check if any tests have failed
-cat rbl/rosette/results.txt | grep "Fail"
-if [ $? -ne 1 ]
-    then
+grep fail "${RESULTS}"
+if [ $? -eq 0 ]
+then
     exit 1
 fi
 
-# Otherwise, return success
+echo All good.
 exit 0

--- a/rosette/rbl/rosette/tests/segfaults/regression-ros-304.rbl
+++ b/rosette/rbl/rosette/tests/segfaults/regression-ros-304.rbl
@@ -1,0 +1,19 @@
+;; -*- Coding: utf-8; Mode: scheme; -*-
+;;
+
+;; Regression test for improvement in ROS-304 (https://github.com/rchain/rchain/pull/137).
+;;
+
+;; This (improper) use of defExpander caused a segfault
+;;
+(defExpander (ros-304 body) (new RequestExpr 'display body "\n"))
+(ros-304 (= (+ 1 2) 3))
+
+;; Ask for clean exit.
+(exit)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; fill-column: 79
+;; comment-column: 37
+;; End:


### PR DESCRIPTION
For example, before something ROS-304 is fixed in #137, we would get this:

```
Summary:
Regression failure (exit code 139) on rbl/rosette/tests/segfaults/regression-ros-304.rbl
```

and after:
```
Summary:
All good.
```

This is super hacky, since I don't see any way to recover from either the segfault or even a reader or parse error in Rosette. Maybe this is where "monitors" come in, but that part of the documentation isn't.