### PR TITLE
Add dockerization of rholang cli and web.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,17 @@
+RHOLANG_JAR	= ../rholang/target/scala-2.12/rholang-assembly-0.1-SNAPSHOT.jar
+ROSETTE_BIN	= ../rosette/build.sh/src/rosette
+RBL_DIR		= ../rosette/rbl/rosette
+
+rholang:
+	@cd ../rholang && sbt bnfc:generate && sbt assembly
+
+rosette:
+	@cd ../rosette && ./build.sh
+
+rholang-web: rholang rosette
+	@docker build -f $@/Dockerfile .. -t $@
+
+rholang-cli: rholang rosette
+	@docker build -f $@/Dockerfile .. -t $@
+
+.PHONY: rholang rosette rholang-web rholang-cli

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,51 @@
+# Building docker images
+
+The facilities in this directory merely bundle various RChain subprojects into docker images so that they may be run in containers. One advantage of this is that run-time dependencies do not have to be installed on every machine running this software. Another is that it makes perfectly clear what the runtime dependencies are.
+
+## Premliminaries
+
+The first step is to ensure that the RChain subprojects at `rchain/rholang` and `rchain/rosette` build independent of the docker process. Each subproject includes build instructions, and that's a great place to start.
+
+## Building images and running containers
+
+There are two main `make` targets:
+
+### rholang-cli
+`make rholang-cli` constructs a docker image that can compile and execute a Rholang contract. It bundles together the Rholang-to-Rosette compiler in `rchain/rholang` and the Rosette interpreter in `rchain/rosette`. The resulting image is tagged `rholang-cli`.
+
+Once built, run it like this:
+
+```
+$ docker run -v $PWD/rholang/examples/hello_world_again.rho:/tmp/input.rho rholang-cli
+compiled /tmp/input.rho to /tmp/input.rbl
+*** warning: more than one result may be returned from a block expression
+Rosette System, Version 4.0.0 - Copyright 1989, 1990, 1991, 1992 MCC
+ - Copyright 2017, 2018 RChain Cooperative
+"Hello World"
+"Hello World again"
+[]
+```
+
+The filename is passed into the container with the `-v` (volume) command. The full path must be specified, and it will be mapped to `/tmp/input.rho` in the container, which is where the script that runs the Rholang compiler expects its input. The output of that is then passed to Rosette, which executes it. There is a shell script included that does this thing (`docker/rholang-cli/rhoscala`), but I'm not sure how to distribute that.
+
+### rholang-web
+`make rholang-web` builds Dan Connolly's (@dckc) web application into a docker image. It also bundles the Rholang compiler and the Rosette interpreter. This process yields an images tagged `rholang-web`.
+
+Run the thing like
+```
+$ docker run -ti --net host rholang-web
+Performing system checks...
+
+System check identified no issues (0 silenced).
+02:58 DEBUG (0.001)
+            SELECT name, type FROM sqlite_master
+            WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
+            ORDER BY name; args=None
+02:58 DEBUG (0.000) SELECT "django_migrations"."app", "django_migrations"."name" FROM "django_migrations"; args=()
+January 19, 2018 - 02:58:24
+Django version 1.11, using settings 'rholang.settings'
+Starting development server at http://127.0.0.1:8000/
+Quit the server with CONTROL-C.
+```
+and you'll be able to point a browser at [http://localhost:8000](http://localhost:8000).
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,10 +13,10 @@ There are two main `make` targets:
 ### rholang-cli
 `make rholang-cli` constructs a docker image that can compile and execute a Rholang contract. It bundles together the Rholang-to-Rosette compiler in `rchain/rholang` and the Rosette interpreter in `rchain/rosette`. The resulting image is tagged `rholang-cli`.
 
-Once built, run it like this:
+Once built, you could run it from this directory like this:
 
 ```
-$ docker run -v $PWD/rholang/examples/hello_world_again.rho:/tmp/input.rho rholang-cli
+$ docker run -v $PWD/../rholang/examples/hello_world_again.rho:/tmp/input.rho rholang-cli
 compiled /tmp/input.rho to /tmp/input.rbl
 *** warning: more than one result may be returned from a block expression
 Rosette System, Version 4.0.0 - Copyright 1989, 1990, 1991, 1992 MCC
@@ -26,7 +26,7 @@ Rosette System, Version 4.0.0 - Copyright 1989, 1990, 1991, 1992 MCC
 []
 ```
 
-The filename is passed into the container with the `-v` (volume) command. The full path must be specified, and it will be mapped to `/tmp/input.rho` in the container, which is where the script that runs the Rholang compiler expects its input. The output of that is then passed to Rosette, which executes it. There is a shell script included that does this thing (`docker/rholang-cli/rhoscala`), but I'm not sure how to distribute that.
+The filename is passed into the container with the `-v` (volume) command. The full path (absolute) must be specified, and it will be mapped to `/tmp/input.rho` in the container, which is where the script that runs the Rholang compiler expects its input. The output of that is then passed to Rosette, which executes it. There is a shell script included that does this thing (`docker/rholang-cli/rhoscala`), but I'm not sure how to distribute that.
 
 ### rholang-web
 `make rholang-web` builds Dan Connolly's (@dckc) web application into a docker image. It also bundles the Rholang compiler and the Rosette interpreter. This process yields an images tagged `rholang-web`.

--- a/docker/rholang-cli/Dockerfile
+++ b/docker/rholang-cli/Dockerfile
@@ -1,0 +1,30 @@
+# -*- coding: utf-8; mode: dockerfile -*-
+#
+# Copyright © 2018 RChain Cooperative
+# Author: Chris Kirkwood-Watts <kirkwood@pyrofex.net>
+#
+# This file is licensed under the Apache License, version 2.0.
+
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386
+RUN apt-get update && apt-get install -y openjdk-8-jre-headless libstdc++6:i386
+
+ENV ESS_SYSDIR /usr/local/lib/rosette
+ENV ROSETTE_LIB /usr/local/lib/rosette
+
+ENV RHOLANG_JAR /usr/local/lib/rholang-assembly-0.1-SNAPSHOT.jar
+ADD rholang/target/scala-2.12/rholang-assembly-0.1-SNAPSHOT.jar /usr/local/lib
+
+ADD rosette/rbl/rosette /usr/local/lib/rosette
+ADD rosette/build.out/src/rosette /usr/local/bin/rosette
+
+COPY docker/rholang-cli/run-rhoscala /usr/local/bin
+
+ENTRYPOINT [ "/usr/local/bin/run-rhoscala" ]
+
+# Local Variables:
+# indent-tabs-mode: nil
+# fill-column: 79
+# comment-column: 37
+# End:

--- a/docker/rholang-cli/Dockerfile
+++ b/docker/rholang-cli/Dockerfile
@@ -14,10 +14,10 @@ ENV ESS_SYSDIR /usr/local/lib/rosette
 ENV ROSETTE_LIB /usr/local/lib/rosette
 
 ENV RHOLANG_JAR /usr/local/lib/rholang-assembly-0.1-SNAPSHOT.jar
-ADD rholang/target/scala-2.12/rholang-assembly-0.1-SNAPSHOT.jar /usr/local/lib
+COPY rholang/target/scala-2.12/rholang-assembly-0.1-SNAPSHOT.jar /usr/local/lib
 
-ADD rosette/rbl/rosette /usr/local/lib/rosette
-ADD rosette/build.out/src/rosette /usr/local/bin/rosette
+COPY rosette/rbl/rosette /usr/local/lib/rosette
+COPY rosette/build.out/src/rosette /usr/local/bin/rosette
 
 COPY docker/rholang-cli/run-rhoscala /usr/local/bin
 

--- a/docker/rholang-cli/rhoscala
+++ b/docker/rholang-cli/rhoscala
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-input=$(basename $1)
+input=$(realpath $1)
 
-docker run -ti -v ${input}:/tmp/input.rho rhoscala -v
+docker run -ti -v ${input}:/tmp/input.rho rholang-cli

--- a/docker/rholang-cli/rhoscala
+++ b/docker/rholang-cli/rhoscala
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-input=$1
+input=$(basename $1)
 
 docker run -ti -v ${input}:/tmp/input.rho rhoscala -v

--- a/docker/rholang-cli/rhoscala
+++ b/docker/rholang-cli/rhoscala
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+input=$1
+
+docker run -ti -v ${input}:/tmp/input.rho rhoscala -v

--- a/docker/rholang-cli/rhoscala
+++ b/docker/rholang-cli/rhoscala
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 input=$(realpath $1)
+shift
 
-docker run -ti -v ${input}:/tmp/input.rho rholang-cli
+docker run -ti -v ${input}:/tmp/input.rho rholang-cli "$@"

--- a/docker/rholang-cli/run-rhoscala
+++ b/docker/rholang-cli/run-rhoscala
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+ulimit -s unlimited
+
+java -jar ${RHOLANG_JAR} /tmp/input.rho
+
+/usr/local/bin/rosette "$@" /tmp/input.rbl

--- a/docker/rholang-web/Dockerfile
+++ b/docker/rholang-web/Dockerfile
@@ -1,0 +1,41 @@
+# -*- coding: utf-8; mode: dockerfile -*-
+#
+# Copyright © 2018 RChain Cooperative
+# Author: Chris Kirkwood-Watts <kirkwood@pyrofex.net>
+#
+# This file is licensed under the Apache License, version 2.0.
+
+FROM ubuntu:16.04
+
+RUN dpkg --add-architecture i386
+RUN apt-get update && apt-get install -y python3-pip openjdk-8-jre-headless libstdc++6:i386
+RUN pip3 install --upgrade pip
+
+RUN mkdir -p /opt/rosette/bin
+RUN mkdir -p /opt/rosette/lib
+COPY rosette/build.out/src/rosette /opt/rosette/bin
+COPY rosette/rbl/rosette /opt/rosette/lib/rosette
+ENV ROSETTE_LIB /opt/rosette/lib/rosette
+ENV ESS_SYSDIR /opt/rosette/lib/rosette # muffle warning
+ENV RHOLANGWEB_VM_PROGRAM /opt/rosette/bin/rosette
+ENV RHOLANGWEB_VM_LIBRARY /opt/rosette/lib/rosette
+
+RUN mkdir -p /opt/rholang/lib
+COPY rholang/target/scala-2.12/rholang-assembly-0.1-SNAPSHOT.jar /opt/rholang/lib
+ENV RHOLANGWEB_COMPILER_JAR /opt/rholang/lib/rholang-assembly-0.1-SNAPSHOT.jar
+
+COPY rholang/examples /opt/rholang/lib/examples
+ENV RHOLANGWEB_EXAMPLES_DIR /opt/rholang/lib/examples
+
+COPY rholangweb /opt/rholangweb
+WORKDIR /opt/rholangweb
+RUN pip3 install -r requirements.txt
+RUN python3 manage.py migrate
+
+ENTRYPOINT [ "python3", "manage.py", "runserver" ]
+
+# Local Variables:
+# indent-tabs-mode: nil
+# fill-column: 79
+# comment-column: 37
+# End:


### PR DESCRIPTION
I'm not sure this is the right place for this stuff. We might want a different repo which can submodule rchain in and do the builds. What say ye?
---


There are two main `make` targets:

### rholang-cli
`make rholang-cli` constructs a docker image that can compile and execute a Rholang contract. Once built, run it like this:

```
$ docker run -v $PWD/rholang/examples/hello_world_again.rho:/tmp/input.rho rholang-cli
compiled /tmp/input.rho to /tmp/input.rbl
*** warning: more than one result may be returned from a block expression
Rosette System, Version 4.0.0 - Copyright 1989, 1990, 1991, 1992 MCC
 - Copyright 2017, 2018 RChain Cooperative
"Hello World"
"Hello World again"
[]
```

The filename is passed into the container with the `-v` (volume) command. The full path must be specified, and it will be mapped to `/tmp/input.rho` in the container, which is where the script that runs the Rholang compiler expects its input. The output of that is then passed to Rosette, which executes it. There is a shell script included that does this thing (`docker/rholang-cli/rhoscala`), but I'm not sure how to distribute that.

### rholang-web
`make rholang-web` builds Dan Connolly's (@dckc) web application into a docker image. Run the thing like
```
$ docker run -ti --net host rholang-web
Performing system checks...

System check identified no issues (0 silenced).
02:58 DEBUG (0.001)
            SELECT name, type FROM sqlite_master
            WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
            ORDER BY name; args=None
02:58 DEBUG (0.000) SELECT "django_migrations"."app", "django_migrations"."name" FROM "django_migrations"; args=()
January 19, 2018 - 02:58:24
Django version 1.11, using settings 'rholang.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
```
and you'll be able to point a browser at [http://localhost:8000](http://localhost:8000).

Note that this is all probably very persnickety.