### PR TITLE
Rholang: Add initial work on normalizer.

### DIFF
--- a/rholang/build.sbt
+++ b/rholang/build.sbt
@@ -34,6 +34,13 @@ lazy val root = (project in file("."))
 // Scalaz
 libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.3.0-M17"
 
+// Scala Test
+libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.4"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
+
+resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
+addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.3")
+
 // Kind projector
 resolvers += Resolver.sonatypeRepo("releases")
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")

--- a/rholang/src/main/scala/rholang/interpreter/Normalize.scala
+++ b/rholang/src/main/scala/rholang/interpreter/Normalize.scala
@@ -1,0 +1,141 @@
+package coop.rchain.interpreter
+
+import coop.rchain.syntax.rholang_mercury
+import coop.rchain.syntax.rholang_mercury.Absyn.{Ground => AbsynGround, _}
+
+import coop.rchain.interpreter._
+
+sealed trait VarSort
+case object ProcSort extends VarSort
+case object NameSort extends VarSort
+
+trait BoolNormalizeVisitor extends Bool.Visitor[GBool, Any] {
+  override def visit( b: BoolTrue, n: Any ) : GBool = GBool(true)
+  override def visit( b: BoolFalse, n: Any ) : GBool = GBool(false)
+}
+
+trait GroundNormalizeVisitor extends AbsynGround.Visitor[Ground, Any] 
+    with BoolNormalizeVisitor {
+  override def visit( gb: GroundBool, n: Any ) : Ground = gb.bool_.accept(this, n)
+  override def visit( gi: GroundInt, n: Any ) : Ground = GInt(gi.integer_)
+  override def visit( gi: GroundString, n: Any ) : Ground = GString(gi.string_)
+  override def visit( gi: GroundUri, n: Any ) : Ground = GUri(gi.uri_)
+}
+
+trait ProcNormalizeVisitor
+    extends Proc.Visitor[ProcVisitOutputs, ProcVisitInputs]
+    with GroundNormalizeVisitor {
+
+  override def visit(p: PGround, input: ProcVisitInputs)
+      : ProcVisitOutputs = {
+    ProcVisitOutputs(
+      input.par.copy(expr = p.ground_.accept(this, input) :: input.par.expr),
+      input.knownFree)
+  }
+
+  override def visit(p: PVar, input: ProcVisitInputs)
+      : ProcVisitOutputs = {
+    input.env.get(p.var_) match {
+      case Some( (level, ProcSort) ) => {
+        ProcVisitOutputs(
+          input.par.copy(expr = EVar(BoundVar(level))
+                         :: input.par.expr),
+          input.knownFree)
+      }
+      case Some( (level, NameSort) ) => {
+        throw new Error("Name variable used in process context.")
+      }
+      case None => {
+        input.knownFree.get(p.var_) match {
+          case None =>
+            val newBindingsPair = 
+              input.knownFree.newBindings(List((p.var_, ProcSort)))
+            ProcVisitOutputs(
+              input.par.copy(expr = EVar(FreeVar(newBindingsPair._2(0)))
+                             :: input.par.expr),
+              newBindingsPair._1)
+          case _ => throw new Error(
+            "Free variable used as binder may not be used twice.")
+        }
+      }
+    }
+  }
+
+  override def visit(p: PNil, input: ProcVisitInputs) : ProcVisitOutputs = {
+    ProcVisitOutputs(input.par, input.knownFree)
+  }
+    
+  override def visit(p: PCollect, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PEval, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PMethod, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PNot, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PNeg, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PMult, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PDiv, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PAdd, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PMinus, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PLt, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PLte, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PGt, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PGte, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PEq, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PMatches, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PNeq, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PAnd, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: POr, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PSend, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PContr, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PInput, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PChoice, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PMatch, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PIf, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PIfElse, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PNew, input: ProcVisitInputs) : ProcVisitOutputs = ???
+  override def visit(p: PPar, input: ProcVisitInputs) : ProcVisitOutputs = ???
+}
+
+
+// Parameterized over T, the kind of typing discipline we are enforcing.
+class DebruijnLevelMap[T]( val next: Int, val env: Map[String, (Int, T)]) {
+  def this() = this(0, Map[String, (Int, T)]())
+
+  def newBindings(bindings: List[(String, T)]): (DebruijnLevelMap[T], List[Int]) = {
+    val result = bindings.foldLeft((this, List[Int]())) {
+      (acc: (DebruijnLevelMap[T], List[Int]), binding: (String,T)) =>
+      (DebruijnLevelMap(
+          acc._1.next + 1,
+          acc._1.env + (binding._1 -> ((acc._1.next, binding._2)))),
+       acc._1.next :: acc._2)
+    }
+    (result._1, result._2.reverse)
+  }
+
+  def getBinding(varName: String) : Option[T] = {
+    for (pair <- env.get(varName)) yield pair._2
+  }
+  def getLevel(varName: String) : Option[Int] = {
+    for (pair <- env.get(varName)) yield pair._1
+  }
+  def get(varName: String) : Option [(Int, T)] = env.get(varName)
+  def isEmpty() = env.isEmpty
+}
+
+object DebruijnLevelMap{
+  def apply[T](next: Int, env: Map[String, (Int, T)])
+      : DebruijnLevelMap[T] = {
+    new DebruijnLevelMap(next, env)
+  }
+
+  def apply[T]() = new DebruijnLevelMap[T]()
+
+  def unapply[T](db: DebruijnLevelMap[T]): Option[(Int, Map[String,(Int, T)])] = {
+    Some((db.next, db.env))
+  }
+}
+
+case class ProcVisitInputs(
+  par: Par,
+  env: DebruijnLevelMap[VarSort],
+  knownFree: DebruijnLevelMap[VarSort] )
+// Returns the update Par and an updated map of free variables.
+case class ProcVisitOutputs( par: Par, knownFree: DebruijnLevelMap[VarSort] )

--- a/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
+++ b/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
@@ -41,7 +41,7 @@ case class WildCard() extends Var
 // In the DeBruijn level paper, they use negatives, but this is more clear.
 case class FreeVar(level: Int) extends Var
 
-// upon send, all free variables in data are substituted with their values.
+// Upon send, all free variables in data are substituted with their values.
 // also if a process is sent, it is auto-quoted.
 case class Send(chan: Channel, data: Channel)
 

--- a/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
+++ b/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
@@ -46,7 +46,7 @@ case class FreeVar(level: Int) extends Var
 case class Send(chan: Channel, data: Channel)
 
 // [Par] is an n-arity Pattern.
-// It's an error for free Variable in the list of patterns to overlap.
+// It's an error for free Variable to occur more than once in a pattern.
 // Don't currently support conditional receive
 case class Receive(binds: List[(List[Par], Channel)])
 

--- a/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
+++ b/rholang/src/main/scala/rholang/interpreter/RholangADT.scala
@@ -1,0 +1,92 @@
+// Normalization:
+// Normalization requires the evaluation of everything that doesn't go through
+// the tuplespace, so the top level of a normalized process must have everything
+
+package coop.rchain.interpreter
+
+case class Par(
+  sends: List[Send],
+  receives: List[Receive],
+  // selects: List[Select],
+  evals: List[Eval],
+  news: List[New],
+  expr: List[Expr]
+  // matches: List[Match]
+) {
+  // TODO: write helper methods to append an X and return a new par
+  // TODO: write helper method to get an empty par
+  def this() =
+    this(List(), List(), List(), List(), List())
+}
+
+object Par {
+  def apply() : Par = new Par()
+}
+
+sealed trait Channel
+case class Quote(p: Par) extends Channel
+case class ChanVar(cvar: Var) extends Channel
+
+// While we use vars in both positions, when producing the normalized
+// representation we need a discipline to track whether a var is a name or a
+// process.
+// These are DeBruijn levels
+sealed trait Var
+case class BoundVar(level: Int) extends Var
+// It is an error to use WildCard() in a non-binding position
+case class WildCard() extends Var
+// Variables that occur free in Par used as a pattern or ChanVar are binders.
+// For the purpose of comparing patterns, we count just like BoundVars.
+
+// In the DeBruijn level paper, they use negatives, but this is more clear.
+case class FreeVar(level: Int) extends Var
+
+// upon send, all free variables in data are substituted with their values.
+// also if a process is sent, it is auto-quoted.
+case class Send(chan: Channel, data: Channel)
+
+// [Par] is an n-arity Pattern.
+// It's an error for free Variable in the list of patterns to overlap.
+// Don't currently support conditional receive
+case class Receive(binds: List[(List[Par], Channel)])
+
+case class Eval(channel: Channel)
+
+// Number of variables bound in the new statement.
+// For normalized form, p should not contain solely another new.
+// Also for normalized form, the first use should be level+0, next use level+1
+// up to level+count for the last used variable.
+case class New(count: Int, p: Par)
+
+// Any process may be an operand to an expression.
+// Only processes equivalent to a ground process of compatible type will reduce.
+sealed trait Expr
+sealed trait Ground extends Expr
+case class EList(ps: List[Par]) extends Ground
+case class ETuple(ps: List[Par]) extends Ground
+case class ESet(ps: List[Par]) extends Ground
+case class EMap(kvs: List[(Par,Par)]) extends Ground
+case class ENeg(p: Par) extends Expr
+// A variable used as a var should be bound in a process context, not a name
+// context. For example:
+// for (@x <- c1; @y <- c2) { z!(x + y) } is fine, but
+// for (x <- c1; y <- c2) { z!(x + y) } should raise an error.
+case class EVar(v: Var) extends Expr
+case class EMult(p1: Par, p2: Par) extends Expr
+case class EDiv(p1: Par, p2: Par) extends Expr
+case class EPlus(p1: Par, p2: Par) extends Expr
+case class EMinus(p1: Par, p2: Par) extends Expr
+case class ELt(p1: Par, p2: Par) extends Expr
+case class ELte(p1: Par, p2: Par) extends Expr
+case class EGt(p1: Par, p2: Par) extends Expr
+case class EGte(p1: Par, p2: Par) extends Expr
+case class EEq(p1: Par, p2: Par) extends Expr
+case class ENeq(p1: Par, p2: Par) extends Expr
+
+case class GBool(b: Boolean) extends Ground
+case class GInt(i: Integer) extends Ground
+case class GString(s: String) extends Ground
+case class GUri(u: String) extends Ground
+// These should only occur as the program is being evaluated. There is no way in
+// the grammar to construct them.
+case class GPrivate(p: String) extends Ground

--- a/rholang/src/test/scala/rholang/interpretr/NormalizeTest.scala
+++ b/rholang/src/test/scala/rholang/interpretr/NormalizeTest.scala
@@ -1,0 +1,93 @@
+import coop.rchain.interpreter._
+import coop.rchain.syntax.rholang_mercury.Absyn.{Ground => AbsynGround, _}
+import org.scalatest._
+
+class BoolVisitorSpec extends FlatSpec with Matchers {
+  val visitor = new BoolNormalizeVisitor() {}
+  "BoolTrue" should "Compile as GBool(true)" in {
+    val btrue = new BoolTrue()
+
+    btrue.accept(visitor, this) should be (GBool(true))
+  }
+  "BoolFalse" should "Compile as GBool(false)" in {
+    val bfalse = new BoolFalse()
+
+    bfalse.accept(visitor, this) should be (GBool(false))
+  }
+}
+
+class GroundVisitorSpec extends FlatSpec with Matchers {
+  val visitor = new GroundNormalizeVisitor() {}
+  "GroundInt" should "Compile as GInt" in {
+    val gi = new GroundInt(7)
+
+    gi.accept(visitor, this) should be (GInt(7))
+  }
+  "GroundString" should "Compile as GString" in {
+    val gs = new GroundString("String")
+
+    gs.accept(visitor, this) should be (GString("String"))
+  }
+  "GroundUri" should "Compile as GUri" in {
+    val gu = new GroundUri("Uri")
+
+    gu.accept(visitor, this) should be (GUri("Uri"))
+  }
+}
+
+class NilVisitSpec extends FlatSpec with Matchers {
+  val visitor = new ProcNormalizeVisitor() {}
+  val inputs = ProcVisitInputs(
+      Par(),
+      DebruijnLevelMap[VarSort](),
+      DebruijnLevelMap[VarSort]())
+
+  "PNil" should "Compile as no modification to the par object" in {
+    val nil = new PNil()
+
+    val result = nil.accept(visitor, inputs)
+    result.par should be (inputs.par)
+    result.knownFree should be (inputs.knownFree)
+  }
+}
+
+class VarVisitSpec extends FlatSpec with Matchers {
+  val visitor = new ProcNormalizeVisitor() {}
+  val inputs = ProcVisitInputs(
+      Par(),
+      DebruijnLevelMap[VarSort](),
+      DebruijnLevelMap[VarSort]())
+  val pvar = new PVar("x")
+
+  "PVar" should "Compile as BoundVar if it's in env" in {
+    val boundinputs = inputs.copy(env =
+      inputs.env.newBindings(List(("x", ProcSort)))._1)
+  
+    val result = pvar.accept(visitor, boundinputs)
+    result.par should be (inputs.par.copy(expr = List(EVar(BoundVar(0)))))
+    result.knownFree should be (inputs.knownFree)
+  }
+  "PVar" should "Compile as FreeVar if it's not in env" in {
+    val result = pvar.accept(visitor, inputs)
+    result.par should be (inputs.par.copy(expr = List(EVar(FreeVar(0)))))
+    result.knownFree should be
+        (inputs.knownFree.newBindings(
+            List(("x", ProcSort)))._1)
+  }
+  "PVar" should "Not compile if it's in env of the wrong sort" in {
+    val boundinputs = inputs.copy(env =
+      inputs.env.newBindings(List(("x", NameSort)))._1)
+    
+    an [Error] should be thrownBy {
+      val result = pvar.accept(visitor, boundinputs)
+    }
+  }
+  "PVar" should "Not compile if it's used free somewhere else" in {
+    val boundinputs = inputs.copy(knownFree =
+      inputs.knownFree.newBindings(List(("x", ProcSort)))._1)
+    
+    an [Error] should be thrownBy {
+      val result = pvar.accept(visitor, boundinputs)
+    }
+  }
+}


### PR DESCRIPTION
Normalizer will work in 2 parts:
Part 1 will "compile" the source down to a partially normalized form, and part 2
will sort the subcomponents of all subproccesses according to an order.

This is the beginning of part 1: it adds some visitor classes to start producing
a normalized form from the syntax, and tests! to make sure that that the few
productions for which we have visitors are working.

Adds scalatest as a testing dependency.