### PR TITLE
Remove print statement from grammar

### DIFF
--- a/rholang/examples/hello_world_again.rho
+++ b/rholang/examples/hello_world_again.rho
@@ -3,7 +3,7 @@
 new helloworld in {
     contract helloworld( world ) = {
         for( msg <- world ) {
-            print(msg)
+            msg.display("\n")
         }
     } |
     new world, world2 in {

--- a/rholang/examples/token.rho
+++ b/rholang/examples/token.rho
@@ -130,7 +130,7 @@ new token in {
             new unused_rtn, balance_of_rtn in {
                 @token_contract.get("transfer")!(me, they, 50, unused_rtn) |
                 @token_contract.get("balance_of")!(they, balance_of_rtn) |
-                for (they_balance <- balance_of_rtn) { print(they_balance) }
+                for (they_balance <- balance_of_rtn) { they_balance.display("\n") }
             }
         }
     } |
@@ -140,7 +140,7 @@ new token in {
             new unused_rtn2, balance_of_rtn2 in {
                 @token_contract2.get("transfer")!(me2, they2, 500, unused_rtn2) |
                 @token_contract2.get("balance_of")!(they2, balance_of_rtn2) |
-                for (they_balance2 <- balance_of_rtn2) { print(they_balance2) }
+                for (they_balance2 <- balance_of_rtn2) { they_balance2.display("\n") }
             }
         }
     }

--- a/rholang/src/main/bnfc/rholang.cf
+++ b/rholang/src/main/bnfc/rholang.cf
@@ -10,7 +10,6 @@ PInput.   Proc1 ::= "for" "(" [Bind] ")" "{" Proc "}" ;
 PChoice.  Proc1 ::= "select" "{" [CBranch] "}" ;
 PMatch.   Proc1 ::= "match" Proc "with" [PMBranch] ;
 PNew.     Proc1 ::= "new" [Var] "in" Proc1 ;
-PPrint.   Proc1 ::= "print" "(" Proc ")" ;
 PConstr.  Proc1 ::= Var "(" [Proc] ")" ;
 PContr.   Proc1 ::= "contract" Var "(" [CPattern] ")" "=" "{" Proc "}" ;
 PPar.     Proc  ::= Proc "|" Proc1 ;

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -205,14 +205,7 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
     B("")(B(_abs)(B(_list)(Tag("")), B(_run)(B(_compile)(B("let")(B(_list)(letBindingsTerm), bodyTerm)))))
   }
 
-  /* Proc */
-  override def visit( p : PPrint, arg : A ) : R = {
-    val pTerm : StrTermCtxt = p.proc_.accept(this, arg)._1
-    val printTerm = B("print")(pTerm)
-    val displayTerm = B("display")(Tag( "#\\\\n"))
-    B( "seq" )( printTerm, displayTerm )
-  }
-  override def visit( p : PNil, arg : A ) : R = {    
+  override def visit( p : PNil, arg : A ) : R = {
     Tag( "#niv" )
   }
   override def visit( p : PValue, arg : A ) : R = {

--- a/rholang/tests/arithmetic_test.rho
+++ b/rholang/tests/arithmetic_test.rho
@@ -45,8 +45,8 @@ match [
     ] with
 
 [ 10, 55, -2, 10.0, 6.283185307179586, 10, 0, 10, 10, 1, 10, 1, 10, 10, 10.0 ] => {
-    print("Pass")
+    "Pass".display("\n")
 }
 _ => {
-    print("Fail")
+    "Fail".display("\n")
 }

--- a/rholang/tests/comparison_test.rho
+++ b/rholang/tests/comparison_test.rho
@@ -86,9 +86,9 @@
   } |
   match 2 == 2 with
     true => {
-      print("Pass")
+      "Pass".display("\n")
     }
     _ => {
-      print("Fail")
+      "Fail".display("\n")
     }
 } 

--- a/rholang/tests/contract_invocation.rho
+++ b/rholang/tests/contract_invocation.rho
@@ -7,13 +7,13 @@ new test in {
   new x, y, z in {
     test(x, y, z) |
     for(_ <- x) {
-      print("x")
+      "x".display("\n")
     } |
     for(_ <- y) {
-      print("y")
+      "y".display("\n")
     } |
     for(_ <- x) {
-      print("z")
+      "z".display("\n")
     }
   }
 }


### PR DESCRIPTION
I originally added the print statement just for debugging purposes. We
are now moving over to use the "string".display("\n") syntax for all
Rholang contracts - we do plan to move away from away from this syntax
too eventually though.

See https://github.com/rchain/rchain/pull/155#issuecomment-357524797