### PR TITLE
dev-interpreter

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -22,21 +22,23 @@ object Substitute {
       case _ => throw new Error(s"Illegal Substitution [$term]")
     }
 
-  def subOrDec(exp: EVar)(implicit env: Env[Par]): Either[EVar, Par] =
-    subOrDec(exp.v.get) match {
+  def subOrDec(term: EVar)(implicit env: Env[Par]): Either[EVar, Par] =
+    subOrDec(term.v.get) match {
       case Left(varue) => Left(EVar(varue))
       case Right(par)  => Right(par)
     }
 
   def substitute(term: Channel)(implicit env: Env[Par]): Channel =
-    term.channelInstance match {
-      case Quote(p) => Quote(substitute(p))
-      case ChanVar(v) =>
-        subOrDec(v) match {
-          case Left(_v) => ChanVar(_v)
-          case Right(p) => Quote(p)
-        }
-    }
+    ChannelSortMatcher.sortMatch(
+      term.channelInstance match {
+        case Quote(p) => Quote(substitute(p))
+        case ChanVar(v) =>
+          subOrDec(v) match {
+            case Left(_v) => ChanVar(_v)
+            case Right(p) => Quote(p)
+          }
+      }
+    ).term
 
   def substitute(term: Par)(implicit env: Env[Par]): Par = {
 
@@ -52,120 +54,132 @@ object Substitute {
         }
       }
 
-    Par(
-      for { s <- term.sends } yield substitute(s),
-      for { r <- term.receives } yield substitute(r),
-      for { e <- term.evals } yield substitute(e),
-      for { n <- term.news } yield substitute(n),
-      Nil,
-      for { m <- term.matches } yield substitute(m),
-      term.ids,
-      term.freeCount,
-      term.locallyFree.from(env.level).map(x => x - env.level)
-    ) ++ subExp(term.exprs.toList)
+    ParSortMatcher.sortMatch(
+      Par(
+        for { s <- term.sends } yield substitute(s),
+        for { r <- term.receives } yield substitute(r),
+        for { e <- term.evals } yield substitute(e),
+        for { n <- term.news } yield substitute(n),
+        Nil,
+        for { m <- term.matches } yield substitute(m),
+        term.ids,
+        term.freeCount,
+        term.locallyFree.from(env.level).map(x => x - env.level)
+      ) ++ subExp(term.exprs.toList)
+    ).term.get
   }
 
   def substitute(term: Send)(implicit env: Env[Par]): Send =
-    Send(
-      substitute(term.chan.get),
-      term.data map { par =>
-        substitute(par)
-      },
-      term.persistent,
-      term.freeCount,
-      term.locallyFree.from(env.level).map(x => x - env.level)
-    )
+    SendSortMatcher.sortMatch(
+      Send(
+        substitute(term.chan.get),
+        term.data map { par =>
+          substitute(par)
+        },
+        term.persistent,
+        term.freeCount,
+        term.locallyFree.from(env.level).map(x => x - env.level)
+      )
+    ).term
 
   def substitute(term: Receive)(implicit env: Env[Par]): Receive =
-    Receive(
-      for { ReceiveBind(xs, Some(chan)) <- term.binds } yield {
-        ReceiveBind(xs, substitute(chan))
-      },
-      substitute(term.body.get),
-      term.persistent,
-      term.bindCount,
-      term.freeCount,
-      term.locallyFree.from(env.level).map(x => x - env.level)
-    )
+    ReceiveSortMatcher.sortMatch(
+      Receive(
+        for { ReceiveBind(xs, Some(chan)) <- term.binds } yield {
+          ReceiveBind(xs, substitute(chan))
+        },
+        substitute(term.body.get),
+        term.persistent,
+        term.bindCount,
+        term.freeCount,
+        term.locallyFree.from(env.level).map(x => x - env.level)
+      )
+    ).term
 
   def substitute(term: Eval)(implicit env: Env[Par]): Eval =
-    Eval(substitute(term.channel.get))
+    EvalSortMatcher.sortMatch(Eval(substitute(term.channel.get))).term
 
   def substitute(term: New)(implicit env: Env[Par]): New =
-    New(term.bindCount,
-        substitute(term.p.get),
-        term.freeCount,
-        term.locallyFree.from(env.level).map(x => x - env.level))
+    NewSortMatcher.sortMatch(
+      New(term.bindCount,
+          substitute(term.p.get),
+          term.freeCount,
+          term.locallyFree.from(env.level).map(x => x - env.level))
+    ).term
 
   def substitute(term: Match)(implicit env: Env[Par]): Match =
-    Match(
-      substitute(term.target.get),
-      for { MatchCase(_case, Some(par)) <- term.cases } yield {
-        MatchCase(_case, substitute(par))
-      },
-      term.freeCount,
-      term.locallyFree.from(env.level).map(x => x - env.level)
-    )
+    MatchSortMatcher.sortMatch(
+      Match(
+        substitute(term.target.get),
+        for { MatchCase(_case, Some(par)) <- term.cases } yield {
+          MatchCase(_case, substitute(par))
+        },
+        term.freeCount,
+        term.locallyFree.from(env.level).map(x => x - env.level)
+      )
+    ).term
 
   def substitute(exp: Expr)(implicit env: Env[Par]): Expr =
-    exp.exprInstance match {
-      case ENotBody(ENot(par))            => ENot(substitute(par.get))
-      case ENegBody(ENeg(par))            => ENeg(substitute(par.get))
-      case EMultBody(EMult(par1, par2))   => EMult(substitute(par1.get), substitute(par2.get))
-      case EDivBody(EDiv(par1, par2))     => EDiv(substitute(par1.get), substitute(par2.get))
-      case EPlusBody(EPlus(par1, par2))   => EPlus(substitute(par1.get), substitute(par2.get))
-      case EMinusBody(EMinus(par1, par2)) => EMinus(substitute(par1.get), substitute(par2.get))
-      case ELtBody(ELt(par1, par2))       => ELt(substitute(par1.get), substitute(par2.get))
-      case ELteBody(ELte(par1, par2))     => ELte(substitute(par1.get), substitute(par2.get))
-      case EGtBody(EGt(par1, par2))       => EGt(substitute(par1.get), substitute(par2.get))
-      case EGteBody(EGte(par1, par2))     => EGte(substitute(par1.get), substitute(par2.get))
-      case EEqBody(EEq(par1, par2))       => EEq(substitute(par1.get), substitute(par2.get))
-      case ENeqBody(ENeq(par1, par2))     => ENeq(substitute(par1.get), substitute(par2.get))
-      case EAndBody(EAnd(par1, par2))     => EAnd(substitute(par1.get), substitute(par2.get))
-      case EOrBody(EOr(par1, par2))       => EOr(substitute(par1.get), substitute(par2.get))
-      case EListBody(EList(ps)) =>
-        val _ps = for { par <- ps } yield {
-          substitute(par.get)
-        }
-        val fc = (0 /: _ps) { (i, par) =>
-          i + par.freeCount
-        }
-        Expr(exprInstance = EListBody(EList(_ps)),
-             freeCount = fc,
-             locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
-      case ETupleBody(ETuple(ps)) =>
-        val _ps = for { par <- ps } yield {
-          substitute(par.get)
-        }
-        val fc = (0 /: _ps) { (i, par) =>
-          i + par.freeCount
-        }
-        Expr(exprInstance = ETupleBody(ETuple(_ps)),
-             freeCount = fc,
-             locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
-      case ESetBody(ESet(ps)) =>
-        val _ps = for { par <- ps } yield {
-          substitute(par.get)
-        }
-        val fc = (0 /: _ps) { (i, par) =>
-          i + par.freeCount
-        }
-        Expr(exprInstance = ESetBody(ESet(_ps)),
-             freeCount = fc,
-             locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
-      case EMapBody(EMap(kvs)) =>
-        val _ps = for { KeyValuePair(p1, p2) <- kvs } yield {
-          KeyValuePair(substitute(p1.get), substitute(p2.get))
-        }
-        val fc = (0 /: _ps) {
-          case ((i, KeyValuePair(p1, p2))) =>
-            i + p1.get.freeCount + p2.get.freeCount
-        }
-        Expr(exprInstance = EMapBody(EMap(_ps)),
-             freeCount = fc,
-             locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
-      case g @ _ => exp
-    }
+    ExprSortMatcher.sortMatch(
+      exp.exprInstance match {
+        case ENotBody(ENot(par))            => ENot(substitute(par.get))
+        case ENegBody(ENeg(par))            => ENeg(substitute(par.get))
+        case EMultBody(EMult(par1, par2))   => EMult(substitute(par1.get), substitute(par2.get))
+        case EDivBody(EDiv(par1, par2))     => EDiv(substitute(par1.get), substitute(par2.get))
+        case EPlusBody(EPlus(par1, par2))   => EPlus(substitute(par1.get), substitute(par2.get))
+        case EMinusBody(EMinus(par1, par2)) => EMinus(substitute(par1.get), substitute(par2.get))
+        case ELtBody(ELt(par1, par2))       => ELt(substitute(par1.get), substitute(par2.get))
+        case ELteBody(ELte(par1, par2))     => ELte(substitute(par1.get), substitute(par2.get))
+        case EGtBody(EGt(par1, par2))       => EGt(substitute(par1.get), substitute(par2.get))
+        case EGteBody(EGte(par1, par2))     => EGte(substitute(par1.get), substitute(par2.get))
+        case EEqBody(EEq(par1, par2))       => EEq(substitute(par1.get), substitute(par2.get))
+        case ENeqBody(ENeq(par1, par2))     => ENeq(substitute(par1.get), substitute(par2.get))
+        case EAndBody(EAnd(par1, par2))     => EAnd(substitute(par1.get), substitute(par2.get))
+        case EOrBody(EOr(par1, par2))       => EOr(substitute(par1.get), substitute(par2.get))
+        case EListBody(EList(ps)) =>
+          val _ps = for { par <- ps } yield {
+            substitute(par.get)
+          }
+          val fc = (0 /: _ps) { (i, par) =>
+            i + par.freeCount
+          }
+          Expr(exprInstance = EListBody(EList(_ps)),
+               freeCount = fc,
+               locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
+        case ETupleBody(ETuple(ps)) =>
+          val _ps = for { par <- ps } yield {
+            substitute(par.get)
+          }
+          val fc = (0 /: _ps) { (i, par) =>
+            i + par.freeCount
+          }
+          Expr(exprInstance = ETupleBody(ETuple(_ps)),
+               freeCount = fc,
+               locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
+        case ESetBody(ESet(ps)) =>
+          val _ps = for { par <- ps } yield {
+            substitute(par.get)
+          }
+          val fc = (0 /: _ps) { (i, par) =>
+            i + par.freeCount
+          }
+          Expr(exprInstance = ESetBody(ESet(_ps)),
+               freeCount = fc,
+               locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
+        case EMapBody(EMap(kvs)) =>
+          val _ps = for { KeyValuePair(p1, p2) <- kvs } yield {
+            KeyValuePair(substitute(p1.get), substitute(p2.get))
+          }
+          val fc = (0 /: _ps) {
+            case ((i, KeyValuePair(p1, p2))) =>
+              i + p1.get.freeCount + p2.get.freeCount
+          }
+          Expr(exprInstance = EMapBody(EMap(_ps)),
+               freeCount = fc,
+               locallyFree = exp.locallyFree.from(env.level).map(x => x - env.level))
+        case g @ _ => exp
+      }
+    ).term
 
   def rename(term: Var, j: Int): Var =
     term.varInstance match {


### PR DESCRIPTION
ATM it's appropriate to integrate sorting with substitution. This reduces the complexity of for-comprehensions in the expression evaluator.
The substitution and sorting of Par should never throw an error.

This finishes RHOL-146: https://rchain.atlassian.net/browse/RHOL-146