### PR TITLE
storage: publicize makeSerializeFromSerializable

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
@@ -7,7 +7,7 @@ import coop.rchain.rspace.util.withResource
 
 package object examples {
 
-  private[rspace] def makeSerializeFromSerializable[T <: Serializable]: Serialize[T] =
+  def makeSerializeFromSerializable[T <: Serializable]: Serialize[T] =
     new Serialize[T] {
 
       def encode(a: T): Array[Byte] =


### PR DESCRIPTION
This PR is needed for making the machine-checked tutorials work.  Not a super huge fan of publicizing it, but it's deliberately in the `examples` package to embarrass actual users and provide a bit of backstory for the day when we deprecate it.