### PR TITLE
Fix rosette command line arguments.

### DIFF
--- a/rosette/cmaketest.sh
+++ b/rosette/cmaketest.sh
@@ -18,10 +18,10 @@ cat > "${RESULTS}" < /dev/null
     ulimit -s unlimited
 
     export ESS_SYSDIR=$PWD/rbl/rosette
-    ROSETTE="./build.out/src/rosette -boot rbl/rosette/boot.rbl"
+    ROSETTE="./build.out/src/rosette --boot rbl/rosette/boot.rbl"
 
     # Execute Rosette instance
-    ${ROSETTE} -run rbl/rosette/hello_world.rbl <<EOF
+    ${ROSETTE} rbl/rosette/hello_world.rbl <<EOF
 (exit)
 EOF
 


### PR DESCRIPTION
GNU-style for flags and the run file is naked.

Keeping up with #144.