### PR TITLE
Currently node should only be depending on comm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val node = project
       }
     },
   )
-  .dependsOn(comm, storage, roscala, rholang) // Not really, but it will
+  .dependsOn(comm)
 
 lazy val rholang = project
   .settings(


### PR DESCRIPTION
`node` was artificially made to be depended on `storage` & `rholang`. This is not yet needed but slows down compilation for those who don't (yet) care. 

This PR removes this dependency. Only dependency on `comm` remains. 