### PR TITLE
Fix Release Blockers, including RHOL-95

### DIFF
--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -14,7 +14,7 @@ PPrint.   Proc1 ::= "print" "(" Proc ")" ;
 PConstr.  Proc1 ::= Var "(" [Proc] ")" ;
 PContr.   Proc1 ::= "contract" Var "(" [CPattern] ")" "=" "{" Proc "}" ;
 PPar.     Proc  ::= Proc "|" Proc1 ;
-separator nonempty Proc "," ;
+separator Proc "," ;
 _. Proc  ::= Proc1 ;
 _. Proc1 ::= Proc2 ;
 _. Proc2 ::= Proc3 ;

--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -110,7 +110,7 @@ VPtInt. ValPattern ::= Integer ;
 VPtDbl. ValPattern ::= Double ;
 VPtNegInt. ValPattern ::= "-" Integer;
 VPtNegDbl. ValPattern ::= "-" Double;
---VPtStr. ValPattern ::= String ;
+VPtStr. ValPattern ::= String ;
 
 -- Variables
 token Var ((letter | '_')(letter | digit | '_' | '\'')*) ;

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -482,7 +482,7 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
               val patternResult: R = pm.ppattern_.accept(this, arg)
               val pattern: StrTermCtxt = patternResult._1
               val qPattern: StrTermCtxt = doQuote(pattern)._1
-              val patternBindings: BoundSet = patternResult._2
+              val patternBindings: BoundSet = arg ++ patternResult._2
               val continuation: StrTermCtxt = pm.proc_.accept(this, patternBindings)._1
               val remainder: StrTermCtxt = acc
               if (isWild(pm.ppattern_)) {

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -735,6 +735,9 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
       )
     (B( _list, tupleContents._1 ), tupleContents._2)
   }
+  override def visit( p : VPtStr, arg : A ) : R = {
+    Tag( s""""${p.string_}"""" )
+  }
   override def visit( p : VPtTrue, arg: A ): R = {
     (Tag( s"""#t"""), arg)
   }

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -306,8 +306,9 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
       val procTerm: StrTermCtxt = p.proc_.accept(this, collectBindings(bindingsResults))._1
       val (chanTerms, ptrnTerms, quotedPtrnTerms, productFreshes, unificationFreshes, wildcards) = toListOfTuples(bindingsResults)
       val consumeTerm = B("consume")(TS, B(_list, chanTerms), B(_list, wildcards), B(_list, quotedPtrnTerms), Tag("#f")) // #f for persistent
+      val wrappedPtrnTerms = ptrnTerms map (x => B(_list)(x))
       val letBindingsTerm = B(_list)(B(_list)(B(_list, unificationFreshes), B(_list, productFreshes)), consumeTerm)
-      val bodyTerm = B("")(B("proc")(B(_list)(B(_list, ptrnTerms)), procTerm), B(_list, productFreshes))
+      val bodyTerm = B("")(B("proc")(B(_list)(B(_list, wrappedPtrnTerms)), procTerm), B(_list, productFreshes))
       B("let")(B(_list)(letBindingsTerm), bodyTerm)
     }
 

--- a/rholang/tests/contract_invocation.rho
+++ b/rholang/tests/contract_invocation.rho
@@ -5,7 +5,7 @@ new test in {
     z!(Nil)
   } |
   new x, y, z in {
-    test([x, y, z]) |
+    test(x, y, z) |
     for(_ <- x) {
       print("x")
     } |

--- a/rosette/rbl/rosette/space.rbl
+++ b/rosette/rbl/rosette/space.rbl
@@ -212,14 +212,17 @@
                             [consummation_results
                                 (map continuation_group (proc [m [unification_ptrn continuations_struct]]
                                     (map continuations_struct (proc [n [product_ptrns_struct ctxt_triple]]
-                                        (map product_ptrns_struct (proc [o [product_ptrn product]]
-                                            (if (match? NameSpace (tuple-safe-nth product_ptrns i) product)
-                                                [
-                                                    [(tuple-safe-nth channels i) (tuple-safe-nth (tuple-safe-nth subspace_groups i) j)]
-                                                    [(tuple-safe-nth unification_ptrns i) [unification_ptrn binding]]
-                                                    ["continuation" (tuple-safe-nth product_ptrns i) [n o product]]
-                                                ]
-                                            )))))))
+                                        (filter-niv
+                                            (map product_ptrns_struct (proc [o [product_ptrn product]]
+                                                (if (and (not (absent? product))
+                                                      (match? NameSpace (tuple-safe-nth product_ptrns i) product))
+                                                    [
+                                                        [(tuple-safe-nth channels i) (tuple-safe-nth (tuple-safe-nth subspace_groups i) j)]
+                                                        [(tuple-safe-nth unification_ptrns i) [unification_ptrn binding]]
+                                                        ["continuation" (tuple-safe-nth product_ptrns i) [n o product]]
+                                                    ]
+                                                    #niv
+                                            ))))))))
                             ]
                         ]
                         (tuple-concat (flatten production_results) (flatten (flatten consummation_results)))
@@ -389,21 +392,23 @@
                 ]
             ]
             (map continuation_group (proc [m [[unification_ptrn binding] continuations_struct]]
-                (map continuations_struct (proc [n [product_ptrns_struct ctxt_triple]]
-                    (let*
-                        [
-                            [channel_position (tuple-safe-nth current_channel_positions i)]
-                                ;;; TODO: This assumes that the channel cannot be in multiple positions in the consume, which is not necessarily true.
-                            [[product_ptrn stored_product] (tuple-safe-nth product_ptrns_struct channel_position)]
-                        ]
-                        (if (match? NameSpace product_ptrn products)
+                (filter-niv
+                    (map continuations_struct (proc [n [product_ptrns_struct ctxt_triple]]
+                        (let*
                             [
-                                [channel (tuple-safe-nth subspaces i)]
-                                [unification_ptrn unification_ptrn]
-                                [products [n channel_position product_ptrn]]
+                                [channel_position (tuple-safe-nth current_channel_positions i)]
+                                    ;;; TODO: This assumes that the channel cannot be in multiple positions in the consume, which is not necessarily true.
+                                [[product_ptrn stored_product] (tuple-safe-nth product_ptrns_struct channel_position)]
                             ]
-                        )
-                    ))))))))]
+                            (if (match? NameSpace product_ptrn products)
+                                [
+                                    [channel (tuple-safe-nth subspaces i)]
+                                    [unification_ptrn unification_ptrn]
+                                    [products [n channel_position product_ptrn]]
+                                ]
+                                #niv
+                            )
+                    )))))))))]
 
    [_
         (if flag-verbose

--- a/rosette/rbl/rosette/space.rbl
+++ b/rosette/rbl/rosette/space.rbl
@@ -86,7 +86,19 @@
     ;;; TODO: We currently do not support prologue style unification (bidirectional) pattern matching
     ;;; Potential implementation: (if (type? ptrn candidate) (seq (update) ((proc [ptrn] ptrn) candidate)) (seq (update) #niv)) )
     (pure (unify? ptrn candidate) #t)
-    (pure (match? ptrn candidate) (if (type? ptrn Symbol) #t (type? ptrn candidate)))
+    (pure (match? ptrn candidate)
+      (if (type? ptrn Symbol)
+        #t
+        (if (type? ptrn candidate)
+          (cond
+            ((type? ptrn String)
+              (= ptrn candidate))
+            ((type? ptrn Tuple)
+              (and (match? (self) (head ptrn) (head candidate))
+                (match? (self) (tail ptrn) (tail candidate))))
+            (else
+              (= ptrn candidate)))
+          #f)))
     ;;; storedValue is the tuple [data continuation]
     (pure (production? storedValue) (not (null? (head storedValue))))
 )

--- a/rosette/rbl/rosette/space.rbl
+++ b/rosette/rbl/rosette/space.rbl
@@ -324,7 +324,7 @@
 (defRMethod NameSpace (produce ctxt-tuple & production)
 (let* [
     [[ctxt _] ctxt-tuple]
-    [[channel unification_ptrn product] production]
+    [[channel unification_ptrn & products] production]
     [_
         (if flag-verbose
             (seq
@@ -333,7 +333,7 @@
                 (print (->symbol ", "))
                 (print unification_ptrn)
                 (print (->symbol ", "))
-                (print product)
+                (print products)
                 (print (->symbol ")"))
                 (p "")))]
 
@@ -396,11 +396,11 @@
                                 ;;; TODO: This assumes that the channel cannot be in multiple positions in the consume, which is not necessarily true.
                             [[product_ptrn stored_product] (tuple-safe-nth product_ptrns_struct channel_position)]
                         ]
-                        (if (match? NameSpace product_ptrn product)
+                        (if (match? NameSpace product_ptrn products)
                             [
                                 [channel (tuple-safe-nth subspaces i)]
                                 [unification_ptrn unification_ptrn]
-                                [product [n channel_position product_ptrn]]
+                                [products [n channel_position product_ptrn]]
                             ]
                         )
                     ))))))))]
@@ -428,9 +428,9 @@
                             [[data_struct continuations_struct] (tbl-get subspace unification_ptrn)]
                             [[n o product_ptrn] product_info]
                             [[product_ptrns_struct ctxt_triple] (tuple-safe-nth continuations_struct n)]
-                            [updated_product_ptrns_struct (replace-i product_ptrns_struct o [product_ptrn product])]
+                            [updated_product_ptrns_struct (replace-i product_ptrns_struct o [product_ptrn products])]
                         ]
-                        (if (all updated_product_ptrns_struct (proc [[product_ptrn product]] (not (= product #absent))))
+                        (if (all updated_product_ptrns_struct (proc [[product_ptrn products]] (not (= products #absent))))
                             candidate
                         ))))
                 ]
@@ -449,30 +449,30 @@
 ]
     (seq
         (if (null? reduction)
-            ;;; If product was not consumed by a matching continuation above, store it directly
+            ;;; If "products" was not consumed by a matching continuation above, store it directly
             (let*
                 [
                     [subspace (tuplespace-tbl-get-or-create chart channel)]
                     [stored_value (tbl-get subspace unification_ptrn)]
                 ]
                 (seq
-                    (if flag-verbose (p "DEBUG: No consumes were filled. Storing product."))
+                    (if flag-verbose (p "DEBUG: No consumes were filled. Storing products."))
                     (tbl-add unification_ptrn_lookup_table (->symbol unification_ptrn) [unification_ptrn])
                     (if (= #absent stored_value)
-                        (tbl-add subspace unification_ptrn [[product] []])
+                        (tbl-add subspace unification_ptrn [[products] []])
                         (let [[[data_struct continuation_struct] (tbl-get subspace unification_ptrn)]]
-                            (tbl-add subspace unification_ptrn [(append data_struct product) continuation_struct])))
-                    (ctxt-rtn ctxt []) ;;; TODO: Update to (ctxt-rtn ctxt product) when unification is required
+                            (tbl-add subspace unification_ptrn [(append data_struct products) continuation_struct])))
+                    (ctxt-rtn ctxt []) ;;; TODO: Update to (ctxt-rtn ctxt products) when unification is required
                     (update!)))
 
-            ;;; If product was consumed, fill consume
+            ;;; If "products" was consumed, fill consume
             (let*
                 [
                     [[[_ subspace] [_ unification_ptrn] [_ product_info]] reduction]
                     [[data_struct continuations_struct] (tbl-get subspace unification_ptrn)]
                     [[n o product_ptrn] product_info]
                     [[product_ptrns_struct [consume_ctxt [consume_code consume_env] consume_persistent]] (tuple-safe-nth continuations_struct n)]
-                    [updated_product_ptrns_struct (replace-i product_ptrns_struct o [product_ptrn product])] ;;; TODO: Eventually store binding
+                    [updated_product_ptrns_struct (replace-i product_ptrns_struct o [product_ptrn products])] ;;; TODO: Eventually store binding
                 ]
 
                 ;;; If all product patterns are filled, send ctxt-rtn
@@ -480,11 +480,11 @@
                     (seq
                         ;;; TODO: Replace dummy bindings
                         (if flag-verbose (p "DEBUG: A consume was fully filled. Sending all products."))
-                        (ctxt-rtn consume_ctxt [(newN Tuple (length updated_product_ptrns_struct) #t) (map updated_product_ptrns_struct (proc [j [product_ptrn product]] product))])
+                        (ctxt-rtn consume_ctxt [(newN Tuple (length updated_product_ptrns_struct) #t) (map updated_product_ptrns_struct (proc [j [product_ptrn products]] products))])
                         (let [[updated_continuations_struct (delete-i continuations_struct n)]]
                             (tbl-add subspace unification_ptrn [data_struct updated_continuations_struct])
                         )
-                        (ctxt-rtn ctxt [])  ;;; TODO: Update to (ctxt-rtn ctxt product) when unification is required
+                        (ctxt-rtn ctxt [])  ;;; TODO: Update to (ctxt-rtn ctxt products) when unification is required
                         (if consume_persistent
                             (seq
                                 (if flag-verbose (p "About to re-post continuation"))


### PR DESCRIPTION
This fixes the most glaring of the omissions in the tuplespace library and the compiler.
Fixes Rhol-{89, 90, 91, 94, 95, 96}