### PR TITLE
Added a feature to defer non-primitive symbol lookup until runtime

### DIFF
--- a/rosette/h/CommandLine.h
+++ b/rosette/h/CommandLine.h
@@ -34,6 +34,7 @@ extern char RunFile[];
 extern int RestoringImage;
 extern bool ForceEnableRepl;
 extern int VerboseFlag;
+extern int DeferLookupFlag;
 
 extern int ParseCommandLine(int, char**);
 

--- a/rosette/h/Compile.h
+++ b/rosette/h/Compile.h
@@ -154,6 +154,7 @@ class AttrNode : public BinaryOb {
 
     Location dest;
     Label resume;
+    bool deferredLookup;
 
     /*
      * The gc routines (traversPtrs and friends) use the address of the

--- a/rosette/h/Opcode.h
+++ b/rosette/h/Opcode.h
@@ -193,6 +193,8 @@ enum Opcode {
 
     opImmediateLitToReg = 0xd0,
 
+    opDeferLookup = 0xe0,
+
     MaxOpcodes = 256
 };
 

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -544,7 +544,7 @@ std::tuple<int, bool> BigBang(int argc, char** argv, char** envp) {
         Define("envp", GetEnvp(envp));
         Define("flag-enable-repl", GetReplFlag());
         Define("flag-verbose", VerboseFlag ? RBLTRUE : RBLFALSE);
-        Define("flag-deferLookup", DeferLookupFlag ? RBLTRUE: RBLFALSE);
+        Define("flag-defer-lookup", DeferLookupFlag ? RBLTRUE: RBLFALSE);
         vm->resetSignals();
 
         /**

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -544,6 +544,7 @@ std::tuple<int, bool> BigBang(int argc, char** argv, char** envp) {
         Define("envp", GetEnvp(envp));
         Define("flag-enable-repl", GetReplFlag());
         Define("flag-verbose", VerboseFlag ? RBLTRUE : RBLFALSE);
+        Define("flag-deferLookup", DeferLookupFlag ? RBLTRUE: RBLFALSE);
         vm->resetSignals();
 
         /**
@@ -589,6 +590,7 @@ std::tuple<int, bool> BigBang(int argc, char** argv, char** envp) {
         Define("envp", GetEnvp(envp));
         Define("flag-enable-repl", GetReplFlag());
         Define("flag-verbose", VerboseFlag ? RBLTRUE : RBLFALSE);
+        Define("flag-deferLookup", DeferLookupFlag ? RBLTRUE: RBLFALSE);
         did_run_file = LoadRunFile();
         LoadBootFiles();
         heap->tenureEverything();

--- a/rosette/src/Code.cc
+++ b/rosette/src/Code.cc
@@ -664,6 +664,10 @@ Instr* CodeVec::dumpInstr(Instr* pc, char* buf, Code* code) {
         dest = CtxtReg((CtxtRegName)OP_f2_op1(insn));
         goto formatDest;
 
+    case opDeferLookup:
+        sprintf(buf, "opDeferLookup");
+        goto noDest;
+
     default:
         sprintf(buf, "illegal 0x%.4x", (int)insn.word);
         goto noDest;
@@ -979,6 +983,8 @@ MODULE_INIT(Code) {
         opcodeStrings[opImmediateLitToReg | 0x9] = "lit #f/reg";
         opcodeStrings[opImmediateLitToReg | 0xa] = "lit nil/reg";
         opcodeStrings[opImmediateLitToReg | 0xb] = "lit #niv/reg";
+
+        opcodeStrings[opDeferLookup] = "opDeferLookup";
     }
 }
 

--- a/rosette/src/CommandLine.cc
+++ b/rosette/src/CommandLine.cc
@@ -41,6 +41,7 @@ char BootFile[MAXPATHLEN] = "boot.rbl";
 char RunFile[MAXPATHLEN] = "";
 bool ForceEnableRepl = false;
 int VerboseFlag = 0;
+int DeferLookupFlag = 0;
 
 /*
  * RestoringImage is set to 0 in the initial boot-rosette image, but it
@@ -61,6 +62,7 @@ void usage(const char* name, bool fatal = false, const char* msg = NULL) {
             " -h, --help             Prints this message and exits.\n"
             " -v, --verbose          Verbose mode\n"
             " -q, --quiet            Disable verbose mode\n"
+            " -l, --defer-lookup     Defer nonprimitive symbol lookup until runtime\n"
             " -t, --tenure=NUM_GCS   Number of GCs before tenuring an object\n"
             " -p, --paranoid-gc      Enable paranoid GC\n"
             " -I, --infant-size=KB   RAM to allocate for infant objects\n"
@@ -105,6 +107,7 @@ int ParseCommandLine(int argc, char** argv) {
         /* Flags */
         {"verbose", no_argument, NULL, 'v'},
         {"quiet", no_argument, NULL, 'q'},
+        {"defer-lookup", no_argument, NULL, 'l'},
         {"interactive-repl", no_argument, NULL, 'i'},
 
         /* Non-flags */
@@ -152,6 +155,10 @@ int ParseCommandLine(int argc, char** argv) {
 
         case 'q':
             VerboseFlag = 0;
+            break;
+
+        case 'l':
+            DeferLookupFlag = 1;
             break;
 
         case 'h':

--- a/rosette/src/Vm.cc
+++ b/rosette/src/Vm.cc
@@ -699,7 +699,7 @@ int idxGlobalEnv(pOb key) {
     int size=TAGVAL(GlobalEnv->keyVec->indexedSize());
     const char *keyStr = BASE(key)->asCstring();
 
-    for(int i=0; i<size; i++) {
+    for(int i = 0; i < size; i++) {
         const char * val = BASE(GlobalEnv->keyVec->nth(i))->asCstring();
 
         if (strcmp(keyStr, val) == 0) {
@@ -1140,7 +1140,7 @@ nextop:
                 if (VerboseFlag) fprintf(stderr, "  Deferred symbol lookup '%s'\n", BASE(key)->asCstring());
                 // Perhaps it's in the GlobalEnv
                 int idx = idxGlobalEnv(key);
-                if (idx>=0) {
+                if (idx >= 0) {
                     val = GlobalEnv->entry(idx);
                 }
             } else {
@@ -1189,7 +1189,7 @@ nextop:
                 if (VerboseFlag) fprintf(stderr, "  Deferred symbol lookup '%s'\n", BASE(key)->asCstring());
                 // Perhaps it's in the GlobalEnv
                 int idx = idxGlobalEnv(key);
-                if (idx>=0) {
+                if (idx >= 0) {
                     val = GlobalEnv->entry(idx);
                 }
             } else {

--- a/rosette/src/Vm.cc
+++ b/rosette/src/Vm.cc
@@ -693,6 +693,24 @@ void VirtualMachine::evaluate(pOb expr) {
 }
 
 
+// This routine is a quick and dirty global environment lookup.  I think there
+// may be a more efficient way to do this, but I haven't researched it yet.
+int idxGlobalEnv(pOb key) {
+    int size=TAGVAL(GlobalEnv->keyVec->indexedSize());
+    const char *keyStr = BASE(key)->asCstring();
+
+    for(int i=0; i<size; i++) {
+        const char * val = BASE(GlobalEnv->keyVec->nth(i))->asCstring();
+
+        if (strcmp(keyStr, val) == 0) {
+            return i;
+        }
+    }
+//    if (VerboseFlag)
+        warning("  %s NOT found in GlobalEnv!\n", keyStr);
+    return -1;
+}
+
 #define FETCH (*pc.absolute++)
 #define ARG_LIMIT (ctxt->argvec->numberOfElements())
 
@@ -712,6 +730,7 @@ nextop:
     if (debugging_level)
         traceOpcode();
 
+    Instr previous = instr;
     instr = FETCH;
     bytecodes[OP_f0_opcode(instr)]++;
 
@@ -1108,14 +1127,30 @@ nextop:
     case opLookupToArg | 0xf: {
         const int argno = OP_f2_op0(instr);
         pOb key = code->lit(OP_f2_op1(instr));
-        pOb const val = BASE(BASE(ctxt->selfEnv)->meta())
+        pOb val = BASE(BASE(ctxt->selfEnv)->meta())
                             ->lookupOBO(ctxt->selfEnv, key, ctxt);
         if (val == UPCALL) {
             ctxt->pc = code->relativize(pc.absolute);
             goto doNextThread;
         } else if (val == ABSENT) {
-            handleMissingBinding(key, ArgReg(argno));
-            goto doNextThread;
+            // If the preceding instruction was a NOP, this is a deferred
+            // lookup that was emitted on purpose by the compiler. In this
+            // case we need to also check the global environment for the symbol.
+            if (OP_f0_opcode(previous) == opDeferLookup) {
+                if (VerboseFlag) fprintf(stderr, "  Deferred symbol lookup '%s'\n", BASE(key)->asCstring());
+                // Perhaps it's in the GlobalEnv
+                int idx = idxGlobalEnv(key);
+                if (idx>=0) {
+                    val = GlobalEnv->entry(idx);
+                }
+            } else {
+                warning("Absent but not deferred symbol lookup '%s'", BASE(key)->asCstring());
+            }
+
+            if (val == ABSENT) {
+                handleMissingBinding(key, ArgReg(argno));
+                goto doNextThread;
+            }
         }
 
         ASSIGN(ctxt->argvec, elem(argno), val);
@@ -1141,14 +1176,30 @@ nextop:
     case opLookupToReg | 0xf: {
         const int regno = OP_f2_op0(instr);
         pOb key = code->lit(OP_f2_op1(instr));
-        pOb const val = BASE(BASE(ctxt->selfEnv)->meta())
+        pOb val = BASE(BASE(ctxt->selfEnv)->meta())
                             ->lookupOBO(ctxt->selfEnv, key, ctxt);
         if (val == UPCALL) {
             ctxt->pc = code->relativize(pc.absolute);
             goto doNextThread;
         } else if (val == ABSENT) {
-            handleMissingBinding(key, CtxtReg((CtxtRegName)regno));
-            goto doNextThread;
+            // If the preceding instruction was a NOP, this is a deferred
+            // lookup that was emitted on purpose by the compiler. In this
+            // case we need to also check the global environment for the symbol.
+            if (OP_f0_opcode(previous) == opDeferLookup) {
+                if (VerboseFlag) fprintf(stderr, "  Deferred symbol lookup '%s'\n", BASE(key)->asCstring());
+                // Perhaps it's in the GlobalEnv
+                int idx = idxGlobalEnv(key);
+                if (idx>=0) {
+                    val = GlobalEnv->entry(idx);
+                }
+            } else {
+                warning("Absent but not deferred symbol lookup '%s'", BASE(key)->asCstring());
+            }
+
+            if (val == ABSENT) {
+                handleMissingBinding(key, ArgReg(regno));
+                goto doNextThread;
+            }
         }
 
         ASSIGN(ctxt, reg(regno), val);
@@ -1328,6 +1379,8 @@ nextop:
         ctxt->reg(OP_f2_op1(instr)) = vmLiterals[OP_f2_op0(instr)];
         goto nextop;
 
+    case opDeferLookup:
+        goto nextop;
 
     default:
         warning("illegal instruction (0x%.4x)", (int)instr.word);


### PR DESCRIPTION
This is controlled by the --defer-lookup command line switch.

https://rchain.atlassian.net/browse/ROS-368
https://rchain.atlassian.net/browse/ROS-381
