### PR TITLE
Rosette logging

### DIFF
--- a/rosette/rbl/rosette/CMakeLists.txt
+++ b/rosette/rbl/rosette/CMakeLists.txt
@@ -4,7 +4,7 @@ file(COPY apropos.rbl async-repl.rbl boot.rbl classes-types.rbl
     hello_world.rbl io-system.rbl meth-proc-oprns.rbl multimethod.rbl
     primitives.rbl que-stk-oprns.rbl sbo-init.rbl space.rbl
     string-oprns.rbl system.rbl table-oprns.rbl time.rbl timesvc.rbl
-    trace.rbl tuple-oprns.rbl vm-heap.rbl
+    trace.rbl tuple-oprns.rbl vm-heap.rbl log.rbl
     DESTINATION lib/rosette)
 
 install(FILES apropos.rbl async-repl.rbl boot.rbl classes-types.rbl
@@ -13,7 +13,7 @@ install(FILES apropos.rbl async-repl.rbl boot.rbl classes-types.rbl
     hello_world.rbl io-system.rbl meth-proc-oprns.rbl multimethod.rbl
     primitives.rbl que-stk-oprns.rbl sbo-init.rbl space.rbl
     string-oprns.rbl system.rbl table-oprns.rbl time.rbl timesvc.rbl
-    trace.rbl tuple-oprns.rbl vm-heap.rbl
+    trace.rbl tuple-oprns.rbl vm-heap.rbl log.rbl
     DESTINATION lib/rosette)
 
 add_test(NAME boot_rbl

--- a/rosette/rbl/rosette/configuration.rbl
+++ b/rosette/rbl/rosette/configuration.rbl
@@ -44,3 +44,4 @@
 (load 'apropos  'silent)
 (load 'space 'silent)
 (load 'primitives 'silent)
+(load 'log 'silent)

--- a/rosette/rbl/rosette/log.rbl
+++ b/rosette/rbl/rosette/log.rbl
@@ -41,8 +41,8 @@
    (define *log-level-map* tbl)))
 
 (define *log-level*
-  (cond ((same? (kind flag-verbose) 'Bool) 'DEBUG)
-        ((same? (kind flag-verbose) 'Fixnum)
+  (cond ((type? flag-verbose Bool) (if flag-verbose 'DEBUG 'WARNING))
+        ((type? flag-verbose Fixnum)
          (iterate loop [[[level & rest] (names *log-level-map*)]]
                   (cond ((= (tbl-get *log-level-map* level) flag-verbose) level)
                         ((null? rest) 'DEBUG)
@@ -55,7 +55,7 @@
 
 (defProc (log:display level & args)
   (let [[prefix (log:%prefix level)]
-        [dargs (reverse [#\\n &args])]]
+        [dargs (reverse [#\\n & args])]]
     (seq
      (if prefix
          (display stderr (log-time-string) " " (->string level) ": " & dargs))

--- a/rosette/rbl/rosette/log.rbl
+++ b/rosette/rbl/rosette/log.rbl
@@ -58,7 +58,7 @@
         [dargs (reverse [#\\n & args])]]
     (seq
      (if prefix
-         (display stderr (log-time-string) " " (->string level) ": " & dargs))
+         (display stderr (log-time-string) " " (->string prefix) ": " & dargs))
      #niv)))
 
 ;;; Local Variables:

--- a/rosette/rbl/rosette/log.rbl
+++ b/rosette/rbl/rosette/log.rbl
@@ -1,0 +1,68 @@
+;;;  -*- coding: utf-8; mode: scheme; -*-
+;;;
+;;;
+;;; Copyright (c) 2018, RChain Cooperative
+;;; Author: Chris Kirkwood-Watts <kirkwood@pyrofex.net>
+;;;
+;;; This file is licensed under the Apache License, version 2.0.
+;;;
+;;;
+;;; This is a simple logging facility. There is a global log level
+;;; (*log-level*) controlled initially by the flag-verbose parameter. There are
+;;; four predefined log level "constants": ERROR, WARNING, INFO, and DEBUG, in
+;;; order of severity.
+;;;
+;;; Expressions of the form
+;;;
+;;;   (log:display 'ERROR "This is a " 'fancy " log message.")
+;;;
+;;; will print a newline-terminated, timestamped log line to the standard error
+;;; stream like:
+;;;
+;;;   2018-01-16 18:35:35 ERROR: This is a fancy log message.
+;;;
+;;; if the given <level> is at least as severe as the global log level.
+;;;
+;;; The global log level may be manipulated, but it's probably best to leave it
+;;; alone:
+;;;
+;;;   rosette> (define *log-level* 'ERROR)
+;;;   '*log-level*
+;;;   rosette> (log:display 'WARNING "This is a warning!")
+;;;   rosette> (define *log-level* 'WARNING)
+;;;   '*log-level*
+;;;   rosette> (log:display 'WARNING "This is a warning!")
+;;;   2018-01-16 18:36:54 WARNING: This is a warning!
+
+(let [[tbl (new RblTable)]]
+  (seq
+   (walk '[ERROR WARNING INFO DEBUG]
+         (proc [v k] (tbl-add tbl k v)))
+   (define *log-level-map* tbl)))
+
+(define *log-level*
+  (cond ((same? (kind flag-verbose) 'Bool) 'DEBUG)
+        ((same? (kind flag-verbose) 'Fixnum)
+         (iterate loop [[[level & rest] (names *log-level-map*)]]
+                  (cond ((= (tbl-get *log-level-map* level) flag-verbose) level)
+                        ((null? rest) 'DEBUG)
+                        (else (loop rest)))))))
+
+(defProc (log:%prefix level)
+  (let [[lvl (tbl-get *log-level-map* level)]
+        [cur (tbl-get *log-level-map* *log-level*)]]
+    (if (>= cur lvl) level #f)))
+
+(defProc (log:display level & args)
+  (let [[prefix (log:%prefix level)]
+        [dargs (reverse [#\\n &args])]]
+    (seq
+     (if prefix
+         (display stderr (log-time-string) " " (->string level) ": " & dargs))
+     #niv)))
+
+;;; Local Variables:
+;;; indent-tabs-mode: nil
+;;; fill-column: 79
+;;; comment-column: 37
+;;; End:

--- a/rosette/src/RBLstream.cc
+++ b/rosette/src/RBLstream.cc
@@ -367,6 +367,17 @@ DEF("ostream-log-time", obLogTime, 1, 1) {
     }
 }
 
+DEF("log-time-string", obLogTimeString, 0, 1) {
+    char      buf[128];
+    time_t    rawtime;
+    struct tm timeinfo;
+
+    rawtime = time(NULL);
+    localtime_r(&rawtime, &timeinfo);
+    strftime(buf, sizeof buf, "%F %T", &timeinfo);
+
+    return RBLstring::create(buf);
+}
 
 DEF("prim-flush", obFlush, 0, 1) {
     if (NARGS == 0) {


### PR DESCRIPTION
This is a simple logging facility. There is a global log level (`*log-level*`) controlled initially by the `flag-verbose` parameter. There are four predefined log level "constants": `'ERROR`, `'WARNING`, `'INFO`, and `'DEBUG`, in order from most to least severe.

Expressions of the form
```
  (log:display 'ERROR "This is a " 'fancy " log message.")
```
emit a newline-terminated, timestamped log line to the standard error stream like:
```
  2018-01-16 18:35:35 ERROR: This is a fancy log message.
```
if the given level is at least as severe as the global log level.

The global log level may be manipulated, though it seems rude:

```scheme
  rosette> (define *log-level* 'ERROR)
  '*log-level*
  rosette> (log:display 'WARNING "This is a warning!")
  rosette> (define *log-level* 'WARNING)
  '*log-level*
  rosette> (log:display 'WARNING "This is a warning!")
  2018-01-16 18:41:17 WARNING: This is a warning!
```

Also included is a primitive `log-time-string` which formats local time into a string and returns it.