### PR TITLE
 Rholang: Add wildcard process support to the grammar.

### DIFF
--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -2,7 +2,7 @@ package coop.rchain.models
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.ScalacheckShapeless._
-import org.scalacheck.Gen.{const, sized, frequency, resize}
+import org.scalacheck.Gen.{const, frequency, resize, sized}
 
 import scala.collection.immutable.BitSet
 
@@ -15,7 +15,7 @@ object testImplicits {
   // become Options. See https://github.com/scalapb/ScalaPB/issues/40 .
   // We override so that we cannot get None for these required objects.
   implicit def arbOption[T](implicit a: Arbitrary[T]): Arbitrary[Option[T]] =
-    Arbitrary(for {s <- a.arbitrary} yield Some(s))
+    Arbitrary(for { s <- a.arbitrary } yield Some(s))
 
   implicit val arbPar = implicitly[Arbitrary[Par]]
 }

--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -21,7 +21,7 @@ _. Proc13 ::= "{" Proc "}" ;
 -- or a collection.
 PGround.      Proc13 ::= Ground ;
 PCollect.     Proc13 ::= Collection ;
-PVar.         Proc13 ::= Var ;
+PVar.         Proc13 ::= ProcVar ;
 PNil.         Proc13 ::= "Nil" ;
 PEval.        Proc12 ::= "*" Name ;
 PMethod.      Proc11 ::= Proc11 "." Var "(" [Proc] ")" ;
@@ -52,6 +52,10 @@ PNew.         Proc1 ::= "new" [NameDecl] "in" Proc1 ;
 PPar.         Proc  ::= Proc "|" Proc1 ;
 
 separator Proc "," ;
+
+-- Process variables
+ProcVarWildcard. ProcVar ::= "_" ;
+ProcVarVar.      ProcVar ::= Var ;
 
 -- Names
 NameWildcard. Name ::= "_" ;
@@ -113,7 +117,7 @@ CollectMap.    Collection ::= "{" [KeyValuePair] "}" ;
 KeyValuePairImpl.  KeyValuePair ::= Proc ":" Proc ;
 separator KeyValuePair "," ;
 
-token Var ((letter | '_' | '\'') (letter | digit | '_' | '\'')*) ;
+token Var (((letter | '\'') (letter | digit | '_' | '\'')*)|(('_') (letter | digit | '_' | '\'')+)) ;
 
 -- Comments:
 comment "//" ;

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -106,6 +106,7 @@ object Score {
   // Vars
   final val BOUND_VAR = 50
   final val FREE_VAR  = 51
+  final val WILDCARD  = 52
 
   // Expr
   final val EVAR   = 100
@@ -286,6 +287,7 @@ object VarSortMatcher {
         v.varInstance match {
           case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level))
           case FreeVar(level)  => ScoredTerm(v, Leaves(Score.FREE_VAR, level))
+          case Wildcard(_)     => ScoredTerm(v, Leaves(Score.WILDCARD))
         }
       case None => throw new Error("VarSortMatcher was passed None")
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortTest.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
+import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
 import org.scalatest._
 import implicits._
@@ -77,6 +77,36 @@ class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
       )
     val result = ReceiveSortMatcher.preSortBinds(binds)
     result should be(sortedBinds)
+  }
+}
+
+class VarSortMatcherSpec extends FlatSpec with Matchers {
+  val p = Par()
+  "Different kinds of variables" should "bin separately" in {
+    val parVars = p.copy(
+      exprs = List(EVar(BoundVar(2)),
+                   EVar(Wildcard(Var.WildcardMsg())),
+                   EVar(BoundVar(1)),
+                   EVar(FreeVar(0)),
+                   EVar(FreeVar(2)),
+                   EVar(BoundVar(0)),
+                   EVar(FreeVar(1))),
+      freeCount = 4,
+      locallyFree = BitSet(0, 1, 2)
+    )
+    val sortedParVars: Option[Par] = p.copy(
+      exprs = List(EVar(BoundVar(0)),
+                   EVar(BoundVar(1)),
+                   EVar(BoundVar(2)),
+                   EVar(FreeVar(0)),
+                   EVar(FreeVar(1)),
+                   EVar(FreeVar(2)),
+                   EVar(Wildcard(Var.WildcardMsg()))),
+      freeCount = 4,
+      locallyFree = BitSet(0, 1, 2)
+    )
+    val result = ParSortMatcher.sortMatch(parVars)
+    result.term should be(sortedParVars)
   }
 }
 


### PR DESCRIPTION
Add wildcards for processes to the rholang grammar. They were missed.
Also includes a fix that prevented the RPL from parsing and printing them.