### PR TITLE
adjust compiler settings, enabling deprecation warnings

### DIFF
--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -6,6 +6,7 @@ object CompilerSettings {
   /*
    * In the future, let's add:
    *
+   *   "-Xfatal-warnings",
    *   "-Xlint:adapted-args",
    *   "-Xlint:inaccessible",
    *   "-Ywarn-value-discard",
@@ -14,12 +15,11 @@ object CompilerSettings {
   private lazy val commonOptions =
     // format: off
     Seq(
-      // "-Xfatal-warnings",
       "-Xfuture",
       "-Ypartial-unification",
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
-      // "-deprecation", // rholang's Term.scala uses some deprecated shit.  Kill it with fire.
+      "-deprecation",
       "-encoding", "UTF-8",
       "-feature",
       "-language:_",
@@ -53,7 +53,7 @@ object CompilerSettings {
     scalacOptions in (Compile, console) ~= {
       _.filterNot(
         Set(
-          // "-Xfatal-warnings",
+          "-Xfatal-warnings",
           "-Ywarn-unused-import",
           "-Ywarn-unused:imports"
         ))


### PR DESCRIPTION
It is helpful to know when we are using deprecated features in our
code, so we should enable this warning.  Since we are not using
`"-Xfatal-warnings"` (yet), it will not prevent us from building code with
deprecated features, it will merely warn us, which is good.

This commit also re-adds `"-Xfatal-warnings"` to the set of options that
will be disabled when using the REPL (aka "console").  It effectively
changes nothing right now, but it defends against a future situation
where we enable `"-Xfatal-warnings"` and forget to change this setting,
resulting in annyoing behavior at the REPL.  Plus, commented-out things
are smelly.