### PR TITLE
CORE-216: storage: Improve IStore

### DIFF
--- a/storage/src/main/scala/coop/rchain/storage/IStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/IStore.scala
@@ -8,9 +8,8 @@ import coop.rchain.models.Serialize
   * @tparam P a type representing a pattern
   * @tparam A a type representing an arbitrary piece of data
   * @tparam K a type representing a continuation
-  * @tparam T a type representing a transaction
   */
-trait IStore[C, P, A, K, T] {
+trait IStore[C, P, A, K] {
 
   /**
     * The type of hashes
@@ -23,9 +22,16 @@ trait IStore[C, P, A, K, T] {
 
   private[storage] def getKey(txn: T, hash: H): List[C]
 
+  /**
+    * The type of transactions
+    */
+  type T
+
   def createTxnRead(): T
 
   def createTxnWrite(): T
+
+  def withTxn[R](txn: T)(f: T => R): R
 
   def putA(txn: T, channels: List[C], a: A): Unit
 


### PR DESCRIPTION
Quoting from [CORE-216](https://rchain.atlassian.net/browse/CORE-216):

> In the course of working with the `IStore` interface created in   CORE-204 DONE  , Henry Till realized that several improvements were needed:
>
> 1. ~~The trait should be be parameterized over the type of transactions. This allows us to bring the current in-memory prototype into the project and use it as reference implementation for testing.~~
> 2. There should be an abstract type member `H` representing the type of hashes.
> 2. `hashC` should return an `H`.
> 3. `getKey` should accept an `H` instead of a `String`.
> 3. The join-related methods should have a transaction parameter.
> 4. There should be an `addJoin` method which mimics the functionality of `joinMap.addBinding`.
> 5. There should be a `close` method.

**Update**, 2018-02-28:

It is probably a bad choice for the API to expose a type parameter for transactions.

Instead, we should add a another abstract type member `T` representing the type of transactions, and add `withTxn` as a method in `IStore`.