### PR TITLE
CORE-76: storage: reduce log level

### DIFF
--- a/storage/src/main/resources/logback.xml
+++ b/storage/src/main/resources/logback.xml
@@ -1,4 +1,6 @@
-<configuration debug="true">
+<configuration>
+
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <!-- encoders are  by default assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
@@ -7,7 +9,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="warn">
     <appender-ref ref="STDOUT" />
   </root>
 

--- a/storage/src/main/scala/coop/rchain/storage/package.scala
+++ b/storage/src/main/scala/coop/rchain/storage/package.scala
@@ -82,13 +82,13 @@ package object storage {
       throw new IllegalArgumentException(msg)
     }
     store.withTxn(store.createTxnWrite()) { txn =>
-      logger.info(
+      logger.debug(
         s"consume: searching for data matching <patterns: $patterns> at <channels: $channels>")
       extractDataCandidates(store, channels, patterns)(txn) match {
         case None =>
           store.putK(txn, channels, WaitingContinuation(patterns, continuation, persist))
           for (channel <- channels) store.addJoin(txn, channel, channels)
-          logger.info(
+          logger.debug(
             s"consume: no data found, storing <(patterns, continuation): ($patterns, $continuation)> at <channels: $channels>")
           None
         case Some(dataCandidates) =>
@@ -99,7 +99,7 @@ package object storage {
             case _ =>
               ()
           }
-          logger.info(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
+          logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
           Some((continuation, dataCandidates.map(_.datum.a)))
       }
     }
@@ -156,7 +156,7 @@ package object storage {
       implicit m: Match[P, A]): Option[(K, List[A])] =
     store.withTxn(store.createTxnWrite()) { txn =>
       val groupedChannels: List[List[C]] = store.getJoin(txn, channel)
-      logger.info(
+      logger.debug(
         s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>")
       extractProduceCandidateAlt(store, groupedChannels, channel, Datum(data, persist))(txn) match {
         case Some(
@@ -176,12 +176,12 @@ package object storage {
             case _ =>
               ()
           }
-          logger.info(s"produce: matching continuation found at <channels: $channels>")
+          logger.debug(s"produce: matching continuation found at <channels: $channels>")
           Some(continuation, dataCandidates.map(_.datum.a))
         case None =>
-          logger.info(s"produce: no matching continuation found")
+          logger.debug(s"produce: no matching continuation found")
           store.putA(txn, List(channel), Datum(data, persist))
-          logger.info(s"produce: persisted <data: $data> at <channel: $channel>")
+          logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
           None
 
       }


### PR DESCRIPTION
This PR reduces the log level of the main storage operations to `DEBUG`.  

It also updates the `logback.xml` configuration to only print messages at the log level of `WARN` or below.  If a library consumer wants to change this setting, they must provide their own `logback.xml`.