### PR TITLE
CORE-341: node: add libsodium as dependency for debs and rpms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val node = (project in file("node"))
     packageSummary in Linux := "RChain Node",
     packageDescription in Linux := "RChain Node - the RChain blockchain node server software.",
     /* Debian */
-    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)"),
+    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.11-1)"),
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val node = (project in file("node"))
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),
-    rpmLicense := Some("Apache 2.0")
+    rpmLicense := Some("Apache 2.0"),
+    rpmPrerequisites := Seq("libsodium >= 1.0.14-1")
   )
   .dependsOn(comm, crypto, rholang)
 


### PR DESCRIPTION
Ref:
https://rchain.atlassian.net/browse/CORE-341

This PR adds `libsodium` as a dependency for the node debs and rpms.