### PR TITLE
storage: use separate sub-databases for each key type

### DIFF
--- a/storage/src/main/scala/coop/rchain/storage/Key.scala
+++ b/storage/src/main/scala/coop/rchain/storage/Key.scala
@@ -8,6 +8,6 @@ import java.nio.charset.StandardCharsets
   * @param bytes the underlying byte-array, suitable for storage
   */
 sealed abstract class Key(val bytes: Array[Byte])
-final case class Hash(bs: Array[Byte])  extends Key(s"hash-".getBytes(StandardCharsets.UTF_8) ++ bs)
-final case class Flat(value: String)    extends Key(s"flat-$value".getBytes(StandardCharsets.UTF_8))
-final case class FlatSys(value: String) extends Key(s"fsys-$value".getBytes(StandardCharsets.UTF_8))
+final case class Hash(bs: Array[Byte])  extends Key(bs)
+final case class Flat(value: String)    extends Key(value.getBytes(StandardCharsets.UTF_8))
+final case class FlatSys(value: String) extends Key(value.getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
One thing about the storage re-implementation that hasn't sat well with me is the way I am partitioning the keyspace based on the type of key.  In the current version, to prevent key collisions across the three different types of keys, I am merely prepending the bytes of a UTF-8 encoded string describing the type in front of underlying the bytes of the key.

I think that a better, more defensive design would be to actually use separate sub-databases for each of the three types of keys.  

If this seems reasonable, I'd like to get it in before the next tranche of work begins on the Storage Layer.

Feedback welcome!