### PR TITLE
Add `set +e` to get back some resiliency.

### DIFF
--- a/rosette/cmaketest.sh
+++ b/rosette/cmaketest.sh
@@ -11,6 +11,9 @@ cat > "${RESULTS}" < /dev/null
 ./build.sh
 
 {
+    # Continue after errors
+    set +e
+
     # Increase stack limit so that Rosette can load all files
     ulimit -s unlimited
 


### PR DESCRIPTION
We want this subshells to continue after errors, so we can detect segfaults and other bad stuff and print useful messages to the user.

This might be the last change before we get cmake's testerizer working.