### PR TITLE
Ignore Vagrant related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,11 @@ crypto/secp256k1/
 ###################
 !rosette/bin/README
 rosette/src/*.o
+rosette/.vagrant
+Vagrantfile
+
 # Actual code editors
+###################
 *~
 \#*
 .ensime*


### PR DESCRIPTION
I'm know we aren't supporting Vagrant but I just want to make sure I don't accidentally commit related files.