### PR TITLE
Update proc to have non-referential equalities for strings

### DIFF
--- a/rosette/h/Ob.h
+++ b/rosette/h/Ob.h
@@ -605,6 +605,7 @@ class Ob : public Base {
     int size();
     int obCount();
     void unvisit();
+    bool compare(pOb);
 
     virtual pOb self();
 

--- a/rosette/h/RBLstring.h
+++ b/rosette/h/RBLstring.h
@@ -43,6 +43,7 @@ class RBLstring : public ByteVec {
     Ob* nth(int);
     Ob* setNth(int, Ob*);
     Ob* subObject(int, int);
+    bool compare(Ob*);
 
     virtual convertArgReturnPair convertActualArg(Ctxt*, Ob*);
     virtual Ob* convertActualRslt(Ctxt*, uint32_t);

--- a/rosette/src/Ob.cc
+++ b/rosette/src/Ob.cc
@@ -275,6 +275,15 @@ int Ob::size() {
 }
 
 
+bool Ob::compare(Ob* other) {
+    if (IS_A(this, RBLstring)) {
+        return ((RBLstring*) this)->compare(other);
+    } else {
+        return this == other;
+    }
+}
+
+
 int Ob::obCount() {
     if (VISITED(this)) {
         return 0;

--- a/rosette/src/Pattern.cc
+++ b/rosette/src/Pattern.cc
@@ -99,7 +99,7 @@ ConstPattern* ConstPattern::create(Ob* val) {
 
 
 bool ConstPattern::matchIntoArgvec(Tuple* argvec, int offset, Ob* val, int) {
-    if (val == this->val) {
+    if (val->compare(this->val)) {
         ASSIGN(argvec, elem(offset), val);
         return true;
     } else {

--- a/rosette/src/RBLstring.cc
+++ b/rosette/src/RBLstring.cc
@@ -153,6 +153,14 @@ Ob* RBLstring::subObject(int start, int n) {
     return result;
 }
 
+bool RBLstring::compare(Ob* other) {
+    if (!IS_A(other, RBLstring)) {
+        return false;
+    }
+    RBLstring* otherStr = (RBLstring*) other;
+    return strcmp((char*)&this->byte(0), (char*)&otherStr->byte(0)) == 0;
+}
+
 
 /* case sensitive compares */
 


### PR DESCRIPTION
As reported by @guardbotmk3

```
rosette> ((proc ["hello" x] x) "hello" 7)
*** formals mismatch:
 formals = ["hello" x]
 actuals = ["hello" 7]
 in (proc ["hello" x] x)

```
becomes
```

rosette> ((proc ["hello" x] x) "hello" 7)
7

```
Includes review changes by @kirkwood and @nashef.

Split off from #175.