### PR TITLE
Do not use null? in Tuple fold exit condition

### DIFF
--- a/rosette/rbl/rosette/CMakeLists.txt
+++ b/rosette/rbl/rosette/CMakeLists.txt
@@ -29,6 +29,8 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/reader-iso-8859-1.ros
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/reader-utf-8.ros
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/fold-tests.rbl
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/consume-tests.rbl
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/produce-tests.rbl

--- a/rosette/rbl/rosette/tests/fold-tests.rbl
+++ b/rosette/rbl/rosette/tests/fold-tests.rbl
@@ -1,0 +1,19 @@
+;;; Copyright (c) 2018, RChain Cooperative
+;;; Author: Michael Birch <birch@pyrofex.net>
+;;; This file is licensed under the Apache License, version 2.0.
+
+(let [[sumproc (proc [hd acc iter] (iter (+ hd acc)))]]
+  (seq
+    (test-form (fold [] sumproc 0) 0)
+    (test-form (fold [1 2 3] sumproc 0) 6)
+  )
+)
+
+(let [[last (proc [list] (fold list (proc [hd acc iter] (iter hd)) #absent))]]
+  (seq
+    (test-form (absent? (last [])) #t)
+    (test-form (last [1 2 3]) 3)
+    (test-form (last [[1] [2] [3]]) [3])
+    (test-form (null? (last [[1] [2] [3] []])) #t)
+  )
+)

--- a/rosette/rbl/rosette/tests/namespace-util-tests.rbl
+++ b/rosette/rbl/rosette/tests/namespace-util-tests.rbl
@@ -52,6 +52,8 @@
 (test-form (any-null? [1 2 3 4]) #f)
 (test-form (any-null? [1 [] 3 4]) #t)
 (test-form (any-null? [1 [2] [3 4] 4]) #f)
+;;; null element at the end counts
+(test-form (any-null? [1 2 3 4 []]) #t)
 
 ;;; tests for append-product-at-channel
 (let* [[channel-subspace-table (new RblTable)]

--- a/rosette/rbl/rosette/tests/run-tests.ros
+++ b/rosette/rbl/rosette/tests/run-tests.ros
@@ -104,6 +104,7 @@
 (load "tests/equiv.ros" 'silent)
 (load "tests/reader-iso-8859-1.ros" 'silent)
 (load "tests/reader-utf-8.ros" 'silent)
+(load "tests/fold-tests.rbl" 'silent)
 
 ;;; tests for tuplespace
 (load "tests/namespace-util-tests.rbl" 'silent)

--- a/rosette/rbl/rosette/tuple-oprns.rbl
+++ b/rosette/rbl/rosette/tuple-oprns.rbl
@@ -33,12 +33,13 @@
 (defPure [] (fold p unit) unit)
 
 (defMethod Tuple (fold p unit)
-  (let [[[hd & tl] (self)]]
+  (let [[[hd & tl] (self)] [elemRemaining (size (self))]]
     (letrec [[iter (proc [acc]
 		     (seq
 		      (set! hd (head tl))
 		      (set! tl (tail tl))
-		      (if (and (null? hd) (null? tl))
+              (set! elemRemaining (- elemRemaining 1))
+		      (if (= elemRemaining 0)
 			  acc
 			  (p hd acc iter))))]]
       (p hd unit iter))))


### PR DESCRIPTION
Fix bug involving fold when the last element of a tuple is []