### PR TITLE
 Rholang: Add helper functions to make par manipulation easier.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -25,6 +25,47 @@ object GroundNormalizeMatcher {
     }
 }
 
+object CollectionNormalizeMatcher {
+  import scala.collection.JavaConverters._
+  def normalizeMatch(c: Collection, input: CollectVisitInputs): CollectVisitOutputs = {
+    def foldMatch(listproc: List[Proc], constructor: List[Par] => Expr): CollectVisitOutputs = {
+      val folded = ((List[Par](), input.knownFree) /: listproc) (
+        (acc, e) => {
+          val result = ProcNormalizeMatcher.normalizeMatch(
+              e, ProcVisitInputs(Par(), input.env, acc._2))
+          (result.par :: acc._1, result.knownFree)
+        }
+      )
+      CollectVisitOutputs(constructor(folded._1.reverse), folded._2)
+    }
+
+    def foldMatchMap(listproc: List[KeyValuePair], constructor: List[(Par,Par)] => Expr): CollectVisitOutputs = {
+      val folded = ((List[(Par, Par)](), input.knownFree) /: listproc) (
+        (acc, e) => {
+          e match {
+            case e: KeyValuePairImpl => {
+              val keyResult = ProcNormalizeMatcher.normalizeMatch(
+                  e.proc_1,
+                  ProcVisitInputs(Par(), input.env, acc._2))
+              val valResult = ProcNormalizeMatcher.normalizeMatch(
+                  e.proc_2,
+                  ProcVisitInputs(Par(), input.env, keyResult.knownFree))
+              ((keyResult.par, valResult.par) :: acc._1, valResult.knownFree)
+            }
+          }
+        }
+      )
+      CollectVisitOutputs(constructor(folded._1.reverse), folded._2)
+    }
+    c match {
+      case cl: CollectList => foldMatch(cl.listproc_.asScala.toList, EList)
+      case ct: CollectTuple => foldMatch(ct.listproc_.asScala.toList, ETuple)
+      case cs: CollectSet => foldMatch(cs.listproc_.asScala.toList, ESet)
+      case cm: CollectMap => foldMatchMap(cm.listkeyvaluepair_.asScala.toList, EMap)
+    }
+  }
+}
+
 object NameNormalizeMatcher {
   def normalizeMatch(n: Name, input: NameVisitInputs): NameVisitOutputs =
     n match {
@@ -93,6 +134,14 @@ object ProcNormalizeMatcher {
           input.par.copy(
             exprs = GroundNormalizeMatcher.normalizeMatch(p.ground_) :: input.par.exprs),
           input.knownFree)
+
+      case p: PCollect => {
+        val collectResult = CollectionNormalizeMatcher.normalizeMatch(
+            p.collection_, CollectVisitInputs(input.env, input.knownFree))
+        ProcVisitOutputs(
+            input.par.copy(exprs = collectResult.expr :: input.par.exprs),
+            collectResult.knownFree)
+      }
 
       case p: PVar =>
         input.env.get(p.var_) match {
@@ -282,9 +331,12 @@ case class ProcVisitInputs(par: Par,
 // Returns the update Par and an updated map of free variables.
 case class ProcVisitOutputs(par: Par, knownFree: DebruijnLevelMap[VarSort])
 
-sealed trait ChanPosition
-case object BindingPosition extends ChanPosition
-case object UsePosition     extends ChanPosition
-
 case class NameVisitInputs(env: DebruijnLevelMap[VarSort], knownFree: DebruijnLevelMap[VarSort])
 case class NameVisitOutputs(chan: Channel, knownFree: DebruijnLevelMap[VarSort])
+
+case class CollectVisitInputs(
+  env: DebruijnLevelMap[VarSort],
+  knownFree: DebruijnLevelMap[VarSort])
+case class CollectVisitOutputs(
+  expr: Expr,
+  knownFree: DebruijnLevelMap[VarSort])

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
@@ -4,6 +4,8 @@
 
 package coop.rchain.rholang.intepreter
 
+import scala.language.implicitConversions
+
 case class Par(
     sends: List[Send],
     receives: List[Receive],
@@ -13,9 +15,27 @@ case class Par(
     exprs: List[Expr]
     // matches: List[Match]
 ) {
-  // TODO: write helper methods to append an X and return a new par
   def this() =
     this(List(), List(), List(), List(), List())
+  // Single element convenience constructors
+  def this(s: Send) =
+    this(List(s), List(), List(), List(), List())
+  def this(r: Receive) =
+    this(List(), List(r), List(), List(), List())
+  def this(e: Eval) =
+    this(List(), List(), List(e), List(), List())
+  def this(n: New) =
+    this(List(), List(), List(), List(n), List())
+  def this(e: Expr) =
+    this(List(), List(), List(), List(), List(e))
+
+  // Convenience prepend methods
+  def prepend(s: Send): Par    = this.copy(sends = s :: this.sends)
+  def prepend(r: Receive): Par = this.copy(receives = r :: this.receives)
+  def prepend(e: Eval): Par    = this.copy(evals = e :: this.evals)
+  def prepend(n: New): Par     = this.copy(news = n :: this.news)
+  def prepend(e: Expr): Par    = this.copy(exprs = e :: this.exprs)
+
   def singleEval(): Option[Eval] =
     if (sends.isEmpty && receives.isEmpty && news.isEmpty && exprs.isEmpty) {
       evals match {
@@ -34,7 +54,18 @@ case class Par(
 }
 
 object Par {
-  def apply(): Par = new Par()
+  def apply(): Par           = new Par()
+  def apply(s: Send): Par    = new Par(s)
+  def apply(r: Receive): Par = new Par(r)
+  def apply(e: Eval): Par    = new Par(e)
+  def apply(n: New): Par     = new Par(n)
+  def apply(e: Expr): Par    = new Par(e)
+
+  implicit def fromSend(s: Send): Par       = apply(s)
+  implicit def fromReceive(r: Receive): Par = apply(r)
+  implicit def fromEval(e: Eval): Par       = apply(e)
+  implicit def fromNew(n: New): Par         = apply(n)
+  implicit def fromExpr(e: Expr): Par       = apply(e)
 }
 
 sealed trait Channel

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -74,7 +74,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
         List((Some("Q"), ProcSort), (Some("y"), NameSort)))._1
     )
   }
-  "Tuple" should "propgate free variables" in {
+  "Tuple" should "propagate free variables" in {
     val tupleData = new ListProc()
     tupleData.add(new PVar("Q"))
     tupleData.add(new PGround(new GroundInt(7)))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -7,12 +7,12 @@ class BoolMatcherSpec extends FlatSpec with Matchers {
   "BoolTrue" should "Compile as GBool(true)" in {
     val btrue = new BoolTrue()
 
-    BoolNormalizeMatcher.normalizeMatch(btrue) should be (GBool(true))
+    BoolNormalizeMatcher.normalizeMatch(btrue) should be(GBool(true))
   }
   "BoolFalse" should "Compile as GBool(false)" in {
     val bfalse = new BoolFalse()
 
-    BoolNormalizeMatcher.normalizeMatch(bfalse) should be (GBool(false))
+    BoolNormalizeMatcher.normalizeMatch(bfalse) should be(GBool(false))
   }
 }
 
@@ -20,26 +20,25 @@ class GroundMatcherSpec extends FlatSpec with Matchers {
   "GroundInt" should "Compile as GInt" in {
     val gi = new GroundInt(7)
 
-    GroundNormalizeMatcher.normalizeMatch(gi) should be (GInt(7))
+    GroundNormalizeMatcher.normalizeMatch(gi) should be(GInt(7))
   }
   "GroundString" should "Compile as GString" in {
     val gs = new GroundString("String")
 
-    GroundNormalizeMatcher.normalizeMatch(gs) should be (GString("String"))
+    GroundNormalizeMatcher.normalizeMatch(gs) should be(GString("String"))
   }
   "GroundUri" should "Compile as GUri" in {
     val gu = new GroundUri("Uri")
 
-    GroundNormalizeMatcher.normalizeMatch(gu) should be (GUri("Uri"))
+    GroundNormalizeMatcher.normalizeMatch(gu) should be(GUri("Uri"))
   }
 }
 
 class CollectMatcherSpec extends FlatSpec with Matchers {
   val inputs = ProcVisitInputs(
-      Par(),
-      DebruijnLevelMap[VarSort]().newBindings(
-          List((Some("P"), ProcSort), (Some("x"), NameSort)))._1,
-      DebruijnLevelMap[VarSort]())
+    Par(),
+    DebruijnLevelMap[VarSort]().newBindings(List((Some("P"), ProcSort), (Some("x"), NameSort)))._1,
+    DebruijnLevelMap[VarSort]())
 
   "List" should "delegate" in {
     val listData = new ListProc()
@@ -49,13 +48,9 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val list = new PCollect(new CollectList(listData))
 
     val result = ProcNormalizeMatcher.normalizeMatch(list, inputs)
-    result.par should be (inputs.par.copy(
-      exprs = EList(List(
-          Par().copy(exprs = List(EVar(BoundVar(0)))),
-          Par().copy(evals = List(Eval(ChanVar(BoundVar(1))))),
-          Par().copy(exprs = List(GInt(7))))
-      ) :: inputs.par.exprs))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(
+      inputs.par.prepend(EList(List[Par](EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1))), GInt(7)))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "Tuple" should "delegate" in {
@@ -65,14 +60,15 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val tuple = new PCollect(new CollectTuple(tupleData))
 
     val result = ProcNormalizeMatcher.normalizeMatch(tuple, inputs)
-    result.par should be (inputs.par.copy(
-      exprs = ETuple(List(
-          Par().copy(exprs = List(EVar(FreeVar(0)))),
-          Par().copy(evals = List(Eval(ChanVar(FreeVar(1))))))
-      ) :: inputs.par.exprs))
-    result.knownFree should be (inputs.knownFree.newBindings(
-        List((Some("Q"), ProcSort), (Some("y"), NameSort)))._1
-    )
+    result.par should be(
+      inputs.par.prepend(
+        ETuple(
+          List[Par](
+            EVar(FreeVar(0)),
+            Eval(ChanVar(FreeVar(1)))
+          ))))
+    result.knownFree should be(
+      inputs.knownFree.newBindings(List((Some("Q"), ProcSort), (Some("y"), NameSort)))._1)
   }
   "Tuple" should "propagate free variables" in {
     val tupleData = new ListProc()
@@ -81,7 +77,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     tupleData.add(new PPar(new PGround(new GroundInt(7)), new PVar("Q")))
     val tuple = new PCollect(new CollectTuple(tupleData))
 
-    an [Error] should be thrownBy {
+    an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(tuple, inputs)
     }
   }
@@ -94,181 +90,143 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val set = new PCollect(new CollectSet(setData))
 
     val result = ProcNormalizeMatcher.normalizeMatch(set, inputs)
-    result.par should be (inputs.par.copy(
-      exprs = ESet(List(
-          Par().copy(exprs = List(EPlus(
-              Par().copy(exprs = List(EVar(BoundVar(0)))),
-              Par().copy(exprs = List(EVar(FreeVar(0))))))),
-          Par().copy(exprs = List(GInt(7))),
-          Par().copy(exprs = List(EVar(FreeVar(1)), GInt(8))))
-      ) :: inputs.par.exprs))
-    result.knownFree should be (inputs.knownFree.newBindings(
-        List((Some("R"), ProcSort), (Some("Q"), ProcSort)))._1
-    )
+    result.par should be(
+      inputs.par.prepend(
+        ESet(List[Par](EPlus(EVar(BoundVar(0)), EVar(FreeVar(0))),
+                       GInt(7),
+                       Par(GInt(8)).prepend((EVar(FreeVar(1))))))))
+    result.knownFree should be(
+      inputs.knownFree.newBindings(List((Some("R"), ProcSort), (Some("Q"), ProcSort)))._1)
   }
 
   "Map" should "delegate" in {
     val mapData = new ListKeyValuePair()
-    mapData.add(new KeyValuePairImpl(new PGround(new GroundInt(7)), new PGround(new GroundString("Seven"))))
+    mapData.add(
+      new KeyValuePairImpl(new PGround(new GroundInt(7)), new PGround(new GroundString("Seven"))))
     mapData.add(new KeyValuePairImpl(new PVar("P"), new PEval(new NameVar("x"))))
     val map = new PCollect(new CollectMap(mapData))
 
     val result = ProcNormalizeMatcher.normalizeMatch(map, inputs)
-    result.par should be (inputs.par.copy(
-      exprs = EMap(List(
-          (Par().copy(exprs = List(GInt(7))),
-          Par().copy(exprs = List(GString("Seven")))),
-          (Par().copy(exprs = List(EVar(BoundVar(0)))),
-          Par().copy(evals = List(Eval(ChanVar(BoundVar(1)))))))
-      ) :: inputs.par.exprs))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(
+      inputs.par.prepend(EMap(List[(Par, Par)]((GInt(7), GString("Seven")),
+                                               (EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1))))))))
+    result.knownFree should be(inputs.knownFree)
   }
 }
 
 class ProcMatcherSpec extends FlatSpec with Matchers {
-  val inputs = ProcVisitInputs(
-      Par(),
-      DebruijnLevelMap[VarSort](),
-      DebruijnLevelMap[VarSort]())
+  val inputs = ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
 
   "PNil" should "Compile as no modification to the par object" in {
     val nil = new PNil()
 
     val result = ProcNormalizeMatcher.normalizeMatch(nil, inputs)
-    result.par should be (inputs.par)
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par)
+    result.knownFree should be(inputs.knownFree)
   }
 
   val pvar = new PVar("x")
   "PVar" should "Compile as BoundVar if it's in env" in {
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
-  
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+
     val result = ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
-    result.par should be (inputs.par.copy(exprs = List(EVar(BoundVar(0)))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(EVar(BoundVar(0))))
+    result.knownFree should be(inputs.knownFree)
   }
   "PVar" should "Compile as FreeVar if it's not in env" in {
     val result = ProcNormalizeMatcher.normalizeMatch(pvar, inputs)
-    result.par should be (inputs.par.copy(exprs = List(EVar(FreeVar(0)))))
+    result.par should be(inputs.par.prepend(EVar(FreeVar(0))))
     result.knownFree shouldEqual
-        (inputs.knownFree.newBindings(
-            List((Some("x"), ProcSort)))._1)
+      (inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
   }
   "PVar" should "Not compile if it's in env of the wrong sort" in {
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
-    
-    an [Error] should be thrownBy {
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+
+    an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
     }
   }
   "PVar" should "Not compile if it's used free somewhere else" in {
-    val boundInputs = inputs.copy(knownFree =
-      inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
-    
-    an [Error] should be thrownBy {
+    val boundInputs =
+      inputs.copy(knownFree = inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
+
+    an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
     }
   }
 
   "PEval" should "Handle a bound name varible" in {
-    val pEval = new PEval(new NameVar("x"))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val pEval       = new PEval(new NameVar("x"))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
-    result.par should be (inputs.par.copy(evals = List(Eval(ChanVar(BoundVar(0))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(Eval(ChanVar(BoundVar(0)))))
+    result.knownFree should be(inputs.knownFree)
   }
   "PEval" should "Collapse a quote" in {
-    val pEval = new PEval(new NameQuote(new PPar(new PVar("x"), new PVar("x"))))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val pEval       = new PEval(new NameQuote(new PPar(new PVar("x"), new PVar("x"))))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
-    result.par should be (inputs.par.copy(exprs = List(EVar(BoundVar(0)), EVar(BoundVar(0)))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(EVar(BoundVar(0))).prepend(EVar(BoundVar(0))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PNot" should "Delegate" in {
     val pNot = new PNot(new PGround(new GroundBool(new BoolFalse())))
 
     val result = ProcNormalizeMatcher.normalizeMatch(pNot, inputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(ENot(Par().copy(exprs = List(GBool(false)))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(ENot(GBool(false))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PNeg" should "Delegate" in {
-    val pNeg = new PNeg(new PVar("x"))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val pNeg        = new PNeg(new PVar("x"))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pNeg, boundInputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(ENeg(Par().copy(exprs = List(EVar(BoundVar(0))))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(ENeg(EVar(BoundVar(0)))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PMult" should "Delegate" in {
-    val pMult = new PMult(new PVar("x"), new PVar("y"))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val pMult       = new PMult(new PVar("x"), new PVar("y"))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pMult, boundInputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(EMult(
-                Par().copy(exprs = List(EVar(BoundVar(0)))),
-                Par().copy(exprs = List(EVar(FreeVar(0))))))))
-    result.knownFree should be (inputs.knownFree.newBindings(List((Some("y"), ProcSort)))._1)
+    result.par should be(inputs.par.prepend(EMult(EVar(BoundVar(0)), EVar(FreeVar(0)))))
+    result.knownFree should be(inputs.knownFree.newBindings(List((Some("y"), ProcSort)))._1)
   }
 
   "PDiv" should "Delegate" in {
     val pDiv = new PDiv(new PGround(new GroundInt(7)), new PGround(new GroundInt(2)))
 
     val result = ProcNormalizeMatcher.normalizeMatch(pDiv, inputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(EDiv(
-                Par().copy(exprs = List(GInt(7))),
-                Par().copy(exprs = List(GInt(2)))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(EDiv(GInt(7), GInt(2))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PAdd" should "Delegate" in {
     val pAdd = new PAdd(new PVar("x"), new PVar("y"))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort), (Some("y"), ProcSort)))._1)
+    val boundInputs = inputs.copy(
+      env = inputs.env.newBindings(List((Some("x"), ProcSort), (Some("y"), ProcSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pAdd, boundInputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(EPlus(
-                Par().copy(exprs = List(EVar(BoundVar(0)))),
-                Par().copy(exprs = List(EVar(BoundVar(1))))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(EPlus(EVar(BoundVar(0)), EVar(BoundVar(1)))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PMinus" should "Delegate" in {
     val pMinus = new PMinus(new PVar("x"), new PMult(new PVar("y"), new PVar("z")))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort),
-                                  (Some("y"), ProcSort),
-                                  (Some("z"), ProcSort)))._1)
+    val boundInputs = inputs.copy(
+      env = inputs.env
+        .newBindings(List((Some("x"), ProcSort), (Some("y"), ProcSort), (Some("z"), ProcSort)))
+        ._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pMinus, boundInputs)
-    result.par should be (
-        inputs.par.copy(
-            exprs = List(EMinus(
-                Par().copy(exprs = List(EVar(BoundVar(0)))),
-                Par().copy(exprs = List(EMult(
-                    Par().copy(exprs = List(EVar(BoundVar(1)))),
-                    Par().copy(exprs = List(EVar(BoundVar(2)))))))))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(
+      inputs.par.prepend(EMinus(EVar(BoundVar(0)), EMult(EVar(BoundVar(1)), EVar(BoundVar(2))))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PSend" should "handle a basic send" in {
@@ -278,33 +236,21 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val pSend = new PSend(new NameQuote(new PNil()), new SendSingle(), sentData)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pSend, inputs)
-    result.par should be (
-        inputs.par.copy(
-            sends = List(Send(
-                Quote(Par()),
-                List(Par().copy(exprs = List(GInt(7))),
-                     Par().copy(exprs = List(GInt(8)))),
-                false))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.prepend(Send(Quote(Par()), List[Par](GInt(7), GInt(8)), false)))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PSend" should "handle a name var" in {
     val sentData = new ListProc()
     sentData.add(new PGround(new GroundInt(7)))
     sentData.add(new PGround(new GroundInt(8)))
-    val pSend = new PSend(new NameVar("x"), new SendSingle(), sentData)
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val pSend       = new PSend(new NameVar("x"), new SendSingle(), sentData)
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pSend, boundInputs)
-    result.par should be (
-        inputs.par.copy(
-            sends = List(Send(
-                ChanVar(BoundVar(0)),
-                List(Par().copy(exprs = List(GInt(7))),
-                     Par().copy(exprs = List(GInt(8)))),
-                false))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(
+      inputs.par.prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(7), GInt(8)), false)))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PSend" should "propagate knownFree" in {
@@ -313,42 +259,29 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     sentData.add(new PVar("x"))
     val pSend = new PSend(new NameQuote(new PVar("x")), new SendSingle(), sentData)
 
-    an [Error] should be thrownBy {
+    an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pSend, inputs)
     }
   }
 
   "PPar" should "Compile both branches into a par object" in {
-    val parGround = new PPar(
-        new PGround(
-            new GroundInt(7)),
-        new PGround(
-            new GroundInt(8)))
-    val result = ProcNormalizeMatcher.normalizeMatch(parGround, inputs)
-    result.par should be (
-        inputs.par.copy(exprs =
-            List(GInt(8), GInt(7))))
-    result.knownFree should be (inputs.knownFree)
+    val parGround = new PPar(new PGround(new GroundInt(7)), new PGround(new GroundInt(8)))
+    val result    = ProcNormalizeMatcher.normalizeMatch(parGround, inputs)
+    result.par should be(inputs.par.copy(exprs = List(GInt(8), GInt(7))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "PPar" should "Compile both branches with the same environment" in {
-    val parDoubleBound = new PPar(
-        new PVar("x"),
-        new PVar("x"))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val parDoubleBound = new PPar(new PVar("x"), new PVar("x"))
+    val boundInputs    = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(parDoubleBound, boundInputs)
-    result.par should be (
-        inputs.par.copy(exprs =
-            List(EVar(BoundVar(0)), EVar(BoundVar(0)))))
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(inputs.par.copy(exprs = List(EVar(BoundVar(0)), EVar(BoundVar(0)))))
+    result.knownFree should be(inputs.knownFree)
   }
   "PPar" should "Not compile if both branches use the same free variable" in {
-    val parDoubleFree = new PPar(
-        new PVar("x"),
-        new PVar("x"))
-    an [Error] should be thrownBy {
+    val parDoubleFree = new PPar(new PVar("x"), new PVar("x"))
+    an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(parDoubleFree, inputs)
     }
   }
@@ -359,81 +292,67 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
           }
         }
         // new is simulated by bindings.
-    */
+     */
     val listBindings = new ListName()
     listBindings.add(new NameVar("ret"))
     listBindings.add(new NameQuote(new PVar("x")))
     listBindings.add(new NameQuote(new PVar("y")))
     val listSend = new ListProc()
     listSend.add(new PAdd(new PVar("x"), new PVar("y")))
-    val pBasicContr = new PContr(new NameVar("add"), listBindings,
-      new PSend(new NameVar("ret"), new SendSingle(), listSend))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("add"), NameSort)))._1)
-    
+    val pBasicContr = new PContr(new NameVar("add"),
+                                 listBindings,
+                                 new PSend(new NameVar("ret"), new SendSingle(), listSend))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("add"), NameSort)))._1)
+
     val result = ProcNormalizeMatcher.normalizeMatch(pBasicContr, boundInputs)
-    result.par should be (
-        inputs.par.copy(receives = 
-            List(Receive(
-                List(
-                    (List(
-                        ChanVar(FreeVar(0)),
-                        Quote(Par().copy(exprs = List(EVar(FreeVar(1))))),
-                        Quote(Par().copy(exprs = List(EVar(FreeVar(2)))))),
-                    ChanVar(BoundVar(0)))),
-                Par().copy(sends = List(Send(
-                    ChanVar(BoundVar(1)),
-                    List(Par().copy(exprs = List(EPlus(
-                        Par().copy(exprs = List(EVar(BoundVar(2)))),
-                        Par().copy(exprs = List(EVar(BoundVar(3)))))))),
-                    false))),
-                true)))) // persistent
-    result.knownFree should be (inputs.knownFree)
+    result.par should be(
+      inputs.par.prepend(Receive(
+        List((List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1))), Quote(EVar(FreeVar(2)))),
+              ChanVar(BoundVar(0)))),
+        Send(ChanVar(BoundVar(1)), List[Par](EPlus(EVar(BoundVar(2)), EVar(BoundVar(3)))), false),
+        true
+      ))) // persistent
+    result.knownFree should be(inputs.knownFree)
   }
 }
 
 class NameMatcherSpec extends FlatSpec with Matchers {
-  val inputs = NameVisitInputs(
-      DebruijnLevelMap[VarSort](),
-      DebruijnLevelMap[VarSort]())
+  val inputs = NameVisitInputs(DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
 
   "NameWildcard" should "Set wildcard flag in knownFree" in {
-    val nw = new NameWildcard()
+    val nw     = new NameWildcard()
     val result = NameNormalizeMatcher.normalizeMatch(nw, inputs)
-    result.chan should be (ChanVar(FreeVar(0)))
+    result.chan should be(ChanVar(FreeVar(0)))
     result.knownFree shouldEqual (inputs.knownFree.setWildcardUsed(1)._1)
   }
 
   val nvar = new NameVar("x")
 
   "NameVar" should "Compile as BoundVar if it's in env" in {
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
-  
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+
     val result = NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
-    result.chan should be (ChanVar(BoundVar(0)))
-    result.knownFree should be (inputs.knownFree)
+    result.chan should be(ChanVar(BoundVar(0)))
+    result.knownFree should be(inputs.knownFree)
   }
   "NameVar" should "Compile as FreeVar if it's not in env" in {
     val result = NameNormalizeMatcher.normalizeMatch(nvar, inputs)
-    result.chan should be (ChanVar(FreeVar(0)))
+    result.chan should be(ChanVar(FreeVar(0)))
     result.knownFree shouldEqual
-        (inputs.knownFree.newBindings(
-            List((Some("x"), NameSort)))._1)
+      (inputs.knownFree.newBindings(List((Some("x"), NameSort)))._1)
   }
   "NameVar" should "Not compile if it's in env of the wrong sort" in {
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
-    
-    an [Error] should be thrownBy {
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+
+    an[Error] should be thrownBy {
       NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
     }
   }
   "NameVar" should "Not compile if it's used free somewhere else" in {
-    val boundInputs = inputs.copy(knownFree =
-      inputs.knownFree.newBindings(List((Some("x"), NameSort)))._1)
-    
-    an [Error] should be thrownBy {
+    val boundInputs =
+      inputs.copy(knownFree = inputs.knownFree.newBindings(List((Some("x"), NameSort)))._1)
+
+    an[Error] should be thrownBy {
       NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
     }
   }
@@ -441,42 +360,40 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   val nqvar = new NameQuote(new PVar("x"))
 
   "NameQuote" should "compile to a quoted var if the var is bound" in {
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
-    val nqvar = new NameQuote(new PVar("x"))
-    val result = NameNormalizeMatcher.normalizeMatch(nqvar, boundInputs)
-    result.chan should be (Quote(Par().copy(exprs = List(EVar(BoundVar(0))))))
-    result.knownFree should be (inputs.knownFree)
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val nqvar       = new NameQuote(new PVar("x"))
+    val result      = NameNormalizeMatcher.normalizeMatch(nqvar, boundInputs)
+    result.chan should be(Quote(EVar(BoundVar(0))))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "NameQuote" should "return a free use if the quoted proc has a free var" in {
     val result = NameNormalizeMatcher.normalizeMatch(nqvar, inputs)
-    result.chan should be (Quote(Par().copy(exprs = List(EVar(FreeVar(0))))))
-    result.knownFree should be (inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
+    result.chan should be(Quote(Par().copy(exprs = List(EVar(FreeVar(0))))))
+    result.knownFree should be(inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
   }
 
   "NameQuote" should "compile to a quoted ground" in {
     val nqground = new NameQuote(new PGround(new GroundInt(7)))
-    val result = NameNormalizeMatcher.normalizeMatch(nqground, inputs)
-    result.chan should be (Quote(Par().copy(exprs = List(GInt(7)))))
-    result.knownFree should be (inputs.knownFree)
+    val result   = NameNormalizeMatcher.normalizeMatch(nqground, inputs)
+    result.chan should be(Quote(GInt(7)))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "NameQuote" should "collapse an eval" in {
-    val nqeval = new NameQuote(new PEval(new NameVar("x")))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
-    val result = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
-    result.chan should be (ChanVar(BoundVar(0)))
-    result.knownFree should be (inputs.knownFree)
+    val nqeval      = new NameQuote(new PEval(new NameVar("x")))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val result      = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
+    result.chan should be(ChanVar(BoundVar(0)))
+    result.knownFree should be(inputs.knownFree)
   }
 
   "NameQuote" should "not collapse an eval | eval" in {
-    val nqeval = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
-    val boundInputs = inputs.copy(env =
-      inputs.env.newBindings(List((Some("x"), NameSort)))._1)
-    val result = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
-    result.chan should be (Quote(Par().copy(evals = List(Eval(ChanVar(BoundVar(0))), Eval(ChanVar(BoundVar(0)))))))
-    result.knownFree should be (inputs.knownFree)
+    val nqeval      = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
+    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val result      = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
+    result.chan should be(
+      Quote(Par(Eval(ChanVar(BoundVar(0)))).prepend(Eval(ChanVar(BoundVar(0))))))
+    result.knownFree should be(inputs.knownFree)
   }
 }


### PR DESCRIPTION
Add helper constructors for single element pars and a prepend method that adds a
single element to a par. This makes the tests and the normalizer more concise.

Relative to #305 