### PR TITLE
add initial nix packages for dependencies

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,25 @@
+let
+
+  pkgs = import <nixpkgs> {};
+
+  bnfcSrc = pkgs.fetchFromGitHub {
+               owner = "BNFC";
+               repo = "bnfc";
+               rev = "7c9e8591902c806c17cc5617db228e5f3e02a2ad";
+               sha256 = "18rr41kabb9dabmaz58k1iyv1ijv9aq0gzg1jyal3nicpmm9159a";
+               postFetch = ''
+                 tar --strip-components=1 -xvzf $downloadedFile
+                 mkdir $out
+                 cp -r source/* $out
+               '';
+             };
+
+  bnfcHEAD = pkgs.haskellPackages.callCabal2nix "bnfc-HEAD" bnfcSrc {};
+
+
+in {
+
+  bnfc = bnfcHEAD;
+
+  rchainPackages = with pkgs; [ bnfcHEAD jflex ];
+}


### PR DESCRIPTION
This adds a `nix` directory with a build specification for `BNFC` from that project's `HEAD`.

For the sake of convenience it also adds an `rchainPackages` set containing `BNFC` and `jflex`.

To install these packages, from the project root a user would issue the following command:
```
nix-env -f nix/default.nix -iA rchainPackages
```

To install just `BNFC`:
```
nix-env -f nix/default.nix -iA bnfc
```