### PR TITLE
Create environment variables for rholang web initialization.

### DIFF
--- a/rholangweb/README.md
+++ b/rholangweb/README.md
@@ -31,7 +31,12 @@ Settings are used to limit
 This is a typical [django][] app.
 
 Be sure you have the rholang compiler jar and the rosette executable
-and `rbl` library; adjust `rholang/settings.py` to say where they are.
+and `rbl` library; adjust `rholang/settings.py` to say where they are. Alternatively, set the following environment variables
+
+ * `RHOLANGWEB_EXAMPLES_DIR` The location of the `examples/` directory of sample Rholang contracts.
+ * `RHOLANGWEB_COMPILER_JAR` The path to the rholang compiler's JAR file.
+ * `RHOLANGWEB_VM_PROGRAM` The path to the `rosette` binary.
+ * `RHOLANGWEB_VM_LIBRARY` The location of the Rosette bootstrap files.
 
 Then:
 

--- a/rholangweb/rholang/settings.py
+++ b/rholangweb/rholang/settings.py
@@ -109,13 +109,14 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
 CORS_ORIGIN_ALLOW_ALL = True
 
-EXAMPLES =  os.path.join(BASE_DIR, 'examples')
-COMPILER_JAR = os.path.join(BASE_DIR, 'rholang-assembly-0.1-SNAPSHOT.jar')
-VM_PROGRAM = os.path.join(BASE_DIR, 'rosette')
+EXAMPLES = os.getenv('RHOLANGWEB_EXAMPLES_DIR', os.path.join(BASE_DIR, 'examples'))
+COMPILER_JAR = os.getenv('RHOLANGWEB_COMPILER_JAR', os.path.join(BASE_DIR, 'rholang-assembly-0.1-SNAPSHOT.jar'))
+VM_PROGRAM = os.getenv('RHOLANGWEB_VM_PROGRAM', os.path.join(BASE_DIR, 'rosette'))
+VM_LIBRARY = os.getenv('RHOLANGWEB_VM_LIBRARY', os.path.join(BASE_DIR, 'rbl/rosette'))
+
 TIMEOUT = 3.0
 STACKLIMIT = 8 * 1024 * 1024 * 1024
 
-VM_LIBRARY = os.path.join(BASE_DIR, 'rbl/rosette')
 
 # Logging
 LOGGING = {


### PR DESCRIPTION
Also updated the README with very terse instructions.

It is much easier for a system like Docker to provide configuration data through environment variables. The defaults work as they used, to.