### PR TITLE
Integrate REPL into Node

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ lazy val node = (project in file("node"))
     rpmUrl := Some("https://rchain.coop"),
     rpmLicense := Some("Apache 2.0")
   )
-  .dependsOn(comm, crypto)
+  .dependsOn(comm, crypto, rholang)
 
 lazy val regex = (project in file("regex"))
   .settings(commonSettings: _*)


### PR DESCRIPTION
There is a lot of code duplication between RholangCLI and this file,
so we might want to clean that up. The Node REPL (this one) uses
the LMDB store and the RholangCLI REPL uses the InMemoryStore.

I've noticed the node just crashes when it takes more than 5 seconds
instead of looping. There is probably a lot of fine tuning to be done.