### PR TITLE
Rholang: Add REPL that prints out case class serialization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,9 +159,9 @@ lazy val rholang = project
       "-language:higherKinds",
       "-Yno-adapted-args",
     ),
-    libraryDependencies ++= commonDependencies ++ Seq(monix),
+    libraryDependencies ++= commonDependencies ++ Seq(monix, argParsing),
     bnfcSettings,
-    mainClass in assembly := Some("coop.rchain.rho2rose.Rholang2RosetteCompiler"),
+    mainClass in assembly := Some("coop.rchain.rholang.interpreter.RholangCLI"),
     coverageExcludedFiles := Seq(
       (javaSource in Compile).value,
       (bnfcGrammarDir in BNFCConfig).value,

--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ lazy val rholang = project
     ),
     libraryDependencies ++= commonDependencies ++ Seq(monix, argParsing),
     bnfcSettings,
-    mainClass in assembly := Some("coop.rchain.rholang.interpreter.RholangCLI"),
+    mainClass in assembly := Some("coop.rchain.rho2rose.Rholang2RosetteCompiler"),
     coverageExcludedFiles := Seq(
       (javaSource in Compile).value,
       (bnfcGrammarDir in BNFCConfig).value,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -1,7 +1,8 @@
 package coop.rchain.rholang.interpreter
 
-import java.io.{BufferedOutputStream, FileNotFoundException, FileOutputStream, FileReader}
+import java.io._
 
+import scala.io.Source
 import coop.rchain.models.Par
 import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
@@ -19,46 +20,49 @@ object RholangCLI {
     footer("\nWill add more options soon.")
 
     val binary = opt[Boolean](descr = "outputs binary protobuf serialization")
-    val file   = trailArg[String](descr = "Rholang source file")
+    val file   = trailArg[String](required = false, descr = "Rholang source file")
     verify()
   }
 
   def reader(fileName: String): FileReader = new FileReader(fileName)
-  def lexer(fileReader: FileReader): Yylex = new Yylex(fileReader)
+  def lexer(fileReader: Reader): Yylex     = new Yylex(fileReader)
   def parser(lexer: Yylex): parser         = new parser(lexer, lexer.getSymbolFactory())
 
-  def buildAST(fileName: String): Option[Proc] =
-    try {
-      val rdr  = reader(fileName)
-      val lxr  = lexer(rdr)
-      val prsr = parser(lxr)
-      Some(prsr.pProc())
-    } catch {
-      case e: FileNotFoundException =>
-        System.err.println(s"""Error: File not found: ${fileName}\n${e}""")
-        None
-      case t: Throwable =>
-        System.err.println(s"""Error while compiling: ${fileName}\n${t}""")
-        None
+  def main(args: Array[String]): Unit = {
+    val conf = new Conf(args)
+    if (conf.file.supplied) {
+      val fileName: String        = conf.file()
+      val source                  = reader(fileName)
+      val sortedTerm: Option[Par] = buildNormalizedTerm(source)
+      if (conf.binary()) {
+        writeBinary(fileName, sortedTerm.get)
+      } else {
+        writeHumanReadable(fileName, sortedTerm.get)
+      }
+    } else {
+      print("> ")
+      repl
+    }
+  }
+
+  private def repl =
+    for (ln <- Source.stdin.getLines) {
+      print(buildNormalizedTerm(new StringReader(ln)).get.toString)
+      print("> ")
     }
 
-  def main(args: Array[String]): Unit = {
-    val conf             = new Conf(args)
-    val fileName: String = conf.file()
-    buildAST(fileName) match {
-      case Some(term) => {
-        val inputs =
-          ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
-        val normalizedTerm: ProcVisitOutputs = normalizeTerm(term, inputs)
-        val sortedTerm                       = ParSortMatcher.sortMatch(Some(normalizedTerm.par)).term.get
-        if (conf.binary()) {
-          writeBinary(fileName, sortedTerm)
-        } else {
-          writeHumanReadable(fileName, sortedTerm)
-        }
-      }
-      case None => System.exit(1)
-    }
+  private def buildNormalizedTerm(source: Reader) = {
+    val term = buildAST(source)
+    val inputs =
+      ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
+    val normalizedTerm: ProcVisitOutputs = normalizeTerm(term, inputs)
+    ParSortMatcher.sortMatch(Some(normalizedTerm.par)).term
+  }
+
+  private def buildAST(source: Reader): Proc = {
+    val lxr = lexer(source)
+    val ast = parser(lxr)
+    ast.pProc()
   }
 
   private def writeHumanReadable(fileName: String, sortedTerm: Par): Unit = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -1,0 +1,55 @@
+package coop.rchain.rholang.interpreter
+
+import java.io.{FileNotFoundException, FileReader}
+
+import coop.rchain.models.Par
+import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
+import org.rogach.scallop.ScallopConf
+
+object RholangCLI {
+  class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+    val file = trailArg[String]()
+    verify()
+  }
+
+  def reader(fileName: String): FileReader = new FileReader(fileName)
+  def lexer(fileReader: FileReader): Yylex = new Yylex(fileReader)
+  def parser(lexer: Yylex): parser         = new parser(lexer, lexer.getSymbolFactory())
+
+  def buildAST(fileName: String): Option[Proc] =
+    try {
+      val rdr  = reader(fileName)
+      val lxr  = lexer(rdr)
+      val prsr = parser(lxr)
+      Some(prsr.pProc())
+    } catch {
+      case e: FileNotFoundException => {
+        System.err.println(s"""Error: File not found: ${fileName}""")
+        None
+      }
+      case t: Throwable => {
+        System.err.println(s"""Error while compiling: ${fileName}\n${t}""")
+        None
+      }
+    }
+
+  def main(args: Array[String]): Unit = {
+    val conf             = new Conf(args)
+    val fileName: String = conf.file()
+    buildAST(fileName) match {
+      case Some(term) => {
+        val inputs =
+          ProcVisitInputs(Par(), DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
+        val normalizedTerm   = ProcNormalizeMatcher.normalizeMatch(term, inputs)
+        val sortedTerm       = ParSortMatcher.sortMatch(Some(normalizedTerm.par)).term.get
+        val compiledFileName = fileName.replaceAll(".rho$", "") + ".rhoc"
+        new java.io.PrintWriter(compiledFileName) {
+          write(sortedTerm.toString); close
+        }
+        println(s"Compiled $fileName to $compiledFileName")
+      }
+      case None => System.exit(1)
+    }
+  }
+}


### PR DESCRIPTION
Relative to #379 and resolves https://rchain.atlassian.net/browse/RHOL-143 .

Below is an example output from the REPL.

```
$ java -jar target/scala-2.12/rholang-assembly-0.1.0-SNAPSHOT.jar
> 2
exprs {
  g_int: 2
  freeCount: 0
  locallyFree: "\000\000\000\000\000\000\000\000"
}
freeCount: 0
locallyFree: "\000\000\000\000\000\000\000\000"
> 5 | 5
exprs {
  g_int: 5
  freeCount: 0
  locallyFree: "\000\000\000\000\000\000\000\000"
}
exprs {
  g_int: 5
  freeCount: 0
  locallyFree: "\000\000\000\000\000\000\000\000"
}
freeCount: 0
locallyFree: "\000\000\000\000\000\000\000\000"
> new x in { x!(5) }
news {
  bindCount: 1
  p {
    sends {
      chan {
        chanVar {
          bound_var: 0
          freeCount: 0
          locallyFree: "\001\000\000\000\000\000\000\000"
        }
        freeCount: 0
        locallyFree: "\001\000\000\000\000\000\000\000"
      }
      data {
        exprs {
          g_int: 5
          freeCount: 0
          locallyFree: "\000\000\000\000\000\000\000\000"
        }
        freeCount: 0
        locallyFree: "\000\000\000\000\000\000\000\000"
      }
      persistent: false
      freeCount: 0
      locallyFree: "\001\000\000\000\000\000\000\000"
    }
    freeCount: 0
    locallyFree: "\001\000\000\000\000\000\000\000"
  }
  freeCount: 0
  locallyFree: "\000\000\000\000\000\000\000\000"
}
freeCount: 0
locallyFree: "\000\000\000\000\000\000\000\000"
```