### PR TITLE
CORE-333: storage: privatize InMemoryStore

### DIFF
--- a/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
+++ b/storage/src/test/scala/coop/rchain/storage/test/InMemoryStore.scala
@@ -1,4 +1,4 @@
-package coop.rchain.storage
+package coop.rchain.storage.test
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -6,6 +6,7 @@ import java.security.MessageDigest
 import coop.rchain.storage.examples._
 import coop.rchain.storage.internal._
 import coop.rchain.storage.util.dropIndex
+import coop.rchain.storage.{IStore, ITestableStore, Serialize}
 import javax.xml.bind.DatatypeConverter.printHexBinary
 
 import scala.collection.mutable


### PR DESCRIPTION
`InMemoryStore` was never really for public consumption, and being exposed to the pressures of Rholang revealed its weaknesses as a general-purpose store.  

In order to prevent weird edge cases, it needs to store serialized byte arrays just like its persistent big brother `LMDBStore`.

Let's keep it for our simpler rspace tests and aim to upgrade it soon. 