### PR TITLE
CORE-315: {rholang,node}: wrap Par in TaggedContinuation

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -21,6 +21,14 @@ message Par {
     bool wildcard = 10;
 }
 
+
+message TaggedContinuation {
+    oneof tagged_cont {
+        Par par_body = 1;
+        int64 scala_body_ref = 2;
+    }
+}
+
 message Channel {
     oneof channel_instance {
         Par quote = 1;


### PR DESCRIPTION
Ref:
https://rchain.atlassian.net/browse/CORE-315

To support static system channels, this PR introduces a `TaggedContinuation` proto message, which is a simple `oneof`-based wrapper around `Par`.  The other member, `scala_body_ref`, is imagined to be a key in a map where the values are Scala functions implementing a given process.