### PR TITLE
CORE-171 rollback to full handshake, if second phase resulted in error

### DIFF
--- a/comm/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
+++ b/comm/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
@@ -1,0 +1,15 @@
+package coop.rchain.catscontrib
+
+import cats._, cats.data._, cats.implicits._
+
+final class ApplicativeError_Ops[F[_], E, A](self: F[A])(implicit err: ApplicativeError_[F, E],
+                                                         ev: Applicative[F]) {
+  def attempt: F[Either[E, A]] = err.attempt(self)
+}
+
+trait ToApplicativeError_Ops {
+  implicit def ToApplicativeError_Ops[F[_], E, A](fa: F[A])(
+      implicit err: ApplicativeError_[F, E],
+      ev: Applicative[F]): ApplicativeError_Ops[F, E, A] =
+    new ApplicativeError_Ops[F, E, A](fa)
+}

--- a/comm/src/main/scala/coop/rchain/catscontrib/Catscontrib.scala
+++ b/comm/src/main/scala/coop/rchain/catscontrib/Catscontrib.scala
@@ -1,5 +1,5 @@
 package coop.rchain.catscontrib
 
-trait Opses extends ToMonadOps with ToBooleanOps with ToOptionOps {}
+trait Opses extends ToMonadOps with ToBooleanOps with ToOptionOps with ToApplicativeError_Ops {}
 
 object Catscontrib extends Opses


### PR DESCRIPTION
Following feature covers scenario:

1. nodes A & B used to know each other
2. node A tries to connect to B (skipping encryption handshake) with stored B's public key
3. node B does not respond (or any other error)
4. node A retries with full handshake (encryption handshake followed by protocol handshake)