### PR TITLE
Fix Rosette C++ pattern match

### DIFF
--- a/rosette/src/Pattern.cc
+++ b/rosette/src/Pattern.cc
@@ -108,7 +108,7 @@ bool ConstPattern::matchIntoArgvec(Tuple* argvec, int offset, Ob* val, int) {
 }
 
 
-int ConstPattern::numberOfKeys(void) { return 0; }
+int ConstPattern::numberOfKeys(void) { return 1; }
 
 
 void ConstPattern::stuffKeys(Tuple*, int) {}


### PR DESCRIPTION
This PR fixes two different pattern match issues in Rosette.

The first issue arises because ConstPattern had 0 length causing the remainder of the variables to be assigned in a shifted fashion.

```
((proc [#t x] x) #t 7)
#t
```

The second issue is that equivalent RBLstrings weren't considered equal.