### PR TITLE
storage: add non-determinism

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/package.scala
@@ -6,6 +6,7 @@ import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.ignore
 
 import scala.annotation.tailrec
+import scala.util.Random
 
 package object rspace {
 
@@ -36,7 +37,7 @@ package object rspace {
       channels.zip(patterns).map {
         case (channel, pattern) =>
           val indexedData: List[(Datum[A], Int)] = store.getAs(txn, List(channel)).zipWithIndex
-          findMatchingDataCandidate(channel, indexedData, pattern)
+          findMatchingDataCandidate(channel, Random.shuffle(indexedData), pattern)
       }
     options.sequence[Option, DataCandidate[C, A]]
   }
@@ -54,7 +55,7 @@ package object rspace {
           findMatchingDataCandidate(channel, indexedData, pattern)
         case (channel, pattern) =>
           val indexedData: List[(Datum[A], Int)] = store.getAs(txn, List(channel)).zipWithIndex
-          findMatchingDataCandidate(channel, indexedData, pattern)
+          findMatchingDataCandidate(channel, Random.shuffle(indexedData), pattern)
       }
     options.sequence[Option, DataCandidate[C, A]]
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/package.scala
@@ -153,7 +153,7 @@ package object rspace {
       case channels :: remaining =>
         val matchCandidates: List[(WaitingContinuation[P, K], Int)] =
           store.getPsK(txn, channels).zipWithIndex
-        extractFirstMatch(store, channels, matchCandidates, channel, data)(txn) match {
+        extractFirstMatch(store, channels, Random.shuffle(matchCandidates), channel, data)(txn) match {
           case None             => extractProduceCandidateAlt(store, remaining, channel, data)(txn)
           case produceCandidate => produceCandidate
         }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -177,19 +177,19 @@ trait StorageActionsTests extends StorageActionsBase {
 
     runK(r4)
 
-    getK(r4).results should contain theSameElementsAs List(List("datum3"))
+    getK(r4).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     val r5 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
     runK(r5)
 
-    getK(r5).results should contain theSameElementsAs List(List("datum2"))
+    getK(r5).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     val r6 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
     runK(r6)
 
-    getK(r6).results should contain theSameElementsAs List(List("datum1"))
+    getK(r6).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     store.isEmpty shouldBe true
   }
@@ -808,8 +808,11 @@ trait StorageActionsTests extends StorageActionsBase {
     val r4 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
     store.withTxn(store.createTxnRead()) { txn =>
-      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum2", persist = false),
-                                                  Datum("datum1", persist = false))
+      store.getAs(txn, List("ch1")) should contain atLeastOneOf (
+        Datum("datum1", persist = false),
+        Datum("datum2", persist = false),
+        Datum("datum3", persist = false)
+      )
       store.getPsK(txn, List("ch1")) shouldBe Nil
     }
 
@@ -817,13 +820,17 @@ trait StorageActionsTests extends StorageActionsBase {
 
     runK(r4)
 
-    getK(r4).results should contain theSameElementsAs List(List("datum3"))
+    getK(r4).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     // Matching data exists so the write will not "stick"
     val r5 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
     store.withTxn(store.createTxnRead()) { txn =>
-      store.getAs(txn, List("ch1")) shouldBe List(Datum("datum1", persist = false))
+      store.getAs(txn, List("ch1")) should contain oneOf (
+        Datum("datum1", persist = false),
+        Datum("datum2", persist = false),
+        Datum("datum3", persist = false)
+      )
       store.getPsK(txn, List("ch1")) shouldBe Nil
     }
 
@@ -831,7 +838,7 @@ trait StorageActionsTests extends StorageActionsBase {
 
     runK(r5)
 
-    getK(r5).results should contain theSameElementsAs List(List("datum2"))
+    getK(r5).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     // Matching data exists so the write will not "stick"
     val r6 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
@@ -842,7 +849,7 @@ trait StorageActionsTests extends StorageActionsBase {
 
     runK(r6)
 
-    getK(r6).results should contain theSameElementsAs List(List("datum1"))
+    getK(r6).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     // All matching data has been consumed, so the write will "stick"
     val r7 = consume(store, List("ch1"), List(Wildcard), new StringsCaptor, persist = true)


### PR DESCRIPTION
This PR adds a naive form of non-determinism to which data and continuation we return by shuffling the lists before doing the matching.