### PR TITLE
Revise rholang doc use rosette run entrypoint

### DIFF
--- a/rholang/README.md
+++ b/rholang/README.md
@@ -44,7 +44,7 @@ compiled examples/token.rho to examples/token.rbl
 ### Running rbl with Rosette
 After generating the rbl:
 1. in ../rosette, run build.sh
-2.  (cd ../rosette && ./build.out/src/rosette --boot-dir=rbl/rosette --boot=boot.rbl ../rholang/token.rbl)
+2.  (cd ../rosette && ./run.sh ../rholang/token.rbl)
 
 ## What's working, what's broken:
 See [the bugtracker](https://rchain.atlassian.net/projects/RHOL/issues/RHOL-95?filter=allopenissues) for an up-to-date list of known issues.


### PR DESCRIPTION
Hi! I opted to build rosette and the rholang assembler locally and noticed a discrepancy in the rholang read me and how the docker environment was being prepped for rosette.

My revision changes the rholang readme to use rosette/run.sh, which matches environment prep as docker.