### PR TITLE
Add OpApplyPrimArg and OpApplyPrimReg

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Location.scala
@@ -3,6 +3,7 @@ package coop.rchain.rosette
 import cats.data.State
 import coop.rchain.rosette.Ob.Lenses._
 import coop.rchain.rosette.Ob.{getAddr, getLex, setLex}
+import coop.rchain.rosette.Ctxt.setReg
 
 sealed trait Location                                               extends Ob
 case class ArgRegister(argReg: Int)                                 extends Location
@@ -55,18 +56,7 @@ object Location {
     val pure = State.pure[Ctxt, StoreResult] _
 
     loc match {
-      case CtxtRegister(reg) =>
-        for {
-          ctxt <- State.get[Ctxt]
-          optCtxt = ctxt.setReg(reg, value)
-          storeRes <- optCtxt match {
-            case Some(newCtxt) =>
-              for {
-                _ <- State.set[Ctxt](newCtxt)
-              } yield Success
-            case None => pure(Failure)
-          }
-        } yield storeRes
+      case CtxtRegister(reg) => setReg(reg, value)
 
       case ArgRegister(argReg) =>
         State { ctxt: Ctxt =>

--- a/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ob.scala
@@ -42,7 +42,7 @@ trait Ob extends Base with Cloneable {
       .getOrElse(Ob.INVALID)
   }
 
-  def is(value: Ob.ObTag): Boolean = true
+  def is(value: Ob.ObTag): Boolean = false
 
   def lookup(key: Ob, ctxt: Ctxt): Result =
     Right(null)

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -59,10 +59,10 @@ object VirtualMachine {
     State { state =>
       optPrim match {
         case Some(prim) =>
-          if (unwind) {
-            val (res, st) = unwindAndApplyPrim(prim, state)
-            (st, res)
-          } else (state, prim.dispatchHelper(state.ctxt))
+          if (unwind)
+            unwindAndApplyPrim(prim, state).swap
+          else
+            (state, prim.dispatchHelper(state.ctxt))
 
         case None =>
           (state, Left(PrimNotFound))
@@ -854,10 +854,7 @@ object VirtualMachine {
   def execute(op: OpUnknown, state: VMState): VMState =
     state.set(_ >> 'exitFlag)(true).set(_ >> 'exitCode)(1)
 
-  def inspect[A](f: VMState => A): State[VMState, A] =
-    State.inspect[VMState, A](f)
+  def inspect[A] = State.inspect[VMState, A] _
 
-  def modify(f: VMState => VMState): State[VMState, Unit] =
-    State.modify[VMState](f)
-
+  val modify = State.modify[VMState] _
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/package.scala
@@ -15,6 +15,7 @@ package object rosette {
   case object Suspend                           extends RblError
   case object Absent                            extends RblError
   case object Upcall                            extends RblError
+  case object PrimNotFound                      extends RblError
   case class PrimErrorWrapper(value: PrimError) extends RblError
   case class RuntimeError(msg: String)          extends RblError
 

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
@@ -25,13 +25,10 @@ abstract class Prim extends Ob {
   def dispatchHelper(ctxt: Ctxt): Result = {
     val n = ctxt.nargs
 
-    if (minArgs <= n && n <= maxArgs) {
-      println(fn(ctxt))
-      println(this.name)
+    if (minArgs <= n && n <= maxArgs)
       fn(ctxt).left.map(PrimErrorWrapper)
-    } else {
+    else
       Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs)))
-    }
   }
 
   override def dispatch(state: VMState): (Result, VMState) = {

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
@@ -26,6 +26,8 @@ abstract class Prim extends Ob {
     val n = ctxt.nargs
 
     if (minArgs <= n && n <= maxArgs) {
+      println(fn(ctxt))
+      println(this.name)
       fn(ctxt).left.map(PrimErrorWrapper)
     } else {
       Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs)))


### PR DESCRIPTION
In Rosette compiling the expression `(fx+ 1 (fx+ 2 3))` results in the following `Code` object:
```
litvec:
  0:   {RequestExpr}
codevec:
  0:   alloc 2
  1:   lit 2,arg[0]
  2:   lit 3,arg[1]
  3:   fx+ 2,arg[1]
  5:   lit 1,arg[0]
  6:   fx+ 2,rslt
  8:   rtn/nxt
```
`fx+ 2,arg[1]` corresponds to `OpApplyPrimArg(unwind = false, next = false, nargs = 2, primNum = 226, arg = 1)` in Roscala and `fx+ 2,rslt` corresponds to `OpApplyPrimReg(unwind = false, next = false, nargs = 2, primNum = 226, reg = 0)`.

Both opcodes run a primitive on the arguments given in `state.ctxt.argvec`. In this example the `fx+` primitive is run (has the number `226`). `OpApplyPrimArg` copies the primitive result to a position in `state.ctxt.argvec` (here to the 1st position) while `OpApplyPrimReg` copies the result to a register in `state.ctxt` (here the `rslt` register). 

The above example can be observed in gdb by setting the following breakpoint: `b src/Vm.cc:795 if code->codevec->instr(0)->word == 1026`