### PR TITLE
CORE-75 storage: support Scala 2.11, cleaning up in my wake

### DIFF
--- a/storage/build.sbt
+++ b/storage/build.sbt
@@ -1,20 +1,31 @@
-lazy val compilerOptions = Seq(
-  "-Xfatal-warnings",
-  "-Xfuture",
-  "-Xlint:-unused",
-  "-Ypartial-unification",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen",
-  "-deprecation",
-  "-encoding", "UTF-8",
-  "-feature",
-  "-language:_",
-  "-unchecked"
+lazy val commonSettings = Seq(
+  organization := "coop.rchain",
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.12", scalaVersion.value),
+  exportJars := true
 )
 
-lazy val nonConsoleOptions = Set(
-  "-Ywarn-unused-import",
-  "-Xfatal-warnings"
+lazy val commonSettingsDependencies = Seq(
+  libraryDependencies ++= Seq(
+    // format: off
+    "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+    // format: on
+  )
+)
+
+lazy val storageSettings = Seq(
+  name := "storage",
+  version := "0.1.0-SNAPSHOT",
+  PB.targets in Compile := Seq(scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value)
+)
+
+lazy val storageSettingsDependencies = Seq(
+  libraryDependencies ++= Seq(
+    // format: off
+    "org.lmdbjava"   % "lmdbjava"  % "0.6.0",
+    "org.typelevel" %% "cats-core" % "1.0.1"
+    // format: on
+  )
 )
 
 lazy val coverageSettings = Seq(
@@ -25,34 +36,8 @@ lazy val coverageSettings = Seq(
   ).mkString(";")
 )
 
-lazy val commonSettingsDependencies = Seq(
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.0.4" % "test"
-  )
-)
-
-lazy val commonSettings = Seq(
-  organization := "coop.rchain",
-  scalaVersion := "2.12.4",
-  scalacOptions ++= compilerOptions,
-  scalacOptions in (Compile, console) ~= { _.filterNot(nonConsoleOptions) },
-  scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
-)
-
-lazy val storageSettingsDependencies = Seq(
-  libraryDependencies ++= Seq(
-    "org.lmdbjava"   % "lmdbjava"  % "0.6.0",
-    "org.typelevel" %% "cats-core" % "1.0.1"
-  )
-)
-
-lazy val storageSettings = Seq(
-  name := "storage",
-  version := "0.1.0-SNAPSHOT",
-  PB.targets in Compile := Seq(scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value)
-)
-
 lazy val storage = (project in file("."))
+  .settings(CompilerSettings.options: _*)
   .settings(commonSettings: _*)
   .settings(commonSettingsDependencies: _*)
   .settings(storageSettings: _*)

--- a/storage/project/CompilerSettings.scala
+++ b/storage/project/CompilerSettings.scala
@@ -1,0 +1,62 @@
+import sbt._
+import sbt.Keys._
+
+object CompilerSettings {
+
+  /*
+   * In the future, let's add:
+   *
+   *   "-Xlint:adapted-args",
+   *   "-Xlint:inaccessible",
+   *   "-Ywarn-value-discard",
+   */
+
+  private lazy val commonOptions =
+    // format: off
+    Seq(
+      "-Xfatal-warnings",
+      "-Xfuture",
+      "-Ypartial-unification",
+      "-Ywarn-dead-code",
+      "-Ywarn-numeric-widen",
+      "-deprecation",
+      "-encoding", "UTF-8",
+      "-feature",
+      "-language:_",
+      "-unchecked"
+    )
+    // format: on
+
+  lazy val options = Seq(
+    scalacOptions ++= commonOptions ++ {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, major)) if major >= 12 =>
+          // We disable warnings about unused imports for Scala 2.12+
+          // because certain imports (ex: cat.syntax.either) provide
+          // compatibility for Scala versions < 2.12
+          Seq(
+            "-Xlint:-unused,-adapted-args,-inaccessible,_",
+            "-Ywarn-unused:implicits",
+            "-Ywarn-unused:locals",
+            "-Ywarn-unused:patvars",
+            "-Ywarn-unused:privates"
+          )
+        case _ =>
+          Seq(
+            "-Xlint:-missing-interpolator,-adapted-args,-inaccessible,_",
+            "-Ywarn-unused",
+            "-Ywarn-unused-import"
+          )
+      }
+    },
+    scalacOptions in (Compile, console) ~= {
+      _.filterNot(
+        Set(
+          "-Xfatal-warnings",
+          "-Ywarn-unused-import",
+          "-Ywarn-unused:imports"
+        ))
+    },
+    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
+  )
+}

--- a/storage/src/test/scala/coop/rchain/storage/regex/FsmUnitTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/regex/FsmUnitTests.scala
@@ -1,11 +1,10 @@
 package coop.rchain.storage.regex
 
-import org.scalatest._
-
-import scala.util.Success
+import coop.rchain.storage.util
+import org.scalatest.{FlatSpec, Matchers}
 
 class FsmUnitTests extends FlatSpec with Matchers {
-  val _ob = -5
+  val _ob: Int = -5
 
   def createFsmA : Fsm = Fsm(
       Set('a', 'b'),
@@ -227,16 +226,16 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Cardinality" should "calculate length of the states set" in {
     val fsmA = createFsmA
-    assert(createFsmA.cardinality.contains(1))
+    assert(fsmA.cardinality.contains(1))
 
     val fsmAbc = createFsmAbc
-    assert(createFsmA.cardinality.contains(1))
+    assert(fsmAbc.cardinality.contains(1))
 
     val nullFsm = Fsm.nullFsm(Set('a'))
     assert(nullFsm.cardinality.contains(0))
 
     val epsFsm = Fsm.epsilonFsm(Set('a'))
-    assert(nullFsm.cardinality.contains(0))
+    assert(epsFsm.cardinality.contains(1))
 
     //check for recursion
     val brFsm = createBrzozowski
@@ -303,16 +302,16 @@ class FsmUnitTests extends FlatSpec with Matchers {
     assert(!concatAeA.accepts("aaa"))
 
     val concatAeeA = Fsm.concatenate(fsmA, epsA, epsA, fsmA)
-    assert(!concatAeA.accepts(""))
-    assert(!concatAeA.accepts("a"))
-    assert(concatAeA.accepts("aa"))
-    assert(!concatAeA.accepts("aaa"))
+    assert(!concatAeeA.accepts(""))
+    assert(!concatAeeA.accepts("a"))
+    assert(concatAeeA.accepts("aa"))
+    assert(!concatAeeA.accepts("aaa"))
 
     val concatEeAA = Fsm.concatenate(epsA, epsA, fsmA, fsmA)
-    assert(!concatAeA.accepts(""))
-    assert(!concatAeA.accepts("a"))
-    assert(concatAeA.accepts("aa"))
-    assert(!concatAeA.accepts("aaa"))
+    assert(!concatEeAA.accepts(""))
+    assert(!concatEeAA.accepts("a"))
+    assert(concatEeAA.accepts("aa"))
+    assert(!concatEeAA.accepts("aaa"))
   }
 
   /**
@@ -358,8 +357,8 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Star" should "pass basic check" in {
-    var fsmA = createFsmA
-    var starA = fsmA.star
+    val fsmA = createFsmA
+    val starA = fsmA.star
 
     assert(starA.accepts(""))
     assert(starA.accepts("a"))
@@ -417,7 +416,6 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Derive" should "pass basic check" in {
     val fsmA = createFsmA
-    val fsmB = createFsmB
 
     assert(fsmA.derive("a").get == Fsm.epsilonFsm(Set('a','b')))
     assert(fsmA.derive("b").get == Fsm.nullFsm(Set('a','b')))
@@ -742,25 +740,25 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Invalid Fsm" should "fail if alphabet null" in {
     assertThrows[IllegalArgumentException] {
-      val fsm1 = Fsm(null, null, 0, null, null)
+      util.ignore{ Fsm(null, null, 0, null, null) }
     }
   }
 
   "Invalid Fsm" should "fail if initial state is not a state" in {
     assertThrows[IllegalArgumentException] {
-      val fsm1 = Fsm(Set('a'), Set(0), 1, Set(0), Map())
+      util.ignore { Fsm(Set('a'), Set(0), 1, Set(0), Map()) }
     }
   }
 
   "Invalid Fsm" should "fail if final state is not a state" in {
     assertThrows[IllegalArgumentException] {
-      val fsm1 = Fsm(Set('a'), Set(1), 1, Set(2), Map())
+      util.ignore { Fsm(Set('a'), Set(1), 1, Set(2), Map()) }
     }
   }
 
   "Invalid Fsm" should "fail if unexpected transition state detected" in {
     assertThrows[IllegalArgumentException] {
-      val fsm1 = Fsm(Set('a'), Set(1, 2), 1, Set(2), Map(1 -> Map('a' -> 3)))
+      util.ignore { Fsm(Set('a'), Set(1, 2), 1, Set(2), Map(1 -> Map('a' -> 3))) }
     }
   }
 }

--- a/storage/src/test/scala/coop/rchain/storage/regex/RegexPatternUnitTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/regex/RegexPatternUnitTests.scala
@@ -213,7 +213,6 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
   "MultPattern common operation" should "work as expected" in {
     val aStar = MultPattern.parse("a*").get.asInstanceOf[MultPattern]
     val aPlus = MultPattern.parse("a+").get.asInstanceOf[MultPattern]
-    val aOne = MultPattern.parse("a").get.asInstanceOf[MultPattern]
 
     assert(aStar.common(aPlus) == aStar)
   }


### PR DESCRIPTION
It's customary for Scala libraries support slightly older versions of Scala.

So as part of our work towards releasing the Storage Layer as a Scala library, here I am setting up cross-build support for Scala 2.11.  I factored out the portions of `build.sbt` that dealt with compiler flag settings into a separate file and dealt with the fact that some flag settings had changed slightly from 2.11 to 2.12.  

Tweaking compiler flags also surfaced a few minor issues in @ys-pyrofex's regex code, so I have attempted to fix those issues here.

After #211 is merged, I will modify our `.travis.yml` and CI scripts to ensure that we are building Storage against all supported Scala versions in CI.

Ref:
https://rchain.atlassian.net/browse/CORE-75