### PR TITLE
Fix any-null? when last element is null

### DIFF
--- a/rosette/rbl/rosette/namespace-util.rbl
+++ b/rosette/rbl/rosette/namespace-util.rbl
@@ -88,7 +88,11 @@
 (defProc (non-niv-head list)
   (fold list (proc [item acc k] (if (niv? item) (k acc) item)) []))
 
-(defProc (any-null? list) (any list null?))
+;;; Without appending a non-null element at the end, a null element at the end doesn't get detected.
+;;; As in the following fails
+;;;     (any [[1] [2] [3] []] null?)
+;;;     #f
+(defProc (any-null? list) (any (concat list ["a-random-non-null-element"]) null?))
 
 ;;; For debugging purposes only.
 (defProc (clean-fresh fresh)

--- a/rosette/rbl/rosette/tests/namespace-util-tests.rbl
+++ b/rosette/rbl/rosette/tests/namespace-util-tests.rbl
@@ -52,6 +52,8 @@
 (test-form (any-null? [1 2 3 4]) #f)
 (test-form (any-null? [1 [] 3 4]) #t)
 (test-form (any-null? [1 [2] [3 4] 4]) #f)
+;;; null element at the end counts
+(test-form (any-null? [1 2 3 4 []]) #t)
 
 ;;; tests for append-product-at-channel
 (let* [[channel-subspace-table (new RblTable)]


### PR DESCRIPTION
When the last element is null, Rosette doesn't iterate on it during a
call to "any". Thus the following fails

(any [[1] [2] [3] []] null?)
\#f

By appending a non-null element to the end of the list, we can force
Rosette to recognize the last empty element.