### PR TITLE
Avoid name conflicts by renaming prim objects

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -84,7 +84,10 @@ trait Ob extends Base with Cloneable {
   def runtimeError(msg: String, state: VMState): (RblError, VMState) =
     (DeadThread, state)
 
-  def setAddr(indirect: Boolean, level: Int, offset: Int, value: Ob): State[Ob, StoreResult] = ???
+  def setAddr(indirect: Boolean,
+              level: Int,
+              offset: Int,
+              value: Ob): State[Ob, StoreResult] = ???
 
   def setField(indirect: Boolean, level: Int, offset: Int, spanSize: Int, value: Int): Ob =
     ??? //TODO

--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -84,10 +84,7 @@ trait Ob extends Base with Cloneable {
   def runtimeError(msg: String, state: VMState): (RblError, VMState) =
     (DeadThread, state)
 
-  def setAddr(indirect: Boolean,
-              level: Int,
-              offset: Int,
-              value: Ob): State[Ob, StoreResult] = ???
+  def setAddr(indirect: Boolean, level: Int, offset: Int, value: Ob): State[Ob, StoreResult] = ???
 
   def setField(indirect: Boolean, level: Int, offset: Int, spanSize: Int, value: Int): Ob =
     ??? //TODO

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/fixnum.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/fixnum.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 
-import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, RblBool}
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, RblBool}
 import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
 import coop.rchain.rosette.prim.Prim._
 
@@ -9,19 +9,19 @@ import coop.rchain.rosette.prim.Prim._
   * There is inconsistent behavior between fx<, fx<=, fx>, fx>=, fx=, fx!= and fl<,
   * fl<=, fl>, fl>=, fl=, fl!=
   **/
-object Fixnum {
+object fixnum {
   object fxPlus extends Prim {
     override val name: String = "fx+"
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(0)) {
-        case (accum, fixnum: RFixnum) => accum + fixnum
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
+        case (accum, fixnum: Fixnum) => accum + fixnum
       })
     }
   }
@@ -31,18 +31,18 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] =
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] =
       ctxt.nargs match {
         case 1 =>
-          val fixval = ctxt.argvec.elem.head.asInstanceOf[RFixnum].value
-          Right(RFixnum(-fixval))
+          val fixval = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+          Right(Fixnum(-fixval))
 
         case 2 =>
-          val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum].value
-          val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum].value
-          Right(RFixnum(m - n))
+          val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
+          val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum].value
+          Right(Fixnum(m - n))
       }
   }
 
@@ -51,13 +51,13 @@ object Fixnum {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(1)) {
-        case (accum, fixnum: RFixnum) => accum * fixnum
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(1)) {
+        case (accum, fixnum: Fixnum) => accum * fixnum
       })
     }
   }
@@ -67,11 +67,11 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       try {
         Right(m / n)
@@ -87,11 +87,11 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       try {
         Right(m % n)
@@ -109,8 +109,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m < n
           case Left(_)  => RblBool(false)
         }
@@ -124,8 +124,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m <= n
           case Left(_)  => RblBool(false)
         }
@@ -139,8 +139,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m > n
           case Left(_)  => RblBool(false)
         }
@@ -154,8 +154,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m >= n
           case Left(_)  => RblBool(false)
         }
@@ -169,8 +169,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m == n
           case Left(_)  => RblBool(false)
         }
@@ -184,8 +184,8 @@ object Fixnum {
 
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
-      checkRFixnum(0, ctxt.argvec.elem).map { m =>
-        checkRFixnum(1, ctxt.argvec.elem) match {
+      checkFixnum(0, ctxt.argvec.elem).map { m =>
+        checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m != n
           case Left(_)  => RblBool(false)
         }
@@ -197,13 +197,13 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(Int.MaxValue)) {
-        case (minVal, fixnum: RFixnum) =>
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(Int.MaxValue)) {
+        case (minVal, fixnum: Fixnum) =>
           if (minVal.value < fixnum.value) minVal else fixnum
       })
     }
@@ -214,13 +214,13 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(Int.MinValue)) {
-        case (maxVal, fixnum: RFixnum) =>
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(Int.MinValue)) {
+        case (maxVal, fixnum: Fixnum) =>
           if (maxVal.value > fixnum.value) maxVal else fixnum
       })
     }
@@ -231,11 +231,11 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      Right(RFixnum(Math.abs(m.value)))
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      Right(Fixnum(Math.abs(m.value)))
     }
   }
 
@@ -244,14 +244,14 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       try {
-        Right(RFixnum(Math.pow(m.value, n.value).toInt))
+        Right(Fixnum(Math.pow(m.value, n.value).toInt))
       } catch {
         case _: ArithmeticException =>
           Left(ArithmeticError)
@@ -264,10 +264,10 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum].value
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
 
       if (m <= 0) {
         Left(ArithmeticError)
@@ -276,7 +276,7 @@ object Fixnum {
           val logn = Math.log(m.toDouble)
           val log2 = Math.log(2.0)
 
-          Right(RFixnum(Math.ceil(logn / log2).toInt))
+          Right(Fixnum(Math.ceil(logn / log2).toInt))
         } catch {
           case _: ArithmeticException =>
             Left(ArithmeticError)
@@ -290,10 +290,10 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum].value
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
 
       if (m <= 0) {
         Left(ArithmeticError)
@@ -302,7 +302,7 @@ object Fixnum {
           val logn = Math.log(m.toDouble)
           val log2 = Math.log(2.0)
 
-          Right(RFixnum(Math.floor(logn / log2).toInt))
+          Right(Fixnum(Math.floor(logn / log2).toInt))
         } catch {
           case _: ArithmeticException =>
             Left(ArithmeticError)
@@ -316,13 +316,13 @@ object Fixnum {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(~0)) {
-        case (accum, fixnum: RFixnum) => accum & fixnum
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(~0)) {
+        case (accum, fixnum: Fixnum) => accum & fixnum
       })
     }
   }
@@ -332,13 +332,13 @@ object Fixnum {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(0)) {
-        case (accum, fixnum: RFixnum) => accum | fixnum
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
+        case (accum, fixnum: Fixnum) => accum | fixnum
       })
     }
   }
@@ -348,13 +348,13 @@ object Fixnum {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFixnum(0)) {
-        case (accum, fixnum: RFixnum) => accum ^ fixnum
+      Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
+        case (accum, fixnum: Fixnum) => accum ^ fixnum
       })
     }
   }
@@ -364,12 +364,12 @@ object Fixnum {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
 
-      Right(RFixnum(~m.value))
+      Right(Fixnum(~m.value))
     }
   }
 
@@ -378,19 +378,19 @@ object Fixnum {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
-      val commonBits = ctxt.argvec.elem.take(n).foldLeft(RFixnum(~0)) {
-        case (accum, fixnum: RFixnum) => accum & fixnum
+      val commonBits = ctxt.argvec.elem.take(n).foldLeft(Fixnum(~0)) {
+        case (accum, fixnum: Fixnum) => accum & fixnum
       }
 
       if (commonBits.value != 0) {
-        Right(RFixnum(1))
+        Right(Fixnum(1))
       } else {
-        Right(RFixnum(0))
+        Right(Fixnum(0))
       }
     }
   }
@@ -400,14 +400,14 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       try {
-        Right(RFixnum(Math.ceil(m.value.toDouble / n.value.toDouble).toInt))
+        Right(Fixnum(Math.ceil(m.value.toDouble / n.value.toDouble).toInt))
       } catch {
         case _: ArithmeticException =>
           Left(ArithmeticError)
@@ -420,11 +420,11 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       Right(m << n)
     }
@@ -435,11 +435,11 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       Right(m >> n)
     }
@@ -450,11 +450,11 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       Right(m << n)
     }
@@ -465,20 +465,20 @@ object Fixnum {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFixnum]
+    @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFixnum]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFixnum]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
+      val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
       Right(m >>> n)
     }
   }
 
-  private def checkRFixnum(n: Int, elem: Seq[Ob]): Either[PrimError, RFixnum] =
-    if (!elem(n).isInstanceOf[RFixnum]) {
-      Left(TypeMismatch(n, RFixnum.getClass().getName()))
+  private def checkFixnum(n: Int, elem: Seq[Ob]): Either[PrimError, Fixnum] =
+    if (!elem(n).isInstanceOf[Fixnum]) {
+      Left(TypeMismatch(n, Fixnum.getClass().getName()))
     } else {
-      Right(elem(n).asInstanceOf[RFixnum])
+      Right(elem(n).asInstanceOf[Fixnum])
     }
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
@@ -2,11 +2,11 @@ package coop.rchain.rosette
 
 package object prim {
   // For now keys in Prims correspond to Prim::primnum in Rosette
-  val Prims = Map[Int, Prim](197 -> RblFloat.flPlus,
-                             222 -> Fixnum.fxMod,
-                             223 -> Fixnum.fxDiv,
-                             224 -> Fixnum.fxTimes,
-                             225 -> Fixnum.fxMinus,
-                             226 -> Fixnum.fxPlus)
+  val Prims = Map[Int, Prim](197 -> rblfloat.flPlus,
+                             222 -> fixnum.fxMod,
+                             223 -> fixnum.fxDiv,
+                             224 -> fixnum.fxTimes,
+                             225 -> fixnum.fxMinus,
+                             226 -> fixnum.fxPlus)
 
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/rblfloat.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/rblfloat.scala
@@ -1,27 +1,27 @@
 package coop.rchain.rosette.prim
 
-import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, RblBool, RblFloat => RFloat}
 import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
 import coop.rchain.rosette.prim.Prim._
+import coop.rchain.rosette.{Ctxt, Fixnum, RblBool, RblFloat}
 
 /**
   * TODO:
   * There is inconsistent behavior between fx<, fx<=, fx>, fx>=, fx=, fx!= and fl<,
   * fl<=, fl>, fl>=, fl=, fl!=
   **/
-object RblFloat {
+object rblfloat {
   object flPlus extends Prim {
     override val name: String = "fl+"
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFloat(0.0)) {
-        case (accum, float: RFloat) => accum + float
+      Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(0.0)) {
+        case (accum, float: RblFloat) => accum + float
       })
     }
   }
@@ -31,17 +31,17 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] =
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] =
       ctxt.nargs match {
         case 1 =>
-          val n = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-          Right(RFloat(-n.value))
+          val n = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+          Right(RblFloat(-n.value))
 
         case 2 =>
-          val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-          val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+          val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+          val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
           Right(m - n)
       }
   }
@@ -51,13 +51,13 @@ object RblFloat {
     override val minArgs: Int = 0
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFloat(1)) {
-        case (accum, float: RFloat) => accum * float
+      Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(1)) {
+        case (accum, float: RblFloat) => accum * float
       })
     }
   }
@@ -67,11 +67,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       try {
         Right(m / n)
@@ -87,11 +87,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m < n)
     }
@@ -102,11 +102,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m <= n)
     }
@@ -117,11 +117,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m > n)
     }
@@ -132,11 +132,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m >= n)
     }
@@ -147,11 +147,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m == n)
     }
@@ -162,11 +162,11 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
     override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
       Right(m != n)
     }
@@ -177,13 +177,13 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFloat(Double.MaxValue)) {
-        case (minVal, float: RFloat) =>
+      Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(Double.MaxValue)) {
+        case (minVal, float: RblFloat) =>
           if (minVal.value < float.value) minVal else float
       })
     }
@@ -194,13 +194,13 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
-      Right(ctxt.argvec.elem.take(n).foldLeft(RFloat(Double.MinValue)) {
-        case (maxVal, float: RFloat) =>
+      Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(Double.MinValue)) {
+        case (maxVal, float: RblFloat) =>
           if (maxVal.value > float.value) maxVal else float
       })
     }
@@ -211,12 +211,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.abs(m.value)))
+      Right(RblFloat(Math.abs(m.value)))
     }
   }
 
@@ -225,12 +225,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.exp(m.value)))
+      Right(RblFloat(Math.exp(m.value)))
     }
   }
 
@@ -239,13 +239,13 @@ object RblFloat {
     override val minArgs: Int = 2
     override val maxArgs: Int = 2
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
-      val n = ctxt.argvec.elem(1).asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
+      val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.pow(m.value, n.value)))
+      Right(RblFloat(Math.pow(m.value, n.value)))
     }
   }
 
@@ -254,12 +254,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.log(m.value)))
+      Right(RblFloat(Math.log(m.value)))
     }
   }
 
@@ -268,12 +268,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.log10(m.value)))
+      Right(RblFloat(Math.log10(m.value)))
     }
   }
 
@@ -282,12 +282,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.floor(m.value)))
+      Right(RblFloat(Math.floor(m.value)))
     }
   }
 
@@ -296,12 +296,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.ceil(m.value)))
+      Right(RblFloat(Math.ceil(m.value)))
     }
   }
 
@@ -310,12 +310,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.atan(m.value)))
+      Right(RblFloat(Math.atan(m.value)))
     }
   }
 
@@ -324,12 +324,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.cos(m.value)))
+      Right(RblFloat(Math.cos(m.value)))
     }
   }
 
@@ -338,12 +338,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFloat] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFloat(Math.sin(m.value)))
+      Right(RblFloat(Math.sin(m.value)))
     }
   }
 
@@ -352,12 +352,12 @@ object RblFloat {
     override val minArgs: Int = 1
     override val maxArgs: Int = 1
 
-    @checkTypeMismatch[RFloat]
+    @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RFixnum] = {
-      val m = ctxt.argvec.elem.head.asInstanceOf[RFloat]
+    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+      val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
-      Right(RFixnum(math.floor(m.value).toInt))
+      Right(Fixnum(math.floor(m.value).toInt))
     }
   }
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/LocationSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/LocationSpec.scala
@@ -79,8 +79,8 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
 
     "store to environment" in {
       val lexVarOffset1 = LexVariable(indirect = false, level = 0, offset = 1)
-      val lexVarLevel0 = LexVariable(indirect = false, level = 0, offset = 0)
-      val lexVarLevel1 = LexVariable(indirect = false, level = 1, offset = 0)
+      val lexVarLevel0  = LexVariable(indirect = false, level = 0, offset = 0)
+      val lexVarLevel1  = LexVariable(indirect = false, level = 1, offset = 0)
 
       {
         val (ctxt, res) =
@@ -112,8 +112,7 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
     {
       val (ctxt, res) =
         Location
-          .store(LexVariable(indirect = false, level = 100, offset = 0),
-                 RblString("test"))
+          .store(LexVariable(indirect = false, level = 100, offset = 0), RblString("test"))
           .run(testCtxt)
           .value
 
@@ -124,8 +123,7 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
     {
       val (ctxt, res) =
         Location
-          .store(LexVariable(indirect = false, level = 0, offset = 100),
-                 RblString("test"))
+          .store(LexVariable(indirect = false, level = 0, offset = 100), RblString("test"))
           .run(testCtxt)
           .value
 

--- a/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/ObSpec.scala
@@ -4,14 +4,14 @@ import coop.rchain.rosette.Ob.setLex
 import org.scalatest.{Matchers, WordSpec}
 
 class ObSpec extends WordSpec with Matchers {
-  val meta = new Ob {}
+  val meta   = new Ob {}
   val parent = new Ob {}
 
   "forwardingAddress" should {
 
     "return meta" in {
       val newMeta = createOb()
-      val ob = createOb(Seq(newMeta))
+      val ob      = createOb(Seq(newMeta))
       ob.forwardingAddress shouldBe newMeta
     }
   }
@@ -19,10 +19,10 @@ class ObSpec extends WordSpec with Matchers {
   "getLex" should {
 
     "return element by offset" in {
-      val third = createOb()
+      val third  = createOb()
       val parent = parentWithThreeSlots(third)
 
-      val ob = createOb(Seq(meta, parent))
+      val ob  = createOb(Seq(meta, parent))
       val lex = ob.getLex(indirect = true, level = 1, offset = 2)
 
       lex shouldEqual third
@@ -30,11 +30,9 @@ class ObSpec extends WordSpec with Matchers {
 
     "return INVALID when offset is out of bounds" in {
       val parent = parentWithThreeSlots()
-      val ob = createOb(Seq(meta, parent))
+      val ob     = createOb(Seq(meta, parent))
       val lex =
-        ob.getLex(indirect = true,
-                  level = 1,
-                  offset = parent.numberOfSlots() + 1)
+        ob.getLex(indirect = true, level = 1, offset = parent.numberOfSlots() + 1)
 
       lex shouldEqual Ob.INVALID
     }
@@ -43,16 +41,14 @@ class ObSpec extends WordSpec with Matchers {
   "setLex" should {
 
     "set an extension slot by offset" in {
-      val ext = createExtension(twoSlots)
-      val value = createOb()
+      val ext        = createExtension(twoSlots)
+      val value      = createOb()
       val parent: Ob = parentWithThreeSlots(extension = Some(ext))
-      val ob = createOb(Seq(meta, parent))
-      val offset = 1
+      val ob         = createOb(Seq(meta, parent))
+      val offset     = 1
 
-      val newOb = setLex(indirect = true,
-                         level = 1,
-                         offset = offset,
-                         value = value).runS(ob).value
+      val newOb =
+        setLex(indirect = true, level = 1, offset = offset, value = value).runS(ob).value
 
       val actorParent = newOb.parent.asInstanceOf[Actor]
 
@@ -69,14 +65,14 @@ class ObSpec extends WordSpec with Matchers {
   }
 
   def twoSlots: Seq[Ob] = {
-    val first = createOb()
+    val first  = createOb()
     val second = createOb()
     Seq(first, second)
   }
 
   def createActor(ext: StdExtension, slots: Seq[Ob]): Actor =
     new Actor {
-      override val extension = ext
+      override val extension     = ext
       override val slot: Seq[Ob] = slots
     }
 

--- a/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.prop.PropertyChecks
 
 class PrimPropertySpec extends PropSpec with PropertyChecks with Matchers {
   property("Primitives should return error for illegal number of arguments") {
-    val nargsGen = Gen.choose(0, 1000)
+    val nargsGen   = Gen.choose(0, 1000)
     val primitives = prim.Prims.values
 
     primitives.foreach { prim =>

--- a/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/TransitionSpec.scala
@@ -325,8 +325,7 @@ class TransitionSpec extends FlatSpec with Matchers {
       testState
         .set(_ >> 'ctxt >> 'ctxt)(testState.ctxt)
         .set(_ >> 'globalEnv)(TblObject(globalEnv))
-        .set(_ >> 'code >> 'litvec)(
-          Tuple(Seq(RequestExpr, RblFloat(1.2), RblFloat(2.3))))
+        .set(_ >> 'code >> 'litvec)(Tuple(Seq(RequestExpr, RblFloat(1.2), RblFloat(2.3))))
 
     val codevec = Seq(
       OpAlloc(2),

--- a/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/VirtualMachineSpec.scala
@@ -7,17 +7,17 @@ import org.scalatest._
 
 class VirtualMachineSpec extends WordSpec with Matchers {
   val someObsInd = someObs.size - 1
-  val regInd = 9
-  val bool = true
-  val n = 4
-  val m = 5
+  val regInd     = 9
+  val bool       = true
+  val n          = 4
+  val m          = 5
 
-  def formatSuffix(suffix: String)(
-      f: (String, String) => String)(name: String, path: String): String =
+  def formatSuffix(suffix: String)(f: (String, String) => String)(name: String,
+                                                                  path: String): String =
     s"${f(name, path)} $suffix"
 
-  def formatPrefix(prefix: String)(
-      f: (String, String) => String)(name: String, path: String): String =
+  def formatPrefix(prefix: String)(f: (String, String) => String)(name: String,
+                                                                  path: String): String =
     s"$prefix ${f(name, path)}"
 
   def rsltSuf(isEq: Boolean) = {
@@ -46,9 +46,7 @@ class VirtualMachineSpec extends WordSpec with Matchers {
       _ shouldBe 0
     }
 
-    (theState >> 'ctxt >> 'argvec >> 'elem on OpImmediateLitToArg(
-      value = m,
-      arg = someObsInd)) {
+    (theState >> 'ctxt >> 'argvec >> 'elem on OpImmediateLitToArg(value = m, arg = someObsInd)) {
       val updatedElem =
         testState.ctxt.argvec.elem
           .updated(someObsInd, VirtualMachine.vmLiterals(m))
@@ -129,10 +127,8 @@ class VirtualMachineSpec extends WordSpec with Matchers {
       _ shouldBe 1
     }
 
-    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferArgToArg(
-      dest = someObsInd,
-      src = someObsInd)) {
-      val elem = testState.ctxt.argvec.elem(someObsInd)
+    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferArgToArg(dest = someObsInd, src = someObsInd)) {
+      val elem    = testState.ctxt.argvec.elem(someObsInd)
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated
     }
@@ -142,10 +138,9 @@ class VirtualMachineSpec extends WordSpec with Matchers {
       _ shouldBe elem
     }
 
-    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferGlobalToArg(
-      arg = someObsInd,
-      global = someObsInd)) {
-      val elem = testState.globalEnv.entry(someObsInd)
+    (theState >> 'ctxt >> 'argvec >> 'elem on OpXferGlobalToArg(arg = someObsInd,
+                                                                global = someObsInd)) {
+      val elem    = testState.globalEnv.entry(someObsInd)
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated
     }
@@ -156,7 +151,7 @@ class VirtualMachineSpec extends WordSpec with Matchers {
     }
 
     (theState >> 'ctxt >> 'argvec >> 'elem on OpXferRsltToArg(someObsInd)) {
-      val elem = testState.ctxt.rslt
+      val elem    = testState.ctxt.rslt
       val updated = testState.ctxt.argvec.elem.updated(someObsInd, elem)
       _ shouldBe updated
     }

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rosette.prim
 
 import coop.rchain.rosette.prim.fixnum._
-import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, PC, RblBool, Tuple}
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, RblBool, Tuple}
 import org.scalatest._
 
 class FixnumSpec extends FlatSpec with Matchers {
@@ -12,7 +12,7 @@ class FixnumSpec extends FlatSpec with Matchers {
     pc = PC.PLACEHOLDER,
     rslt = null,
     trgt = null,
-    argvec = Tuple(1, RFixnum(1)),
+    argvec = Tuple(1, Fixnum(1)),
     env = null,
     code = null,
     ctxt = null,
@@ -23,8 +23,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   )
 
   "fxPlus" should "correctly add numbers" in {
-    val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, RFixnum(1)))
-    fxPlus.fn(newCtxt) should be(Right(RFixnum(5)))
+    val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Fixnum(1)))
+    fxPlus.fn(newCtxt) should be(Right(Fixnum(5)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -33,8 +33,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxMinus" should "correctly subtract numbers" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, RFixnum(1)))
-    fxMinus.fn(newCtxt) should be(Right(RFixnum(0)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(1)))
+    fxMinus.fn(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -43,8 +43,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxTimes" should "correctly multiply numbers" in {
-    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, RFixnum(5)))
-    fxTimes.fn(newCtxt) should be(Right(RFixnum(125)))
+    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Fixnum(5)))
+    fxTimes.fn(newCtxt) should be(Right(Fixnum(125)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -53,8 +53,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxDiv" should "correctly divide numbers" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, RFixnum(5)))
-    fxDiv.fn(newCtxt) should be(Right(RFixnum(1)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
+    fxDiv.fn(newCtxt) should be(Right(Fixnum(1)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -63,8 +63,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxMod" should "correctly return the remainder" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, RFixnum(5)))
-    fxMod.fn(newCtxt) should be(Right(RFixnum(0)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
+    fxMod.fn(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -73,10 +73,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLt" should "correctly return whether former smaller than latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(RFixnum(5))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
     fxLt.fn(newCtxt) should be(Right(RblBool(true)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxLt.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -86,10 +86,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLe" should "correctly return whether former smaller than or equal to latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(RFixnum(2))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(2))))
     fxLe.fn(newCtxt) should be(Right(RblBool(true)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxLe.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -99,10 +99,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxGt" should "correctly return whether former greater than latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(2))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
     fxGt.fn(newCtxt) should be(Right(RblBool(true)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxGt.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -112,10 +112,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxGe" should "correctly return whether former greater than or equal to latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(5))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
     fxGe.fn(newCtxt) should be(Right(RblBool(true)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxGe.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -125,10 +125,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxEq" should "correctly return whether former equal to latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(5))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
     fxEq.fn(newCtxt) should be(Right(RblBool(true)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxEq.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -138,10 +138,10 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxNe" should "correctly return whether former is not equal to latter" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(5))))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
     fxNe.fn(newCtxt) should be(Right(RblBool(false)))
 
-    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     fxNe.fn(newCtxt2) should be(Right(RblBool(false)))
   }
 
@@ -151,8 +151,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxMin" should "correctly return the smallest one" in {
-    val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, RFixnum(2)), Tuple(RFixnum(5))))
-    fxMin.fn(newCtxt) should be(Right(RFixnum(2)))
+    val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, Fixnum(2)), Tuple(Fixnum(5))))
+    fxMin.fn(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -161,8 +161,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxMax" should "correctly return the greatest one" in {
-    val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, RFixnum(2)), Tuple(1, RFixnum(5))))
-    fxMax.fn(newCtxt) should be(Right(RFixnum(5)))
+    val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, Fixnum(2)), Tuple(1, Fixnum(5))))
+    fxMax.fn(newCtxt) should be(Right(Fixnum(5)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -171,8 +171,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxAbs" should "correctly return absolute value" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(-2)))
-    fxAbs.fn(newCtxt) should be(Right(RFixnum(2)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-2)))
+    fxAbs.fn(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -181,8 +181,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxExpt" should "correctly return base-number raised to the power power-number" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(RFixnum(5))))
-    fxExpt.fn(newCtxt) should be(Right(RFixnum(32)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
+    fxExpt.fn(newCtxt) should be(Right(Fixnum(32)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -191,33 +191,33 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLg" should "correctly compute Ceil(ln(input_value))" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(10)))
-    fxLg.fn(newCtxt) should be(Right(RFixnum(4)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
+    fxLg.fn(newCtxt) should be(Right(Fixnum(4)))
   }
 
   it should "fail for input value <= 0" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(-1)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-1)))
     fxLg.fn(newCtxt) should be('left)
   }
 
   "fxLgf" should "correctly compute Floor(ln(input_value))" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(10)))
-    fxLgf.fn(newCtxt) should be(Right(RFixnum(3)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
+    fxLgf.fn(newCtxt) should be(Right(Fixnum(3)))
   }
 
   it should "fail for input value <= 0" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(-1)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-1)))
     fxLgf.fn(newCtxt) should be('left)
   }
 
   "fxLogand" should "correctly return the bitwise 'and' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
-                argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
-    fxLogand.fn(newCtxt) should be(Right(RFixnum(0)))
+                argvec = Tuple(Tuple(Fixnum(8)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
+    fxLogand.fn(newCtxt) should be(Right(Fixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogand.fn(newCtxt2) should be(Right(RFixnum(~0)))
+    fxLogand.fn(newCtxt2) should be(Right(Fixnum(~0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -228,11 +228,11 @@ class FixnumSpec extends FlatSpec with Matchers {
   "fxLogor" should "correctly return the bitwise 'or' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
-                argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
-    fxLogor.fn(newCtxt) should be(Right(RFixnum(14)))
+                argvec = Tuple(Tuple(Fixnum(8)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
+    fxLogor.fn(newCtxt) should be(Right(Fixnum(14)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogor.fn(newCtxt2) should be(Right(RFixnum(0)))
+    fxLogor.fn(newCtxt2) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -243,11 +243,11 @@ class FixnumSpec extends FlatSpec with Matchers {
   "fxLogxor" should "correctly return the bitwise 'xor' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
-                argvec = Tuple(Tuple(RFixnum(6)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
-    fxLogxor.fn(newCtxt) should be(Right(RFixnum(0)))
+                argvec = Tuple(Tuple(Fixnum(6)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
+    fxLogxor.fn(newCtxt) should be(Right(Fixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogxor.fn(newCtxt2) should be(Right(RFixnum(0)))
+    fxLogxor.fn(newCtxt2) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -256,8 +256,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLognot" should "correctly compute bitwise '!' of input value" in {
-    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFixnum(10)))
-    fxLognot.fn(newCtxt) should be(Right(RFixnum(-11)))
+    val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
+    fxLognot.fn(newCtxt) should be(Right(Fixnum(-11)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -266,8 +266,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxMdiv" should "correctly return former value module division latter value" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(RFixnum(5))))
-    fxMdiv.fn(newCtxt) should be(Right(RFixnum(0)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
+    fxMdiv.fn(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -276,8 +276,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxCdiv" should "correctly compute Ceil(n/m)" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(2))))
-    fxCdiv.fn(newCtxt) should be(Right(RFixnum(3)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
+    fxCdiv.fn(newCtxt) should be(Right(Fixnum(3)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -286,8 +286,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxAsl" should "correctly compute arithmetical left shift of input value" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(5)), Tuple(RFixnum(2))))
-    fxAsl.fn(newCtxt) should be(Right(RFixnum(20)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
+    fxAsl.fn(newCtxt) should be(Right(Fixnum(20)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -296,8 +296,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxAsr" should "correctly compute arithmetical right shift of input value" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(-1)), Tuple(RFixnum(2))))
-    fxAsr.fn(newCtxt) should be(Right(RFixnum(-1)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(2))))
+    fxAsr.fn(newCtxt) should be(Right(Fixnum(-1)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -306,8 +306,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLsl" should "correctly compute logical left shift of input value" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(-1)), Tuple(RFixnum(1))))
-    fxLsl.fn(newCtxt) should be(Right(RFixnum(-2)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(1))))
+    fxLsl.fn(newCtxt) should be(Right(Fixnum(-2)))
   }
 
   it should "fail for non-fixnum arguments" in {
@@ -316,8 +316,8 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLsr" should "correctly compute logical right shift of input value" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(-1)), Tuple(RFixnum(31))))
-    fxLsr.fn(newCtxt) should be(Right(RFixnum(1)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(31))))
+    fxLsr.fn(newCtxt) should be(Right(Fixnum(1)))
   }
 
   it should "fail for non-fixnum arguments" in {

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 
-import coop.rchain.rosette.prim.Fixnum._
+import coop.rchain.rosette.prim.fixnum._
 import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, PC, RblBool, Tuple}
 import org.scalatest._
 
@@ -211,7 +211,9 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLogand" should "correctly return the bitwise 'and' of all input values" in {
-    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
+    val newCtxt =
+      ctxt.copy(nargs = 3,
+                argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
     fxLogand.fn(newCtxt) should be(Right(RFixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
@@ -224,7 +226,9 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLogor" should "correctly return the bitwise 'or' of all input values" in {
-    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
+    val newCtxt =
+      ctxt.copy(nargs = 3,
+                argvec = Tuple(Tuple(RFixnum(8)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
     fxLogor.fn(newCtxt) should be(Right(RFixnum(14)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
@@ -237,7 +241,9 @@ class FixnumSpec extends FlatSpec with Matchers {
   }
 
   "fxLogxor" should "correctly return the bitwise 'xor' of all input values" in {
-    val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(Tuple(RFixnum(6)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
+    val newCtxt =
+      ctxt.copy(nargs = 3,
+                argvec = Tuple(Tuple(RFixnum(6)), Tuple(Tuple(RFixnum(4)), Tuple(RFixnum(2)))))
     fxLogxor.fn(newCtxt) should be(Right(RFixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rosette.prim
 
 import coop.rchain.rosette.prim.rblfloat._
-import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, PC, RblBool, RblFloat => RFloat, Tuple}
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, RblBool, RblFloat => RFloat, Tuple}
 import org.scalatest._
 
 class RblFloatSpec extends FlatSpec with Matchers {
@@ -12,7 +12,7 @@ class RblFloatSpec extends FlatSpec with Matchers {
     pc = PC.PLACEHOLDER,
     rslt = null,
     trgt = null,
-    argvec = Tuple(1, RFixnum(1)),
+    argvec = Tuple(1, Fixnum(1)),
     env = null,
     code = null,
     ctxt = null,
@@ -119,7 +119,7 @@ class RblFloatSpec extends FlatSpec with Matchers {
   }
 
   it should "fail for non-RblFloat arguments" in {
-    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFixnum(2)), Tuple(Ob.NIV)))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
     flEq.fn(newCtxt) should be('left)
   }
 
@@ -256,7 +256,7 @@ class RblFloatSpec extends FlatSpec with Matchers {
 
   "flToFx" should "correctly convert the RblFloat value to Fixnum" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(2.1)))
-    flToFx.fn(newCtxt) should be(Right(RFixnum(2)))
+    flToFx.fn(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-RblFloat arguments" in {

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 
-import coop.rchain.rosette.prim.RblFloat._
+import coop.rchain.rosette.prim.rblfloat._
 import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, PC, RblBool, RblFloat => RFloat, Tuple}
 import org.scalatest._
 

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/TupleSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/TupleSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rosette.prim
 
 import coop.rchain.rosette.prim.tuple._
-import coop.rchain.rosette.{Ctxt, Fixnum => RFixnum, Ob, PC, RblBool, Tuple}
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, Tuple}
 import org.scalatest._
 
 class TupleSpec extends FlatSpec with Matchers {
@@ -12,7 +12,7 @@ class TupleSpec extends FlatSpec with Matchers {
     pc = PC.PLACEHOLDER,
     rslt = null,
     trgt = null,
-    argvec = Tuple(1, RFixnum(1)),
+    argvec = Tuple(1, Fixnum(1)),
     env = null,
     code = null,
     ctxt = null,
@@ -24,10 +24,10 @@ class TupleSpec extends FlatSpec with Matchers {
 
   /** tuple-cons */
   "tplCons" should "correctly cons an Ob with a Tuple" in {
-    val tup = Seq(RFixnum(2), RFixnum(3), RFixnum(4))
+    val tup = Seq(Fixnum(2), Fixnum(3), Fixnum(4))
     val newCtxt =
-      ctxt.copy(nargs = 2, argvec = Tuple.cons(RFixnum(1), Tuple(Tuple(tup))))
-    tplCons.fn(newCtxt) should be(Right(Tuple.cons(RFixnum(1), Tuple(tup))))
+      ctxt.copy(nargs = 2, argvec = Tuple.cons(Fixnum(1), Tuple(Tuple(tup))))
+    tplCons.fn(newCtxt) should be(Right(Tuple.cons(Fixnum(1), Tuple(tup))))
   }
 
   it should "fail for non-tuple arguments" in {
@@ -37,20 +37,20 @@ class TupleSpec extends FlatSpec with Matchers {
 
   /** tuple-cons* */
   "tplConsStar" should "correctly cons n Obs with a Tuple" in {
-    val tup = Seq(RFixnum(4), RFixnum(5), RFixnum(6))
+    val tup = Seq(Fixnum(4), Fixnum(5), Fixnum(6))
 
     val newCtxt =
-      ctxt.copy(nargs = 4,
-                argvec =
-                  Tuple.cons(RFixnum(1),
-                             Tuple.cons(RFixnum(2), Tuple.cons(RFixnum(3), Tuple(Tuple(tup))))))
+      ctxt.copy(
+        nargs = 4,
+        argvec =
+          Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(Tuple(tup))))))
 
     tplConsStar.fn(newCtxt) should be(
-      Right(Tuple.cons(RFixnum(1), Tuple.cons(RFixnum(2), Tuple.cons(RFixnum(3), Tuple(tup))))))
+      Right(Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(tup))))))
   }
 
   "tplConsStar" should "correctly cons 0 Obs with a Tuple" in {
-    val tup = Seq(RFixnum(4), RFixnum(5), RFixnum(6))
+    val tup = Seq(Fixnum(4), Fixnum(5), Fixnum(6))
 
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
@@ -65,10 +65,10 @@ class TupleSpec extends FlatSpec with Matchers {
 
   /** tuple-rcons */
   "tplRcons" should "correctly rcons an Ob with a Tuple" in {
-    val tup = Seq(RFixnum(1), RFixnum(2), RFixnum(3))
+    val tup = Seq(Fixnum(1), Fixnum(2), Fixnum(3))
     val newCtxt =
-      ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(Tuple(tup)), RFixnum(4)))
-    tplRcons.fn(newCtxt) should be(Right(Tuple.rcons(Tuple(tup), RFixnum(4))))
+      ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(Tuple(tup)), Fixnum(4)))
+    tplRcons.fn(newCtxt) should be(Right(Tuple.rcons(Tuple(tup), Fixnum(4))))
   }
 
   it should "fail for non-tuple arguments" in {
@@ -78,12 +78,12 @@ class TupleSpec extends FlatSpec with Matchers {
 
   /** tuple-concat */
   "tplConcat" should "correctly concat n Tuples" in {
-    val tup1 = Seq(RFixnum(1), RFixnum(2))
-    val tup2 = Seq(RFixnum(3))
-    val tup3 = Seq(RFixnum(4), RFixnum(5), RFixnum(6))
+    val tup1 = Seq(Fixnum(1), Fixnum(2))
+    val tup2 = Seq(Fixnum(3))
+    val tup3 = Seq(Fixnum(4), Fixnum(5), Fixnum(6))
     val tups = Seq(Tuple(tup1), Tuple(tup2), Tuple(tup3))
 
-    val result = Seq(RFixnum(1), RFixnum(2), RFixnum(3), RFixnum(4), RFixnum(5), RFixnum(6))
+    val result = Seq(Fixnum(1), Fixnum(2), Fixnum(3), Fixnum(4), Fixnum(5), Fixnum(6))
 
     val newCtxt =
       ctxt.copy(nargs = 3, argvec = Tuple(tups))
@@ -92,7 +92,7 @@ class TupleSpec extends FlatSpec with Matchers {
   }
 
   "tplConcat" should "correctly concat 1 Tuple" in {
-    val tup1 = Seq(RFixnum(1))
+    val tup1 = Seq(Fixnum(1))
     val tups = Seq(Tuple(tup1))
 
     val newCtxt =

--- a/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/DeepSelector.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/DeepSelector.scala
@@ -4,19 +4,17 @@ import shapeless.{::, ops, DepFn1, HList, HNil, LabelledGeneric, Witness}
 
 import scala.annotation.implicitNotFound
 
-@implicitNotFound(
-  "Can not derive instance for DeepSelector. Possibly wrong path is specified.")
+@implicitNotFound("Can not derive instance for DeepSelector. Possibly wrong path is specified.")
 trait DeepSelector[K <: HList, T] extends DepFn1[T]
 object DeepSelector {
-  type WrList[A] = (List[Witness], A)
+  type WrList[A]                  = (List[Witness], A)
   type Aux[K1 <: HList, T1, Out0] = DeepSelector[K1, T1] { type Out = Out0 }
 
   abstract class Impl[Path <: HList, A, B] extends DeepSelector[Path, A] {
     type Out = B
   }
 
-  def apply[Path <: HList, A](
-      implicit sel: DeepSelector[Path, A]): Aux[Path, A, sel.Out] = sel
+  def apply[Path <: HList, A](implicit sel: DeepSelector[Path, A]): Aux[Path, A, sel.Out] = sel
 
   implicit def nil[A]: Impl[HNil, A, WrList[A]] = x => (Nil, x)
 

--- a/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/Dsl.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/utils/opcodes/Dsl.scala
@@ -18,14 +18,13 @@ object Dsl {
     def on(op: Op,
            state: VMState = testState,
            formatter: (String, String) => String = defaultFormatter)(
-        f: Any => Unit)(implicit sel: DeepSelector[Path, VMState],
-                        m: WordSpec): Unit = {
+        f: Any => Unit)(implicit sel: DeepSelector[Path, VMState], m: WordSpec): Unit = {
 
       val newState = dispatch(op, state)
       sel(newState) match {
         case (l: List[Witness], r) =>
-          val path = buildPath(l)
-          val name = op.getClass.getSimpleName
+          val path    = buildPath(l)
+          val name    = op.getClass.getSimpleName
           val message = formatter(name, path)
           m.registerTest(message)(f(r))
       }


### PR DESCRIPTION
Just changing names of the objects containing `Fixnum` and `RblFloat` primitives.