### PR TITLE
{rholang, node}: consolidate Serialize instances

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -2,13 +2,15 @@ package coop.rchain.rholang.interpreter.storage
 
 import cats.implicits._
 import coop.rchain.models.Channel.ChannelInstance.Quote
-import coop.rchain.models.{Channel, HasLocallyFree, Par}
+import coop.rchain.models._
 import coop.rchain.rholang.interpreter.SpatialMatcher._
 import coop.rchain.rholang.interpreter.implicits._
-import coop.rchain.rspace.{Match => StorageMatch}
+import coop.rchain.rspace.{Serialize, Match => StorageMatch}
 
 //noinspection ConvertExpressionToSAM
 object implicits {
+
+  /* Match instance */
 
   private def toChannels(fm: FreeMap, max: Int): Seq[Channel] =
     (0 until max).map { (i: Int) =>
@@ -30,4 +32,22 @@ object implicits {
             toChannels(freeMap, patterns.map((c: Channel) => freeCount(c)).sum)
           }
     }
+
+  /* Serialize instances */
+
+  implicit val serializeChannel: Serialize[Channel] =
+    Serialize.mkProtobufInstance(Channel)
+
+  implicit val serializeChannels: Serialize[Seq[Channel]] =
+    new Serialize[Seq[Channel]] {
+
+      override def encode(a: Seq[Channel]): Array[Byte] =
+        ListChannel.toByteArray(ListChannel(a))
+
+      override def decode(bytes: Array[Byte]): Either[Throwable, Seq[Channel]] =
+        Either.catchNonFatal(ListChannel.parseFrom(bytes).channels.toList)
+    }
+
+  implicit val serializeTaggedContinuation: Serialize[TaggedContinuation] =
+    Serialize.mkProtobufInstance(TaggedContinuation)
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceTest.scala
@@ -9,6 +9,7 @@ import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.{GPrivate => _, _}
+import coop.rchain.rholang.interpreter.storage.implicits._
 import implicits._
 
 import scala.collection.immutable.BitSet
@@ -22,14 +23,6 @@ import cats.syntax.either._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 
 trait PersistentStoreTester {
-  implicit val serializer = Serialize.mkProtobufInstance(Channel)
-  implicit val serializer2 = new Serialize[Seq[Channel]] {
-    override def encode(a: Seq[Channel]): Array[Byte] =
-      ListChannel.toByteArray(ListChannel(a))
-    override def decode(bytes: Array[Byte]): Either[Throwable, Seq[Channel]] =
-      Either.catchNonFatal(ListChannel.parseFrom(bytes).channels.toList)
-  }
-  implicit val serializer3 = Serialize.mkProtobufInstance(TaggedContinuation)
   def withTestStore[R](
       f: IStore[Channel, Seq[Channel], Seq[Channel], TaggedContinuation] => R): R = {
     val dbDir = Files.createTempDirectory("rchain-storage-test-")


### PR DESCRIPTION
We were defining `Serialize` instances in multiple places for no reason.  This PR consolidates them into the `coop.rchain.rholang.interpreter.storage.implicits` package which I had created for them and the `Match` instance.