### PR TITLE
CORE-349 grpc service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,12 @@ lazy val node = (project in file("node"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "coop.rchain.node",
     mainClass in assembly := Some("coop.rchain.node.Main"),
+    assemblyMergeStrategy in assembly := {
+      case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
+      case x =>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    },
     /* Dockerization */
     dockerfile in docker := {
       val artifact: File     = assembly.value

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val node = (project in file("node"))
     name := "rnode",
     libraryDependencies ++=
       apiServerDependencies ++ commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
-        scalapbRuntimegRrpc,
+        scalapbRuntimegGrpc,
         grpcNetty,
         catsCore,
         scallop,

--- a/build.sbt
+++ b/build.sbt
@@ -87,8 +87,8 @@ lazy val node = (project in file("node"))
         scalaUri
       ),
     PB.targets in Compile := Seq(
-      PB.gens.java                        -> (sourceManaged in Compile).value,
-      scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value
+      PB.gens.java                        -> (sourceManaged in Compile).value / "protobuf",
+      scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value / "protobuf"
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "coop.rchain.node",

--- a/build.sbt
+++ b/build.sbt
@@ -80,10 +80,16 @@ lazy val node = (project in file("node"))
     name := "rnode",
     libraryDependencies ++=
       apiServerDependencies ++ commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
+        scalapbRuntimegRrpc,
+        grpcNetty,
         catsCore,
         scallop,
         scalaUri
       ),
+    PB.targets in Compile := Seq(
+      PB.gens.java                        -> (sourceManaged in Compile).value,
+      scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value
+    ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "coop.rchain.node",
     mainClass in assembly := Some("coop.rchain.node.Main"),

--- a/comm/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/comm/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -8,7 +8,6 @@ import cats._, cats.data._, cats.implicits._
 
 object TaskContrib {
   implicit class TaskOps[A](task: Task[A])(implicit scheduler: Scheduler) {
-    def unsafeRunSync(handle: A => Unit): Unit =
-      Await.result(task.runAsync, Duration.Inf)
+    def unsafeRunSync: A = Await.result(task.runAsync, Duration.Inf)
   }
 }

--- a/node/src/main/protobuf/repl.proto
+++ b/node/src/main/protobuf/repl.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package cooop.rchain.node;
+package coop.rchain.node;
 
 service Repl {
   rpc Run (ReplRequest) returns (ReplResponse) {}

--- a/node/src/main/protobuf/repl.proto
+++ b/node/src/main/protobuf/repl.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package cooop.rchain.node;
+
+service Repl {
+  rpc Run (ReplRequest) returns (ReplResponse) {}
+}
+
+message ReplRequest {
+  string line = 1;
+}
+
+message ReplResponse {
+  string output = 1;
+}

--- a/node/src/main/protobuf/repl.proto
+++ b/node/src/main/protobuf/repl.proto
@@ -13,3 +13,4 @@ message ReplRequest {
 message ReplResponse {
   string output = 1;
 }
+

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -18,6 +18,13 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val httpPort =
     opt[Int](default = Some(8080), short = 'x', descr = "HTTP port.")
 
+  val grpcPort =
+    opt[Int](default = Some(50000), short = 'g', descr = "gRPC port.")
+
+  val grpcHost =
+    opt[String](default = Some("localhost"),
+                descr = "Hostname or IP of node you try to connect to via gRPC.")
+
   val bootstrap =
     opt[String](default = Some("rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012"),
                 short = 'b',

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -1,6 +1,10 @@
 package coop.rchain.node
 
+import coop.rchain.comm.UPnP
+import com.typesafe.scalalogging.Logger
 import org.rogach.scallop._
+import java.net.{InetAddress, NetworkInterface}
+import scala.collection.JavaConverters._
 
 final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   version(s"RChain Node ${BuildInfo.version}")
@@ -30,6 +34,44 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
                           descr = "Start node with REPL (but without P2P network)")
   val eval = opt[String](default = None,
                          descr = "Start node to evaluate rholang in file (but without P2P network)")
+
+  def fetchHost(): String =
+    host.toOption match {
+      case Some(host) => host
+      case None       => whoami(port()).fold("localhost")(_.getHostAddress)
+    }
+
+  private def whoami(port: Int): Option[InetAddress] = {
+
+    val logger = Logger("conf")
+    val upnp   = new UPnP(port)
+
+    logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
+
+    upnp.localAddress match {
+      case Some(addy) => Some(addy)
+      case None => {
+        val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
+        val addresses = ifaces
+          .flatMap(_.asScala)
+          .map(_.getAddress)
+          .toList
+          .groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress || x.isSiteLocalAddress)
+        if (addresses.contains(false)) {
+          Some(addresses(false).head)
+        } else {
+          val locals = addresses(true).groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress)
+          if (locals.contains(false)) {
+            Some(locals(false).head)
+          } else if (locals.contains(true)) {
+            Some(locals(true).head)
+          } else {
+            None
+          }
+        }
+      }
+    }
+  }
 
   verify()
 }

--- a/node/src/main/scala/coop/rchain/node/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/grpc.scala
@@ -1,0 +1,36 @@
+package coop.rchain.node
+
+import io.grpc.{Server, ServerBuilder}
+import scala.concurrent.{ExecutionContext, Future}
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.node.repl._
+
+class GrpcServer(executionContext: ExecutionContext, port: Int) { self =>
+
+  var server: Option[Server] = None
+
+  def start(): Unit = {
+    server = ServerBuilder
+      .forPort(port)
+      .addService(ReplGrpc.bindService(new ReplImpl, executionContext))
+      .build
+      .start
+      .some
+
+    println("Server started, listening on " + port)
+    sys.addShutdownHook {
+      System.err.println("*** shutting down gRPC server since JVM is shutting down")
+      self.stop()
+      System.err.println("*** server shut down")
+    }
+  }
+
+  def stop(): Unit =
+    server.foreach(_.shutdown())
+
+  class ReplImpl extends ReplGrpc.Repl {
+    def run(request: ReplRequest): Future[ReplResponse] =
+      Future.successful(ReplResponse(s"running ${request.line}"))
+  }
+
+}

--- a/node/src/main/scala/coop/rchain/node/main.scala
+++ b/node/src/main/scala/coop/rchain/node/main.scala
@@ -31,7 +31,7 @@ object Main {
 
   private def executeP2p(conf: Conf): Unit = {
     import monix.execution.Scheduler.Implicits.global
-    new NodeRuntime(conf).recipe.value.unsafeRunSync {
+    new NodeRuntime(conf).recipe.value.unsafeRunSync match {
       case Right(_) => ()
       case Left(commError) =>
         throw new Exception(commError.toString) // TODO use Show instance instead

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -28,6 +28,9 @@ class NodeRuntime(conf: Conf) {
   val http = HttpServer(conf.httpPort())
   http.start
 
+  val grpc = new GrpcServer(ExecutionContext.global, conf.grpcPort())
+  grpc.start()
+
   val net = new UnicastNetwork(src, Some(p2p.Network))
 
   /** This is essentially a final effect that will accumulate all effects from the system */
@@ -63,6 +66,7 @@ class NodeRuntime(conf: Conf) {
     sys.addShutdownHook {
       metricsServer.stop
       http.stop
+      grpc.stop()
       net.broadcast(
         DisconnectMessage(ProtocolMessage.disconnect(net.local), System.currentTimeMillis))
       println("Goodbye.")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,6 @@ object Dependencies {
   val circeVersion  = "0.9.1"
   val http4sVersion = "0.18.0"
   val kamonVersion  = "1.0.0"
-  // val scalapbVer    = com.trueaccord.scalapb.compiler.Version
 
   // format: off
   val bitcoinjCore        = "org.bitcoinj"                % "bitcoinj-core"             % "0.14.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.1" % "test"
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
-  val scalapbRuntimegRrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
+  val scalapbRuntimegGrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
   val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.0.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
   val circeVersion  = "0.9.1"
   val http4sVersion = "0.18.0"
   val kamonVersion  = "1.0.0"
+  // val scalapbVer    = com.trueaccord.scalapb.compiler.Version
 
   // format: off
   val bitcoinjCore        = "org.bitcoinj"                % "bitcoinj-core"             % "0.14.6"
@@ -33,7 +34,7 @@ object Dependencies {
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.13.4" % "test"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.1" % "test"
-  val scalapbRuntime      = "com.trueaccord.scalapb"     %% "scalapb-runtime"           % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf"
+  val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.0.3"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,8 @@ object Dependencies {
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.1" % "test"
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
+  val scalapbRuntimegRrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
+  val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.0.3"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.2"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
-
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"
 
 addSbtPlugin("com.geirsson"        % "sbt-scalafmt"        % "1.4.0")
 addSbtPlugin("com.eed3si9n"        % "sbt-assembly"        % "0.14.5")


### PR DESCRIPTION
This PR will: 

1. Upgrade scalapb to 0.7.1
2. Introduce gRPC dependencies
3. Refactor node.scala (move things around)
4. Introduce simple repl service (simple stub to see if things are working)
5. Fix unsafeRunSync to return a value
6. Move whoami and introduce fetchHost in Conf
7. Add gRPC configuration
8. Run GRPC on node start

TL;DR: It will start GRPC that runs stub REPL service.
Client code and real REPL is on the way, but current changes are big enough for their own PR.