### PR TITLE
Refactor Network constructor to take PeerNode

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -90,7 +90,7 @@ object Main {
     }
 
     val addy = p2p.NetworkAddress.parse(s"rnode://$name@$host:${conf.port()}") match {
-      case Right(node)           => node
+      case Right(node)               => node
       case Left(p2p.ParseError(msg)) => throw new Exception(msg)
     }
 

--- a/comm/src/main/scala/coop/rchain/comm/main.scala
+++ b/comm/src/main/scala/coop/rchain/comm/main.scala
@@ -89,7 +89,10 @@ object Main {
         }
     }
 
-    val addy = s"rnode://$name@$host:${conf.port()}"
+    val addy = p2p.NetworkAddress.parse(s"rnode://$name@$host:${conf.port()}") match {
+      case Right(node)           => node
+      case Left(p2p.ParseError(msg)) => throw new Exception(msg)
+    }
 
     val net = p2p.Network(addy)
     logger.info(s"Listening for traffic on $net.")

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -51,13 +51,8 @@ case object NetworkAddress {
     }
 }
 
-case class Network(homeAddress: String) extends ProtocolDispatcher[java.net.SocketAddress] {
+case class Network(local: PeerNode) extends ProtocolDispatcher[java.net.SocketAddress] {
   val logger = Logger("p2p")
-
-  val local = NetworkAddress.parse(homeAddress) match {
-    case Right(node)           => node
-    case Left(ParseError(msg)) => throw new Exception(msg)
-  }
 
   val net = new UnicastNetwork(local, Some(this))
 
@@ -172,7 +167,7 @@ case class Network(homeAddress: String) extends ProtocolDispatcher[java.net.Sock
       }
     }
 
-  override def toString = s"#{Network $homeAddress}"
+  override def toString = s"#{Network ${local.toAddress}}"
 }
 
 object NetworkProtocol {


### PR DESCRIPTION
Parsing String should not be concern of `Network` constructor. A
dedicated `PeerNode` should be created by the client and any error
handling of peerNode creation should happen out side of this scope.

Also this change did not require any tests to be modified which is
troubling to say the least.

Further work should consider proper error handling in main method as
well as removing `connect` method that take `String` as an argument.