### PR TITLE
Turn on scalafmt + unify formatting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ def commonSettings: Seq[Setting[_]] =
       (sourceManaged in Compile).value.getPath ++ "/.*"
     ).mkString(";"),
 
-    // scalafmtOnCompile := true // pretty destructive still
+    scalafmtOnCompile := true,
 
     /*
      * By default, tag docker images with organization and the

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -36,10 +36,9 @@ trait ProtocolHandler {
     * Send a message to a single, remote node, and wait up to the
     * specified duration for a response.
     */
-  def roundTrip(
-      msg: ProtocolMessage,
-      remote: ProtocolNode,
-      timeout: Duration = Duration(500, MILLISECONDS)): Either[CommError, ProtocolMessage]
+  def roundTrip(msg: ProtocolMessage,
+                remote: ProtocolNode,
+                timeout: Duration = Duration(500, MILLISECONDS)): Either[CommError, ProtocolMessage]
 
   /**
     * Asynchronously broadcast a message to all known peers.
@@ -153,8 +152,7 @@ final case class LookupMessage(proto: Protocol, timestamp: Long) extends Protoco
 
   def response(src: ProtocolNode, nodes: Seq[PeerNode]): Option[ProtocolMessage] =
     header.map { h =>
-      LookupResponseMessage(ProtocolMessage.lookupResponse(src, h, nodes),
-                            System.currentTimeMillis)
+      LookupResponseMessage(ProtocolMessage.lookupResponse(src, h, nodes), System.currentTimeMillis)
     }
 }
 

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -38,8 +38,7 @@ class UPnP(port: Int) {
     try {
       gateway match {
         case Some(device) =>
-          Right(
-            device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
+          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
         case None => Left(UnknownCommError("no gateway"))
       }
     } catch {

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -68,8 +68,7 @@ final case class Network(local: PeerNode) extends ProtocolDispatcher[java.net.So
     val remote = new ProtocolNode(peer, this.net)
     net.roundTrip(ehs, remote) match {
       case Right(resp) => {
-        logger.debug(
-          s"connect(): Received encryption handshake response from ${resp.sender.get}.")
+        logger.debug(s"connect(): Received encryption handshake response from ${resp.sender.get}.")
         val phs = ProtocolHandshakeMessage(NetworkProtocol.protocolHandshake(net.local),
                                            System.currentTimeMillis)
         net.roundTrip(phs, remote) match {
@@ -104,8 +103,7 @@ final case class Network(local: PeerNode) extends ProtocolDispatcher[java.net.So
       }
     }
 
-  private def handleProtocolHandshake(sender: PeerNode,
-                                      handshake: ProtocolHandshakeMessage): Unit =
+  private def handleProtocolHandshake(sender: PeerNode, handshake: ProtocolHandshakeMessage): Unit =
     for {
       resp <- handshake.response(net.local)
     } {

--- a/comm/src/test/scala/coop/rchain/p2p/ProtocolTest.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/ProtocolTest.scala
@@ -16,8 +16,8 @@ class ProtocolTest extends FlatSpec with Matchers {
     node should not be null
 
     val src = new ProtocolNode(node.id, node.endpoint, null)
-    val hs = EncryptionHandshakeMessage(NetworkProtocol.encryptionHandshake(src),
-                                        System.currentTimeMillis)
+    val hs =
+      EncryptionHandshakeMessage(NetworkProtocol.encryptionHandshake(src), System.currentTimeMillis)
     val result = hs.response(src)
 
     val upstream = result match {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.9")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -8,27 +8,25 @@ case object ProcSort extends VarSort
 case object NameSort extends VarSort
 
 object BoolNormalizeMatcher {
-  def normalizeMatch(b: Bool): GBool = {
+  def normalizeMatch(b: Bool): GBool =
     b match {
-      case b: BoolTrue => GBool(true)
+      case b: BoolTrue  => GBool(true)
       case b: BoolFalse => GBool(false)
     }
-  }
 }
 
 object GroundNormalizeMatcher {
-  def normalizeMatch(g: AbsynGround): Ground = {
+  def normalizeMatch(g: AbsynGround): Ground =
     g match {
-      case gb: GroundBool => BoolNormalizeMatcher.normalizeMatch(gb.bool_)
-      case gi: GroundInt => GInt(gi.integer_)
+      case gb: GroundBool   => BoolNormalizeMatcher.normalizeMatch(gb.bool_)
+      case gi: GroundInt    => GInt(gi.integer_)
       case gs: GroundString => GString(gs.string_)
-      case gu: GroundUri => GUri(gu.uri_)
+      case gu: GroundUri    => GUri(gu.uri_)
     }
-  }
 }
 
 object NameNormalizeMatcher {
-  def normalizeMatch(n: Name, input: NameVisitInputs): NameVisitOutputs = {
+  def normalizeMatch(n: Name, input: NameVisitInputs): NameVisitOutputs =
     n match {
       case n: NameWildcard =>
         val wildcardBindResult = input.knownFree.setWildcardUsed(1)
@@ -36,9 +34,7 @@ object NameNormalizeMatcher {
       case n: NameVar =>
         input.env.get(n.var_) match {
           case Some((level, NameSort)) => {
-            NameVisitOutputs(
-              ChanVar(BoundVar(level)),
-              input.knownFree)
+            NameVisitOutputs(ChanVar(BoundVar(level)), input.knownFree)
           }
           case Some((level, ProcSort)) => {
             throw new Error("Proc variable used in name context.")
@@ -46,130 +42,120 @@ object NameNormalizeMatcher {
           case None => {
             input.knownFree.get(n.var_) match {
               case None =>
-                val newBindingsPair = 
+                val newBindingsPair =
                   input.knownFree.newBindings(List((Some(n.var_), NameSort)))
-                NameVisitOutputs(
-                  ChanVar(FreeVar(newBindingsPair._2(0))),
-                  newBindingsPair._1)
-              case _ => throw new Error(
-                "Free variable used as binder may not be used twice.")
+                NameVisitOutputs(ChanVar(FreeVar(newBindingsPair._2(0))), newBindingsPair._1)
+              case _ => throw new Error("Free variable used as binder may not be used twice.")
             }
           }
         }
 
       case n: NameQuote => {
-        def collapseQuoteEval(p: Par): Channel = {
+        def collapseQuoteEval(p: Par): Channel =
           p.singleEval() match {
             case Some(Eval(chanNew)) => chanNew
-            case _ => Quote(p)
+            case _                   => Quote(p)
           }
-        }
 
         val procVisitResult: ProcVisitOutputs = ProcNormalizeMatcher.normalizeMatch(
-            n.proc_,
-            ProcVisitInputs(Par(), input.env, input.knownFree))
+          n.proc_,
+          ProcVisitInputs(Par(), input.env, input.knownFree))
 
-        NameVisitOutputs(collapseQuoteEval(procVisitResult.par),
-          procVisitResult.knownFree)
+        NameVisitOutputs(collapseQuoteEval(procVisitResult.par), procVisitResult.knownFree)
       }
     }
-  }
 }
 
 object ProcNormalizeMatcher {
   def normalizeMatch(p: Proc, input: ProcVisitInputs): ProcVisitOutputs = {
-    def unaryExp(
-        subProc: Proc, input: ProcVisitInputs, constructor: Par => Expr): ProcVisitOutputs = {
+    def unaryExp(subProc: Proc,
+                 input: ProcVisitInputs,
+                 constructor: Par => Expr): ProcVisitOutputs = {
       val subResult = normalizeMatch(subProc, input.copy(par = Par()))
-      ProcVisitOutputs(
-          input.par.copy(exprs = constructor(subResult.par) :: input.par.exprs),
-          subResult.knownFree)
+      ProcVisitOutputs(input.par.copy(exprs = constructor(subResult.par) :: input.par.exprs),
+                       subResult.knownFree)
     }
-    def binaryExp(
-        subProcLeft: Proc,
-        subProcRight: Proc,
-        input: ProcVisitInputs,
-        constructor: (Par, Par) => Expr): ProcVisitOutputs = {
+    def binaryExp(subProcLeft: Proc,
+                  subProcRight: Proc,
+                  input: ProcVisitInputs,
+                  constructor: (Par, Par) => Expr): ProcVisitOutputs = {
       val leftResult = normalizeMatch(subProcLeft, input.copy(par = Par()))
-      val rightResult = normalizeMatch(
-          subProcRight, input.copy(par = Par(), knownFree = leftResult.knownFree))
+      val rightResult =
+        normalizeMatch(subProcRight, input.copy(par = Par(), knownFree = leftResult.knownFree))
       ProcVisitOutputs(
-          input.par.copy(exprs = constructor(leftResult.par, rightResult.par) :: input.par.exprs),
-          rightResult.knownFree)
+        input.par.copy(exprs = constructor(leftResult.par, rightResult.par) :: input.par.exprs),
+        rightResult.knownFree)
     }
 
     p match {
-      case p: PGround => ProcVisitOutputs(
-          input.par.copy(exprs = GroundNormalizeMatcher.normalizeMatch(p.ground_) :: input.par.exprs),
+      case p: PGround =>
+        ProcVisitOutputs(
+          input.par.copy(
+            exprs = GroundNormalizeMatcher.normalizeMatch(p.ground_) :: input.par.exprs),
           input.knownFree)
 
-      case p: PVar => input.env.get(p.var_) match {
-        case Some((level, ProcSort)) => {
-          ProcVisitOutputs(
-            input.par.copy(exprs = EVar(BoundVar(level))
-                           :: input.par.exprs),
-            input.knownFree)
-        }
-        case Some((level, NameSort)) => {
-          throw new Error("Name variable used in process context.")
-        }
-        case None => {
-          input.knownFree.get(p.var_) match {
-            case None =>
-              val newBindingsPair = 
-                input.knownFree.newBindings(List((Some(p.var_), ProcSort)))
-              ProcVisitOutputs(
-                input.par.copy(exprs = EVar(FreeVar(newBindingsPair._2(0)))
-                               :: input.par.exprs),
-                newBindingsPair._1)
-            case _ => throw new Error(
-              "Free variable used as binder may not be used twice.")
+      case p: PVar =>
+        input.env.get(p.var_) match {
+          case Some((level, ProcSort)) => {
+            ProcVisitOutputs(input.par.copy(
+                               exprs = EVar(BoundVar(level))
+                                 :: input.par.exprs),
+                             input.knownFree)
+          }
+          case Some((level, NameSort)) => {
+            throw new Error("Name variable used in process context.")
+          }
+          case None => {
+            input.knownFree.get(p.var_) match {
+              case None =>
+                val newBindingsPair =
+                  input.knownFree.newBindings(List((Some(p.var_), ProcSort)))
+                ProcVisitOutputs(input.par.copy(
+                                   exprs = EVar(FreeVar(newBindingsPair._2(0)))
+                                     :: input.par.exprs),
+                                 newBindingsPair._1)
+              case _ => throw new Error("Free variable used as binder may not be used twice.")
+            }
           }
         }
-      }
 
       case p: PNil => ProcVisitOutputs(input.par, input.knownFree)
 
       case p: PEval => {
-        def collapseEvalQuote(chan: Channel): Par = {
+        def collapseEvalQuote(chan: Channel): Par =
           chan match {
             case Quote(p) => p
-            case _ => Par().copy(evals = List(Eval(chan)))
+            case _        => Par().copy(evals = List(Eval(chan)))
           }
-        }
 
-        val nameMatchResult = NameNormalizeMatcher.normalizeMatch(
-          p.name_,
-          NameVisitInputs(input.env, input.knownFree))
-        ProcVisitOutputs(
-          input.par.merge(collapseEvalQuote(nameMatchResult.chan)),
-          nameMatchResult.knownFree)
+        val nameMatchResult =
+          NameNormalizeMatcher.normalizeMatch(p.name_, NameVisitInputs(input.env, input.knownFree))
+        ProcVisitOutputs(input.par.merge(collapseEvalQuote(nameMatchResult.chan)),
+                         nameMatchResult.knownFree)
       }
 
       case p: PNot => unaryExp(p.proc_, input, ENot)
       case p: PNeg => unaryExp(p.proc_, input, ENeg)
 
-      case p: PMult => binaryExp(p.proc_1, p.proc_2, input, EMult)
-      case p: PDiv => binaryExp(p.proc_1, p.proc_2, input, EDiv)
-      case p: PAdd => binaryExp(p.proc_1, p.proc_2, input, EPlus)
+      case p: PMult  => binaryExp(p.proc_1, p.proc_2, input, EMult)
+      case p: PDiv   => binaryExp(p.proc_1, p.proc_2, input, EDiv)
+      case p: PAdd   => binaryExp(p.proc_1, p.proc_2, input, EPlus)
       case p: PMinus => binaryExp(p.proc_1, p.proc_2, input, EMinus)
 
-      case p: PLt => binaryExp(p.proc_1, p.proc_2, input, ELt)
+      case p: PLt  => binaryExp(p.proc_1, p.proc_2, input, ELt)
       case p: PLte => binaryExp(p.proc_1, p.proc_2, input, ELte)
-      case p: PGt => binaryExp(p.proc_1, p.proc_2, input, EGt)
+      case p: PGt  => binaryExp(p.proc_1, p.proc_2, input, EGt)
       case p: PGte => binaryExp(p.proc_1, p.proc_2, input, EGte)
 
-      case p: PEq => binaryExp(p.proc_1, p.proc_2, input, EEq)
+      case p: PEq  => binaryExp(p.proc_1, p.proc_2, input, EEq)
       case p: PNeq => binaryExp(p.proc_1, p.proc_2, input, ENeq)
 
       case p: PAnd => binaryExp(p.proc_1, p.proc_2, input, EAnd)
-      case p: POr => binaryExp(p.proc_1, p.proc_2, input, EOr)
+      case p: POr  => binaryExp(p.proc_1, p.proc_2, input, EOr)
 
       case p: PPar => {
-        val result = normalizeMatch(p.proc_1, input)
-        val chainedInput = input.copy(
-          knownFree = result.knownFree,
-          par = result.par)
+        val result       = normalizeMatch(p.proc_1, input)
+        val chainedInput = input.copy(knownFree = result.knownFree, par = result.par)
         normalizeMatch(p.proc_2, chainedInput)
       }
 
@@ -184,73 +170,60 @@ class DebruijnLevelMap[T](val next: Int, val env: Map[String, (Int, T)]) {
 
   def newBindings(bindings: List[(Option[String], T)]): (DebruijnLevelMap[T], List[Int]) = {
     val result = bindings.foldLeft((this, List[Int]())) {
-      (acc: (DebruijnLevelMap[T], List[Int]), binding: (Option[String], T)) => {
-        val newMap = binding._1 match {
-          case None => acc._1.env
-          case Some(varName) => acc._1.env + (varName -> ((acc._1.next, binding._2)))
+      (acc: (DebruijnLevelMap[T], List[Int]), binding: (Option[String], T)) =>
+        {
+          val newMap = binding._1 match {
+            case None          => acc._1.env
+            case Some(varName) => acc._1.env + (varName -> ((acc._1.next, binding._2)))
+          }
+          (DebruijnLevelMap(acc._1.next + 1, newMap), acc._1.next :: acc._2)
         }
-        (DebruijnLevelMap(
-            acc._1.next + 1,
-            newMap),
-         acc._1.next :: acc._2)
-      }
     }
     (result._1, result._2.reverse)
   }
 
   // Returns the new map, and the starting level of the newly "bound" wildcards
-  def setWildcardUsed(count: Int): (DebruijnLevelMap[T], Int) = {
+  def setWildcardUsed(count: Int): (DebruijnLevelMap[T], Int) =
     (DebruijnLevelMap(next + count, env), next)
-  }
 
-  def getBinding(varName: String): Option[T] = {
+  def getBinding(varName: String): Option[T] =
     for (pair <- env.get(varName)) yield pair._2
-  }
-  def getLevel(varName: String): Option[Int] = {
+  def getLevel(varName: String): Option[Int] =
     for (pair <- env.get(varName)) yield pair._1
-  }
-  def get(varName: String): Option [(Int, T)] = env.get(varName)
-  def isEmpty() = next == 0
+  def get(varName: String): Option[(Int, T)] = env.get(varName)
+  def isEmpty()                              = next == 0
 
-  override def equals(that: Any): Boolean = {
+  override def equals(that: Any): Boolean =
     that match {
       case that: DebruijnLevelMap[T] =>
         next == that.next &&
-        env == that.env
+          env == that.env
       case _ => false
     }
-  }
 
-  override def hashCode(): Int = {
+  override def hashCode(): Int =
     (next.hashCode() * 37 + env.hashCode)
-  }
 }
 
-object DebruijnLevelMap{
-  def apply[T](
-      next: Int, env: Map[String, (Int, T)]): DebruijnLevelMap[T] = {
+object DebruijnLevelMap {
+  def apply[T](next: Int, env: Map[String, (Int, T)]): DebruijnLevelMap[T] =
     new DebruijnLevelMap(next, env)
-  }
 
   def apply[T](): DebruijnLevelMap[T] = new DebruijnLevelMap[T]()
 
-  def unapply[T](db: DebruijnLevelMap[T]): Option[(Int, Map[String,(Int, T)])] = {
+  def unapply[T](db: DebruijnLevelMap[T]): Option[(Int, Map[String, (Int, T)])] =
     Some((db.next, db.env))
-  }
 }
 
-case class ProcVisitInputs(
-  par: Par,
-  env: DebruijnLevelMap[VarSort],
-  knownFree: DebruijnLevelMap[VarSort])
+case class ProcVisitInputs(par: Par,
+                           env: DebruijnLevelMap[VarSort],
+                           knownFree: DebruijnLevelMap[VarSort])
 // Returns the update Par and an updated map of free variables.
 case class ProcVisitOutputs(par: Par, knownFree: DebruijnLevelMap[VarSort])
 
 sealed trait ChanPosition
 case object BindingPosition extends ChanPosition
-case object UsePosition extends ChanPosition
+case object UsePosition     extends ChanPosition
 
-case class NameVisitInputs(
-  env: DebruijnLevelMap[VarSort],
-  knownFree: DebruijnLevelMap[VarSort])
+case class NameVisitInputs(env: DebruijnLevelMap[VarSort], knownFree: DebruijnLevelMap[VarSort])
 case class NameVisitOutputs(chan: Channel, knownFree: DebruijnLevelMap[VarSort])

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
@@ -5,33 +5,32 @@
 package coop.rchain.rholang.intepreter
 
 case class Par(
-  sends: List[Send],
-  receives: List[Receive],
-  // selects: List[Select],
-  evals: List[Eval],
-  news: List[New],
-  exprs: List[Expr]
-  // matches: List[Match]
+    sends: List[Send],
+    receives: List[Receive],
+    // selects: List[Select],
+    evals: List[Eval],
+    news: List[New],
+    exprs: List[Expr]
+    // matches: List[Match]
 ) {
   // TODO: write helper methods to append an X and return a new par
   def this() =
     this(List(), List(), List(), List(), List())
-  def singleEval(): Option[Eval] = {
+  def singleEval(): Option[Eval] =
     if (sends.isEmpty && receives.isEmpty && news.isEmpty && exprs.isEmpty) {
       evals match {
         case List(single) => Some(single)
-        case _ => None
+        case _            => None
       }
     } else {
       None
     }
-  }
-  def merge(that: Par) = Par(
-      that.sends ++ sends,
-      that.receives ++ receives,
-      that.evals ++ evals,
-      that.news ++ news,
-      that.exprs ++ exprs)
+  def merge(that: Par) =
+    Par(that.sends ++ sends,
+        that.receives ++ receives,
+        that.evals ++ evals,
+        that.news ++ news,
+        that.exprs ++ exprs)
 }
 
 object Par {
@@ -39,7 +38,7 @@ object Par {
 }
 
 sealed trait Channel
-case class Quote(p: Par) extends Channel
+case class Quote(p: Par)      extends Channel
 case class ChanVar(cvar: Var) extends Channel
 
 // While we use vars in both positions, when producing the normalized
@@ -78,35 +77,35 @@ case class New(count: Int, p: Par)
 // Any process may be an operand to an expression.
 // Only processes equivalent to a ground process of compatible type will reduce.
 sealed trait Expr
-sealed trait Ground extends Expr
-case class EList(ps: List[Par]) extends Ground
-case class ETuple(ps: List[Par]) extends Ground
-case class ESet(ps: List[Par]) extends Ground
-case class EMap(kvs: List[(Par,Par)]) extends Ground
+sealed trait Ground                    extends Expr
+case class EList(ps: List[Par])        extends Ground
+case class ETuple(ps: List[Par])       extends Ground
+case class ESet(ps: List[Par])         extends Ground
+case class EMap(kvs: List[(Par, Par)]) extends Ground
 // A variable used as a var should be bound in a process context, not a name
 // context. For example:
 // for (@x <- c1; @y <- c2) { z!(x + y) } is fine, but
 // for (x <- c1; y <- c2) { z!(x + y) } should raise an error.
-case class EVar(v: Var) extends Expr
-case class ENot(p: Par) extends Expr
-case class ENeg(p: Par) extends Expr
-case class EMult(p1: Par, p2: Par) extends Expr
-case class EDiv(p1: Par, p2: Par) extends Expr
-case class EPlus(p1: Par, p2: Par) extends Expr
+case class EVar(v: Var)             extends Expr
+case class ENot(p: Par)             extends Expr
+case class ENeg(p: Par)             extends Expr
+case class EMult(p1: Par, p2: Par)  extends Expr
+case class EDiv(p1: Par, p2: Par)   extends Expr
+case class EPlus(p1: Par, p2: Par)  extends Expr
 case class EMinus(p1: Par, p2: Par) extends Expr
-case class ELt(p1: Par, p2: Par) extends Expr
-case class ELte(p1: Par, p2: Par) extends Expr
-case class EGt(p1: Par, p2: Par) extends Expr
-case class EGte(p1: Par, p2: Par) extends Expr
-case class EEq(p1: Par, p2: Par) extends Expr
-case class ENeq(p1: Par, p2: Par) extends Expr
-case class EAnd(p1: Par, p2: Par) extends Expr
-case class EOr(p1: Par, p2: Par) extends Expr
+case class ELt(p1: Par, p2: Par)    extends Expr
+case class ELte(p1: Par, p2: Par)   extends Expr
+case class EGt(p1: Par, p2: Par)    extends Expr
+case class EGte(p1: Par, p2: Par)   extends Expr
+case class EEq(p1: Par, p2: Par)    extends Expr
+case class ENeq(p1: Par, p2: Par)   extends Expr
+case class EAnd(p1: Par, p2: Par)   extends Expr
+case class EOr(p1: Par, p2: Par)    extends Expr
 
-case class GBool(b: Boolean) extends Ground
-case class GInt(i: Integer) extends Ground
+case class GBool(b: Boolean)  extends Ground
+case class GInt(i: Integer)   extends Ground
 case class GString(s: String) extends Ground
-case class GUri(u: String) extends Ground
+case class GUri(u: String)    extends Ground
 // These should only occur as the program is being evaluated. There is no way in
 // the grammar to construct them.
 case class GPrivate(p: String) extends Ground

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -12,7 +12,6 @@
   * In order to sort an term, call [Type]SortMatcher.sortMatch(term)
   * and extract the .term  of the returned ScoredTerm.
   */
-
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.intepreter._
@@ -23,28 +22,27 @@ sealed trait Tree[T] {
 case class Leaf[T](item: T) extends Tree[T] {
   def size = 1
 }
-case class Node[T] (children: Seq[Tree[T]]) extends Tree[T] {
+case class Node[T](children: Seq[Tree[T]]) extends Tree[T] {
   def size = children.map(_.size).sum
 }
 
-case class ScoreAtom(value : Either[Int, String]) {
-  def compare(that: ScoreAtom) : Int = {
+case class ScoreAtom(value: Either[Int, String]) {
+  def compare(that: ScoreAtom): Int =
     (this.value, that.value) match {
-      case (Left(i1), Left(i2)) => i1.compare(i2)
-      case (Left(i), Right(s)) => -1
-      case (Right(s), Left(i)) => 1
+      case (Left(i1), Left(i2))   => i1.compare(i2)
+      case (Left(i), Right(s))    => -1
+      case (Right(s), Left(i))    => 1
       case (Right(s1), Right(s2)) => s1.compare(s2)
     }
-  }
 }
 
 object ScoreAtom {
-  def apply(value: Int): ScoreAtom = new ScoreAtom(Left(value))
+  def apply(value: Int): ScoreAtom    = new ScoreAtom(Left(value))
   def apply(value: String): ScoreAtom = new ScoreAtom(Right(value))
 }
 
 object Leaf {
-  def apply(item: Int) = new Leaf(ScoreAtom(item))
+  def apply(item: Int)    = new Leaf(ScoreAtom(item))
   def apply(item: String) = new Leaf(ScoreAtom(item))
 }
 
@@ -55,13 +53,14 @@ object Leaves {
 
 object Node {
   // Shortcut to write Node(1, Leaf(1)) instead of Node(Seq(Leaf(ScoreAtom(1)), Leaf(ScoreAtom(1))))
-  def apply(left: Int, right: Tree[ScoreAtom]*) : Tree[ScoreAtom] = new Node(Seq(Leaf(left)) ++ right)
+  def apply(left: Int, right: Tree[ScoreAtom]*): Tree[ScoreAtom] =
+    new Node(Seq(Leaf(left)) ++ right)
 }
 
 // Effectively a tuple that groups the term to its score tree.
 case class ScoredTerm[T](term: T, score: Tree[ScoreAtom]) extends Ordered[ScoredTerm[T]] {
-  def compare(that: ScoredTerm[T]) : Int = {
-    def compareScore(s1: Tree[ScoreAtom], s2: Tree[ScoreAtom]) : Int = {
+  def compare(that: ScoredTerm[T]): Int = {
+    def compareScore(s1: Tree[ScoreAtom], s2: Tree[ScoreAtom]): Int =
       (s1, s2) match {
         case (Leaf(a), Leaf(b)) => a.compare(b)
         case (Leaf(a), Node(b)) => -1
@@ -69,16 +68,15 @@ case class ScoredTerm[T](term: T, score: Tree[ScoreAtom]) extends Ordered[Scored
         case (Node(a), Node(b)) =>
           (a, b) match {
             case (Nil, Nil) => 0
-            case (Nil, _) => -1
-            case (_, Nil) => 1
+            case (Nil, _)   => -1
+            case (_, Nil)   => 1
             case (h1 +: t1, h2 +: t2) =>
               compareScore(h1, h2) match {
-                case 0 => compareScore(Node(t1), Node(t2))
+                case 0     => compareScore(Node(t1), Node(t2))
                 case other => other
               }
           }
       }
-    }
     compareScore(this.score, that.score)
   }
 }
@@ -90,195 +88,186 @@ case class ScoredTerm[T](term: T, score: Tree[ScoreAtom]) extends Ordered[Scored
   */
 object Score {
   // Ground types
-  final val BOOL = 1
-  final val INT = 2
-  final val STRING = 3
-  final val URI = 4
+  final val BOOL    = 1
+  final val INT     = 2
+  final val STRING  = 3
+  final val URI     = 4
   final val PRIVATE = 5
-  final val ELIST = 6
-  final val ETUPLE = 7
-  final val ESET = 8
-  final val EMAP = 9
+  final val ELIST   = 6
+  final val ETUPLE  = 7
+  final val ESET    = 8
+  final val EMAP    = 9
 
   // Vars
   final val BOUND_VAR = 50
-  final val FREE_VAR = 51
+  final val FREE_VAR  = 51
 
   // Expr
-  final val EVAR = 100
-  final val ENEG = 101
-  final val EMULT = 102
-  final val EDIV = 103
-  final val EPLUS = 104
+  final val EVAR   = 100
+  final val ENEG   = 101
+  final val EMULT  = 102
+  final val EDIV   = 103
+  final val EPLUS  = 104
   final val EMINUS = 105
-  final val ELT = 106
-  final val ELTE = 107
-  final val EGT = 108
-  final val EGTE = 109
-  final val EEQ = 110
-  final val ENEQ = 111
-  final val ENOT = 112
-  final val EAND = 113
-  final val EOR = 114
+  final val ELT    = 106
+  final val ELTE   = 107
+  final val EGT    = 108
+  final val EGTE   = 109
+  final val EEQ    = 110
+  final val ENEQ   = 111
+  final val ENOT   = 112
+  final val EAND   = 113
+  final val EOR    = 114
 
   // Other
-  final val QUOTE = 203
+  final val QUOTE    = 203
   final val CHAN_VAR = 204
 
-  final val SEND = 300
+  final val SEND    = 300
   final val RECEIVE = 301
-  final val EVAL = 302
-  final val NEW = 303
+  final val EVAL    = 302
+  final val NEW     = 303
 
   final val PAR = 999
 }
 
 object BoolSortMatcher {
-  def sortMatch(g: GBool) : ScoredTerm[GBool] = {
+  def sortMatch(g: GBool): ScoredTerm[GBool] =
     if (g.b) {
       ScoredTerm(g, Leaves(Score.BOOL, 0))
     } else {
       ScoredTerm(g, Leaves(Score.BOOL, 1))
     }
-  }
 }
 
 object GroundSortMatcher {
-  def sortMatch(g: Ground) : ScoredTerm[Ground] = {
+  def sortMatch(g: Ground): ScoredTerm[Ground] =
     g match {
-      case gb: GBool => ScoredTerm(g, BoolSortMatcher.sortMatch(gb).score)
-      case gi: GInt => ScoredTerm(g, Leaves(Score.INT, gi.i))
-      case gs: GString => ScoredTerm(g, Node(Score.STRING, Leaf(gs.s)))
-      case gu: GUri => ScoredTerm(g, Node(Score.URI, Leaf(gu.u)))
+      case gb: GBool    => ScoredTerm(g, BoolSortMatcher.sortMatch(gb).score)
+      case gi: GInt     => ScoredTerm(g, Leaves(Score.INT, gi.i))
+      case gs: GString  => ScoredTerm(g, Node(Score.STRING, Leaf(gs.s)))
+      case gu: GUri     => ScoredTerm(g, Node(Score.URI, Leaf(gu.u)))
       case gp: GPrivate => ScoredTerm(gp, Node(Score.PRIVATE, Leaf(gp.p)))
       case gl: EList =>
         val pars = gl.ps.map(par => ParSortMatcher.sortMatch(par))
-        ScoredTerm(EList(pars.map(_.term)), Node(Score.ELIST, pars.map(_.score):_*))
+        ScoredTerm(EList(pars.map(_.term)), Node(Score.ELIST, pars.map(_.score): _*))
       case gt: ETuple =>
         val pars = gt.ps.map(par => ParSortMatcher.sortMatch(par))
-        ScoredTerm(ETuple(pars.map(_.term)), Node(Score.ETUPLE, pars.map(_.score):_*))
+        ScoredTerm(ETuple(pars.map(_.term)), Node(Score.ETUPLE, pars.map(_.score): _*))
       case gs: ESet =>
         val sortedPars = gs.ps.map(par => ParSortMatcher.sortMatch(par)).sorted
-        ScoredTerm(ESet(sortedPars.map(_.term)), Node(Score.ESET, sortedPars.map(_.score):_*))
+        ScoredTerm(ESet(sortedPars.map(_.term)), Node(Score.ESET, sortedPars.map(_.score): _*))
       case gm: EMap =>
         def sortKeyValuePair(kv: (Par, Par)): ScoredTerm[Tuple2[Par, Par]] = {
           val (key, value) = kv
-          val sortedKey = ParSortMatcher.sortMatch(key)
-          val sortedValue = ParSortMatcher.sortMatch(value)
+          val sortedKey    = ParSortMatcher.sortMatch(key)
+          val sortedValue  = ParSortMatcher.sortMatch(value)
           ScoredTerm((sortedKey.term, sortedValue.term),
                      Node(Seq(sortedKey.score, sortedValue.score)))
         }
         val sortedPars = gm.kvs.map(kv => sortKeyValuePair(kv)).sorted
-        ScoredTerm(EMap(sortedPars.map(_.term)), Node(Score.EMAP, sortedPars.map(_.score):_*))
+        ScoredTerm(EMap(sortedPars.map(_.term)), Node(Score.EMAP, sortedPars.map(_.score): _*))
     }
-  }
 }
 
 object ExprSortMatcher {
-  def sortBinaryOperation(p1: Par, p2: Par) : Tuple2[ScoredTerm[Par], ScoredTerm[Par]] = {
+  def sortBinaryOperation(p1: Par, p2: Par): Tuple2[ScoredTerm[Par], ScoredTerm[Par]] =
     Seq(ParSortMatcher.sortMatch(p1), ParSortMatcher.sortMatch(p2)) match {
-      case (p1+:p2+:_) =>  (p1, p2)
-      case _ => throw new Error("Unexpected sequence length.")
+      case (p1 +: p2 +: _) => (p1, p2)
+      case _               => throw new Error("Unexpected sequence length.")
     }
-  }
 
-  def sortMatch(e: Expr) : ScoredTerm[Expr] = {
+  def sortMatch(e: Expr): ScoredTerm[Expr] =
     e match {
       case eg: Ground =>
         val sortedGround = GroundSortMatcher.sortMatch(eg)
         ScoredTerm(sortedGround.term, sortedGround.score)
       case en: ENeg =>
         val sortedPar = ParSortMatcher.sortMatch(en.p)
-        ScoredTerm(ENeg(sortedPar.term),
-          Node(Score.ENEG, sortedPar.score))
+        ScoredTerm(ENeg(sortedPar.term), Node(Score.ENEG, sortedPar.score))
       case ev: EVar =>
         val sortedVar = VarSortMatcher.sortMatch(ev.v)
-        ScoredTerm(EVar(sortedVar.term),
-          Node(Score.EVAR, sortedVar.score))
-      case em : EMult =>
+        ScoredTerm(EVar(sortedVar.term), Node(Score.EVAR, sortedVar.score))
+      case em: EMult =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(em.p1, em.p2)
         ScoredTerm(EMult(sortedPar1.term, sortedPar2.term),
-          Node(Score.EMULT, sortedPar1.score, sortedPar2.score))
-      case ed : EDiv =>
+                   Node(Score.EMULT, sortedPar1.score, sortedPar2.score))
+      case ed: EDiv =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(ed.p1, ed.p2)
         ScoredTerm(EDiv(sortedPar1.term, sortedPar2.term),
-          Node(Score.EDIV, sortedPar1.score, sortedPar2.score))
-      case ep : EPlus =>
+                   Node(Score.EDIV, sortedPar1.score, sortedPar2.score))
+      case ep: EPlus =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(ep.p1, ep.p2)
         ScoredTerm(EPlus(sortedPar1.term, sortedPar2.term),
-          Node(Score.EPLUS, sortedPar1.score, sortedPar2.score))
-      case em : EMinus =>
+                   Node(Score.EPLUS, sortedPar1.score, sortedPar2.score))
+      case em: EMinus =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(em.p1, em.p2)
         ScoredTerm(EMinus(sortedPar1.term, sortedPar2.term),
-          Node(Score.EMINUS, sortedPar1.score, sortedPar2.score))
-      case el : ELt =>
+                   Node(Score.EMINUS, sortedPar1.score, sortedPar2.score))
+      case el: ELt =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(el.p1, el.p2)
         ScoredTerm(ELt(sortedPar1.term, sortedPar2.term),
-          Node(Score.ELT, sortedPar1.score, sortedPar2.score))
-      case el : ELte =>
+                   Node(Score.ELT, sortedPar1.score, sortedPar2.score))
+      case el: ELte =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(el.p1, el.p2)
         ScoredTerm(ELte(sortedPar1.term, sortedPar2.term),
-          Node(Score.ELTE, sortedPar1.score, sortedPar2.score))
-      case eg : EGt =>
+                   Node(Score.ELTE, sortedPar1.score, sortedPar2.score))
+      case eg: EGt =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(eg.p1, eg.p2)
         ScoredTerm(EGt(sortedPar1.term, sortedPar2.term),
-          Node(Score.EGT, sortedPar1.score, sortedPar2.score))
-      case eg : EGte =>
+                   Node(Score.EGT, sortedPar1.score, sortedPar2.score))
+      case eg: EGte =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(eg.p1, eg.p2)
         ScoredTerm(EGte(sortedPar1.term, sortedPar2.term),
-          Node(Score.EGTE, sortedPar1.score, sortedPar2.score))
-      case ee : EEq =>
+                   Node(Score.EGTE, sortedPar1.score, sortedPar2.score))
+      case ee: EEq =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(ee.p1, ee.p2)
         ScoredTerm(EEq(sortedPar1.term, sortedPar2.term),
-          Node(Score.EEQ, sortedPar1.score, sortedPar2.score))
-      case en : ENeq =>
+                   Node(Score.EEQ, sortedPar1.score, sortedPar2.score))
+      case en: ENeq =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(en.p1, en.p2)
         ScoredTerm(ENeq(sortedPar1.term, sortedPar2.term),
-          Node(Score.ENEQ, sortedPar1.score, sortedPar2.score))
+                   Node(Score.ENEQ, sortedPar1.score, sortedPar2.score))
       case en: ENot =>
         val sortedPar = ParSortMatcher.sortMatch(en.p)
-        ScoredTerm(ENot(sortedPar.term),
-          Node(Score.ENOT, sortedPar.score))
-      case ea : EAnd =>
+        ScoredTerm(ENot(sortedPar.term), Node(Score.ENOT, sortedPar.score))
+      case ea: EAnd =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(ea.p1, ea.p2)
         ScoredTerm(EAnd(sortedPar1.term, sortedPar2.term),
-          Node(Score.EAND, sortedPar1.score, sortedPar2.score))
-      case eo : EOr =>
+                   Node(Score.EAND, sortedPar1.score, sortedPar2.score))
+      case eo: EOr =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(eo.p1, eo.p2)
         ScoredTerm(EOr(sortedPar1.term, sortedPar2.term),
-          Node(Score.EOR, sortedPar1.score, sortedPar2.score))
+                   Node(Score.EOR, sortedPar1.score, sortedPar2.score))
     }
-  }
 }
 
 object VarSortMatcher {
-  def sortMatch(v : Var) : ScoredTerm[Var] = {
+  def sortMatch(v: Var): ScoredTerm[Var] =
     v match {
-      case bv : BoundVar => ScoredTerm(bv, Leaves(Score.BOUND_VAR, bv.level))
-      case fv : FreeVar => ScoredTerm(fv, Leaves(Score.FREE_VAR, fv.level))
+      case bv: BoundVar => ScoredTerm(bv, Leaves(Score.BOUND_VAR, bv.level))
+      case fv: FreeVar  => ScoredTerm(fv, Leaves(Score.FREE_VAR, fv.level))
     }
-  }
 }
 
 object ChannelSortMatcher {
-  def sortMatch(c: Channel) : ScoredTerm[Channel] = {
+  def sortMatch(c: Channel): ScoredTerm[Channel] =
     c match {
-      case cq : Quote =>
+      case cq: Quote =>
         val sortedPar = ParSortMatcher.sortMatch(cq.p)
         ScoredTerm(Quote(sortedPar.term), Node(Score.QUOTE, sortedPar.score))
-      case cv : ChanVar =>
+      case cv: ChanVar =>
         val sortedVar = VarSortMatcher.sortMatch(cv.cvar)
         ScoredTerm(ChanVar(sortedVar.term), Node(Score.CHAN_VAR, sortedVar.score))
     }
-  }
 }
 
 object SendSortMatcher {
-  def sortMatch(s: Send) : ScoredTerm[Send] = {
+  def sortMatch(s: Send): ScoredTerm[Send] = {
     val sortedChan = ChannelSortMatcher.sortMatch(s.chan)
     val sortedData = s.data.map(d => ParSortMatcher.sortMatch(d))
     val sortedSend = Send(chan = sortedChan.term, data = sortedData.map(_.term))
-    val sendScore = Node(Score.SEND, Seq(sortedChan.score) ++ sortedData.map(_.score):_*)
+    val sendScore  = Node(Score.SEND, Seq(sortedChan.score) ++ sortedData.map(_.score): _*)
     ScoredTerm(sortedSend, sendScore)
   }
 }
@@ -286,18 +275,18 @@ object SendSortMatcher {
 object ReceiveSortMatcher {
   def sortBind(bind: (List[Channel], Channel)): ScoredTerm[Tuple2[List[Channel], Channel]] = {
     val (patterns, channel) = bind
-    val sortedPatterns = patterns.map(channel => ChannelSortMatcher.sortMatch(channel))
-    val sortedChannel = ChannelSortMatcher.sortMatch(channel)
+    val sortedPatterns      = patterns.map(channel => ChannelSortMatcher.sortMatch(channel))
+    val sortedChannel       = ChannelSortMatcher.sortMatch(channel)
     ScoredTerm((sortedPatterns.map(_.term), sortedChannel.term),
-                Node(Seq(sortedChannel.score) ++ sortedPatterns.map(_.score)))
+               Node(Seq(sortedChannel.score) ++ sortedPatterns.map(_.score)))
   }
 
   // Used during normalize to presort the binds.
-  def preSortBinds[T](binds: List[Tuple3[List[Channel], Channel, DebruijnLevelMap[T]]]) :
-    List[Tuple3[List[Channel], Channel, DebruijnLevelMap[T]]] = {
+  def preSortBinds[T](binds: List[Tuple3[List[Channel], Channel, DebruijnLevelMap[T]]])
+    : List[Tuple3[List[Channel], Channel, DebruijnLevelMap[T]]] = {
     val sortedBind = binds.map {
-      case (patterns : List[Channel], channel: Channel, knownFree : DebruijnLevelMap[T]) =>
-        val sortedBind = sortBind((patterns, channel))
+      case (patterns: List[Channel], channel: Channel, knownFree: DebruijnLevelMap[T]) =>
+        val sortedBind                      = sortBind((patterns, channel))
         val (sortedPatterns, sortedChannel) = sortedBind.term
         ScoredTerm((sortedPatterns, sortedChannel, knownFree), sortedBind.score)
     }.sorted
@@ -306,42 +295,43 @@ object ReceiveSortMatcher {
 
   // The order of the binds must already be presorted by the time this is called.
   // This function will then sort the insides of the preordered binds.
-  def sortMatch(r: Receive) : ScoredTerm[Receive] = {
+  def sortMatch(r: Receive): ScoredTerm[Receive] = {
     val sortedBinds = r.binds.map(bind => sortBind(bind))
-    ScoredTerm(Receive(sortedBinds.map(_.term)), Node(Score.RECEIVE, sortedBinds.map(_.score):_*))
+    ScoredTerm(Receive(sortedBinds.map(_.term)), Node(Score.RECEIVE, sortedBinds.map(_.score): _*))
   }
 }
 
 object EvalSortMatcher {
-  def sortMatch(e: Eval) : ScoredTerm[Eval] = {
+  def sortMatch(e: Eval): ScoredTerm[Eval] = {
     val sortedChannel = ChannelSortMatcher.sortMatch(e.channel)
     ScoredTerm(Eval(sortedChannel.term), Node(Score.EVAL, sortedChannel.score))
   }
 }
 
 object NewSortMatcher {
-  def sortMatch(n: New) : ScoredTerm[New] = {
+  def sortMatch(n: New): ScoredTerm[New] = {
     val sortedPar = ParSortMatcher.sortMatch(n.p)
-    ScoredTerm(New(count=n.count, p=sortedPar.term), Node(Score.NEW, Leaf(n.count), sortedPar.score))
+    ScoredTerm(New(count = n.count, p = sortedPar.term),
+               Node(Score.NEW, Leaf(n.count), sortedPar.score))
   }
 }
 
 object ParSortMatcher {
-  def sortMatch(p: Par) : ScoredTerm[Par] = {
-    val sends = p.sends.map(s => SendSortMatcher.sortMatch(s)).sorted
+  def sortMatch(p: Par): ScoredTerm[Par] = {
+    val sends    = p.sends.map(s => SendSortMatcher.sortMatch(s)).sorted
     val receives = p.receives.map(r => ReceiveSortMatcher.sortMatch(r)).sorted
-    val exprs = p.exprs.map(e => ExprSortMatcher.sortMatch(e)).sorted
-    val evals = p.evals.map(e => EvalSortMatcher.sortMatch(e)).sorted
-    val news = p.news.map(n => NewSortMatcher.sortMatch(n)).sorted
-    val sortedPar = Par(sends=sends.map(_.term),
-                        receives=receives.map(_.term),
-                        exprs=exprs.map(_.term),
-                        evals=evals.map(_.term),
-                        news=news.map(_.term))
-    val parScore = Node(Score.PAR, sends.map(_.score) ++
-                        receives.map(_.score) ++ exprs.map(_.score) ++
-                        evals.map(_.score) ++ news.map(_.score):_*)
+    val exprs    = p.exprs.map(e => ExprSortMatcher.sortMatch(e)).sorted
+    val evals    = p.evals.map(e => EvalSortMatcher.sortMatch(e)).sorted
+    val news     = p.news.map(n => NewSortMatcher.sortMatch(n)).sorted
+    val sortedPar = Par(sends = sends.map(_.term),
+                        receives = receives.map(_.term),
+                        exprs = exprs.map(_.term),
+                        evals = evals.map(_.term),
+                        news = news.map(_.term))
+    val parScore = Node(Score.PAR,
+                        sends.map(_.score) ++
+                          receives.map(_.score) ++ exprs.map(_.score) ++
+                          evals.map(_.score) ++ news.map(_.score): _*)
     ScoredTerm(sortedPar, parScore)
   }
 }
-

--- a/rholang/src/main/scala/lib/term/Term.scala
+++ b/rholang/src/main/scala/lib/term/Term.scala
@@ -1,9 +1,9 @@
-// -*- mode: Scala;-*- 
-// Filename:    Term.scala 
-// Authors:     luciusmeredith                                                    
-// Creation:    Wed Feb  1 08:55:51 2017 
+// -*- mode: Scala;-*-
+// Filename:    Term.scala
+// Authors:     luciusmeredith
+// Creation:    Wed Feb  1 08:55:51 2017
 // Copyright:   See site license
-// Description: 
+// Description:
 // ------------------------------------------------------------------------
 
 package coop.rchain.lib.term
@@ -11,235 +11,212 @@ package coop.rchain.lib.term
 import coop.rchain.lib.zipper._
 import scala.collection.SeqProxy
 
-trait Term[Namespace, /*+*/TagType]
-extends Tree[TagType] with SeqProxy[Term[Namespace,TagType]]
-  with Serializable {
+trait Term[Namespace, /*+*/ TagType]
+    extends Tree[TagType]
+    with SeqProxy[Term[Namespace, TagType]]
+    with Serializable {
   // Collects a list of all the tags in the tree.
-  def collectTags /* [Tag1 >: Tag] */ ( term : Term[Namespace,TagType] )
-   : List[TagType] = {
+  def collectTags /* [Tag1 >: Tag] */ (term: Term[Namespace, TagType]): List[TagType] =
     term match {
-      case TermLeaf( t ) => List( t )
-      case TermBranch( ns, lbls ) => {
-	( List[TagType]() /: lbls.flatMap( _.self ) )(
-	  {
-	    ( acc, e ) => {
-	      acc ++ collectTags/*[Tag1]*/( e )
-	    }
-	  }
-	)
+      case TermLeaf(t) => List(t)
+      case TermBranch(ns, lbls) => {
+        (List[TagType]() /: lbls.flatMap(_.self))(
+          { (acc, e) =>
+            {
+              acc ++ collectTags /*[Tag1]*/ (e)
+            }
+          }
+        )
       }
     }
-  }
 
-  def atoms : Seq[TagType] = { this flatMap( collectTags ) }
-  def self : List[Term[Namespace,TagType]]
+  def atoms: Seq[TagType] = this flatMap (collectTags)
+  def self: List[Term[Namespace, TagType]]
 }
 
-class TermLeaf[Namespace,TagType]( val tag : TagType )
-extends TreeItem[TagType]( tag )
-with Term[Namespace,TagType] {
-  override def self = List( this )
+class TermLeaf[Namespace, TagType](val tag: TagType)
+    extends TreeItem[TagType](tag)
+    with Term[Namespace, TagType] {
+  override def self = List(this)
 }
 
 object TermLeaf extends Serializable {
-  def unapply[Namespace,TagType](
-    cnxnLeaf : TermLeaf[Namespace,TagType]
-  ) : Option[( TagType )] = {
-    Some( ( cnxnLeaf.tag ) )
-  }
+  def unapply[Namespace, TagType](
+      cnxnLeaf: TermLeaf[Namespace, TagType]
+  ): Option[(TagType)] =
+    Some((cnxnLeaf.tag))
 }
 
-trait AbstractTermBranch[Namespace,TagType]
-extends Term[Namespace,TagType] {
-  def nameSpace : Namespace
-  def labels : List[Term[Namespace,TagType]]
+trait AbstractTermBranch[Namespace, TagType] extends Term[Namespace, TagType] {
+  def nameSpace: Namespace
+  def labels: List[Term[Namespace, TagType]]
   override def self = labels
 }
 
-class TermBranch[Namespace,TagType](
-  override val nameSpace : Namespace,
-  val factuals : List[Term[Namespace,TagType]]
-) extends TreeSection[TagType]( factuals )
-with AbstractTermBranch[Namespace,TagType]
-with Term[Namespace,TagType] {
-  override def labels : List[Term[Namespace,TagType]] = {
+class TermBranch[Namespace, TagType](
+    override val nameSpace: Namespace,
+    val factuals: List[Term[Namespace, TagType]]
+) extends TreeSection[TagType](factuals)
+    with AbstractTermBranch[Namespace, TagType]
+    with Term[Namespace, TagType] {
+  override def labels: List[Term[Namespace, TagType]] =
     factuals
-  }
 }
 
 object TermBranch extends Serializable {
-  def unapply[Namespace,TagType](
-    cnxnBranch : TermBranch[Namespace,TagType]
-  ) : Option[( Namespace, List[Term[Namespace,TagType]] )] = {
-    Some( ( cnxnBranch.nameSpace, cnxnBranch.labels ) )
-  }
+  def unapply[Namespace, TagType](
+      cnxnBranch: TermBranch[Namespace, TagType]
+  ): Option[(Namespace, List[Term[Namespace, TagType]])] =
+    Some((cnxnBranch.nameSpace, cnxnBranch.labels))
 }
 
 sealed trait TagOrVar[+TagType, +VarType]
 
-final case class Tag[+TagType]( tag : TagType ) extends TagOrVar[TagType, Nothing]
-final case class Var[+VarType]( variable : VarType ) extends TagOrVar[Nothing, VarType]
+final case class Tag[+TagType](tag: TagType)      extends TagOrVar[TagType, Nothing]
+final case class Var[+VarType](variable: VarType) extends TagOrVar[Nothing, VarType]
 
 sealed trait NamespaceOrVar[+NSType, +VarType]
 
-final case class NS[+NSType]( ns : NSType ) extends NamespaceOrVar[NSType, Nothing]
-final case class NsVar[+VarType]( variable : VarType ) extends NamespaceOrVar[Nothing, VarType]
+final case class NS[+NSType](ns: NSType)            extends NamespaceOrVar[NSType, Nothing]
+final case class NsVar[+VarType](variable: VarType) extends NamespaceOrVar[Nothing, VarType]
 
-trait TermCtxt[Namespace,VarType,TagType]
-extends Term[NamespaceOrVar[Namespace,VarType],TagOrVar[TagType,VarType]] {
+trait TermCtxt[Namespace, VarType, TagType]
+    extends Term[NamespaceOrVar[Namespace, VarType], TagOrVar[TagType, VarType]] {
   type U =
-    Term[NamespaceOrVar[Namespace,VarType],TagOrVar[TagType,VarType]]
+    Term[NamespaceOrVar[Namespace, VarType], TagOrVar[TagType, VarType]]
 
-  def names : Seq[TagOrVar[TagType,VarType]] = {
-    atoms filter(
+  def names: Seq[TagOrVar[TagType, VarType]] =
+    atoms filter ({ (ctxtLbl) =>
       {
-	( ctxtLbl ) => {
-	  ctxtLbl match { 
-	    case Tag( _ ) => false
-	    case Var( _ ) => true
-	  }
-	}
+        ctxtLbl match {
+          case Tag(_) => false
+          case Var(_) => true
+        }
       }
-    )
-  }
+    })
 
-  def show : String = {
+  def show: String =
     this match {
-      case leaf : TermCtxtLeaf[Namespace,VarType,TagType] =>
+      case leaf: TermCtxtLeaf[Namespace, VarType, TagType] =>
         leaf.showLeaf
-      case branch : TermCtxtBranch[Namespace,VarType,TagType] =>
+      case branch: TermCtxtBranch[Namespace, VarType, TagType] =>
         branch.showBranch
-      case _ => throw new Exception( "unexpected CCL type" )
+      case _ => throw new Exception("unexpected CCL type")
     }
-  }
 }
 
-class TermCtxtLeaf[Namespace,VarType,TagType]( val tag : TagOrVar[TagType,VarType] )
-extends TreeItem[TagOrVar[TagType,VarType]]( tag )
-with TermCtxt[Namespace,VarType,TagType] {
-  override def self = List( this )
-  override def toString = {
+class TermCtxtLeaf[Namespace, VarType, TagType](val tag: TagOrVar[TagType, VarType])
+    extends TreeItem[TagOrVar[TagType, VarType]](tag)
+    with TermCtxt[Namespace, VarType, TagType] {
+  override def self = List(this)
+  override def toString =
     tag match {
-      case Tag( t ) => "" + t + ""
-      case Var( v ) => "'" + v
+      case Tag(t) => "" + t + ""
+      case Var(v) => "'" + v
     }
-  }
-  def showLeaf : String = {
+  def showLeaf: String =
     tag match {
-      case Tag( t : String ) => "\"" + t + "\""
-      case Tag( t ) => t + ""
-      case Var( v ) => v + ""
+      case Tag(t: String) => "\"" + t + "\""
+      case Tag(t)         => t + ""
+      case Var(v)         => v + ""
     }
-  }
 }
 
 object TermCtxtLeaf extends Serializable {
-  def unapply[Namespace,VarType,TagType](
-    cnxnCtxtLeaf : TermCtxtLeaf[Namespace,VarType,TagType]
-  ) : Option[( TagOrVar[TagType,VarType] )] = {
-    Some( ( cnxnCtxtLeaf.tag ) )
-  }
+  def unapply[Namespace, VarType, TagType](
+      cnxnCtxtLeaf: TermCtxtLeaf[Namespace, VarType, TagType]
+  ): Option[(TagOrVar[TagType, VarType])] =
+    Some((cnxnCtxtLeaf.tag))
 }
 
-trait AbstractTermCtxtBranch[Namespace,VarType,TagType]
-extends TermCtxt[Namespace,VarType,TagType] {  
-  def nameSpace : Namespace
-  def labels : List[TermCtxt[Namespace,VarType,TagType]]
+trait AbstractTermCtxtBranch[Namespace, VarType, TagType]
+    extends TermCtxt[Namespace, VarType, TagType] {
+  def nameSpace: Namespace
+  def labels: List[TermCtxt[Namespace, VarType, TagType]]
   override def self = labels
   override def toString = {
     val lblStr =
       labels match {
-	case albl :: rlbls => {
-	  ( albl.toString /: rlbls )( 
-	    {
-	      ( acc, lbl ) => {
-		acc + ", " + lbl
-	      }
-	    }
-	  )
-	}
-	case Nil => ""
+        case albl :: rlbls => {
+          (albl.toString /: rlbls)(
+            { (acc, lbl) =>
+              {
+                acc + ", " + lbl
+              }
+            }
+          )
+        }
+        case Nil => ""
       }
     nameSpace + "(" + lblStr + ")"
   }
-  def showBranch : String = {
+  def showBranch: String = {
     val lblStr =
       labels match {
-	case albl :: rlbls => {
-	  ( albl.show /: rlbls )( 
-	    {
-	      ( acc, lbl ) => {
-		acc + ", " + lbl.show
-	      }
-	    }
-	  )
-	}
-	case Nil => ""
+        case albl :: rlbls => {
+          (albl.show /: rlbls)(
+            { (acc, lbl) =>
+              {
+                acc + ", " + lbl.show
+              }
+            }
+          )
+        }
+        case Nil => ""
       }
     nameSpace + "(" + lblStr + ")"
   }
 }
 
-class TermCtxtBranch[Namespace,VarType,TagType](
-  override val nameSpace : Namespace,
-  val factuals : List[TermCtxt[Namespace,VarType,TagType]]
-) extends TreeSection[TagOrVar[TagType,VarType]]( factuals )
-with AbstractTermCtxtBranch[Namespace,VarType,TagType] {
-  override def labels : List[TermCtxt[Namespace,VarType,TagType]] = {
+class TermCtxtBranch[Namespace, VarType, TagType](
+    override val nameSpace: Namespace,
+    val factuals: List[TermCtxt[Namespace, VarType, TagType]]
+) extends TreeSection[TagOrVar[TagType, VarType]](factuals)
+    with AbstractTermCtxtBranch[Namespace, VarType, TagType] {
+  override def labels: List[TermCtxt[Namespace, VarType, TagType]] =
     factuals
-  }
-  override def equals( o : Any ) : Boolean = {
+  override def equals(o: Any): Boolean =
     o match {
-      case that : TermCtxtBranch[Namespace,VarType,TagType] => {
-	(
-	  nameSpace.equals( that.nameSpace )
-	  && factuals.equals( that.factuals ) 
-	)
+      case that: TermCtxtBranch[Namespace, VarType, TagType] => {
+        (
+          nameSpace.equals(that.nameSpace)
+          && factuals.equals(that.factuals)
+        )
       }
       case _ => false
     }
-  }
-  override def hashCode( ) : Int = {
+  override def hashCode(): Int =
     (
-      ( 37 * nameSpace.hashCode )
-      + ( 37 * factuals.hashCode )
+      (37 * nameSpace.hashCode)
+        + (37 * factuals.hashCode)
     )
-  }
 }
 
 object TermCtxtBranch extends Serializable {
-  def unapply[Namespace,VarType,TagType](
-    cnxnCtxtBranch : TermCtxtBranch[Namespace,VarType,TagType]
-  ) : Option[
-	(
-	  Namespace,
-	  List[TermCtxt[Namespace,VarType,TagType]]
-	)
-      ] = {
-    Some( ( cnxnCtxtBranch.nameSpace, cnxnCtxtBranch.factuals
- ) )
-  }
+  def unapply[Namespace, VarType, TagType](
+      cnxnCtxtBranch: TermCtxtBranch[Namespace, VarType, TagType]
+  ): Option[
+    (
+        Namespace,
+        List[TermCtxt[Namespace, VarType, TagType]]
+    )
+  ] =
+    Some((cnxnCtxtBranch.nameSpace, cnxnCtxtBranch.factuals))
 }
 
-trait TermCtxtInjector[Namespace,VarType,TagType] {
-  def injectLabel( cLabel : Term[Namespace,TagType] )
-  : TermCtxt[Namespace,VarType,TagType] = {
+trait TermCtxtInjector[Namespace, VarType, TagType] {
+  def injectLabel(cLabel: Term[Namespace, TagType]): TermCtxt[Namespace, VarType, TagType] =
     cLabel match {
-      case cLeaf : TermLeaf[Namespace,TagType] =>
-	inject( cLeaf )
-      case cBranch : TermBranch[Namespace,TagType] =>
-	inject( cBranch )
+      case cLeaf: TermLeaf[Namespace, TagType] =>
+        inject(cLeaf)
+      case cBranch: TermBranch[Namespace, TagType] =>
+        inject(cBranch)
     }
-  }
-  def inject( cLabel : TermLeaf[Namespace,TagType] )
-  : TermCtxt[Namespace,VarType,TagType] = {
-    new TermCtxtLeaf( Tag( cLabel.tag ) )
-  }
-  def inject( cLabel : TermBranch[Namespace,TagType] )
-  : TermCtxt[Namespace,VarType,TagType] = {
+  def inject(cLabel: TermLeaf[Namespace, TagType]): TermCtxt[Namespace, VarType, TagType] =
+    new TermCtxtLeaf(Tag(cLabel.tag))
+  def inject(cLabel: TermBranch[Namespace, TagType]): TermCtxt[Namespace, VarType, TagType] =
     new TermCtxtBranch(
       cLabel.nameSpace,
-      cLabel.factuals.map( injectLabel( _ ) )
+      cLabel.factuals.map(injectLabel(_))
     )
-  }
 }

--- a/rholang/src/main/scala/lib/zipper/tree.scala
+++ b/rholang/src/main/scala/lib/zipper/tree.scala
@@ -1,65 +1,56 @@
-// -*- mode: Scala;-*- 
-// Filename:    tree.scala 
-// Authors:     luciusmeredith                                                    
-// Creation:    Wed Feb  1 09:13:01 2017 
-// Copyright:   See site license 
-// Description: 
+// -*- mode: Scala;-*-
+// Filename:    tree.scala
+// Authors:     luciusmeredith
+// Creation:    Wed Feb  1 09:13:01 2017
+// Copyright:   See site license
+// Description:
 // ------------------------------------------------------------------------
 
 package coop.rchain.lib.zipper
 
 trait Tree[+A] extends Serializable
 
-case object TZero
-extends Tree[Nothing]
+case object TZero extends Tree[Nothing]
 
-class TreeItem[+A]( val item : A ) extends Tree[A] {
-  override def equals( o : Any ) : Boolean = {
+class TreeItem[+A](val item: A) extends Tree[A] {
+  override def equals(o: Any): Boolean =
     o match {
-      case that : TreeItem[A] => {
-        item.equals( that.item )
+      case that: TreeItem[A] => {
+        item.equals(that.item)
       }
       case _ => {
         false
       }
     }
-  }
-  override def hashCode( ) : Int = {
+  override def hashCode(): Int =
     37 * item.hashCode
-  }
 }
 object TreeItem {
-  def apply[A]( item : A ) = { new TreeItem( item ) }
-  def unapply[A]( tree : TreeItem[A] )
-  : Option[( A )] = {
-    Some( ( tree.item ) )
-  }
+  def apply[A](item: A) = new TreeItem(item)
+  def unapply[A](tree: TreeItem[A]): Option[(A)] =
+    Some((tree.item))
 }
-case class CTreeItem[+A]( val item : A ) extends Tree[A]
+case class CTreeItem[+A](val item: A) extends Tree[A]
 class TreeSection[+A](
-  val section: List[Tree[A]]
+    val section: List[Tree[A]]
 ) extends Tree[A] {
-  override def equals( o : Any ) : Boolean = {
+  override def equals(o: Any): Boolean =
     o match {
-      case that : TreeSection[A] => {
-        section.equals( that.section )
+      case that: TreeSection[A] => {
+        section.equals(that.section)
       }
       case _ => {
         false
       }
     }
-  }
-  override def hashCode( ) : Int = {
+  override def hashCode(): Int =
     37 * section.hashCode
-  }
 }
 object TreeSection {
-  def apply[A]( section : List[Tree[A]] ) = { new TreeSection( section ) }
-  def unapply[A]( tree : TreeSection[A] )
-  : Option[( List[Tree[A]] )] = {
-    Some( ( tree.section ) )
-  }
+  def apply[A](section: List[Tree[A]]) = new TreeSection(section)
+  def unapply[A](tree: TreeSection[A]): Option[(List[Tree[A]])] =
+    Some((tree.section))
 }
 case class CTreeSection[+A](
-  val section: List[Tree[A]]
+    val section: List[Tree[A]]
 ) extends Tree[A]

--- a/rholang/src/main/scala/rholang/rosette/Compiler.scala
+++ b/rholang/src/main/scala/rholang/rosette/Compiler.scala
@@ -1,8 +1,8 @@
-// -*- mode: Scala;-*- 
-// Filename:    Compiler.scala 
-// Authors:     luciusmeredith                                                    
-// Creation:    Wed Mar  8 09:51:33 2017 
-// Copyright:   See site license 
+// -*- mode: Scala;-*-
+// Filename:    Compiler.scala
+// Authors:     luciusmeredith
+// Creation:    Wed Mar  8 09:51:33 2017
+// Copyright:   See site license
 // Description: Basic loading of source from a stream and running it
 // through the source-to-source translation.
 // ------------------------------------------------------------------------
@@ -14,54 +14,50 @@ import coop.rchain.rholang.syntax.rholang._
 import java.io._
 
 trait Rholang2RosetteCompilerT {
-  self : RholangASTToTerm =>
-  def reader( fileName : String ) : FileReader
-  def lexer( fileReader : FileReader ) : Yylex
-  def parser( lexer : Yylex ) : parser
-  def serialize( ast : VisitorTypes.R ) : String
+  self: RholangASTToTerm =>
+  def reader(fileName: String): FileReader
+  def lexer(fileReader: FileReader): Yylex
+  def parser(lexer: Yylex): parser
+  def serialize(ast: VisitorTypes.R): String
 
-  def compile( fileName : String ) : Option[VisitorTypes.R]
+  def compile(fileName: String): Option[VisitorTypes.R]
 }
 
-object Rholang2RosetteCompiler extends RholangASTToTerm
-    with Rholang2RosetteCompilerT
-{
-     // Members declared in coop.rchain.rho2rose.RholangASTToTerm
-  def theTupleSpaceVar : String = s"""TupleSpaceVar${Fresh()}"""
+object Rholang2RosetteCompiler extends RholangASTToTerm with Rholang2RosetteCompilerT {
+  // Members declared in coop.rchain.rho2rose.RholangASTToTerm
+  def theTupleSpaceVar: String = s"""TupleSpaceVar${Fresh()}"""
 
-  override def reader( fileName : String ) : FileReader = { new FileReader( fileName ) }
-  override def lexer( fileReader : FileReader ) : Yylex = { new Yylex( fileReader ) }
-  override def parser( lexer : Yylex ) : parser = { new parser( lexer, lexer.getSymbolFactory() ) }
-  override def serialize( ast : VisitorTypes.R ) : String = {
+  override def reader(fileName: String): FileReader = new FileReader(fileName)
+  override def lexer(fileReader: FileReader): Yylex = new Yylex(fileReader)
+  override def parser(lexer: Yylex): parser         = new parser(lexer, lexer.getSymbolFactory())
+  override def serialize(ast: VisitorTypes.R): String = {
     val term = ast._1
     term.rosetteSerializeOperation + term.rosetteSerialize
   }
 
-  override def compile( fileName : String ) : Option[VisitorTypes.R] = {
+  override def compile(fileName: String): Option[VisitorTypes.R] =
     try {
-      val rdr = reader( fileName )
-      val lxr = lexer( rdr )
-      val prsr = parser( lxr )
-      val ast = prsr.pContr()
+      val rdr  = reader(fileName)
+      val lxr  = lexer(rdr)
+      val prsr = parser(lxr)
+      val ast  = prsr.pContr()
       Some(visit(ast, Set[String]()))
-    }
-    catch {
-      case e : FileNotFoundException => {
+    } catch {
+      case e: FileNotFoundException => {
         System.err.println(s"""Error: File not found: ${fileName}""")
         None
       }
-      case e : CompilerExceptions.CompilerException => {
+      case e: CompilerExceptions.CompilerException => {
         System.err.println(s"""Error while compiling: ${fileName}\n${e.toString()}""")
         None
       }
-      case t : Throwable => {
+      case t: Throwable => {
         System.err.println(s"""Error while compiling: ${fileName}\n${t.toString()}""")
         None
       }
     }
-  }
 
-  def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit =
     args match {
       case Array(fileName) => {
         compile(fileName) match {
@@ -79,5 +75,4 @@ object Rholang2RosetteCompiler extends RholangASTToTerm
         System.exit(1)
       }
     }
-  }
 }

--- a/rholang/src/main/scala/rholang/rosette/Roselang.scala
+++ b/rholang/src/main/scala/rholang/rosette/Roselang.scala
@@ -1,9 +1,9 @@
-// -*- mode: Scala;-*- 
-// Filename:    Roselang.scala 
-// Authors:     luciusmeredith                                                    
-// Creation:    Thu Feb  2 14:34:16 2017 
-// Copyright:   See site license 
-// Description: 
+// -*- mode: Scala;-*-
+// Filename:    Roselang.scala
+// Authors:     luciusmeredith
+// Creation:    Thu Feb  2 14:34:16 2017
+// Copyright:   See site license
+// Description:
 // ------------------------------------------------------------------------
 
 package coop.rchain.rho2rose
@@ -18,18 +18,19 @@ import scala.language.postfixOps
 
 // B for Branch
 object StrTermCtorAbbrevs {
-  type ValOrVar = TagOrVar[String,String]
-  type StrTermCtxt = TermCtxt[String,String,String] with RosetteSerialization[String,String,String]
-  def Leaf( v : ValOrVar ) : StrTermCtxt = StrTermPtdCtxtLf( v )
-  def B( v : String )( terms : StrTermCtxt* ) : StrTermCtxt = StrTermPtdCtxtBr( v, terms.toList )
-  def B( v : String, terms : List[StrTermCtxt] ) : StrTermCtxt = StrTermPtdCtxtBr( v, terms )
+  type ValOrVar = TagOrVar[String, String]
+  type StrTermCtxt =
+    TermCtxt[String, String, String] with RosetteSerialization[String, String, String]
+  def Leaf(v: ValOrVar): StrTermCtxt                      = StrTermPtdCtxtLf(v)
+  def B(v: String)(terms: StrTermCtxt*): StrTermCtxt      = StrTermPtdCtxtBr(v, terms.toList)
+  def B(v: String, terms: List[StrTermCtxt]): StrTermCtxt = StrTermPtdCtxtBr(v, terms)
 }
 
 object VisitorTypes {
   // Arg Type
   // Set of bound names.
   type BoundSet = Set[String]
-  type A = Set[String]
+  type A        = Set[String]
   // Return Type
   type R = (StrTermCtorAbbrevs.StrTermCtxt, A)
 }
@@ -37,14 +38,14 @@ object VisitorTypes {
 object S2SImplicits {
   import StrTermCtorAbbrevs._
   implicit def asR(
-    term : StrTermCtxt
-  ) : VisitorTypes.R = (term, Set[String]())
+      term: StrTermCtxt
+  ): VisitorTypes.R = (term, Set[String]())
   implicit def asTerm(
-    item : ValOrVar
-  ) : StrTermCtxt = StrTermPtdCtxtLf( item )
+      item: ValOrVar
+  ): StrTermCtxt = StrTermPtdCtxtLf(item)
   implicit def asR(
-    item : ValOrVar
-  ) : VisitorTypes.R = (StrTermPtdCtxtLf( item ), Set[String]())
+      item: ValOrVar
+  ): VisitorTypes.R = (StrTermPtdCtxtLf(item), Set[String]())
 }
 
 object CompilerExceptions {
@@ -53,109 +54,111 @@ object CompilerExceptions {
   trait SemanticsException
 
   case class UnexpectedContractType(
-    c : Contr
-  ) extends Exception( s"$c found in unexpected context" )
-      with CompilerException with SyntaxException
+      c: Contr
+  ) extends Exception(s"$c found in unexpected context")
+      with CompilerException
+      with SyntaxException
   case class NoComprehensionBindings(
-    p : PInput 
-  ) extends Exception( s"$p has no bindings" )
-      with CompilerException with SyntaxException
+      p: PInput
+  ) extends Exception(s"$p has no bindings")
+      with CompilerException
+      with SyntaxException
   case class UnexpectedBindingType(
-    b : Bind
-  ) extends Exception( s"$b found in unexpected context" )
-      with CompilerException with SyntaxException
+      b: Bind
+  ) extends Exception(s"$b found in unexpected context")
+      with CompilerException
+      with SyntaxException
   case class UnexpectedBranchType(
-    b : CBranch
-  ) extends Exception( s"$b found in unexpected context" )
-      with CompilerException with SyntaxException
+      b: CBranch
+  ) extends Exception(s"$b found in unexpected context")
+      with CompilerException
+      with SyntaxException
   case class UnexpectedPMBranchType(
-    b : PMBranch
-  ) extends Exception( s"$b found in unexpected context" )
-    with CompilerException with SyntaxException
+      b: PMBranch
+  ) extends Exception(s"$b found in unexpected context")
+      with CompilerException
+      with SyntaxException
   case class FailedQuotation(
-    b : AnyRef
-  ) extends Exception( s"$b found in unexpected context" )
-      with CompilerException with SyntaxException
+      b: AnyRef
+  ) extends Exception(s"$b found in unexpected context")
+      with CompilerException
+      with SyntaxException
   case class InternalCompilerError(
-    b : AnyRef
-  ) extends Exception( s"internal compiler error: $b" )
+      b: AnyRef
+  ) extends Exception(s"internal compiler error: $b")
       with CompilerException
   case class UnboundVariable(
-    varName : String,
-    line : Int,
-    col : Int
-  ) extends Exception( s"Unbound variable: $varName at $line:$col" )
+      varName: String,
+      line: Int,
+      col: Int
+  ) extends Exception(s"Unbound variable: $varName at $line:$col")
       with CompilerException
 }
 
 object ComprehensionOps {
-  val _map = "map"
-  val _unit = "unit"
-  val _mult = "mult"
-  val _join = "flatMap"
+  val _map    = "map"
+  val _unit   = "unit"
+  val _mult   = "mult"
+  val _join   = "flatMap"
   val _filter = "filter"
 }
 
 object RosetteOps {
-  val _abs = "proc"
+  val _abs      = "proc"
   val _defActor = "defActor"
-  val _method = "method"
-  val _produce = "produce"
-  val _block = "block"
-  val _quote = "Q"
-  val _rx = "RX"
-  val _run = "run"
-  val _compile = "compile"
-  val _if = "if"
-  val _match = "match-pattern" // TODO: Adjust based on Rosette implementation. This operation checks for equality in the "match" implementation.
-  val _list = "list" // TODO: Extract into "temporary operations" set
+  val _method   = "method"
+  val _produce  = "produce"
+  val _block    = "block"
+  val _quote    = "Q"
+  val _rx       = "RX"
+  val _run      = "run"
+  val _compile  = "compile"
+  val _if       = "if"
+  val _match    = "match-pattern" // TODO: Adjust based on Rosette implementation. This operation checks for equality in the "match" implementation.
+  val _list     = "list" // TODO: Extract into "temporary operations" set
 }
 
-trait RholangASTToTerm 
-extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
+trait RholangASTToTerm extends AllVisitor[VisitorTypes.R, VisitorTypes.A] {
   import VisitorTypes._
   import StrTermCtorAbbrevs._
   import S2SImplicits._
   import CompilerExceptions._
   import RosetteOps._
 
-  def TS() : StrTermCtxt = Var("t") // TODO: Replace with V( theTupleSpaceVar ) ?
+  def TS(): StrTermCtxt = Var("t") // TODO: Replace with V( theTupleSpaceVar ) ?
   // TODO: Review cryptographic secureness and ensure Fresh and FreshSymbol are of uniform length
   // A FreshSymbol contains a quote in Rosette while a Fresh doesn't
   def Fresh() = {
-    val prefix = "Rholang"
+    val prefix         = "Rholang"
     val uuidComponents = java.util.UUID.randomUUID.toString.split("-")
     prefix + uuidComponents(uuidComponents.length - 1)
   }
-  def FreshSymbol( debugSymbol: String ) = {
+  def FreshSymbol(debugSymbol: String) =
     s"""(generateFresh "${debugSymbol}")"""
-  }
 
   /* TODO : rewrite this to be amenable to tail recursion elimination */
-  def doQuote( expr : StrTermCtxt ) : StrTermCtxt = {
+  def doQuote(expr: StrTermCtxt): StrTermCtxt =
     expr match {
-      case leaf : StrTermPtdCtxtLf => {
-        B( _quote )( leaf )
+      case leaf: StrTermPtdCtxtLf => {
+        B(_quote)(leaf)
       }
-      case StrTermPtdCtxtBr( op, subterms ) => {
-        val qterms = subterms.map(( term ) => doQuote( term ))
-        if ( op == _list )
-          B( _list, qterms )
+      case StrTermPtdCtxtBr(op, subterms) => {
+        val qterms = subterms.map((term) => doQuote(term))
+        if (op == _list)
+          B(_list, qterms)
         else
-          B( _rx, Var(op) :: qterms )
+          B(_rx, Var(op) :: qterms)
       }
     }
-  }
 
   /* Contr */
-  def visit( p : Contr, arg : A ) : R = {
+  def visit(p: Contr, arg: A): R =
     p match {
-      case dcontr : DContr => dcontr.proc_.accept(this, arg)
-      case _ => throw new UnexpectedContractType( p )
+      case dcontr: DContr => dcontr.proc_.accept(this, arg)
+      case _              => throw new UnexpectedContractType(p)
     }
-  }
   // TODO: Handle case no arguments to contract
-  override def visit( p : PContr, bound : A ) : R = {
+  override def visit(p: PContr, bound: A): R = {
     import scala.collection.JavaConverters._
 
     /*
@@ -166,52 +169,52 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
      * )
      *
      */
-    def toListOfTuples(bindingsResults: List[(List[StrTermCtxt], A)]) = {
+    def toListOfTuples(bindingsResults: List[(List[StrTermCtxt], A)]) =
       (bindingsResults map (x => x._1)) transpose match {
         case List(a, b, c) => (a, b, c)
-        case List() => (List(), List(), List())
+        case List()        => (List(), List(), List())
       }
-    }
 
-    def collectBindings(bindingsResults: List[(List[StrTermCtxt], A)]) : A = {
-      (bound /: (bindingsResults map (x => x._2)))(
-          (acc : A, binding : A) => acc ++ binding )
-    }
+    def collectBindings(bindingsResults: List[(List[StrTermCtxt], A)]): A =
+      (bound /: (bindingsResults map (x => x._2)))((acc: A, binding: A) => acc ++ binding)
 
     val ptrnTermList = p.listcpattern_.asScala.toList
-    val bindingsResults : List[(List[StrTermCtxt], Set[String])] = ptrnTermList map {
+    val bindingsResults: List[(List[StrTermCtxt], Set[String])] = ptrnTermList map {
       case ptrn: CPattern => {
         val ptrnResult = ptrn.accept(this, bound)
         // an explicit call to Leaf is necessary here, because rather than
         // apply an implicit, instead scala simply infers a useless type for
         // the list, and then fails to compile.
-        val ptrnTerm = ptrnResult._1
-        val newlyBound = ptrnResult._2
-        val productFresh = Leaf(Var(Fresh()))
+        val ptrnTerm       = ptrnResult._1
+        val newlyBound     = ptrnResult._2
+        val productFresh   = Leaf(Var(Fresh()))
         val quotedPtrnTerm = doQuote(ptrnTerm)._1
         (List(ptrnTerm, quotedPtrnTerm, productFresh), newlyBound)
       }
     }
 
-    val pTerm : StrTermCtxt = p.proc_.accept(this, collectBindings(bindingsResults))._1
+    val pTerm: StrTermCtxt = p.proc_.accept(this, collectBindings(bindingsResults))._1
     val (formals, quotedFormals, productFreshes) = {
-      val (formalsUnwrapped, quotedFormalsUnwrapped, productFreshesUnwrapped) = toListOfTuples(bindingsResults)
-      (B(_list, formalsUnwrapped), B(_list, quotedFormalsUnwrapped), B(_list, productFreshesUnwrapped))
+      val (formalsUnwrapped, quotedFormalsUnwrapped, productFreshesUnwrapped) = toListOfTuples(
+        bindingsResults)
+      (B(_list, formalsUnwrapped),
+       B(_list, quotedFormalsUnwrapped),
+       B(_list, productFreshesUnwrapped))
     }
 
-    val consumeTerm = B("consume")(TS, B(_list)( Tag(p.var_) ), B(_list)(quotedFormals), Tag("#t"))
+    val consumeTerm     = B("consume")(TS, B(_list)(Tag(p.var_)), B(_list)(quotedFormals), Tag("#t"))
     val letBindingsTerm = B(_list)(B(_list)(productFreshes), consumeTerm)
-    val bodyTerm = B("")(B("proc")(B(_list)(formals), pTerm), productFreshes)
-    B("")(B(_abs)(B(_list)(Tag("")), B(_run)(B(_compile)(B("let")(B(_list)(letBindingsTerm), bodyTerm)))))
+    val bodyTerm        = B("")(B("proc")(B(_list)(formals), pTerm), productFreshes)
+    B("")(
+      B(_abs)(B(_list)(Tag("")),
+              B(_run)(B(_compile)(B("let")(B(_list)(letBindingsTerm), bodyTerm)))))
   }
 
-  override def visit( p : PNil, arg : A ) : R = {
-    Tag( "#niv" )
-  }
-  override def visit( p : PValue, arg : A ) : R = {
-    p.value_.accept(this, arg )
-  }
-  override def visit( p : PDrop, boundVars : A ) : R = {
+  override def visit(p: PNil, arg: A): R =
+    Tag("#niv")
+  override def visit(p: PValue, arg: A): R =
+    p.value_.accept(this, arg)
+  override def visit(p: PDrop, boundVars: A): R =
     /*
      *  Note that there are at least two different approaches to the
      *  lift/drop semantics. One is to compile the actuals supplied to
@@ -226,21 +229,20 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
      *  recover the code. This technique can be composed with either
      *  of the other two techniques.
      */
-    ( p.chan_ match {
-      case quote : CQuote => {
-        quote.proc_.accept( this, boundVars )
+    (p.chan_ match {
+      case quote: CQuote => {
+        quote.proc_.accept(this, boundVars)
       }
-      case v : CVar => {
+      case v: CVar => {
         if (boundVars(v.var_)) {
-          B( _run )( B( _compile )( Var( v.var_ ) ) )
+          B(_run)(B(_compile)(Var(v.var_)))
         } else {
           throw new UnboundVariable(v.var_, v.line_num, v.col_num)
         }
       }
-    } )
-  }
+    })
 
-  override def visit( p : PLift, arg : A ) : R = {
+  override def visit(p: PLift, arg: A): R = {
     import scala.collection.JavaConverters._
     /*
      *  [| x!( P1, ..., PN ) |]( t )
@@ -249,58 +251,57 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
      */
 
     val actls =
-      ( List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse )(
-        ( acc, e ) => e.accept( this, arg )._1 :: acc
+      (List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse)(
+        (acc, e) => e.accept(this, arg)._1 :: acc
       )
 
-    val cTerm : StrTermCtxt = p.chan_.accept(this, arg )._1
-    B( _produce, TS :: cTerm :: actls )
+    val cTerm: StrTermCtxt = p.chan_.accept(this, arg)._1
+    B(_produce, TS :: cTerm :: actls)
   }
 
-  override def visit( p : PInput, bound : A ) : R = {
+  override def visit(p: PInput, bound: A): R = {
     import scala.collection.JavaConverters._
 
     def forToConsume(bindings: List[Bind]) = {
-      def toListOfTuples(bindingsResults: List[(List[StrTermCtxt], A)]) = {
+      def toListOfTuples(bindingsResults: List[(List[StrTermCtxt], A)]) =
         (bindingsResults map (x => x._1)) transpose match {
           case List(a, b, c, d) => (a, b, c, d)
-          case List() => (List(), List(), List(), List())
+          case List()           => (List(), List(), List(), List())
         }
-      }
 
-      def collectBindings(bindingsResults: List[(List[StrTermCtxt], A)]) : A = {
-        (bound /: (bindingsResults map (x => x._2)))(
-            (acc : A, binding : A) => acc ++ binding )
-      }
+      def collectBindings(bindingsResults: List[(List[StrTermCtxt], A)]): A =
+        (bound /: (bindingsResults map (x => x._2)))((acc: A, binding: A) => acc ++ binding)
 
-      val bindingsResults : List[(List[StrTermCtxt], BoundSet)] = bindings map {
+      val bindingsResults: List[(List[StrTermCtxt], BoundSet)] = bindings map {
         case inBind: InputBind => {
           val chanTerm: StrTermCtxt = inBind.chan_.accept(this, bound)._1
-          val ptrnResult = inBind.cpattern_.accept(this, bound)
+          val ptrnResult            = inBind.cpattern_.accept(this, bound)
           val ptrnTerm: StrTermCtxt = ptrnResult._1
-          val newlyBound = ptrnResult._2
+          val newlyBound            = ptrnResult._2
           // explicit calls to Leaf are necessary here, because rather than
           // apply an implicit, instead scala simply infers a useless type for
           // the list, and then fails to compile.
-          val productFresh = Leaf(Var(Fresh()))
+          val productFresh   = Leaf(Var(Fresh()))
           val quotedPtrnTerm = doQuote(ptrnTerm)._1
           (List(chanTerm, ptrnTerm, quotedPtrnTerm, productFresh), newlyBound)
         }
-        case condBind: CondInputBind => throw new NotImplementedError("TODO: Handle condBind inside consume")
+        case condBind: CondInputBind =>
+          throw new NotImplementedError("TODO: Handle condBind inside consume")
         case bind => throw new UnexpectedBindingType(bind)
       }
-      val procTerm: StrTermCtxt = p.proc_.accept(this, collectBindings(bindingsResults))._1
+      val procTerm: StrTermCtxt                                   = p.proc_.accept(this, collectBindings(bindingsResults))._1
       val (chanTerms, ptrnTerms, quotedPtrnTerms, productFreshes) = toListOfTuples(bindingsResults)
-      val consumeTerm = B("consume")(TS, B(_list, chanTerms), B(_list, quotedPtrnTerms), Tag("#f")) // #f for persistent
-      val wrappedPtrnTerms = ptrnTerms map (x => B(_list)(x))
-      val letBindingsTerm = B(_list)(B(_list, productFreshes), consumeTerm)
-      val bodyTerm = B("")(B("proc")(B(_list)(B(_list, wrappedPtrnTerms)), procTerm), B(_list, productFreshes))
+      val consumeTerm                                             = B("consume")(TS, B(_list, chanTerms), B(_list, quotedPtrnTerms), Tag("#f")) // #f for persistent
+      val wrappedPtrnTerms                                        = ptrnTerms map (x => B(_list)(x))
+      val letBindingsTerm                                         = B(_list)(B(_list, productFreshes), consumeTerm)
+      val bodyTerm =
+        B("")(B("proc")(B(_list)(B(_list, wrappedPtrnTerms)), procTerm), B(_list, productFreshes))
       B("let")(B(_list)(letBindingsTerm), bodyTerm)
     }
 
     p.listbind_.asScala.toList match {
       case Nil => {
-        throw new NoComprehensionBindings( p )
+        throw new NoComprehensionBindings(p)
       }
       case bindings => {
         /*
@@ -316,129 +317,135 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
     }
   }
 
-  override def visit( p : PNew, arg : A ) : R = {
+  override def visit(p: PNew, arg: A): R = {
     import scala.collection.JavaConverters._
-    val newVars = p.listvar_.asScala.toList
-    val newlyBound : A = arg ++ newVars.toSet
-    val pTerm : StrTermCtxt = p.proc_.accept( this, newlyBound )._1
-    val newBindings = newVars.map( { ( v ) => {
-      val fresh = Var(FreshSymbol(v))
-      B(_list)(Var( v ), fresh)
-    } } )
-    B( "let" )( (B(_list, newBindings)), pTerm )
+    val newVars            = p.listvar_.asScala.toList
+    val newlyBound: A      = arg ++ newVars.toSet
+    val pTerm: StrTermCtxt = p.proc_.accept(this, newlyBound)._1
+    val newBindings = newVars.map({ (v) =>
+      {
+        val fresh = Var(FreshSymbol(v))
+        B(_list)(Var(v), fresh)
+      }
+    })
+    B("let")((B(_list, newBindings)), pTerm)
   }
-  override def visit( p : PChoice, arg : A ) : R = {
+  override def visit(p: PChoice, arg: A): R = {
     import scala.collection.JavaConverters._
 
-    def cBranchToParPair( b : CBranch ) = {
+    def cBranchToParPair(b: CBranch) =
       b match {
-        case branch : Choice => {
+        case branch: Choice => {
           // bverity = 1, babsurdity = 0
-          val ( bverity, babsurdity ) = 
-            ( 
-              new PValue( new VQuant( new QInt( 1 ) ) ), 
-              new PValue( new VQuant( new QInt( 0 ) ) ) 
+          val (bverity, babsurdity) =
+            (
+              new PValue(new VQuant(new QInt(1))),
+              new PValue(new VQuant(new QInt(0)))
             )
 
           // bmsg <- bchan
           val bmsgVStr = Fresh()
-          val ( bmsg, bchan ) = 
-            ( new CPtVar( new VarPtVar( bmsgVStr ) ), new CVar( Fresh() ) )
-          val bbind = new InputBind( bmsg, bchan )
+          val (bmsg, bchan) =
+            (new CPtVar(new VarPtVar(bmsgVStr)), new CVar(Fresh()))
+          val bbind = new InputBind(bmsg, bchan)
 
           // lmsg <- lchan
           val lmsgVStr = Fresh()
-          val ( lmsg, lchan ) = 
-            ( new CPtVar( new VarPtVar( lmsgVStr ) ), new CVar( Fresh() ) )
-          val lbind = new InputBind( lmsg, lchan )
+          val (lmsg, lchan) =
+            (new CPtVar(new VarPtVar(lmsgVStr)), new CVar(Fresh()))
+          val lbind = new InputBind(lmsg, lchan)
 
           val balertActls = new ListProc()
-          balertActls.add( babsurdity )
+          balertActls.add(babsurdity)
 
           // case 1 => P_i | lchan!(0)
           val bvericase =
-            new PatternMatch( new PPtVal( new VPtInt( 1 ) ), new PPar(branch.proc_, new PLift( lchan, balertActls )))
+            new PatternMatch(new PPtVal(new VPtInt(1)),
+                             new PPar(branch.proc_, new PLift(lchan, balertActls)))
 
           // case 0 => lchan!( 0 )
           val babsucase =
-            new PatternMatch( 
-              new PPtVal( new VPtInt( 0 ) ), 
-              new PLift( lchan, balertActls ) 
+            new PatternMatch(
+              new PPtVal(new VPtInt(0)),
+              new PLift(lchan, balertActls)
             )
-         
+
           val bcases = new ListPMBranch()
-          bcases.add( bvericase )
-          bcases.add( babsucase )
+          bcases.add(bvericase)
+          bcases.add(babsucase)
 
           val bsatActls = new ListProc()
-          bsatActls.add( new PValue( new VQuant( new QInt( 1 ) ) ) )
+          bsatActls.add(new PValue(new VQuant(new QInt(1))))
 
           val blocks = new ListBind()
-          blocks.add( bbind )
-          blocks.add( lbind )
+          blocks.add(bbind)
+          blocks.add(lbind)
 
-          val bmatch = new PMatch( new PValue( new VQuant( new QVar( lmsgVStr ) ) ), bcases )
+          val bmatch = new PMatch(new PValue(new VQuant(new QVar(lmsgVStr))), bcases)
 
-          val bpair = 
+          val bpair =
             new PPar(
               // for( binding_i ){ bchan!( 1 ) }
-              new PInput( branch.listbind_, new PLift( bchan, bsatActls ) ),
+              new PInput(branch.listbind_, new PLift(bchan, bsatActls)),
               // for( bmsg <- bchan; lmsg <- lchan ){
               //   match lmsg with
               //    case 1 => P_i | lchan!(0)
               //    case 0 => lchan!( 0 )
-              // }          
-              new PInput( blocks, bmatch )
+              // }
+              new PInput(blocks, bmatch)
             )
 
-          ( bchan, bpair )
+          (bchan, bpair)
         }
         case _ => {
-          throw new UnexpectedBranchType( b )
+          throw new UnexpectedBranchType(b)
         }
       }
-    }
 
     p.listcbranch_.asScala.toList match {
       // select {} = Nil
       case Nil => {
-        Tag( "#niv" )
+        Tag("#niv")
       }
       // select { case bindings => P } = for( bindings )P
-      case ( branch : Choice ) :: Nil => {
-        visit( new PInput( branch.listbind_, branch.proc_ ), arg )
+      case (branch: Choice) :: Nil => {
+        visit(new PInput(branch.listbind_, branch.proc_), arg)
       }
       /*
        * select { case bindings1 => P1; ...; case bindingsN => PN }
        * =
-       * new b1, ..., bN, lock in 
+       * new b1, ..., bN, lock in
        *   lock!( true )
-       *   | for( bindings1 ){ b1!( true ) } 
-       *   | for( b <- b1; l <- lock ){ 
-       *      match l with 
+       *   | for( bindings1 ){ b1!( true ) }
+       *   | for( b <- b1; l <- lock ){
+       *      match l with
        *       case true => P1 | lock!(false)
        *       case false => lock!( false )
        *     }
        *    ...
-       *   | for( bindingsN ){ bN!( true ) } 
-       *   | for( b <- b1; l <- lock ){ 
-       *      match l with 
+       *   | for( bindingsN ){ bN!( true ) }
+       *   | for( b <- b1; l <- lock ){
+       *      match l with
        *       case true => P1 | lock!(false)
        *       case false => lock!( false )
        *     }
        */
       case branches => {
-        val ( bvars, bpar :: rbpars ) = branches.map( cBranchToParPair ).unzip
-        val bigbpar = ( bpar /: rbpars )( { ( acc, e ) => { new PPar( acc, e ) } } )
+        val (bvars, bpar :: rbpars) = branches.map(cBranchToParPair).unzip
+        val bigbpar = (bpar /: rbpars)({ (acc, e) =>
+          { new PPar(acc, e) }
+        })
         val bnewVars = new ListVar()
-        bvars.map( { ( bvar ) => { bnewVars.add( bvar.var_ ) } } )
+        bvars.map({ (bvar) =>
+          { bnewVars.add(bvar.var_) }
+        })
 
-        visit( new PNew( bnewVars, bigbpar ), arg )
+        visit(new PNew(bnewVars, bigbpar), arg)
       }
     }
   }
 
-  override def visit( p : PMatch, arg : A ) : R = {
+  override def visit(p: PMatch, arg: A): R = {
     import scala.collection.JavaConverters._
     /*
      *  match <var> with
@@ -461,16 +468,16 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
     def patternMatchVisitAux: R = {
       val reverseListPMBranch = p.listpmbranch_.asScala.toList.reverse
       // We return the result of this fold
-      (nonExhaustiveMatch /: reverseListPMBranch) {
-        (acc, e) => {
+      (nonExhaustiveMatch /: reverseListPMBranch) { (acc, e) =>
+        {
           e match {
             case pm: PatternMatch => {
-              val patternResult: R = pm.ppattern_.accept(this, arg)
-              val pattern: StrTermCtxt = patternResult._1
-              val qPattern: StrTermCtxt = doQuote(pattern)._1
+              val patternResult: R          = pm.ppattern_.accept(this, arg)
+              val pattern: StrTermCtxt      = patternResult._1
+              val qPattern: StrTermCtxt     = doQuote(pattern)._1
               val patternBindings: BoundSet = arg ++ patternResult._2
               val continuation: StrTermCtxt = pm.proc_.accept(this, patternBindings)._1
-              val remainder: StrTermCtxt = acc
+              val remainder: StrTermCtxt    = acc
               if (isWild(pm.ppattern_)) {
                 // Assumes VarPtWild comes at the end of a list of case statements
                 continuation
@@ -498,35 +505,33 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
     patternMatchVisitAux
   }
 
-  def isWild(p: PPattern): Boolean = {
+  def isWild(p: PPattern): Boolean =
     p match {
       case pPtVar: PPtVar => {
         pPtVar.varpattern_ match {
-          case wild : VarPtWild => true
-          case _ => false
+          case wild: VarPtWild => true
+          case _               => false
         }
       }
       case _ => false
     }
-  }
 
-  def hasVariable(p: PPattern): Boolean = {
+  def hasVariable(p: PPattern): Boolean =
     // TODO: Fill in rest of cases
     p match {
-      case pPtVar : PPtVar => true
-      case pPtVal : PPtVal => hasVariable( pPtVal.valpattern_ )
+      case pPtVar: PPtVar => true
+      case pPtVal: PPtVal => hasVariable(pPtVal.valpattern_)
     }
-  }
 
-  def hasVariable(p: ValPattern) : Boolean = {
+  def hasVariable(p: ValPattern): Boolean = {
     import scala.collection.JavaConverters._
     p match {
       case vPtTuple: VPtTuple => vPtTuple.listppattern_.asScala.toList.exists(hasVariable)
-      case _ => false
+      case _                  => false
     }
   }
 
-  override def visit( p : PConstr, arg : A ) : R = {
+  override def visit(p: PConstr, arg: A): R = {
     import scala.collection.JavaConverters._
     /*
      *  [| <Name>( P1, ..., PN ) |]( t )
@@ -534,219 +539,194 @@ extends AllVisitor[VisitorTypes.R,VisitorTypes.A] {
      *  ( <Name> [| P1 |]( t ) ... [| PN |]( t ) )
      */
     val actls =
-      ( List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse )(
-        ( acc, e ) => e.accept( this, arg )._1 :: acc
+      (List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse)(
+        (acc, e) => e.accept(this, arg)._1 :: acc
       )
 
-    B( _produce, TS :: Leaf(Var(p.var_)) :: actls)
+    B(_produce, TS :: Leaf(Var(p.var_)) :: actls)
   }
 
-  override def visit( p : PPar, arg : A ) : R = {
+  override def visit(p: PPar, arg: A): R = {
     // TODO: Collect all processes at the same level and place them in a single block.
     /*
-     * [| P1 | P2 |]( t ) 
+     * [| P1 | P2 |]( t )
      * =
      * ( block [| P1 |]( t ) [| P2 |]( t ) )
      */
-    val pTerm1 : StrTermCtxt = p.proc_1.accept(this, arg)._1
-    val pTerm2 : StrTermCtxt = p.proc_2.accept(this, arg)._1
-    B( _block )( pTerm1, pTerm2 )
+    val pTerm1: StrTermCtxt = p.proc_1.accept(this, arg)._1
+    val pTerm2: StrTermCtxt = p.proc_2.accept(this, arg)._1
+    B(_block)(pTerm1, pTerm2)
   }
 
   /* Chan */
-  override def visit( p : CVar, boundVars : A ) : R = {
+  override def visit(p: CVar, boundVars: A): R =
     if (boundVars(p.var_)) {
       Var(p.var_)
     } else {
       throw new UnboundVariable(p.var_, p.line_num, p.col_num)
     }
-  }
-  override def visit( p : CQuote, arg : A ) : R = {
+  override def visit(p: CQuote, arg: A): R =
     // TODO: Handle quoting and unquoting
     p.proc_.accept(this, arg)
-  }
   /* Bind */
   // def visit( b : Bind, arg : A ) : R
-  override def visit( p : InputBind, arg : A ) : R = {
+  override def visit(p: InputBind, arg: A): R =
     throw new InternalCompilerError("Input bindings should not be visited directly.")
-  }
   /* CBranch */
 
   /* Value */
-  override def visit( p : VQuant, arg : A ) : R = {
-    p.quantity_.accept(this, arg )
-  }
+  override def visit(p: VQuant, arg: A): R =
+    p.quantity_.accept(this, arg)
   /* Quantity */
-  override def visit( p : QVar, boundVars : A ) : R = {
+  override def visit(p: QVar, boundVars: A): R =
     if (boundVars(p.var_)) {
       Var(p.var_)
     } else {
       throw new UnboundVariable(p.var_, p.line_num, p.col_num)
     }
-  }
-  override def visit( p : QInt, arg : A ) : R = {
-    Tag( s"""${p.integer_}""")
-  }
-  override def visit( p : QDouble, arg : A ) : R = {
-    Tag( s"""${p.double_}""")
-  }
-  override def visit( p : QBool, arg : A) : R = {
+  override def visit(p: QInt, arg: A): R =
+    Tag(s"""${p.integer_}""")
+  override def visit(p: QDouble, arg: A): R =
+    Tag(s"""${p.double_}""")
+  override def visit(p: QBool, arg: A): R =
     p.rhobool_.accept(this, arg)
-  }
-  override def visit( p : QTrue, arg : A) : R = {
-    Tag( s"""#t""")
-  }
-  override def visit( p : QFalse, arg : A) : R = {
-    Tag( s"""#f""")
-  }
-  override def visit( p : QString, arg : A ) : R = {
-    Tag( s""""${p.string_}"""" )
-  }
-  override def visit( p : QMap, arg : A) : R = {
-    Tag( s"""(new RblTable)""")
-  }
-  override def visit( p : QDot, arg : A) : R = {
+  override def visit(p: QTrue, arg: A): R =
+    Tag(s"""#t""")
+  override def visit(p: QFalse, arg: A): R =
+    Tag(s"""#f""")
+  override def visit(p: QString, arg: A): R =
+    Tag(s""""${p.string_}"""")
+  override def visit(p: QMap, arg: A): R =
+    Tag(s"""(new RblTable)""")
+  override def visit(p: QDot, arg: A): R = {
     import scala.collection.JavaConverters._
 
     /* [[ quantity ]].method_name( [ [[ quantity_arg1 ]], [[ quantity_arg2 ]], ... ] )
      * =
      * (method_name quantity quantity_arg1 quantity_arg2)
      */
-    val q : StrTermCtxt = p.quantity_.accept(this, arg)._1
+    val q: StrTermCtxt = p.quantity_.accept(this, arg)._1
     val qArgs =
-      ( List[StrTermCtxt]() /: p.listquantity_.asScala.toList.reverse )(
-        ( acc, e ) => e.accept(this, arg)._1 :: acc
+      (List[StrTermCtxt]() /: p.listquantity_.asScala.toList.reverse)(
+        (acc, e) => e.accept(this, arg)._1 :: acc
       )
-    B("", Var(s"""${p.var_}""") :: q :: qArgs )
+    B("", Var(s"""${p.var_}""") :: q :: qArgs)
   }
-  override def visit( p : QNeg, arg : A) : R = {
-    val q : StrTermCtxt = p.quantity_.accept(this, arg)._1
+  override def visit(p: QNeg, arg: A): R = {
+    val q: StrTermCtxt = p.quantity_.accept(this, arg)._1
     B("-")(q)
   }
-  override def visit( p : QMult, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("*")(q1,q2)
+  override def visit(p: QMult, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("*")(q1, q2)
   }
-  override def visit( p : QDiv, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("/")(q1,q2)
+  override def visit(p: QDiv, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("/")(q1, q2)
   }
-  override def visit( p : QAdd, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("+")(q1,q2)
+  override def visit(p: QAdd, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("+")(q1, q2)
   }
-  override def visit( p : QLt, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("<")(q1,q2)
+  override def visit(p: QLt, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("<")(q1, q2)
   }
-  override def visit( p : QLte, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("<=")(q1,q2)
+  override def visit(p: QLte, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("<=")(q1, q2)
   }
-  override def visit( p : QGt, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B(">")(q1,q2)
+  override def visit(p: QGt, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B(">")(q1, q2)
   }
-  override def visit( p : QGte, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B(">=")(q1,q2)
+  override def visit(p: QGte, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B(">=")(q1, q2)
   }
-  override def visit( p : QEq, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("=")(q1,q2)
+  override def visit(p: QEq, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("=")(q1, q2)
   }
-  override def visit( p : QNeq, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("!=")(q1,q2)
+  override def visit(p: QNeq, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("!=")(q1, q2)
   }
-  override def visit( p : QMinus, arg : A) : R = {
-    val q1 : StrTermCtxt = p.quantity_1.accept(this, arg)._1
-    val q2 : StrTermCtxt = p.quantity_2.accept(this, arg)._1
-    B("-")(q1,q2)
+  override def visit(p: QMinus, arg: A): R = {
+    val q1: StrTermCtxt = p.quantity_1.accept(this, arg)._1
+    val q2: StrTermCtxt = p.quantity_2.accept(this, arg)._1
+    B("-")(q1, q2)
   }
 
   /* Entity */
-  override def visit( p : EChar, arg : A ) : R = {
-    Tag( s"""'${p.char_}'""")
-  }
-  override def visit( p : ETuple, arg : A ) : R = {
+  override def visit(p: EChar, arg: A): R =
+    Tag(s"""'${p.char_}'""")
+  override def visit(p: ETuple, arg: A): R = {
     import scala.collection.JavaConverters._
     val procTerms =
-      ( List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse )(
-        ( acc, e ) => e.accept(this, arg)._1 :: acc
+      (List[StrTermCtxt]() /: p.listproc_.asScala.toList.reverse)(
+        (acc, e) => e.accept(this, arg)._1 :: acc
       )
-    B( _list, procTerms )
+    B(_list, procTerms)
   }
 
   /* Pattern */
-  override def visit(p: VarPtVar, arg: A): R = {
+  override def visit(p: VarPtVar, arg: A): R =
     // A variable in a pattern produces a new binding.
     (Var(p.var_), arg + p.var_)
-  }
-  override def visit( p : VarPtWild, arg : A ) : R = {
+  override def visit(p: VarPtWild, arg: A): R =
     (Var("**wildcard**"), arg)
-  }
 
   /* PPattern */
-  override def visit( p : PPtVar, arg : A ) : R = {
+  override def visit(p: PPtVar, arg: A): R =
     p.varpattern_.accept(this, arg)
-  }
-  override def visit( p : PPtVal, arg : A ) : R = {
+  override def visit(p: PPtVal, arg: A): R =
     p.valpattern_.accept(this, arg)
-  }
 
   /* CPattern */
-  override def visit(p: CPtVar, arg: A): R = {
+  override def visit(p: CPtVar, arg: A): R =
     p.varpattern_.accept(this, arg)
-  }
   /* ValPattern */
-  override def visit( p : VPtTuple, arg : A ) : R = {
+  override def visit(p: VPtTuple, arg: A): R = {
     import scala.collection.JavaConverters._
 
-    val tupleContents : (List[StrTermCtxt], BoundSet) =
-      ( (List[StrTermCtxt](), Set[String]()) /: p.listppattern_.asScala.toList.reverse )(
-        ( acc, e ) => {
+    val tupleContents: (List[StrTermCtxt], BoundSet) =
+      ((List[StrTermCtxt](), Set[String]()) /: p.listppattern_.asScala.toList.reverse)(
+        (acc, e) => {
           val result = e.accept(this, arg)
           (result._1 :: acc._1, result._2 ++ acc._2)
         }
       )
-    (B( _list, tupleContents._1 ), tupleContents._2)
+    (B(_list, tupleContents._1), tupleContents._2)
   }
-  override def visit( p : VPtStr, arg : A ) : R = {
-    Tag( s""""${p.string_}"""" )
-  }
-  override def visit( p : VPtTrue, arg: A ): R = {
-    (Tag( s"""#t"""), arg)
-  }
-  override def visit( p : VPtFalse, arg: A ): R = {
-    (Tag( s"""#f"""), arg)
-  }
-  override def visit( p : VPtInt, arg: A ): R = {
-    (Tag( s"""${p.integer_}"""), arg)
-  }
-  override def visit( p : VPtDbl, arg: A ): R = {
-    (Tag( s"""${p.double_}"""), arg)
-  }
-  override def visit( p : VPtNegInt, arg: A ): R = {
-    (Tag( s"""-${p.integer_}"""), arg)
-  }
-  override def visit( p : VPtNegDbl, arg: A ): R = {
-    (Tag( s"""-${p.double_}"""), arg)
-  }
+  override def visit(p: VPtStr, arg: A): R =
+    Tag(s""""${p.string_}"""")
+  override def visit(p: VPtTrue, arg: A): R =
+    (Tag(s"""#t"""), arg)
+  override def visit(p: VPtFalse, arg: A): R =
+    (Tag(s"""#f"""), arg)
+  override def visit(p: VPtInt, arg: A): R =
+    (Tag(s"""${p.integer_}"""), arg)
+  override def visit(p: VPtDbl, arg: A): R =
+    (Tag(s"""${p.double_}"""), arg)
+  override def visit(p: VPtNegInt, arg: A): R =
+    (Tag(s"""-${p.integer_}"""), arg)
+  override def visit(p: VPtNegDbl, arg: A): R =
+    (Tag(s"""-${p.double_}"""), arg)
 
-  override def visit( p: CPtQuote, arg: A ): R = ???
-  override def visit( p: Choice, arg: A ): R = ???
-  override def visit( p: DContr, arg: A ): R = ???
-  override def visit( p: CValPtrn, arg: A ): R = ???
-  override def visit( p: PatternMatch, arg: A ): R = ???
-  override def visit( p: CondInputBind, arg: A ): R = ???
+  override def visit(p: CPtQuote, arg: A): R      = ???
+  override def visit(p: Choice, arg: A): R        = ???
+  override def visit(p: DContr, arg: A): R        = ???
+  override def visit(p: CValPtrn, arg: A): R      = ???
+  override def visit(p: PatternMatch, arg: A): R  = ???
+  override def visit(p: CondInputBind, arg: A): R = ???
 }

--- a/rholang/src/main/scala/rholang/rosette/RoselangTerm.scala
+++ b/rholang/src/main/scala/rholang/rosette/RoselangTerm.scala
@@ -1,21 +1,19 @@
 /**
   * Term classes specifically used in Rholang to Rosette Base Language source to source compiler. *
   */
-
 package coop.rchain.rho2rose
 
 import coop.rchain.lib.term._
 
 trait RosetteSerialization[Namespace, VarType, TagType] {
-  def rosetteSerializeOperation: String = {
+  def rosetteSerializeOperation: String =
     this match {
-      case leaf: StrTermPtdCtxtLf => ""
+      case leaf: StrTermPtdCtxtLf   => ""
       case branch: StrTermPtdCtxtBr => branch.rosetteSerializeOperation
-      case _ => throw new Exception("unexpected CCL type")
+      case _                        => throw new Exception("unexpected CCL type")
     }
-  }
 
-  def rosetteSerialize: String = {
+  def rosetteSerialize: String =
     this match {
       case leaf: StrTermPtdCtxtLf =>
         leaf.rosetteSerialize
@@ -23,22 +21,24 @@ trait RosetteSerialization[Namespace, VarType, TagType] {
         branch.rosetteSerialize
       case _ => throw new Exception("unexpected CCL type")
     }
-  }
 }
 
 case class StrTermPtdCtxtLf(override val tag: TagOrVar[String, String])
-  extends TermCtxtLeaf[String, String, String](tag) with RosetteSerialization[String, String, String] {
-  override def rosetteSerialize: String = {
+    extends TermCtxtLeaf[String, String, String](tag)
+    with RosetteSerialization[String, String, String] {
+  override def rosetteSerialize: String =
     tag match {
       case Tag(t) => "" + t
       case Var(v) => "" + v
     }
-  }
 }
 
-case class StrTermPtdCtxtBr(override val nameSpace: String,
-                            override val labels: List[TermCtxt[String, String, String] with RosetteSerialization[String, String, String]]
-                           ) extends TermCtxtBranch[String, String, String](nameSpace, labels) with RosetteSerialization[String, String, String] {
+case class StrTermPtdCtxtBr(
+    override val nameSpace: String,
+    override val labels: List[
+      TermCtxt[String, String, String] with RosetteSerialization[String, String, String]])
+    extends TermCtxtBranch[String, String, String](nameSpace, labels)
+    with RosetteSerialization[String, String, String] {
   override def rosetteSerializeOperation: String = {
     val result = labels match {
       case (albl: StrTermPtdCtxtBr) :: rlbls => {
@@ -48,18 +48,18 @@ case class StrTermPtdCtxtBr(override val nameSpace: String,
         } else {
           ""
         }
-        (seed /: rlbls) (
-          {
-            (acc, lbl) => {
+        (seed /: rlbls)(
+          { (acc, lbl) =>
+            {
               acc + lbl.rosetteSerializeOperation
             }
           }
         )
       }
       case _ :: rlbls => {
-        ("" /: rlbls) (
-          {
-            (acc, lbl) => {
+        ("" /: rlbls)(
+          { (acc, lbl) =>
+            {
               acc + lbl.rosetteSerializeOperation
             }
           }
@@ -76,14 +76,15 @@ case class StrTermPtdCtxtBr(override val nameSpace: String,
         case _ :: _ => {
           var acc = ""
 
-
-          def serializeExpr(lbl: TermCtxt[String, String, String] with RosetteSerialization[String, String, String], i: Int) = {
+          def serializeExpr(lbl: TermCtxt[String, String, String] with RosetteSerialization[String,
+                                                                                            String,
+                                                                                            String],
+                            i: Int) =
             if (i == 0) {
               acc = lbl.rosetteSerialize
             } else {
               acc = acc + " " + lbl.rosetteSerialize
             }
-          }
 
           for ((lbl, i) <- labels.zipWithIndex) {
             serializeExpr(lbl, i)

--- a/storage/src/main/scala/coop/rchain/storage/regex/Multiplier.scala
+++ b/storage/src/main/scala/coop/rchain/storage/regex/Multiplier.scala
@@ -6,11 +6,11 @@ package coop.rchain.storage.regex
 private[regex] object Multiplier {
   val Inf: Option[Int] = None
 
-  val presetZero: Multiplier = Multiplier(Some(0), Some(0))
+  val presetZero: Multiplier     = Multiplier(Some(0), Some(0))
   val presetQuestion: Multiplier = Multiplier(Some(0), Some(1))
-  val presetOne: Multiplier = Multiplier(Some(1), Some(1))
-  val presetStar: Multiplier = Multiplier(Some(0), Inf)
-  val presetPlus: Multiplier = Multiplier(Some(1), Inf)
+  val presetOne: Multiplier      = Multiplier(Some(1), Some(1))
+  val presetStar: Multiplier     = Multiplier(Some(0), Inf)
+  val presetPlus: Multiplier     = Multiplier(Some(1), Inf)
 
   def apply(min: Int, max: Int): Multiplier = new Multiplier(Some(min), Some(max))
 
@@ -106,7 +106,7 @@ final case class Multiplier(min: Option[Int], max: Option[Int]) {
     */
   def common(that: Multiplier): Multiplier = {
     val newMandatory = minVal(mandatory, that.mandatory)
-    val newOptional = minVal(optional, that.optional)
+    val newOptional  = minVal(optional, that.optional)
     Multiplier(newMandatory, newMandatory + newOptional)
   }
 
@@ -165,7 +165,7 @@ final case class Multiplier(min: Option[Int], max: Option[Int]) {
     if (first >= second) first else second
 
   def mandatory: Option[Int] = min
-  def optional: Option[Int] = max - min
+  def optional: Option[Int]  = max - min
 
   override def toString: String = (min, max) match {
     case (Some(x), Some(0))           => s"{$x,0}"
@@ -215,7 +215,7 @@ final case class Multiplier(min: Option[Int], max: Option[Int]) {
     */
   def -(that: Multiplier): Multiplier = {
     val diffMandatory = mandatory - that.mandatory
-    val diffOptional = optional - that.optional
+    val diffOptional  = optional - that.optional
     Multiplier(diffMandatory, diffMandatory + diffOptional)
   }
 

--- a/storage/src/main/scala/coop/rchain/storage/regex/RegexPattern.scala
+++ b/storage/src/main/scala/coop/rchain/storage/regex/RegexPattern.scala
@@ -195,7 +195,7 @@ private[regex] object RangeState extends Enumeration {
   * Companion object for the CharClassPattern, used only for easy testing
   */
 object CharClassPattern extends ParsedPattern {
-  def apply(charSet: String): CharClassPattern = new CharClassPattern(charSet.toSet)
+  def apply(charSet: String): CharClassPattern    = new CharClassPattern(charSet.toSet)
   def apply(charSet: Seq[Char]): CharClassPattern = new CharClassPattern(charSet.toSet)
   def apply(charSet: Set[Char]): CharClassPattern = new CharClassPattern(charSet)
   def apply(charSet: String, negateCharSet: Boolean): CharClassPattern =
@@ -472,15 +472,15 @@ final case class CharClassPattern(charSet: Set[Char], negateCharSet: Boolean = f
 
     def unknownSetToString: String = {
       def listToString(lst: List[Char]): String = lst.size match {
-        case 0 => ""
-        case 1 => singleCharToString(lst.head)
+        case 0     => ""
+        case 1     => singleCharToString(lst.head)
         case 2 | 3 =>
           //sequence like "abc", no sense to convert to "a-c"
           lst.map(singleCharToString).mkString
         case _ =>
           //sequence of 4 chars or more "abcd" -> "a-d"
           val startChar = singleCharToString(lst.last)
-          val endChar = singleCharToString(lst.head)
+          val endChar   = singleCharToString(lst.head)
           s"$startChar-$endChar"
       }
 
@@ -646,7 +646,7 @@ object ConcPattern extends ParsedPattern {
       MultPattern.tryParse(str.subSequence(startPosition, str.length)) match {
         case Some((mult, pos)) => {
           val nextMults = mult :: parsed
-          val nextPos = startPosition + pos
+          val nextPos   = startPosition + pos
           if (nextPos < str.length) {
             //we have one more alternation option
             parseRecursive(nextPos, nextMults)
@@ -738,7 +738,7 @@ final case class ConcPattern(mults: List[MultPattern]) extends RegexPattern {
 }
 
 object AltPattern extends ParsedPattern {
-  def apply(pattern: ConcPattern): AltPattern = new AltPattern(Set(pattern))
+  def apply(pattern: ConcPattern): AltPattern        = new AltPattern(Set(pattern))
   def apply(patterns: List[ConcPattern]): AltPattern = new AltPattern(patterns.toSet)
   def apply(patterns: CharClassPattern*): AltPattern =
     new AltPattern(patterns.map(cp => ConcPattern(cp)).toSet)
@@ -749,7 +749,7 @@ object AltPattern extends ParsedPattern {
       ConcPattern.tryParse(str.subSequence(startPosition, str.length)) match {
         case Some((conc, pos)) => {
           val nextConcs = conc :: parsed
-          val nextPos = startPosition + pos
+          val nextPos   = startPosition + pos
           if ((nextPos < str.length) && (str.charAt(nextPos) == '|')) {
             //we have one more alternation option
             parseRecursive(nextPos + 1, nextConcs)

--- a/storage/src/test/scala/coop/rchain/storage/regex/FsmUnitTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/regex/FsmUnitTests.scala
@@ -6,43 +6,45 @@ import org.scalatest.{FlatSpec, Matchers}
 class FsmUnitTests extends FlatSpec with Matchers {
   val _ob: Int = -5
 
-  def createFsmA : Fsm = Fsm(
-      Set('a', 'b'),
-      Set(0, 1, _ob),
-      0,
-      Set(1),
-      Map(
-        0 -> Map('a' -> 1, 'b' -> _ob),
-        1 -> Map('a' -> _ob, 'b' -> _ob),
-        _ob -> Map('a' -> _ob, 'b' -> _ob)
-      )
-    )
-
-  def createFsmB : Fsm = Fsm(
+  def createFsmA: Fsm = Fsm(
     Set('a', 'b'),
     Set(0, 1, _ob),
     0,
     Set(1),
     Map(
-      0 -> Map('a' -> _ob, 'b' -> 1),
-      1 -> Map('a' -> _ob, 'b' -> _ob),
+      0   -> Map('a' -> 1, 'b'   -> _ob),
+      1   -> Map('a' -> _ob, 'b' -> _ob),
       _ob -> Map('a' -> _ob, 'b' -> _ob)
     )
   )
 
-  def createFsmAbc : Fsm = Fsm(
-    Set('a', 'b', 'c'),
-    Set(0, 1, 2, 3, _ob),
+  def createFsmB: Fsm = Fsm(
+    Set('a', 'b'),
+    Set(0, 1, _ob),
     0,
-    Set(3),
+    Set(1),
     Map(
-      0 -> Map('a' -> 1, 'b' -> _ob, 'c' -> _ob),
-      1 -> Map('a' -> _ob, 'b' -> 2, 'c' -> _ob),
-      2 -> Map('a' -> _ob, 'b' -> _ob, 'c' -> 3),
-      3 -> Map('a' -> _ob, 'b'-> _ob, 'c' -> _ob)
-    ))
+      0   -> Map('a' -> _ob, 'b' -> 1),
+      1   -> Map('a' -> _ob, 'b' -> _ob),
+      _ob -> Map('a' -> _ob, 'b' -> _ob)
+    )
+  )
 
-  def createBrzozowski : Fsm = Fsm(
+  def createFsmAbc: Fsm =
+    Fsm(
+      Set('a', 'b', 'c'),
+      Set(0, 1, 2, 3, _ob),
+      0,
+      Set(3),
+      Map(
+        0 -> Map('a' -> 1, 'b'   -> _ob, 'c' -> _ob),
+        1 -> Map('a' -> _ob, 'b' -> 2, 'c'   -> _ob),
+        2 -> Map('a' -> _ob, 'b' -> _ob, 'c' -> 3),
+        3 -> Map('a' -> _ob, 'b' -> _ob, 'c' -> _ob)
+      )
+    )
+
+  def createBrzozowski: Fsm = Fsm(
     Set('a', 'b'),
     Set(0, 1, 2, 3, 4),
     0,
@@ -78,20 +80,23 @@ class FsmUnitTests extends FlatSpec with Matchers {
     val epsilonFsmAB = Fsm.epsilonFsm(Set('a', 'b'))
     assert(!epsilonFsmAB.isEmpty)
 
-    assert(Fsm(Set(), Set(0, 1), 0, Set(1), Map(0 -> Map(), 1 -> Map()))
-      .isEmpty)
+    assert(Fsm(Set(), Set(0, 1), 0, Set(1), Map(0 -> Map(), 1 -> Map())).isEmpty)
 
     assert(!Fsm(Set(), Set(0), 0, Set(0), Map(0 -> Map())).isEmpty)
 
-    assert(Fsm(Set(), Set(0,1), 1, Set(0), Map(0 -> Map())).isEmpty)
+    assert(Fsm(Set(), Set(0, 1), 1, Set(0), Map(0 -> Map())).isEmpty)
 
-    assert(Fsm(Set('a', 'b'), Set(0, 1, _ob, 2), 0, Set(2),
-      Map(
-        0 -> Map('a' -> 1, 'b' -> 1),
-        1 -> Map('a' -> _ob, 'b' -> _ob),
-        _ob -> Map('a' -> _ob, 'b' -> _ob),
-        2 -> Map('a' -> _ob, 'b' -> _ob),
-      )).isEmpty)
+    assert(
+      Fsm(Set('a', 'b'),
+          Set(0, 1, _ob, 2),
+          0,
+          Set(2),
+          Map(
+            0   -> Map('a' -> 1, 'b'   -> 1),
+            1   -> Map('a' -> _ob, 'b' -> _ob),
+            _ob -> Map('a' -> _ob, 'b' -> _ob),
+            2   -> Map('a' -> _ob, 'b' -> _ob),
+          )).isEmpty)
   }
 
   "Null FSM" should "behave as expected" in {
@@ -117,11 +122,14 @@ class FsmUnitTests extends FlatSpec with Matchers {
     val fsmE2 = Fsm(Set(), Set(0), 0, Set(0), Map(0 -> Map()))
     assert(!fsmE2.isEmpty)
 
-    val fsmE3 = Fsm(Set('a', 'b'), Set(0, 1, _ob, 2), 0, Set(2), Map(
-      0 -> Map('a' -> 1, 'b' -> 1),
-      1 -> Map('a' -> _ob, 'b' -> _ob),
-      _ob -> Map('a' -> _ob, 'b' -> _ob),
-      2 -> Map('a' -> _ob, 'b' -> _ob)))
+    val fsmE3 = Fsm(Set('a', 'b'),
+                    Set(0, 1, _ob, 2),
+                    0,
+                    Set(2),
+                    Map(0   -> Map('a' -> 1, 'b'   -> 1),
+                        1   -> Map('a' -> _ob, 'b' -> _ob),
+                        _ob -> Map('a' -> _ob, 'b' -> _ob),
+                        2   -> Map('a' -> _ob, 'b' -> _ob)))
 
     assert(fsmE3.isEmpty)
   }
@@ -171,7 +179,7 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Reversed Epsilon" should "stay Epsilon" in {
-    val epsA = Fsm.epsilonFsm(Set('a'))
+    val epsA    = Fsm.epsilonFsm(Set('a'))
     val revEpsA = epsA.reversed
     assert(revEpsA.accepts(""))
   }
@@ -189,11 +197,11 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Anything Else" should "be accepted" in {
     val fsm = Fsm(
-      Set('a','b', 'c', Fsm.anythingElse),
+      Set('a', 'b', 'c', Fsm.anythingElse),
       Set(1),
       1,
       Set(1),
-      Map(1 -> Map('a' -> 1, 'b'->1, 'c'->1, Fsm.anythingElse -> 1))
+      Map(1 -> Map('a' -> 1, 'b' -> 1, 'c' -> 1, Fsm.anythingElse -> 1))
     )
 
     assert(fsm.accepts("a"))
@@ -210,15 +218,16 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * Finally, the oblivion state should be omitted.
     */
   "Crawl reduction" should "do it's job" in {
-    val merged = Fsm(Set('0', '1'),
+    val merged = Fsm(
+      Set('0', '1'),
       Set(1, 2, 3, 4, _ob),
       1,
       Set(4),
-      Map(1 -> Map('0' -> 2, '1' -> 4),
-        2 -> Map('0' -> 3, '1' -> 4),
-        3 -> Map('0' -> 3, '1' -> 4),
-        4 -> Map('0' -> _ob, '1' -> _ob),
-        _ob -> Map('0' -> _ob, '1' -> _ob))
+      Map(1   -> Map('0' -> 2, '1'   -> 4),
+          2   -> Map('0' -> 3, '1'   -> 4),
+          3   -> Map('0' -> 3, '1'   -> 4),
+          4   -> Map('0' -> _ob, '1' -> _ob),
+          _ob -> Map('0' -> _ob, '1' -> _ob))
     )
 
     assert(merged.reversed.states.size == 2)
@@ -244,13 +253,10 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Reduce" should "remove unreachable states" in {
     val fsm = Fsm(Set('a'),
-      Set(0, 1, 2),
-      0,
-      Set(1),
-      Map(0 -> Map('a' -> 2),
-        1 -> Map('a' -> 2),
-        2 -> Map('a' -> 2)
-      ))
+                  Set(0, 1, 2),
+                  0,
+                  Set(1),
+                  Map(0 -> Map('a' -> 2), 1 -> Map('a' -> 2), 2 -> Map('a' -> 2)))
 
     assert(fsm.isEmpty)
     assert(!fsm.accepts("a"))
@@ -318,18 +324,26 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * original greenery test named: "test_addbug"
     */
   "Concatenate [bc]*c" should "work" in {
-    val fsm1 = Fsm(Set('a', 'b', 'c', Fsm.anythingElse),
-      Set(0, 1), 1, Set(1), Map(
-        0 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 0, 'c' -> 0),
-        1 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 1, 'c' -> 1)))
+    val fsm1 = Fsm(
+      Set('a', 'b', 'c', Fsm.anythingElse),
+      Set(0, 1),
+      1,
+      Set(1),
+      Map(0 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 0, 'c' -> 0),
+          1 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 1, 'c' -> 1))
+    )
 
     assert(fsm1.accepts(""))
 
-    val fsm2 = Fsm(Set('a', 'b', 'c', Fsm.anythingElse),
-      Set(0, 1, 2), 1, Set(0), Map(
-        0 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2),
-        1 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 0),
-        2 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2)))
+    val fsm2 = Fsm(
+      Set('a', 'b', 'c', Fsm.anythingElse),
+      Set(0, 1, 2),
+      1,
+      Set(0),
+      Map(0 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2),
+          1 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 0),
+          2 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2))
+    )
 
     assert(fsm2.accepts("c"))
 
@@ -357,7 +371,7 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Star" should "pass basic check" in {
-    val fsmA = createFsmA
+    val fsmA  = createFsmA
     val starA = fsmA.star
 
     assert(starA.accepts(""))
@@ -369,16 +383,16 @@ class FsmUnitTests extends FlatSpec with Matchers {
   /**
     * This is (a*ba)*. Naively connecting the final states to the initial state
     * gives the incorrect result here.
-  */
+    */
   "Star" should "pass advanced check" in {
     val fsmS = Fsm(Set('a', 'b'),
-      Set(0, 1, 2, _ob),
-      0,
-      Set(2), Map(
-        0 -> Map('a' -> 0, 'b' -> 1),
-        1 -> Map('a' -> 2, 'b' -> _ob),
-        2 -> Map('a' -> _ob, 'b' -> _ob),
-        _ob -> Map('a'->_ob, 'b' ->_ob))).star
+                   Set(0, 1, 2, _ob),
+                   0,
+                   Set(2),
+                   Map(0   -> Map('a' -> 0, 'b'   -> 1),
+                       1   -> Map('a' -> 2, 'b'   -> _ob),
+                       2   -> Map('a' -> _ob, 'b' -> _ob),
+                       _ob -> Map('a' -> _ob, 'b' -> _ob))).star
 
     assert(fsmS.alphabet == Set('a', 'b'))
     assert(fsmS.accepts(""))
@@ -395,12 +409,8 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Fsm (ab*)*" should "work properly (greenery bug 28)" in {
-    val abStar = Fsm(Set('a','b'),
-      Set(0,1),
-      0,
-      Set(1),
-      Map(0 -> Map('a' -> 1),
-        1 -> Map('b' -> 1)))
+    val abStar =
+      Fsm(Set('a', 'b'), Set(0, 1), 0, Set(1), Map(0 -> Map('a' -> 1), 1 -> Map('b' -> 1)))
 
     assert(abStar.accepts("a"))
     assert(!abStar.accepts("b"))
@@ -417,14 +427,14 @@ class FsmUnitTests extends FlatSpec with Matchers {
   "Derive" should "pass basic check" in {
     val fsmA = createFsmA
 
-    assert(fsmA.derive("a").get == Fsm.epsilonFsm(Set('a','b')))
-    assert(fsmA.derive("b").get == Fsm.nullFsm(Set('a','b')))
+    assert(fsmA.derive("a").get == Fsm.epsilonFsm(Set('a', 'b')))
+    assert(fsmA.derive("b").get == Fsm.nullFsm(Set('a', 'b')))
 
     assert(fsmA.derive("c").isFailure)
 
     assert(fsmA.derive("a").get == Fsm.epsilonFsm(Set('a', 'b')))
     assert(fsmA.derive("b").get == Fsm.nullFsm(Set('a', 'b')))
-    assert((fsmA.star - Fsm.epsilonFsm(Set('a','b'))).derive("a").get == fsmA.star)
+    assert((fsmA.star - Fsm.epsilonFsm(Set('a', 'b'))).derive("a").get == fsmA.star)
     assert((fsmA * 3).derive("a").get == fsmA * 2)
   }
 
@@ -461,7 +471,7 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Multiply" should "correctly applied to unions" in {
-    val fsmAB = createFsmA + createFsmB
+    val fsmAB  = createFsmA + createFsmB
     val fsmOpt = Fsm.epsilonFsm(createFsmA.alphabet) | fsmAB
     //fsmOpt now accepts (ab)?
 
@@ -525,12 +535,12 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Difference" should "work" in {
     val fsmAorB = Fsm(Set('a', 'b'),
-      Set(0, 1, _ob),
-      0,
-      Set(1),
-      Map(0 -> Map('a' -> 1, 'b' -> 1),
-        1 -> Map('a' -> _ob, 'b' -> _ob),
-        _ob -> Map('a' -> _ob, 'b' -> _ob)))
+                      Set(0, 1, _ob),
+                      0,
+                      Set(1),
+                      Map(0   -> Map('a' -> 1, 'b'   -> 1),
+                          1   -> Map('a' -> _ob, 'b' -> _ob),
+                          _ob -> Map('a' -> _ob, 'b' -> _ob)))
 
     val fsmA = createFsmA
     val fsmB = createFsmB
@@ -553,11 +563,15 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * FSM accepts no strings but has 3 states, needs only 1
     */
   "Reduce" should "eliminate unused states" in {
-    val fsm3 = Fsm(Set('a'), Set(0, 1, 2), 0, Set(1), Map(
-      0 -> Map('a' -> 2),
-      1 -> Map('a' -> 2),
-      2 -> Map('a' -> 2)
-    ))
+    val fsm3 = Fsm(Set('a'),
+                   Set(0, 1, 2),
+                   0,
+                   Set(1),
+                   Map(
+                     0 -> Map('a' -> 2),
+                     1 -> Map('a' -> 2),
+                     2 -> Map('a' -> 2)
+                   ))
 
     val fsm1 = fsm3.reduced
     assert(fsm1.states.size == 1)
@@ -571,15 +585,17 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * Finally, the oblivion state should be omitted.
     */
   "Crawl reduction" should "resolve duplication" in {
-    val mergedFsm = Fsm(Set('a', 'b'),
+    val mergedFsm = Fsm(
+      Set('a', 'b'),
       Set(1, 2, 3, 4, _ob),
       1,
       Set(4),
-      Map(1 -> Map('a' -> 2, 'b' -> 4),
-        2 -> Map('a' -> 3, 'b' -> 4),
-        3 -> Map('a' -> 3, 'b' -> 4),
-        4 -> Map('a' -> _ob, 'b' -> _ob),
-        _ob -> Map('a' -> _ob, 'b' -> _ob)))
+      Map(1   -> Map('a' -> 2, 'b'   -> 4),
+          2   -> Map('a' -> 3, 'b'   -> 4),
+          3   -> Map('a' -> 3, 'b'   -> 4),
+          4   -> Map('a' -> _ob, 'b' -> _ob),
+          _ob -> Map('a' -> _ob, 'b' -> _ob))
+    )
 
     val reducedFsm = mergedFsm.reduced
 
@@ -607,14 +623,20 @@ class FsmUnitTests extends FlatSpec with Matchers {
     val _init = -2
     val _zero = -1
     //states 0 1 and 2 are for division results
-    val fsm3 = Fsm(Set('0', '1'), Set(_init, _zero, 0, 1, 2, _ob), _init, Set(_zero, 0), Map(
-      _init -> Map('0' -> _zero, '1' -> 1),
-      _zero -> Map('0' -> _ob, '1' -> _ob),
-      0 -> Map('0' -> 0, '1' -> 1),
-      1 -> Map('0' -> 2, '1' -> 0),
-      2 -> Map('0' -> 1, '1' -> 2),
-      _ob -> Map('0' -> _ob, '1' -> _ob)
-    ))
+    val fsm3 = Fsm(
+      Set('0', '1'),
+      Set(_init, _zero, 0, 1, 2, _ob),
+      _init,
+      Set(_zero, 0),
+      Map(
+        _init -> Map('0' -> _zero, '1' -> 1),
+        _zero -> Map('0' -> _ob, '1'   -> _ob),
+        0     -> Map('0' -> 0, '1'     -> 1),
+        1     -> Map('0' -> 2, '1'     -> 0),
+        2     -> Map('0' -> 1, '1'     -> 2),
+        _ob   -> Map('0' -> _ob, '1'   -> _ob)
+      )
+    )
 
     assert(!fsm3.accepts(""))
     assert(fsm3.accepts("0"))
@@ -677,11 +699,16 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * This affects every usage of `fsm.transitions`.
     */
   "Dead states" should "be allowed" in {
-    val fsm = Fsm(Set('/', '*', Fsm.anythingElse), Set(0, 1, 2, 3, 4, 5), 0, Set(4), Map(
-      0 -> Map('/' -> 1),
-      1 -> Map('*' -> 2),
-      2 -> Map('/' -> 2, Fsm.anythingElse -> 2, '*' -> 3),
-      3 -> Map('/' -> 4, Fsm.anythingElse -> 2, '*' -> 3)))
+    val fsm = Fsm(
+      Set('/', '*', Fsm.anythingElse),
+      Set(0, 1, 2, 3, 4, 5),
+      0,
+      Set(4),
+      Map(0 -> Map('/' -> 1),
+          1 -> Map('*' -> 2),
+          2 -> Map('/' -> 2, Fsm.anythingElse -> 2, '*' -> 3),
+          3 -> Map('/' -> 4, Fsm.anythingElse -> 2, '*' -> 3))
+    )
 
     assert(fsm.strings.take(1).toList == "/**/" :: Nil)
 
@@ -703,7 +730,7 @@ class FsmUnitTests extends FlatSpec with Matchers {
     val fsmB = createFsmB
 
     assert(fsmA.length.contains(1))
-    assert(((fsmA | fsmB)*4).length.contains(16))
+    assert(((fsmA | fsmB) * 4).length.contains(16))
     assert(fsmA.star.length.isEmpty)
 
     assert(Fsm.union(fsmA, fsmB) == fsmA.union(fsmB))
@@ -740,7 +767,7 @@ class FsmUnitTests extends FlatSpec with Matchers {
 
   "Invalid Fsm" should "fail if alphabet null" in {
     assertThrows[IllegalArgumentException] {
-      util.ignore{ Fsm(null, null, 0, null, null) }
+      util.ignore { Fsm(null, null, 0, null, null) }
     }
   }
 

--- a/storage/src/test/scala/coop/rchain/storage/regex/RegexPatternUnitTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/regex/RegexPatternUnitTests.scala
@@ -79,8 +79,7 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       CharClassPattern.parse("[^\\t\\[]").contains(CharClassPattern("\t[", negateCharSet = true)))
 
     assert(CharClassPattern.parse("a").contains(CharClassPattern("a")))
-    assert(
-      CharClassPattern.parse("\\s").contains(CharClassPattern(CharClassPattern.spacesCharSet)))
+    assert(CharClassPattern.parse("\\s").contains(CharClassPattern(CharClassPattern.spacesCharSet)))
     assert(
       CharClassPattern
         .parse("\\S")
@@ -103,14 +102,12 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
                            negateCharSet = true)))
     assert(CharClassPattern.parse(".").contains(~CharClassPattern("")))
     assert(CharClassPattern.parse("[abc]").contains(CharClassPattern("abc")))
-    assert(
-      CharClassPattern.parse("[^abc]").contains(CharClassPattern("abc", negateCharSet = true)))
+    assert(CharClassPattern.parse("[^abc]").contains(CharClassPattern("abc", negateCharSet = true)))
 
     assert(CharClassPattern.parse("[\\x41]").contains(CharClassPattern("A")))
     assert(CharClassPattern.parse("[\\x41-\\x44]").contains(CharClassPattern("ABCD")))
 
-    assert(
-      CharClassPattern.parse("[^\\x41]").contains(CharClassPattern("A", negateCharSet = true)))
+    assert(CharClassPattern.parse("[^\\x41]").contains(CharClassPattern("A", negateCharSet = true)))
     assert(
       CharClassPattern
         .parse("[^\\x41-\\x44]")
@@ -180,8 +177,8 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       MultPattern(CharClassPattern("a"), Multiplier(Some(2), Some(2))) == a.multiply(
         Multiplier(Some(2), Some(2))))
     assert(
-      MultPattern(CharClassPattern("a"), Multiplier.presetPlus).multiply(
-        Multiplier(Some(3), Some(4))) == a.multiply(Multiplier(Some(3), Multiplier.Inf)))
+      MultPattern(CharClassPattern("a"), Multiplier.presetPlus)
+        .multiply(Multiplier(Some(3), Some(4))) == a.multiply(Multiplier(Some(3), Multiplier.Inf)))
   }
 
   "RegexPattern parse" should "parse groups" in {
@@ -322,7 +319,7 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
   }
 
   "MultPattern" should "produce good Fsm" in {
-    val a = CharClassPattern("a")
+    val a  = CharClassPattern("a")
     val a1 = a * 1
     assert(a1.accepts("a"))
     assert(!a1.accepts("b"))
@@ -494,8 +491,7 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     assert(CharClassPattern.parse("[^\\dABCD]").get.toString == "[^0-9A-D]")
     //char codes
     assert(CharClassPattern.parse("[\\uFFF1-\\uFFF80-9]").get.toString == "[0-9\\uFFF1-\\uFFF8]")
-    assert(
-      CharClassPattern.parse("[^\\uFFF1-\\uFFF80-9]").get.toString == "[^0-9\\uFFF1-\\uFFF8]")
+    assert(CharClassPattern.parse("[^\\uFFF1-\\uFFF80-9]").get.toString == "[^0-9\\uFFF1-\\uFFF8]")
     //empty and anythingElse sets
     assert(CharClassPattern.parse(".").get.toString == ".")
     assert(CharClassPattern.parse(".").get.negated.toString == "")


### PR DESCRIPTION
This PR will turn on scalafmt (was turned off after recent @kirkwood changes), it will start working for all subprojects that use `commonsettings`.

I've reformatted the whole project as it is currently on `dev`. The sooner we have it merged to `dev` the better. Each subproject was formatted in separate commit so you can review it individually for each of the subprojects.

Please consider this PR ASAP review so we have this done once and don't have to come back :)

Adding : 

@kirkwood to check `comm`
@guardbotmk3  to check `rholang`
@henrytill to check `storage`