### PR TITLE
CORE-76: storage: rejigger traits to not leak non-public API

### DIFF
--- a/storage/src/main/scala/coop/rchain/storage/IStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/IStore.scala
@@ -12,52 +12,50 @@ trait IStore[C, P, A, K] {
   /**
     * The type of hashes
     */
-  type H
+  private[storage] type H
+
+  /**
+    * The type of transactions
+    */
+  private[storage] type T
 
   private[storage] def hashCs(channels: List[C])(implicit sc: Serialize[C]): H
-
-  private[storage] def putCs(txn: T, channels: List[C]): Unit
 
   private[storage] def getKey(txn: T, hash: H): List[C]
 
   private[storage] def removeA(txn: T, channels: List[C], index: Int): Unit
 
-  /**
-    * The type of transactions
-    */
-  type T
+  private[storage] def createTxnRead(): T
 
-  def createTxnRead(): T
+  private[storage] def createTxnWrite(): T
 
-  def createTxnWrite(): T
+  private[storage] def withTxn[R](txn: T)(f: T => R): R
 
-  def withTxn[R](txn: T)(f: T => R): R
+  private[storage] def putA(txn: T, channels: List[C], datum: Datum[A]): Unit
 
-  def putA(txn: T, channels: List[C], datum: Datum[A]): Unit
+  private[storage] def putK(txn: T,
+                            channels: List[C],
+                            continuation: WaitingContinuation[P, K]): Unit
 
-  def putK(txn: T, channels: List[C], continuation: WaitingContinuation[P, K]): Unit
+  private[storage] def getAs(txn: T, channels: List[C]): List[Datum[A]]
 
-  private[storage] def getPs(txn: T, channels: List[C]): List[List[P]]
+  private[storage] def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]]
 
-  def getAs(txn: T, channels: List[C]): List[Datum[A]]
+  private[storage] def removeA(txn: T, channel: C, index: Int): Unit
 
-  def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]]
-
-  def removeA(txn: T, channel: C, index: Int): Unit
-
-  def removePsK(txn: T, channels: List[C], index: Int): Unit
+  private[storage] def removePsK(txn: T, channels: List[C], index: Int): Unit
 
   // compare to store.joinMap.addBinding
-  def addJoin(txn: T, c: C, cs: List[C]): Unit
+  private[storage] def addJoin(txn: T, c: C, cs: List[C]): Unit
 
   // compare to store.joinMap.get(c).toList.flatten
-  def getJoin(txn: T, c: C): List[List[C]]
+  private[storage] def getJoin(txn: T, c: C): List[List[C]]
 
   // compare to store.joinMap.removeBinding
-  def removeJoin(txn: T, c: C, cs: List[C]): Unit
+  private[storage] def removeJoin(txn: T, c: C, cs: List[C]): Unit
 
   // compare to store.joinMap.remove
-  def removeAllJoins(txn: T, c: C): Unit
+  private[storage] def removeAllJoins(txn: T, c: C): Unit
 
   def close(): Unit
 }

--- a/storage/src/main/scala/coop/rchain/storage/ITestableStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/ITestableStore.scala
@@ -3,6 +3,11 @@ package coop.rchain.storage
 /**
   * Used for unit-tests and other package-local calls
   */
-private[storage] trait ITestableStore {
+private[storage] trait ITestableStore[C, P] {
+
+  private[storage] type T
+
+  def getPs(txn: T, channels: List[C]): List[List[P]]
+
   def isEmpty: Boolean
 }

--- a/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
@@ -10,7 +10,7 @@ import org.scalatest._
 
 abstract class StorageActionsBase extends FlatSpec with Matchers with OptionValues {
 
-  type TestStore = IStore[String, Pattern, String, StringsCaptor] with ITestableStore
+  type TestStore = IStore[String, Pattern, String, StringsCaptor] with ITestableStore[String, Pattern]
 
   val logger: Logger = Logger[StorageActionsTests]
 

--- a/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
+++ b/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
@@ -17,9 +17,11 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     _joinMap: mutable.MultiMap[C, String]
 )(implicit sc: Serialize[C])
     extends IStore[C, P, A, K]
-    with ITestableStore {
+    with ITestableStore[C, P] {
 
-  type H = String
+  private[storage] type H = String
+
+  private[storage] type T = Unit
 
   private[storage] def hashCs(cs: List[C])(implicit sc: Serialize[C]): H =
     printHexBinary(InMemoryStore.hashBytes(cs.flatMap(sc.encode).toArray))
@@ -30,13 +32,11 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
   private[storage] def getKey(txn: T, s: H) =
     _keys.getOrElse(s, List.empty[C])
 
-  type T = Unit
+  private[storage] def createTxnRead(): Unit = ()
 
-  def createTxnRead(): Unit = ()
+  private[storage] def createTxnWrite(): Unit = ()
 
-  def createTxnWrite(): Unit = ()
-
-  def withTxn[R](txn: T)(f: T => R): R =
+  private[storage] def withTxn[R](txn: T)(f: T => R): R =
     f(txn)
 
   def collectGarbage(key: H): Unit = {
@@ -60,14 +60,16 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     }
   }
 
-  def putA(txn: T, channels: List[C], datum: Datum[A]): Unit = {
+  private[storage] def putA(txn: T, channels: List[C], datum: Datum[A]): Unit = {
     val key = hashCs(channels)
     putCs(txn, channels)
     val datums = _data.getOrElseUpdate(key, List.empty[Datum[A]])
     _data.update(key, datums :+ datum)
   }
 
-  def putK(txn: T, channels: List[C], continuation: WaitingContinuation[P, K]): Unit = {
+  private[storage] def putK(txn: T,
+                            channels: List[C],
+                            continuation: WaitingContinuation[P, K]): Unit = {
     val key = hashCs(channels)
     putCs(txn, channels)
     val waitingContinuations =
@@ -75,23 +77,20 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     _waitingContinuations.update(key, waitingContinuations :+ continuation)
   }
 
-  private[storage] def getPs(txn: T, channels: List[C]): List[List[P]] =
-    _waitingContinuations.getOrElse(hashCs(channels), Nil).map(_.patterns)
-
-  def getAs(txn: T, channels: List[C]): List[Datum[A]] =
+  private[storage] def getAs(txn: T, channels: List[C]): List[Datum[A]] =
     _data.getOrElse(hashCs(channels), List.empty[Datum[A]])
 
-  def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]] =
+  private[storage] def getPsK(txn: T, curr: List[C]): List[WaitingContinuation[P, K]] =
     _waitingContinuations
       .getOrElse(hashCs(curr), List.empty[WaitingContinuation[P, K]])
       .map { (wk: WaitingContinuation[P, K]) =>
         wk.copy(continuation = InMemoryStore.roundTrip(wk.continuation))
       }
 
-  def removeA(txn: T, channel: C, index: Int): Unit =
+  private[storage] def removeA(txn: T, channel: C, index: Int): Unit =
     removeA(txn, List(channel), index)
 
-  def removeA(txn: T, channels: List[C], index: Int): Unit = {
+  private[storage] def removeA(txn: T, channels: List[C], index: Int): Unit = {
     val key = hashCs(channels)
     for (as <- _data.get(key)) {
       _data.update(key, dropIndex(as, index))
@@ -99,7 +98,7 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     collectGarbage(key)
   }
 
-  def removePsK(txn: T, channels: List[C], index: Int): Unit = {
+  private[storage] def removePsK(txn: T, channels: List[C], index: Int): Unit = {
     val key = hashCs(channels)
     for (psks <- _waitingContinuations.get(key)) {
       _waitingContinuations.update(key, dropIndex(psks, index))
@@ -107,13 +106,13 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     collectGarbage(key)
   }
 
-  def addJoin(txn: T, c: C, cs: List[C]): Unit =
+  private[storage] def addJoin(txn: T, c: C, cs: List[C]): Unit =
     _joinMap.addBinding(c, hashCs(cs))
 
-  def getJoin(txn: T, c: C): List[List[C]] =
+  private[storage] def getJoin(txn: T, c: C): List[List[C]] =
     _joinMap.getOrElse(c, Set.empty[String]).toList.map(getKey(txn, _))
 
-  def removeJoin(txn: T, c: C, cs: List[C]): Unit = {
+  private[storage] def removeJoin(txn: T, c: C, cs: List[C]): Unit = {
     val joinKey = hashCs(List(c))
     val csKey   = hashCs(cs)
     if (_waitingContinuations.get(csKey).forall(_.isEmpty)) {
@@ -122,12 +121,15 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     collectGarbage(joinKey)
   }
 
-  def removeAllJoins(txn: T, c: C): Unit = {
+  private[storage] def removeAllJoins(txn: T, c: C): Unit = {
     _joinMap.remove(c)
     collectGarbage(hashCs(List(c)))
   }
 
   def close(): Unit = ()
+
+  def getPs(txn: T, channels: List[C]): List[List[P]] =
+    _waitingContinuations.getOrElse(hashCs(channels), Nil).map(_.patterns)
 
   def isEmpty: Boolean =
     _waitingContinuations.isEmpty && _data.isEmpty && _keys.isEmpty && _joinMap.isEmpty


### PR DESCRIPTION
Ref:
https://rchain.atlassian.net/browse/CORE-76

This PR performs more API cleanup.  Specifically, it changes access modifiers to prevent library clients from using the non-public API of `IStore`.  It also removes a few unnecessary bits, moves a few more definitions to `ITestableStore`, and does a little bit of rearranging.