### PR TITLE
Rholang: Reduce: Substitute before doing equality comparison.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -372,12 +372,17 @@ object Reduce {
           for {
             v1 <- evalExpr(p1.get)
             v2 <- evalExpr(p2.get)
-          } yield GBool(v1 == v2)
+            // TODO: build an equality operator that takes in an environment.
+            sv1 = substitute(v1)
+            sv2 = substitute(v2)
+          } yield GBool(sv1 == sv2)
         case ENeqBody(ENeq(p1, p2)) =>
           for {
-            v1 <- evalExpr(p1.get)
-            v2 <- evalExpr(p2.get)
-          } yield GBool(v1 != v2)
+            v1  <- evalExpr(p1.get)
+            v2  <- evalExpr(p2.get)
+            sv1 = substitute(v1)
+            sv2 = substitute(v2)
+          } yield GBool(sv1 != sv2)
         case EAndBody(EAnd(p1, p2)) =>
           for {
             b1 <- evalToBool(p1.get)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
@@ -75,6 +75,17 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(expected)
   }
 
+  "evalExpr" should "substitute before comparison." in {
+    val result = withTestStore { store =>
+      val env        = Env.makeEnv(Par(), Par())
+      val eqExpr     = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
+      val resultTask = Reduce.makeInterpreter(store).evalExpr(eqExpr)(env)
+      Await.result(resultTask.runAsync, 3.seconds)
+    }
+    val expected: Expr = GBool(true)
+    result should be(expected)
+  }
+
   "eval of Send" should "place something in the tuplespace." in {
     val result = withTestStore { store =>
       val send =


### PR DESCRIPTION
Equality without substitution is really tricky, and we may not ever do it.
Equality with substitution is just a byte compare, although it costs a full
substitution. We have the substitution libraries already, so lets use those.