### PR TITLE
CORE-165 storage: add StorableData.proto

### DIFF
--- a/storage/src/main/protobuf/StorableData.proto
+++ b/storage/src/main/protobuf/StorableData.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+option java_package = "coop.rchain.storage.models";
+
+import "Block.proto";
+import "Contract.proto";
+import "SystemContract.proto";
+
+message StorableData {
+  oneof value {
+    Block block = 1;
+    Contract contract = 2;
+    SystemContract system_contract = 3;
+  }
+}

--- a/storage/src/main/scala/coop/rchain/storage/Error.scala
+++ b/storage/src/main/scala/coop/rchain/storage/Error.scala
@@ -4,6 +4,6 @@ package coop.rchain.storage
   * Represents an error that can occur in the storage layer
   */
 sealed trait Error
-final case class SerializeError(throwable: Throwable) extends Error
-final case class StorageError(throwable: Throwable)   extends Error
-case object NotFound                                  extends Error
+final case class SerializeError(msg: String)        extends Error
+final case class StorageError(throwable: Throwable) extends Error
+case object NotFound                                extends Error

--- a/storage/src/main/scala/coop/rchain/storage/models/SerializeInstances.scala
+++ b/storage/src/main/scala/coop/rchain/storage/models/SerializeInstances.scala
@@ -1,6 +1,7 @@
 package coop.rchain.storage.models
 
 import cats.syntax.either._
+import coop.rchain.storage.models.StorableData.Value
 import coop.rchain.storage.{Serialize, SerializeError}
 
 trait SerializeInstances {
@@ -8,33 +9,39 @@ trait SerializeInstances {
   implicit object blockInstance extends Serialize[Block] {
 
     def encode(a: Block): Array[Byte] =
-      a.toByteArray
+      StorableData(value = Value.Block(a)).toByteArray
 
     def decode(bytes: Array[Byte]): Either[SerializeError, Block] =
-      Either
-        .catchNonFatal(Block.parseFrom(bytes))
-        .leftMap(SerializeError.apply)
+      StorableData
+        .parseFrom(bytes)
+        .value
+        .block
+        .toRight(SerializeError("decode: could not parse Block"))
   }
 
   implicit object contractInstance extends Serialize[Contract] {
 
     def encode(a: Contract): Array[Byte] =
-      a.toByteArray
+      StorableData(value = Value.Contract(a)).toByteArray
 
     def decode(bytes: Array[Byte]): Either[SerializeError, Contract] =
-      Either
-        .catchNonFatal(Contract.parseFrom(bytes))
-        .leftMap(SerializeError.apply)
+      StorableData
+        .parseFrom(bytes)
+        .value
+        .contract
+        .toRight(SerializeError("decode: could not parse Contract"))
   }
 
   implicit object systemContractInstance extends Serialize[SystemContract] {
 
     def encode(a: SystemContract): Array[Byte] =
-      a.toByteArray
+      StorableData(value = Value.SystemContract(a)).toByteArray
 
     def decode(bytes: Array[Byte]): Either[SerializeError, SystemContract] =
-      Either
-        .catchNonFatal(SystemContract.parseFrom(bytes))
-        .leftMap(SerializeError.apply)
+      StorableData
+        .parseFrom(bytes)
+        .value
+        .systemContract
+        .toRight(SerializeError("decode: could not parse SystemContract"))
   }
 }

--- a/storage/src/test/scala/coop/rchain/storage/StorageTest.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageTest.scala
@@ -68,4 +68,47 @@ class StorageTest extends FlatSpec with Matchers with EitherValues with StorageF
 
       storage.get[SystemContract](testKey).left.value shouldBe NotFound
   }
+
+  it should """return Left(SerializeError("...") after putting a Contract and trying to get a Block""" in withTestStorage {
+    (storage: Storage) =>
+      val bytes: Array[Byte]  = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
+      val testKey: Key        = Flat("quux")
+      val testValue: Contract = Contract(value = ByteString.copyFrom(bytes))
+
+      val getResult: Either[Error, Block] =
+        storage.put(testKey, testValue).flatMap { (_: Unit) =>
+          storage.get[Block](testKey)
+        }
+
+      getResult.left.value shouldBe SerializeError("decode: could not parse Block")
+  }
+
+  it should """return Left(SerializeError("...") after putting a SystemContract and trying to get a Contract""" in withTestStorage {
+    (storage: Storage) =>
+      val bytes: Array[Byte]        = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
+      val testKey: Key              = FlatSys("quux")
+      val testValue: SystemContract = SystemContract(value = ByteString.copyFrom(bytes))
+
+      val getResult: Either[Error, Contract] =
+        storage.put(testKey, testValue).flatMap { (_: Unit) =>
+          storage.get[Contract](testKey)
+        }
+
+      getResult.left.value shouldBe SerializeError("decode: could not parse Contract")
+  }
+
+  it should """return Left(SerializeError("...") after putting a Block and trying to get a SystemContract""" in withTestStorage {
+    (storage: Storage) =>
+      val bytes: Array[Byte] = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
+      val hash: Array[Byte]  = MessageDigest.getInstance("SHA-256").digest(bytes)
+      val testKey: Key       = Hash(hash)
+      val testValue: Block   = Block(value = ByteString.copyFrom(bytes))
+
+      val getResult: Either[Error, SystemContract] =
+        storage.put(testKey, testValue).flatMap { (_: Unit) =>
+          storage.get[SystemContract](testKey)
+        }
+
+      getResult.left.value shouldBe SerializeError("decode: could not parse SystemContract")
+  }
 }


### PR DESCRIPTION
In order to improve test coverage, I needed to test failure cases in the new storage re-implementation.

One important failure case:
```scala
val bytes: Array[Byte] = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
val hash: Array[Byte]  = MessageDigest.getInstance("SHA-256").digest(bytes)
val testKey: Key       = Hash(hash)
val testValue: Block   = Block(value = ByteString.copyFrom(bytes))

val getResult = 
  for {
    _ <- storage.put(testKey, testValue)
    r <- storage.get[Contract](testKey)
  } yield r
```

Here we are putting in a value of type `Block` at key `testKey`, and then attempting to `get` the value at `testKey` but are specifying that we want to deserialize it as a `Contract` value.  The right thing to do is to fail with a `Left(SerializeError("<msg>"))`.  However, serialized protobuf messages are not self-describing in terms of their type, and if they are structurally similar, it is entirely possible to successfully parse one type of thing when you are attempting to parse another, thought the actual parsed data might not be what is expected.  So instead here we'd get back a `Right(Contract(<bytes of a Block>))`.  This is obviously not the correct behavior and should be fixed so that we get an error in this case.

The proposed solution is to create a wrapper protobuf message, `StorableData` with a `oneof`/union type containing the different types of messages we are handling (currently `Block`, `Contract`, and `SystemContract`).  You can then use the code generated by this `oneof` member to disambiguate what type of message is contained in a value of type `StorableData`.  A value of type `StorableData` serialized to bytes is what gets stored in LMDB. 

Ref: (improving test coverage)
https://rchain.atlassian.net/browse/CORE-165