### PR TITLE
storage: add extended package

### DIFF
--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path}
 import cats.syntax.either._
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.extended._
 import coop.rchain.rspace.{LMDBStore, _}
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -67,14 +67,4 @@ object StringExamples {
     implicit val patternSerialize: Serialize[Pattern] =
       makeSerializeFromSerializable[Pattern]
   }
-
-  /* Convenience Functions */
-
-  /** Runs a given test continuation with given data as its arguments.
-    */
-  def runK(t: Option[(StringsCaptor, List[String])]): Unit =
-    t.foreach { case (k, data) => k(data) }
-
-  def getK(t: Option[(StringsCaptor, List[String])]): StringsCaptor =
-    t.map(_._1).get
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/extended/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/extended/package.scala
@@ -1,0 +1,63 @@
+package coop.rchain.rspace
+
+import scala.annotation.tailrec
+
+package object extended {
+
+  def getK[A, K](t: Option[(K, A)]): K =
+    t.map(_._1).get
+
+  /** Runs a continuation with the accompanying data
+    */
+  def runK[T](t: Option[(Function1[T, Unit], T)]): Unit =
+    t.foreach { case (k, data) => k(data) }
+
+  /** Runs a list of continuations with the accompanying data
+    */
+  def runKs[T](t: List[Option[(Function1[T, Unit], T)]]): Unit =
+    t.foreach { case Some((k, data)) => k(data); case None => () }
+
+  /** Consume all
+    */
+  def consumeAll[C, P, A, K](
+      store: IStore[C, P, A, K],
+      channels: List[C],
+      patterns: List[P],
+      continuation: K)(implicit m: Match[P, A]): List[Option[(K, List[A])]] = {
+    @tailrec
+    def loop(acc: List[Option[(K, List[A])]]): List[Option[(K, List[A])]] =
+      consume(store, channels, patterns, continuation, persist = false) match {
+        case r @ Some(_) => loop(r :: acc)
+        case None        => acc
+      }
+    loop(List.empty[Option[(K, List[A])]])
+  }
+
+  /** Persistent consume
+    */
+  def pconsume[C, P, A, K](store: IStore[C, P, A, K],
+                           channels: List[C],
+                           patterns: List[P],
+                           continuation: K)(implicit m: Match[P, A]): List[(K, List[A])] = {
+    @tailrec
+    def loop(acc: List[(K, List[A])]): List[(K, List[A])] =
+      consume(store, channels, patterns, continuation, persist = true) match {
+        case Some(res) => loop(res :: acc)
+        case None      => acc
+      }
+    loop(List.empty[(K, List[A])])
+  }
+
+  /** Persistent produce
+    */
+  def pproduce[C, P, A, K](store: IStore[C, P, A, K], channel: C, data: A)(
+      implicit m: Match[P, A]): List[(K, List[A])] = {
+    @tailrec
+    def loop(acc: List[(K, List[A])]): List[(K, List[A])] =
+      produce(store, channel, data, persist = true) match {
+        case Some(res) => loop(res :: acc)
+        case None      => acc
+      }
+    loop(List.empty[(K, List[A])])
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import com.typesafe.scalalogging.Logger
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.extended._
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.test._
 import org.scalatest._


### PR DESCRIPTION
This PR reshuffles some preexisting convenience functions and adds more of them in the `coop.rchain.rspace.extended` package.  I'm putting these here so that I can leverage them in tutorial examples.