### PR TITLE
Rholang: Contract normalization.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -181,28 +181,28 @@ object ProcNormalizeMatcher {
         // And we start with the empty free variable map because these free
         // variables aren't free in the surrounding context: they're binders.
         val initAcc = (List[Channel](), DebruijnLevelMap[VarSort]())
-        val nameMatchResult = NameNormalizeMatcher.normalizeMatch(
-          p.name_,
-          NameVisitInputs(input.env, input.knownFree))
+        val nameMatchResult =
+          NameNormalizeMatcher.normalizeMatch(p.name_, NameVisitInputs(input.env, input.knownFree))
         // Note that we go over these in the order they were given and reverse
         // down below. This is because it makes more sense to number the free
         // variables in the order given, rather than in reverse.
         val formalsResults = (initAcc /: p.listname_.asScala.toList)(
-            (acc, n: Name) => {
-              val result = NameNormalizeMatcher.normalizeMatch(
-                n, NameVisitInputs(DebruijnLevelMap(), acc._2))
-              (result.chan :: acc._1, result.knownFree)
-            }
+          (acc, n: Name) => {
+            val result =
+              NameNormalizeMatcher.normalizeMatch(n, NameVisitInputs(DebruijnLevelMap(), acc._2))
+            (result.chan :: acc._1, result.knownFree)
+          }
         )
         val newEnv = input.env.absorbFree(formalsResults._2)
         val bodyResult = ProcNormalizeMatcher.normalizeMatch(
           p.proc_,
           ProcVisitInputs(Par(), newEnv, nameMatchResult.knownFree))
         ProcVisitOutputs(
-            input.par.copy(receives = Receive(
-                List((formalsResults._1.reverse, nameMatchResult.chan)),
-                bodyResult.par, true) :: input.par.receives),
-            bodyResult.knownFree)
+          input.par.copy(
+            receives = Receive(List((formalsResults._1.reverse, nameMatchResult.chan)),
+                               bodyResult.par,
+                               true) :: input.par.receives),
+          bodyResult.knownFree)
       }
 
       case p: PPar => {
@@ -235,7 +235,7 @@ class DebruijnLevelMap[T](val next: Int, val env: Map[String, (Int, T)]) {
   }
 
   def absorbFree(binders: DebruijnLevelMap[T]): DebruijnLevelMap[T] = {
-    val finalNext = next + binders.next
+    val finalNext  = next + binders.next
     val adjustNext = next
     binders.env.foldLeft(this) {
       case (db: DebruijnLevelMap[T], (k: String, (level: Int, varType: T @unchecked))) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -236,7 +236,7 @@ class DebruijnLevelMap[T](val next: Int, val env: Map[String, (Int, T)]) {
 
   def absorbFree(binders: DebruijnLevelMap[T]): DebruijnLevelMap[T] = {
     val finalNext = next + binders.next
-    val adjustNext = this.next
+    val adjustNext = next
     binders.env.foldLeft(this) {
       case (db: DebruijnLevelMap[T], (k: String, (level: Int, varType: T @unchecked))) =>
         DebruijnLevelMap(finalNext, db.env + (k -> ((level + adjustNext, varType))))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
@@ -64,7 +64,7 @@ case class Send(chan: Channel, data: List[Par], persistent: Boolean)
 // [Par] is an n-arity Pattern.
 // It's an error for free Variable to occur more than once in a pattern.
 // Don't currently support conditional receive
-case class Receive(binds: List[(List[Channel], Channel)])
+case class Receive(binds: List[(List[Channel], Channel)], body: Par, persistent: Boolean)
 
 case class Eval(channel: Channel)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -301,7 +301,10 @@ object ReceiveSortMatcher {
   // This function will then sort the insides of the preordered binds.
   def sortMatch(r: Receive): ScoredTerm[Receive] = {
     val sortedBinds = r.binds.map(bind => sortBind(bind))
-    ScoredTerm(Receive(sortedBinds.map(_.term)), Node(Score.RECEIVE, sortedBinds.map(_.score): _*))
+    val persistentScore = if (r.persistent) 1 else 0
+    val sortedBody = ParSortMatcher.sortMatch(r.body)
+    ScoredTerm(Receive(sortedBinds.map(_.term), sortedBody.term, r.persistent),
+        Node(Score.RECEIVE, Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*))
   }
 }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -300,11 +300,14 @@ object ReceiveSortMatcher {
   // The order of the binds must already be presorted by the time this is called.
   // This function will then sort the insides of the preordered binds.
   def sortMatch(r: Receive): ScoredTerm[Receive] = {
-    val sortedBinds = r.binds.map(bind => sortBind(bind))
+    val sortedBinds     = r.binds.map(bind => sortBind(bind))
     val persistentScore = if (r.persistent) 1 else 0
-    val sortedBody = ParSortMatcher.sortMatch(r.body)
-    ScoredTerm(Receive(sortedBinds.map(_.term), sortedBody.term, r.persistent),
-        Node(Score.RECEIVE, Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*))
+    val sortedBody      = ParSortMatcher.sortMatch(r.body)
+    ScoredTerm(
+      Receive(sortedBinds.map(_.term), sortedBody.term, r.persistent),
+      Node(Score.RECEIVE,
+           Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*)
+    )
   }
 }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
@@ -387,7 +387,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be (sortedParExpr)
   }
 
-  "Par" should "Sort Receives based on their channel and then pattern" in {
+  "Par" should "Sort Receives based on persistence and then channels and then patterns and then body" in {
     val parExpr =
       p.copy(receives=
         List(
@@ -396,19 +396,36 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(1))))),
-                Quote(p.copy(exprs=List(GInt(3))))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), false),
           Receive(
             List(
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(0))))),
-                Quote(p.copy(exprs=List(GInt(3))))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            p.copy(exprs = List(EVar(BoundVar(0)))), false),
+          Receive(
+            List(
+              (
+                List(
+                  Quote(p.copy(exprs=List(GInt(0))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), false),
+          Receive(
+            List(
+              (
+                List(
+                  Quote(p.copy(exprs=List(GInt(0))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), true),
           Receive(
             List(
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(100))))),
-                Quote(p.copy(exprs=List(GInt(2)))))))))
+                Quote(p.copy(exprs=List(GInt(2)))))),
+            Par(), false)))
     val sortedParExpr =
       p.copy(receives=
         List(
@@ -417,19 +434,36 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(100))))),
-                Quote(p.copy(exprs=List(GInt(2))))))),
+                Quote(p.copy(exprs=List(GInt(2)))))),
+            Par(), false),
           Receive(
             List(
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(0))))),
-                Quote(p.copy(exprs=List(GInt(3))))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), false),
+          Receive(
+            List(
+              (
+                List(
+                  Quote(p.copy(exprs=List(GInt(0))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            p.copy(exprs = List(EVar(BoundVar(0)))), false),
           Receive(
             List(
               (
                 List(
                   Quote(p.copy(exprs=List(GInt(1))))),
-                Quote(p.copy(exprs=List(GInt(3)))))))))
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), false),
+          Receive(
+            List(
+              (
+                List(
+                  Quote(p.copy(exprs=List(GInt(0))))),
+                Quote(p.copy(exprs=List(GInt(3)))))),
+            Par(), true)))
     val result = ParSortMatcher.sortMatch(parExpr)
     result.term should be (sortedParExpr)
   }


### PR DESCRIPTION
This is slightly simpler than receive normalization because a contract listens
on only one channel. The test is complex enough to walk through a lot of the
functionality.