### PR TITLE
Add packages to the travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ notifications:
     on_failure: always
 addons:
     apt:
+        sources:
+            - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
         packages:
             - sbt
-            - cup
             - jlex
             - haskell-platform
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
             - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
         packages:
             - sbt
-            - jlex
+            - jflex
             - haskell-platform
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,12 @@ notifications:
       - rchain-makers@pyrofex.net
     on_success: never
     on_failure: always
+addons:
+    apt:
+        packages:
+            - sbt
+            - cup
+            - jlex
+            - haskell-platform
+
 

--- a/rholang/install.sh
+++ b/rholang/install.sh
@@ -2,6 +2,8 @@
 # Ubuntu 14.04 has an outdated BNFC package, so we build BNFC from source
 #
 # see also: ../.travis.yml, ../scripts/install.sh
+set -e
+
 sudo apt install haskell-platform
 git clone https://github.com/BNFC/bnfc.git
 cd bnfc/source


### PR DESCRIPTION
The `sbt` build needs several packages to be installed in the container before it can run correctly.