### PR TITLE
Use ROT23 for PrettyPrinter

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -113,7 +113,9 @@ case class PrettyPrinter(freeShift: Int,
               this
                 .copy(
                   freeShift = boundShift + free,
-                  freeId = boundId
+                  boundShift = 0,
+                  freeId = boundId,
+                  baseId = setBaseId()
                 )
                 .buildPattern(bind.patterns)
             (free + patternFree, string + bindString + {
@@ -202,13 +204,7 @@ case class PrettyPrinter(freeShift: Int,
     ((0, "") /: patterns.zipWithIndex) {
       case ((patternsFree, string), (pattern, i)) =>
         (patternsFree + freeCount(pattern),
-          string +
-            this
-              .copy(
-                boundShift = 0,
-                baseId = setBaseId()
-              )
-              .buildString(pattern) + {
+          string + buildString(pattern) + {
             if (i != patterns.length - 1) ", "
             else ""
           })

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -11,20 +11,19 @@ import coop.rchain.models._
 import coop.rchain.rholang.interpreter.implicits.ChannelLocallyFree._
 
 object PrettyPrinter {
-  def apply(): PrettyPrinter = PrettyPrinter(0, 0, "INVALID", "x", "a", 23, 128)
-  def apply(i: Int, j: Int): PrettyPrinter = PrettyPrinter(i, j, "INVALID", "x", "a", 23, 128)
+  def apply(): PrettyPrinter = PrettyPrinter(0, 0, "INVALID", "a", 23, 128)
+
+  def apply(i: Int, j: Int): PrettyPrinter = PrettyPrinter(i, j, "INVALID", "a", 23, 128)
 }
 
 case class PrettyPrinter(freeShift: Int,
                          boundShift: Int,
                          freeId: String,
-                         boundId: String,
                          baseId: String,
                          rotation: Int,
                          maxVarCount: Int) {
 
-  def setBoundId(): String = rotate(increment(baseId))
-
+  def boundId: String = rotate(baseId)
   def setBaseId(): String = increment(baseId)
 
   def buildString(e: Expr): String =
@@ -143,13 +142,7 @@ case class PrettyPrinter(freeShift: Int,
         "match " + buildString(m.target.get) + " { " +
           ("" /: m.cases.zipWithIndex) {
             case (string, (matchCase, i)) =>
-              string +
-                this
-                  .copy(
-                    freeShift = boundShift,
-                    freeId = boundId
-                  )
-                  .buildMatchCase(matchCase) + {
+              string + buildMatchCase(matchCase) + {
                 if (i != m.cases.length - 1) " ; "
                 else ""
               }
@@ -213,7 +206,6 @@ case class PrettyPrinter(freeShift: Int,
             this
               .copy(
                 boundShift = 0,
-                boundId = setBoundId(),
                 baseId = setBaseId()
               )
               .buildString(pattern) + {
@@ -226,8 +218,9 @@ case class PrettyPrinter(freeShift: Int,
     val patternFree: Int = matchCase.pattern.get.freeCount
     this
       .copy(
+        freeShift = boundShift,
         boundShift = 0,
-        boundId = setBoundId(),
+        freeId = boundId,
         baseId = setBaseId()
       )
       .buildString(matchCase.pattern.get) + " => " +

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -12,7 +12,6 @@ import coop.rchain.rholang.interpreter.implicits.ChannelLocallyFree._
 
 object PrettyPrinter {
   def apply(): PrettyPrinter = PrettyPrinter(0, 0, "a", "x", 23, 128)
-
   def apply(i: Int, j: Int): PrettyPrinter = PrettyPrinter(i, j, "a", "x", 23, 128)
 }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -12,7 +12,6 @@ import coop.rchain.rholang.interpreter.implicits.ChannelLocallyFree._
 
 object PrettyPrinter {
   def apply(): PrettyPrinter = PrettyPrinter(0, 0, "INVALID", "x", "a", 23, 128)
-
   def apply(i: Int, j: Int): PrettyPrinter = PrettyPrinter(i, j, "INVALID", "x", "a", 23, 128)
 }
 
@@ -168,6 +167,19 @@ case class PrettyPrinter(freeShift: Int,
       case _ => throw new Error("Attempt to print unknown GeneratedMessage type")
     }
 
+  def increment(id: String): String = {
+    def incChar(charId: Char): Char = ((charId + 1 - 97) % 26 + 97).toChar
+
+    val newId = incChar(id.last).toString
+    if (newId equals "a")
+      if (id.length > 1) increment(id.dropRight(1)) + newId
+      else newId * 2
+    else id.dropRight(1) + newId
+  }
+
+  def rotate(id: String): String =
+    id.map(char => ((char + rotation - 97) % 26 + 97).toChar)
+
   private def buildVariables(bindCount: Int): String =
     (0 until Math.min(maxVarCount, bindCount))
       .map(i => s"$boundId${boundShift + i}")
@@ -213,15 +225,6 @@ case class PrettyPrinter(freeShift: Int,
       this
         .copy(boundShift = boundShift + patternFree)
         .buildString(matchCase.source.get)
-  }
-
-  private def rotate(id: String): String =
-    id.map(char => ((char + rotation - 97) % 26 + 97).toChar)
-
-  private def increment(id: String): String = {
-    val newId = ((id.last + 1 - 97) % 26 + 97).toChar
-    if (newId equals id(0)) id.dropRight(1) ++ newId.toString * 2
-    else id.dropRight(1) ++ newId.toString
   }
 
   private def isEmpty(p: Par) =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -510,6 +510,35 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
 
 }
 
+class IncrementTester extends FlatSpec with Matchers {
+
+  val printer = PrettyPrinter()
+
+  "Increment" should "increment the id prefix every 26 increments" in {
+    val id: String = ("a" /: (0 until 26)) { (s, _) =>
+      printer.increment(s)
+    }
+    val _id: String = (id /: (0 until 26)) { (s, _) =>
+      printer.increment(s)
+    }
+    id shouldBe "aa"
+    _id shouldBe "ba"
+  }
+
+  "Increment and Rotate" should "" in {
+    val _printer: PrettyPrinter = (printer /: (0 until 52)) { (p, _) =>
+      p.copy(
+        freeId = p.boundId,
+        boundId = p.rotate(p.increment(p.baseId)),
+        baseId = p.increment(p.baseId)
+      )
+    }
+    _printer.freeId shouldBe "xw"
+    _printer.boundId shouldBe "yx"
+    _printer.baseId shouldBe "ba"
+  }
+}
+
 class NamePrinterSpec extends FlatSpec with Matchers {
 
   val inputs = NameVisitInputs(DebruijnIndexMap[VarSort](), DebruijnLevelMap[VarSort]())

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -521,10 +521,10 @@ class IncrementTester extends FlatSpec with Matchers {
   }
 
   "Increment and Rotate" should "" in {
+
     val _printer: PrettyPrinter = (printer /: (0 until 52)) { (p, _) =>
       p.copy(
         freeId = p.boundId,
-        boundId = p.setBoundId(),
         baseId = p.setBaseId()
       )
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -64,17 +64,6 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
     result shouldBe target
   }
 
-  "Set" should "Print" in {
-    val setData = new ListProc()
-    setData.add(new PAdd(new PVar(new ProcVarVar("P")), new PVar(new ProcVarVar("R"))))
-    setData.add(new PGround(new GroundInt(7)))
-    setData.add(new PPar(new PGround(new GroundInt(8)), new PVar(new ProcVarVar("Q"))))
-    val set = new PCollect(new CollectSet(setData))
-    val result =
-      PrettyPrinter(0, 2).buildString(ProcNormalizeMatcher.normalizeMatch(set, inputs).par)
-    result shouldBe "(x0 + a0, 7, a1 | 8)"
-  }
-
   "Map" should "Print" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
@@ -367,7 +356,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val parDoubleFree = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
     val result =
       PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(parDoubleFree, inputs).par)
-    result shouldBe "a1 | a0"
+    result shouldBe "INVALID1 | INVALID0"
   }
 
   "PInput" should "Print a receive" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -3,25 +3,106 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
-import coop.rchain.models._
+import coop.rchain.models.{Send, _}
 import coop.rchain.rholang.interpreter.implicits.{GPrivate, _}
-import org.scalatest.prop.PropertyChecks
+import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 
-class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
+class BoolPrinterSpec extends FlatSpec with Matchers {
+
+  "GBool(true)" should "Print as \"" + true + "\"" in {
+    val btrue = new BoolTrue()
+    PrettyPrinter().buildString(BoolNormalizeMatcher.normalizeMatch(btrue)) shouldBe "true"
+  }
+
+  "GBool(false)" should "Print as \"" + false + "\"" in {
+    val bfalse = new BoolFalse()
+    PrettyPrinter().buildString(BoolNormalizeMatcher.normalizeMatch(bfalse)) shouldBe "false"
+  }
+}
+
+class GroundPrinterSpec extends FlatSpec with Matchers {
+
+  "GroundInt" should "Print as \"" + 7 + "\"" in {
+    val gi = new GroundInt(7)
+    val target: String = "7"
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch(gi)) shouldBe target
+  }
+
+  "GroundString" should "Print as \"" + "String" + "\"" in {
+    val gs = new GroundString("String")
+    val target: String = "\"" + "String" + "\""
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch(gs)) shouldBe target
+  }
+
+  "GroundUri" should "Print with back-ticks" in {
+    val gu = new GroundUri("Uri")
+    val target: String = "`" + "Uri" + "`"
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch(gu)) shouldBe target
+  }
+}
+
+class CollectPrinterSpec extends FlatSpec with Matchers {
+
+  val inputs = ProcVisitInputs(
+    Par(),
+    DebruijnIndexMap[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0))),
+    DebruijnLevelMap[VarSort]())
+
+  "List" should "Print" in {
+    val listData = new ListProc()
+    listData.add(new PVar(new ProcVarVar("P")))
+    listData.add(new PEval(new NameVar("x")))
+    listData.add(new PGround(new GroundInt(7)))
+    val list = new PCollect(new CollectList(listData))
+
+    val result =
+      PrettyPrinter(0, 2).buildString(ProcNormalizeMatcher.normalizeMatch(list, inputs).par)
+    val target = "[x0, *x1, 7]"
+    result shouldBe target
+  }
+
+  "Set" should "Print" in {
+    val setData = new ListProc()
+    setData.add(new PAdd(new PVar(new ProcVarVar("P")), new PVar(new ProcVarVar("R"))))
+    setData.add(new PGround(new GroundInt(7)))
+    setData.add(new PPar(new PGround(new GroundInt(8)), new PVar(new ProcVarVar("Q"))))
+    val set = new PCollect(new CollectSet(setData))
+    val result =
+      PrettyPrinter(0, 2).buildString(ProcNormalizeMatcher.normalizeMatch(set, inputs).par)
+    result shouldBe "(x0 + a0, 7, a1 | 8)"
+  }
+
+  "Map" should "Print" in {
+    val mapData = new ListKeyValuePair()
+    mapData.add(
+      new KeyValuePairImpl(new PGround(new GroundInt(7)), new PGround(new GroundString("Seven"))))
+    mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("x"))))
+    val map = new PCollect(new CollectMap(mapData))
+
+    val result =
+      PrettyPrinter(0, 2).buildString(ProcNormalizeMatcher.normalizeMatch(map, inputs).par)
+    result shouldBe "{7 : \"" + "Seven" + "\", x0 : *x1}"
+  }
+
+}
+
+class ProcPrinterSpec extends FlatSpec with Matchers {
+
+  val inputs = ProcVisitInputs(Par(), DebruijnIndexMap[VarSort](), DebruijnLevelMap[VarSort]())
 
   val p: Par = Par()
 
   "New" should "use 0-based indexing" in {
-    val neu    = p.copy(news = Seq(New(3, Par())))
-    val result = PrettyPrinter().buildString(neu)
+    val source = p.copy(news = Seq(New(3, Par())))
+    val result = PrettyPrinter().buildString(source)
     val target = "new x0, x1, x2 in { Nil }"
     result shouldBe target
   }
 
-  "Par" should "pretty print" in {
+  "Par" should "Print" in {
     val source: Par = p.copy(
       exprs = Seq(GInt(0), GBool(true), GString("2"), GUri("www.3cheese.com")),
       ids = Seq(GPrivate("4"), GPrivate("5"))
@@ -31,15 +112,15 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
     result shouldBe target
   }
 
-  "Send" should "pretty print" in {
+  "Send" should "Print" in {
     val source: Par =
       p.copy(sends = Seq(Send(Quote(Par()), List(Par(), Par()), true, 0, BitSet())))
     val result = PrettyPrinter().buildString(source)
-    val target = "@{ Nil }!!(Nil, Nil)"
+    val target = "@{Nil}!!(Nil, Nil)"
     result shouldBe target
   }
 
-  "Receive" should "print variable names consistently" in {
+  "Receive" should "Print variable names consistently" in {
 
     // new x0 in { for( z0 <- x0 ) { *x0 } }
     val source = p.copy(
@@ -60,11 +141,11 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
             ))))
 
     val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { for( z1 <- x0 ) { *x1 } }"
+    val target = "new x0 in { for( x1 <- x0 ) { *x1 } }"
     result shouldBe target
   }
 
-  "Receive" should "pretty print multiple patterns" in {
+  "Receive" should "Print multiple patterns" in {
 
     // new x0 in { for( z0, z1 <- x0 ) { *x1 | *x0 } }
     val source = p.copy(
@@ -86,12 +167,11 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
       )))
 
     val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { for( z1, z2 <- x0 ) { *x1 | *x2 } }"
+    val target = "new x0 in { for( x1, x2 <- x0 ) { *x1 | *x2 } }"
     result shouldBe target
   }
 
-  "Receive" should "pretty print multiple binds" in {
-
+  "Receive" should "Print multiple binds" in {
     // new x0 in { for( z0 <- x0 ; z0 <- x0 ) { *x1 | *x0 } }
     val source = p.copy(
       news = Seq(New(
@@ -116,11 +196,11 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
       )))
 
     val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { for( z1 <- x0 ; z2 <- x0 ) { *x1 | *x2 } }"
+    val target = "new x0 in { for( x1 <- x0 ; x2 <- x0 ) { *x1 | *x2 } }"
     result shouldBe target
   }
 
-  "Receive" should "pretty print multiple binds with multiple patterns" in {
+  "Receive" should "Print multiple binds with multiple patterns" in {
 
     // new x0, x1 in { for( z0, z1 <- x0 ; z0, z1 <- x1 ){ *x3 | *x2 | *x1 | *x0 } }
     val source = p.copy(
@@ -149,11 +229,49 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
       )))
 
     val result = PrettyPrinter().buildString(source)
-    val target = "new x0, x1 in { for( z2, z3 <- x0 ; z4, z5 <- x1 ) { *x2 | *x3 | *x4 | *x5 } }"
+    val target = "new x0, x1 in { for( x2, x3 <- x0 ; x4, x5 <- x1 ) { *x2 | *x3 | *x4 | *x5 } }"
     result shouldBe target
   }
 
-  "Reducible" should "use variable names consistently" in {
+  "Receive" should "Print partially empty Pars" in {
+    val source = p.copy(
+      news = Seq(New(
+        2,
+        p.copy(
+          receives = Seq(
+            Receive(
+              Seq(
+                ReceiveBind(
+                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
+                  ChanVar(BoundVar(1))
+                ),
+                ReceiveBind(
+                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
+                  ChanVar(BoundVar(0))
+                )
+              ),
+              p.copy(
+                evals = Seq(
+                  Eval(ChanVar(BoundVar(3))),
+                  Eval(ChanVar(BoundVar(2))),
+                  Eval(ChanVar(BoundVar(1)))
+                ),
+                sends = Seq(
+                  Send(ChanVar(BoundVar(0)), List(Par()), false)
+                )
+              )
+            )
+          )
+        )
+      )))
+
+    val result = PrettyPrinter().buildString(source)
+    val target =
+      "new x0, x1 in { for( x2, x3 <- x0 ; x4, x5 <- x1 ) { x5!(Nil) | *x2 | *x3 | *x4 } }"
+    result shouldBe target
+  }
+
+  "Reducible" should "Print variable names consistently" in {
     val source = p.copy(
       news = Seq(New(
         1,
@@ -174,7 +292,262 @@ class PrettyPrinterTest extends FlatSpec with PropertyChecks with Matchers {
       )))
 
     val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { x0!(Nil) | for( z1 <- x0 ) { *x1 } }"
+    val target = "new x0 in { x0!(Nil) | for( x1 <- x0 ) { *x1 } }"
     result shouldBe target
   }
+
+  "PNil" should "Print" in {
+    val nil = new PNil()
+    val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(nil, inputs).par)
+    result shouldBe "Nil"
+  }
+
+  val pvar = new PVar(new ProcVarVar("x"))
+  "PVar" should "Print with fresh identifier" in {
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(ProcNormalizeMatcher.normalizeMatch(pvar, boundInputs).par)
+    result shouldBe "x0"
+  }
+
+  "PEval" should "Print eval with fresh identifier" in {
+    val pEval = new PEval(new NameVar("x"))
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs).par)
+    result shouldBe "*x0"
+  }
+
+  "PEval" should "Recognize occurrences of the same variable during collapses" in {
+    val pEval = new PEval(
+      new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))))
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(ProcNormalizeMatcher.normalizeMatch(pEval, boundInputs).par)
+    result shouldBe "x0 | x0"
+  }
+
+  "PSend" should "Print" in {
+    val sentData = new ListProc()
+    sentData.add(new PGround(new GroundInt(7)))
+    sentData.add(new PGround(new GroundInt(8)))
+    val pSend = new PSend(new NameQuote(new PNil()), new SendSingle(), sentData)
+
+    val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pSend, inputs).par)
+    result shouldBe "@{Nil}!(7, 8)"
+  }
+
+  "PSend" should "Identify variables as they're bound" in {
+    val sentData = new ListProc()
+    sentData.add(new PGround(new GroundInt(7)))
+    sentData.add(new PGround(new GroundInt(8)))
+    val pSend = new PSend(new NameVar("x"), new SendSingle(), sentData)
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(ProcNormalizeMatcher.normalizeMatch(pSend, boundInputs).par)
+    result shouldBe "x0!(7, 8)"
+  }
+
+  "PPar" should "Respect sorting" in {
+    val parGround = new PPar(new PGround(new GroundInt(7)), new PGround(new GroundInt(8)))
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(parGround, inputs).par)
+    result shouldBe "8 | 7"
+  }
+
+  "PPar" should "Print" in {
+    val parDoubleBound = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
+    val result = PrettyPrinter(0, 1).buildString(
+      ProcNormalizeMatcher.normalizeMatch(parDoubleBound, boundInputs).par)
+    result shouldBe "x0 | x0"
+  }
+
+  "PPar" should "Use fresh identifiers for free variables" in {
+    val parDoubleFree = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(parDoubleFree, inputs).par)
+    result shouldBe "a1 | a0"
+  }
+
+  "PInput" should "Print a receive" in {
+    // for ( x, y <- @Nil ) { x!(*y) }
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("x"))
+    listBindings.add(new NameVar("y"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameQuote(new PNil())))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val listSend = new ListProc()
+    listSend.add(new PEval(new NameVar("y")))
+    val body = new PSend(new NameVar("x"), new SendSingle(), listSend)
+    val basicInput = new PInput(receipt, body)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
+    val target = "for( x0, x1 <- @{Nil} ) { x0!(*x1) }"
+    result shouldBe target
+  }
+
+  "PInput" should "Print a more complicated receive" in {
+    // for ( (x1, @y1) <- @Nil ; (x2, @y2) <- @1) { x1!(y2) | x2!(y1) }
+    val listBindings1 = new ListName()
+    listBindings1.add(new NameVar("x1"))
+    listBindings1.add(new NameQuote(new PVar(new ProcVarVar("y1"))))
+    val listBindings2 = new ListName()
+    listBindings2.add(new NameVar("x2"))
+    listBindings2.add(new NameQuote(new PVar(new ProcVarVar("y2"))))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameQuote(new PNil())))
+    listLinearBinds.add(
+      new LinearBindImpl(listBindings2, new NameQuote(new PGround(new GroundInt(1)))))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+
+    val listSend1 = new ListProc()
+    listSend1.add(new PVar(new ProcVarVar("y2")))
+    val listSend2 = new ListProc()
+    listSend2.add(new PVar(new ProcVarVar("y1")))
+    val body = new PPar(new PSend(new NameVar("x1"), new SendSingle(), listSend1),
+      new PSend(new NameVar("x2"), new SendSingle(), listSend2))
+    val pInput = new PInput(receipt, body)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pInput, inputs).par)
+    result shouldBe "for( x0, @{x1} <- @{Nil} ; x2, @{x3} <- @{1} ) { x2!(x1) | x0!(x3) }"
+  }
+
+  "PNew" should "Adjust levels of variables as they're bound" in {
+    val listNameDecl = new ListNameDecl()
+    listNameDecl.add(new NameDeclSimpl("x"))
+    listNameDecl.add(new NameDeclSimpl("y"))
+    listNameDecl.add(new NameDeclSimpl("z"))
+    val listData1 = new ListProc()
+    listData1.add(new PGround(new GroundInt(7)))
+    val listData2 = new ListProc()
+    listData2.add(new PGround(new GroundInt(8)))
+    val listData3 = new ListProc()
+    listData3.add(new PGround(new GroundInt(9)))
+    val pNew = new PNew(
+      listNameDecl,
+      new PPar(
+        new PPar(new PSend(new NameVar("x"), new SendSingle(), listData1),
+          new PSend(new NameVar("y"), new SendSingle(), listData2)),
+        new PSend(new NameVar("z"), new SendSingle(), listData3)
+      )
+    )
+    val result = PrettyPrinter()
+      .buildString(
+        ProcNormalizeMatcher
+          .normalizeMatch(pNew, inputs)
+          .par)
+    result shouldBe "new x0, x1, x2 in { x2!(9) | x1!(8) | x0!(7) }"
+  }
+
+  "PMatch" should "Print recognize pattern bindings" in {
+    // for (@x <- @Nil) { match x { case 42 => Nil ; case y => Nil } | @Nil!(47)
+    val listBindings = new ListName()
+    listBindings.add(new NameQuote(new PVar(new ProcVarVar("x"))))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameQuote(new PNil())))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val listCases = new ListCase()
+    listCases.add(new CaseImpl(new PGround(new GroundInt(42)), new PNil()))
+    listCases.add(new CaseImpl(new PVar(new ProcVarVar("y")), new PNil()))
+    val body = new PMatch(new PVar(new ProcVarVar("x")), listCases)
+    val listData = new ListProc()
+    listData.add(new PGround(new GroundInt(47)))
+    val send47OnNil = new PSend(new NameQuote(new PNil()), new SendSingle(), listData)
+    val pPar = new PPar(
+      new PInput(receipt, body),
+      send47OnNil
+    )
+    val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pPar, inputs).par)
+    result shouldBe "@{Nil}!(47) | for( @{x0} <- @{Nil} ) { match x0 { case 42 => Nil ; case x1 => Nil } }"
+  }
+
+  "PIf" should "Print as a match" in {
+    val condition = new PGround(new GroundBool(new BoolTrue()))
+    val listSend = new ListProc()
+    listSend.add(new PGround(new GroundInt(47)))
+    val body = new PSend(new NameQuote(new PNil()), new SendSingle(), listSend)
+    val basicInput = new PIf(condition, body)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
+    result shouldBe "match true { case true => @{Nil}!(47) ; case false => Nil }"
+  }
+
+  "PIfElse" should "Print" in {
+    // if (47 == 47) { new x in { x!(47) } } else { new y in { y!(47) } }
+    val condition = new PEq(new PGround(new GroundInt(47)), new PGround(new GroundInt(47)))
+    val xNameDecl = new ListNameDecl()
+    xNameDecl.add(new NameDeclSimpl("x"))
+    val xSendData = new ListProc()
+    xSendData.add(new PGround(new GroundInt(47)))
+    val pNewIf = new PNew(
+      xNameDecl,
+      new PSend(new NameVar("x"), new SendSingle(), xSendData)
+    )
+    val yNameDecl = new ListNameDecl()
+    yNameDecl.add(new NameDeclSimpl("y"))
+    val ySendData = new ListProc()
+    ySendData.add(new PGround(new GroundInt(47)))
+    val pNewElse = new PNew(
+      yNameDecl,
+      new PSend(new NameVar("y"), new SendSingle(), ySendData)
+    )
+    val basicInput = new PIfElse(condition, pNewIf, pNewElse)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
+    result shouldBe "match 47 == 47 { case true => new x0 in { x0!(47) } ; case false => new x0 in { x0!(47) } }"
+  }
+
+  "PMatch" should "Print" in {
+    // for (@{match {x | y} { 47 => Nil }} <- @Nil) { Nil }
+    val listCases = new ListCase()
+    listCases.add(new CaseImpl(new PGround(new GroundInt(47)), new PNil()))
+    val pMatch =
+      new PMatch(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y"))), listCases)
+    val listBindings = new ListName()
+    listBindings.add(new NameQuote(pMatch))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameQuote(new PNil())))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val input = new PInput(receipt, new PNil())
+    val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(input, inputs).par)
+    result shouldBe "for( @{match x0 | x1 { case 47 => Nil }} <- @{Nil} ) { Nil }"
+  }
+
+}
+
+class NamePrinterSpec extends FlatSpec with Matchers {
+
+  val inputs = NameVisitInputs(DebruijnIndexMap[VarSort](), DebruijnLevelMap[VarSort]())
+
+  "NameWildcard" should "Print" in {
+    val nw = new NameWildcard()
+    val result = PrettyPrinter().buildString(NameNormalizeMatcher.normalizeMatch(nw, inputs).chan)
+    result shouldBe "_"
+  }
+
+  val nvar = new NameVar("x")
+
+  "NameVar" should "Print" in {
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(NameNormalizeMatcher.normalizeMatch(nvar, boundInputs).chan)
+    result shouldBe "x0"
+  }
+
+  val nqvar = new NameQuote(new PVar(new ProcVarVar("x")))
+
+  "NameQuote" should "Print" in {
+    val nqeval = new NameQuote(new PPar(new PEval(new NameVar("x")), new PEval(new NameVar("x"))))
+    val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
+    val result =
+      PrettyPrinter(0, 1).buildString(NameNormalizeMatcher.normalizeMatch(nqeval, boundInputs).chan)
+    result shouldBe "@{*x0 | *x0}"
+  }
+
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -2,7 +2,6 @@ package coop.rchain.rholang.interpreter
 
 import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
 import coop.rchain.models.{Send, _}
 import coop.rchain.rholang.interpreter.implicits.{GPrivate, _}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
@@ -110,178 +109,147 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   }
 
   "Receive" should "Print variable names consistently" in {
+    // new x in { for( z <- x ) { *z } }
 
-    // new x0 in { for( z0 <- x0 ) { *x0 } }
-    val source = p.copy(
-      news = Seq(
-        New(1,
-            p.copy(
-              receives = Seq(
-                Receive(
-                  Seq(
-                    ReceiveBind(
-                      Seq(ChanVar(FreeVar(0))),
-                      ChanVar(BoundVar(0))
-                    )
-                  ),
-                  p.copy(evals = Seq(Eval(ChanVar(BoundVar(0)))))
-                )
-              )
-            ))))
-
-    val result = PrettyPrinter().buildString(source)
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("z"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val cont = new PEval(new NameVar("z"))
+    val receive = new PInput(receipt, cont)
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    val source = new PNew(nameDec, receive)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
     val target = "new x0 in { for( x1 <- x0 ) { *x1 } }"
     result shouldBe target
   }
 
   "Receive" should "Print multiple patterns" in {
+    // new x in { for( y, z <- x ) { *y | *z } }
 
-    // new x0 in { for( z0, z1 <- x0 ) { *x1 | *x0 } }
-    val source = p.copy(
-      news = Seq(New(
-        1,
-        p.copy(
-          receives = Seq(
-            Receive(
-              Seq(
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
-                  ChanVar(BoundVar(0))
-                )
-              ),
-              p.copy(evals = Seq(Eval(ChanVar(BoundVar(1))), Eval(ChanVar(BoundVar(0)))))
-            )
-          )
-        )
-      )))
-
-    val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { for( x1, x2 <- x0 ) { *x1 | *x2 } }"
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("y"))
+    listBindings.add(new NameVar("z"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val cont = new PPar(new PEval(new NameVar("y")), new PEval(new NameVar("z")))
+    val receive = new PInput(receipt, cont)
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    val source = new PNew(nameDec, receive)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
+    val target = "new x0 in { for( x1, x2 <- x0 ) { *x2 | *x1 } }"
     result shouldBe target
   }
 
   "Receive" should "Print multiple binds" in {
-    // new x0 in { for( z0 <- x0 ; z0 <- x0 ) { *x1 | *x0 } }
-    val source = p.copy(
-      news = Seq(New(
-        1,
-        p.copy(
-          receives = Seq(
-            Receive(
-              Seq(
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0))),
-                  ChanVar(BoundVar(0))
-                ),
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0))),
-                  ChanVar(BoundVar(0))
-                )
-              ),
-              p.copy(evals = Seq(Eval(ChanVar(BoundVar(1))), Eval(ChanVar(BoundVar(0)))))
-            )
-          )
-        )
-      )))
+    // new x in { for( y <- x ; z <- x ){ *y | *z } }
 
-    val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { for( x1 <- x0 ; x2 <- x0 ) { *x1 | *x2 } }"
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("y"))
+    val listBindings1 = new ListName()
+    listBindings1.add(new NameVar("z"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameVar("x")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val cont = new PPar(new PEval(new NameVar("y")), new PEval(new NameVar("z")))
+    val receive = new PInput(receipt, cont)
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    val source = new PNew(nameDec, receive)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
+    val target = "new x0 in { for( x1 <- x0 ; x2 <- x0 ) { *x2 | *x1 } }"
     result shouldBe target
   }
 
   "Receive" should "Print multiple binds with multiple patterns" in {
+    // new x, y in { for( z, v <- x ; a, b <- y ){ *z | *v | *a | *b }
 
-    // new x0, x1 in { for( z0, z1 <- x0 ; z0, z1 <- x1 ){ *x3 | *x2 | *x1 | *x0 } }
-    val source = p.copy(
-      news = Seq(New(
-        2,
-        p.copy(
-          receives = Seq(
-            Receive(
-              Seq(
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
-                  ChanVar(BoundVar(1))
-                ),
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
-                  ChanVar(BoundVar(0))
-                )
-              ),
-              p.copy(evals = Seq(Eval(ChanVar(BoundVar(3))),
-                                 Eval(ChanVar(BoundVar(2))),
-                                 Eval(ChanVar(BoundVar(1))),
-                                 Eval(ChanVar(BoundVar(0)))))
-            )
-          )
-        )
-      )))
-
-    val result = PrettyPrinter().buildString(source)
-    val target = "new x0, x1 in { for( x2, x3 <- x0 ; x4, x5 <- x1 ) { *x2 | *x3 | *x4 | *x5 } }"
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("z"))
+    listBindings.add(new NameVar("v"))
+    val listBindings1 = new ListName()
+    listBindings1.add(new NameVar("a"))
+    listBindings1.add(new NameVar("b"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameVar("y")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val cont = new PPar(new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
+      new PPar(new PEval(new NameVar("a")), new PEval(new NameVar("b"))))
+    val receive = new PInput(receipt, cont)
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    nameDec.add(new NameDeclSimpl("y"))
+    val source = new PNew(nameDec, receive)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
+    val target = "new x0, x1 in { for( x2, x3 <- x1 ; x4, x5 <- x0 ) { *x3 | *x2 | *x5 | *x4 } }"
     result shouldBe target
   }
 
   "Receive" should "Print partially empty Pars" in {
-    val source = p.copy(
-      news = Seq(New(
-        2,
-        p.copy(
-          receives = Seq(
-            Receive(
-              Seq(
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
-                  ChanVar(BoundVar(1))
-                ),
-                ReceiveBind(
-                  Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))),
-                  ChanVar(BoundVar(0))
-                )
-              ),
-              p.copy(
-                evals = Seq(
-                  Eval(ChanVar(BoundVar(3))),
-                  Eval(ChanVar(BoundVar(2))),
-                  Eval(ChanVar(BoundVar(1)))
-                ),
-                sends = Seq(
-                  Send(ChanVar(BoundVar(0)), List(Par()), false)
-                )
-              )
-            )
-          )
-        )
-      )))
+    // new x, y in { for( z, v <- x ; a, b <- y ){ *b!(Nil) | *z | *v | *a }
 
-    val result = PrettyPrinter().buildString(source)
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("z"))
+    listBindings.add(new NameVar("v"))
+    val listBindings1 = new ListName()
+    listBindings1.add(new NameVar("a"))
+    listBindings1.add(new NameVar("b"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameVar("y")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val sentData = new ListProc()
+    sentData.add(new PNil())
+    val pSend = new PSend(new NameVar("b"), new SendSingle(), sentData)
+    val cont = new PPar(new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
+      new PPar(new PEval(new NameVar("a")), pSend))
+    val receive = new PInput(receipt, cont)
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    nameDec.add(new NameDeclSimpl("y"))
+    val source = new PNew(nameDec, receive)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
     val target =
-      "new x0, x1 in { for( x2, x3 <- x0 ; x4, x5 <- x1 ) { x5!(Nil) | *x2 | *x3 | *x4 } }"
+      "new x0, x1 in { for( x2, x3 <- x1 ; x4, x5 <- x0 ) { x3!(Nil) | *x2 | *x5 | *x4 } }"
     result shouldBe target
   }
 
   "Reducible" should "Print variable names consistently" in {
-    val source = p.copy(
-      news = Seq(New(
-        1,
-        p.copy(
-          receives = Seq(
-            Receive(
-              Seq(ReceiveBind(
-                Seq(ChanVar(FreeVar(0))),
-                ChanVar(BoundVar(0))
-              )),
-              p.copy(evals = Seq(Eval(ChanVar(BoundVar(0)))))
-            )
-          ),
-          sends = Seq(
-            Send(ChanVar(BoundVar(0)), List(Par()), false, 0, BitSet())
-          )
-        )
-      )))
+    // new x in { x!(*x) | for( z <- x ){ *z } }
 
-    val result = PrettyPrinter().buildString(source)
-    val target = "new x0 in { x0!(Nil) | for( x1 <- x0 ) { *x1 } }"
+    val listBindings = new ListName()
+    listBindings.add(new NameVar("z"))
+    val listLinearBinds = new ListLinearBind()
+    listLinearBinds.add(new LinearBindImpl(listBindings, new NameVar("x")))
+    val linearSimple = new LinearSimple(listLinearBinds)
+    val receipt = new ReceiptLinear(linearSimple)
+    val cont = new PEval(new NameVar("z"))
+    val sentData = new ListProc()
+    sentData.add(new PEval(new NameVar("x")))
+    val body =
+      new PPar(new PSend(new NameVar("x"), new SendSingle(), sentData), new PInput(receipt, cont))
+    val nameDec = new ListNameDecl()
+    nameDec.add(new NameDeclSimpl("x"))
+    val source = new PNew(nameDec, body)
+    val result =
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(source, inputs).par)
+    val target = "new x0 in { x0!(*x0) | for( x1 <- x0 ) { *x1 } }"
     result shouldBe target
   }
 
@@ -321,7 +289,6 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     sentData.add(new PGround(new GroundInt(7)))
     sentData.add(new PGround(new GroundInt(8)))
     val pSend = new PSend(new NameQuote(new PNil()), new SendSingle(), sentData)
-
     val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pSend, inputs).par)
     result shouldBe "@{Nil}!(7, 8)"
   }
@@ -360,26 +327,38 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   }
 
   "PInput" should "Print a receive" in {
-    // for ( x, y <- @Nil ) { x!(*y) }
+    // for ( x, @for( @y, z <- @Nil ){ y | u | *z } <- @Nil ) { x!(u) }
+
     val listBindings = new ListName()
-    listBindings.add(new NameVar("x"))
-    listBindings.add(new NameVar("y"))
+    listBindings.add(new NameQuote(new PVar(new ProcVarVar("y"))))
+    listBindings.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(new LinearBindImpl(listBindings, new NameQuote(new PNil())))
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt = new ReceiptLinear(linearSimple)
-    val listSend = new ListProc()
-    listSend.add(new PEval(new NameVar("y")))
-    val body = new PSend(new NameVar("x"), new SendSingle(), listSend)
+    val body = new PPar(new PVar(new ProcVarVar("y")),
+      new PPar(new PEval(new NameVar("z")), new PVar(new ProcVarVar("u"))))
     val basicInput = new PInput(receipt, body)
+    val listBindings1 = new ListName()
+    listBindings1.add(new NameVar("x"))
+    listBindings1.add(new NameQuote(basicInput))
+    val listLinearBinds1 = new ListLinearBind()
+    listLinearBinds1.add(new LinearBindImpl(listBindings1, new NameQuote(new PNil())))
+    val linearSimple1 = new LinearSimple(listLinearBinds1)
+    val receipt1 = new ReceiptLinear(linearSimple1)
+    val listSend1 = new ListProc()
+    listSend1.add(new PVar(new ProcVarVar("u")))
+    val body1 = new PSend(new NameVar("x"), new SendSingle(), listSend1)
+    val basicInput1 = new PInput(receipt1, body1)
     val result =
-      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
-    val target = "for( x0, x1 <- @{Nil} ) { x0!(*x1) }"
+      PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput1, inputs).par)
+    val target = "for( x0, @{for( @{y0}, y1 <- @{Nil} ) { *y1 | y0 | x1 }} <- @{Nil} ) { x0!(x1) }"
     result shouldBe target
   }
 
   "PInput" should "Print a more complicated receive" in {
-    // for ( (x1, @y1) <- @Nil ; (x2, @y2) <- @1) { x1!(y2) | x2!(y1) }
+    // new x, y in { for ( z, @a <- y ; b, @c <- x ) { z!(c) | b!(a) | for( d <- b ){ *d | match d { case 42 => Nil ; case e => c } }
+
     val listBindings1 = new ListName()
     listBindings1.add(new NameVar("x1"))
     listBindings1.add(new NameQuote(new PVar(new ProcVarVar("y1"))))
@@ -387,25 +366,40 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings2.add(new NameVar("x2"))
     listBindings2.add(new NameQuote(new PVar(new ProcVarVar("y2"))))
     val listLinearBinds = new ListLinearBind()
-    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameQuote(new PNil())))
-    listLinearBinds.add(
-      new LinearBindImpl(listBindings2, new NameQuote(new PGround(new GroundInt(1)))))
+    listLinearBinds.add(new LinearBindImpl(listBindings1, new NameVar("x")))
+    listLinearBinds.add(new LinearBindImpl(listBindings2, new NameVar("v")))
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt = new ReceiptLinear(linearSimple)
-
     val listSend1 = new ListProc()
     listSend1.add(new PVar(new ProcVarVar("y2")))
     val listSend2 = new ListProc()
     listSend2.add(new PVar(new ProcVarVar("y1")))
+    val listBindings3 = new ListName()
+    listBindings3.add(new NameVar("z"))
+    val listLinearBinds2 = new ListLinearBind()
+    listLinearBinds2.add(new LinearBindImpl(listBindings3, new NameVar("x1")))
+    val receipt2 = new ReceiptLinear(new LinearSimple(listLinearBinds2))
     val body = new PPar(new PSend(new NameVar("x1"), new SendSingle(), listSend1),
       new PSend(new NameVar("x2"), new SendSingle(), listSend2))
-    val pInput = new PInput(receipt, body)
+    val listCases = new ListCase()
+    listCases.add(new CaseImpl(new PGround(new GroundInt(42)), new PNil()))
+    listCases.add(new CaseImpl(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("y2"))))
+    val body3 = new PPar(body,
+      new PInput(receipt2,
+        new PPar(new PEval(new NameVar("z")),
+          new PMatch(new PEval(new NameVar("z")), listCases))))
+    val listNameDecl = new ListNameDecl()
+    listNameDecl.add(new NameDeclSimpl("x"))
+    listNameDecl.add(new NameDeclSimpl("v"))
+    val pInput = new PNew(listNameDecl, new PInput(receipt, body3))
     val result =
       PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pInput, inputs).par)
-    result shouldBe "for( x0, @{x1} <- @{Nil} ; x2, @{x3} <- @{1} ) { x2!(x1) | x0!(x3) }"
+    result shouldBe "new x0, x1 in { for( x2, @{x3} <- x1 ; x4, @{x5} <- x0 ) { x2!(x5) | x4!(x3) | for( x6 <- x4 ) { *x6 | match *x6 { 42 => Nil ; x7 => x3 } } } }"
   }
 
   "PNew" should "Adjust levels of variables as they're bound" in {
+    // new x, y, z in { x!(7) | y!(8) | z!(9) }
+
     val listNameDecl = new ListNameDecl()
     listNameDecl.add(new NameDeclSimpl("x"))
     listNameDecl.add(new NameDeclSimpl("y"))
@@ -433,7 +427,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   }
 
   "PMatch" should "Print recognize pattern bindings" in {
-    // for (@x <- @Nil) { match x { case 42 => Nil ; case y => Nil } | @Nil!(47)
+    // for (@x <- @Nil) { match x { 42 => Nil ; y => Nil } } | @Nil!(47)
+
     val listBindings = new ListName()
     listBindings.add(new NameQuote(new PVar(new ProcVarVar("x"))))
     val listLinearBinds = new ListLinearBind()
@@ -452,7 +447,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       send47OnNil
     )
     val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(pPar, inputs).par)
-    result shouldBe "@{Nil}!(47) | for( @{x0} <- @{Nil} ) { match x0 { case 42 => Nil ; case x1 => Nil } }"
+    result shouldBe "@{Nil}!(47) | for( @{x0} <- @{Nil} ) { match x0 { 42 => Nil ; x1 => Nil } }"
   }
 
   "PIf" should "Print as a match" in {
@@ -463,7 +458,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val basicInput = new PIf(condition, body)
     val result =
       PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
-    result shouldBe "match true { case true => @{Nil}!(47) ; case false => Nil }"
+    result shouldBe "match true { true => @{Nil}!(47) ; false => Nil }"
   }
 
   "PIfElse" should "Print" in {
@@ -488,7 +483,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val basicInput = new PIfElse(condition, pNewIf, pNewElse)
     val result =
       PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(basicInput, inputs).par)
-    result shouldBe "match 47 == 47 { case true => new x0 in { x0!(47) } ; case false => new x0 in { x0!(47) } }"
+    result shouldBe "match 47 == 47 { true => new x0 in { x0!(47) } ; false => new x0 in { x0!(47) } }"
   }
 
   "PMatch" should "Print" in {
@@ -505,7 +500,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val receipt = new ReceiptLinear(linearSimple)
     val input = new PInput(receipt, new PNil())
     val result = PrettyPrinter().buildString(ProcNormalizeMatcher.normalizeMatch(input, inputs).par)
-    result shouldBe "for( @{match x0 | x1 { case 47 => Nil }} <- @{Nil} ) { Nil }"
+    result shouldBe "for( @{match x0 | x1 { 47 => Nil }} <- @{Nil} ) { Nil }"
   }
 
 }
@@ -529,8 +524,8 @@ class IncrementTester extends FlatSpec with Matchers {
     val _printer: PrettyPrinter = (printer /: (0 until 52)) { (p, _) =>
       p.copy(
         freeId = p.boundId,
-        boundId = p.rotate(p.increment(p.baseId)),
-        baseId = p.increment(p.baseId)
+        boundId = p.setBoundId(),
+        baseId = p.setBaseId()
       )
     }
     _printer.freeId shouldBe "xw"


### PR DESCRIPTION
This PR contains changes to PrettyPrinter that removes a previous distinction between bound and free occurrences of the same variable. Instead, a ROT-N (default 23) encoding is used to generate a fresh variable prefix when a pattern is introduced.

This PR also contains updates to tests for the PrettyPrinter. It uses NormalizeTest for base expressions, printing the output of normalizations to show that pretty printing after normalization outputs a rholang term semantically equivalent to the input term.

This concludes RHOL-241