### PR TITLE
Fix up the way we protect references during allocation.

### DIFF
--- a/rosette/h/Heap.h
+++ b/rosette/h/Heap.h
@@ -25,8 +25,6 @@
 
 #include "Ob.h"
 
-#include <tuple>
-#include <vector>
 
 class RootSet {
    public:


### PR DESCRIPTION
Storing the references in a tuple wasn't good enough to prevent the GC from eating those references. The following _ought_ to do it. Passes tests.