### PR TITLE
Add port argument to rholang-web.

### DIFF
--- a/docker/rholang-web/Dockerfile
+++ b/docker/rholang-web/Dockerfile
@@ -32,7 +32,9 @@ WORKDIR /opt/rholangweb
 RUN pip3 install -r requirements.txt
 RUN python3 manage.py migrate
 
-ENTRYPOINT [ "python3", "manage.py", "runserver" ]
+COPY docker/rholang-web/run-server .
+
+ENTRYPOINT [ "/opt/rholangweb/run-server" ]
 
 # Local Variables:
 # indent-tabs-mode: nil

--- a/docker/rholang-web/run-server
+++ b/docker/rholang-web/run-server
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PORT=8000
+
+if [ $# -gt 0 ]
+then
+    PORT=$1
+fi
+
+HOSTPORT=0.0.0.0:$PORT
+
+python3 manage.py runserver $HOSTPORT


### PR DESCRIPTION
Medha discovered that MacDocker does not always allow traffic to localhost:8000 for some reason. This adds a positional argument for the port. Just tack it on the end, like this:
```
docker run -ti --net host rholang-web 80
```
to get it onto the HTTP port, for example.

Or, without `--net host` like
```
docker run -ti -p 80:80 rholang-web 80
```