### PR TITLE
Updates log-time to use the QDot syntax

### DIFF
--- a/rholang/examples/log_time.rho
+++ b/rholang/examples/log_time.rho
@@ -4,9 +4,9 @@
 // and the use of a primitive (log-time) in Rholang.
 
 new time_contract in {
-	contract time_contract(stream) = {
-        log-time(stream)
-	} |
-	time_contract!(ostream-new("test.txt")) |
-	time_contract!(ostream-new("test2.txt"))
+    contract time_contract(stream) = {
+        stream.log-time()
+    } |
+    time_contract!("test.txt".ostream-new()) |
+    time_contract!("test2.txt".ostream-new())
 }

--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -113,7 +113,7 @@ VPtNegDbl. ValPattern ::= "-" Double;
 --VPtStr. ValPattern ::= String ;
 
 -- Variables
-token Var ((letter | '_')(letter | digit | '_' | '\'')*) ;
+token Var ((letter | '_')(letter | digit | '_' | '-' | '\'')*) ;
 
 separator nonempty Var "," ;
 


### PR DESCRIPTION
As of https://github.com/rchain/rchain/pull/181 , the constructor can no longer be used as a primitive call. We need to allow hyphens in variable names or else whatever.ostream-new() will not compile, as it contains a hyphen.

I've cherry-picked these two commits off #150 . 