### PR TITLE
Rholang: Normalizer: Add support for match

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -362,8 +362,9 @@ object ProcNormalizeMatcher {
           caseImpl match {
             case (pattern, caseBody) => {
               val patternResult =
-                normalizeMatch(pattern,
-                               ProcVisitInputs(Par(), input.env, DebruijnLevelMap[VarSort]()))
+                normalizeMatch(
+                  pattern,
+                  ProcVisitInputs(Par(), DebruijnLevelMap(), DebruijnLevelMap[VarSort]()))
               val caseEnv = input.env.absorbFree(patternResult.knownFree)._1
               val caseBodyResult =
                 normalizeMatch(caseBody, ProcVisitInputs(Par(), caseEnv, acc._2))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -364,7 +364,7 @@ object ProcNormalizeMatcher {
               val patternResult =
                 normalizeMatch(
                   pattern,
-                  ProcVisitInputs(Par(), DebruijnLevelMap(), DebruijnLevelMap[VarSort]()))
+                  ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]()))
               val caseEnv = input.env.absorbFree(patternResult.knownFree)._1
               val caseBodyResult =
                 normalizeMatch(caseBody, ProcVisitInputs(Par(), caseEnv, acc._2))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -340,7 +340,7 @@ object ProcNormalizeMatcher {
       case p: PMatch => {
         import scala.collection.JavaConverters._
 
-        val value = normalizeMatch(p.proc_, input)
+        val targetResult = normalizeMatch(p.proc_, input)
         val cases = p.listcase_.asScala.toList.map {
           case ci: CaseImpl => (ci.proc_1, ci.proc_2)
           case _            => throw new Error("Unexpected Case implementation.")
@@ -351,7 +351,8 @@ object ProcNormalizeMatcher {
           caseImpl match {
             case (pattern, caseBody) => {
               val patternResult =
-                normalizeMatch(pattern, ProcVisitInputs(Par(), input.env, input.knownFree))
+                normalizeMatch(pattern,
+                               ProcVisitInputs(Par(), input.env, DebruijnLevelMap[VarSort]()))
               val caseEnv = input.env.absorbFree(patternResult.knownFree)._1
               val caseBodyResult =
                 normalizeMatch(caseBody, ProcVisitInputs(Par(), caseEnv, acc._2))
@@ -359,7 +360,7 @@ object ProcNormalizeMatcher {
             }
           }
         }
-        ProcVisitOutputs(input.par.prepend(Match(value.par, casesResult._1.reverse)),
+        ProcVisitOutputs(input.par.prepend(Match(targetResult.par, casesResult._1.reverse)),
                          casesResult._2)
       }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -371,8 +371,10 @@ object ProcNormalizeMatcher {
             }
           }
         }
-        ProcVisitOutputs(input.par.prepend(Match(targetResult.par, casesResult._1.reverse)),
-                         casesResult._2)
+        val freeCount = casesResult._2.next - input.knownFree.next
+        ProcVisitOutputs(
+          input.par.prepend(Match(targetResult.par, casesResult._1.reverse, freeCount)),
+          casesResult._2)
       }
 
       case _ => throw new Error("Compilation of construct not yet supported.")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -515,16 +515,20 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       send47OnNil
     )
     val result    = ProcNormalizeMatcher.normalizeMatch(pPar, inputs)
-    val freeCount = 1
+    val bindCount = 1
+    val freeCount = 0
 
     val expectedResult =
       inputs.par.copy(
-        sends = List(Send(Quote(Par()), List[Par](GInt(47)), false)),
+        sends = List(Send(Quote(Par()), List[Par](GInt(47)), false, 0)),
         receives = List(
-          Receive(List((List(Quote(EVar(FreeVar(0)))), Quote(Par()))),
-                  Match(EVar(BoundVar(0)), List((GInt(42), Par()), (EVar(FreeVar(0)), Par()))),
-                  false,
-                  freeCount))
+          Receive(
+            List((List(Quote(EVar(FreeVar(0)))), Quote(Par()))),
+            Match(EVar(BoundVar(0)), List((GInt(42), Par()), (EVar(FreeVar(0)), Par())), 0),
+            false,
+            bindCount,
+            freeCount
+          ))
       )
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -464,6 +464,44 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       )))
     result.knownFree should be(inputs.knownFree)
   }
+
+  "PMatch" should "Handle a match inside a for comprehension" in {
+    // for (@x <- @Nil) { match x { case 42 => Nil ; case 47 => Nil } | @Nil!(47)
+    val listBindings = new ListName()
+    listBindings.add(new NameQuote(new PVar("x")))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameQuote(new PNil())))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt      = new ReceiptLinear(linearSimple)
+
+    val listCases = new ListCase()
+    listCases.add(new CaseImpl(new PGround(new GroundInt(42)), new PNil()))
+    listCases.add(new CaseImpl(new PGround(new GroundInt(47)), new PNil()))
+    val body = new PMatch(new PVar("x"), listCases)
+
+    val listData = new ListProc()
+    listData.add(new PGround(new GroundInt(47)))
+    val send47OnNil = new PSend(new NameQuote(new PNil()), new SendSingle(), listData)
+
+    val pPar = new PPar(
+      new PInput(receipt, body),
+      send47OnNil
+    )
+    val result    = ProcNormalizeMatcher.normalizeMatch(pPar, inputs)
+    val freeCount = 1
+
+    val expectedResult =
+      inputs.par.copy(
+        sends = List(Send(Quote(Par()), List[Par](GInt(47)), false)),
+        receives = List(
+          Receive(List((List(Quote(EVar(FreeVar(0)))), Quote(Par()))),
+                  Match(EVar(BoundVar(0)), List((GInt(42), Par()), (GInt(47), Par()))),
+                  false,
+                  freeCount))
+      )
+    result.par should be(expectedResult)
+    result.knownFree should be(inputs.knownFree)
+  }
 }
 
 class NameMatcherSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Note this allows duplicate case patterns. The following is
still valid.

```
for (x <- @Nil) {
    match x {
        case (a|b) => Nil
        case (a|b) => Nil
    }
}
```