### PR TITLE
CORE-292 Change key store to persistent kvs

### DIFF
--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/keystore.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/keystore.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package coop.rchain.comm;
+
+import "scalapb/scalapb.proto";
+
+
+option (scalapb.options) = {
+  package_name: "coop.rchain.comm"
+  flat_package: true
+};
+
+message KeysStore {
+  map<string, bytes>    keys   = 1;
+}


### PR DESCRIPTION
Serialize map to a file on each write. Read file on startup. Uses immutable map. Does not block on concurrent access (which is not needed as comm is sequential in its nature)