### PR TITLE
Ensure java file coding set properly.

### DIFF
--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -28,6 +28,7 @@ object CompilerSettings {
     // format: on
 
   lazy val options = Seq(
+    javacOptions ++= Seq("-encoding", "UTF-8"),
     scalacOptions ++= commonOptions ++ {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, major)) if major >= 12 =>


### PR DESCRIPTION
Takes care of, _e.g._, French comments that break builds in environments that otherwise demand ASCII.