### PR TITLE
Models: Add pretty printer to protobuf terms

### DIFF
--- a/models/src/main/scala/coop/rchain/models/PrettyPrinter.scala
+++ b/models/src/main/scala/coop/rchain/models/PrettyPrinter.scala
@@ -1,0 +1,231 @@
+package coop.rchain.models
+
+import com.trueaccord.scalapb.{GeneratedMessage, TextFormat}
+import coop.rchain.models.Channel.ChannelInstance
+import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
+import coop.rchain.models.Expr.ExprInstance
+import coop.rchain.models.Expr.ExprInstance._
+import coop.rchain.models.Var.VarInstance
+import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
+
+object PrettyPrinter {
+  def prettyPrint(e: Expr): Unit = {
+    e.exprInstance match {
+      case ENegBody(ENeg(p)) =>
+        print("-")
+        prettyPrint(p.get)
+      case EMultBody(EMult(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" * ")
+        prettyPrint(p2.get)
+      case EDivBody(EDiv(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" / ")
+        prettyPrint(p2.get)
+      case EPlusBody(EPlus(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" + ")
+        prettyPrint(p2.get)
+      case EMinusBody(EMinus(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" - ")
+        prettyPrint(p2.get)
+
+      case ENotBody(ENot(p)) =>
+        print("~")
+        prettyPrint(p.get)
+      case EAndBody(EAnd(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" && ")
+        prettyPrint(p2.get)
+      case EOrBody(EOr(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" || ")
+        prettyPrint(p2.get)
+
+      case EEqBody(EEq(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" == ")
+        prettyPrint(p2.get)
+      case ENeqBody(ENeq(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" != ")
+        prettyPrint(p2.get)
+      case EGtBody(EGt(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" > ")
+        prettyPrint(p2.get)
+      case EGteBody(EGte(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" >= ")
+        prettyPrint(p2.get)
+      case ELtBody(ELt(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" < ")
+        prettyPrint(p2.get)
+      case ELteBody(ELte(p1, p2)) =>
+        prettyPrint(p1.get)
+        print(" <= ")
+        prettyPrint(p2.get)
+
+      case EListBody(EList(s)) =>
+        print("[")
+        printSeq(s)
+        print("]")
+      case ETupleBody(ETuple(s)) =>
+        print("[")
+        printSeq(s)
+        print("]")
+      case ESetBody(ESet(s)) =>
+        print("(")
+        printSeq(s)
+        print(")")
+      case EMapBody(EMap(kvs)) =>
+        print("{")
+        for {(kv, i) <- kvs.zipWithIndex} yield {
+          prettyPrint(kv.key.get)
+          print(":")
+          prettyPrint(kv.value.get)
+          if (i != kvs.length - 1)
+            print(",")
+        }
+        print("}")
+
+      case EVarBody(EVar(v)) =>
+        prettyPrint(v.get)
+
+      case GBool(b) => print(b)
+      case GInt(i) => print(i)
+      case GString(s) => print(s)
+      case GUri(u) => print(u)
+
+      // TODO: Figure out if we can prevent ScalaPB from generating
+      case ExprInstance.Empty => print("Nil")
+
+      case _ => throw new Error("Attempted to print unknown Expr type")
+    }
+  }
+
+  def prettyPrint(v: Var): Unit = {
+    v.varInstance match {
+      case FreeVar(level) =>
+        print(s"_${level}")
+      case BoundVar(level) =>
+        print(s"_${level}")
+      // TODO: Figure out if we can prevent ScalaPB from generating
+      case VarInstance.Empty =>
+        print("@Nil")
+    }
+  }
+
+  def prettyPrint(c: Channel): Unit = {
+    c.channelInstance match {
+      case Quote(p) =>
+        print("@{ ")
+        prettyPrint(p)
+        print(" }")
+      case ChanVar(cv) =>
+        prettyPrint(cv)
+      // TODO: Figure out if we can prevent ScalaPB from generating
+      case ChannelInstance.Empty =>
+        print("@Nil")
+    }
+  }
+
+  def prettyPrint(t: GeneratedMessage): Unit = {
+    t match {
+      case v: Var => prettyPrint(v)
+      case c: Channel => prettyPrint(c)
+      case s: Send =>
+        prettyPrint(s.chan.get)
+        print("!(")
+        for { (datum, i) <- s.data.zipWithIndex } yield {
+          prettyPrint(datum)
+          if (i != s.data.length - 1)
+            print(",")
+        }
+        print(")")
+      case r: Receive =>
+        print("for (")
+        for { (bind, i) <- r.binds.zipWithIndex } yield {
+          printSeq(bind.patterns)
+          print(" <- ")
+          prettyPrint(bind.source.get)
+          if (i != r.binds.length - 1) {
+            print("; ")
+          }
+        }
+        print(") { ")
+        prettyPrint(r.body.get)
+        print(" }")
+      case e: Eval =>
+        print("*")
+        prettyPrint(e.channel.get)
+      case n: New =>
+        print("new ")
+        printNewVariables(n.bindCount)
+        print(" in {")
+        prettyPrint(n.p.get)
+        print("}")
+      case e: Expr =>
+        prettyPrint(e)
+      case m: Match =>
+        print("match { ")
+        prettyPrint(m.target.get)
+        print(" } { ")
+        for {(matchCase, i) <- m.cases.zipWithIndex} yield {
+          prettyPrint(matchCase.pattern.get)
+          print(" => ")
+          prettyPrint(matchCase.source.get)
+          if (i != m.cases.length - 1) {
+            print("; ")
+          }
+        }
+        print(" }")
+      case g: GPrivate =>
+        print(g.id)
+      case p: Par =>
+        if (isEmpty(p)) {
+          print("Nil")
+        } else {
+          val list = List(p.sends, p.receives, p.evals, p.news, p.exprs, p.matches, p.ids)
+          list.foldLeft(false)((acc: Boolean, items: Seq[GeneratedMessage]) => {
+            if (items.nonEmpty) {
+              if (acc)
+                print(" | ")
+              for {(item, i) <- items.zipWithIndex} yield {
+                prettyPrint(item)
+                if (i != items.length - 1) {
+                  print(" | ")
+                }
+              }
+              true
+            } else {
+              acc
+            }
+          })
+        }
+      case _ => throw new Error("Attempt to print unknown GeneratedMessage type")
+    }
+  }
+
+  // TODO: Calculate proper numbering/naming
+  private def printNewVariables(bindCount: Int) = {
+    // We arbitrarily limit the new variable printing count to MAX_NEW_VAR_COUNT
+    // to prevent exploding the state of the shapeless generator
+    val MAX_NEW_VAR_COUNT = 128
+    printSeq(Range(0, List(MAX_NEW_VAR_COUNT,bindCount).min).map(x => Expr(exprInstance=GString(s"_${x}"))))
+  }
+
+  private def printSeq[T <: GeneratedMessage](s: Seq[T]) = {
+    for {(p, i) <- s.zipWithIndex} yield {
+      prettyPrint(p)
+      if (i != s.length - 1)
+        print(",")
+    }
+  }
+
+  private def isEmpty(p: Par) = {
+    p.sends.isEmpty && p.receives.isEmpty && p.evals.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.ids.isEmpty
+  }
+}

--- a/models/src/test/scala/coop/rchain/models/PrettyPrinterTest.scala
+++ b/models/src/test/scala/coop/rchain/models/PrettyPrinterTest.scala
@@ -1,0 +1,17 @@
+package coop.rchain.models
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import testImplicits._
+
+class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
+
+  // This test doesn't actually check anything.
+  // It is for checking the pretty print of an arbitrarily generated Par.
+  "Par" should "Pretty print " in {
+    forAll { (par: Par) =>
+      PrettyPrinter.prettyPrint(par)
+      println()
+    }
+  }
+}

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -2,6 +2,7 @@ package coop.rchain.models
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.ScalacheckShapeless._
+import org.scalacheck.Gen.{const, sized, frequency, resize}
 
 import scala.collection.immutable.BitSet
 
@@ -9,6 +10,12 @@ object testImplicits {
   val genBitSet = for { bitMask <- Arbitrary.arbitrary[Array[Long]] } yield
     BitSet.fromBitMask(bitMask)
   implicit val arbBitSet: Arbitrary[BitSet] = Arbitrary(genBitSet)
+
+  // The ScalaPB generators have quirks in which required objects
+  // become Options. See https://github.com/scalapb/ScalaPB/issues/40 .
+  // We override so that we cannot get None for these required objects.
+  implicit def arbOption[T](implicit a: Arbitrary[T]): Arbitrary[Option[T]] =
+    Arbitrary(for {s <- a.arbitrary} yield Some(s))
 
   implicit val arbPar = implicitly[Arbitrary[Par]]
 }


### PR DESCRIPTION
This more or less prints back out as Rholang source. Here are 10
example generations by shapeless that are then pretty printed.
Shapeless generates some Empty/Nones in various areas where they
shouldn't exist, making the output look a bit odd.

```
Nil
_0!() | for (@Nil <- @{ Nil }) { Nil } | new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {match { Nil }
{  }} | new _0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in
{Nil} | Nil > Nil | match { Nil } {  }
for ( <- _-1) { Nil } | for () { Nil } | for () { Nil } | Nil + Nil |
Nil <= Nil | match { Nil } {  } | match { Nil != Nil } { Nil => Nil } |
➇ |
@{ Nil }!() | *_1 | *@{ Nil } | *@Nil | -Nil | match { Nil } { Nil / Nil
=> Nil } | ⸲և | שּׂ㼮奈 | 㫞泿㵳
@Nil!(Nil) | _1601605265!(Nil) | @{ Nil }!() | for () { 㹟 } | for (@{
Nil } <- @{ Nil }) { Nil } | *_-2147483648 | new  in {match { Nil } {
new  in {Nil} => Nil } | ⺷} | new  in {for () { Nil }} | new  in {match
{ Nil } {  }} | Nil != Nil | [] | () | match { Nil } {  } | match {
*@Nil } { Nil => Nil } | match { Nil } {  } | 끉籖곧
_0!(Nil) | @Nil!(䍾) | for () { Nil } | for (_1124116913 <- @{ Nil }) {
Nil } | for (@{ Nil } <- @Nil) { Nil } | *@{ Nil } | *@Nil | *@{ Nil } |
*_0 | new  in {Nil - Nil} | match { Nil } {  } | match { Nil } {  }
@Nil!(@{ Nil }!() | match { match { for () { Nil } } {  } } {  }) | for
() { new  in {Nil} } | for () { Nil } | for () { Nil } | *@Nil | *@Nil |
-Nil | match { Nil * Nil } {  } | match {  } { Nil => Nil; Nil => Nil }
| match { for () { Nil } | match { new  in {Nil} } {  } } {  } | match {
_512171654!() | new  in {Nil} } { Nil => Nil } | match { Nil } { @Nil!()
=> Nil; Nil => *@{ Nil } } | match { for () { Nil } } {  } | ⣝긋㢀⃋롏뫭
for () { Nil != Nil } | for () { *@{ Nil } | match { Nil } {  } } | for
(_1 <- @Nil; @{ Nil } <- @Nil) { Nil } | for () {  } | for ( <-
_-935581693) { Nil } | *@{ Nil } | *@{ Nil } | *_-1 | new  in {for () {
Nil }} | new _0 in {_-2147483648!()} | new  in {} | new  in {Nil} | new
in {@Nil!()} | new _0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15
in {@Nil!() | match { Nil } {  }} | new  in {new  in {Nil}} | new  in
{@Nil} |  && Nil | () | {} | match { for () { Nil } } { @{ Nil }!(Nil)
=> Nil; Nil => Nil } | match { for () { Nil } } { Nil => Nil; @Nil!() =>
for () { Nil } } | match { @Nil!(Nil) } {  } | match { @Nil!() } { new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {Nil} =>
@Nil!();  => 阂 } | match { Nil } { Nil => Nil } |  | ï·©諫 | 釷嘪뺮泂꘽
@{ Nil }!() | @{ Nil }!(Nil) | for (_2147483647 <- @Nil) { @Nil!() } |
for () { Nil } | for ( <- @Nil) { Nil } | for (@Nil <- @{ Nil }) { Nil }
| *@{ Nil } | *_1843790822 | *@Nil | *@{ Nil } | *@{ Nil } | *@{ Nil } |
*@Nil | new  in {Nil} | new  in {Nil} | new  in {_0!() | match { Nil } {
}} | new _0 in {Nil} | new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {@{ Nil }!() |
()} | new  in {Nil} | new _0 in {new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {Nil}} | new
in {Nil} | new _0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in
{for () { Nil }} | -Nil | Nil - Nil | {} | match { Nil } {  } | match {
Nil >= Nil } {  } | match { for () { Nil } } {  } | match { *@{ Nil } |
new _0 in {Nil} } { Nil => Nil; for () { Nil } => match { Nil } {  };
*@Nil => @Nil!() } | 홝賱੎ | ⤠ି蓣 | ⻦쟣曲㲒㥱콹
_2147483647!() | @Nil!() | @{ Nil }!(@Nil!()) | @Nil!(for () { Nil }) |
for () { -Nil | match { Nil == Nil } {  } } | for ( <- @{ Nil };  <-
@Nil) { Nil } | for ( <- _-349115839;  <- @{ Nil }) { Nil } | for ( <-
@{ Nil }) { Nil } | *@Nil | *@{ Nil } | *@{ Nil } | *@Nil | *@{ Nil } |
*@{ Nil } | *@Nil | *_-1525395267 | new  in {Nil} | new _0 in {@{ Nil
}!(Nil) | *_1} | new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {쌏} | new
_0,_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15 in {@{ Nil }!() |
Nil | match { Nil } {  }} | new  in {Nil} | new  in {Nil} | new  in {} |
match { @Nil!() } { ꧕ => match { Nil } { for () { Nil } => Nil } } |
match { Nil } { Nil => Nil } | match { *_-1295027011 | Nil || Nil |
match { Nil } {  } } { Nil => @Nil!(); Nil == Nil => Nil } | match { Nil
} { for (_1003204961 <- @{ Nil }) { Nil } | match { Nil } {  } => Nil;
Nil => Nil } | match { for ( <- @{ Nil }) { Nil } | *@{ Nil } } { [] =>
*_0 } | match { Nil } { match { [] } {  } => Nil; for () { Nil } =>
match { [] } {  }; match { {} } {  } => match { Nil } { Nil => Nil } } |
match { match { Nil } {  } } {  } | ꈏﵑ햝ಫ | 壝뵸ꓨ밦묉 | Ꙋ䮷퇡㝐河憳
```