### PR TITLE
CORE-164: Add test coverage measurement to Storage build

### DIFF
--- a/storage/README.md
+++ b/storage/README.md
@@ -4,12 +4,32 @@ Key-value storage for the RChain blockchain.
 
 ### Prerequisites
 
-[sbt](http://www.scala-sbt.org/download.html)
+* [sbt](http://www.scala-sbt.org/download.html)
 
-### Installing
+### Building
 
-`sbt`
+```
+sbt compile
+```
 
-## Running the tests
+### Testing
 
-`sbt`
+```
+sbt test
+```
+
+Testing with coverage:
+
+```
+sbt clean coverage test
+```
+
+Generating a coverage report:
+
+```
+sbt coverageReport
+```
+
+The HTML version of the generated report is located at:
+
+ `./target/scala-<version>/scoverage-report/index.html`

--- a/storage/build.sbt
+++ b/storage/build.sbt
@@ -17,6 +17,14 @@ lazy val nonConsoleOptions = Set(
   "-Xfatal-warnings"
 )
 
+lazy val coverageSettings = Seq(
+  coverageMinimum := 90,
+  coverageFailOnMinimum := false,
+  coverageExcludedFiles := Seq(
+    (sourceManaged in Compile).value.getPath ++ "/.*"
+  ).mkString(";")
+)
+
 lazy val commonSettingsDependencies = Seq(
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.4" % "test"
@@ -49,3 +57,4 @@ lazy val storage = (project in file("."))
   .settings(commonSettingsDependencies: _*)
   .settings(storageSettings: _*)
   .settings(storageSettingsDependencies: _*)
+  .settings(coverageSettings: _*)

--- a/storage/project/plugins.sbt
+++ b/storage/project/plugins.sbt
@@ -1,3 +1,5 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")


### PR DESCRIPTION
This PR adds test coverage measurement to the Storage build using the [`sbt-scoverage`](https://github.com/scoverage/sbt-scoverage) plugin.

My goal is to have Travis CI run the coverage task on every build and upload the reports to [CodeCov](https://codecov.io/), where they can be browsed by all.

Ref:
https://rchain.atlassian.net/browse/CORE-164