### PR TITLE
CORE-8: storage: add basic logging

### DIFF
--- a/storage/src/main/resources/logback.xml
+++ b/storage/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration debug="true">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are  by default assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/storage/src/main/scala/coop/rchain/storage/StorageActions.scala
+++ b/storage/src/main/scala/coop/rchain/storage/StorageActions.scala
@@ -1,12 +1,15 @@
 package coop.rchain.storage
 
 import cats.implicits._
+import com.typesafe.scalalogging.Logger
 import coop.rchain.storage.util.ignore
 
 import scala.annotation.tailrec
 
 // TODO(ht): improve docstrings
 trait StorageActions {
+
+  private val logger: Logger = Logger[this.type]
 
   /* Consume */
 
@@ -53,19 +56,27 @@ trait StorageActions {
                           channels: List[C],
                           patterns: List[P],
                           continuation: K)(implicit m: Match[P, A]): Option[(K, List[A])] = {
-    if (channels.length =!= patterns.length)
-      throw new IllegalArgumentException("channels.length must equal patterns.length")
+    if (channels.length =!= patterns.length) {
+      val msg = "channels.length must equal patterns.length"
+      logger.error(msg)
+      throw new IllegalArgumentException(msg)
+    }
     store.withTxn(store.createTxnWrite()) { txn =>
+      logger.info(
+        s"consume: searching for data matching <patterns: $patterns> at <channels: $channels>")
       extractDataCandidates(store, channels, patterns)(txn) match {
         case None =>
           store.putK(txn, channels, patterns, continuation)
           for (channel <- channels) store.addJoin(txn, channel, channels)
+          logger.info(
+            s"consume: no data found, storing <(patterns, continuation): ($patterns, $continuation)> at <channels: $channels>")
           None
         case Some(dataCandidates) =>
           dataCandidates.foreach {
             case DataCandidate(candidateChannel, _, dataIndex) =>
               store.removeA(txn, candidateChannel, dataIndex)
           }
+          logger.info(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
           Some((continuation, dataCandidates.map(_.datum)))
       }
     }
@@ -119,15 +130,25 @@ trait StorageActions {
     store.withTxn(store.createTxnWrite()) { txn =>
       val groupedChannels: List[List[C]] = store.getJoin(txn, channel)
       store.putA(txn, List(channel), data)
-      extractProduceCandidate(store, groupedChannels)(txn).map {
-        case ProduceCandidate(channels, continuation, continuationIndex, dataCandidates) =>
-          dataCandidates.foreach {
-            case DataCandidate(candidateChannel, _, dataIndex) =>
-              store.removeA(txn, candidateChannel, dataIndex)
-              ignore { store.removeJoin(txn, candidateChannel, channels) }
-          }
-          store.removePsK(txn, channels, continuationIndex)
-          (continuation, dataCandidates.map(_.datum))
-      }
+      logger.info(s"produce: persisted <data: $data> at <channel: $channel>")
+      logger.info(
+        s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>")
+      extractProduceCandidate(store, groupedChannels)(txn)
+        .map {
+          case ProduceCandidate(channels, continuation, continuationIndex, dataCandidates) =>
+            dataCandidates.foreach {
+              case DataCandidate(candidateChannel, _, dataIndex) =>
+                store.removeA(txn, candidateChannel, dataIndex)
+                ignore { store.removeJoin(txn, candidateChannel, channels) }
+            }
+            store.removePsK(txn, channels, continuationIndex)
+            logger.info(s"produce: matching continuation found at <channels: $channels>")
+            (continuation, dataCandidates.map(_.datum))
+        }
+        .recoverWith {
+          case _: Unit =>
+            logger.info(s"produce: no matching continuation found")
+            None
+        }
     }
 }


### PR DESCRIPTION
Ref:
https://rchain.atlassian.net/browse/CORE-8

As an initial approach, I'm logging entire lists of channels, lists of patterns, and continuations.  This may prove to be too verbose when we start using Rholang datatypes.  Once we can exercise the logger with those datatypes, I will revisit the format of the messages.