### PR TITLE
Move tests to cmake.

### DIFF
--- a/rosette/rbl/rosette/CMakeLists.txt
+++ b/rosette/rbl/rosette/CMakeLists.txt
@@ -1,4 +1,3 @@
-#add_test(NAME boot_rbl COMMAND rosette -boot boot.rbl)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/apropos.rbl
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/async-repl.rbl
@@ -55,3 +54,23 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tuple-oprns.rbl
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/vm-heap.rbl
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+
+
+add_test(NAME boot_rbl COMMAND rosette --boot-dir ${CMAKE_CURRENT_BINARY_DIR} /dev/null)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/run-tests.ros
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/equiv.ros
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/reader-iso-8859-1.ros
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/reader-utf-8.ros
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+
+add_test(NAME test_scripts COMMAND rosette --boot-dir ${CMAKE_CURRENT_BINARY_DIR} tests/run-tests.ros)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/segfaults/regression-ros-304.rbl
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests/segfaults)
+
+add_test(NAME regression_ros_304 COMMAND rosette --boot-dir ${CMAKE_CURRENT_BINARY_DIR} tests/segfaults/regression-ros-304.rbl)

--- a/rosette/rbl/rosette/tests/run-tests.ros
+++ b/rosette/rbl/rosette/tests/run-tests.ros
@@ -66,9 +66,11 @@
           '#niv))))
 
 
-(load "equiv.ros" 'silent)
-(load "reader-iso-8859-1.ros" 'silent)
-(load "reader-utf-8.ros" 'silent)
+(load "tests/equiv.ros" 'silent)
+(load "tests/reader-iso-8859-1.ros" 'silent)
+(load "tests/reader-utf-8.ros" 'silent)
+
+(exit (if (> failures 0) 1 0))
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil


### PR DESCRIPTION
Still runs most of them via `run-test.ros`, but now it detects failures.