### PR TITLE
fixed syntax issue in rho file that was for testing

### DIFF
--- a/rholang/failure_tests/unbound_name_test.rho
+++ b/rholang/failure_tests/unbound_name_test.rho
@@ -1,4 +1,4 @@
 new typo in {
-  for (x <- typpo) { print(x) } |
+  for (x <- typo) { print(x) } |
   typo!("Hello world")
 }


### PR DESCRIPTION
Fixed syntax issue in rho file that was used for testing rho-to-rbl compile failures.