### PR TITLE
Rosette: Fix ::hashAdd -- out of room in hash table

### DIFF
--- a/rosette/h/Table.h
+++ b/rosette/h/Table.h
@@ -49,6 +49,7 @@ class RblTable : public BinaryOb {
 
     int maxEntries;
     int numberOfEntries;
+    int numberOfDeletedHashEntries;
     bool gcSensitiveKeys;
     bool registered;
 


### PR DESCRIPTION
This is a subtle bug in Rosette in which deleting entries in the table
decreased the number of entries count but didn't contribute to the
rehashing threshold.

The fix here is to keep track of the deleted entries with a separate
variable and rehash when the sum of the number of entries and the number
of deleted entries is greater than 75% of the table size. Note the table
size is increased "unnecessarily" with this fix this shouldn't be that
big of a deal.