### PR TITLE
CORE-76: storage: move InMemoryStore to main, objectify 'internal'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val rholang = (project in file("rholang"))
     ).map(_.getPath ++ "/.*").mkString(";"),
     fork in Test := true
   )
-  .dependsOn(models, storage % "test->test;compile->compile;compile->test")
+  .dependsOn(models, storage)
 
 lazy val roscala_macros = (project in file("roscala/macros"))
   .settings(commonSettings: _*)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
@@ -15,8 +15,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import coop.rchain.storage.{Datum, Serialize, WaitingContinuation}
-import coop.rchain.storage.test.{InMemoryStore, Row}
+import coop.rchain.storage.{InMemoryStore, Serialize}
+import coop.rchain.storage.internal.{Datum, Row, WaitingContinuation}
 
 trait InMemoryStoreTester {
   def withTestStore[C, P, A, K <: Serializable, R](store: InMemoryStore[C, P, A, K])(

--- a/storage/src/main/scala/coop/rchain/storage/IStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/IStore.scala
@@ -1,5 +1,7 @@
 package coop.rchain.storage
 
+import coop.rchain.storage.internal._
+
 /** The interface for the underlying store
   *
   * @tparam C a type representing a channel

--- a/storage/src/main/scala/coop/rchain/storage/InMemoryStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/InMemoryStore.scala
@@ -1,10 +1,10 @@
-package coop.rchain.storage.test
+package coop.rchain.storage
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
-import coop.rchain.storage._
 import coop.rchain.storage.examples._
+import coop.rchain.storage.internal._
 import coop.rchain.storage.util.dropIndex
 import javax.xml.bind.DatatypeConverter.printHexBinary
 

--- a/storage/src/main/scala/coop/rchain/storage/LMDBStore.scala
+++ b/storage/src/main/scala/coop/rchain/storage/LMDBStore.scala
@@ -8,6 +8,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.storage.Serialize.mkProtobufInstance
 import coop.rchain.storage.datamodels._
+import coop.rchain.storage.internal._
 import coop.rchain.storage.util._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.{Dbi, Env, Txn}

--- a/storage/src/main/scala/coop/rchain/storage/internal.scala
+++ b/storage/src/main/scala/coop/rchain/storage/internal.scala
@@ -1,13 +1,18 @@
 package coop.rchain.storage
 
-final case class Datum[A](a: A, persist: Boolean)
+object internal {
 
-private[storage] final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
+  final case class Datum[A](a: A, persist: Boolean)
 
-final case class WaitingContinuation[P, K](patterns: List[P], continuation: K, persist: Boolean)
+  final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
 
-private[storage] final case class ProduceCandidate[C, P, A, K](
-    channels: List[C],
-    continuation: WaitingContinuation[P, K],
-    continuationIndex: Int,
-    dataCandidates: List[DataCandidate[C, A]])
+  final case class WaitingContinuation[P, K](patterns: List[P], continuation: K, persist: Boolean)
+
+  final case class ProduceCandidate[C, P, A, K](channels: List[C],
+                                                continuation: WaitingContinuation[P, K],
+                                                continuationIndex: Int,
+                                                dataCandidates: List[DataCandidate[C, A]])
+
+  case class Row[P, A, K](data: Option[List[Datum[A]]],
+                          wks: Option[List[WaitingContinuation[P, K]]])
+}

--- a/storage/src/main/scala/coop/rchain/storage/package.scala
+++ b/storage/src/main/scala/coop/rchain/storage/package.scala
@@ -2,6 +2,7 @@ package coop.rchain
 
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
+import coop.rchain.storage.internal._
 import coop.rchain.storage.util.ignore
 
 import scala.annotation.tailrec

--- a/storage/src/main/scala/coop/rchain/storage/util/package.scala
+++ b/storage/src/main/scala/coop/rchain/storage/util/package.scala
@@ -1,5 +1,8 @@
 package coop.rchain.storage
 
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
 package object util {
 
   /**

--- a/storage/src/test/scala/coop/rchain/storage/JoinOperationsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/JoinOperationsTests.scala
@@ -1,6 +1,7 @@
 package coop.rchain.storage
 
 import coop.rchain.storage.examples.StringExamples.{StringsCaptor, Wildcard}
+import coop.rchain.storage.internal._
 
 trait JoinOperationsTests extends StorageActionsBase {
 

--- a/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
+++ b/storage/src/test/scala/coop/rchain/storage/StorageActionsTests.scala
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import com.typesafe.scalalogging.Logger
 import coop.rchain.storage.examples.StringExamples._
 import coop.rchain.storage.examples.StringExamples.implicits._
+import coop.rchain.storage.internal._
 import coop.rchain.storage.test._
 import org.scalatest._
 

--- a/storage/src/test/scala/coop/rchain/storage/test/Row.scala
+++ b/storage/src/test/scala/coop/rchain/storage/test/Row.scala
@@ -1,5 +1,0 @@
-package coop.rchain.storage.test
-
-import coop.rchain.storage.{Datum, WaitingContinuation}
-
-case class Row[P, A, K](data: Option[List[Datum[A]]], wks: Option[List[WaitingContinuation[P, K]]])


### PR DESCRIPTION
This PR exposes `InMemoryStore` as part of the public API so that it can be used by `node`'s RPEL (sic).  

It also consolidates several types that need to remain exposed to other projects like `rholang` into an `internal` object, whose name and structure should help to indicate (along with forthcoming documentation) that these types are not part of the public API but are still available to library consumers at their own risk.