### PR TITLE
Add support for bypassing compiler.

### DIFF
--- a/docker/rholang-cli/run-rhoscala
+++ b/docker/rholang-cli/run-rhoscala
@@ -4,6 +4,12 @@ set -e
 
 ulimit -s unlimited
 
-java -jar ${RHOLANG_JAR} /tmp/input.rho
+if [ -f /tmp/input.rho ]; then
+    java -jar ${RHOLANG_JAR} /tmp/input.rho
+fi
 
-/usr/local/bin/rosette "$@" /tmp/input.rbl
+if [ -f /tmp/input.rbl ]; then
+    /usr/local/bin/rosette "$@" /tmp/input.rbl
+else
+    /usr/local/bin/rosette "$@"
+fi


### PR DESCRIPTION
This makes the docker image 100% more useful. By one particular metric, anyway. If no `-v` argument is supplied (so not input file is given), the thing skips the compilation step and drops into the Rosette REPL.