### PR TITLE
scripts/create-artifacts.sh: only create artifacts on tagged releases

### DIFF
--- a/scripts/create-artifacts.sh
+++ b/scripts/create-artifacts.sh
@@ -1,8 +1,8 @@
 #! /usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
-if [ $SUBPROJECT = "core" ]
+if [ "$SUBPROJECT" = "core" -a -n "$TRAVIS_TAG" ]
 then
     sbt -Dsbt.log.noformat=true clean node/debian:packageBin node/rpm:packageBin
 fi


### PR DESCRIPTION
Right now we test the creation of artifacts as part of our normal test run on Travis.  We also still do a clean creation of artifacts in the event that this is a tagged release, in which case they will be pushed to GitHub releases.

We should only do the clean creation of artifacts if it is a tagged release.  It is important to note here that **we will still be testing the creation of artifacts** as part of the normal test run on Travis, we just won't have to pay the additional cost of cleanly creating artifacts which are not getting pushed.

This should have the added benefit of speeding up Travis runs.