### PR TITLE
ChanImpl_Joe

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Chan.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Chan.scala
@@ -1,0 +1,66 @@
+package coop.rchain.rholang.interpreter
+
+import monix.eval.{MVar, Task}
+
+/**
+  * Chan[A] is a reimplementation of
+  * Scalaz's Chan[A] for Task.
+  *
+  * Originally, I wanted to define this interface
+  * for the "Quote" case class, so that
+  * we didn't need to maintain a separate "store"
+  * mapping Quotes to Chans and could send on quotes
+  * directly.
+  *
+  * My next step was to determine if un-quoting and
+  * re-quoting a process would destroy the quote's
+  * reader/writer queues. If not, we have a concise
+  * store implementation.
+  *
+  * @tparam A The type of data to be sent over a channel
+  */
+abstract class Chan[A] {
+  def read: Task[A]
+  def write(data: A): Task[Unit]
+}
+
+object Chan {
+
+  import MVarOps._
+
+  private type ChannelStream[A] = MVar[ChItem[A]]
+
+  def empty[A]: Task[Chan[A]] =
+    Task now new ChanImpl[A](MVar(MVar.empty[ChItem[A]]), MVar(MVar.empty[ChItem[A]]))
+
+  private[this] case class ChItem[A](head: A, tail: ChannelStream[A])
+
+  private[this] class ChanImpl[A](readVar: MVar[ChannelStream[A]], writeVar: MVar[ChannelStream[A]])
+      extends Chan[A] {
+
+    def write(a: A): Task[Unit] =
+      for {
+        hole <- writeVar.take
+        _    <- hole.put(ChItem(a, MVar.empty[ChItem[A]]))
+        _    <- writeVar.put(MVar.empty[ChItem[A]])
+      } yield ()
+
+    def read: Task[A] =
+      modify(readVar)(readEnd =>
+        for {
+          item <- readEnd.read
+        } yield (item.tail, item.head))
+
+  }
+}
+
+object MVarOps {
+  def modify[A, B](mvar: MVar[A])(f: A => Task[(A, B)]): Task[B] =
+    for {
+      a <- mvar.take
+      (_a, b) <- f(a).doOnFinish(
+                  _ => mvar.put(a)
+                )
+      _ <- mvar.put(_a)
+    } yield b
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Chan.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Chan.scala
@@ -58,9 +58,10 @@ object MVarOps {
   def modify[A, B](mvar: MVar[A])(f: A => Task[(A, B)]): Task[B] =
     for {
       a <- mvar.take
-      (_a, b) <- f(a).doOnFinish(
-                  _ => mvar.put(a)
-                )
-      _ <- mvar.put(_a)
+      tmp <- f(a).doOnFinish(
+              _ => mvar.put(a)
+            )
+      (_a, b) = tmp
+      _       <- mvar.put(_a)
     } yield b
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
@@ -1,23 +1,23 @@
 package coop.rchain.rholang.interpreter
 
-import scala.collection.mutable
+import scala.collection.immutable.SortedMap
 
-/* Env reifies the Env[A] = mutable.LinkedHashMap[Int,A] type alias.
-   It extends HashMap with functions that manipulate
+/* Env reifies the Env[A] = SortedMap[Int,A] type alias.
+   It extends SortedMap with functions that manipulate
    the map based on level indices. */
 
 object Env {
 
-  type Env[A] = mutable.LinkedHashMap[Int, A]
+  type Env[A] = SortedMap[Int, A]
 
   def apply[A](a: A): Env[A] =
-    DeBruijn(mutable.LinkedHashMap.empty[Int, A]) put a
+    DeBruijn(SortedMap.empty[Int, A]) put a
 
   def apply[A](a: A, b: A, k: A*): Env[A] =
-    DeBruijn(mutable.LinkedHashMap.empty[Int, A]) put (a, b, k: _*)
+    DeBruijn(SortedMap.empty[Int, A]) put (a, b, k: _*)
 
   def apply[A](elems: (Int, A)*): Env[A] =
-    mutable.LinkedHashMap[Int, A](elems: _*)
+    SortedMap[Int, A](elems: _*)
 
   implicit class DeBruijn[A](env: Env[A]) {
 
@@ -27,14 +27,14 @@ object Env {
       case (k, data) => (k + j, data)
     }
 
-    def put(a: A): Env[A] = env += (env.level -> a)
+    def put(a: A): Env[A] = env + (env.level -> a)
 
     def put(a: A, b: A, k: A*): Env[A] = (env.put(a).put(b) /: k) { (_env, data) =>
       _env put data
     }
 
     def merge(_env: Env[A]): Env[A] =
-      env ++= _env.rename(env.level)
+      env ++ _env.rename(env.level)
 
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
@@ -14,7 +14,7 @@ object Env {
     DeBruijn(SortedMap.empty[Int, A]) put a
 
   def apply[A](a: A, b: A, k: A*): Env[A] =
-    DeBruijn(SortedMap.empty[Int, A]) put (a, b, k: _*)
+    DeBruijn(SortedMap.empty[Int, A]) put (a +: b +: k: _*)
 
   def apply[A](elems: (Int, A)*): Env[A] =
     SortedMap[Int, A](elems: _*)
@@ -29,7 +29,7 @@ object Env {
 
     def put(a: A): Env[A] = env + (env.level -> a)
 
-    def put(a: A, b: A, k: A*): Env[A] = (env.put(a).put(b) /: k) { (_env, data) =>
+    def put(k: A*): Env[A] = (env /: k) { (_env, data) =>
       _env put data
     }
 


### PR DESCRIPTION
Implemented Chan interface for Task. It's worth checking
to investigate if this interface can be defined for "Quote".
If quoting/unquoting doesn't destroy the internal reader/writer
queues, then our "store" is just the JVM heap. Otherwise,
we'll likely need to add a "Store" to the implementation as
a mapping from quotes to Chan. Then, any functions
that include consume or produce will need an additional
store argument.