### PR TITLE
 Rholang: Protobuf: Simplify implicits and freeCount/locallyFree

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -25,8 +25,6 @@ message Channel {
         Par quote = 1;
         Var chanVar = 2;
     }
-    int32 freeCount = 3;
-    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 // While we use vars in both positions, when producing the normalized
@@ -46,8 +44,6 @@ message Var {
         // In the DeBruijn level paper, they use negatives, but this is more clear.
         sint32 free_var = 2;
     }
-    int32 freeCount = 3;
-    bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 // Upon send, all free variables in data are substituted with their values.
@@ -79,8 +75,6 @@ message Receive {
 
 message Eval {
     Channel channel = 1;
-    int32 freeCount = 2;
-    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 // Number of variables bound in the new statement.
@@ -90,7 +84,6 @@ message Eval {
 message New {
     sint32 bindCount = 1;
     Par p = 2;
-    int32 freeCount = 3;
     bytes locallyFree = 4 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
@@ -136,24 +129,30 @@ message Expr {
         ESet e_set_body = 22;
         EMap e_map_body = 23;
     }
-    int32 freeCount = 24;
-    bytes locallyFree = 25 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message EList {
     repeated Par ps = 1;
+    int32 freeCount = 2;
+    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message ETuple {
     repeated Par ps = 1;
+    int32 freeCount = 2;
+    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message ESet {
     repeated Par ps = 1;
+    int32 freeCount = 2;
+    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message EMap {
     repeated KeyValuePair kvs = 1;
+    int32 freeCount = 2;
+    bytes locallyFree = 3 [(scalapb.field).type = "scala.collection.immutable.BitSet"];
 }
 
 message KeyValuePair {

--- a/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
@@ -35,7 +35,7 @@ object BitSetBytesMapper {
       val byteBuffer = ByteBuffer.wrap(byteArray).order(ByteOrder.LITTLE_ENDIAN)
       val longBuffer = byteBuffer.asLongBuffer
       // Hack to force long buffer to dump array. See https://stackoverflow.com/a/19003601/2750819
-      var longs = Array.fill[Long](longBuffer.capacity)(0)
+      val longs = Array.fill[Long](longBuffer.capacity)(0)
       longBuffer.get(longs)
       BitSet.fromBitMask(longs)
     }

--- a/models/src/main/scala/coop/rchain/models/HasLocallyFree.scala
+++ b/models/src/main/scala/coop/rchain/models/HasLocallyFree.scala
@@ -1,0 +1,8 @@
+package coop.rchain.models
+
+import scala.collection.immutable.BitSet
+
+trait HasLocallyFree[T] {
+  def locallyFree(source: T): BitSet
+  def freeCount(source: T): Int
+}

--- a/models/src/main/scala/coop/rchain/models/PrettyPrinter.scala
+++ b/models/src/main/scala/coop/rchain/models/PrettyPrinter.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.Var.VarInstance
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
 
 object PrettyPrinter {
-  def prettyPrint(e: Expr): Unit = {
+  def prettyPrint(e: Expr): Unit =
     e.exprInstance match {
       case ENegBody(ENeg(p)) =>
         print("-")
@@ -68,21 +68,21 @@ object PrettyPrinter {
         print(" <= ")
         prettyPrint(p2.get)
 
-      case EListBody(EList(s)) =>
+      case EListBody(EList(s, _, _)) =>
         print("[")
         printSeq(s)
         print("]")
-      case ETupleBody(ETuple(s)) =>
+      case ETupleBody(ETuple(s, _, _)) =>
         print("[")
         printSeq(s)
         print("]")
-      case ESetBody(ESet(s)) =>
+      case ESetBody(ESet(s, _, _)) =>
         print("(")
         printSeq(s)
         print(")")
-      case EMapBody(EMap(kvs)) =>
+      case EMapBody(EMap(kvs, _, _)) =>
         print("{")
-        for {(kv, i) <- kvs.zipWithIndex} yield {
+        for { (kv, i) <- kvs.zipWithIndex } yield {
           prettyPrint(kv.key.get)
           print(":")
           prettyPrint(kv.value.get)
@@ -94,19 +94,18 @@ object PrettyPrinter {
       case EVarBody(EVar(v)) =>
         prettyPrint(v.get)
 
-      case GBool(b) => print(b)
-      case GInt(i) => print(i)
+      case GBool(b)   => print(b)
+      case GInt(i)    => print(i)
       case GString(s) => print(s)
-      case GUri(u) => print(u)
+      case GUri(u)    => print(u)
 
       // TODO: Figure out if we can prevent ScalaPB from generating
       case ExprInstance.Empty => print("Nil")
 
       case _ => throw new Error("Attempted to print unknown Expr type")
     }
-  }
 
-  def prettyPrint(v: Var): Unit = {
+  def prettyPrint(v: Var): Unit =
     v.varInstance match {
       case FreeVar(level) =>
         print(s"_${level}")
@@ -116,9 +115,8 @@ object PrettyPrinter {
       case VarInstance.Empty =>
         print("@Nil")
     }
-  }
 
-  def prettyPrint(c: Channel): Unit = {
+  def prettyPrint(c: Channel): Unit =
     c.channelInstance match {
       case Quote(p) =>
         print("@{ ")
@@ -130,11 +128,10 @@ object PrettyPrinter {
       case ChannelInstance.Empty =>
         print("@Nil")
     }
-  }
 
-  def prettyPrint(t: GeneratedMessage): Unit = {
+  def prettyPrint(t: GeneratedMessage): Unit =
     t match {
-      case v: Var => prettyPrint(v)
+      case v: Var     => prettyPrint(v)
       case c: Channel => prettyPrint(c)
       case s: Send =>
         prettyPrint(s.chan.get)
@@ -173,7 +170,7 @@ object PrettyPrinter {
         print("match { ")
         prettyPrint(m.target.get)
         print(" } { ")
-        for {(matchCase, i) <- m.cases.zipWithIndex} yield {
+        for { (matchCase, i) <- m.cases.zipWithIndex } yield {
           prettyPrint(matchCase.pattern.get)
           print(" => ")
           prettyPrint(matchCase.source.get)
@@ -193,7 +190,7 @@ object PrettyPrinter {
             if (items.nonEmpty) {
               if (acc)
                 print(" | ")
-              for {(item, i) <- items.zipWithIndex} yield {
+              for { (item, i) <- items.zipWithIndex } yield {
                 prettyPrint(item)
                 if (i != items.length - 1) {
                   print(" | ")
@@ -207,25 +204,23 @@ object PrettyPrinter {
         }
       case _ => throw new Error("Attempt to print unknown GeneratedMessage type")
     }
-  }
 
   // TODO: Calculate proper numbering/naming
   private def printNewVariables(bindCount: Int) = {
     // We arbitrarily limit the new variable printing count to MAX_NEW_VAR_COUNT
     // to prevent exploding the state of the shapeless generator
     val MAX_NEW_VAR_COUNT = 128
-    printSeq(Range(0, List(MAX_NEW_VAR_COUNT,bindCount).min).map(x => Expr(exprInstance=GString(s"_${x}"))))
+    printSeq(Range(0, List(MAX_NEW_VAR_COUNT, bindCount).min).map(x =>
+      Expr(exprInstance = GString(s"_${x}"))))
   }
 
-  private def printSeq[T <: GeneratedMessage](s: Seq[T]) = {
-    for {(p, i) <- s.zipWithIndex} yield {
+  private def printSeq[T <: GeneratedMessage](s: Seq[T]) =
+    for { (p, i) <- s.zipWithIndex } yield {
       prettyPrint(p)
       if (i != s.length - 1)
         print(",")
     }
-  }
 
-  private def isEmpty(p: Par) = {
+  private def isEmpty(p: Par) =
     p.sends.isEmpty && p.receives.isEmpty && p.evals.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.ids.isEmpty
-  }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
@@ -13,161 +13,97 @@ import scala.collection.immutable.BitSet
 object implicits {
 
   // Channel Related
-  def apply(c: ChannelInstance): Channel =
-    c match {
-      case Quote(q) =>
-        new Channel(channelInstance = c, freeCount = q.freeCount, locallyFree = q.locallyFree)
-      case ChanVar(v) =>
-        new Channel(channelInstance = c, freeCount = v.freeCount, locallyFree = v.locallyFree)
-    }
+  def apply(c: ChannelInstance): Channel                                               = new Channel(channelInstance = c)
   implicit def fromChannelInstance(c: ChannelInstance): Channel                        = apply(c)
   implicit def fromChannel[T](c: T)(implicit toChannel: T => Channel): Option[Channel] = Some(c)
 
   // Var Related
 
-  def apply(v: VarInstance): Var = v match {
-    case b: BoundVar => new Var(varInstance = b, freeCount = 0, locallyFree = BitSet(b.value))
-    case FreeVar(_)  => new Var(varInstance = v, freeCount = 1, locallyFree = BitSet())
-  }
+  def apply(v: VarInstance): Var                                       = new Var(v)
   implicit def fromVarInstance(v: VarInstance): Var                    = apply(v)
   implicit def fromVar[T](v: T)(implicit toVar: T => Var): Option[Var] = Some(v)
 
   // Expr Related
-  def apply(e: ExprInstance)                 = new Expr(exprInstance = e, freeCount = 0, locallyFree = BitSet())
+  def apply(e: ExprInstance)                 = new Expr(exprInstance = e)
   implicit def fromGBool(g: GBool): Expr     = apply(g)
   implicit def fromGInt(g: GInt): Expr       = apply(g)
   implicit def fromGString(g: GString): Expr = apply(g)
   implicit def fromGUri(g: GUri): Expr       = apply(g)
 
-  implicit def fromEList(e: EList): EListBody    = EListBody(e)
-  implicit def fromETuple(e: ETuple): ETupleBody = ETupleBody(e)
-  implicit def fromESet(e: ESet): ESetBody       = ESetBody(e)
-  implicit def fromEMap(e: EMap): EMapBody       = EMapBody(e)
+  def apply(e: EList): Expr =
+    new Expr(exprInstance = EListBody(e))
+  implicit def fromEList(e: EList): Expr = apply(e)
 
-  def apply(e: ENot): Expr = {
-    val p: Par = e.p.get
-    new Expr(exprInstance = ENotBody(e), freeCount = p.freeCount, locallyFree = p.locallyFree)
-  }
+  def apply(e: ETuple): Expr =
+    new Expr(exprInstance = ETupleBody(e))
+  implicit def fromEList(e: ETuple): Expr = apply(e)
+
+  def apply(e: ESet): Expr =
+    new Expr(exprInstance = ESetBody(e))
+  implicit def fromESet(e: ESet): Expr = apply(e)
+
+  def apply(e: EMap): Expr =
+    new Expr(exprInstance = EMapBody(e))
+  implicit def fromEMap(e: EMap): Expr = apply(e)
+
+  def apply(e: ENot): Expr =
+    new Expr(exprInstance = ENotBody(e))
   implicit def fromENot(e: ENot): Expr = apply(e)
 
-  def apply(e: ENeg): Expr = {
-    val p: Par = e.p.get
-    new Expr(exprInstance = ENegBody(e), freeCount = p.freeCount, locallyFree = p.locallyFree)
-  }
+  def apply(e: ENeg): Expr =
+    new Expr(exprInstance = ENegBody(e))
   implicit def fromENeg(e: ENeg): Expr = apply(e)
 
-  def apply(e: EVar): Expr = {
-    val v: Var = e.v.get
-    new Expr(exprInstance = EVarBody(e), freeCount = v.freeCount, locallyFree = v.locallyFree)
-  }
+  def apply(e: EVar): Expr =
+    new Expr(exprInstance = EVarBody(e))
   implicit def fromEVar(e: EVar): Expr = apply(e)
 
-  def apply(e: EMult): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EMultBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EMult): Expr =
+    new Expr(exprInstance = EMultBody(e))
   implicit def fromEMult(e: EMult): Expr = apply(e)
 
-  def apply(e: EDiv): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EDivBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EDiv): Expr =
+    new Expr(exprInstance = EDivBody(e))
   implicit def fromEDiv(e: EDiv): Expr = apply(e)
 
-  def apply(e: EPlus): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EPlusBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EPlus): Expr =
+    new Expr(exprInstance = EPlusBody(e))
   implicit def fromEPlus(e: EPlus): Expr = apply(e)
 
-  def apply(e: EMinus): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EMinusBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EMinus): Expr =
+    new Expr(exprInstance = EMinusBody(e))
   implicit def fromEMinus(e: EMinus): Expr = apply(e)
 
-  def apply(e: ELt): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = ELtBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: ELt): Expr =
+    new Expr(exprInstance = ELtBody(e))
   implicit def fromELt(e: ELt): Expr = apply(e)
 
-  def apply(e: ELte): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = ELteBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: ELte): Expr =
+    new Expr(exprInstance = ELteBody(e))
   implicit def fromELte(e: ELte): Expr = apply(e)
 
-  def apply(e: EGt): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EGtBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EGt): Expr =
+    new Expr(exprInstance = EGtBody(e))
   implicit def fromEGt(e: EGt): Expr = apply(e)
 
-  def apply(e: EGte): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EGteBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EGte): Expr =
+    new Expr(exprInstance = EGteBody(e))
   implicit def fromEGte(e: EGte): Expr = apply(e)
 
-  def apply(e: EEq): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EEqBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EEq): Expr =
+    new Expr(exprInstance = EEqBody(e))
   implicit def fromEEq(e: EEq): Expr = apply(e)
 
-  def apply(e: ENeq): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = ENeqBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: ENeq): Expr =
+    new Expr(exprInstance = ENeqBody(e))
   implicit def fromENeq(e: ENeq): Expr = apply(e)
 
-  def apply(e: EAnd): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EAndBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EAnd): Expr =
+    new Expr(exprInstance = EAndBody(e))
   implicit def fromEAnd(e: EAnd): Expr = apply(e)
 
-  def apply(e: EOr): Expr = {
-    val p1: Par = e.p1.get
-    val p2: Par = e.p2.get
-    new Expr(exprInstance = EOrBody(e),
-             freeCount = p1.freeCount + p2.freeCount,
-             locallyFree = p1.locallyFree | p2.locallyFree)
-  }
+  def apply(e: EOr): Expr =
+    new Expr(exprInstance = EOrBody(e))
   implicit def fromEOr(e: EOr): Expr = apply(e)
 
   // Par Related
@@ -178,11 +114,15 @@ object implicits {
   def apply(r: Receive): Par =
     new Par(receives = List(r), freeCount = r.freeCount, locallyFree = r.locallyFree)
   def apply(e: Eval): Par =
-    new Par(evals = List(e), freeCount = e.freeCount, locallyFree = e.locallyFree)
+    new Par(evals = List(e),
+            freeCount = EvalLocallyFree.freeCount(e),
+            locallyFree = EvalLocallyFree.locallyFree(e))
   def apply(n: New): Par =
-    new Par(news = List(n), freeCount = n.freeCount, locallyFree = n.locallyFree)
+    new Par(news = List(n), freeCount = n.p.get.freeCount, locallyFree = n.locallyFree)
   def apply(e: Expr): Par =
-    new Par(exprs = List(e), freeCount = e.freeCount, locallyFree = e.locallyFree)
+    new Par(exprs = List(e),
+            freeCount = ExprLocallyFree.freeCount(e),
+            locallyFree = ExprLocallyFree.locallyFree(e))
   def apply(m: Match): Par =
     new Par(matches = List(m), freeCount = m.freeCount, locallyFree = m.locallyFree)
   def apply(g: GPrivate): Par =
@@ -197,7 +137,8 @@ object implicits {
   implicit def fromGPrivate(g: GPrivate): Par                     = apply(g)
 
   object GPrivate {
-    def apply(): GPrivate = new GPrivate(java.util.UUID.randomUUID.toString)
+    def apply(): GPrivate          = new GPrivate(java.util.UUID.randomUUID.toString)
+    def apply(s: String): GPrivate = new GPrivate(s)
   }
 
   implicit class ParExtension[T](p: T)(implicit toPar: T => Par) {
@@ -212,16 +153,16 @@ object implicits {
              locallyFree = p.locallyFree | r.locallyFree)
     def prepend(e: Eval): Par =
       p.copy(evals = Seq(e) ++ p.evals,
-             freeCount = p.freeCount + e.freeCount,
-             locallyFree = p.locallyFree | e.locallyFree)
+             freeCount = p.freeCount + EvalLocallyFree.freeCount(e),
+             locallyFree = p.locallyFree | EvalLocallyFree.locallyFree(e))
     def prepend(n: New): Par =
       p.copy(news = Seq(n) ++ p.news,
-             freeCount = p.freeCount + n.freeCount,
+             freeCount = p.freeCount + n.p.get.freeCount,
              locallyFree = p.locallyFree | n.locallyFree)
     def prepend(e: Expr): Par =
       p.copy(exprs = Seq(e) ++ p.exprs,
-             freeCount = p.freeCount + e.freeCount,
-             locallyFree = p.locallyFree | e.locallyFree)
+             freeCount = p.freeCount + ExprLocallyFree.freeCount(e),
+             locallyFree = p.locallyFree | ExprLocallyFree.locallyFree(e))
     def prepend(m: Match): Par =
       p.copy(matches = Seq(m) ++ p.matches,
              freeCount = p.freeCount + m.freeCount,
@@ -262,4 +203,100 @@ object implicits {
   }
 
   implicit def fromPar[T](p: T)(implicit toPar: T => Par): Option[Par] = Some(p)
+
+  implicit val SendLocallyFree: HasLocallyFree[Send] = new HasLocallyFree[Send] {
+    def freeCount(s: Send)   = s.freeCount
+    def locallyFree(s: Send) = s.locallyFree
+  }
+
+  implicit val ExprLocallyFree: HasLocallyFree[Expr] = new HasLocallyFree[Expr] {
+    def freeCount(e: Expr) =
+      e.exprInstance match {
+        case GBool(_)                   => 0
+        case GInt(_)                    => 0
+        case GString(_)                 => 0
+        case GUri(_)                    => 0
+        case EListBody(e)               => e.freeCount
+        case ETupleBody(e)              => e.freeCount
+        case ESetBody(e)                => e.freeCount
+        case EMapBody(e)                => e.freeCount
+        case EVarBody(EVar(v))          => VarLocallyFree.freeCount(v.get)
+        case ENotBody(ENot(p))          => p.get.freeCount
+        case ENegBody(ENeg(p))          => p.get.freeCount
+        case EMultBody(EMult(p1, p2))   => p1.get.freeCount + p2.get.freeCount
+        case EDivBody(EDiv(p1, p2))     => p1.get.freeCount + p2.get.freeCount
+        case EPlusBody(EPlus(p1, p2))   => p1.get.freeCount + p2.get.freeCount
+        case EMinusBody(EMinus(p1, p2)) => p1.get.freeCount + p2.get.freeCount
+        case ELtBody(ELt(p1, p2))       => p1.get.freeCount + p2.get.freeCount
+        case ELteBody(ELte(p1, p2))     => p1.get.freeCount + p2.get.freeCount
+        case EGtBody(EGt(p1, p2))       => p1.get.freeCount + p2.get.freeCount
+        case EGteBody(EGte(p1, p2))     => p1.get.freeCount + p2.get.freeCount
+        case EEqBody(EEq(p1, p2))       => p1.get.freeCount + p2.get.freeCount
+        case ENeqBody(ENeq(p1, p2))     => p1.get.freeCount + p2.get.freeCount
+        case EAndBody(EAnd(p1, p2))     => p1.get.freeCount + p2.get.freeCount
+        case EOrBody(EOr(p1, p2))       => p1.get.freeCount + p2.get.freeCount
+      }
+
+    def locallyFree(e: Expr) =
+      e.exprInstance match {
+        case GBool(_)      => BitSet()
+        case GInt(_)       => BitSet()
+        case GString(_)    => BitSet()
+        case GUri(_)       => BitSet()
+        case EListBody(e)  => e.locallyFree
+        case ETupleBody(e) => e.locallyFree
+        case ESetBody(e)   => e.locallyFree
+        case EMapBody(e)   => e.locallyFree
+        case EVarBody(EVar(v)) => {
+          VarLocallyFree.locallyFree(v.get)
+        }
+        case ENotBody(ENot(p))          => p.get.locallyFree
+        case ENegBody(ENeg(p))          => p.get.locallyFree
+        case EMultBody(EMult(p1, p2))   => p1.get.locallyFree | p2.get.locallyFree
+        case EDivBody(EDiv(p1, p2))     => p1.get.locallyFree | p2.get.locallyFree
+        case EPlusBody(EPlus(p1, p2))   => p1.get.locallyFree | p2.get.locallyFree
+        case EMinusBody(EMinus(p1, p2)) => p1.get.locallyFree | p2.get.locallyFree
+        case ELtBody(ELt(p1, p2))       => p1.get.locallyFree | p2.get.locallyFree
+        case ELteBody(ELte(p1, p2))     => p1.get.locallyFree | p2.get.locallyFree
+        case EGtBody(EGt(p1, p2))       => p1.get.locallyFree | p2.get.locallyFree
+        case EGteBody(EGte(p1, p2))     => p1.get.locallyFree | p2.get.locallyFree
+        case EEqBody(EEq(p1, p2))       => p1.get.locallyFree | p2.get.locallyFree
+        case ENeqBody(ENeq(p1, p2))     => p1.get.locallyFree | p2.get.locallyFree
+        case EAndBody(EAnd(p1, p2))     => p1.get.locallyFree | p2.get.locallyFree
+        case EOrBody(EOr(p1, p2))       => p1.get.locallyFree | p2.get.locallyFree
+      }
+  }
+
+  implicit val ChannelLocallyFree: HasLocallyFree[Channel] = new HasLocallyFree[Channel] {
+    def freeCount(c: Channel) =
+      c.channelInstance match {
+        case Quote(p)   => p.freeCount
+        case ChanVar(v) => VarLocallyFree.freeCount(v)
+      }
+
+    def locallyFree(c: Channel) =
+      c.channelInstance match {
+        case Quote(p)   => p.locallyFree
+        case ChanVar(v) => VarLocallyFree.locallyFree(v)
+      }
+  }
+
+  implicit val EvalLocallyFree: HasLocallyFree[Eval] = new HasLocallyFree[Eval] {
+    def freeCount(e: Eval)   = ChannelLocallyFree.freeCount(e.channel.get)
+    def locallyFree(e: Eval) = ChannelLocallyFree.locallyFree(e.channel.get)
+  }
+
+  implicit val VarLocallyFree: HasLocallyFree[Var] = new HasLocallyFree[Var] {
+    def freeCount(v: Var) =
+      v.varInstance match {
+        case BoundVar(_) => 0
+        case FreeVar(_)  => 1
+      }
+
+    def locallyFree(v: Var) =
+      v.varInstance match {
+        case BoundVar(level) => BitSet(level)
+        case FreeVar(_)      => BitSet()
+      }
+  }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -155,10 +155,12 @@ object GroundSortMatcher {
       case gu: GUri    => ScoredTerm(g, Node(Score.URI, Leaf(gu.value)))
       case EListBody(gl) =>
         val pars = gl.ps.map(par => ParSortMatcher.sortMatch(par))
-        ScoredTerm(EList(pars.map(_.term.get)), Node(Score.ELIST, pars.map(_.score): _*))
+        ScoredTerm(EListBody(gl.withPs(pars.map(_.term.get))),
+                   Node(Score.ELIST, pars.map(_.score): _*))
       case ETupleBody(gt) =>
         val pars = gt.ps.map(par => ParSortMatcher.sortMatch(par))
-        ScoredTerm(ETuple(pars.map(_.term.get)), Node(Score.ETUPLE, pars.map(_.score): _*))
+        ScoredTerm(ETupleBody(gt.withPs(pars.map(_.term.get))),
+                   Node(Score.ETUPLE, pars.map(_.score): _*))
       // Note ESet and EMap rely on the stableness of Scala's sort
       // See https://github.com/scala/scala/blob/2.11.x/src/library/scala/collection/SeqLike.scala#L627
       case ESetBody(gs) =>
@@ -174,7 +176,7 @@ object GroundSortMatcher {
           }
         val sortedPars       = gs.ps.map(par => ParSortMatcher.sortMatch(par)).sorted
         val deduplicatedPars = deduplicate(sortedPars)
-        ScoredTerm(ESet(deduplicatedPars.map(_.term.get)),
+        ScoredTerm(ESetBody(gs.withPs(deduplicatedPars.map(_.term.get))),
                    Node(Score.ESET, deduplicatedPars.map(_.score): _*))
       case EMapBody(gm) =>
         def sortKeyValuePair(kv: KeyValuePair): ScoredTerm[KeyValuePair] = {
@@ -194,7 +196,7 @@ object GroundSortMatcher {
           }.reverse
         val sortedPars       = gm.kvs.map(kv => sortKeyValuePair(kv)).sorted
         val deduplicatedPars = deduplicateLastWriteWins(sortedPars)
-        ScoredTerm(EMap(deduplicatedPars.map(_.term)),
+        ScoredTerm(EMapBody(gm.withKvs(deduplicatedPars.map(_.term))),
                    Node(Score.EMAP, deduplicatedPars.map(_.score): _*))
       case _ => throw new Error("GroundSortMatcher passed unknown Expr instance")
     }
@@ -211,9 +213,7 @@ object ExprSortMatcher {
 
   def sortMatch(e: Expr): ScoredTerm[Expr] = {
     def constructExpr(exprInstance: ExprInstance, score: Tree[ScoreAtom]) =
-      ScoredTerm(
-        Expr(exprInstance = exprInstance, freeCount = e.freeCount, locallyFree = e.locallyFree),
-        score)
+      ScoredTerm(Expr(exprInstance = exprInstance), score)
     e.exprInstance match {
       case ENegBody(en) =>
         val sortedPar = ParSortMatcher.sortMatch(en.p)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -30,18 +30,18 @@ class BoolMatcherSpec extends FlatSpec with Matchers {
 
 class GroundMatcherSpec extends FlatSpec with Matchers {
   "GroundInt" should "Compile as GInt" in {
-    val gi = new GroundInt(7)
-    val expectedResult : Expr = GInt(7)
+    val gi                   = new GroundInt(7)
+    val expectedResult: Expr = GInt(7)
     GroundNormalizeMatcher.normalizeMatch(gi) should be(expectedResult)
   }
   "GroundString" should "Compile as GString" in {
-    val gs = new GroundString("String")
-    val expectedResult : Expr = GString("String")
+    val gs                   = new GroundString("String")
+    val expectedResult: Expr = GString("String")
     GroundNormalizeMatcher.normalizeMatch(gs) should be(expectedResult)
   }
   "GroundUri" should "Compile as GUri" in {
-    val gu = new GroundUri("Uri")
-    val expectedResult : Expr = GUri("Uri")
+    val gu                   = new GroundUri("Uri")
+    val expectedResult: Expr = GUri("Uri")
     GroundNormalizeMatcher.normalizeMatch(gu) should be(expectedResult)
   }
 }
@@ -61,8 +61,10 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch(list, inputs)
     result.par should be(
-      inputs.par.prepend(Expr(
-        exprInstance=EList(List[Par](EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1)), 0, BitSet(1)), GInt(7))), freeCount=0, locallyFree=BitSet(0, 1))))
+      inputs.par.prepend(
+        EList(List[Par](EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1))), GInt(7)),
+              freeCount = 0,
+              locallyFree = BitSet(0, 1))))
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -75,13 +77,12 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch(tuple, inputs)
     result.par should be(
       inputs.par.prepend(
-        Expr(
-        exprInstance=ETuple(List[Par](
+        ETuple(List[Par](
                  EVar(FreeVar(0)),
-                 Eval(ChanVar(FreeVar(1)), 1, BitSet())
-               )),
-          freeCount=2,
-         locallyFree=BitSet())))
+                 Eval(ChanVar(FreeVar(1)))
+               ),
+               freeCount = 2,
+               locallyFree = BitSet())))
     result.knownFree should be(
       inputs.knownFree.newBindings(List((Some("Q"), ProcSort), (Some("y"), NameSort)))._1)
   }
@@ -107,12 +108,11 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch(set, inputs)
     result.par should be(
       inputs.par.prepend(
-        Expr(exprInstance=
-          ESet(List[Par](EPlus(EVar(BoundVar(0)), EVar(FreeVar(0))),
-            GInt(7),
-            GInt(8).prepend(EVar(FreeVar(1))))),
-          freeCount=2,
-          locallyFree=BitSet(0))))
+        ESet(List[Par](EPlus(EVar(BoundVar(0)), EVar(FreeVar(0))),
+                       GInt(7),
+                       GInt(8).prepend(EVar(FreeVar(1)))),
+             freeCount = 2,
+             locallyFree = BitSet(0))))
     result.knownFree should be(
       inputs.knownFree.newBindings(List((Some("R"), ProcSort), (Some("Q"), ProcSort)))._1)
   }
@@ -126,11 +126,12 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch(map, inputs)
     result.par should be(
-      inputs.par.prepend(
-        Expr(exprInstance=EMap(List[KeyValuePair](KeyValuePair(GInt(7), GString("Seven")),
-                              KeyValuePair(EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1)),0,BitSet(1))))),
-          freeCount=0,
-             locallyFree=BitSet(0, 1))))
+      inputs.par.prepend(EMap(
+        List[KeyValuePair](KeyValuePair(GInt(7), GString("Seven")),
+                           KeyValuePair(EVar(BoundVar(0)), Eval(ChanVar(BoundVar(1))))),
+        freeCount = 0,
+        locallyFree = BitSet(0, 1)
+      )))
     result.knownFree should be(inputs.knownFree)
   }
 }
@@ -182,7 +183,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
-    result.par should be(inputs.par.prepend(Eval(ChanVar(BoundVar(0)),0,BitSet(0))))
+    result.par should be(inputs.par.prepend(Eval(ChanVar(BoundVar(0)))))
     result.knownFree should be(inputs.knownFree)
   }
   "PEval" should "Collapse a quote" in {
@@ -344,8 +345,9 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch(pBasicContr, boundInputs)
     result.par should be(
       inputs.par.prepend(Receive(
-        List(ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1))), Quote(EVar(FreeVar(2)))),
-              ChanVar(BoundVar(0)))),
+        List(
+          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1))), Quote(EVar(FreeVar(2)))),
+                      ChanVar(BoundVar(0)))),
         Send(ChanVar(BoundVar(1)),
              List[Par](EPlus(EVar(BoundVar(2)), EVar(BoundVar(3)))),
              false,
@@ -383,7 +385,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be(
       inputs.par.prepend(Receive(
         List(ReceiveBind(List(ChanVar(FreeVar(0)), Quote(Par().copy(exprs = List(GInt(5))))),
-              ChanVar(BoundVar(0)))),
+                         ChanVar(BoundVar(0)))),
         Send(ChanVar(BoundVar(1)), List(Par().copy(exprs = List(GInt(5)))), false, 0, BitSet(1)),
         true, // persistent
         bindCount,
@@ -414,7 +416,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be(
       inputs.par.prepend(Receive(
         List(ReceiveBind(List(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))), Quote(Par()))),
-        Send(ChanVar(BoundVar(0)), List[Par](Eval(ChanVar(BoundVar(1)),0,BitSet(1))), false, 0, BitSet(0, 1)),
+        Send(ChanVar(BoundVar(0)), List[Par](Eval(ChanVar(BoundVar(1)))), false, 0, BitSet(0, 1)),
         false, // persistent
         bindCount,
         freeCount,
@@ -450,8 +452,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch(pInput, inputs)
     result.par should be(
       inputs.par.prepend(Receive(
-        List(ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))), Quote(Par())),
-             ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))), Quote(GInt(1)))),
+        List(
+          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))), Quote(Par())),
+          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))), Quote(GInt(1)))
+        ),
         Par().copy(
           sends = List(
             Send(ChanVar(BoundVar(2)), List[Par](EVar(BoundVar(1))), false, 0, BitSet(1, 2)),
@@ -516,7 +520,6 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         Send(ChanVar(BoundVar(0)), List[Par](GInt(7)), false, 0, BitSet(0))
           .prepend(Send(ChanVar(BoundVar(1)), List[Par](GInt(8)), false, 0, BitSet(1)))
           .prepend(Send(ChanVar(BoundVar(2)), List[Par](GInt(9)), false, 0, BitSet(2))),
-        0,
         BitSet()
       )))
     result.knownFree should be(inputs.knownFree)
@@ -617,10 +620,12 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       inputs.par.prepend(Match(
         EEq(GInt(47), GInt(47)),
         List(
-          MatchCase(GBool(true),
-           New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, 0, BitSet(0)), 0, BitSet())),
-          MatchCase(GBool(false),
-           New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, 0, BitSet(0)), 0, BitSet()))
+          MatchCase(
+            GBool(true),
+            New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, 0, BitSet(0)), BitSet())),
+          MatchCase(
+            GBool(false),
+            New(1, Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, 0, BitSet(0)), BitSet()))
           // TODO: Fill in type error case
         ),
         freeCount,
@@ -661,7 +666,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       inputs.par.copy(
         receives = List(
           Receive(
-            List(ReceiveBind(List(Quote(Match(matchTarget, List(MatchCase(GInt(47), Par())), 2))), Quote(Par()))),
+            List(ReceiveBind(List(Quote(Match(matchTarget, List(MatchCase(GInt(47), Par())), 2))),
+                             Quote(Par()))),
             Par(),
             false,
             bindCount,
@@ -677,9 +683,9 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   val inputs = NameVisitInputs(DebruijnLevelMap[VarSort](), DebruijnLevelMap[VarSort]())
 
   "NameWildcard" should "Set wildcard flag in knownFree" in {
-    val nw     = new NameWildcard()
-    val result = NameNormalizeMatcher.normalizeMatch(nw, inputs)
-    val expectedResult : Channel = ChanVar(FreeVar(0))
+    val nw                      = new NameWildcard()
+    val result                  = NameNormalizeMatcher.normalizeMatch(nw, inputs)
+    val expectedResult: Channel = ChanVar(FreeVar(0))
     result.chan should be(expectedResult)
     result.knownFree shouldEqual (inputs.knownFree.setWildcardUsed(1)._1)
   }
@@ -689,14 +695,14 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   "NameVar" should "Compile as BoundVar if it's in env" in {
     val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
 
-    val result = NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
-    val expectedResult : Channel = ChanVar(BoundVar(0))
+    val result                  = NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
+    val expectedResult: Channel = ChanVar(BoundVar(0))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
   "NameVar" should "Compile as FreeVar if it's not in env" in {
-    val result = NameNormalizeMatcher.normalizeMatch(nvar, inputs)
-    val expectedResult : Channel = ChanVar(FreeVar(0))
+    val result                  = NameNormalizeMatcher.normalizeMatch(nvar, inputs)
+    val expectedResult: Channel = ChanVar(FreeVar(0))
     result.chan should be(expectedResult)
     result.knownFree shouldEqual
       (inputs.knownFree.newBindings(List((Some("x"), NameSort)))._1)
@@ -720,34 +726,34 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   val nqvar = new NameQuote(new PVar("x"))
 
   "NameQuote" should "compile to a quoted var if the var is bound" in {
-    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
-    val nqvar       = new NameQuote(new PVar("x"))
-    val result      = NameNormalizeMatcher.normalizeMatch(nqvar, boundInputs)
-    val expectedResult : Channel = Quote(EVar(BoundVar(0)))
+    val boundInputs             = inputs.copy(env = inputs.env.newBindings(List((Some("x"), ProcSort)))._1)
+    val nqvar                   = new NameQuote(new PVar("x"))
+    val result                  = NameNormalizeMatcher.normalizeMatch(nqvar, boundInputs)
+    val expectedResult: Channel = Quote(EVar(BoundVar(0)))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
 
   "NameQuote" should "return a free use if the quoted proc has a free var" in {
-    val result = NameNormalizeMatcher.normalizeMatch(nqvar, inputs)
-    val expectedResult : Channel = Quote(EVar(FreeVar(0)))
+    val result                  = NameNormalizeMatcher.normalizeMatch(nqvar, inputs)
+    val expectedResult: Channel = Quote(EVar(FreeVar(0)))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree.newBindings(List((Some("x"), ProcSort)))._1)
   }
 
   "NameQuote" should "compile to a quoted ground" in {
-    val nqground = new NameQuote(new PGround(new GroundInt(7)))
-    val result   = NameNormalizeMatcher.normalizeMatch(nqground, inputs)
-    val expectedResult : Channel = Quote(GInt(7))
+    val nqground                = new NameQuote(new PGround(new GroundInt(7)))
+    val result                  = NameNormalizeMatcher.normalizeMatch(nqground, inputs)
+    val expectedResult: Channel = Quote(GInt(7))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
 
   "NameQuote" should "collapse an eval" in {
-    val nqeval      = new NameQuote(new PEval(new NameVar("x")))
-    val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
-    val result      = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
-    val expectedResult : Channel = ChanVar(BoundVar(0))
+    val nqeval                  = new NameQuote(new PEval(new NameVar("x")))
+    val boundInputs             = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
+    val result                  = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
+    val expectedResult: Channel = ChanVar(BoundVar(0))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
@@ -756,7 +762,8 @@ class NameMatcherSpec extends FlatSpec with Matchers {
     val nqeval      = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
     val boundInputs = inputs.copy(env = inputs.env.newBindings(List((Some("x"), NameSort)))._1)
     val result      = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
-    val expectedResult : Channel = Quote(Eval(ChanVar(BoundVar(0)),0,BitSet(0)).prepend(Eval(ChanVar(BoundVar(0)),0,BitSet(0))))
+    val expectedResult: Channel =
+      Quote(Eval(ChanVar(BoundVar(0))).prepend(Eval(ChanVar(BoundVar(0)))))
     result.chan should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
@@ -104,28 +104,24 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
 
   "Par" should "Sort and deduplicate sets insides" in {
     val parGround =
-      Expr(
-        exprInstance = ESet(
-          List(
-            GInt(2),
-            GInt(1),
-            Expr(exprInstance = ESet(List(GInt(1), GInt(2))),
-                 freeCount = 0,
-                 locallyFree = BitSet()),
-            Expr(exprInstance = ESet(List(GInt(1), GInt(1))), freeCount = 0, locallyFree = BitSet())
-          )),
+      ESet(
+        List(
+          GInt(2),
+          GInt(1),
+          ESet(List(GInt(1), GInt(2)), freeCount = 0, locallyFree = BitSet()),
+          ESet(List(GInt(1), GInt(1)), freeCount = 0, locallyFree = BitSet())
+        ),
         freeCount = 0,
         locallyFree = BitSet()
       )
     val sortedParGround: Option[Par] =
-      Expr(
-        exprInstance = ESet(
-          List(
-            GInt(1),
-            GInt(2),
-            Expr(exprInstance = ESet(List(GInt(1))), freeCount = 0, locallyFree = BitSet()),
-            Expr(exprInstance = ESet(List(GInt(1), GInt(2))), freeCount = 0, locallyFree = BitSet())
-          )),
+      ESet(
+        List(
+          GInt(1),
+          GInt(2),
+          ESet(List(GInt(1)), freeCount = 0, locallyFree = BitSet()),
+          ESet(List(GInt(1), GInt(2)), freeCount = 0, locallyFree = BitSet())
+        ),
         freeCount = 0,
         locallyFree = BitSet()
       )
@@ -135,24 +131,20 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
 
   "Par" should "Sort map insides by key and last write should win" in {
     val parGround =
-      Expr(
-        exprInstance = EMap(
-          List(
-            KeyValuePair(GInt(2),
-                         Expr(exprInstance = ESet(List(GInt(2), GInt(1))),
-                              freeCount = 0,
-                              locallyFree = BitSet())),
-            KeyValuePair(GInt(2), GInt(1)),
-            KeyValuePair(GInt(1), GInt(1))
-          )),
+      EMap(
+        List(
+          KeyValuePair(GInt(2),
+                       ESet(List(GInt(2), GInt(1)), freeCount = 0, locallyFree = BitSet())),
+          KeyValuePair(GInt(2), GInt(1)),
+          KeyValuePair(GInt(1), GInt(1))
+        ),
         freeCount = 0,
         locallyFree = BitSet()
       )
     val sortedParGround: Option[Par] =
-      Expr(
-        exprInstance = EMap(List(KeyValuePair(GInt(1), GInt(1)), KeyValuePair(GInt(2), GInt(1)))),
-        freeCount = 0,
-        locallyFree = BitSet())
+      EMap(List(KeyValuePair(GInt(1), GInt(1)), KeyValuePair(GInt(2), GInt(1))),
+           freeCount = 0,
+           locallyFree = BitSet())
     val result = ParSortMatcher.sortMatch(parGround)
     result.term should be(sortedParGround)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -126,17 +126,17 @@ class SendSubSpec extends FlatSpec with Matchers {
   "Send" should "substitute all channels for renamed, quoted process in environment" in {
     val chan0       = ChanVar(BoundVar(0))
     val chan1       = ChanVar(BoundVar(1))
-    val source: Par = New(1, Send(chan0, List(Par()), false, 0, BitSet(0)), 0, BitSet())
+    val source: Par = New(1, Send(chan0, List(Par()), false, 0, BitSet(0)), BitSet())
     val env         = Env(source)
     val target =
       Send(chan0, List(Send(chan0, List(Par()), false, 0, BitSet(0))), false, 0, BitSet(0))
     val result = substitute(target)(env)
     result should be(
       Send(
-        Quote(New(1, Send(chan1, List(Par()), false, 0, BitSet(1)), 0, BitSet())),
+        Quote(New(1, Send(chan1, List(Par()), false, 0, BitSet(1)), BitSet())),
         List(
           Send(
-            Quote(New(1, Send(chan1, List(Par()), false, 0, BitSet(1)), 0, BitSet())),
+            Quote(New(1, Send(chan1, List(Par()), false, 0, BitSet(1)), BitSet())),
             List(Par()),
             false,
             0,
@@ -156,10 +156,10 @@ class NewSubSpec extends FlatSpec with Matchers {
   "New" should "only substitute body of expression" in {
     val source: Par = GPrivate()
     val env         = Env(source)
-    val target      = New(1, Send(ChanVar(BoundVar(0)), List(Par()), false, 0, BitSet(0)), 0, BitSet(0))
+    val target      = New(1, Send(ChanVar(BoundVar(0)), List(Par()), false, 0, BitSet(0)), BitSet(0))
     val result      = substitute(target)(env)
     result should be(
-      New(1, Send(Quote(source), List(Par()), false, 0, BitSet()), 0, BitSet())
+      New(1, Send(Quote(source), List(Par()), false, 0, BitSet()), BitSet())
     )
   }
 
@@ -172,7 +172,6 @@ class NewSubSpec extends FlatSpec with Matchers {
                           List(Send(ChanVar(BoundVar(1)), List(Par()), false, 0, BitSet(1))),
                           false,
                           0),
-                     0,
                      BitSet(0, 1))
 
     val result = substitute(target)(env)


### PR DESCRIPTION
Rholang: Protobuf: Simplify implicits and freeCount/locallyFree ￼…
This removes freeCount/locallyFree from places where it doesn't belong. In its
place, we have an implicit class that says how to get this information for the
protos that don't have it. This allows us to use more uniform implicits for the
E{List,Tuple,Set,Map} expressions.
01e2a60
