### PR TITLE
CORE-164 storage: run coverage in CI, sending reports to CodeCov

### DIFF
--- a/storage/test.sh
+++ b/storage/test.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+SBT_OPTS="${SBT_OPTS:-} -Dsbt.log.noformat=true"
+
+run_tests ()
+{
+    sbt ${SBT_OPTS} clean coverage test coverageReport
+}
+
+if run_tests
+then
+    # Upload test coverage reports to CodeCov
+    bash <(curl -s https://codecov.io/bash)
+    exit 0
+else
+    # On failure, exit with exit status of last command (run_tests)
+    exit $?
+fi

--- a/storage/test.sh
+++ b/storage/test.sh
@@ -12,7 +12,7 @@ run_tests ()
 if run_tests
 then
     # Upload test coverage reports to CodeCov
-    bash <(curl -s https://codecov.io/bash)
+    bash <(curl -s https://codecov.io/bash) -c -F storage
     exit 0
 else
     # On failure, exit with exit status of last command (run_tests)


### PR DESCRIPTION
In order to run Storage tests with coverage in CI and upload them to CodeCov, I added a `test.sh` script to the storage subdirectory, overriding the default sbt invocation in `./scripts/build-subproject.sh`.

Otherwise, everything else roughly based on example here:
https://github.com/codecov/example-scala

However, rather than adding the upload invocation to `.travis.yml`, where it would be run from the root directory of the project, I'm running the upload invocation from the `storage/test.sh` script, so that it can find the coverage reports in `storage/target` without needing to provide any additional arguments to the script.  

My hope is that, eventually, as we add test coverage reporting to the other projects in the repo, we can then switch to running the upload invocation from the project's root directory with the proper arguments to pick up the reports from all projects.