### PR TITLE
Continue 0.1 linking examples translation to 0.2

### DIFF
--- a/rholang/examples/linking/v0.2/packages/LinkedList.rho
+++ b/rholang/examples/linking/v0.2/packages/LinkedList.rho
@@ -141,9 +141,24 @@ export LinkedList in {
       } | loop!(end - 1, [])
     }
   } |
+  //Create a linked list from an ordinary list of length
+  //6 or less by pattern matching. This constructor is
+  //only temporary until list processes have methods.
+  contract @[*LinkedList, "fromSmallList"](@list, return) = {
+    match list {
+      []                 => { return!([]) }
+      [a]                => { return!([a, []]) }
+      [a, b]             => { return!([a, [b, []]]) }
+      [a, b, c]          => { return!([a, [b, [c, []]]]) }
+      [a, b, c, d]       => { return!([a, [b, [c, [d, []]]]]) }
+      [a, b, c, d, e]    => { return!([a, [b, [c, [d, [e, []]]]]]) }
+      [a, b, c, d, e, f] => { return!([a, [b, [c, [d, [e, [f, []]]]]]]) }
+      _ => { return!("Error! List to long for conversion to linked list.") }
+    }
+  } |
   import RhoClass in {
-    contract LinkedList(@method, @args) = {
-      @[*RhoClass, "apply"]!([*LinkedList, method], args)
+    contract LinkedList(@method, @input, return) = {
+      @[*RhoClass, "functionApply"]!([*LinkedList, method], input, *return)
     }
   }
 }

--- a/rholang/examples/linking/v0.2/packages/LinkedList.rho
+++ b/rholang/examples/linking/v0.2/packages/LinkedList.rho
@@ -81,7 +81,7 @@ export LinkedList in {
   contract @[*LinkedList, "foreach"](@list, proc, isDone) = {
     new combinator, nilReturn in {
       contract combinator(@head, @accumulatedValue, return) = {
-        //need return flag from `proc` in order to guarantee execution order
+        //Need return flag from `proc` in order to guarantee execution order
         new isDone in { proc!(head, *isDone) | for(_ <- isDone){ return!(Nil) } }
       } | 
       @[*LinkedList, "fold"]!(list, Nil, *combinator, *nilReturn) | for(_ <- nilReturn){ isDone!(true) }
@@ -99,7 +99,7 @@ export LinkedList in {
         for(@r <- result) {
           match r {
             [true, [_, v]] => { return!(v) }
-            _ => { return!(Nil) } //index out of bounds
+            _ => { return!(Nil) } //Index out of bounds
           }
         }
       }
@@ -115,7 +115,7 @@ export LinkedList in {
         for(@r <- result) {
           match r {
             [true, i] => { return!(i) }
-            _ => { return!(-1) } //element not found
+            _ => { return!(-1) } //Element not found
           }
         }
       }

--- a/rholang/examples/linking/v0.2/packages/LinkedList.rho
+++ b/rholang/examples/linking/v0.2/packages/LinkedList.rho
@@ -153,7 +153,7 @@ export LinkedList in {
       [a, b, c, d]       => { return!([a, [b, [c, [d, []]]]]) }
       [a, b, c, d, e]    => { return!([a, [b, [c, [d, [e, []]]]]]) }
       [a, b, c, d, e, f] => { return!([a, [b, [c, [d, [e, [f, []]]]]]]) }
-      _ => { return!("Error! List to long for conversion to linked list.") }
+      _ => { return!("Error! List too long for conversion to linked list.") }
     }
   } |
   import RhoClass in {

--- a/rholang/examples/linking/v0.2/packages/NonNegativeNumber.rho
+++ b/rholang/examples/linking/v0.2/packages/NonNegativeNumber.rho
@@ -1,4 +1,4 @@
-//this is a contract to explicitly implement the int >= 0 behavioural type
+//This is a contract to explicitly implement the int >= 0 behavioural type
 export NonNegativeNumber in {
   import RhoClass in {
     contract NonNegativeNumber(@init, return) = {
@@ -39,7 +39,7 @@ export NonNegativeNumber in {
         return!(*this) |
         match init >= 0 {
           true => { valueStore!(init) }
-          _ => { valueStore!(0) } //initial balance is zero if given is negative
+          _ => { valueStore!(0) } //Initial balance is zero if given is negative
         }
       }
     }

--- a/rholang/examples/linking/v0.2/packages/NonNegativeNumber.rho
+++ b/rholang/examples/linking/v0.2/packages/NonNegativeNumber.rho
@@ -1,0 +1,47 @@
+//this is a contract to explicitly implement the int >= 0 behavioural type
+export NonNegativeNumber in {
+  import RhoClass in {
+    contract NonNegativeNumber(@init, return) = {
+      new this, valueStore in {
+        contract @[*this, "add"](@x, success) = {
+          match x >= 0 {
+            true => {
+              for(@v <- valueStore){
+                valueStore!(v + x) | success!(true)
+              }
+            }
+            _ => { success!(false)  }
+          }
+        } |
+        contract @[*this, "sub"](@x, success) = {
+          match x >= 0 {
+            true => {
+              for(@v <- valueStore) {
+                match x <= v {
+                  true => {
+                    valueStore!(v - x) | success!(true)
+                  }
+                  _ => { valueStore!(v) | success!(false) }
+                }
+              }
+            }
+            _ => { success!(false) }
+          }
+        } |
+        contract @[*this, "value"](return) = {
+          for(@v <- valueStore) {
+            valueStore!(v) | return!(v)
+          }
+        } |
+        contract this(@method, @input, return) = {
+          @[*RhoClass, "functionApply"]!([*this, method], input, *return)
+        } |
+        return!(*this) |
+        match init >= 0 {
+          true => { valueStore!(init) }
+          _ => { valueStore!(0) } //initial balance is zero if given is negative
+        }
+      }
+    }
+  }
+}

--- a/rholang/examples/linking/v0.2/packages/RhoClass.rho
+++ b/rholang/examples/linking/v0.2/packages/RhoClass.rho
@@ -9,5 +9,19 @@ export RhoClass in {
       [a, b, c, d, e, f] => { name!(a, b, c, d, e, f) }
       _                  => { name!(args) }
     }
+  } |
+  //Allow a function to be called with input arguments given as a list 
+  //and return channel given explicitly.
+  contract @[*RhoClass, "functionApply"](name, @input, return) = {
+    match input {
+      []                 => { name!(*return) }
+      [a]                => { name!(a, *return) }
+      [a, b]             => { name!(a, b, *return) }
+      [a, b, c]          => { name!(a, b, c, *return) }
+      [a, b, c, d]       => { name!(a, b, c, d, *return) }
+      [a, b, c, d, e]    => { name!(a, b, c, d, e, *return) }
+      [a, b, c, d, e, f] => { name!(a, b, c, d, e, f, *return) }
+      _                  => { name!(input, *return) }
+    }
   }
 }

--- a/rholang/examples/linking/v0.2/packages/TestSet.rho
+++ b/rholang/examples/linking/v0.2/packages/TestSet.rho
@@ -38,7 +38,7 @@ export TestSet in {
                 }
               }
             } |
-            //transform to linked list in order to have easy map and fold methods
+            //Transform to linked list in order to have easy map and fold methods
             LinkedList!("fromSmallList", [tests], *linkedListCh) |
             for(@linkedList <- linkedListCh) {
               LinkedList!("map", [linkedList, *toContract], *testsCh)

--- a/rholang/examples/linking/v0.2/packages/TestSet.rho
+++ b/rholang/examples/linking/v0.2/packages/TestSet.rho
@@ -1,0 +1,53 @@
+export TestSet in {
+  import RhoClass, LinkedList in {
+    contract TestSet(desc, @tests) = {
+      new addTests, execTests, testsCh in {
+        contract execTests(return) = {
+          new combinator in {
+            contract combinator(head, @accumulatedValue, return) = {
+              new result in {
+                head!(*result) |
+                for(@r <- result) {
+                  match [r, accumulatedValue] {
+                    [true, true] => return!(true)
+                    _            => return!(false)
+                  }
+                }
+              }
+            } |
+            for(@tests <- testsCh) {
+              LinkedList!("fold", [tests, true, *combinator], *return)
+            }
+          }
+        } |
+        contract addTests(@tests) = {
+          new toContract, linkedListCh, rListCh in {
+            contract toContract(@test, return) = {
+              match test {
+                [class, function, input, answer] => {
+                  new tContract in {
+                    contract tContract(return) = {
+                      new result in {
+                        @class!(function, input, *result) | for(@r <- result) {
+                          return!(r == answer)
+                        }
+                      }
+                    } |
+                    return!(*tContract)
+                  }
+                }
+              }
+            } |
+            //transform to linked list in order to have easy map and fold methods
+            LinkedList!("fromSmallList", [tests], *linkedListCh) |
+            for(@linkedList <- linkedListCh) {
+              LinkedList!("map", [linkedList, *toContract], *testsCh)
+            }
+          }
+        } |
+        addTests!(tests) |
+        execTests!(*desc)
+      }
+    }
+  }
+}

--- a/rholang/examples/linking/v0.2/tests/LinkedListTest.rho
+++ b/rholang/examples/linking/v0.2/tests/LinkedListTest.rho
@@ -1,21 +1,21 @@
 import LinkedList in {
-  LinkedList!("range", [0, 10, "myList"]) |
+  LinkedList!("range", [0, 10], "myList") |
   for(@myList <- @"myList") {
-    LinkedList!("head", [myList, "headResult"]) | LinkedList!("tail", [myList, "tailResult"]) |
+    LinkedList!("head", [myList], "headResult") | LinkedList!("tail", [myList], "tailResult") |
     for(@h <- @"headResult"; @t <- @"tailResult") {
-      LinkedList!("prepend", [h, t, "newList"]) | for(@l <- @"newList") {
+      LinkedList!("prepend", [h, t], "newList") | for(@l <- @"newList") {
         @"head/tail/prepend test"!(l == myList)
       }
     } |
     contract @"sum"(@x, @y, return) = { return!(x + y) } |
-    LinkedList!("fold", [myList, 0, "sum", "foldResult"]) | for(@r <- @"foldResult"){ @"foldTest"!(r == 45) } |
-    LinkedList!("get", [myList, 7, "getResult"]) | for(@r <- @"getResult"){ @"getTest"!(r == 7) } |
-    LinkedList!("reverse", [myList, "reversedList"]) | for(@r <- @"reversedList"){ @"reverseTest"!(r == [9, [8, [7, [6, [5, [4, [3, [2, [1, [0, []]]]]]]]]]]) } |
+    LinkedList!("fold", [myList, 0, "sum"], "foldResult") | for(@r <- @"foldResult"){ @"foldTest"!(r == 45) } |
+    LinkedList!("get", [myList, 7], "getResult") | for(@r <- @"getResult"){ @"getTest"!(r == 7) } |
+    LinkedList!("reverse", [myList], "reversedList") | for(@r <- @"reversedList"){ @"reverseTest"!(r == [9, [8, [7, [6, [5, [4, [3, [2, [1, [0, []]]]]]]]]]]) } |
     contract @"double"(@x, return) = { return!(2 * x) } |
-    LinkedList!("map", [myList, "double", "doubledList"]) | for(@r <- @"doubledList"){ @"mapTest"!(r == [0, [2, [4, [6, [8, [10, [12, [14, [16, [18, []]]]]]]]]]]) } |
+    LinkedList!("map", [myList, "double"], "doubledList") | for(@r <- @"doubledList"){ @"mapTest"!(r == [0, [2, [4, [6, [8, [10, [12, [14, [16, [18, []]]]]]]]]]]) } |
     contract @"selfSend"(x, isDone) = { x!(*x) | isDone!(true) } |
-    LinkedList!("foreach", [myList, "selfSend", "foreachTest"]) |
-    LinkedList!("indexOf", [myList, 4, "indexOfResult"]) | for(@r <- @"indexOfResult"){ @"indexOfTest"!(r == 4) } |
-    LinkedList!("length", [myList, "lengthResult"]) | for(@r <- @"lengthResult"){ @"lengthTest"!(r == 10) }
+    LinkedList!("foreach", [myList, "selfSend"], "foreachTest") |
+    LinkedList!("indexOf", [myList, 4], "indexOfResult") | for(@r <- @"indexOfResult"){ @"indexOfTest"!(r == 4) } |
+    LinkedList!("length", [myList], "lengthResult") | for(@r <- @"lengthResult"){ @"lengthTest"!(r == 10) }
   }
 }

--- a/rholang/examples/linking/v0.2/tests/NonNegativeNumberTest.rho
+++ b/rholang/examples/linking/v0.2/tests/NonNegativeNumberTest.rho
@@ -1,0 +1,47 @@
+import NonNegativeNumber, TestSet in {
+  NonNegativeNumber!(-5, "negBal") |
+  NonNegativeNumber!(15, "properBal") |
+  NonNegativeNumber!(100, "addTest") |
+  NonNegativeNumber!(100, "subTest") |
+  for(@negBal <- @"negBal"; @properBal <- @"properBal"; @addTest <- @"addTest"; @subTest <- @"subTest") {
+    TestSet!(
+      "Initially negative balances are be converted to 0.",
+      [
+        [negBal, "value", [], 0]
+      ]
+    ) |
+    TestSet!(
+      "Positive initial balances are preserved.",
+      [
+        [properBal, "value", [], 15]
+      ]
+    ) | 
+    TestSet!(
+      "Adding or subtracting a negative number fails.",
+      [
+        [properBal, "add", [-1], false],
+        [properBal, "sub", [-1], false]
+      ]
+    ) |
+    TestSet!(
+      "Subtracting an amount larger than the balance fails.",
+      [
+        [properBal, "sub", [27], false]
+      ]
+    ) |
+    TestSet!(
+      "Adding a positive number works.",
+      [
+        [addTest, "add", [50], true],
+        [addTest, "value", [], 150]
+      ]
+    ) |
+    TestSet!(
+      "Subtracting a positive number less than or equal to the balance works",
+      [
+        [subTest, "sub", [30], true],
+        [subTest, "value", [], 70]
+      ]
+    )
+  }
+}


### PR DESCRIPTION
-separate return channel from inputs in RhoClass apply
-update LinkedList API to take explicit return channel
-translate TestSet and NonNegativeNumber

The updated `TestSet.rho` accepts a description of the test as the first argument and sends the result of the test (true = pass, false = fail) on the name created by quoting the description.