### PR TITLE
Change SDK 0.2 to RNode - 0.2

### DIFF
--- a/rholang/doc/rholangtut-0.2.md
+++ b/rholang/doc/rholangtut-0.2.md
@@ -1,6 +1,6 @@
 # A Rholang tutorial
 
-Rholang is a new programming language designed for use in distributed systems.  Like all newborn things, it is growing and changing rapidly; this document describes the syntax that will be used in the 0.2 SDK release.
+Rholang is a new programming language designed for use in distributed systems.  Like all newborn things, it is growing and changing rapidly; this document describes the syntax that will be used in the RNode-0.2 release.
 
 Rholang is "process-oriented": all computation is done by means of message passing.  Messages are passed on "channels", which are rather like message queues but behave like sets rather than queues.  Rholang is completely asynchronous, in the sense that while you can read a message from a channel and then do something with it, you can't send a message and then do something once it has been received---at least, not without explicitly waiting for an acknowledgment message from the receiver. Note that throughout this document the words "name" and "channel" are used interchangeably. This is because in the rho-calculus (on which Rholang is based) the term name is used, however because you can send and receive information on names, semantically they are like channels.
 


### PR DESCRIPTION
Since this tutorial will support people using Rholang in the RNode - 0.2 release and since we are not yet releasing SDK 0.2. This request is to change the reference from SDK to RNode in the first paragraph.