### PR TITLE
Add support for primitives that modify state

### DIFF
--- a/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
+++ b/roscala/macros/src/main/scala/coop/rchain/rosette/macros/Prim.scala
@@ -20,8 +20,8 @@ object ArgumentMismatchMacro {
 
     val result =
       annottees.map(_.tree).toList match {
-        case q"$mods def fn(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
-          q"""$mods def fn(ctxt: Ctxt): $returnType =  {
+        case q"$mods def fnSimple(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
+          q"""$mods def fnSimple(ctxt: Ctxt): $returnType =  {
               if(ctxt.nargs < minArgs || ctxt.nargs > maxArgs)
                 Left(mismatchArgs(ctxt, minArgs, maxArgs))
               else
@@ -48,8 +48,8 @@ object TypeMismatchMacro {
 
     val result =
       annottees.map(_.tree).toList match {
-        case q"$mods def fn(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
-          q"""$mods def fn(ctxt: Ctxt): $returnType =  {
+        case q"$mods def fnSimple(ctxt: Ctxt): $returnType = { ..$body }" :: Nil =>
+          q"""$mods def fnSimple(ctxt: Ctxt): $returnType =  {
               mismatchType[$typeParam](ctxt) match {
                 case Some(typeMismatch) => Left(typeMismatch)
                 case None => {..$body}

--- a/roscala/src/main/scala/coop/rchain/rosette/Actor.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Actor.scala
@@ -1,11 +1,10 @@
 package coop.rchain.rosette
 
-import cats.data.State._
-import coop.rchain.rosette.Ctxt.{Continuation, CtxtTransition}
+import coop.rchain.rosette.Ctxt.Continuation
 
 abstract class Actor extends Ob {
   val extension: StdExtension
 
   // TODO:
-  override def lookupAndInvoke: CtxtTransition[(Result, Option[Continuation])] = ???
+  override def lookupAndInvoke: CtxtTransition[Result] = ???
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Ctxt.scala
@@ -2,8 +2,9 @@ package coop.rchain.rosette
 
 import coop.rchain.rosette.VirtualMachine.loggerStrand
 import Location._
+import cats.Eval
 import cats.data.State
-import cats.data.State._
+import cats.implicits._
 import coop.rchain.rosette.Ob.Lenses._
 
 case class Ctxt(tag: Location,
@@ -47,8 +48,6 @@ case class Ctxt(tag: Location,
 }
 
 object Ctxt {
-  type CtxtTransition[A] = State[Ctxt, A]
-
   type Continuation = Ctxt
 
   val empty = Ctxt(
@@ -86,59 +85,100 @@ object Ctxt {
     id = ctxt.id + 1000
   )
 
-  /** Save result to a location in the parent ctxt.
+  /** Save result to a location in the continuation of a given `ctxt`
     *
-    * The location is defined by tag.
-    * applyK potentially returns a ctxt which needs to be scheduled to the VM.
+    * The location is defined by `tag`.
+    * `applyK` potentially returns a `ctxt` which needs to be scheduled to the VM.
+    *
+    * The first element in the return tuple is false if storing was successful
+    * and true if it failed.
+    *
+    * TODO: `applyK` does not need access to `GlobalEnv`
     */
-  def applyK(result: Ob, tag: Location): CtxtTransition[(Boolean, Option[Continuation])] =
-    rcv(result, tag)
-      .transformS[Ctxt](_.ctxt, (child, updatedParent) => child.copy(ctxt = updatedParent))
+  def applyK(result: Ob, tag: Location): CtxtTransition[Boolean] = {
+
+    /**
+      * This transformation is needed because `result` has to be received in
+      * `ctxt.ctxt` (the continuation of the current `ctxt`) and not `ctxt` itself.
+      */
+    val transformToRcvInCont: CtxtTransition[Boolean] => CtxtTransition[Boolean] = trans =>
+      trans.transformS[(GlobalEnv, Ctxt)](
+        state => (state._1, state._2.ctxt),
+        (state, rcvGlobalEnvAndCont) => {
+          val globalEnv = state._1
+          val ctxt      = state._2
+          val cont      = rcvGlobalEnvAndCont._2
+
+          (globalEnv, ctxt.copy(ctxt = cont))
+        }
+    )
+
+    transformToRcvInCont(rcv(result, tag))
+  }
 
   /**
-    * Try to save a value to a particular location in the given ctxt.
-    * If successfully saved and outstanding equals zero, schedule the ctxt.
-    */
-  def rcv(result: Ob, loc: Location): CtxtTransition[(Boolean, Option[Continuation])] =
-    for {
-      storeRes         <- store(loc, result)
-      _                <- modify[Ctxt](_.update(_ >> 'outstanding)(_ - 1))
-      outstanding      <- inspect[Ctxt, Int](_.outstanding)
-      continuationCtxt <- get[Ctxt]
-    } yield {
-      storeRes match {
-        case Success =>
-          if (outstanding == 0)
-            (false, Some(continuationCtxt))
-          else
-            (false, None)
-
-        case Failure => (true, None)
-      }
-    }
-
-  /** Return result to parent ctxt.
+    * Try to save a value to a particular location in the given `ctxt`.
+    * If successfully saved and `outstanding` equals zero, schedule the `ctxt`.
     *
-    * This potentially returns the parent ctxt which then has to be scheduled
-    * to the VM by the caller of ret.
+    * The return value is false if storing was successful and true if it failed.
+    *
+    * TODO: `rcv` does not need access to `GlobalEnv`
+    */
+  def rcv(result: Ob, loc: Location): CtxtTransition[Boolean] = {
+    def scheduleIfStoredAndOutstandingIsZero(storeResult: StoreResult,
+                                             outstanding: Int,
+                                             ctxt: Ctxt): CtxtTransition[Boolean] =
+      storeResult match {
+        case Success =>
+          for (_ <- if (outstanding == 0) tellCont(List(ctxt)) else pureCtxt[Unit](())) yield false
+
+        case Failure => pureCtxt[Boolean](true)
+      }
+
+    for {
+      storeRes     <- transformCtxtToCtxtTrans(store(loc, result))
+      _            <- modifyCtxt(_.update(_ >> 'outstanding)(_ - 1))
+      outstanding  <- inspectCtxt[Int](_.outstanding)
+      continuation <- getCtxt
+      res          <- scheduleIfStoredAndOutstandingIsZero(storeRes, outstanding, continuation)
+    } yield res
+  }
+
+  val transformCtxtToCtxtTrans: State[Ctxt, StoreResult] => CtxtTransition[StoreResult] = trans =>
+    liftRWS[Eval, Unit, List[Continuation], (GlobalEnv, Ctxt), StoreResult](
+      trans.transformS[(GlobalEnv, Ctxt)](globalEnvAndCtxt => globalEnvAndCtxt._2,
+                                          (oldGlobalEnvAndCtxt, newCtxt) =>
+                                            oldGlobalEnvAndCtxt.copy(_2 = newCtxt)))
+
+  /** Return result to the continuation of the given `ctxt`
+    *
+    * The return value is false if storing was successful and true if it failed.
+    *
+    * `ret` potentially schedules the continuation of the given `ctxt`.
+    * This happens when `outstanding` equals 1 and the last argument is about
+    * to be received.
+    * A scheduled continuation is captured in the writer monad of the
+    * `CtxtTransition` type.
     *
     * The location we want to save the result to is given by the tag field.
-    * If the tag field contains no location (equals LocLimbo), (false, None) is returned.
+    * If the tag field contains no location (`LocLimbo`), false is returned.
     * Otherwise the result of applyK is returned.
+    *
+    * TODO: `ret` does not need the `GlobalEnv`.
     */
-  def ret(result: Ob): CtxtTransition[(Boolean, Option[Continuation])] =
+  def ret(result: Ob): CtxtTransition[Boolean] =
     for {
-      tag <- inspect[Ctxt, Location](_.tag)
+      tag <- inspectCtxt[Location](_.tag)
       res <- tag match {
-              case Limbo => pure[Ctxt, (Boolean, Option[Continuation])](false, None)
+              case Limbo => pureCtxt[Boolean](false)
               case _     => applyK(result, tag)
             }
     } yield res
 
-  def setReg(r: Int, ob: Ob): CtxtTransition[StoreResult] = {
-    lazy val p = pure[Ctxt, StoreResult](Failure)
+  def setReg(r: Int, ob: Ob): State[Ctxt, StoreResult] = {
+    lazy val p = State.pure[Ctxt, StoreResult](Failure)
 
-    def modify(f: Ctxt => Ctxt): CtxtTransition[StoreResult] =
+    def modify(f: Ctxt => Ctxt): State[Ctxt, StoreResult] =
       State.apply[Ctxt, StoreResult](f andThen ((_, Success)))
 
     r match {

--- a/roscala/src/main/scala/coop/rchain/rosette/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Location.scala
@@ -1,9 +1,11 @@
 package coop.rchain.rosette
 
-import cats.data.State
+import cats.Eval
+import cats.data.{ReaderWriterState, ReaderWriterStateT, State}
+import cats.implicits._
 import coop.rchain.rosette.Ob.Lenses._
 import coop.rchain.rosette.Ob.{getAddr, getLex, setLex}
-import coop.rchain.rosette.Ctxt.setReg
+import coop.rchain.rosette.Ctxt._
 
 sealed trait Location extends Ob {
   override val meta   = null
@@ -27,37 +29,39 @@ object Location {
   val LocRslt = CtxtRegister(0)
   val LocTrgt = CtxtRegister(1)
 
-  def fetch(loc: Location, globalEnv: TblObject): State[Ctxt, Option[Ob]] = {
-    val pure = State.pure[Ctxt, Option[Ob]] _
-
+  /** Try to fetch an `Ob` which is stored at a position described by `loc`
+    *
+    * TODO: Type signature should be changed to `Reader[GlobalEnv, Option[Ob]]`
+    * since fetching a location can't schedule a continuation.
+    */
+  def fetch(loc: Location): CtxtTransition[Option[Ob]] =
     for {
-      ctxt <- State.get[Ctxt]
-      res <- loc match {
-              case CtxtRegister(reg) => pure(ctxt.getReg(reg))
+      ctxt      <- getCtxt
+      globalEnv <- getGlobalEnv
 
-              case ArgRegister(argReg) => pure(ctxt.argvec.elem.lift(argReg))
+      res <- loc match {
+              case CtxtRegister(reg) => pureCtxt(ctxt.getReg(reg))
+
+              case ArgRegister(argReg) => pureCtxt(ctxt.argvec.elem.lift(argReg))
 
               case LexVariable(indirect, level, offset) =>
-                pure(getLex(indirect, level, offset).runA(ctxt.env).value)
+                pureCtxt(getLex(indirect, level, offset).runA(ctxt.env).value)
 
               case AddrVariable(indirect, level, offset) =>
-                pure(getAddr(indirect, level, offset).runA(ctxt.env).value)
+                pureCtxt(getAddr(indirect, level, offset).runA(ctxt.env).value)
 
-              case GlobalVariable(offset) => pure(globalEnv.slot.lift(offset))
+              case GlobalVariable(offset) => pureCtxt(globalEnv.slot.lift(offset))
 
-              case BitField(indirect, level, offset, spanSize, sign) => pure(None)
+              case BitField(indirect, level, offset, spanSize, sign) => pureCtxt(None)
 
-              case BitField00(offset, spanSize, sign) => pure(None)
+              case BitField00(offset, spanSize, sign) => pureCtxt(None)
 
               // TODO:
-              case _ => pure(None)
+              case _ => pureCtxt(None)
             }
     } yield res
-  }
 
-  def store(loc: Location, value: Ob): State[Ctxt, StoreResult] = {
-    val pure = State.pure[Ctxt, StoreResult] _
-
+  def store(loc: Location, value: Ob): State[Ctxt, StoreResult] =
     loc match {
       case CtxtRegister(reg) => setReg(reg, value)
 
@@ -71,10 +75,9 @@ object Location {
 
       case LexVariable(indirect, level, offset) =>
         setLex(indirect, level, offset, value)
-          .transformS(_.env, (ctxt, env) => ctxt.copy(env = env))
+          .transformS[Ctxt](_.env, (ctxt, env) => ctxt.copy(env = env))
 
       // TODO:
-      case _ => pure(Failure)
+      case _ => State.pure[Ctxt, StoreResult](Failure)
     }
-  }
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Meta.scala
@@ -1,13 +1,10 @@
 package coop.rchain.rosette
 
-import cats.data.State._
-import coop.rchain.rosette.Ctxt.CtxtTransition
-
 object Meta {
   case class StdMeta(meta: Ob, parent: Ob, override val extension: StdExtension) extends Actor {
     // TODO:
     def get(client: Ob, key: Ob): CtxtTransition[Result] =
-      pure[Ctxt, Result](Left(Absent))
+      pureCtxt[Result](Left(Absent))
 
     // TODO:
     def lookupOBOStdMeta(client: Ob, key: Ob): CtxtTransition[Result] =

--- a/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
@@ -1,18 +1,17 @@
 package coop.rchain.rosette
 
-import cats.data.State._
-import coop.rchain.rosette.Ctxt.{Continuation, CtxtTransition}
+import cats.implicits._
 
 case class StdOprn(meta: Ob, parent: Ob, override val extension: StdExtension) extends Actor {
-  override def dispatch: CtxtTransition[(Result, Option[Continuation])] =
+  override def dispatch: CtxtTransition[Result] =
     for {
-      optArg0 <- inspect[Ctxt, Option[Ob]](_.arg(0))
+      ctxt      <- getCtxt
+      globalEnv <- getGlobalEnv
+      optArg0   = ctxt.arg(0)
 
       result <- optArg0 match {
                  case Some(ob) => ob.lookupAndInvoke
-                 case None =>
-                   pure[Ctxt, (Result, Option[Continuation])](
-                     (Left(RuntimeError("no argument for dispatch")), None))
+                 case None     => pureCtxt[Result](Left(RuntimeError("no argument for dispatch")))
                }
     } yield result
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/Operation.scala
@@ -5,9 +5,8 @@ import cats.implicits._
 case class StdOprn(meta: Ob, parent: Ob, override val extension: StdExtension) extends Actor {
   override def dispatch: CtxtTransition[Result] =
     for {
-      ctxt      <- getCtxt
-      globalEnv <- getGlobalEnv
-      optArg0   = ctxt.arg(0)
+      ctxt    <- getCtxt
+      optArg0 = ctxt.arg(0)
 
       result <- optArg0 match {
                  case Some(ob) => ob.lookupAndInvoke

--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -2,9 +2,10 @@ package coop.rchain.rosette
 
 import cats.data.State
 import cats.data.State._
+import cats.implicits._
 import com.typesafe.scalalogging.Logger
 import coop.rchain.rosette.Ob._
-import coop.rchain.rosette.Ctxt.{setReg, Continuation, CtxtTransition}
+import coop.rchain.rosette.Ctxt.{NIV => _, apply => _, _}
 import coop.rchain.rosette.prim.Prim
 
 sealed trait Work
@@ -34,8 +35,10 @@ object VirtualMachine {
   )
 
   val doNextThread = modify[VMState](_.copy(doNextThreadFlag = true))
-  val doNothing    = pure[VMState, Unit](())
+  val doNothing    = pureVm[Unit](())
   val vmError      = modify[VMState](_.copy(exitFlag = true, exitCode = 1))
+
+  def pureVm[A](a: A) = State.pure[VMState, A](a)
 
   def handleApplyPrimSuspend(op: Op): Unit                = ()
   def handleApplyPrimUpcall(op: Op, tag: Location): Unit  = ()
@@ -61,14 +64,27 @@ object VirtualMachine {
       case Left(_) => doNextThread
     }
 
-  def runPrim(unwind: Boolean, optPrim: Option[Prim]): VMTransition[Result] =
-    for {
-      result <- optPrim match {
-                 case Some(prim) if unwind  => unwindAndApplyPrim(prim).embedCtxt
-                 case Some(prim) if !unwind => prim.dispatchHelper.embedCtxt
-                 case None                  => pure[VMState, Result](Left(PrimNotFound))
-               }
-    } yield result
+  /** Executes a primitive which will return a result.
+    *
+    * Executing a primitive returns a list of continuations that has to be
+    * scheduled by the VM. The list can be empty.
+    * For example `ctxt-rtn` is a primitive that can return a continuation.
+    */
+  def runPrim(unwind: Boolean,
+              optPrim: Option[Prim]): VMTransition[(Result, List[Continuation])] = {
+    val primRes: CtxtTransition[Result] = optPrim match {
+      case Some(prim) if unwind  => unwindAndApplyPrim(prim)
+      case Some(prim) if !unwind => prim.dispatchHelper
+      case None                  => pureCtxt[Result](Left(PrimNotFound))
+    }
+
+    /**
+      * Transform `CtxtTransition` into `VMTransition`.
+      * Involves updating `ctxt` and `globalEnv` and pulling out continuations into
+      * the result.
+      */
+    transformCtxtTransToVMTrans[Result](primRes)
+  }
 
   // TODO: Finish
   def unwindAndApplyPrim(prim: Prim): CtxtTransition[Result] = {
@@ -76,7 +92,7 @@ object VirtualMachine {
     val recoil: Ctxt => CtxtTransition[Unit] = ???
 
     for {
-      oldCtxt    <- get[Ctxt]
+      oldCtxt    <- getCtxt
       _          <- unwind
       primResult <- prim.dispatchHelper
       _          <- recoil(oldCtxt)
@@ -312,6 +328,9 @@ object VirtualMachine {
     modify[VMState](_.update(_ >> 'strandPool)(_ :+ ctxt))
   }
 
+  def scheduleConts(ctxts: Seq[Ctxt]): VMTransition[Unit] =
+    ctxts.foldLeft(pureVm[Unit](()))((state, cont) => state.flatMap(_ => schedule(cont)))
+
   /** Return current result
     *
     * This returns the current result to the parent ctxt.
@@ -319,13 +338,15 @@ object VirtualMachine {
     */
   def doRtn: VMTransition[Unit] =
     for {
-      rslt        <- inspect[VMState, Ob](_.ctxt.rslt)
-      ctxtRet     <- Ctxt.ret(rslt).embedCtxt
+      rslt    <- inspect[VMState, Ob](_.ctxt.rslt)
+      ctxtRet <- transformCtxtTransToVMTrans[Boolean](Ctxt.ret(rslt))
+
       isDoRtnFlag <- inspect[VMState, Boolean](_.doRtnFlag)
 
-      (isError, optContinuation) = ctxtRet
+      (isError, continuations) = ctxtRet
 
-      _ <- optContinuation.map(schedule).getOrElse(pure(()))
+      // Schedule continuations to `strandPool`
+      _ <- scheduleConts(continuations)
 
       _ <- if (isError)
             modify[VMState](_.copy(vmErrorFlag = true))
@@ -345,12 +366,13 @@ object VirtualMachine {
   def doXmit: VMTransition[Unit] =
     for {
       target         <- inspect[VMState, Ob](_.ctxt.trgt)
-      dispatchResult <- target.dispatch.embedCtxt
+      dispatchResult <- transformCtxtTransToVMTrans(target.dispatch)
       next           <- inspect[VMState, Boolean](_.xmitData._2)
 
-      (result, optContinuation) = dispatchResult
+      (result, conts) = dispatchResult
 
-      _ <- optContinuation.map(schedule).getOrElse(pure(()))
+      // Schedule continuations to `strandPool`
+      _ <- scheduleConts(conts)
 
       _ <- result match {
             // TODO: Add missing case where result is OTsysval
@@ -527,8 +549,13 @@ object VirtualMachine {
       _   <- modify[VMState](_.set(_ >> 'ctxt >> 'nargs)(op.nargs))
       _   <- modify[VMState](_.set(_ >> 'loc)(loc))
 
-      prim   = Prim.nthPrim(op.primNum)
-      result <- runPrim(op.unwind, prim)
+      prim          = Prim.nthPrim(op.primNum)
+      runPrimResult <- runPrim(op.unwind, prim)
+
+      (result, continuations) = runPrimResult
+
+      // Schedule continuations to `strandPool`
+      _ <- scheduleConts(continuations)
 
       _ <- handlePrimResult(
             result,
@@ -552,8 +579,13 @@ object VirtualMachine {
     for {
       _ <- modify[VMState](_.set(_ >> 'ctxt >> 'nargs)(op.nargs))
 
-      prim   = Prim.nthPrim(op.primNum)
-      result <- runPrim(op.unwind, prim)
+      prim          = Prim.nthPrim(op.primNum)
+      runPrimResult <- runPrim(op.unwind, prim)
+
+      (result, continuations) = runPrimResult
+
+      // Schedule continuation to `strandPool`
+      _ <- scheduleConts(continuations)
 
       _ <- handlePrimResult(
             result,
@@ -577,13 +609,18 @@ object VirtualMachine {
     for {
       _ <- modify[VMState](_.set(_ >> 'ctxt >> 'nargs)(op.nargs))
 
-      prim   = Prim.nthPrim(op.primNum)
-      result <- runPrim(op.unwind, prim)
+      prim          = Prim.nthPrim(op.primNum)
+      runPrimResult <- runPrim(op.unwind, prim)
+
+      (result, continuations) = runPrimResult
+
+      // Schedule continuation to `strandPool`
+      _ <- scheduleConts(continuations)
 
       _ <- handlePrimResult(
             result,
             ob =>
-              setReg(op.reg, ob).embedCtxt
+              setReg(op.reg, ob).embedCtxtInVM
                 .transform { (vmState, storeResult) =>
                   storeResult match {
                     case Success =>
@@ -599,8 +636,13 @@ object VirtualMachine {
     for {
       _ <- modify[VMState](_.set(_ >> 'ctxt >> 'nargs)(op.nargs))
 
-      prim   = Prim.nthPrim(op.primNum)
-      result <- runPrim(op.unwind, prim)
+      prim          = Prim.nthPrim(op.primNum)
+      runPrimResult <- runPrim(op.unwind, prim)
+
+      (result, continuations) = runPrimResult
+
+      // Schedule continuation to `strandPool`
+      _ <- scheduleConts(continuations)
 
       _ <- handlePrimResult(
             result,
@@ -664,7 +706,7 @@ object VirtualMachine {
       _ <- if (exit)
             modify[VMState](_.set(_ >> 'exitFlag)(true).set(_ >> 'exitCode)(0))
           else
-            pure[VMState, Unit](())
+            pureVm[Unit](())
     } yield ()
 
   def execute(op: OpJmp): VMTransition[Unit] = modify(_.set(_ >> 'pc >> 'relative)(op.pc))
@@ -789,7 +831,7 @@ object VirtualMachine {
       optOb <- getCtxtReg(op.reg)
       _ <- optOb match {
             case Some(ob) => modify[VMState](_.set(_ >> 'ctxt >> 'rslt)(ob))
-            case None     => pure[VMState, Unit](())
+            case None     => pureVm[Unit](())
           }
     } yield ()
 
@@ -801,7 +843,7 @@ object VirtualMachine {
 
       _ <- Location
             .store(location, rslt)
-            .embedCtxt
+            .embedCtxtInVM
             .transform { (vmState, storeRes) =>
               storeRes match {
                 case Success => (vmState, ())
@@ -815,10 +857,9 @@ object VirtualMachine {
       location  <- inspect[VMState, Location](_.code.lit(op.lit).asInstanceOf[Location])
       globalEnv <- inspect[VMState, TblObject](_.globalEnv)
       _         <- modify[VMState](_.copy(loc = location))
-      _ <- Location
-            .fetch(location, globalEnv)
-            .transform((ctxt, optRes) => (ctxt.copy(rslt = optRes.getOrElse(Ob.INVALID)), ()))
-            .transformS[VMState](_.ctxt, (vmState, ctxt) => vmState.copy(ctxt = ctxt))
+      optRes <- transformCtxtTransToVMTrans(Location.fetch(location))
+                 .map(_._1) // `fetch` doesn't emit continuations
+      _ <- modify[VMState](_.set(_ >> 'ctxt >> 'rslt)(optRes.getOrElse(Ob.INVALID)))
     } yield ()
 
   def execute(op: OpIndLitToArg): VMTransition[Unit] =

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/Prim.scala
@@ -1,8 +1,6 @@
 package coop.rchain.rosette.prim
 
-import cats.data.State
-import cats.data.State._
-import coop.rchain.rosette.Ctxt.{Continuation, CtxtTransition}
+import cats.implicits._
 import coop.rchain.rosette._
 import coop.rchain.rosette.prim.Prim.mismatchArgs
 
@@ -22,66 +20,63 @@ abstract class Prim extends Ob {
   override val meta   = null
   override val parent = null
 
-  def fn(ctxt: Ctxt): Either[PrimError, Ob]
+  def fn: CtxtTransition[PrimResult] =
+    for {
+      ctxt       <- getCtxt
+      globalEnv  <- getGlobalEnv
+      primResult = fnSimple(ctxt)
+    } yield primResult
 
-  /**
-    * Rosette seems to potentially return INVALID, UPCALL or DEADTHREAD here
-    * Therefore we return RblError for the error case
-    */
-  def dispatchHelper: CtxtTransition[Result] = State { ctxt =>
-    val n = ctxt.nargs
+  def fnSimple(ctxt: Ctxt): PrimResult = ???
 
-    if (minArgs <= n && n <= maxArgs)
-      (ctxt, fn(ctxt).left.map(PrimErrorWrapper))
-    else
-      (ctxt, Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs))))
-  }
+  def dispatchHelper: CtxtTransition[Result] =
+    for {
+      ctxt      <- getCtxt
+      globalEnv <- getGlobalEnv
+      n         = ctxt.nargs
+
+      result <- if (minArgs <= n && n <= maxArgs)
+                 fn.transform((writer, state, res) =>
+                   (writer, state, res.left.map(PrimErrorWrapper)))
+               else
+                 pureCtxt[Result](Left(PrimErrorWrapper(mismatchArgs(ctxt, minArgs, maxArgs))))
+    } yield result
 
   /** Dispatch primitive
     *
     * This runs a primitive with dispatchHelper and tries
-    * to return the result to the parent ctxt.
+    * to return the result to the parent `ctxt`.
     *
-    * Returning the result to the parent ctxt, will potentially
-    * return the parent ctxt which then has to be scheduled by
+    * Returning the result to the parent `ctxt` will potentially
+    * return the parent `ctxt` which then has to be scheduled by
     * the caller.
+    *
+    * Running a primitive through `dispatchHelper` can also potentially
+    * return a ctxt that has to be scheduled (see `ctxt-rtn`). Therefore `dispatchPrim`
+    * returns a `List[Continuation]`.
     */
-  override def dispatch: CtxtTransition[(Result, Option[Continuation])] = {
-
-    /**
-      * Try to return the primitive result to the parent ctxt.
-      * This can potentially return the parent ctxt as a ctxt
-      * that needs to be scheduled by the caller.
-      */
-    def returnResultToParent(result: Ob): CtxtTransition[(Result, Option[Continuation])] =
-      Ctxt
-        .ret(result)
-        .transform(
-          (ctxt, res) =>
-            if (res._1)
-              (ctxt, (Right(result), res._2))
-            else
-              (ctxt, (Right(result), res._2))
-        )
-
+  override def dispatch: CtxtTransition[Result] =
     for {
       primResult <- dispatchHelper
 
       result <- primResult match {
-                 case Right(ob) => returnResultToParent(ob)
 
-                 case _ =>
+                 /**
+                   * Return the primitive result to the continuation
+                   * of the current `ctxt`.
+                   */
+                 case Right(res) => Ctxt.ret(res).map(_ => primResult)
+
+                 case error =>
                    /**
                      * Something went wrong with running the primitive.
-                     * Report the error back and there is no ctxt to be
-                     * scheduled.
+                     * Report the error back.
                      */
-                   pure[Ctxt, (Result, Option[Continuation])]((primResult, None))
+                   pureCtxt[Result](error)
                }
     } yield result
-  }
 
-  def invoke: CtxtTransition[(Result, Option[Continuation])] = dispatch
+  def invoke: CtxtTransition[Result] = dispatch
 }
 
 object Prim {

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
@@ -14,10 +14,9 @@ object ctxt {
 
     override def fn: CtxtTransition[PrimResult] =
       for {
-        ctxt      <- getCtxt
-        globalEnv <- getGlobalEnv
-        optArg0   = ctxt.arg(0).map(_.asInstanceOf[Ctxt])
-        optArg1   = ctxt.arg(1)
+        ctxt    <- getCtxt
+        optArg0 = ctxt.arg(0).map(_.asInstanceOf[Ctxt])
+        optArg1 = ctxt.arg(1)
 
         result <- (optArg0, optArg1) match {
                    // Both ARG(0) and ARG(1) are available

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
@@ -1,0 +1,43 @@
+package coop.rchain.rosette.prim
+
+import cats.implicits._
+import coop.rchain.rosette._
+import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
+import coop.rchain.rosette.{Ctxt, CtxtTransition, Ob}
+import coop.rchain.rosette.Ob.Lenses._
+
+object ctxt {
+  object ctxtRtn extends Prim {
+    override val name: String = "ctxt-rtn"
+    override val minArgs: Int = 2
+    override val maxArgs: Int = 2
+
+    override def fn: CtxtTransition[PrimResult] =
+      for {
+        ctxt      <- getCtxt
+        globalEnv <- getGlobalEnv
+        optArg0   = ctxt.arg(0).map(_.asInstanceOf[Ctxt])
+        optArg1   = ctxt.arg(1)
+
+        result <- (optArg0, optArg1) match {
+                   // Both ARG(0) and ARG(1) are available
+                   case (Some(arg0), Some(arg1)) =>
+                     for (returnRes <- returnResultToCtxt(arg0, arg1))
+                       yield Right[PrimError, Ob](if (returnRes) Ob.INVALID else Ob.NIV)
+
+                   case _ =>
+                     pureCtxt[PrimResult](Left(TypeMismatch(0, Ctxt.getClass.getName)))
+                 }
+
+      } yield result
+
+    private def returnResultToCtxt(k: Ctxt, result: Ob): CtxtTransition[Boolean] =
+      for {
+        ctxt                        <- getCtxt
+        globalEnv                   <- getGlobalEnv
+        (conts, (_, kUpdated), res) = Ctxt.ret(result).run((), (globalEnv, k)).value
+        _                           <- modifyCtxt(_.update(_ >> 'argvec >> 'elem)(_.updated(0, kUpdated)))
+        _                           <- tellCont(conts)
+      } yield res
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/ctxt.scala
@@ -18,16 +18,13 @@ object ctxt {
         optArg0 = ctxt.arg(0).map(_.asInstanceOf[Ctxt])
         optArg1 = ctxt.arg(1)
 
-        result <- (optArg0, optArg1) match {
-                   // Both ARG(0) and ARG(1) are available
-                   case (Some(arg0), Some(arg1)) =>
-                     for (returnRes <- returnResultToCtxt(arg0, arg1))
-                       yield Right[PrimError, Ob](if (returnRes) Ob.INVALID else Ob.NIV)
-
-                   case _ =>
-                     pureCtxt[PrimResult](Left(TypeMismatch(0, Ctxt.getClass.getName)))
-                 }
-
+        result <- (optArg0, optArg1)
+                   .mapN(
+                     // Both ARG(0) and ARG(1) are available
+                     (arg0, arg1) =>
+                       for (returnRes <- returnResultToCtxt(arg0, arg1))
+                         yield Right[PrimError, Ob](if (returnRes) Ob.INVALID else Ob.NIV))
+                   .getOrElse(pureCtxt[PrimResult](Left(TypeMismatch(0, Ctxt.getClass.getName))))
       } yield result
 
     private def returnResultToCtxt(k: Ctxt, result: Ob): CtxtTransition[Boolean] =

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/fixnum.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/fixnum.scala
@@ -17,7 +17,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
@@ -33,7 +33,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] =
       ctxt.nargs match {
         case 1 =>
           val fixval = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
@@ -53,7 +53,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(1)) {
@@ -69,7 +69,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -89,7 +89,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -108,7 +108,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m < n
@@ -123,7 +123,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m <= n
@@ -138,7 +138,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m > n
@@ -153,7 +153,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m >= n
@@ -168,7 +168,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m == n
@@ -183,7 +183,7 @@ object fixnum {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] =
       checkFixnum(0, ctxt.argvec.elem).map { m =>
         checkFixnum(1, ctxt.argvec.elem) match {
           case Right(n) => m != n
@@ -199,7 +199,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(Int.MaxValue)) {
@@ -216,7 +216,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(Int.MinValue)) {
@@ -233,7 +233,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       Right(Fixnum(Math.abs(m.value)))
     }
@@ -246,7 +246,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -266,7 +266,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
 
       if (m <= 0) {
@@ -292,7 +292,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum].value
 
       if (m <= 0) {
@@ -318,7 +318,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(~0)) {
@@ -334,7 +334,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
@@ -350,7 +350,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(Fixnum(0)) {
@@ -366,7 +366,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
 
       Right(Fixnum(~m.value))
@@ -380,7 +380,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val n = ctxt.nargs
 
       val commonBits = ctxt.argvec.elem.take(n).foldLeft(Fixnum(~0)) {
@@ -402,7 +402,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -422,7 +422,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -437,7 +437,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -452,7 +452,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 
@@ -467,7 +467,7 @@ object fixnum {
 
     @checkTypeMismatch[Fixnum]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[Fixnum]
       val n = ctxt.argvec.elem(1).asInstanceOf[Fixnum]
 

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/package.scala
@@ -1,6 +1,10 @@
 package coop.rchain.rosette
 
+import cats.data.State
+
 package object prim {
+  type PrimResult = Either[PrimError, Ob]
+
   // For now keys in Prims correspond to Prim::primnum in Rosette
   val Prims = Map[Int, Prim](197 -> rblfloat.flPlus,
                              222 -> fixnum.fxMod,

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/rblfloat.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/rblfloat.scala
@@ -17,7 +17,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(0.0)) {
@@ -33,7 +33,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] =
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] =
       ctxt.nargs match {
         case 1 =>
           val n = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
@@ -53,7 +53,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(1)) {
@@ -69,7 +69,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -89,7 +89,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -104,7 +104,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -119,7 +119,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -134,7 +134,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -149,7 +149,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -164,7 +164,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -179,7 +179,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(Double.MaxValue)) {
@@ -196,7 +196,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val n = ctxt.nargs
 
       Right(ctxt.argvec.elem.take(n).foldLeft(RblFloat(Double.MinValue)) {
@@ -213,7 +213,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.abs(m.value)))
@@ -227,7 +227,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.exp(m.value)))
@@ -241,7 +241,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
       val n = ctxt.argvec.elem(1).asInstanceOf[RblFloat]
 
@@ -256,7 +256,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.log(m.value)))
@@ -270,7 +270,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.log10(m.value)))
@@ -284,7 +284,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.floor(m.value)))
@@ -298,7 +298,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.ceil(m.value)))
@@ -312,7 +312,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.atan(m.value)))
@@ -326,7 +326,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.cos(m.value)))
@@ -340,7 +340,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblFloat] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblFloat] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(RblFloat(Math.sin(m.value)))
@@ -354,7 +354,7 @@ object rblfloat {
 
     @checkTypeMismatch[RblFloat]
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val m = ctxt.argvec.elem.head.asInstanceOf[RblFloat]
 
       Right(Fixnum(math.floor(m.value).toInt))

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/rblstring.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/rblstring.scala
@@ -18,7 +18,7 @@ object rblstring {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val elem = ctxt.argvec.elem
 
       checkType[RblString](0, elem).flatMap { s1 =>
@@ -59,7 +59,7 @@ object rblstring {
 
     @checkTypeMismatch[RblString] // All args must be strings
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblString] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
       val n    = ctxt.nargs
       val init = ""
@@ -89,7 +89,7 @@ object rblstring {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblString] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
 
       for {
@@ -122,7 +122,7 @@ object rblstring {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblString] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
 
       for {
@@ -147,7 +147,7 @@ object rblstring {
 
     @checkTypeMismatch[RblString] // All args must be strings
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Fixnum] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Fixnum] = {
       val elem = ctxt.argvec.elem
 
       Right(Fixnum(elem(0).asInstanceOf[RblString].value.length))
@@ -169,7 +169,7 @@ object rblstring {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblString] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem  = ctxt.argvec.elem
       val nargs = ctxt.nargs
 
@@ -197,7 +197,7 @@ object rblstring {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val elem = ctxt.argvec.elem
 
       for {
@@ -227,7 +227,7 @@ object rblstring {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblString] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
 
       for {
@@ -272,7 +272,7 @@ object rblstring {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
 
       for {

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/tuple.scala
@@ -17,7 +17,7 @@ object tuple {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
       checkTuple(1, elem).map(Tuple.cons(elem.head, _)) // arg1 must be a Tuple
     }
@@ -34,7 +34,7 @@ object tuple {
     override val maxArgs: Int = MaxArgs
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem  = ctxt.argvec.elem
       val nargs = ctxt.nargs
       val last  = nargs - 1
@@ -56,7 +56,7 @@ object tuple {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
 
       checkTuple(0, elem).map(Tuple.rcons(_, elem(1))) // arg0 must be a Tuple
@@ -75,7 +75,7 @@ object tuple {
 
     @checkTypeMismatch[Tuple] // All args must be Tuples
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
       val n    = ctxt.nargs
       val init = Tuple(Seq.empty)
@@ -99,7 +99,7 @@ object tuple {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Ob] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Ob] = {
       val elem = ctxt.argvec.elem
 
       checkTuple(0, elem).flatMap( // Ensure arg0 is a Tuple
@@ -129,7 +129,7 @@ object tuple {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
 
       def wrapper[A, B](f: Int => Option[Ob], v: Int, size: Int): Either[PrimError, Ob] =
@@ -165,7 +165,7 @@ object tuple {
 
     @checkTypeMismatch[Tuple] // Only arg must be a Tuple
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Ob] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Ob] = {
       val elem = ctxt.argvec.elem
 
       checkTuple(0, elem).map { t => // Ensure arg0 is a Tuple
@@ -190,7 +190,7 @@ object tuple {
 
     @checkTypeMismatch[Tuple] // Only arg must be a Tuple
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Ob] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Ob] = {
       val elem = ctxt.argvec.elem
 
       checkTuple(0, elem).map { t => // Ensure arg0 is a Tuple
@@ -216,7 +216,7 @@ object tuple {
 
     @checkTypeMismatch[Tuple] // Only arg must be a Tuple
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
       val t    = elem(0).asInstanceOf[Tuple]
       if (t.elem.size > 0)
@@ -251,7 +251,7 @@ object tuple {
     override val maxArgs: Int = MaxArgs
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem  = ctxt.argvec.elem
       val nargs = ctxt.nargs
 
@@ -274,7 +274,7 @@ object tuple {
     override val maxArgs: Int = 3
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, Tuple] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem  = ctxt.argvec.elem
       val nargs = ctxt.nargs
 
@@ -293,7 +293,7 @@ object tuple {
     override val maxArgs: Int = 2
 
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val elem  = ctxt.argvec.elem
       val nargs = ctxt.nargs
 
@@ -310,7 +310,7 @@ object tuple {
 
     @checkTypeMismatch[Tuple] // Args must be Tuples
     @checkArgumentMismatch
-    override def fn(ctxt: Ctxt): Either[PrimError, RblBool] = {
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
       val elem = ctxt.argvec.elem
       val pat  = elem(0).asInstanceOf[Tuple]
       val tup  = elem(1).asInstanceOf[Tuple]

--- a/roscala/src/test/scala/coop/rchain/rosette/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/CtxtSpec.scala
@@ -23,7 +23,7 @@ class CtxtSpec extends FlatSpec with Matchers {
     val ctxt0               = ctxt.set(_ >> 'ctxt >> 'outstanding)(1)
     val (conts, state, res) = Ctxt.applyK(Fixnum(1), LocTrgt).run((), (globalEnv, ctxt0)).value
 
-    conts.nonEmpty should be(true)
+    conts should not be empty
     conts.head.id should be(1)
     conts.head.outstanding should be(0)
   }
@@ -32,7 +32,7 @@ class CtxtSpec extends FlatSpec with Matchers {
     val ctxt0               = ctxt.copy(outstanding = 1)
     val (conts, state, res) = Ctxt.rcv(Fixnum(1), LocTrgt).run((), (globalEnv, ctxt0)).value
 
-    conts.nonEmpty should be(true)
+    conts should not be empty
     conts.head.id should be(0)
   }
 
@@ -58,7 +58,7 @@ class CtxtSpec extends FlatSpec with Matchers {
 
     res should be(false)
     ctxt1.ctxt.trgt should be(Fixnum(1))
-    conts.isEmpty should be(true)
+    conts should be(empty)
   }
 
   it should "schedule continuation if outstanding field of continuation is one" in {

--- a/roscala/src/test/scala/coop/rchain/rosette/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/CtxtSpec.scala
@@ -9,51 +9,65 @@ class CtxtSpec extends FlatSpec with Matchers {
     .copy(id = 0)
     .copy(ctxt = Ctxt.empty.copy(id = 1))
 
-  "applyK" should "save result into parent ctxt" in {
-    val ctxt0 = Ctxt.applyK(Fixnum(1), LocTrgt).runS(ctxt).value
+  val globalEnv = TblObject(Seq())
+
+  val initial = (globalEnv, ctxt)
+
+  "applyK" should "save result into ctxt's continuation" in {
+    val (conts, (_, ctxt0), res) = Ctxt.applyK(Fixnum(1), LocTrgt).run((), initial).value
 
     ctxt0.ctxt.trgt should be(Fixnum(1))
   }
 
-  it should "return parent ctxt as a continuation if outstanding field of parent is one" in {
-    val ctxt0                = ctxt.set(_ >> 'ctxt >> 'outstanding)(1)
-    val (_, optContinuation) = Ctxt.applyK(Fixnum(1), LocTrgt).runA(ctxt0).value
+  it should "return continuation if outstanding field of continuation is one" in {
+    val ctxt0               = ctxt.set(_ >> 'ctxt >> 'outstanding)(1)
+    val (conts, state, res) = Ctxt.applyK(Fixnum(1), LocTrgt).run((), (globalEnv, ctxt0)).value
 
-    optContinuation.isDefined should be(true)
-    optContinuation.get.id should be(1)
-    optContinuation.get.outstanding should be(0)
+    conts.nonEmpty should be(true)
+    conts.head.id should be(1)
+    conts.head.outstanding should be(0)
   }
 
-  "rcv" should "return itself as a continuation if outstanding field is one" in {
-    val ctxt0                = ctxt.copy(outstanding = 1)
-    val (_, optContinuation) = Ctxt.rcv(Fixnum(1), LocTrgt).runA(ctxt0).value
+  "rcv" should "schedule itself if outstanding field is one" in {
+    val ctxt0               = ctxt.copy(outstanding = 1)
+    val (conts, state, res) = Ctxt.rcv(Fixnum(1), LocTrgt).run((), (globalEnv, ctxt0)).value
 
-    optContinuation.isDefined should be(true)
-    optContinuation.get.id should be(0)
+    conts.nonEmpty should be(true)
+    conts.head.id should be(0)
   }
 
   it should "decrease the outstanding field by one if storing was successful" in {
-    val ctxt0           = ctxt.copy(outstanding = 1)
-    val (ctxt1, result) = Ctxt.rcv(Fixnum(1), LocTrgt).run(ctxt0).value
+    val ctxt0                    = ctxt.copy(outstanding = 1)
+    val (conts, (_, ctxt1), res) = Ctxt.rcv(Fixnum(1), LocTrgt).run((), (globalEnv, ctxt0)).value
 
     ctxt1.trgt should be(Fixnum(1))
-    result._1 should be(false)
+    res should be(false)
     ctxt1.outstanding should be(0)
   }
 
-  "ret" should "return false if tag is Limbo" in {
-    val ctxt0  = ctxt.copy(tag = Limbo)
-    val result = Ctxt.rcv(Fixnum(1), LocTrgt).runA(ctxt0).value
+  it should "return false if tag is `Limbo`" in {
+    val ctxt0 = ctxt.copy(tag = Limbo)
+    val res   = Ctxt.rcv(Fixnum(1), LocTrgt).runA((), (globalEnv, ctxt0)).value
 
-    result._1 should be(false)
+    res should be(false)
   }
 
-  it should "return parent ctxt as a continuation if outstanding field of parent is one" in {
-    val ctxt0                = ctxt.set(_ >> 'ctxt >> 'outstanding)(1)
-    val (_, optContinuation) = Ctxt.applyK(Fixnum(1), LocTrgt).runA(ctxt0).value
+  "ret" should "save result to given location in its continuation" in {
+    val ctxt0                    = ctxt.copy(tag = LocTrgt)
+    val (conts, (_, ctxt1), res) = Ctxt.ret(Fixnum(1)).run((), (globalEnv, ctxt0)).value
 
-    optContinuation.isDefined should be(true)
-    optContinuation.get.id should be(1)
-    optContinuation.get.outstanding should be(0)
+    res should be(false)
+    ctxt1.ctxt.trgt should be(Fixnum(1))
+    conts.isEmpty should be(true)
+  }
+
+  it should "schedule continuation if outstanding field of continuation is one" in {
+    val ctxt0                    = ctxt.set(_ >> 'ctxt >> 'outstanding)(1).set(_ >> 'tag)(LocTrgt)
+    val (conts, (_, ctxt1), res) = Ctxt.ret(Fixnum(1)).run((), (globalEnv, ctxt0)).value
+
+    res should be(false)
+    ctxt1.ctxt.trgt should be(Fixnum(1))
+    conts.nonEmpty should be(true)
+    conts.head.trgt should be(Fixnum(1))
   }
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/LocationSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/LocationSpec.scala
@@ -30,6 +30,10 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
     monitor = null
   )
 
+  val globalEnv = TblObject(Seq())
+
+  val initial = (globalEnv, testCtxt)
+
   "Location.store" should {
 
     "store to register" in {
@@ -148,15 +152,15 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
       regs.map(
         reg =>
           Location
-            .fetch(CtxtRegister(reg), null)
-            .runA(testCtxt)
+            .fetch(CtxtRegister(reg))
+            .runA((), initial)
             .value shouldBe testCtxt.getReg(reg))
     }
 
     "return None for invalid register" in {
       Location
-        .fetch(CtxtRegister(100), null)
-        .runA(testCtxt)
+        .fetch(CtxtRegister(100))
+        .runA((), initial)
         .value shouldBe None
     }
 
@@ -166,16 +170,16 @@ class LocationSpec extends WordSpec with PropertyChecks with Matchers {
       argRegs.map(
         argReg =>
           Location
-            .fetch(ArgRegister(argReg), null)
-            .runA(testCtxt)
+            .fetch(ArgRegister(argReg))
+            .runA((), initial)
             .value shouldBe testCtxt.argvec.elem.lift(argReg)
       )
     }
 
     "return None for invalid argvec position" in {
       Location
-        .fetch(ArgRegister(100), null)
-        .runA(testCtxt)
+        .fetch(ArgRegister(100))
+        .runA((), initial)
         .value shouldBe None
     }
 

--- a/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/PrimPropertySpec.scala
@@ -15,7 +15,7 @@ class PrimPropertySpec extends PropSpec with PropertyChecks with Matchers {
           val ctxt =
             utils.opcodes.ctxt.copy(nargs = i, argvec = Tuple(i, Fixnum(1)))
 
-          prim.fn(ctxt) should be('left)
+          prim.fnSimple(ctxt) should be('left)
         }
       }
     }

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/FixnumSpec.scala
@@ -24,304 +24,304 @@ class FixnumSpec extends FlatSpec with Matchers {
 
   "fxPlus" should "correctly add numbers" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Fixnum(1)))
-    fxPlus.fn(newCtxt) should be(Right(Fixnum(5)))
+    fxPlus.fnSimple(newCtxt) should be(Right(Fixnum(5)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    fxPlus.fn(newCtxt) should be('left)
+    fxPlus.fnSimple(newCtxt) should be('left)
   }
 
   "fxMinus" should "correctly subtract numbers" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(1)))
-    fxMinus.fn(newCtxt) should be(Right(Fixnum(0)))
+    fxMinus.fnSimple(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    fxMinus.fn(newCtxt) should be('left)
+    fxMinus.fnSimple(newCtxt) should be('left)
   }
 
   "fxTimes" should "correctly multiply numbers" in {
     val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Fixnum(5)))
-    fxTimes.fn(newCtxt) should be(Right(Fixnum(125)))
+    fxTimes.fnSimple(newCtxt) should be(Right(Fixnum(125)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Ob.NIV))
-    fxTimes.fn(newCtxt) should be('left)
+    fxTimes.fnSimple(newCtxt) should be('left)
   }
 
   "fxDiv" should "correctly divide numbers" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
-    fxDiv.fn(newCtxt) should be(Right(Fixnum(1)))
+    fxDiv.fnSimple(newCtxt) should be(Right(Fixnum(1)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxDiv.fn(newCtxt) should be('left)
+    fxDiv.fnSimple(newCtxt) should be('left)
   }
 
   "fxMod" should "correctly return the remainder" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Fixnum(5)))
-    fxMod.fn(newCtxt) should be(Right(Fixnum(0)))
+    fxMod.fnSimple(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxMod.fn(newCtxt) should be('left)
+    fxMod.fnSimple(newCtxt) should be('left)
   }
 
   "fxLt" should "correctly return whether former smaller than latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
-    fxLt.fn(newCtxt) should be(Right(RblBool(true)))
+    fxLt.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxLt.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxLt.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxLt.fn(newCtxt) should be('left)
+    fxLt.fnSimple(newCtxt) should be('left)
   }
 
   "fxLe" should "correctly return whether former smaller than or equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(2))))
-    fxLe.fn(newCtxt) should be(Right(RblBool(true)))
+    fxLe.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxLe.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxLe.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxLe.fn(newCtxt) should be('left)
+    fxLe.fnSimple(newCtxt) should be('left)
   }
 
   "fxGt" should "correctly return whether former greater than latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
-    fxGt.fn(newCtxt) should be(Right(RblBool(true)))
+    fxGt.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxGt.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxGt.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxGt.fn(newCtxt) should be('left)
+    fxGt.fnSimple(newCtxt) should be('left)
   }
 
   "fxGe" should "correctly return whether former greater than or equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
-    fxGe.fn(newCtxt) should be(Right(RblBool(true)))
+    fxGe.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxGe.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxGe.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxGe.fn(newCtxt) should be('left)
+    fxGe.fnSimple(newCtxt) should be('left)
   }
 
   "fxEq" should "correctly return whether former equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
-    fxEq.fn(newCtxt) should be(Right(RblBool(true)))
+    fxEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxEq.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxEq.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxEq.fn(newCtxt) should be('left)
+    fxEq.fnSimple(newCtxt) should be('left)
   }
 
   "fxNe" should "correctly return whether former is not equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(5))))
-    fxNe.fn(newCtxt) should be(Right(RblBool(false)))
+    fxNe.fnSimple(newCtxt) should be(Right(RblBool(false)))
 
     val newCtxt2 = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    fxNe.fn(newCtxt2) should be(Right(RblBool(false)))
+    fxNe.fnSimple(newCtxt2) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxNe.fn(newCtxt) should be('left)
+    fxNe.fnSimple(newCtxt) should be('left)
   }
 
   "fxMin" should "correctly return the smallest one" in {
     val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, Fixnum(2)), Tuple(Fixnum(5))))
-    fxMin.fn(newCtxt) should be(Right(Fixnum(2)))
+    fxMin.fnSimple(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxMin.fn(newCtxt) should be('left)
+    fxMin.fnSimple(newCtxt) should be('left)
   }
 
   "fxMax" should "correctly return the greatest one" in {
     val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, Fixnum(2)), Tuple(1, Fixnum(5))))
-    fxMax.fn(newCtxt) should be(Right(Fixnum(5)))
+    fxMax.fnSimple(newCtxt) should be(Right(Fixnum(5)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxMax.fn(newCtxt) should be('left)
+    fxMax.fnSimple(newCtxt) should be('left)
   }
 
   "fxAbs" should "correctly return absolute value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-2)))
-    fxAbs.fn(newCtxt) should be(Right(Fixnum(2)))
+    fxAbs.fnSimple(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(1, Ob.NIV))
-    fxAbs.fn(newCtxt) should be('left)
+    fxAbs.fnSimple(newCtxt) should be('left)
   }
 
   "fxExpt" should "correctly return base-number raised to the power power-number" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
-    fxExpt.fn(newCtxt) should be(Right(Fixnum(32)))
+    fxExpt.fnSimple(newCtxt) should be(Right(Fixnum(32)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxExpt.fn(newCtxt) should be('left)
+    fxExpt.fnSimple(newCtxt) should be('left)
   }
 
   "fxLg" should "correctly compute Ceil(ln(input_value))" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
-    fxLg.fn(newCtxt) should be(Right(Fixnum(4)))
+    fxLg.fnSimple(newCtxt) should be(Right(Fixnum(4)))
   }
 
   it should "fail for input value <= 0" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-1)))
-    fxLg.fn(newCtxt) should be('left)
+    fxLg.fnSimple(newCtxt) should be('left)
   }
 
   "fxLgf" should "correctly compute Floor(ln(input_value))" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
-    fxLgf.fn(newCtxt) should be(Right(Fixnum(3)))
+    fxLgf.fnSimple(newCtxt) should be(Right(Fixnum(3)))
   }
 
   it should "fail for input value <= 0" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(-1)))
-    fxLgf.fn(newCtxt) should be('left)
+    fxLgf.fnSimple(newCtxt) should be('left)
   }
 
   "fxLogand" should "correctly return the bitwise 'and' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
                 argvec = Tuple(Tuple(Fixnum(8)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
-    fxLogand.fn(newCtxt) should be(Right(Fixnum(0)))
+    fxLogand.fnSimple(newCtxt) should be(Right(Fixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogand.fn(newCtxt2) should be(Right(Fixnum(~0)))
+    fxLogand.fnSimple(newCtxt2) should be(Right(Fixnum(~0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxLogand.fn(newCtxt) should be('left)
+    fxLogand.fnSimple(newCtxt) should be('left)
   }
 
   "fxLogor" should "correctly return the bitwise 'or' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
                 argvec = Tuple(Tuple(Fixnum(8)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
-    fxLogor.fn(newCtxt) should be(Right(Fixnum(14)))
+    fxLogor.fnSimple(newCtxt) should be(Right(Fixnum(14)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogor.fn(newCtxt2) should be(Right(Fixnum(0)))
+    fxLogor.fnSimple(newCtxt2) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxLogor.fn(newCtxt) should be('left)
+    fxLogor.fnSimple(newCtxt) should be('left)
   }
 
   "fxLogxor" should "correctly return the bitwise 'xor' of all input values" in {
     val newCtxt =
       ctxt.copy(nargs = 3,
                 argvec = Tuple(Tuple(Fixnum(6)), Tuple(Tuple(Fixnum(4)), Tuple(Fixnum(2)))))
-    fxLogxor.fn(newCtxt) should be(Right(Fixnum(0)))
+    fxLogxor.fnSimple(newCtxt) should be(Right(Fixnum(0)))
 
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple.NIL)
-    fxLogxor.fn(newCtxt2) should be(Right(Fixnum(0)))
+    fxLogxor.fnSimple(newCtxt2) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    fxLogxor.fn(newCtxt) should be('left)
+    fxLogxor.fnSimple(newCtxt) should be('left)
   }
 
   "fxLognot" should "correctly compute bitwise '!' of input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Fixnum(10)))
-    fxLognot.fn(newCtxt) should be(Right(Fixnum(-11)))
+    fxLognot.fnSimple(newCtxt) should be(Right(Fixnum(-11)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxLognot.fn(newCtxt) should be('left)
+    fxLognot.fnSimple(newCtxt) should be('left)
   }
 
   "fxMdiv" should "correctly return former value module division latter value" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Fixnum(5))))
-    fxMdiv.fn(newCtxt) should be(Right(Fixnum(0)))
+    fxMdiv.fnSimple(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxMdiv.fn(newCtxt) should be('left)
+    fxMdiv.fnSimple(newCtxt) should be('left)
   }
 
   "fxCdiv" should "correctly compute Ceil(n/m)" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
-    fxCdiv.fn(newCtxt) should be(Right(Fixnum(3)))
+    fxCdiv.fnSimple(newCtxt) should be(Right(Fixnum(3)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxCdiv.fn(newCtxt) should be('left)
+    fxCdiv.fnSimple(newCtxt) should be('left)
   }
 
   "fxAsl" should "correctly compute arithmetical left shift of input value" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(5)), Tuple(Fixnum(2))))
-    fxAsl.fn(newCtxt) should be(Right(Fixnum(20)))
+    fxAsl.fnSimple(newCtxt) should be(Right(Fixnum(20)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxAsl.fn(newCtxt) should be('left)
+    fxAsl.fnSimple(newCtxt) should be('left)
   }
 
   "fxAsr" should "correctly compute arithmetical right shift of input value" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(2))))
-    fxAsr.fn(newCtxt) should be(Right(Fixnum(-1)))
+    fxAsr.fnSimple(newCtxt) should be(Right(Fixnum(-1)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxAsr.fn(newCtxt) should be('left)
+    fxAsr.fnSimple(newCtxt) should be('left)
   }
 
   "fxLsl" should "correctly compute logical left shift of input value" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(1))))
-    fxLsl.fn(newCtxt) should be(Right(Fixnum(-2)))
+    fxLsl.fnSimple(newCtxt) should be(Right(Fixnum(-2)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxLsl.fn(newCtxt) should be('left)
+    fxLsl.fnSimple(newCtxt) should be('left)
   }
 
   "fxLsr" should "correctly compute logical right shift of input value" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(-1)), Tuple(Fixnum(31))))
-    fxLsr.fn(newCtxt) should be(Right(Fixnum(1)))
+    fxLsr.fnSimple(newCtxt) should be(Right(Fixnum(1)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    fxLsr.fn(newCtxt) should be('left)
+    fxLsr.fnSimple(newCtxt) should be('left)
   }
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/RblFloatSpec.scala
@@ -24,243 +24,243 @@ class RblFloatSpec extends FlatSpec with Matchers {
 
   "flPlus" should "correctly add float numbers" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, RFloat(.1)))
-    flPlus.fn(newCtxt) should be(Right(RFloat(.5)))
+    flPlus.fnSimple(newCtxt) should be(Right(RFloat(.5)))
 
     val newCtxt2 = ctxt.copy(nargs = 0, argvec = Tuple.NIL)
-    flPlus.fn(newCtxt2) should be(Right(RFloat(0)))
+    flPlus.fnSimple(newCtxt2) should be(Right(RFloat(0)))
 
     val newCtxt3 = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(.1)))
-    flPlus.fn(newCtxt3) should be(Right(RFloat(0.1)))
+    flPlus.fnSimple(newCtxt3) should be(Right(RFloat(0.1)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    flPlus.fn(newCtxt) should be('left)
+    flPlus.fnSimple(newCtxt) should be('left)
   }
 
   "flMinus" should "correctly subtract RblFloat" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, RFloat(1.1)))
-    flMinus.fn(newCtxt) should be(Right(RFloat(0.0)))
+    flMinus.fnSimple(newCtxt) should be(Right(RFloat(0.0)))
   }
 
   it should "correctly invert the RblFloat" in {
     val newCtxt2 = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(1.1)))
-    flMinus.fn(newCtxt2) should be(Right(RFloat(-1.1)))
+    flMinus.fnSimple(newCtxt2) should be(Right(RFloat(-1.1)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    flMinus.fn(newCtxt) should be('left)
+    flMinus.fnSimple(newCtxt) should be('left)
   }
 
   "flTimes" should "correctly multiply float number" in {
     val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, RFloat(0.5)))
-    flTimes.fn(newCtxt) should be(Right(RFloat(0.125)))
+    flTimes.fnSimple(newCtxt) should be(Right(RFloat(0.125)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 3, argvec = Tuple(3, Ob.NIV))
-    flTimes.fn(newCtxt) should be('left)
+    flTimes.fnSimple(newCtxt) should be('left)
   }
 
   "flDiv" should "correctly divide float numbers" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(7.5)), Tuple(RFloat(2.5))))
-    flDiv.fn(newCtxt) should be(Right(RFloat(3)))
+    flDiv.fnSimple(newCtxt) should be(Right(RFloat(3)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    flDiv.fn(newCtxt) should be('left)
+    flDiv.fnSimple(newCtxt) should be('left)
   }
 
   "flLt" should "correctly return whether former smaller than latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.1)), Tuple(RFloat(2.2))))
-    flLt.fn(newCtxt) should be(Right(RblBool(true)))
+    flLt.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.1)), Tuple(Ob.NIV)))
-    flLt.fn(newCtxt) should be('left)
+    flLt.fnSimple(newCtxt) should be('left)
   }
 
   "flLe" should "correctly return whether former smaller than or equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, RFloat(2.1)))
-    flLe.fn(newCtxt) should be(Right(RblBool(true)))
+    flLe.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2)), Tuple(Ob.NIV)))
-    flLe.fn(newCtxt) should be('left)
+    flLe.fnSimple(newCtxt) should be('left)
   }
 
   "flGt" should "correctly return whether former greater than latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.3)), Tuple(RFloat(2.2))))
-    flGt.fn(newCtxt) should be(Right(RblBool(true)))
+    flGt.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "fail for non-fixnum arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.1)), Tuple(Ob.NIV)))
-    flGt.fn(newCtxt) should be('left)
+    flGt.fnSimple(newCtxt) should be('left)
   }
 
   "flGe" should "correctly return whether former greater than or equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.2)), Tuple(RFloat(2.2))))
-    flGe.fn(newCtxt) should be(Right(RblBool(true)))
+    flGe.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.1)), Tuple(Ob.NIV)))
-    flGe.fn(newCtxt) should be('left)
+    flGe.fnSimple(newCtxt) should be('left)
   }
 
   "flEq" should "correctly return whether former equal to the latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2.2)), Tuple(RFloat(2.2))))
-    flEq.fn(newCtxt) should be(Right(RblBool(true)))
+    flEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(Fixnum(2)), Tuple(Ob.NIV)))
-    flEq.fn(newCtxt) should be('left)
+    flEq.fnSimple(newCtxt) should be('left)
   }
 
   "flNe" should "correctly return whether former is not equal to latter" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(5)), Tuple(RFloat(5))))
-    flNe.fn(newCtxt) should be(Right(RblBool(false)))
+    flNe.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2)), Tuple(Ob.NIV)))
-    flNe.fn(newCtxt) should be('left)
+    flNe.fnSimple(newCtxt) should be('left)
   }
 
   "flMin" should "correctly return the smallest input value" in {
     val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, RFloat(2.1)), Tuple(RFloat(2.2))))
-    flMin.fn(newCtxt) should be(Right(RFloat(2.1)))
+    flMin.fnSimple(newCtxt) should be(Right(RFloat(2.1)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    flMin.fn(newCtxt) should be('left)
+    flMin.fnSimple(newCtxt) should be('left)
   }
 
   "flMax" should "correctly return the greatest input value" in {
     val newCtxt = ctxt.copy(nargs = 4, argvec = Tuple(Tuple(3, RFloat(2.1)), Tuple(RFloat(2.2))))
-    flMax.fn(newCtxt) should be(Right(RFloat(2.2)))
+    flMax.fnSimple(newCtxt) should be(Right(RFloat(2.2)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    flMax.fn(newCtxt) should be('left)
+    flMax.fnSimple(newCtxt) should be('left)
   }
 
   "flAbs" should "correctly return absolute value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(-2.1)))
-    flAbs.fn(newCtxt) should be(Right(RFloat(2.1)))
+    flAbs.fnSimple(newCtxt) should be(Right(RFloat(2.1)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(1, Ob.NIV))
-    flAbs.fn(newCtxt) should be('left)
+    flAbs.fnSimple(newCtxt) should be('left)
   }
 
   "flExp" should "correctly return e to the power of the input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(2.5)))
-    flExp.fn(newCtxt) should be(Right(RFloat(math.exp(2.5))))
+    flExp.fnSimple(newCtxt) should be(Right(RFloat(math.exp(2.5))))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flExp.fn(newCtxt) should be('left)
+    flExp.fnSimple(newCtxt) should be('left)
   }
 
   "flExpt" should "correctly return first argument to the power of second argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(Tuple(RFloat(2)), Tuple(RFloat(.5))))
-    flExpt.fn(newCtxt) should be(Right(RFloat(math.pow(2, .5))))
+    flExpt.fnSimple(newCtxt) should be(Right(RFloat(math.pow(2, .5))))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    flExpt.fn(newCtxt) should be('left)
+    flExpt.fnSimple(newCtxt) should be('left)
   }
 
   "flLog" should "correctly return result of natural logarithm for input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(Math.E)))
-    flLog.fn(newCtxt) should be(Right(RFloat(1)))
+    flLog.fnSimple(newCtxt) should be(Right(RFloat(1)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flLog.fn(newCtxt) should be('left)
+    flLog.fnSimple(newCtxt) should be('left)
   }
 
   "flLog10" should "correctly return result of common logarithm for input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(100.0)))
-    flLog10.fn(newCtxt) should be(Right(RFloat(2.0)))
+    flLog10.fnSimple(newCtxt) should be(Right(RFloat(2.0)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flLog10.fn(newCtxt) should be('left)
+    flLog10.fnSimple(newCtxt) should be('left)
   }
 
   "flCeil" should "correctly return ceiling of input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(2.1)))
-    flCeil.fn(newCtxt) should be(Right(RFloat(3.0)))
+    flCeil.fnSimple(newCtxt) should be(Right(RFloat(3.0)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flCeil.fn(newCtxt) should be('left)
+    flCeil.fnSimple(newCtxt) should be('left)
   }
 
   "flFloor" should "correctly return floor of input value" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(2.1)))
-    flFloor.fn(newCtxt) should be(Right(RFloat(2.0)))
+    flFloor.fnSimple(newCtxt) should be(Right(RFloat(2.0)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flFloor.fn(newCtxt) should be('left)
+    flFloor.fnSimple(newCtxt) should be('left)
   }
 
   "flAtan" should "correctly return the arc tangent of a value " in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(1.0)))
     // the returned angle is in the range -pi/2 through pi/2.
-    flAtan.fn(newCtxt) should be(Right(RFloat(Math.PI / 4)))
+    flAtan.fnSimple(newCtxt) should be(Right(RFloat(Math.PI / 4)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flAtan.fn(newCtxt) should be('left)
+    flAtan.fnSimple(newCtxt) should be('left)
   }
 
   "flSin" should "correctly return the trigonometric sine of an angle." in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(Math.PI)))
-    flSin.fn(newCtxt) should be(Right(RFloat(Math.sin(Math.PI))))
+    flSin.fnSimple(newCtxt) should be(Right(RFloat(Math.sin(Math.PI))))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flSin.fn(newCtxt) should be('left)
+    flSin.fnSimple(newCtxt) should be('left)
   }
 
   "flCos" should "correctly return the trigonometric cosine of an angle." in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(Math.PI)))
-    flCos.fn(newCtxt) should be(Right(RFloat(Math.cos(Math.PI))))
+    flCos.fnSimple(newCtxt) should be(Right(RFloat(Math.cos(Math.PI))))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flFloor.fn(newCtxt) should be('left)
+    flFloor.fnSimple(newCtxt) should be('left)
   }
 
   "flToFx" should "correctly convert the RblFloat value to Fixnum" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(RFloat(2.1)))
-    flToFx.fn(newCtxt) should be(Right(Fixnum(2)))
+    flToFx.fnSimple(newCtxt) should be(Right(Fixnum(2)))
   }
 
   it should "fail for non-RblFloat arguments" in {
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Ob.NIV))
-    flToFx.fn(newCtxt) should be('left)
+    flToFx.fnSimple(newCtxt) should be('left)
   }
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/RblStringSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/RblStringSpec.scala
@@ -34,7 +34,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings do not match" in {
@@ -47,17 +47,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringEq.fn(newCtxt) should be('left)
+    stringEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string!= */
@@ -71,7 +71,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringNEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringNEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings do match" in {
@@ -84,17 +84,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringNEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringNEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringNEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringNEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringNEq.fn(newCtxt) should be('left)
+    stringNEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string< */
@@ -108,7 +108,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLess.fn(newCtxt) should be(Right(RblBool(true)))
+    stringLess.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings are equal" in {
@@ -121,7 +121,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false if the right string is less than the left one" in {
@@ -134,17 +134,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringLess.fn(newCtxt) should be('left)
+    stringLess.fnSimple(newCtxt) should be('left)
   }
 
   /** string<= */
@@ -158,7 +158,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringLEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return true if the strings are equal" in {
@@ -171,7 +171,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringLEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the right string is less than the left one" in {
@@ -184,17 +184,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringLEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringLEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringLEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringLEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringLEq.fn(newCtxt) should be('left)
+    stringLEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string> */
@@ -208,7 +208,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGtr.fn(newCtxt) should be(Right(RblBool(true)))
+    stringGtr.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings are equal" in {
@@ -221,7 +221,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false if the right string is greater than the left one" in {
@@ -234,17 +234,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringGtr.fn(newCtxt) should be('left)
+    stringGtr.fnSimple(newCtxt) should be('left)
   }
 
   /** string>= */
@@ -258,7 +258,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringGEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return true if the strings are equal" in {
@@ -271,7 +271,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringGEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the right string is greater than the left one" in {
@@ -284,17 +284,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringGEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringGEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringGEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringGEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringGEq.fn(newCtxt) should be('left)
+    stringGEq.fnSimple(newCtxt) should be('left)
   }
 
   /** Case Insensitive compares */
@@ -309,7 +309,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings do not match" in {
@@ -322,17 +322,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiEq.fn(newCtxt) should be('left)
+    stringCiEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string-ci!= */
@@ -346,7 +346,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiNEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiNEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings do match" in {
@@ -359,17 +359,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiNEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiNEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiNEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiNEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiNEq.fn(newCtxt) should be('left)
+    stringCiNEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string-ci< */
@@ -383,7 +383,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLess.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiLess.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings are equal" in {
@@ -396,7 +396,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false if the right string is less than the left one" in {
@@ -409,17 +409,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiLess.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiLess.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiLess.fn(newCtxt) should be('left)
+    stringCiLess.fnSimple(newCtxt) should be('left)
   }
 
   /** string-ci<= */
@@ -433,7 +433,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiLEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return true if the strings are equal" in {
@@ -446,7 +446,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiLEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the right string is less than the left one" in {
@@ -459,17 +459,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiLEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiLEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiLEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiLEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiLEq.fn(newCtxt) should be('left)
+    stringCiLEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string-ci> */
@@ -483,7 +483,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGtr.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiGtr.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the strings are equal" in {
@@ -496,7 +496,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false if the right string is greater than the left one" in {
@@ -509,17 +509,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiGtr.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiGtr.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiGtr.fn(newCtxt) should be('left)
+    stringCiGtr.fnSimple(newCtxt) should be('left)
   }
 
   /** string-ci>= */
@@ -533,7 +533,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiGEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return true if the strings are equal" in {
@@ -546,7 +546,7 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGEq.fn(newCtxt) should be(Right(RblBool(true)))
+    stringCiGEq.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the right string is greater than the left one" in {
@@ -559,17 +559,17 @@ class RblStringSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(strs)
       )
-    stringCiGEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiGEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return RblBool(false) for invalid right side argument" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(RblString("foo")), Fixnum(42)))
-    stringCiGEq.fn(newCtxt) should be(Right(RblBool(false)))
+    stringCiGEq.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringCiGEq.fn(newCtxt) should be('left)
+    stringCiGEq.fnSimple(newCtxt) should be('left)
   }
 
   /** string-concat */
@@ -582,7 +582,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = strs.length, argvec = Tuple(strs))
 
-    stringConcat.fn(newCtxt) should be(Right(RblString(res)))
+    stringConcat.fnSimple(newCtxt) should be(Right(RblString(res)))
   }
 
   it should "return an empty string with no input strings" in {
@@ -591,12 +591,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = strs.length, argvec = Tuple(strs))
 
-    stringConcat.fn(newCtxt) should be(Right(RblString(res)))
+    stringConcat.fnSimple(newCtxt) should be(Right(RblString(res)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringConcat.fn(newCtxt) should be('left)
+    stringConcat.fnSimple(newCtxt) should be('left)
   }
 
   /** string-join */
@@ -619,10 +619,10 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val res = s1 + sep + s2 + sep + s3
 
-    stringJoin.fn(ctxtNeither) should be(Right(RblString(res)))
-    stringJoin.fn(ctxtFront) should be(Right(RblString(sep + res)))
-    stringJoin.fn(ctxtRear) should be(Right(RblString(res + sep)))
-    stringJoin.fn(ctxtBoth) should be(Right(RblString(sep + res + sep)))
+    stringJoin.fnSimple(ctxtNeither) should be(Right(RblString(res)))
+    stringJoin.fnSimple(ctxtFront) should be(Right(RblString(sep + res)))
+    stringJoin.fnSimple(ctxtRear) should be(Right(RblString(res + sep)))
+    stringJoin.fnSimple(ctxtBoth) should be(Right(RblString(sep + res + sep)))
   }
 
   it should "return an empty string for an empty Tuple" in {
@@ -632,7 +632,7 @@ class RblStringSpec extends FlatSpec with Matchers {
     val res       = ""
 
     val ctxtBoth = ctxt.copy(nargs = 3, argvec = parmsBoth)
-    stringJoin.fn(ctxtBoth) should be(Right(RblString(res)))
+    stringJoin.fnSimple(ctxtBoth) should be(Right(RblString(res)))
   }
 
   it should "fail if tuple contains non-RblString objects" in {
@@ -642,12 +642,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val ctxtBoth = ctxt.copy(nargs = 3, argvec = parms)
 
-    stringJoin.fn(ctxtBoth) should be('left)
+    stringJoin.fnSimple(ctxtBoth) should be('left)
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringJoin.fn(newCtxt) should be('left)
+    stringJoin.fnSimple(newCtxt) should be('left)
   }
 
   /** string-length */
@@ -657,7 +657,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(strs))
 
-    stringLength.fn(newCtxt) should be(Right(Fixnum(9)))
+    stringLength.fnSimple(newCtxt) should be(Right(Fixnum(9)))
   }
 
   it should "return 0 for an empty string" in {
@@ -666,12 +666,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(strs))
 
-    stringLength.fn(newCtxt) should be(Right(Fixnum(0)))
+    stringLength.fnSimple(newCtxt) should be(Right(Fixnum(0)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringJoin.fn(newCtxt) should be('left)
+    stringJoin.fnSimple(newCtxt) should be('left)
   }
 
   /** string-set-nth */
@@ -681,7 +681,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
 
-    stringSetNth.fn(newCtxt) should be(Right(RblString("abCdefghi")))
+    stringSetNth.fnSimple(newCtxt) should be(Right(RblString("abCdefghi")))
 
   }
 
@@ -691,12 +691,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
 
-    stringSetNth.fn(newCtxt) should be('left)
+    stringSetNth.fnSimple(newCtxt) should be('left)
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringSetNth.fn(newCtxt) should be('left)
+    stringSetNth.fnSimple(newCtxt) should be('left)
   }
 
   /** string-new */
@@ -704,19 +704,19 @@ class RblStringSpec extends FlatSpec with Matchers {
     val parms   = Tuple(Seq(Fixnum(5), RblChar('C')))
     val newCtxt = ctxt.copy(nargs = 2, argvec = parms)
 
-    stringNew.fn(newCtxt) should be(Right(RblString("CCCCC")))
+    stringNew.fnSimple(newCtxt) should be(Right(RblString("CCCCC")))
   }
 
   it should "create a string of n spaces if no character specified" in {
     val parms   = Tuple(Seq(Fixnum(5)))
     val newCtxt = ctxt.copy(nargs = 1, argvec = parms)
 
-    stringNew.fn(newCtxt) should be(Right(RblString("     ")))
+    stringNew.fnSimple(newCtxt) should be(Right(RblString("     ")))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringNew.fn(newCtxt) should be('left)
+    stringNew.fnSimple(newCtxt) should be('left)
   }
 
   /** string-mem? */
@@ -726,7 +726,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 2, argvec = parms)
 
-    stringMemQ.fn(newCtxt) should be(Right(RblBool(true)))
+    stringMemQ.fnSimple(newCtxt) should be(Right(RblBool(true)))
 
   }
 
@@ -736,13 +736,13 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val newCtxt = ctxt.copy(nargs = 2, argvec = parms)
 
-    stringMemQ.fn(newCtxt) should be(Right(RblBool(false)))
+    stringMemQ.fnSimple(newCtxt) should be(Right(RblBool(false)))
 
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringMemQ.fn(newCtxt) should be('left)
+    stringMemQ.fnSimple(newCtxt) should be('left)
   }
 
   /** string-get-token */
@@ -752,7 +752,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(0), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("aZ")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("aZ")))
   }
 
   it should "correctly return the last token" in {
@@ -761,7 +761,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(6), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("gT")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("gT")))
   }
 
   it should "correctly return a token from the middle" in {
@@ -770,7 +770,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(3), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("dW")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("dW")))
   }
 
   it should "return an empty string for index out of bounds" in {
@@ -779,7 +779,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(8), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("")))
   }
 
   it should "return an empty string if delimiter not found" in {
@@ -788,7 +788,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(8), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("")))
   }
 
   it should "return an empty string for an empty string" in {
@@ -797,12 +797,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), Fixnum(8), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringGetToken.fn(newCtxt) should be(Right(RblString("")))
+    stringGetToken.fnSimple(newCtxt) should be(Right(RblString("")))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringMemQ.fn(newCtxt) should be('left)
+    stringMemQ.fnSimple(newCtxt) should be('left)
   }
 
   /** string-split */
@@ -821,7 +821,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep), Fixnum(33)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(res))
+    stringSplit.fnSimple(newCtxt) should be(Right(res))
   }
 
   it should "correctly tokenize a full string with unspecified count" in {
@@ -839,7 +839,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(res))
+    stringSplit.fnSimple(newCtxt) should be(Right(res))
   }
 
   it should "correctly ignore leading and trailing separators" in {
@@ -857,7 +857,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(res))
+    stringSplit.fnSimple(newCtxt) should be(Right(res))
   }
 
   it should "return an empty Tuple with a count of zero" in {
@@ -866,7 +866,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep), Fixnum(0)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(Tuple.NIL))
+    stringSplit.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   it should "return an empty Tuple with a count less than zero" in {
@@ -875,7 +875,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep), Fixnum(-1)))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(Tuple.NIL))
+    stringSplit.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   it should "return a Tuple of chars if no separators" in {
@@ -885,7 +885,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep)))
     val newCtxt = ctxt.copy(nargs = 2, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(res))
+    stringSplit.fnSimple(newCtxt) should be(Right(res))
   }
 
   it should "correctly return a Tuple of selected tokens and the remaining string" in {
@@ -895,7 +895,7 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep), Fixnum(2)))
     val newCtxt = ctxt.copy(nargs = 2, argvec = parms)
-    stringSplit.fn(newCtxt) should be(Right(res))
+    stringSplit.fnSimple(newCtxt) should be(Right(res))
   }
 
   it should "fail for invalid Count type" in {
@@ -905,12 +905,12 @@ class RblStringSpec extends FlatSpec with Matchers {
 
     val parms   = Tuple(Seq(RblString(str), RblString(sep), RblString("foo")))
     val newCtxt = ctxt.copy(nargs = 3, argvec = parms)
-    stringSplit.fn(newCtxt) should be('left)
+    stringSplit.fnSimple(newCtxt) should be('left)
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    stringSplit.fn(newCtxt) should be('left)
+    stringSplit.fnSimple(newCtxt) should be('left)
   }
 
 }

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/TupleSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/TupleSpec.scala
@@ -27,12 +27,12 @@ class TupleSpec extends FlatSpec with Matchers {
     val tup = Seq(Fixnum(2), Fixnum(3), Fixnum(4))
     val newCtxt =
       ctxt.copy(nargs = 2, argvec = Tuple.cons(Fixnum(1), Tuple(Tuple(tup))))
-    tplCons.fn(newCtxt) should be(Right(Tuple.cons(Fixnum(1), Tuple(tup))))
+    tplCons.fnSimple(newCtxt) should be(Right(Tuple.cons(Fixnum(1), Tuple(tup))))
   }
 
   it should "fail for non-tuple arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplCons.fn(newCtxt) should be('left)
+    tplCons.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-cons* */
@@ -45,7 +45,7 @@ class TupleSpec extends FlatSpec with Matchers {
         argvec =
           Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(Tuple(tup))))))
 
-    tplConsStar.fn(newCtxt) should be(
+    tplConsStar.fnSimple(newCtxt) should be(
       Right(Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(tup))))))
   }
 
@@ -55,12 +55,12 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
 
-    tplConsStar.fn(newCtxt) should be(Right(Tuple(tup)))
+    tplConsStar.fnSimple(newCtxt) should be(Right(Tuple(tup)))
   }
 
   it should "fail for non-tuple arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplCons.fn(newCtxt) should be('left)
+    tplCons.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-rcons */
@@ -68,12 +68,12 @@ class TupleSpec extends FlatSpec with Matchers {
     val tup = Seq(Fixnum(1), Fixnum(2), Fixnum(3))
     val newCtxt =
       ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(Tuple(tup)), Fixnum(4)))
-    tplRcons.fn(newCtxt) should be(Right(Tuple.rcons(Tuple(tup), Fixnum(4))))
+    tplRcons.fnSimple(newCtxt) should be(Right(Tuple.rcons(Tuple(tup), Fixnum(4))))
   }
 
   it should "fail for non-tuple arguments" in {
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(2, Ob.NIV))
-    tplRcons.fn(newCtxt) should be('left)
+    tplRcons.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-concat */
@@ -88,7 +88,7 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 3, argvec = Tuple(tups))
 
-    tplConcat.fn(newCtxt) should be(Right(Tuple(result)))
+    tplConcat.fnSimple(newCtxt) should be(Right(Tuple(result)))
   }
 
   "tplConcat" should "correctly concat 1 Tuple" in {
@@ -98,7 +98,7 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(tups))
 
-    tplConcat.fn(newCtxt) should be(
+    tplConcat.fnSimple(newCtxt) should be(
       Right(Tuple(tup1))
     )
   }
@@ -109,14 +109,14 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 0, argvec = Tuple(tups))
 
-    tplConcat.fn(newCtxt) should be(
+    tplConcat.fnSimple(newCtxt) should be(
       Right(Tuple(Seq.empty))
     )
   }
 
   it should "fail for non-tuple arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplCons.fn(newCtxt) should be('left)
+    tplCons.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-safe-nth */
@@ -127,14 +127,14 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 2, argvec = Tuple.rcons(Tuple(Tuple(tup)), n))
 
-    tplSafeNth.fn(newCtxt) should be(
+    tplSafeNth.fnSimple(newCtxt) should be(
       Right(Fixnum(4))
     )
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplSafeNth.fn(newCtxt) should be('left)
+    tplSafeNth.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-xchg */
@@ -146,7 +146,7 @@ class TupleSpec extends FlatSpec with Matchers {
       ctxt.copy(nargs = 3,
                 argvec = Tuple.rcons(Tuple.rcons(Tuple(Tuple(tup)), Fixnum(1)), Fixnum(3)))
 
-    tplXchg.fn(newCtxt) should be(Right(Tuple(result)))
+    tplXchg.fnSimple(newCtxt) should be(Right(Tuple(result)))
   }
 
   it should "fail for out of bounds arguments" in {
@@ -154,12 +154,12 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 3,
                 argvec = Tuple.rcons(Tuple.rcons(Tuple(Tuple(tup)), Fixnum(-100)), Fixnum(100)))
-    tplXchg.fn(newCtxt) should be('left)
+    tplXchg.fnSimple(newCtxt) should be('left)
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplXchg.fn(newCtxt) should be('left)
+    tplXchg.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-head */
@@ -169,20 +169,20 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
 
-    tplHead.fn(newCtxt) should be(
+    tplHead.fnSimple(newCtxt) should be(
       Right(Fixnum(1))
     )
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplHead.fn(newCtxt) should be('left)
+    tplHead.fnSimple(newCtxt) should be('left)
   }
 
   it should "return NIL for an empty Tuple" in {
     val tup     = Seq()
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
-    tplHead.fn(newCtxt) should be(Right(Tuple.NIL))
+    tplHead.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   /** tuple-last */
@@ -192,20 +192,20 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
 
-    tplLast.fn(newCtxt) should be(
+    tplLast.fnSimple(newCtxt) should be(
       Right(Fixnum(6))
     )
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplLast.fn(newCtxt) should be('left)
+    tplLast.fnSimple(newCtxt) should be('left)
   }
 
   it should "return NIL for an empty Tuple" in {
     val tup     = Seq()
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
-    tplLast.fn(newCtxt) should be(Right(Tuple.NIL))
+    tplLast.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   /** tuple-tail */
@@ -216,27 +216,27 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
 
-    tplTail.fn(newCtxt) should be(
+    tplTail.fnSimple(newCtxt) should be(
       Right(Tuple(tail))
     )
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplTail.fn(newCtxt) should be('left)
+    tplTail.fnSimple(newCtxt) should be('left)
   }
 
   it should "return empty Tuple for an empty Tuple input" in {
     val empty   = Seq.empty
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Tuple(empty)))
-    tplTail.fn(newCtxt) should be(Right(Tuple.NIL))
+    tplTail.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   it should "return empty Tuple for a single element Tuple input" in {
     val tup     = Seq(Fixnum(1))
     val empty   = Seq.empty
     val newCtxt = ctxt.copy(nargs = 1, argvec = Tuple(Tuple(tup)))
-    tplTail.fn(newCtxt) should be(Right(Tuple(empty)))
+    tplTail.fnSimple(newCtxt) should be(Right(Tuple(empty)))
   }
 
   /** tuple-new */
@@ -249,7 +249,7 @@ class TupleSpec extends FlatSpec with Matchers {
         argvec = Tuple.cons(Fixnum(1), Tuple(tup))
       )
 
-    tplNew.fn(newCtxt) should be(Right(Tuple(tup)))
+    tplNew.fnSimple(newCtxt) should be(Right(Tuple(tup)))
   }
 
   it should "correctly create a new Tuple with 0 Obs" in {
@@ -258,7 +258,7 @@ class TupleSpec extends FlatSpec with Matchers {
     val newCtxt =
       ctxt.copy(nargs = 1, argvec = Tuple(Tuple(empty)))
 
-    tplNew.fn(newCtxt) should be(Right(Tuple(empty)))
+    tplNew.fnSimple(newCtxt) should be(Right(Tuple(empty)))
   }
 
   /** tuple-new-n */
@@ -269,7 +269,7 @@ class TupleSpec extends FlatSpec with Matchers {
         nargs = 3,
         argvec = Tuple(Seq(Fixnum(0), Fixnum(6), Fixnum(1)))
       )
-    tplNewN.fn(newCtxt) should be(Right(tup))
+    tplNewN.fnSimple(newCtxt) should be(Right(tup))
   }
 
   it should "return NIL for n<=0" in {
@@ -279,12 +279,12 @@ class TupleSpec extends FlatSpec with Matchers {
         argvec = Tuple(Seq(Fixnum(0), Fixnum(0), Fixnum(1)))
       )
 
-    tplNewN.fn(newCtxt) should be(Right(Tuple.NIL))
+    tplNewN.fnSimple(newCtxt) should be(Right(Tuple.NIL))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplNewN.fn(newCtxt) should be('left)
+    tplNewN.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-mem? */
@@ -295,7 +295,7 @@ class TupleSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple.rcons(Tuple(Tuple(tup)), Fixnum(4))
       )
-    tplMemQ.fn(newCtxt) should be(Right(RblBool(true)))
+    tplMemQ.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the Ob is not in the Tuple" in {
@@ -306,7 +306,7 @@ class TupleSpec extends FlatSpec with Matchers {
         argvec = Tuple.rcons(Tuple(Tuple(tup)), Fixnum(17))
       )
 
-    tplMemQ.fn(newCtxt) should be(Right(RblBool(false)))
+    tplMemQ.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false for an empty Tuple" in {
@@ -317,12 +317,12 @@ class TupleSpec extends FlatSpec with Matchers {
         argvec = Tuple.rcons(Tuple(Tuple(tup)), Fixnum(17))
       )
 
-    tplMemQ.fn(newCtxt) should be(Right(RblBool(false)))
+    tplMemQ.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplMemQ.fn(newCtxt) should be('left)
+    tplMemQ.fnSimple(newCtxt) should be('left)
   }
 
   /** tuple-matches? */
@@ -336,7 +336,7 @@ class TupleSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(tups)
       )
-    tplMatchesP.fn(newCtxt) should be(Right(RblBool(true)))
+    tplMatchesP.fnSimple(newCtxt) should be(Right(RblBool(true)))
   }
 
   it should "return false if the Tuple does not match the pattern" in {
@@ -349,7 +349,7 @@ class TupleSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(tups)
       )
-    tplMatchesP.fn(newCtxt) should be(Right(RblBool(false)))
+    tplMatchesP.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "return false for an empty Tuple" in {
@@ -362,12 +362,12 @@ class TupleSpec extends FlatSpec with Matchers {
         nargs = 2,
         argvec = Tuple(tups)
       )
-    tplMatchesP.fn(newCtxt) should be(Right(RblBool(false)))
+    tplMatchesP.fnSimple(newCtxt) should be(Right(RblBool(false)))
   }
 
   it should "fail for invalid arguments" in {
     val newCtxt = ctxt.copy(nargs = 5, argvec = Tuple(5, Ob.NIV))
-    tplMemQ.fn(newCtxt) should be('left)
+    tplMemQ.fnSimple(newCtxt) should be('left)
   }
 
 }


### PR DESCRIPTION
Existing "simple" primitives that do not change any kind of state from now on can be defined by overriding `fnSimple(ctxt: Ctxt): PrimResult`.
Primitives that need access to the `GlobalEnv`, the given `Ctxt` or have to schedule a `Ctxt` have to override `fn: CtxtTransition[PrimResult]`.