### PR TITLE
Rholang: Fix for Rhol-63

### DIFF
--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -490,7 +490,7 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
                   B("")(procTerm, pTerm) // TODO: Potentially allow StrTermPtdCtxtBr without Namespace ?
                 }
 
-                val matchTerm = B(_match)(pTerm, pattern)
+                val matchTerm = B(_match)(TS, pTerm, pattern)
                 val matchTrueTerm = if (hasVariable(pm.ppattern_)) {
                   createProcForPatternBindings
                 } else {

--- a/rholang/tests/comparison_test.rho
+++ b/rholang/tests/comparison_test.rho
@@ -3,7 +3,8 @@
 // Rosette's output. We probably want to change a lot of behavior
 // in the reimplementation.
 
-match [
+{
+  match [
     // Equal
 
     2 == 2,                        // true
@@ -72,14 +73,22 @@ match [
 
     ] with
 
-< true, true, true, false, false, false,
-  false, false, false, true, true, true,
-  true, false, false, true, false, false, true, false, false,
-  true, true, false, true, true, false, true, true, false,
-  false, false, true, false, false,true, false, false, true,
-  false, true, true, false, true, true, false, true, true > => {
-    print("Pass")
-}
-_ => {
-    print("Fail")
-}
+  < true, true, true, false, false, false,
+    false, false, false, true, true, true,
+    true, false, false, true, false, false, true, false, false,
+    true, true, false, true, true, false, true, true, false,
+    false, false, true, false, false,true, false, false, true,
+    false, true, true, false, true, true, false, true, true > => {
+      print("Pass")
+  }
+  _ => {
+      print("Fail")
+  } |
+  match 2 == 2 with
+    true => {
+      print("Pass")
+    }
+    _ => {
+      print("Fail")
+    }
+} 


### PR DESCRIPTION
This change allows for the matching of constants not in a tuple. As Kent
mentioned in the bug, the complete match is a method on the namespace.