### PR TITLE
Measure bytes in and out.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val comm = project
   .settings(
     commonSettings,
     version := "0.1",
-    libraryDependencies ++= commonDependencies ++ protobufDependencies ++ Seq(
+    libraryDependencies ++= commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
       uriParsing,
       uPnP,
       hasher,

--- a/comm/src/main/scala/coop/rchain/catscontrib/Time.scala
+++ b/comm/src/main/scala/coop/rchain/catscontrib/Time.scala
@@ -5,6 +5,7 @@ import Catscontrib._
 
 trait Time[F[_]] {
   def currentMillis: F[Long]
+  def nanoTime: F[Long]
 }
 
 object Time extends TimeInstances {
@@ -13,6 +14,7 @@ object Time extends TimeInstances {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit TM: Time[F]): Time[T[F, ?]] =
     new Time[T[F, ?]] {
       def currentMillis: T[F, Long] = TM.currentMillis.liftM[T]
+      def nanoTime: T[F, Long]      = TM.nanoTime.liftM[T]
     }
 }
 

--- a/node/src/main/scala/coop/rchain/node/main.scala
+++ b/node/src/main/scala/coop/rchain/node/main.scala
@@ -124,6 +124,9 @@ object Main {
       def currentMillis: Task[Long] = Task.delay {
         System.currentTimeMillis
       }
+      def nanoTime: Task[Long] = Task.delay {
+        System.nanoTime
+      }
     }
 
     val net = new UnicastNetwork(src, Some(p2p.Network))

--- a/node/src/main/scala/coop/rchain/node/metrics.scala
+++ b/node/src/main/scala/coop/rchain/node/metrics.scala
@@ -4,7 +4,7 @@ import kamon.prometheus._
 import kamon._
 import scala.util.control.NonFatal
 
-final case class MetricsServer(port: Int = 9095) {
+final case class MetricsServer() {
   val reporter = new PrometheusReporter()
 
   Kamon.addReporter(reporter)


### PR DESCRIPTION
Pushed Prometheus metrics into comms layer. Includes

 * `network-roundtrip-micros` microseconds (histogram) for each roundtrip message
 * `ping-recv-count` number of PING messages received
 * `lookup-recv-count` number of LOOKUP messages received
 * `disconnect-recv-count` number of DISCONNECT messages received
 * `protocol-ping-sends` number PING messages sent
 * `protocol-lookup-sends` number of LOOKUP messages sent
 * `unicast-sends` number of messages (<= number of packets) sent via UDP
 * `unicast-recvs` number of messages (<= number of packets) received via UDP
 * `unicast-send-bytes` number of bytes sent via UDP
 * `unicast-recv-bytes` number of bytes received via UDP
 * `connect-time-ms` number of milliseconds (histogram) spent in `connect()`

Some of these metrics generate more than one value for a collector. For instance, histograms also generate counts and some %ile information.
