### PR TITLE
Add support for eval normalization.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -102,6 +102,15 @@ object ProcNormalizeMatcher {
 
       case p: PNil => ProcVisitOutputs(input.par, input.knownFree)
 
+      case p: PEval => {
+        val nameMatchResult = NameNormalizeMatcher.normalizeMatch(
+          p.name_,
+          NameVisitInputs(input.env, input.knownFree))
+        ProcVisitOutputs(
+          input.par.copy(evals = Eval(nameMatchResult.chan) :: input.par.evals),
+          nameMatchResult.knownFree)
+      }
+
       case p: PPar => {
         val result = normalizeMatch(p.proc_1, input)
         val chainedInput = input.copy(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -58,10 +58,18 @@ object NameNormalizeMatcher {
         }
 
       case n: NameQuote => {
+        def collapseQuoteEval(p: Par): Channel = {
+          p.singleEval() match {
+            case Some(Eval(chanNew)) => chanNew
+            case _ => Quote(p)
+          }
+        }
+
         val procVisitResult: ProcVisitOutputs = ProcNormalizeMatcher.normalizeMatch(
             n.proc_,
             ProcVisitInputs(Par(), input.env, input.knownFree))
-        NameVisitOutputs(Quote(procVisitResult.par),
+
+        NameVisitOutputs(collapseQuoteEval(procVisitResult.par),
           procVisitResult.knownFree)
       }
     }
@@ -103,11 +111,18 @@ object ProcNormalizeMatcher {
       case p: PNil => ProcVisitOutputs(input.par, input.knownFree)
 
       case p: PEval => {
+        def collapseEvalQuote(chan: Channel): Par = {
+          chan match {
+            case Quote(p) => p
+            case _ => Par().copy(evals = List(Eval(chan)))
+          }
+        }
+
         val nameMatchResult = NameNormalizeMatcher.normalizeMatch(
           p.name_,
           NameVisitInputs(input.env, input.knownFree))
         ProcVisitOutputs(
-          input.par.copy(evals = Eval(nameMatchResult.chan) :: input.par.evals),
+          input.par.merge(collapseEvalQuote(nameMatchResult.chan)),
           nameMatchResult.knownFree)
       }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
@@ -14,9 +14,24 @@ case class Par(
   // matches: List[Match]
 ) {
   // TODO: write helper methods to append an X and return a new par
-  // TODO: write helper method to get an empty par
   def this() =
     this(List(), List(), List(), List(), List())
+  def singleEval(): Option[Eval] = {
+    if (sends.isEmpty && receives.isEmpty && news.isEmpty && expr.isEmpty) {
+      evals match {
+        case List(single) => Some(single)
+        case _ => None
+      }
+    } else {
+      None
+    }
+  }
+  def merge(that: Par) = Par(
+      that.sends ++ sends,
+      that.receives ++ receives,
+      that.evals ++ evals,
+      that.news ++ news,
+      that.expr ++ expr)
 }
 
 object Par {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -83,6 +83,16 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     }
   }
 
+  "PEval" should "Handle a bound name varible" in {
+    val pEval = new PEval(new NameVar("x"))
+    val boundInputs = inputs.copy(env =
+      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+
+    val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
+    result.par should be (inputs.par.copy(evals = List(Eval(ChanVar(BoundVar(0))))))
+    result.knownFree should be (inputs.knownFree)
+  }
+
   "PPar" should "Compile both branches into a par object" in {
     val parGround = new PPar(
         new PGround(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -92,6 +92,15 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be (inputs.par.copy(evals = List(Eval(ChanVar(BoundVar(0))))))
     result.knownFree should be (inputs.knownFree)
   }
+  "PEval" should "Collapse a quote" in {
+    val pEval = new PEval(new NameQuote(new PPar(new PVar("x"), new PVar("x"))))
+    val boundInputs = inputs.copy(env =
+      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+
+    val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
+    result.par should be (inputs.par.copy(expr = List(EVar(BoundVar(0)), EVar(BoundVar(0)))))
+    result.knownFree should be (inputs.knownFree)
+  }
 
   "PPar" should "Compile both branches into a par object" in {
     val parGround = new PPar(
@@ -195,6 +204,24 @@ class NameMatcherSpec extends FlatSpec with Matchers {
     val nqground = new NameQuote(new PGround(new GroundInt(7)))
     val result = NameNormalizeMatcher.normalizeMatch(nqground, inputs)
     result.chan should be (Quote(Par().copy(expr = List(GInt(7)))))
+    result.knownFree should be (inputs.knownFree)
+  }
+
+  "NameQuote" should "collapse an eval" in {
+    val nqeval = new NameQuote(new PEval(new NameVar("x")))
+    val boundInputs = inputs.copy(env =
+      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val result = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
+    result.chan should be (ChanVar(BoundVar(0)))
+    result.knownFree should be (inputs.knownFree)
+  }
+
+  "NameQuote" should "not collapse an eval | eval" in {
+    val nqeval = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
+    val boundInputs = inputs.copy(env =
+      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val result = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
+    result.chan should be (Quote(Par().copy(evals = List(Eval(ChanVar(BoundVar(0))), Eval(ChanVar(BoundVar(0)))))))
     result.knownFree should be (inputs.knownFree)
   }
 }


### PR DESCRIPTION
This handles the proc/name delegation and also adds squashing to both eval and quote normalization.
See e46b7f0 for a longer description of why we can squash from both sides.