### PR TITLE
CORE-365 - uncaught error when consuming the same joined channel

### DIFF
--- a/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
@@ -3,7 +3,7 @@ package coop.rchain.rspace
 import coop.rchain.rspace.examples.StringExamples.{StringsCaptor, Wildcard}
 import coop.rchain.rspace.internal._
 
-trait JoinOperationsTests extends StorageActionsBase {
+trait JoinOperationsTests extends StorageActionsTests {
 
   "joins" should "remove joins if no PsK" in withTestStore { store =>
     store.withTxn(store.createTxnWrite()) { txn =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -432,6 +432,27 @@ trait StorageActionsTests extends StorageActionsBase {
     store.isEmpty shouldBe true
   }
 
+  "A joined consume with the same channel given twice followed by a produce" should
+    "not raises any errors (CORE-365)" in withTestStore { store =>
+    var channels = List("ch1", "ch1")
+
+    val r1 = consume(store,
+                     channels,
+                     List(StringMatch("datum1"), StringMatch("datum1")),
+                     new StringsCaptor,
+                     persist = false)
+
+    val r2 = produce(store, "ch1", "datum1", persist = false)
+
+    r1 shouldBe None
+    r2 shouldBe defined
+
+    runK(r2)
+    getK(r2).results shouldBe List(List("datum1", "datum1"))
+
+    store.isEmpty shouldBe true
+  }
+
   "consuming twice on the same channels with different patterns, and then producing on those channels" should
     "return continuations with the expected data" in withTestStore { store =>
     val channels = List("ch1", "ch2")

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -10,12 +10,8 @@ import coop.rchain.rspace.internal._
 import coop.rchain.rspace.test._
 import org.scalatest._
 
-abstract class StorageActionsBase extends FlatSpec with Matchers with OptionValues {
-
-  type TestStore =
-    IStore[String, Pattern, String, StringsCaptor] with ITestableStore[String, Pattern]
-
-  val logger: Logger = Logger[StorageActionsTests]
+abstract class StorageActionsBase[T] extends FlatSpec with Matchers with OptionValues {
+  val logger: Logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   override def withFixture(test: NoArgTest): Outcome = {
     logger.debug(s"Test: ${test.name}")
@@ -24,10 +20,15 @@ abstract class StorageActionsBase extends FlatSpec with Matchers with OptionValu
 
   /** A fixture for creating and running a test with a fresh instance of the test store.
     */
-  def withTestStore(f: TestStore => Unit): Unit
+  def withTestStore(f: T => Unit): Unit
 }
 
-trait StorageActionsTests extends StorageActionsBase {
+trait StorageActionsTests
+    extends StorageActionsBase[
+      IStore[String, Pattern, String, StringsCaptor] with ITestableStore[String, Pattern]] {
+
+  type TestStore =
+    IStore[String, Pattern, String, StringsCaptor] with ITestableStore[String, Pattern]
 
   /* Tests */
 
@@ -434,7 +435,7 @@ trait StorageActionsTests extends StorageActionsBase {
 
   "A joined consume with the same channel given twice followed by a produce" should
     "not raises any errors (CORE-365)" in withTestStore { store =>
-    var channels = List("ch1", "ch1")
+    val channels = List("ch1", "ch1")
 
     val r1 = consume(store,
                      channels,
@@ -889,6 +890,7 @@ class InMemoryStoreStorageActionsTests extends StorageActionsTests with JoinOper
 
   override def withTestStore(f: TestStore => Unit): Unit = {
     val testStore = InMemoryStore.create[String, Pattern, String, StringsCaptor]
+    testStore.clear()
     try {
       f(testStore)
     } finally {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTest.scala
@@ -1,0 +1,47 @@
+package coop.rchain.rspace
+
+import java.nio.file.Files
+
+import coop.rchain.rspace.examples.AddressBookExample._
+import coop.rchain.rspace.examples.AddressBookExample.implicits._
+import coop.rchain.rspace.test.recursivelyDeletePath
+import org.scalatest.BeforeAndAfterAll
+
+class StorageExamplesTest
+    extends StorageActionsBase[
+      IStore[Channel, Pattern, Entry, Printer] with ITestableStore[Channel, Pattern]]
+    with BeforeAndAfterAll {
+  private[this] val dbDir = Files.createTempDirectory("rchain-storage-test-")
+
+  "A joined consume with the same channel given twice followed by a produce" should
+    "not raises any errors (CORE-365)" in withTestStore { store =>
+    val r1 = consume(store,
+                     List(Channel("friends"), Channel("friends")),
+                     List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+                     new Printer,
+                     persist = false)
+
+    val r2 = produce(store, Channel("friends"), bob, persist = false)
+
+    r1 shouldBe None
+    r2 shouldBe defined
+
+    store.isEmpty shouldBe true
+  }
+
+  override def withTestStore(
+      f: IStore[Channel, Pattern, Entry, Printer] with ITestableStore[Channel, Pattern] => Unit)
+    : Unit = {
+    val testStore =
+      LMDBStore.create[Channel, Pattern, Entry, Printer](dbDir, 1024 * 1024 * 1024)
+    testStore.clear()
+    try {
+      f(testStore)
+    } finally {
+      testStore.close()
+    }
+  }
+
+  override def afterAll(): Unit =
+    recursivelyDeletePath(dbDir)
+}


### PR DESCRIPTION
I've fixed the error and added unit-test, but not sure if we're doing everything right:
Since creation LMDBStore didn't tracked or counted number of identical joins. I.e. if addJoin("ch1", ["ch2", "ch3"]) called many times only one join record is stored in the DB. If this behavior is correct - than the fix will work as expected. Otherwise instead of this fix I will implement a logic that tracks number of identical joins.