### PR TITLE
Rholang: Normalizer: Add support for if/else 

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -135,13 +135,15 @@ object ProcNormalizeMatcher {
 
       val targetResult = normalizeMatch(valueProc, input)
       val trueCaseBody =
-        normalizeMatch(trueBodyProc, ProcVisitInputs(Par(), input.env, input.knownFree))
+        normalizeMatch(trueBodyProc, ProcVisitInputs(Par(), input.env, targetResult.knownFree))
       val falseCaseBody =
         normalizeMatch(falseBodyProc, ProcVisitInputs(Par(), input.env, trueCaseBody.knownFree))
+      val freeCount = falseCaseBody.knownFree.next - input.knownFree.next
 
       val desugaredIf = Match(
         targetResult.par,
-        List((GBool(true), trueCaseBody.par), (GBool(false), falseCaseBody.par)))
+        List((GBool(true), trueCaseBody.par), (GBool(false), falseCaseBody.par)),
+        freeCount)
       ProcVisitOutputs(input.par.prepend(desugaredIf), falseCaseBody.knownFree)
     }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -128,21 +128,15 @@ object ProcNormalizeMatcher {
     def normalizeIfElse(valueProc: Proc, trueBodyProc: Proc, falseBodyProc: Proc) = {
       import scala.collection.JavaConverters._
 
-      val value = normalizeMatch(valueProc, input)
-      val trueCasePattern = normalizeMatch(new PGround(new GroundBool(new BoolTrue())),
-                                           ProcVisitInputs(Par(), input.env, input.knownFree))
+      val targetResult = normalizeMatch(valueProc, input)
       val trueCaseBody =
         normalizeMatch(trueBodyProc, ProcVisitInputs(Par(), input.env, input.knownFree))
-
-      val falseCasePattern = normalizeMatch(new PGround(new GroundBool(new BoolFalse())),
-                                            ProcVisitInputs(Par(), input.env, input.knownFree))
       val falseCaseBody =
         normalizeMatch(falseBodyProc, ProcVisitInputs(Par(), input.env, trueCaseBody.knownFree))
 
       val desugaredIf = Match(
-        value.par,
-        List((trueCasePattern.par, trueCaseBody.par), (falseCasePattern.par, falseCaseBody.par)))
-
+        targetResult.par,
+        List((GBool(true), trueCaseBody.par), (GBool(false), falseCaseBody.par)))
       ProcVisitOutputs(input.par.prepend(desugaredIf), falseCaseBody.knownFree)
     }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -502,6 +502,60 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
+
+  "PIf" should "Desugar to match with true/false cases" in {
+    // if (true) { @Nil!(47) }
+    val condition = new PGround(new GroundBool(new BoolTrue()))
+    val listSend  = new ListProc()
+    listSend.add(new PGround(new GroundInt(47)))
+    val body       = new PSend(new NameQuote(new PNil()), new SendSingle(), listSend)
+    val basicInput = new PIf(condition, body)
+
+    val result = ProcNormalizeMatcher.normalizeMatch(basicInput, inputs)
+    result.par should be(
+      inputs.par.prepend(
+        Match(
+          GBool(true),
+          List((GBool(true), Send(Quote(Par()), List[Par](GInt(47)), false)),
+               (GBool(false), Par())
+               // TODO: Fill in type error case
+          )
+        )))
+    result.knownFree should be(inputs.knownFree)
+  }
+  "PIfElse" should "Handle a more complicated if statement with an else clause" in {
+    // if (47 == 47) { new x in { x!(47) } } else { new y in { y!(47) } }
+    val condition = new PEq(new PGround(new GroundInt(47)), new PGround(new GroundInt(47)))
+    val xNameDecl = new ListNameDecl()
+    xNameDecl.add(new NameDeclSimpl("x"))
+    val xSendData = new ListProc()
+    xSendData.add(new PGround(new GroundInt(47)))
+    val pNewIf = new PNew(
+      xNameDecl,
+      new PSend(new NameVar("x"), new SendSingle(), xSendData)
+    )
+    val yNameDecl = new ListNameDecl()
+    yNameDecl.add(new NameDeclSimpl("y"))
+    val ySendData = new ListProc()
+    ySendData.add(new PGround(new GroundInt(47)))
+    val pNewElse = new PNew(
+      yNameDecl,
+      new PSend(new NameVar("y"), new SendSingle(), ySendData)
+    )
+    val basicInput = new PIfElse(condition, pNewIf, pNewElse)
+
+    val result = ProcNormalizeMatcher.normalizeMatch(basicInput, inputs)
+    result.par should be(
+      inputs.par.prepend(Match(
+        EEq(GInt(47), GInt(47)),
+        List(
+          (GBool(true), New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false))),
+          (GBool(false), New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false)))
+          // TODO: Fill in type error case
+        )
+      )))
+    result.knownFree should be(inputs.knownFree)
+  }
 }
 
 class NameMatcherSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Relative to #344 (see commit ba9b435). This resolves https://rchain.atlassian.net/browse/RHOL-141 .

If/else desugars to match as follows.

```
if (cond) P

match cond {
    case true => P
    case false => Nil
    case _ => error
}

if (cond) P else Q

match cond {
    case true => P
    case false => Q
    case _ => error
}
```
Note the case _ => type error is still not implemented.
