### PR TITLE
 Rholang: Normalizer: Add support for Receive.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -1,4 +1,4 @@
-package coop.rchain.rholang.intepreter
+package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.syntax.rholang_mercury
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{Ground => AbsynGround, _}
@@ -242,7 +242,7 @@ object ProcNormalizeMatcher {
             (result.chan :: acc._1, result.knownFree)
           }
         )
-        val newEnv = input.env.absorbFree(formalsResults._2)
+        val newEnv = input.env.absorbFree(formalsResults._2)._1
         val bodyResult = ProcNormalizeMatcher.normalizeMatch(
           p.proc_,
           ProcVisitInputs(Par(), newEnv, nameMatchResult.knownFree))
@@ -252,6 +252,74 @@ object ProcNormalizeMatcher {
                                bodyResult.par,
                                true) :: input.par.receives),
           bodyResult.knownFree)
+      }
+
+      case p: PInput => {
+        import scala.collection.JavaConverters._
+        // To handle the most common case where we can sort the binds because
+        // they're from different sources, Each channel read starts its free variables at 0.
+        // We check for overlap at the end before sorting.
+
+        // We split this into parts. First we process all the sources, then we process all the bindings.
+        def processSources(bindings: List[(List[Name], Name)])
+          : (List[(List[Name], Channel)], DebruijnLevelMap[VarSort]) = {
+          val initAcc = (List[(List[Name], Channel)](), input.knownFree)
+          val foldResult = (initAcc /: bindings)((acc, e) => {
+            val sourceResult =
+              NameNormalizeMatcher.normalizeMatch(e._2, NameVisitInputs(input.env, acc._2))
+            ((e._1, sourceResult.chan) :: acc._1, sourceResult.knownFree)
+          })
+          (foldResult._1.reverse, foldResult._2)
+        }
+        def processBindings(bindings: List[(List[Name], Channel)])
+          : List[(List[Channel], Channel, DebruijnLevelMap[VarSort])] =
+          bindings map {
+            case (names: List[Name], chan: Channel) => {
+              val initAcc = (List[Channel](), DebruijnLevelMap[VarSort]())
+              val formalsResults = (initAcc /: names)(
+                (acc, n: Name) => {
+                  val result =
+                    NameNormalizeMatcher.normalizeMatch(n,
+                                                        NameVisitInputs(DebruijnLevelMap(), acc._2))
+                  (result.chan :: acc._1, result.knownFree)
+                }
+              )
+              (formalsResults._1.reverse, chan, formalsResults._2)
+            }
+          }
+        val (bindings, persistent) = p.receipt_ match {
+          case rl: ReceiptLinear =>
+            rl.receiptlinearimpl_ match {
+              case ls: LinearSimple =>
+                (ls.listlinearbind_.asScala.toList.map {
+                  case lbi: LinearBindImpl => (lbi.listname_.asScala.toList, lbi.name_)
+                  case _                   => throw new Error("Unexpected LinearBind production.")
+                }, false)
+              case _ => throw new Error("Unexpected LinearReceipt production.")
+            }
+          case rl: ReceiptRepeated =>
+            rl.receiptrepeatedimpl_ match {
+              case ls: RepeatedSimple =>
+                (ls.listrepeatedbind_.asScala.toList.map {
+                  case lbi: RepeatedBindImpl => (lbi.listname_.asScala.toList, lbi.name_)
+                  case _                     => throw new Error("Unexpected RepeatedBind production.")
+                }, true)
+              case _ => throw new Error("Unexpected RepeatedReceipt production.")
+            }
+        }
+        val (sources, thisLevelFree) = processSources(bindings)
+        val receipts                 = ReceiveSortMatcher.preSortBinds(processBindings(sources))
+        val groupedFrees = (DebruijnLevelMap[VarSort]() /: receipts)((env, receipt) =>
+          env.absorbFree(receipt._3) match {
+            case (newEnv, Nil) => newEnv
+            case _ =>
+              throw new Error("Free variable used as binder may not be used twice.")
+        })
+        val binds      = receipts.map((receipt) => (receipt._1, receipt._2))
+        val updatedEnv = input.env.absorbFree(groupedFrees)._1
+        val bodyResult = normalizeMatch(p.proc_, ProcVisitInputs(Par(), updatedEnv, thisLevelFree))
+        ProcVisitOutputs(input.par.prepend(Receive(binds, bodyResult.par, persistent)),
+                         bodyResult.knownFree)
       }
 
       case p: PPar => {
@@ -283,12 +351,15 @@ class DebruijnLevelMap[T](val next: Int, val env: Map[String, (Int, T)]) {
     (result._1, result._2.reverse)
   }
 
-  def absorbFree(binders: DebruijnLevelMap[T]): DebruijnLevelMap[T] = {
+  // Returns the new map, and a list of the shadowed variables.
+  def absorbFree(binders: DebruijnLevelMap[T]): (DebruijnLevelMap[T], List[String]) = {
     val finalNext  = next + binders.next
     val adjustNext = next
-    binders.env.foldLeft(this) {
-      case (db: DebruijnLevelMap[T], (k: String, (level: Int, varType: T @unchecked))) =>
-        DebruijnLevelMap(finalNext, db.env + (k -> ((level + adjustNext, varType))))
+    binders.env.foldLeft((this, List[String]())) {
+      case ((db: DebruijnLevelMap[T], shadowed: List[String]),
+            (k: String, (level: Int, varType: T @unchecked))) =>
+        val shadowedNew = if (db.env.contains(k)) k :: shadowed else shadowed
+        (DebruijnLevelMap(finalNext, db.env + (k -> ((level + adjustNext, varType)))), shadowedNew)
     }
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/rholangADT.scala
@@ -2,7 +2,7 @@
 // Normalization requires the evaluation of everything that doesn't go through
 // the tuplespace, so the top level of a normalized process must have everything
 
-package coop.rchain.rholang.intepreter
+package coop.rchain.rholang.interpreter
 
 import scala.language.implicitConversions
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -14,8 +14,6 @@
   */
 package coop.rchain.rholang.interpreter
 
-import coop.rchain.rholang.intepreter._
-
 sealed trait Tree[T] {
   def size: Int
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -151,7 +151,7 @@ object GroundSortMatcher {
         ScoredTerm(EList(pars.map(_.term)), Node(Score.ELIST, pars.map(_.score): _*))
       case gt: ETuple =>
         val pars = gt.ps.map(par => ParSortMatcher.sortMatch(par))
-        ScoredTerm(ETuple(pars.map(_.term)), Node(Score.ETUPLE, pars.map(_.score):_*))
+        ScoredTerm(ETuple(pars.map(_.term)), Node(Score.ETUPLE, pars.map(_.score): _*))
       // Note ESet and EMap rely on the stableness of Scala's sort
       // See https://github.com/scala/scala/blob/2.11.x/src/library/scala/collection/SeqLike.scala#L627
       case gs: ESet =>
@@ -172,8 +172,8 @@ object GroundSortMatcher {
       case gm: EMap =>
         def sortKeyValuePair(kv: (Par, Par)): ScoredTerm[Tuple2[Par, Par]] = {
           val (key, value) = kv
-          val sortedKey = ParSortMatcher.sortMatch(key)
-          val sortedValue = ParSortMatcher.sortMatch(value)
+          val sortedKey    = ParSortMatcher.sortMatch(key)
+          val sortedValue  = ParSortMatcher.sortMatch(value)
           ScoredTerm((sortedKey.term, sortedValue.term), sortedKey.score)
         }
         def deduplicateLastWriteWins(scoredTerms: List[ScoredTerm[Tuple2[Par, Par]]]) =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -350,6 +350,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   }
 
   "PInput" should "Handle a simple receive" in {
+    // for ( x, y <- @Nil ) { x!(*y) }
     val listBindings = new ListName()
     listBindings.add(new NameVar("x"))
     listBindings.add(new NameVar("y"))
@@ -375,6 +376,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.knownFree should be(inputs.knownFree)
   }
   "PInput" should "Handle a more complicated receive" in {
+    // for ( (x1, @y1) <- @Nil ; (x2, @y2) <- @1) { x1!(y2) | x2!(y1) }
     val listBindings1 = new ListName()
     listBindings1.add(new NameVar("x1"))
     listBindings1.add(new NameQuote(new PVar("y1")))
@@ -410,6 +412,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.knownFree should be(inputs.knownFree)
   }
   "PInput" should "Fail if a free variable is used in 2 different receives" in {
+    // for ( (x1, @y1) <- @Nil ; (x2, @y1) <- @1) { Nil }
     val listBindings1 = new ListName()
     listBindings1.add(new NameVar("x1"))
     listBindings1.add(new NameQuote(new PVar("y1")))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rholang.interpreter
 
-import coop.rchain.rholang.intepreter._
 import org.scalatest._
 
 class ScoredTermSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Before processing the body of a Receive, we sort the channels/patterns. This
means that join is *mostly* commutative. Things commute as long they aren't the
same. Most useful terms will be fully commutative.