### PR TITLE
Rholang: Add option to CLI to serialize out as binary protobuf

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -9,7 +9,7 @@ import org.rogach.scallop.ScallopConf
 
 object RholangCLI {
   class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-    version("Rholang Mercury 0.1")
+    version("Rholang Mercury 0.2")
     banner("""
              |Takes in a rholang source file and
              |outputs a normalized case class serialization for now.


### PR DESCRIPTION
Relative to #378 and closes https://rchain.atlassian.net/browse/RHOL-154 .

Also add help option to CLI that looks like the following. Note I haven't
switched out the main class for the Rholang subproject in built.sbt
to allow this yet.

```
$ java -jar target/scala-2.12/rholang-assembly-0.1.0-SNAPSHOT.jar --help
Rholang Mercury 0.1

Takes in a rholang source file and
outputs a normalized case class serialization for now.

Options:

  -b, --binary    outputs binary protobuf serialization
      --help      Show help message
      --version   Show version of this program

 trailing arguments:
  file (required)   Rholang source file

Will add more options soon.
```