### PR TITLE
Remove link to 'committing code to github'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 * [Code Review Process](https://rchain.atlassian.net/wiki/spaces/DOC/pages/44040200/Code+Review+Process)
 * [Coding Standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards)
-* [Committing Code to Github](https://rchain.atlassian.net/wiki/spaces/DOC/pages/13140032/Committing+Code+to+Github)
 * [Github Workflow](https://rchain.atlassian.net/wiki/spaces/DOC/pages/44007462/Github+Fork-n-Beans+Workflow)
 * [Github Structure](https://rchain.atlassian.net/wiki/spaces/DOC/pages/10616833/Github+structure)
 


### PR DESCRIPTION
This page is deprecated. All instructions about using Github on the RChain projects can be found in the Github Fork n Beans Workflow page