### PR TITLE
{rholang,node}: convert List to Seq

### DIFF
--- a/node/src/main/scala/coop/rchain/node/main.scala
+++ b/node/src/main/scala/coop/rchain/node/main.scala
@@ -118,12 +118,12 @@ object Main {
 
   private def repl = {
     implicit val serializer = Serialize.mkProtobufInstance(Channel)
-    implicit val serializer2 = new Serialize[List[Channel]] {
+    implicit val serializer2 = new Serialize[Seq[Channel]] {
 
-      override def encode(a: List[Channel]): Array[Byte] =
+      override def encode(a: Seq[Channel]): Array[Byte] =
         ListChannel.toByteArray(ListChannel(a))
 
-      override def decode(bytes: Array[Byte]): Either[Throwable, List[Channel]] =
+      override def decode(bytes: Array[Byte]): Either[Throwable, Seq[Channel]] =
         Either.catchNonFatal(ListChannel.parseFrom(bytes).channels.toList)
     }
 
@@ -131,7 +131,7 @@ object Main {
 
     val dbDir = Files.createTempDirectory("rchain-storage-test-")
     val persistentStore =
-      LMDBStore.create[Channel, List[Channel], List[Channel], Par](dbDir, 1024 * 1024 * 1024)
+      LMDBStore.create[Channel, Seq[Channel], Seq[Channel], Par](dbDir, 1024 * 1024 * 1024)
     val interp = Reduce.makeInterpreter(persistentStore)
 
     for (ln <- Source.stdin.getLines) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -8,12 +8,12 @@ import coop.rchain.storage.IStore
 import coop.rchain.storage.internal.{Datum, Row, WaitingContinuation}
 
 object StoragePrinter {
-  def prettyPrint(store: IStore[Channel, List[Channel], List[Channel], Par]): Unit = {
+  def prettyPrint(store: IStore[Channel, Seq[Channel], Seq[Channel], Par]): Unit = {
     val pars: Seq[Par] = store.toMap.map {
-      case ((channels: List[Channel], row: Row[List[Channel], List[Channel], Par])) => {
-        def toSends(data: List[Datum[List[Channel]]]): Par = {
+      case ((channels: Seq[Channel], row: Row[Seq[Channel], Seq[Channel], Par])) => {
+        def toSends(data: Seq[Datum[Seq[Channel]]]): Par = {
           val sends: Seq[Send] = data.flatMap {
-            case Datum(as: List[Channel], persist: Boolean) =>
+            case Datum(as: Seq[Channel], persist: Boolean) =>
               channels.map { channel =>
                 Send(Some(channel), as.map { case Channel(Quote(p)) => p }, persist)
               }
@@ -23,9 +23,9 @@ object StoragePrinter {
           }
         }
 
-        def toReceive(wks: List[WaitingContinuation[List[Channel], Par]]): Par = {
+        def toReceive(wks: Seq[WaitingContinuation[Seq[Channel], Par]]): Par = {
           val receives: Seq[Receive] = wks.map {
-            case WaitingContinuation(patterns: List[List[Channel]],
+            case WaitingContinuation(patterns: Seq[Seq[Channel]],
                                      continuation: Par,
                                      persist: Boolean) =>
               val receiveBinds: Seq[ReceiveBind] = (channels zip patterns).map {
@@ -42,12 +42,12 @@ object StoragePrinter {
         row match {
           case Row(Nil, Nil) =>
             Par()
-          case Row(data: List[Datum[List[Channel]]], Nil) =>
+          case Row(data: Seq[Datum[Seq[Channel]]], Nil) =>
             toSends(data)
-          case Row(Nil, wks: List[WaitingContinuation[List[Channel], Par]]) =>
+          case Row(Nil, wks: Seq[WaitingContinuation[Seq[Channel], Par]]) =>
             toReceive(wks)
-          case Row(data: List[Datum[List[Channel]]],
-                   wks: List[WaitingContinuation[List[Channel], Par]]) =>
+          case Row(data: Seq[Datum[Seq[Channel]]],
+                   wks: Seq[WaitingContinuation[Seq[Channel], Par]]) =>
             toSends(data) ++ toReceive(wks)
         }
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -10,20 +10,20 @@ import coop.rchain.storage.{Match => StorageMatch}
 //noinspection ConvertExpressionToSAM
 object implicits {
 
-  private def toChannels(fm: FreeMap, max: Int): List[Channel] =
+  private def toChannels(fm: FreeMap, max: Int): Seq[Channel] =
     (0 until max).map { (i: Int) =>
       fm.get(i) match {
         case Some(par) => Channel(Quote(par))
         case None      => Channel(Quote(Par.defaultInstance))
       }
-    }.toList
+    }
 
   private def freeCount(c: Channel): Int = implicitly[HasLocallyFree[Channel]].freeCount(c)
 
-  implicit val matchListQuote: StorageMatch[List[Channel], List[Channel]] =
-    new StorageMatch[List[Channel], List[Channel]] {
+  implicit val matchListQuote: StorageMatch[Seq[Channel], Seq[Channel]] =
+    new StorageMatch[Seq[Channel], Seq[Channel]] {
 
-      def get(patterns: List[Channel], data: List[Channel]): Option[List[Channel]] =
+      def get(patterns: Seq[Channel], data: Seq[Channel]): Option[Seq[Channel]] =
         foldMatch(data, patterns, (t: Channel, p: Channel) => spatialMatch(t, p))
           .runS(emptyMap)
           .map { (freeMap: FreeMap) =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
@@ -22,17 +22,17 @@ import cats.syntax.either._
 
 trait PersistentStoreTester {
   implicit val serializer = Serialize.mkProtobufInstance(Channel)
-  implicit val serializer2 = new Serialize[List[Channel]] {
-    override def encode(a: List[Channel]): Array[Byte] =
+  implicit val serializer2 = new Serialize[Seq[Channel]] {
+    override def encode(a: Seq[Channel]): Array[Byte] =
       ListChannel.toByteArray(ListChannel(a))
-    override def decode(bytes: Array[Byte]): Either[Throwable, List[Channel]] =
+    override def decode(bytes: Array[Byte]): Either[Throwable, Seq[Channel]] =
       Either.catchNonFatal(ListChannel.parseFrom(bytes).channels.toList)
   }
   implicit val serializer3 = Serialize.mkProtobufInstance(Par)
-  def withTestStore[R](f: IStore[Channel, List[Channel], List[Channel], Par] => R): R = {
+  def withTestStore[R](f: IStore[Channel, Seq[Channel], Seq[Channel], Par] => R): R = {
     val dbDir = Files.createTempDirectory("rchain-storage-test-")
-    val store: IStore[Channel, List[Channel], List[Channel], Par] =
-      LMDBStore.create[Channel, List[Channel], List[Channel], Par](dbDir, 1024 * 1024 * 1024)
+    val store: IStore[Channel, Seq[Channel], Seq[Channel], Par] =
+      LMDBStore.create[Channel, Seq[Channel], Seq[Channel], Par](dbDir, 1024 * 1024 * 1024)
     try {
       f(store)
     } finally {


### PR DESCRIPTION
Using `List` instead of `Seq` was causing a particularly nasty bug to manifest in `coat_check_test.rho` as a result of the protobuf serializers spitting out `Vector`s somewhere deep in the code.