### PR TITLE
Rholang: Add CLI that reads Rholang, normalizes, sorts, and outputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,9 +159,9 @@ lazy val rholang = project
       "-language:higherKinds",
       "-Yno-adapted-args",
     ),
-    libraryDependencies ++= commonDependencies ++ Seq(monix),
+    libraryDependencies ++= commonDependencies ++ Seq(monix, argParsing),
     bnfcSettings,
-    mainClass in assembly := Some("coop.rchain.rho2rose.Rholang2RosetteCompiler"),
+    mainClass in assembly := Some("coop.rchain.rholang.interpreter.RholangCLI"),
     coverageExcludedFiles := Seq(
       (javaSource in Compile).value,
       (bnfcGrammarDir in BNFCConfig).value,

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val rholang = project
     ),
     libraryDependencies ++= commonDependencies ++ Seq(monix, argParsing),
     bnfcSettings,
-    mainClass in assembly := Some("coop.rchain.rholang.interpreter.RholangCLI"),
+    mainClass in assembly := Some("coop.rchain.rho2rose.Rholang2RosetteCompiler"),
     coverageExcludedFiles := Seq(
       (javaSource in Compile).value,
       (bnfcGrammarDir in BNFCConfig).value,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -1,0 +1,55 @@
+package coop.rchain.rholang.interpreter
+
+import java.io.{FileNotFoundException, FileReader}
+
+import coop.rchain.models.Par
+import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
+import org.rogach.scallop.ScallopConf
+
+object RholangCLI {
+  class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+    val file = trailArg[String]()
+    verify()
+  }
+
+  def reader(fileName: String): FileReader = new FileReader(fileName)
+  def lexer(fileReader: FileReader): Yylex = new Yylex(fileReader)
+  def parser(lexer: Yylex): parser         = new parser(lexer, lexer.getSymbolFactory())
+
+  def buildAST(fileName: String): Option[Proc] =
+    try {
+      val rdr  = reader(fileName)
+      val lxr  = lexer(rdr)
+      val prsr = parser(lxr)
+      Some(prsr.pProc())
+    } catch {
+      case e: FileNotFoundException => {
+        System.err.println(s"""Error: File not found: ${fileName}""")
+        None
+      }
+      case t: Throwable => {
+        System.err.println(s"""Error while compiling: ${fileName}\n${t}""")
+        None
+      }
+    }
+
+  def main(args: Array[String]): Unit = {
+    val conf             = new Conf(args)
+    val fileName: String = conf.file()
+    buildAST(fileName) match {
+      case Some(term) => {
+        val inputs =
+          ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
+        val normalizedTerm   = ProcNormalizeMatcher.normalizeMatch(term, inputs)
+        val sortedTerm       = ParSortMatcher.sortMatch(Some(normalizedTerm.par)).term.get
+        val compiledFileName = fileName.replaceAll(".rho$", "") + ".rhoc"
+        new java.io.PrintWriter(compiledFileName) {
+          write(sortedTerm.toString); close
+        }
+        println(s"Compiled $fileName to $compiledFileName")
+      }
+      case None => System.exit(1)
+    }
+  }
+}


### PR DESCRIPTION
Relative to #373

The CLI uses the same scallop library that node uses for arg parsing -
although currently it is only the file name. Note the examples/ folder
no longer works because we don't have methods to display/print. This CLI
uses the rholang mercury BNFC to build up the AST.

This resolves https://rchain.atlassian.net/browse/RHOL-125 .