### PR TITLE
Add OpIndLitToRslt and OpIndLitToReg

### DIFF
--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -338,4 +338,52 @@ class TransitionSpec extends FlatSpec with Matchers {
     val end = VirtualMachine.executeSeq(codevec, start)
     end.ctxt.ctxt.rslt shouldBe RblFloat(3.5)
   }
+
+  "Executing bytecode from expression \"100\"" should "result in Fixnum(100)" in {
+
+    /**
+      * litvec:
+      *   0:   100
+      * codevec:
+      *   0:   liti 0,rslt
+      *   1:   rtn/nxt
+      */
+    val start =
+      testState
+        .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
+        .update(_ >> 'code >> 'litvec)(_ => Tuple(Seq(Fixnum(100))))
+
+    val codevec = Seq(
+      OpIndLitToRslt(lit = 0),
+      OpRtn(next = true)
+    )
+
+    val end = VirtualMachine.executeSeq(codevec, start)
+    end.ctxt.ctxt.rslt shouldBe Fixnum(100)
+  }
+
+  "Executing bytecode from expression \"(100)\"" should "result in Fixnum(100)" in {
+
+    /**
+      * litvec:
+      *   0:   {RequestExpr}
+      *   1:   100
+      * codevec:
+      *   0:   liti 1,trgt
+      *   1:   xmit/nxt 0
+      */
+    val start =
+      testState
+        .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
+        .update(_ >> 'code >> 'litvec)(_ =>
+          Tuple(Seq(RequestExpr, Fixnum(100))))
+
+    val codevec = Seq(
+      OpIndLitToReg(reg = 1, lit = 1),
+      OpXmit(unwind = false, next = true, nargs = 0)
+    )
+
+    val end = VirtualMachine.executeSeq(codevec, start)
+    end.ctxt.trgt shouldBe Fixnum(100)
+  }
 }


### PR DESCRIPTION
In Rosette compiling the expression `100` results in the following `Code` object:
```
litvec:
   0:   100
codevec:
   0:   liti 0,rslt
   1:   rtn/nxt
```
`liti 0, rslt` which corresponds to `OpIndLitToRslt(lit = 0)` in Roscala takes the first `litvec` element, `Fixnum(100)`, and puts it into `state.ctxt.rslt`.
Afterwards `rtn/nxt` stores the result in `state.ctxt.ctxt.rslt`.

This can be observed in gdb with: `b src/Vm.cc:1286` (setting a breakpoint to the position of the `opIndLitToRslt` case).

---

In Rosette compiling the expression `(100)` results in the following `Code` object:
```
litvec:
   0:   {RequestExpr}
   1:   100
codevec:
   0:   liti 1,trgt
   1:   xmit/nxt 0
```

`liti 1,trgt` which corresponds to `OpIndLitToReg(reg = 1, lit = 1)` in Roscala takes the second `litvec` element and puts it into a register (here: `state.ctxt.trgt`).
`xmit/nxt 0` then tries to dispatch on `Fixnum(100)` which fails with a `DeadThread` error.

This can be observed in gdb with: `b src/Vm.cc:1281` (setting a breakpoint to the position of the `opIndLitToReg` case).