### PR TITLE
storage: fix deprecation warning in IStore

### DIFF
--- a/storage/src/main/scala/coop/rchain/storage/IStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/IStore.scala
@@ -59,5 +59,5 @@ trait IStore[C, P, A, K] {
   // compare to store.joinMap.remove
   def removeAllJoins(txn: T, c: C): Unit
 
-  def close()
+  def close(): Unit
 }


### PR DESCRIPTION
Scala's deprecated "procedure syntax" allows for writing an abstract method with no return type. 
 
In this case, the code compiled without a specific warning (just a non-specific one telling us to re-run our compilation with `-deprecation` turned on, which is easy to ignore).

Turning on deprecation warnings, as done in #347, will hopefully help prevent such a thing from happening in the future.