### PR TITLE
rholangweb: include django license in Docker image (RHOL-103)

### DIFF
--- a/docker/rholang-web/Dockerfile
+++ b/docker/rholang-web/Dockerfile
@@ -34,6 +34,9 @@ RUN python3 manage.py migrate
 
 COPY docker/rholang-web/run-server .
 
+RUN python3 -c \
+    "from urllib.request import urlretrieve as wget; wget('https://github.com/django/django/raw/master/LICENSE', filename='/opt/rholangweb/rholang/main/static/django-license')"
+
 ENTRYPOINT [ "/opt/rholangweb/run-server" ]
 
 # Local Variables:

--- a/rholangweb/rholang/main/templates/index.html
+++ b/rholangweb/rholang/main/templates/index.html
@@ -128,6 +128,8 @@
     <hr />
     <address class="footer">
       Copyright (c) 2017-2018 <a href="https://rchain.coop">RChain Cooperative</a>
+      <br />
+      made with <a href="https://www.djangoproject.com/">django</a>
     </address>
   </div>
 


### PR DESCRIPTION
Ack django in the page footer, while we're at it.