### PR TITLE
Models: Update RhoTypes.proto with updates to rholangADT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,8 @@ lazy val models = project
     commonSettings,
     libraryDependencies ++= commonDependencies ++ protobufDependencies ++ Seq(
       cats,
-      scalaCheck
+      scalaCheck,
+      scalaCheckShapeless
     ),
     connectInput in run := true,
     PB.targets in Compile := Seq(

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -163,7 +163,7 @@ message ETuple {
 }
 
 message ESet {
-    repeated Par ps = 1;
+    repeated Par ps = 1 [(scalapb.field).collection_type="collection.immutable.Set"];
 }
 
 message EMap {

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -1,6 +1,12 @@
 syntax = "proto3";
 
+import "scalapb/scalapb.proto";
+
 option java_package = "coop.rchain.models";
+
+option (scalapb.options) = {
+  import: "coop.rchain.models.BitSetBytesMapper.bitSetBytesMapper"
+};
 
 message Par {
     repeated Send sends = 1;
@@ -8,6 +14,8 @@ message Par {
     repeated Eval evals = 3;
     repeated New news = 4;
     repeated Expr exprs = 5;
+    int32 freeCount = 6;
+    bytes locallyFree = 7 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message Channel {
@@ -15,6 +23,8 @@ message Channel {
         Quote quote = 1;
         ChanVar chanVar = 2;
     }
+    int32 freeCount = 3;
+    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message Quote {
@@ -22,7 +32,7 @@ message Quote {
 }
 
 message ChanVar {
-    Var cvar = 2;
+    Var cvar = 1;
 }
 
 // While we use vars in both positions, when producing the normalized
@@ -34,6 +44,8 @@ message Var {
         BoundVar bound_var = 1;
         FreeVar free_var = 2;
     }
+    int32 freeCount = 3;
+    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message BoundVar {
@@ -57,6 +69,9 @@ message FreeVar {
 message Send {
     Channel chan = 1;
     repeated Par data = 2;
+    bool persistent = 3;
+    int32 freeCount = 4;
+    bytes locallyFree = 5 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message ReceiveBind {
@@ -69,10 +84,17 @@ message ReceiveBind {
 // Don't currently support conditional receive
 message Receive {
     repeated ReceiveBind binds = 1;
+    Par body = 2;
+    bool persistent = 3;
+    int32 bindCount = 4;
+    int32 freeCount = 5;
+    bytes locallyFree = 6 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message Eval {
     Channel channel = 1;
+    int32 freeCount = 2;
+    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 // Number of variables bound in the new statement.
@@ -80,8 +102,22 @@ message Eval {
 // Also for normalized form, the first use should be level+0, next use level+1
 // up to level+count for the last used variable.
 message New {
-    sint32 count = 1;
+    sint32 bindCount = 1;
     Par p = 2;
+    int32 freeCount = 3;
+    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
+}
+
+message Case {
+    Par pattern = 1;
+    Par source = 2;
+}
+
+message Match {
+    Par target = 1;
+    repeated Case cases = 2;
+    int32 freeCount = 3;
+    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 // Any process may be an operand to an expression.
@@ -114,6 +150,8 @@ message Expr {
         GUri g_uri = 23;
         GPrivate g_private = 24;
     }
+    int32 freeCount = 25;
+    bytes locallyFree = 26 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message EList {
@@ -129,12 +167,12 @@ message ESet {
 }
 
 message EMap {
-    repeated ParTuple kvs = 1;
+    repeated KeyValuePair kvs = 1;
 }
 
-message ParTuple {
-    Par p1 = 1;
-    Par p2 = 2;
+message KeyValuePair {
+    Par key = 1;
+    Par value = 2;
 }
 
 // A variable used as a var should be bound in a process context, not a name

--- a/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
@@ -1,0 +1,40 @@
+package coop.rchain.models
+
+import com.trueaccord.scalapb.TypeMapper
+
+import scala.collection.immutable.BitSet
+import java.nio.ByteBuffer
+
+import com.google.protobuf.ByteString
+
+object BitSetBytesMapper {
+  val BYTES_PER_LONG = 8
+
+  implicit val bitSetBytesMapper: TypeMapper[ByteString, BitSet] =
+    TypeMapper(
+      byteStringToBitSet
+    )(bitSetToByteString)
+
+  def bitSetToByteString(bitset: BitSet): ByteString = {
+    val longs: Array[Long] = bitset.toBitMask
+    val bytes: Array[Byte] = (ByteBuffer.allocate(BYTES_PER_LONG * longs.length) /: longs) {
+      (acc, long) =>
+        acc putLong long
+    }.array
+    ByteString.copyFrom(bytes)
+  }
+
+  def byteStringToBitSet(byteString: ByteString): BitSet = {
+    if (byteString.isEmpty) {
+      BitSet()
+    } else {
+      val byteArray = byteString.toByteArray
+      val buffer = ByteBuffer.wrap(byteArray)
+      val longBuffer = buffer.asLongBuffer
+      // Hack to force long buffer to dump array. See https://stackoverflow.com/a/19003601/2750819
+      var longs = Array.fill[Long](longBuffer.capacity)(0)
+      longBuffer.get(longs)
+      BitSet.fromBitMask(longs)
+    }
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
@@ -17,7 +17,7 @@ object BitSetBytesMapper {
 
   def bitSetToByteString(bitset: BitSet): ByteString = {
     val longs: Array[Long] = bitset.toBitMask
-    val bytes: Array[Byte] = (ByteBuffer.allocate(BYTES_PER_LONG * longs.length) /: longs) {
+    val bytes: Array[Byte] = longs.foldLeft(ByteBuffer.allocate(BYTES_PER_LONG * longs.length)) {
       (acc, long) =>
         acc putLong long
     }.array

--- a/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
@@ -15,26 +15,28 @@ object BitSetBytesMapper {
       byteStringToBitSet
     )(bitSetToByteString)
 
+  // Bitsets in Scala are represented as an array of longs.
+  // We serialize this in big endian as an ByteString.
   def bitSetToByteString(bitset: BitSet): ByteString = {
     val longs: Array[Long] = bitset.toBitMask
-    val bytes: Array[Byte] = longs.foldLeft(ByteBuffer.allocate(BYTES_PER_LONG * longs.length)) {
-      (acc, long) =>
+    val bytes: Array[Byte] = longs
+      .foldLeft(ByteBuffer.allocate(BYTES_PER_LONG * longs.length)) { (acc, long) =>
         acc putLong long
-    }.array
+      }
+      .array
     ByteString.copyFrom(bytes)
   }
 
-  def byteStringToBitSet(byteString: ByteString): BitSet = {
+  def byteStringToBitSet(byteString: ByteString): BitSet =
     if (byteString.isEmpty) {
       BitSet()
     } else {
-      val byteArray = byteString.toByteArray
-      val buffer = ByteBuffer.wrap(byteArray)
+      val byteArray  = byteString.toByteArray
+      val buffer     = ByteBuffer.wrap(byteArray)
       val longBuffer = buffer.asLongBuffer
       // Hack to force long buffer to dump array. See https://stackoverflow.com/a/19003601/2750819
       var longs = Array.fill[Long](longBuffer.capacity)(0)
       longBuffer.get(longs)
       BitSet.fromBitMask(longs)
     }
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/implicits.scala
@@ -3,7 +3,7 @@ package coop.rchain.models
 import cats.syntax.either._
 import com.trueaccord.scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
-trait SerializeInstances {
+object implicits {
   case class rhoInstanceWrapper[T <: GeneratedMessage with com.trueaccord.scalapb.Message[T]](
       companion: GeneratedMessageCompanion[T])
       extends Serialize[T] {
@@ -25,4 +25,5 @@ trait SerializeInstances {
   implicit object evalInstance     extends rhoInstanceWrapper(Eval)
   implicit object newInstance      extends rhoInstanceWrapper(New)
   implicit object exprInstance     extends rhoInstanceWrapper(Expr)
+  implicit object matchInstance    extends rhoInstanceWrapper(Match)
 }

--- a/models/src/main/scala/coop/rchain/models/package.scala
+++ b/models/src/main/scala/coop/rchain/models/package.scala
@@ -1,3 +1,0 @@
-package coop.rchain
-
-package object models extends SerializeInstances

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -26,11 +26,12 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
 class BitSetBytesMapperTest extends FlatSpec with PropertyChecks with Matchers {
   "BitSetBytesMapper" should "Pass round-trip serialization on empty bitset" in {
     val emptyBitSet = BitSet()
-    byteStringToBitSet(bitSetToByteString(emptyBitSet)) should be (emptyBitSet)
+    byteStringToBitSet(bitSetToByteString(emptyBitSet)) should be(emptyBitSet)
   }
 
   "BitSetBytesMapper" should "Pass round-trip serialization on a long bitset" in {
-    val nonEmptyBitSet = BitSet(0, 3, 4, 8, 13, 14, 17, 19, 21, 22, 24, 25, 26, 27, 36, 41, 44, 46, 47, 50, 51, 53, 56, 57, 58, 60, 63, 65, 66, 67, 68, 70, 72, 88, 910, 911)
-    byteStringToBitSet(bitSetToByteString(nonEmptyBitSet)) should be (nonEmptyBitSet)
+    val nonEmptyBitSet = BitSet(0, 3, 4, 8, 13, 14, 17, 19, 21, 22, 24, 25, 26, 27, 36, 41, 44, 46,
+      47, 50, 51, 53, 56, 57, 58, 60, 63, 65, 66, 67, 68, 70, 72, 88, 910, 911)
+    byteStringToBitSet(bitSetToByteString(nonEmptyBitSet)) should be(nonEmptyBitSet)
   }
 }

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -1,38 +1,36 @@
 package coop.rchain.models
 
-import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import implicits._
+import testImplicits._
+import BitSetBytesMapper._
 
-class RhoTypesTest extends PropSpec with PropertyChecks with Matchers {
-  def rtt[T](msg: T, serializeInstance: Serialize[T]): Unit = {
+import scala.collection.immutable.BitSet
+
+class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
+
+  def rtt[T](msg: T)(implicit serializeInstance: Serialize[T]): Either[Throwable, T] = {
     val bytes = serializeInstance.encode(msg)
-    val msg2  = serializeInstance.decode(bytes)
-    assert(msg2.isRight && msg == msg2.right.get)
-
-    val errBytes = Array[Byte](1, 2, 3, 4)
-    val msg3     = serializeInstance.decode(errBytes)
-    assert(msg3.isLeft)
+    serializeInstance.decode(bytes)
   }
 
-  property("complex value should pass round-trip serialization") {
-    val lenVariants = for (n <- Gen.choose(0, 50)) yield n
-    forAll(lenVariants) { (len: Int) =>
-      forAll { (p1: Int, p2: Int) =>
-        val n1 = New().withCount(p1)
-        val n2 = New().withCount(p2)
-
-        val par1 = Par().withNews(List.fill(len)(n1))
-        val par2 = Par().withNews(List.fill(len)(n2))
-        val kv   = ParTuple().withP1(par1).withP2(par2)
-
-        val emap = EMap().withKvs(List.fill(len)(kv))
-        val expr = Expr().withEMap(emap)
-
-        val outerPar = Par().withExprs(List(expr))
-
-        rtt(outerPar, parInstance)
-      }
+  "Par" should "Pass round-trip serialization" in {
+    forAll { (par: Par) =>
+      val result = rtt(par)
+      result.right.get should be(par)
     }
+  }
+}
+
+class BitSetBytesMapperTest extends FlatSpec with PropertyChecks with Matchers {
+  "BitSetBytesMapper" should "Pass round-trip serialization on empty bitset" in {
+    val emptyBitSet = BitSet()
+    byteStringToBitSet(bitSetToByteString(emptyBitSet)) should be (emptyBitSet)
+  }
+
+  "BitSetBytesMapper" should "Pass round-trip serialization on a long bitset" in {
+    val nonEmptyBitSet = BitSet(0, 3, 4, 8, 13, 14, 17, 19, 21, 22, 24, 25, 26, 27, 36, 41, 44, 46, 47, 50, 51, 53, 56, 57, 58, 60, 63, 65, 66, 67, 68, 70, 72, 88, 910, 911)
+    byteStringToBitSet(bitSetToByteString(nonEmptyBitSet)) should be (nonEmptyBitSet)
   }
 }

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -1,0 +1,14 @@
+package coop.rchain.models
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.ScalacheckShapeless._
+
+import scala.collection.immutable.BitSet
+
+object testImplicits {
+  val genBitSet = for { bitMask <- Arbitrary.arbitrary[Array[Long]] } yield
+    BitSet.fromBitMask(bitMask)
+  implicit val arbBitSet: Arbitrary[BitSet] = Arbitrary(genBitSet)
+
+  implicit val arbPar = implicitly[Arbitrary[Par]]
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val scalaCheck           = "org.scalacheck"         %% "scalacheck"      % "1.13.4" % "test"
   val guav                 = "com.google.guava"       % "guava"            % "16.0"
   val jaxb                 = "javax.xml.bind"         % "jaxb-api"         % "2.1"
+  val scalaCheckShapeless  = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % "test"
 
   val http4sVersion = "0.18.0"
   val http4sDependencies = Seq(
@@ -42,8 +43,7 @@ object Dependencies {
     "io.circe" %% "circe-generic"        % circeVersion,
     "io.circe" %% "circe-generic-extras" % circeVersion,
     "io.circe" %% "circe-parser"         % circeVersion,
-    "io.circe" %% "circe-literal"        % circeVersion,
-  )
+    "io.circe" %% "circe-literal"        % circeVersion)
 
   val apiServerDependencies = http4sDependencies ++ circeDependencies
 


### PR DESCRIPTION
This includes adding bitsets through the use of a custom type and
a TypeMapper from ByteString <=> BitSet. The tests use
ScalacheckShapeless which automatically generate arbitrary ADTs based on
the generated protobufs case classes. This is a really powerful testing
feature.

This supersedes #360 and is part of
https://rchain.atlassian.net/browse/RHOL-142.

Thanks to @henrytill for his help in coding these changes.