### PR TITLE
CORE-184: storage: remove {Block,Contract,SystemContract}.proto

### DIFF
--- a/storage/src/main/protobuf/Block.proto
+++ b/storage/src/main/protobuf/Block.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-option java_package = "coop.rchain.storage.models";
-
-message Block {
-  bytes value = 1;
-}

--- a/storage/src/main/protobuf/Contract.proto
+++ b/storage/src/main/protobuf/Contract.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-option java_package = "coop.rchain.storage.models";
-
-message Contract {
-  bytes value = 1;
-}

--- a/storage/src/main/protobuf/SystemContract.proto
+++ b/storage/src/main/protobuf/SystemContract.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-option java_package = "coop.rchain.storage.models";
-
-message SystemContract {
-  bytes value = 1;
-}

--- a/storage/src/main/scala/coop/rchain/storage/models/SerializeInstances.scala
+++ b/storage/src/main/scala/coop/rchain/storage/models/SerializeInstances.scala
@@ -1,40 +1,20 @@
 package coop.rchain.storage.models
 
+import java.nio.charset.StandardCharsets
+
 import cats.syntax.either._
 import coop.rchain.storage.{Serialize, SerializeError}
 
 trait SerializeInstances {
 
-  implicit object blockInstance extends Serialize[Block] {
+  implicit object stringInstance extends Serialize[String] {
 
-    def encode(a: Block): Array[Byte] =
-      a.toByteArray
+    def encode(s: String): Array[Byte] =
+      s.getBytes(StandardCharsets.UTF_8)
 
-    def decode(bytes: Array[Byte]): Either[SerializeError, Block] =
+    def decode(bytes: Array[Byte]): Either[SerializeError, String] =
       Either
-        .catchNonFatal(Block.parseFrom(bytes))
-        .leftMap(SerializeError.apply)
-  }
-
-  implicit object contractInstance extends Serialize[Contract] {
-
-    def encode(a: Contract): Array[Byte] =
-      a.toByteArray
-
-    def decode(bytes: Array[Byte]): Either[SerializeError, Contract] =
-      Either
-        .catchNonFatal(Contract.parseFrom(bytes))
-        .leftMap(SerializeError.apply)
-  }
-
-  implicit object systemContractInstance extends Serialize[SystemContract] {
-
-    def encode(a: SystemContract): Array[Byte] =
-      a.toByteArray
-
-    def decode(bytes: Array[Byte]): Either[SerializeError, SystemContract] =
-      Either
-        .catchNonFatal(SystemContract.parseFrom(bytes))
+        .catchNonFatal(new String(bytes, StandardCharsets.UTF_8))
         .leftMap(SerializeError.apply)
   }
 }

--- a/storage/src/test/scala/coop/rchain/storage/StorageTest.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageTest.scala
@@ -2,8 +2,6 @@ package coop.rchain.storage
 
 import java.security.MessageDigest
 
-import com.google.protobuf.ByteString
-import coop.rchain.storage.models.{Block, Contract, SystemContract}
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 
 //noinspection ScalaUnnecessaryParentheses
@@ -11,61 +9,23 @@ class StorageTest extends FlatSpec with Matchers with EitherValues with StorageF
 
   behavior of "A Storage instance"
 
-  it should "allow a Block value to be round-tripped and then removed" in withTestStorage {
+  it should "allow a String value to be round-tripped and then removed" in withTestStorage {
     (storage: Storage) =>
       val bytes: Array[Byte] = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
       val hash: Array[Byte]  = MessageDigest.getInstance("SHA-256").digest(bytes)
       val testKey: Key       = Hash(hash)
-      val testValue: Block   = Block(value = ByteString.copyFrom(bytes))
+      val testValue: String  = "Fiery the angels fell"
 
-      for {
-        putResult    <- storage.put(testKey, testValue)
-        getResult    <- storage.get[Block](testKey)
-        removeResult <- storage.remove(testKey)
-      } {
-        putResult shouldBe (())
-        getResult shouldBe testValue
-        removeResult shouldBe true
-      }
+      val Right((putResult, getResult, removeResult)) = for {
+        pr <- storage.put(testKey, testValue)
+        gr <- storage.get[String](testKey)
+        yr <- storage.remove(testKey)
+      } yield (pr, gr, yr)
 
-      storage.get[Block](testKey).left.value shouldBe NotFound
-  }
+      putResult shouldBe (())
+      getResult shouldBe testValue
+      removeResult shouldBe true
 
-  it should "allow a Contract value to be round-tripped and then removed" in withTestStorage {
-    (storage: Storage) =>
-      val bytes: Array[Byte]  = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
-      val testKey: Key        = Flat("quux")
-      val testValue: Contract = Contract(value = ByteString.copyFrom(bytes))
-
-      for {
-        putResult    <- storage.put(testKey, testValue)
-        getResult    <- storage.get[Contract](testKey)
-        removeResult <- storage.remove(testKey)
-      } {
-        putResult shouldBe (())
-        getResult shouldBe testValue
-        removeResult shouldBe true
-      }
-
-      storage.get[Contract](testKey).left.value shouldBe NotFound
-  }
-
-  it should "allow a SystemContract value to be round-tripped and then removed" in withTestStorage {
-    (storage: Storage) =>
-      val bytes: Array[Byte]        = Array(0xDE, 0xAD, 0xBE, 0xEF).map(_.toByte)
-      val testKey: Key              = FlatSys("quux")
-      val testValue: SystemContract = SystemContract(value = ByteString.copyFrom(bytes))
-
-      for {
-        putResult    <- storage.put(testKey, testValue)
-        getResult    <- storage.get[SystemContract](testKey)
-        removeResult <- storage.remove(testKey)
-      } {
-        putResult shouldBe (())
-        getResult shouldBe testValue
-        removeResult shouldBe true
-      }
-
-      storage.get[SystemContract](testKey).left.value shouldBe NotFound
+      storage.get[String](testKey).left.value shouldBe NotFound
   }
 }


### PR DESCRIPTION
These files were originally added as placeholders.

They are being replaced by the work in #282.

As such, they can be removed.

