### PR TITLE
storage: add Match type class

### DIFF
--- a/storage/src/main/scala/coop/rchain/storage/Match.scala
+++ b/storage/src/main/scala/coop/rchain/storage/Match.scala
@@ -1,0 +1,14 @@
+package coop.rchain.storage
+
+/**
+  * Type class for matching patterns with data.
+  *
+  * In Rholang, `P` is `List[Channel]`, and `A` is `List[Quote]`.
+  *
+  * @tparam P The type of Patterns
+  * @tparam A The type of Data
+  */
+trait Match[P, A] {
+
+  def get(p: P, a: A): Option[A]
+}


### PR DESCRIPTION
Storage is designed to be agnostic to the underlying types of patterns and data that it persists.  It does this by providing a generic, type class-based API.

In order to use the library, a user will need to provide an instance of the `Match` type class. This instance is used for matching a user-determined pattern against the data they store in the storage layer.