### PR TITLE
Reposition Travis badge, add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build Status](https://travis-ci.org/rchain/rchain.svg?branch=dev)](https://travis-ci.org/rchain/rchain)
-
 # RChain
+
+[![Build Status](https://travis-ci.org/rchain/rchain.svg?branch=dev)](https://travis-ci.org/rchain/rchain)
+[![codecov](https://codecov.io/gh/rchain/rchain/branch/master/graph/badge.svg)](https://codecov.io/gh/rchain/rchain)
 
 The open-source RChain project is building a decentralized, economic, censorship-resistant, public compute infrastructure and blockchain. It will host and execute programs popularly referred to as “smart contracts”. It will be trustworthy, scalable, concurrent, with proof-of-stake consensus and content delivery.
 


### PR DESCRIPTION
This PR adds a Codecov badge to `README.md`, while repositioning the Travis badge.

**Motivations:**
1. It's common to see Codecov badges on projects that use it (and it offers a handy link to our Codecov reports).
2. It's also common to see the Travis badge positioned below the project name.