### PR TITLE
 Rholang: Add line/col numbers to normalizer errors

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -84,8 +84,13 @@ object RholangCLI {
 
   private def normalizeTerm(term: Proc, inputs: ProcVisitInputs) = {
     val normalizedTerm = ProcNormalizeMatcher.normalizeMatch(term, inputs)
-    if (normalizedTerm.par.freeCount > 0)
-      throw new Error("Top-level free variables are not allowed.")
+    if (normalizedTerm.par.freeCount > 0) {
+      val topLevelFreeList = normalizedTerm.knownFree.env.map {
+        case (name, (_, _, line, col)) => s"$name at $line:$col"
+      }
+      throw new Error(
+        s"Top level free variables are not allowed: ${topLevelFreeList.mkString("", ", ", "")}.")
+    }
     normalizedTerm
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -13,6 +13,8 @@ import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
+import coop.rchain.rholang.interpreter.NameNormalizeMatcher.UnexpectedNameContext
+import coop.rchain.rholang.interpreter.ProcNormalizeMatcher.UnexpectedProcContext
 import implicits._
 
 class BoolMatcherSpec extends FlatSpec with Matchers {
@@ -49,7 +51,7 @@ class GroundMatcherSpec extends FlatSpec with Matchers {
 class CollectMatcherSpec extends FlatSpec with Matchers {
   val inputs = ProcVisitInputs(
     Par(),
-    DebruijnLevelMap[VarSort]().newBindings(List(("P", ProcSort), ("x", NameSort)))._1,
+    DebruijnLevelMap[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0)))._1,
     DebruijnLevelMap[VarSort]())
 
   "List" should "delegate" in {
@@ -84,7 +86,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
                freeCount = 2,
                locallyFree = BitSet())))
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("Q", ProcSort), ("y", NameSort)))._1)
+      inputs.knownFree.newBindings(List(("Q", ProcSort, 0, 0), ("y", NameSort, 0, 0)))._1)
   }
   "Tuple" should "propagate free variables" in {
     val tupleData = new ListProc()
@@ -114,7 +116,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
              freeCount = 2,
              locallyFree = BitSet(0))))
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("R", ProcSort), ("Q", ProcSort)))._1)
+      inputs.knownFree.newBindings(List(("R", ProcSort, 0, 0), ("Q", ProcSort, 0, 0)))._1)
   }
 
   "Map" should "delegate" in {
@@ -149,7 +151,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   val pvar = new PVar(new ProcVarVar("x"))
   "PVar" should "Compile as BoundVar if it's in env" in {
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
     result.par should be(inputs.par.prepend(EVar(BoundVar(0))))
@@ -160,18 +162,18 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch(pvar, inputs)
     result.par should be(inputs.par.prepend(EVar(FreeVar(0))))
     result.knownFree shouldEqual
-      (inputs.knownFree.newBinding(("x", ProcSort))._1)
+      (inputs.knownFree.newBinding(("x", ProcSort, 0, 0))._1)
   }
   "PVar" should "Not compile if it's in env of the wrong sort" in {
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedProcContext] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
     }
   }
   "PVar" should "Not compile if it's used free somewhere else" in {
     val boundInputs =
-      inputs.copy(knownFree = inputs.knownFree.newBinding(("x", ProcSort))._1)
+      inputs.copy(knownFree = inputs.knownFree.newBinding(("x", ProcSort, 0, 0))._1)
 
     an[Error] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
@@ -180,7 +182,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PEval" should "Handle a bound name varible" in {
     val pEval       = new PEval(new NameVar("x"))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
     result.par should be(inputs.par.prepend(Eval(ChanVar(BoundVar(0)))))
@@ -189,7 +191,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   "PEval" should "Collapse a quote" in {
     val pEval = new PEval(
       new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs)
     result.par should be(inputs.par.prepend(EVar(BoundVar(0))).prepend(EVar(BoundVar(0))))
@@ -206,7 +208,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PNeg" should "Delegate" in {
     val pNeg        = new PNeg(new PVar(new ProcVarVar("x")))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pNeg, boundInputs)
     result.par should be(inputs.par.prepend(ENeg(EVar(BoundVar(0)))))
@@ -215,11 +217,11 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PMult" should "Delegate" in {
     val pMult       = new PMult(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pMult, boundInputs)
     result.par should be(inputs.par.prepend(EMult(EVar(BoundVar(0)), EVar(FreeVar(0)))))
-    result.knownFree should be(inputs.knownFree.newBinding(("y", ProcSort))._1)
+    result.knownFree should be(inputs.knownFree.newBinding(("y", ProcSort, 0, 0))._1)
   }
 
   "PDiv" should "Delegate" in {
@@ -233,7 +235,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   "PAdd" should "Delegate" in {
     val pAdd = new PAdd(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
     val boundInputs =
-      inputs.copy(env = inputs.env.newBindings(List(("x", ProcSort), ("y", ProcSort)))._1)
+      inputs.copy(
+        env = inputs.env.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pAdd, boundInputs)
     result.par should be(inputs.par.prepend(EPlus(EVar(BoundVar(0)), EVar(BoundVar(1)))))
@@ -245,7 +248,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
                             new PMult(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("z"))))
     val boundInputs = inputs.copy(
       env = inputs.env
-        .newBindings(List(("x", ProcSort), ("y", ProcSort), ("z", ProcSort)))
+        .newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0), ("z", ProcSort, 0, 0)))
         ._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pMinus, boundInputs)
@@ -271,7 +274,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     sentData.add(new PGround(new GroundInt(7)))
     sentData.add(new PGround(new GroundInt(8)))
     val pSend       = new PSend(new NameVar("x"), new SendSingle(), sentData)
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pSend, boundInputs)
     result.par should be(
@@ -300,7 +303,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PPar" should "Compile both branches with the same environment" in {
     val parDoubleBound = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))
-    val boundInputs    = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs    = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(parDoubleBound, boundInputs)
     result.par should be(
@@ -320,7 +323,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be(
       inputs.par.copy(exprs = List(EVar(FreeVar(1)), EVar(FreeVar(0))), freeCount = 2))
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("x", ProcSort), ("y", ProcSort)))._1)
+      inputs.knownFree.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1)
   }
 
   "PContr" should "Handle a basic contract" in {
@@ -342,7 +345,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val pBasicContr = new PContr(new NameVar("add"),
                                  listBindings,
                                  new PSend(new NameVar("ret"), new SendSingle(), listSend))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("add", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("add", NameSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pBasicContr, boundInputs)
     result.par should be(
@@ -381,7 +384,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val pBasicContr = new PContr(new NameVar("ret5"),
                                  listBindings,
                                  new PSend(new NameVar("ret"), new SendSingle(), listSend))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("ret5", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("ret5", NameSort, 0, 0))._1)
 
     val result = ProcNormalizeMatcher.normalizeMatch(pBasicContr, boundInputs)
     result.par should be(
@@ -698,7 +701,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   val nvar = new NameVar("x")
 
   "NameVar" should "Compile as BoundVar if it's in env" in {
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
 
     val result                  = NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
     val expectedResult: Channel = ChanVar(BoundVar(0))
@@ -710,18 +713,18 @@ class NameMatcherSpec extends FlatSpec with Matchers {
     val expectedResult: Channel = ChanVar(FreeVar(0))
     result.chan should be(expectedResult)
     result.knownFree shouldEqual
-      (inputs.knownFree.newBinding(("x", NameSort))._1)
+      (inputs.knownFree.newBinding(("x", NameSort, 0, 0))._1)
   }
   "NameVar" should "Not compile if it's in env of the wrong sort" in {
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedNameContext] should be thrownBy {
       NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
     }
   }
   "NameVar" should "Not compile if it's used free somewhere else" in {
     val boundInputs =
-      inputs.copy(knownFree = inputs.knownFree.newBinding(("x", NameSort))._1)
+      inputs.copy(knownFree = inputs.knownFree.newBinding(("x", NameSort, 0, 0))._1)
 
     an[Error] should be thrownBy {
       NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
@@ -731,7 +734,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
   val nqvar = new NameQuote(new PVar(new ProcVarVar("x")))
 
   "NameQuote" should "compile to a quoted var if the var is bound" in {
-    val boundInputs             = inputs.copy(env = inputs.env.newBinding(("x", ProcSort))._1)
+    val boundInputs             = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0))._1)
     val nqvar                   = new NameQuote(new PVar(new ProcVarVar("x")))
     val result                  = NameNormalizeMatcher.normalizeMatch(nqvar, boundInputs)
     val expectedResult: Channel = Quote(EVar(BoundVar(0)))
@@ -743,7 +746,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
     val result                  = NameNormalizeMatcher.normalizeMatch(nqvar, inputs)
     val expectedResult: Channel = Quote(EVar(FreeVar(0)))
     result.chan should be(expectedResult)
-    result.knownFree should be(inputs.knownFree.newBinding(("x", ProcSort))._1)
+    result.knownFree should be(inputs.knownFree.newBinding(("x", ProcSort, 0, 0))._1)
   }
 
   "NameQuote" should "compile to a quoted ground" in {
@@ -756,7 +759,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
 
   "NameQuote" should "collapse an eval" in {
     val nqeval                  = new NameQuote(new PEval(new NameVar("x")))
-    val boundInputs             = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs             = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
     val result                  = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
     val expectedResult: Channel = ChanVar(BoundVar(0))
     result.chan should be(expectedResult)
@@ -765,7 +768,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
 
   "NameQuote" should "not collapse an eval | eval" in {
     val nqeval      = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
-    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort))._1)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0))._1)
     val result      = NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs)
     val expectedResult: Channel =
       Quote(Eval(ChanVar(BoundVar(0))).prepend(Eval(ChanVar(BoundVar(0)))))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -13,8 +13,7 @@ import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
-import coop.rchain.rholang.interpreter.NameNormalizeMatcher.UnexpectedNameContext
-import coop.rchain.rholang.interpreter.ProcNormalizeMatcher.UnexpectedProcContext
+import coop.rchain.rholang.interpreter.NormalizerExceptions._
 import implicits._
 
 class BoolMatcherSpec extends FlatSpec with Matchers {
@@ -95,7 +94,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     tupleData.add(new PPar(new PGround(new GroundInt(7)), new PVar(new ProcVarVar("Q"))))
     val tuple = new PCollect(new CollectTuple(tupleData))
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfProcContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(tuple, inputs)
     }
   }
@@ -175,7 +174,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val boundInputs =
       inputs.copy(knownFree = inputs.knownFree.newBinding(("x", ProcSort, 0, 0))._1)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfProcContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs)
     }
   }
@@ -289,7 +288,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     sentData.add(new PVar(new ProcVarVar("x")))
     val pSend = new PSend(new NameQuote(new PVar(new ProcVarVar("x"))), new SendSingle(), sentData)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfProcContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pSend, inputs)
     }
   }
@@ -312,7 +311,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   }
   "PPar" should "Not compile if both branches use the same free variable" in {
     val parDoubleFree = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfProcContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(parDoubleFree, inputs)
     }
   }
@@ -493,7 +492,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val body   = new PNil()
     val pInput = new PInput(receipt, body)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfNameContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pInput, inputs)
     }
   }
@@ -646,7 +645,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
                    new PNil()))
     val pMatch = new PMatch(new PGround(new GroundInt(47)), listCases)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfProcContextFree] should be thrownBy {
       ProcNormalizeMatcher.normalizeMatch(pMatch, inputs)
     }
   }
@@ -726,7 +725,7 @@ class NameMatcherSpec extends FlatSpec with Matchers {
     val boundInputs =
       inputs.copy(knownFree = inputs.knownFree.newBinding(("x", NameSort, 0, 0))._1)
 
-    an[Error] should be thrownBy {
+    an[UnexpectedReuseOfNameContextFree] should be thrownBy {
       NameNormalizeMatcher.normalizeMatch(nvar, boundInputs)
     }
   }


### PR DESCRIPTION
Line/col numbers are now injected into the Debrujin level map. This resolves https://rchain.atlassian.net/browse/RHOL-163 .

The errors looks like follows:

```
> new x in { match { x } { 47 => Nil } }
Exception in thread "main"
coop.rchain.rholang.interpreter.ProcNormalizeMatcher$UnexpectedProcContext:

> match { 47 } { { x | x } => Nil }
Exception in thread "main"
coop.rchain.rholang.interpreter.ProcNormalizeMatcher$UnexpectedReuseOfProcContextFree:
Free variable x is used twice as a binder (at 1:18 and 1:22) in process
context.

> 5 | x | y | z
Exception in thread "main" java.lang.Error: Top level free variables are
not allowed: x at 1:5, y at 1:9, z at 1:13.
```