### PR TITLE
CORE-297: storage: add persist parameter to {consume,produce}

### DIFF
--- a/storage-bench/src/main/scala/coop/rchain/storage/bench/BasicBench.scala
+++ b/storage-bench/src/main/scala/coop/rchain/storage/bench/BasicBench.scala
@@ -18,13 +18,14 @@ class BasicBench {
     consume(state.testStore,
             List("ch1", "ch2"),
             List(StringMatch("bad"), StringMatch("finger")),
-            new StringsCaptor)
+            new StringsCaptor,
+            false)
 
-    val r1 = produce(state.testStore, "ch1", "bad")
+    val r1 = produce(state.testStore, "ch1", "bad", false)
 
     assert(r1.isEmpty)
 
-    val r2 = produce(state.testStore, "ch2", "finger")
+    val r2 = produce(state.testStore, "ch2", "finger", false)
 
     runK(r2)
 

--- a/storage/src/main/protobuf/StorageBlobs.proto
+++ b/storage/src/main/protobuf/StorageBlobs.proto
@@ -9,8 +9,18 @@ message BytesList {
 message PsKsBytes {
     BytesList patterns = 1;
     bytes kvalue = 2;
+    bool persist = 3;
 }
 
 message PsKsBytesList {
     repeated PsKsBytes values = 1;
+}
+
+message AsBytes {
+    bytes avalue = 1;
+    bool persist = 2;
+}
+
+message AsBytesList {
+    repeated AsBytes values = 1;
 }

--- a/storage/src/main/scala/coop/rchain/storage/IStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/IStore.scala
@@ -20,7 +20,7 @@ trait IStore[C, P, A, K] {
 
   private[storage] def getKey(txn: T, hash: H): List[C]
 
-  private[storage] def removeA(txn: T, channels: List[C], index: Int)
+  private[storage] def removeA(txn: T, channels: List[C], index: Int): Unit
 
   /**
     * The type of transactions
@@ -33,15 +33,15 @@ trait IStore[C, P, A, K] {
 
   def withTxn[R](txn: T)(f: T => R): R
 
-  def putA(txn: T, channels: List[C], a: A): Unit
+  def putA(txn: T, channels: List[C], datum: Datum[A]): Unit
 
-  def putK(txn: T, channels: List[C], patterns: List[P], k: K): Unit
+  def putK(txn: T, channels: List[C], continuation: WaitingContinuation[P, K]): Unit
 
-  def getPs(txn: T, channels: List[C]): List[List[P]]
+  private[storage] def getPs(txn: T, channels: List[C]): List[List[P]]
 
-  def getAs(txn: T, channels: List[C]): List[A]
+  def getAs(txn: T, channels: List[C]): List[Datum[A]]
 
-  def getPsK(txn: T, curr: List[C]): List[(List[P], K)]
+  def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]]
 
   def removeA(txn: T, channel: C, index: Int): Unit
 

--- a/storage/src/main/scala/coop/rchain/storage/candidates.scala
+++ b/storage/src/main/scala/coop/rchain/storage/candidates.scala
@@ -1,9 +1,0 @@
-package coop.rchain.storage
-
-private[storage] final case class DataCandidate[C, A](channel: C, datum: A, datumIndex: Int)
-
-private[storage] final case class ProduceCandidate[C, A, K](
-    channels: List[C],
-    continuation: K,
-    continuationIndex: Int,
-    dataCandidates: List[DataCandidate[C, A]])

--- a/storage/src/main/scala/coop/rchain/storage/examples/StringExamples.scala
+++ b/storage/src/main/scala/coop/rchain/storage/examples/StringExamples.scala
@@ -36,6 +36,14 @@ object StringExamples {
     final def results: List[List[String]] = res.toList
 
     final def apply(v1: List[String]): Unit = ignore(res += v1)
+
+    override def hashCode(): Int =
+      res.hashCode() * 37
+
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case sc: StringsCaptor => sc.res == res
+      case _                 => false
+    }
   }
 
   object implicits {

--- a/storage/src/main/scala/coop/rchain/storage/examples/package.scala
+++ b/storage/src/main/scala/coop/rchain/storage/examples/package.scala
@@ -7,7 +7,7 @@ import coop.rchain.storage.util.withResource
 
 package object examples {
 
-  private[examples] def makeSerializeFromSerializable[T <: Serializable]: Serialize[T] =
+  private[storage] def makeSerializeFromSerializable[T <: Serializable]: Serialize[T] =
     new Serialize[T] {
 
       def encode(a: T): Array[Byte] =

--- a/storage/src/main/scala/coop/rchain/storage/internal.scala
+++ b/storage/src/main/scala/coop/rchain/storage/internal.scala
@@ -1,0 +1,15 @@
+package coop.rchain.storage
+
+private[storage] final case class Datum[A](a: A, persist: Boolean)
+
+private[storage] final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
+
+private[storage] final case class WaitingContinuation[P, K](patterns: List[P],
+                                                            continuation: K,
+                                                            persist: Boolean)
+
+private[storage] final case class ProduceCandidate[C, P, A, K](
+    channels: List[C],
+    continuation: WaitingContinuation[P, K],
+    continuationIndex: Int,
+    dataCandidates: List[DataCandidate[C, A]])

--- a/storage/src/main/scala/coop/rchain/storage/package.scala
+++ b/storage/src/main/scala/coop/rchain/storage/package.scala
@@ -15,15 +15,15 @@ package object storage {
   @tailrec
   private[storage] final def findMatchingDataCandidate[C, P, A](
       channel: C,
-      data: List[(A, Int)],
+      data: List[(Datum[A], Int)],
       pattern: P
   )(implicit m: Match[P, A]): Option[DataCandidate[C, A]] =
     data match {
       case Nil => None
-      case (matchCandidate, dataIndex) :: remaining =>
+      case (Datum(matchCandidate, persist), dataIndex) :: remaining =>
         m.get(pattern, matchCandidate) match {
           case None      => findMatchingDataCandidate(channel, remaining, pattern)
-          case Some(mat) => Some(DataCandidate(channel, mat, dataIndex))
+          case Some(mat) => Some(DataCandidate(channel, Datum(mat, persist), dataIndex))
         }
     }
 
@@ -34,7 +34,7 @@ package object storage {
     val options: List[Option[DataCandidate[C, A]]] =
       channels.zip(patterns).map {
         case (channel, pattern) =>
-          val indexedData: List[(A, Int)] = store.getAs(txn, List(channel)).zipWithIndex
+          val indexedData: List[(Datum[A], Int)] = store.getAs(txn, List(channel)).zipWithIndex
           findMatchingDataCandidate(channel, indexedData, pattern)
       }
     options.sequence[Option, DataCandidate[C, A]]
@@ -46,6 +46,7 @@ package object storage {
     * @param channels
     * @param patterns
     * @param continuation
+    * @param persist
     * @tparam C a type representing a channel
     * @tparam P a type representing a pattern
     * @tparam A a type representing a piece of data
@@ -54,7 +55,8 @@ package object storage {
   def consume[C, P, A, K](store: IStore[C, P, A, K],
                           channels: List[C],
                           patterns: List[P],
-                          continuation: K)(implicit m: Match[P, A]): Option[(K, List[A])] = {
+                          continuation: K,
+                          persist: Boolean)(implicit m: Match[P, A]): Option[(K, List[A])] = {
     if (channels.length =!= patterns.length) {
       val msg = "channels.length must equal patterns.length"
       logger.error(msg)
@@ -65,18 +67,25 @@ package object storage {
         s"consume: searching for data matching <patterns: $patterns> at <channels: $channels>")
       extractDataCandidates(store, channels, patterns)(txn) match {
         case None =>
-          store.putK(txn, channels, patterns, continuation)
+          store.putK(txn, channels, WaitingContinuation(patterns, continuation, persist))
           for (channel <- channels) store.addJoin(txn, channel, channels)
           logger.info(
             s"consume: no data found, storing <(patterns, continuation): ($patterns, $continuation)> at <channels: $channels>")
           None
         case Some(dataCandidates) =>
           dataCandidates.foreach {
-            case DataCandidate(candidateChannel, _, dataIndex) =>
+            case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex)
+                if !persistData =>
               store.removeA(txn, candidateChannel, dataIndex)
+            case _ =>
+              ()
+          }
+          if (persist) {
+            store.putK(txn, channels, WaitingContinuation(patterns, continuation, persist))
+            for (channel <- channels) store.addJoin(txn, channel, channels)
           }
           logger.info(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
-          Some((continuation, dataCandidates.map(_.datum)))
+          Some((continuation, dataCandidates.map(_.datum.a)))
       }
     }
   }
@@ -87,27 +96,28 @@ package object storage {
   private[storage] final def extractFirstMatch[C, P, A, K](
       store: IStore[C, P, A, K],
       channels: List[C],
-      matchCandidates: List[((List[P], K), Int)])(txn: store.T)(
-      implicit m: Match[P, A]): Option[ProduceCandidate[C, A, K]] =
+      matchCandidates: List[(WaitingContinuation[P, K], Int)])(txn: store.T)(
+      implicit m: Match[P, A]): Option[ProduceCandidate[C, P, A, K]] =
     matchCandidates match {
       case Nil => None
-      case ((patterns, continuation), index) :: remaining =>
+      case (p @ WaitingContinuation(patterns, _, _), index) :: remaining =>
         extractDataCandidates(store, channels, patterns)(txn) match {
           case None =>
             extractFirstMatch(store, channels, remaining)(txn)
           case Some(dataCandidates) =>
-            Some(ProduceCandidate(channels, continuation, index, dataCandidates))
+            Some(ProduceCandidate(channels, p, index, dataCandidates))
         }
     }
 
   @tailrec
   private[storage] final def extractProduceCandidate[C, P, A, K](store: IStore[C, P, A, K],
                                                                  groupedChannels: List[List[C]])(
-      txn: store.T)(implicit m: Match[P, A]): Option[ProduceCandidate[C, A, K]] =
+      txn: store.T)(implicit m: Match[P, A]): Option[ProduceCandidate[C, P, A, K]] =
     groupedChannels match {
       case Nil => None
       case channels :: remaining =>
-        val matchCandidates: List[((List[P], K), Int)] = store.getPsK(txn, channels).zipWithIndex
+        val matchCandidates: List[(WaitingContinuation[P, K], Int)] =
+          store.getPsK(txn, channels).zipWithIndex
         extractFirstMatch(store, channels, matchCandidates)(txn) match {
           case None             => extractProduceCandidate(store, remaining)(txn)
           case produceCandidate => produceCandidate
@@ -119,30 +129,39 @@ package object storage {
     * @param store
     * @param channel
     * @param data
+    * @param persist
     * @tparam C a type representing a channel
     * @tparam P a type representing a pattern
     * @tparam A a type representing a piece of data
     * @tparam K a type representing a continuation
     */
-  def produce[C, P, A, K](store: IStore[C, P, A, K], channel: C, data: A)(
+  def produce[C, P, A, K](store: IStore[C, P, A, K], channel: C, data: A, persist: Boolean)(
       implicit m: Match[P, A]): Option[(K, List[A])] =
     store.withTxn(store.createTxnWrite()) { txn =>
       val groupedChannels: List[List[C]] = store.getJoin(txn, channel)
-      store.putA(txn, List(channel), data)
+      store.putA(txn, List(channel), Datum(data, persist))
       logger.info(s"produce: persisted <data: $data> at <channel: $channel>")
       logger.info(
         s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>")
       extractProduceCandidate(store, groupedChannels)(txn)
         .map {
-          case ProduceCandidate(channels, continuation, continuationIndex, dataCandidates) =>
+          case ProduceCandidate(channels,
+                                WaitingContinuation(_, continuation, persistK),
+                                continuationIndex,
+                                dataCandidates) =>
             dataCandidates.foreach {
-              case DataCandidate(candidateChannel, _, dataIndex) =>
+              case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex)
+                  if !persistData =>
                 store.removeA(txn, candidateChannel, dataIndex)
                 ignore { store.removeJoin(txn, candidateChannel, channels) }
+              case _ =>
+                ()
             }
-            store.removePsK(txn, channels, continuationIndex)
+            if (!persistK) {
+              store.removePsK(txn, channels, continuationIndex)
+            }
             logger.info(s"produce: matching continuation found at <channels: $channels>")
-            (continuation, dataCandidates.map(_.datum))
+            (continuation, dataCandidates.map(_.datum.a))
         }
         .recoverWith {
           case _: Unit =>

--- a/storage/src/test/scala/coop/rchain/storage/JoinOperationsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/JoinOperationsTests.scala
@@ -1,95 +1,99 @@
 package coop.rchain.storage
 
 import coop.rchain.storage.examples.StringExamples.{StringsCaptor, Wildcard}
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 trait JoinOperationsTests extends StorageActionsBase {
-  "joins" should "remove joins if no PsK" in
-    withTestStore { store =>
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.putA(txn, List("ch1"), Datum("datum1", persist = false))
-        store.putA(txn, List("ch2"), Datum("datum2", persist = false))
 
-        store.addJoin(txn, "ch1", List("ch1", "ch2"))
-        store.addJoin(txn, "ch2", List("ch1", "ch2"))
-        //ensure that doubled addJoin creates only one entry
-        store.addJoin(txn, "ch1", List("ch1", "ch2"))
-        store.addJoin(txn, "ch2", List("ch1", "ch2"))
+  "joins" should "remove joins if no PsK" in withTestStore { store =>
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.putA(txn, List("ch1"), Datum("datum1", persist = false))
+      store.putA(txn, List("ch2"), Datum("datum2", persist = false))
+      store.addJoin(txn, "ch1", List("ch1", "ch2"))
+      store.addJoin(txn, "ch2", List("ch1", "ch2"))
 
-        store.putA(txn, List("ch1", "ch2"), Datum("datum_ch1_ch2", persist = false))
-      }
+      //ensure that doubled addJoin creates only one entry
+      store.addJoin(txn, "ch1", List("ch1", "ch2"))
+      store.addJoin(txn, "ch2", List("ch1", "ch2"))
 
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-        store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.removeJoin(txn, "ch1", List("ch1", "ch2"))
-        store.removeJoin(txn, "ch2", List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
-        store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
-      }
-
-      store.isEmpty shouldBe false
-      //now ensure that garbage-collection works and all joins
-      //are removed when we remove As
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.removeA(txn, "ch1", 0)
-        store.removeA(txn, "ch2", 0)
-        store.removeA(txn, List("ch1", "ch2"), 0)
-      }
-      store.isEmpty shouldBe true
+      store.putA(txn, List("ch1", "ch2"), Datum("datum_ch1_ch2", persist = false))
     }
 
-  "removeAllJoins" should "should not clear joins if PsK exists" in
-    withTestStore { store =>
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.putK(txn, List("ch1"), WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
-        store.putK(txn, List("ch2"), WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
-
-        store.putK(txn, List("ch1", "ch2"), WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
-
-        store.addJoin(txn, "ch1", List("ch1", "ch2"))
-        store.addJoin(txn, "ch2", List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-        store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.removeJoin(txn, "ch1", List("ch1", "ch2"))
-        store.removeJoin(txn, "ch2", List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-        store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-      }
-
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.removeAllJoins(txn, "ch1")
-        store.removeAllJoins(txn, "ch2")
-      }
-
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
-        store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
-      }
-
-      //now ensure that garbage-collection works and all joins
-      //are removed when we remove PsK
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.removePsK(txn, List("ch1", "ch2"), 0)
-        store.removePsK(txn, List("ch1"), 0)
-        store.removePsK(txn, List("ch2"), 0)
-      }
-
-      store.isEmpty shouldBe true
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+      store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
     }
+
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.removeJoin(txn, "ch1", List("ch1", "ch2"))
+      store.removeJoin(txn, "ch2", List("ch1", "ch2"))
+    }
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
+      store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
+    }
+
+    store.isEmpty shouldBe false
+
+    //now ensure that garbage-collection works and all joins
+    //are removed when we remove As
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.removeA(txn, "ch1", 0)
+      store.removeA(txn, "ch2", 0)
+      store.removeA(txn, List("ch1", "ch2"), 0)
+    }
+
+    store.isEmpty shouldBe true
+  }
+
+  "removeAllJoins" should "should not clear joins if PsK exists" in withTestStore { store =>
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.putK(txn,
+                 List("ch1"),
+                 WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
+      store.putK(txn,
+                 List("ch2"),
+                 WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
+      store.putK(txn,
+                 List("ch1", "ch2"),
+                 WaitingContinuation(List(Wildcard), new StringsCaptor, persist = false))
+      store.addJoin(txn, "ch1", List("ch1", "ch2"))
+      store.addJoin(txn, "ch2", List("ch1", "ch2"))
+    }
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+      store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+    }
+
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.removeJoin(txn, "ch1", List("ch1", "ch2"))
+      store.removeJoin(txn, "ch2", List("ch1", "ch2"))
+    }
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+      store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+    }
+
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.removeAllJoins(txn, "ch1")
+      store.removeAllJoins(txn, "ch2")
+    }
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
+      store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
+    }
+
+    //now ensure that garbage-collection works and all joins
+    //are removed when we remove PsK
+    store.withTxn(store.createTxnWrite()) { txn =>
+      store.removePsK(txn, List("ch1", "ch2"), 0)
+      store.removePsK(txn, List("ch1"), 0)
+      store.removePsK(txn, List("ch2"), 0)
+    }
+
+    store.isEmpty shouldBe true
+  }
 }

--- a/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
@@ -744,7 +744,7 @@ class InMemoryStoreStorageActionsTests extends StorageActionsTests with JoinOper
 }
 
 class LMDBStoreStorageActionsTests
-  extends StorageActionsTests
+    extends StorageActionsTests
     with JoinOperationsTests
     with BeforeAndAfterAll {
 

--- a/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
@@ -30,12 +30,12 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val key     = List("ch1")
     val keyHash = store.hashCs(key)
 
-    val r = produce(store, key.head, "datum")
+    val r = produce(store, key.head, "datum", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe key
       store.getPs(txn, key) shouldBe Nil
-      store.getAs(txn, key) shouldBe List("datum")
+      store.getAs(txn, key) shouldBe List(Datum("datum", persist = false))
       store.getPsK(txn, key) shouldBe Nil
     }
 
@@ -53,23 +53,24 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val key     = List("ch1")
     val keyHash = store.hashCs(key)
 
-    val r1 = produce(store, key.head, "datum1")
+    val r1 = produce(store, key.head, "datum1", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe key
       store.getPs(txn, key) shouldBe Nil
-      store.getAs(txn, key) shouldBe List("datum1")
+      store.getAs(txn, key) shouldBe List(Datum("datum1", persist = false))
       store.getPsK(txn, key) shouldBe Nil
     }
 
     r1 shouldBe None
 
-    val r2 = produce(store, key.head, "datum2")
+    val r2 = produce(store, key.head, "datum2", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe key
       store.getPs(txn, key) shouldBe Nil
-      store.getAs(txn, key) should contain theSameElementsAs List("datum1", "datum2")
+      store.getAs(txn, key) should contain theSameElementsAs List(Datum("datum1", persist = false),
+                                                                  Datum("datum2", persist = false))
       store.getPsK(txn, key) shouldBe Nil
     }
 
@@ -89,7 +90,7 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val patterns = List(Wildcard)
     val keyHash  = store.hashCs(key)
 
-    val r = consume(store, key, patterns, new StringsCaptor)
+    val r = consume(store, key, patterns, new StringsCaptor, persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe List("ch1")
@@ -111,7 +112,7 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
   "consuming with a list of patterns that is a different length than the list of channels" should
     "throw" in withTestStore { store =>
     an[IllegalArgumentException] shouldBe thrownBy(
-      consume(store, List("ch1", "ch2"), List(Wildcard), new StringsCaptor))
+      consume(store, List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false))
 
     store.isNoGarbage shouldBe true
   }
@@ -122,7 +123,7 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val patterns = List(Wildcard, Wildcard, Wildcard)
     val keyHash  = store.hashCs(key)
 
-    val r = consume(store, key, patterns, new StringsCaptor)
+    val r = consume(store, key, patterns, new StringsCaptor, persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe key
@@ -148,18 +149,18 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val key     = List("ch1")
     val keyHash = store.hashCs(key)
 
-    val r1 = produce(store, key.head, "datum")
+    val r1 = produce(store, key.head, "datum", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, keyHash) shouldBe key
       store.getPs(txn, key) shouldBe Nil
-      store.getAs(txn, key) shouldBe List("datum")
+      store.getAs(txn, key) shouldBe List(Datum("datum", persist = false))
       store.getPsK(txn, key) shouldBe Nil
     }
 
     r1 shouldBe None
 
-    val r2 = consume(store, key, List(Wildcard), new StringsCaptor)
+    val r2 = consume(store, key, List(Wildcard), new StringsCaptor, persist = false)
 
     store.isNoGarbage shouldBe true
 
@@ -184,12 +185,12 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val produceKey1     = List("ch1")
     val produceKey1Hash = store.hashCs(produceKey1)
 
-    val r1 = produce(store, produceKey1.head, "datum1")
+    val r1 = produce(store, produceKey1.head, "datum1", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey1Hash) shouldBe produceKey1
       store.getPs(txn, produceKey1) shouldBe Nil
-      store.getAs(txn, produceKey1) shouldBe List("datum1")
+      store.getAs(txn, produceKey1) shouldBe List(Datum("datum1", persist = false))
       store.getPsK(txn, produceKey1) shouldBe Nil
     }
 
@@ -199,12 +200,12 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val consumeKeyHash = store.hashCs(consumeKey)
     val consumePattern = List(Wildcard, Wildcard)
 
-    val r2 = consume(store, consumeKey, consumePattern, new StringsCaptor)
+    val r2 = consume(store, consumeKey, consumePattern, new StringsCaptor, persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey1Hash) shouldBe produceKey1
       store.getPs(txn, produceKey1) shouldBe Nil
-      store.getAs(txn, produceKey1) shouldBe List("datum1")
+      store.getAs(txn, produceKey1) shouldBe List(Datum("datum1", persist = false))
       store.getPsK(txn, produceKey1) shouldBe Nil
       store.getKey(txn, consumeKeyHash) shouldBe consumeKey
       store.getPs(txn, consumeKey) shouldBe List(consumePattern)
@@ -217,7 +218,7 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val produceKey2     = List("ch2")
     val produceKey2Hash = store.hashCs(produceKey2)
 
-    val r3 = produce(store, produceKey2.head, "datum2")
+    val r3 = produce(store, produceKey2.head, "datum2", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey1Hash) shouldBe produceKey1
@@ -260,40 +261,40 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val produceKey3Hash = store.hashCs(produceKey3)
     val consumeKeyHash  = store.hashCs(consumeKey)
 
-    val r1 = produce(store, produceKey1.head, "datum1")
+    val r1 = produce(store, produceKey1.head, "datum1", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey1Hash) shouldBe produceKey1
       store.getPs(txn, produceKey1) shouldBe Nil
-      store.getAs(txn, produceKey1) shouldBe List("datum1")
+      store.getAs(txn, produceKey1) shouldBe List(Datum("datum1", persist = false))
       store.getPsK(txn, produceKey1) shouldBe Nil
     }
 
     r1 shouldBe None
 
-    val r2 = produce(store, produceKey2.head, "datum2")
+    val r2 = produce(store, produceKey2.head, "datum2", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey2Hash) shouldBe produceKey2
       store.getPs(txn, produceKey2) shouldBe Nil
-      store.getAs(txn, produceKey2) shouldBe List("datum2")
+      store.getAs(txn, produceKey2) shouldBe List(Datum("datum2", persist = false))
       store.getPsK(txn, produceKey2) shouldBe Nil
     }
 
     r2 shouldBe None
 
-    val r3 = produce(store, produceKey3.head, "datum3")
+    val r3 = produce(store, produceKey3.head, "datum3", persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, produceKey3Hash) shouldBe produceKey3
       store.getPs(txn, produceKey3) shouldBe Nil
-      store.getAs(txn, produceKey3) shouldBe List("datum3")
+      store.getAs(txn, produceKey3) shouldBe List(Datum("datum3", persist = false))
       store.getPsK(txn, produceKey3) shouldBe Nil
     }
 
     r3 shouldBe None
 
-    val r4 = consume(store, List("ch1", "ch2", "ch3"), patterns, new StringsCaptor)
+    val r4 = consume(store, List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, consumeKeyHash) shouldBe Nil
@@ -317,17 +318,17 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
 
     val key = List("ch1")
 
-    val r1 = produce(store, key.head, "datum1")
-    val r2 = produce(store, key.head, "datum2")
-    val r3 = produce(store, key.head, "datum3")
+    val r1 = produce(store, key.head, "datum1", persist = false)
+    val r2 = produce(store, key.head, "datum2", persist = false)
+    val r3 = produce(store, key.head, "datum3", persist = false)
 
     r1 shouldBe None
     r2 shouldBe None
     r3 shouldBe None
 
-    val r4 = consume(store, key, List(Wildcard), captor)
-    val r5 = consume(store, key, List(Wildcard), captor)
-    val r6 = consume(store, key, List(Wildcard), captor)
+    val r4 = consume(store, key, List(Wildcard), captor, persist = false)
+    val r5 = consume(store, key, List(Wildcard), captor, persist = false)
+    val r6 = consume(store, key, List(Wildcard), captor, persist = false)
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getKey(txn, store.hashCs(key)) shouldBe Nil
@@ -352,13 +353,13 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
   "consuming three times on the same channel, then producing three times on that channel" should
     "return three continuations, each paired with distinct pieces of data" in withTestStore {
     store =>
-      consume(store, List("ch1"), List(Wildcard), new StringsCaptor)
-      consume(store, List("ch1"), List(Wildcard), new StringsCaptor)
-      consume(store, List("ch1"), List(Wildcard), new StringsCaptor)
+      consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+      consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      val r1 = produce(store, "ch1", "datum1")
-      val r2 = produce(store, "ch1", "datum2")
-      val r3 = produce(store, "ch1", "datum3")
+      val r1 = produce(store, "ch1", "datum1", persist = false)
+      val r2 = produce(store, "ch1", "datum2", persist = false)
+      val r3 = produce(store, "ch1", "datum3", persist = false)
 
       r1 shouldBe defined
       r2 shouldBe defined
@@ -383,13 +384,13 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
 
   "consuming three times on the same channel with non-trivial matches, then producing three times on that channel" should
     "return three continuations, each paired with matching data" in withTestStore { store =>
-    consume(store, List("ch1"), List(StringMatch("datum1")), new StringsCaptor)
-    consume(store, List("ch1"), List(StringMatch("datum2")), new StringsCaptor)
-    consume(store, List("ch1"), List(StringMatch("datum3")), new StringsCaptor)
+    consume(store, List("ch1"), List(StringMatch("datum1")), new StringsCaptor, persist = false)
+    consume(store, List("ch1"), List(StringMatch("datum2")), new StringsCaptor, persist = false)
+    consume(store, List("ch1"), List(StringMatch("datum3")), new StringsCaptor, persist = false)
 
-    val r1 = produce(store, "ch1", "datum1")
-    val r2 = produce(store, "ch1", "datum2")
-    val r3 = produce(store, "ch1", "datum3")
+    val r1 = produce(store, "ch1", "datum1", persist = false)
+    val r2 = produce(store, "ch1", "datum2", persist = false)
+    val r3 = produce(store, "ch1", "datum3", persist = false)
 
     r1 shouldBe defined
     r2 shouldBe defined
@@ -410,9 +411,13 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
 
   "consuming on two channels, producing on one, then producing on the other" should
     "return a continuation with both pieces of data" in withTestStore { store =>
-    val r1 = consume(store, List("ch1", "ch2"), List(Wildcard, Wildcard), new StringsCaptor)
-    val r2 = produce(store, "ch1", "datum1")
-    val r3 = produce(store, "ch2", "datum2")
+    val r1 = consume(store,
+                     List("ch1", "ch2"),
+                     List(Wildcard, Wildcard),
+                     new StringsCaptor,
+                     persist = false)
+    val r2 = produce(store, "ch1", "datum1", persist = false)
+    val r3 = produce(store, "ch2", "datum2", persist = false)
 
     r1 shouldBe None
     r2 shouldBe None
@@ -437,16 +442,18 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
     val r1 = consume(store,
                      channels,
                      List(StringMatch("datum1"), StringMatch("datum2")),
-                     new StringsCaptor)
+                     new StringsCaptor,
+                     persist = false)
     val r2 = consume(store,
                      channels,
                      List(StringMatch("datum3"), StringMatch("datum4")),
-                     new StringsCaptor)
+                     new StringsCaptor,
+                     persist = false)
 
-    val r3 = produce(store, "ch1", "datum3")
-    val r4 = produce(store, "ch2", "datum4")
-    val r5 = produce(store, "ch1", "datum1")
-    val r6 = produce(store, "ch2", "datum2")
+    val r3 = produce(store, "ch1", "datum3", persist = false)
+    val r4 = produce(store, "ch2", "datum4", persist = false)
+    val r5 = produce(store, "ch1", "datum1", persist = false)
+    val r6 = produce(store, "ch2", "datum2", persist = false)
 
     r1 shouldBe None
     r2 shouldBe None
@@ -474,17 +481,18 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
       store,
       List("ch1", "ch2"),
       List(Wildcard, StringMatch("datum1")),
-      new StringsCaptor
+      new StringsCaptor,
+      persist = false
     )
 
-    val r2 = produce(store, "ch1", "datum1")
+    val r2 = produce(store, "ch1", "datum1", persist = false)
 
     r1 shouldBe None
     r2 shouldBe None
 
     store.withTxn(store.createTxnRead()) { txn =>
       store.getAs(txn, List("ch1", "ch2")) shouldBe Nil
-      store.getAs(txn, List("ch1")) shouldBe List("datum1")
+      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = false))
     }
 
     store.withTxn(store.createTxnWrite()) { txn =>
@@ -499,10 +507,12 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
 
   "consuming twice and producing twice with non-trivial matches" should
     "work" in withTestStore { store =>
-    val r1 = consume(store, List("ch1"), List(StringMatch("datum1")), new StringsCaptor)
-    val r2 = consume(store, List("ch2"), List(StringMatch("datum2")), new StringsCaptor)
-    val r3 = produce(store, "ch1", "datum1")
-    val r4 = produce(store, "ch2", "datum2")
+    val r1 =
+      consume(store, List("ch1"), List(StringMatch("datum1")), new StringsCaptor, persist = false)
+    val r2 =
+      consume(store, List("ch2"), List(StringMatch("datum2")), new StringsCaptor, persist = false)
+    val r3 = produce(store, "ch1", "datum1", persist = false)
+    val r4 = produce(store, "ch2", "datum2", persist = false)
 
     List(r1, r2, r3, r4).foreach(runK)
 
@@ -525,18 +535,22 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
   "consuming on two channels, consuming on one of those channels, and then producing on both of those channels separately" should
     "return a continuation paired with one piece of data" in
     withTestStore { store =>
-      consume(store, List("ch1", "ch2"), List(Wildcard, Wildcard), new StringsCaptor)
-      consume(store, List("ch1"), List(Wildcard), new StringsCaptor)
+      consume(store,
+              List("ch1", "ch2"),
+              List(Wildcard, Wildcard),
+              new StringsCaptor,
+              persist = false)
+      consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      val r3 = produce(store, "ch1", "datum1")
-      val r4 = produce(store, "ch2", "datum2")
+      val r3 = produce(store, "ch1", "datum1", persist = false)
+      val r4 = produce(store, "ch2", "datum2", persist = false)
 
       store.withTxn(store.createTxnRead()) { txn =>
         store.getPsK(txn, List("ch1", "ch2")) should not be empty
         store.getPsK(txn, List("ch1")) shouldBe Nil
         store.getPsK(txn, List("ch2")) shouldBe Nil
         store.getAs(txn, List("ch1")) shouldBe Nil
-        store.getAs(txn, List("ch2")) shouldBe List("datum2")
+        store.getAs(txn, List("ch2")) shouldBe List(Datum("datum2", persist = false))
       }
 
       r3 shouldBe defined
@@ -560,8 +574,8 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
   "joins" should "remove joins if no PsK" in
     withTestStore { store =>
       store.withTxn(store.createTxnWrite()) { txn =>
-        store.putA(txn, List("ch1"), "datum1")
-        store.putA(txn, List("ch2"), "datum2")
+        store.putA(txn, List("ch1"), Datum("datum1", persist = false))
+        store.putA(txn, List("ch2"), Datum("datum2", persist = false))
 
         store.addJoin(txn, "ch1", List("ch1", "ch2"))
         store.addJoin(txn, "ch2", List("ch1", "ch2"))
@@ -569,7 +583,7 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
         store.addJoin(txn, "ch1", List("ch1", "ch2"))
         store.addJoin(txn, "ch2", List("ch1", "ch2"))
 
-        store.putA(txn, List("ch1", "ch2"), "datum_ch1_ch2")
+        store.putA(txn, List("ch1", "ch2"), Datum("datum_ch1_ch2", persist = false))
       }
 
       store.withTxn(store.createTxnRead()) { txn =>
@@ -599,10 +613,16 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
   "removeAllJoins" should "should not clear joins if PsK exists" in
     withTestStore { store =>
       store.withTxn(store.createTxnWrite()) { txn =>
-        store.putK(txn, List("ch1"), List(Wildcard), new StringsCaptor)
-        store.putK(txn, List("ch2"), List(Wildcard), new StringsCaptor)
+        store.putK(txn,
+                   List("ch1"),
+                   WaitingContinuation(List(Wildcard), new StringsCaptor, persist = true))
+        store.putK(txn,
+                   List("ch2"),
+                   WaitingContinuation(List(Wildcard), new StringsCaptor, persist = true))
 
-        store.putK(txn, List("ch1", "ch2"), List(Wildcard), new StringsCaptor)
+        store.putK(txn,
+                   List("ch1", "ch2"),
+                   WaitingContinuation(List(Wildcard), new StringsCaptor, persist = true))
 
         store.addJoin(txn, "ch1", List("ch1", "ch2"))
         store.addJoin(txn, "ch2", List("ch1", "ch2"))
@@ -641,6 +661,215 @@ abstract class StorageActionsTests extends FlatSpec with Matchers with OptionVal
 
       store.isNoGarbage shouldBe true
     }
+
+  /* Persist tests */
+
+  "producing and then doing a persistent consume on the same channel" should
+    "return the continuation and data" in withTestStore { store =>
+    val key     = List("ch1")
+    val keyHash = store.hashCs(key)
+
+    val r1 = produce(store, key.head, "datum", persist = false)
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getKey(txn, keyHash) shouldBe key
+      store.getPs(txn, key) shouldBe Nil
+      store.getAs(txn, key) shouldBe List(Datum("datum", persist = false))
+      store.getPsK(txn, key) shouldBe Nil
+    }
+
+    r1 shouldBe None
+
+    store.isNoGarbage shouldBe false
+
+    val r2 = consume(store, key, List(Wildcard), new StringsCaptor, persist = true)
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getKey(txn, keyHash) shouldBe List("ch1")
+      store.getPs(txn, key) shouldBe List(List(Wildcard))
+      store.getAs(txn, key) shouldBe Nil
+      store.getPsK(txn, key) should not be empty
+    }
+
+    r2 shouldBe defined
+
+    runK(r2)
+
+    getK(r2).results should contain theSameElementsAs List(List("datum"))
+
+    store.isNoGarbage shouldBe false
+  }
+
+  "producing, doing a persistent consume, and producing again on the same channel" should
+    "return the continuation for the first produce, and then the second produce" in withTestStore {
+    store =>
+      val key     = List("ch1")
+      val keyHash = store.hashCs(key)
+
+      val r1 = produce(store, key.head, "datum1", persist = false)
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getKey(txn, keyHash) shouldBe key
+        store.getPs(txn, key) shouldBe Nil
+        store.getAs(txn, key) shouldBe List(Datum("datum1", persist = false))
+        store.getPsK(txn, key) shouldBe Nil
+      }
+
+      r1 shouldBe None
+
+      store.isNoGarbage shouldBe false
+
+      val r2 = consume(store, key, List(Wildcard), new StringsCaptor, persist = true)
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getKey(txn, keyHash) shouldBe List("ch1")
+        store.getPs(txn, key) shouldBe List(List(Wildcard))
+        store.getAs(txn, key) shouldBe Nil
+        store.getPsK(txn, key) should not be empty
+      }
+
+      r2 shouldBe defined
+
+      runK(r2)
+
+      getK(r2).results should contain theSameElementsAs List(List("datum1"))
+
+      val r3 = produce(store, key.head, "datum2", persist = false)
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getKey(txn, keyHash) shouldBe List("ch1")
+        store.getPs(txn, key) shouldBe List(List(Wildcard))
+        store.getAs(txn, key) shouldBe Nil
+        store.getPsK(txn, key) should not be empty
+      }
+
+      r3 shouldBe defined
+
+      runK(r3)
+
+      getK(r3).results should contain theSameElementsAs List(List("datum2"))
+
+      store.isNoGarbage shouldBe false
+  }
+
+  "doing a persistent consume and producing multiple times" should "work" in withTestStore {
+    store =>
+      val r1 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
+
+      r1 shouldBe None
+
+      val r2 = produce(store, "ch1", "datum1", persist = false)
+
+      r2 shouldBe defined
+
+      runK(r2)
+
+      getK(r2).results should contain theSameElementsAs List(List("datum1"))
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getAs(txn, List("ch1")) shouldBe Nil
+        store.getPsK(txn, List("ch1")) should not be empty
+      }
+
+      val r3 = produce(store, "ch1", "datum2", persist = false)
+
+      r3 shouldBe defined
+
+      runK(r3)
+
+      getK(r3).results should contain theSameElementsAs List(List("datum2"))
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getAs(txn, List("ch1")) shouldBe Nil
+        store.getPsK(txn, List("ch1")) should not be empty
+      }
+
+      store.isNoGarbage shouldBe false
+  }
+
+  "consuming and doing a persistient produce" should "work" in withTestStore { store =>
+    val r1 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+
+    r1 shouldBe None
+
+    val r2 = produce(store, "ch1", "datum1", persist = true)
+
+    r2 shouldBe defined
+
+    runK(r2)
+
+    getK(r2).results should contain theSameElementsAs List(List("datum1"))
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
+      store.getPsK(txn, List("ch1")) shouldBe Nil
+    }
+  }
+
+  "consuming, doing a persistient produce, and consuming again" should "work" in withTestStore {
+    store =>
+      val r1 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+
+      r1 shouldBe None
+
+      val r2 = produce(store, "ch1", "datum1", persist = true)
+
+      r2 shouldBe defined
+
+      runK(r2)
+
+      getK(r2).results should contain theSameElementsAs List(List("datum1"))
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
+        store.getPsK(txn, List("ch1")) shouldBe Nil
+      }
+
+      val r3 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+
+      r3 shouldBe defined
+
+      runK(r3)
+
+      getK(r3).results should contain theSameElementsAs List(List("datum1"))
+
+      store.withTxn(store.createTxnRead()) { txn =>
+        store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
+        store.getPsK(txn, List("ch1")) shouldBe Nil
+      }
+  }
+
+  "doing a persistent produce and consuming twice" should "work" in withTestStore { store =>
+    val r1 = produce(store, "ch1", "datum1", persist = true)
+
+    r1 shouldBe None
+
+    val r2 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+
+    r2 shouldBe defined
+
+    runK(r2)
+
+    getK(r2).results should contain theSameElementsAs List(List("datum1"))
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
+      store.getPsK(txn, List("ch1")) shouldBe Nil
+    }
+
+    val r3 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+
+    r3 shouldBe defined
+
+    runK(r3)
+
+    getK(r3).results should contain theSameElementsAs List(List("datum1"))
+
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
+      store.getPsK(txn, List("ch1")) shouldBe Nil
+    }
+  }
 }
 
 class InMemoryStoreStorageActionsTests extends StorageActionsTests {

--- a/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
+++ b/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
@@ -3,7 +3,8 @@ package coop.rchain.storage.test
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
-import coop.rchain.storage.{IStore, IStoreTest, Serialize}
+import coop.rchain.storage._
+import coop.rchain.storage.examples._
 import coop.rchain.storage.util.dropIndex
 import javax.xml.bind.DatatypeConverter.printHexBinary
 
@@ -11,8 +12,8 @@ import scala.collection.mutable
 
 class InMemoryStore[C, P, A, K] private (
     _keys: mutable.HashMap[String, List[C]],
-    _psks: mutable.HashMap[String, List[(List[P], K)]],
-    _as: mutable.HashMap[String, List[A]],
+    _waitingContinuations: mutable.HashMap[String, List[WaitingContinuation[P, K]]],
+    _data: mutable.HashMap[String, List[Datum[A]]],
     _joinMap: mutable.MultiMap[C, String]
 )(implicit sc: Serialize[C])
     extends IStore[C, P, A, K]
@@ -39,16 +40,16 @@ class InMemoryStore[C, P, A, K] private (
     f(txn)
 
   def collectGarbage(key: H): Unit = {
-    val as = _as.get(key).exists(_.nonEmpty)
+    val as = _data.get(key).exists(_.nonEmpty)
     if (!as) {
       //we still may have empty list, remove it as well
-      _as.remove(key)
+      _data.remove(key)
     }
 
-    val psks = _psks.get(key).exists(_.nonEmpty)
+    val psks = _waitingContinuations.get(key).exists(_.nonEmpty)
     if (!psks) {
       //we still may have empty list, remove it as well
-      _psks.remove(key)
+      _waitingContinuations.remove(key)
     }
 
     val cs    = _keys.getOrElse(key, List.empty[C])
@@ -59,44 +60,47 @@ class InMemoryStore[C, P, A, K] private (
     }
   }
 
-  def putA(txn: T, channels: List[C], a: A): Unit = {
+  def putA(txn: T, channels: List[C], datum: Datum[A]): Unit = {
     val key = hashCs(channels)
     putCs(txn, channels)
-    val as = _as.getOrElseUpdate(key, List.empty[A])
-    _as.update(key, scala.util.Random.shuffle(a +: as))
+    val datums = _data.getOrElseUpdate(key, List.empty[Datum[A]])
+    _data.update(key, datums :+ datum)
   }
 
-  def putK(txn: T, channels: List[C], patterns: List[P], k: K): Unit = {
+  def putK(txn: T, channels: List[C], continuation: WaitingContinuation[P, K]): Unit = {
     val key = hashCs(channels)
     putCs(txn, channels)
-    val ps = _psks.getOrElseUpdate(key, List.empty[(List[P], K)])
-    _psks.update(key, ps :+ (patterns, k))
+    val waitingContinuations =
+      _waitingContinuations.getOrElseUpdate(key, List.empty[WaitingContinuation[P, K]])
+    _waitingContinuations.update(key, waitingContinuations :+ continuation)
   }
 
-  def getPs(txn: T, channels: List[C]): List[List[P]] =
-    _psks.getOrElse(hashCs(channels), Nil).map(_._1)
+  private[storage] def getPs(txn: T, channels: List[C]): List[List[P]] =
+    _waitingContinuations.getOrElse(hashCs(channels), Nil).map(_.patterns)
 
-  def getAs(txn: T, channels: List[C]): List[A] =
-    _as.getOrElse(hashCs(channels), Nil)
+  def getAs(txn: T, channels: List[C]): List[Datum[A]] =
+    _data.getOrElse(hashCs(channels), List.empty[Datum[A]])
 
-  def getPsK(txn: T, curr: List[C]): List[(List[P], K)] =
-    _psks.getOrElse(hashCs(curr), List.empty[(List[P], K)])
+  def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]] =
+    _waitingContinuations
+      .getOrElse(hashCs(curr), List.empty[WaitingContinuation[P, K]])
+      .map(InMemoryStore.roundTrip)
 
   def removeA(txn: T, channel: C, index: Int): Unit =
     removeA(txn, List(channel), index)
 
   def removeA(txn: T, channels: List[C], index: Int): Unit = {
     val key = hashCs(channels)
-    for (as <- _as.get(key)) {
-      _as.update(key, dropIndex(as, index))
+    for (as <- _data.get(key)) {
+      _data.update(key, dropIndex(as, index))
     }
     collectGarbage(key)
   }
 
   def removePsK(txn: T, channels: List[C], index: Int): Unit = {
     val key = hashCs(channels)
-    for (psks <- _psks.get(key)) {
-      _psks.update(key, dropIndex(psks, index))
+    for (psks <- _waitingContinuations.get(key)) {
+      _waitingContinuations.update(key, dropIndex(psks, index))
     }
     collectGarbage(key)
   }
@@ -110,7 +114,7 @@ class InMemoryStore[C, P, A, K] private (
   def removeJoin(txn: T, c: C, cs: List[C]): Unit = {
     val joinKey = hashCs(List(c))
     val csKey   = hashCs(cs)
-    if (_psks.get(csKey).forall(_.isEmpty)) {
+    if (_waitingContinuations.get(csKey).forall(_.isEmpty)) {
       _joinMap.removeBinding(c, csKey)
     }
     collectGarbage(joinKey)
@@ -124,10 +128,16 @@ class InMemoryStore[C, P, A, K] private (
   def close(): Unit = ()
 
   def isNoGarbage: Boolean =
-    _psks.isEmpty && _as.isEmpty && _keys.isEmpty && _joinMap.isEmpty
+    _waitingContinuations.isEmpty && _data.isEmpty && _keys.isEmpty && _joinMap.isEmpty
 }
 
 object InMemoryStore {
+
+  /* UGLY HACK FOR TESTING */
+  def roundTrip[A <: Serializable](a: A): A =
+    makeSerializeFromSerializable[A]
+      .decode(makeSerializeFromSerializable[A].encode(a))
+      .fold(throw _, identity)
 
   def hashBytes(bs: Array[Byte]): Array[Byte] =
     MessageDigest.getInstance("SHA-256").digest(bs)
@@ -138,8 +148,8 @@ object InMemoryStore {
   def create[C, P, A, K](implicit sc: Serialize[C]): InMemoryStore[C, P, A, K] =
     new InMemoryStore[C, P, A, K](
       _keys = mutable.HashMap.empty[String, List[C]],
-      _psks = mutable.HashMap.empty[String, List[(List[P], K)]],
-      _as = mutable.HashMap.empty[String, List[A]],
+      _waitingContinuations = mutable.HashMap.empty[String, List[WaitingContinuation[P, K]]],
+      _data = mutable.HashMap.empty[String, List[Datum[A]]],
       _joinMap = new mutable.HashMap[C, mutable.Set[String]] with mutable.MultiMap[C, String]
     )
 }


### PR DESCRIPTION
Depends on #443 (**MERGED**) (~~so the diff is rather incoherent ATM~~)

Ref:
https://rchain.atlassian.net/browse/CORE-297

This PR introduces the `persist` Boolean parameter to the `produce` and `consume` functions.  It allows data or continuations to be persisted in manner where subsequent `produce`s and `consume`s will not remove them from the store.