### PR TITLE
CORE-372 - Add BNFC requirement to RNode README

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -18,7 +18,19 @@ In P2P mode, node will instantiate a peer-to-peer network. It will either connec
 
 ### Building from source
 
-Node depends on the following subprojects: 
+#### Prerequisites
+* Java Development Kit (JDK), version 8
+    - We recommend using the OpenJDK 
+    - Alternatively, the [Oracle JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) is an option
+* [sbt](https://www.scala-sbt.org/download.html)
+* For crypto, the [Sodium crypto library](https://github.com/jedisct1/libsodium)
+* For Rholang
+    - [CUP](http://www2.cs.tum.edu/projects/cup/install.php) 0.11b-2014-06-11 or later. See [Rholang README](https://github.com/rchain/rchain/blob/master/rholang/README.md) for notes on installation requirements.
+     - Flex
+     - BNFC - must be built from [git](https://github.com/BNFC/bnfc) b0252e5f666ed67a65b6e986748eccbfe802bc17 or later 
+
+
+#### Node depends on the following subprojects: 
 
 1. comm
 2. crypto

--- a/node/README.md
+++ b/node/README.md
@@ -27,8 +27,10 @@ In P2P mode, node will instantiate a peer-to-peer network. It will either connec
 * For Rholang
     - [CUP](http://www2.cs.tum.edu/projects/cup/install.php) 0.11b-2014-06-11 or later. See [Rholang README](https://github.com/rchain/rchain/blob/master/rholang/README.md) for notes on installation requirements.
      - [jflex](http://jflex.de/)
-     - Build BNFC from the following commit or later: [BNFC/bnfc@7c9e859](BNFC/bnfc@7c9e859)
-    
+     - Build [BNFC](http://bnfc.digitalgrammars.com/) from the following commit or later: BNFC/bnfc@7c9e859
+ 
+ 
+     
 #### Node depends on the following subprojects: 
 
 1. comm

--- a/node/README.md
+++ b/node/README.md
@@ -26,10 +26,9 @@ In P2P mode, node will instantiate a peer-to-peer network. It will either connec
 * For crypto, the [Sodium crypto library](https://github.com/jedisct1/libsodium)
 * For Rholang
     - [CUP](http://www2.cs.tum.edu/projects/cup/install.php) 0.11b-2014-06-11 or later. See [Rholang README](https://github.com/rchain/rchain/blob/master/rholang/README.md) for notes on installation requirements.
-     - Flex
-     - BNFC - must be built from [git](https://github.com/BNFC/bnfc) b0252e5f666ed67a65b6e986748eccbfe802bc17 or later 
-
-
+     - [jflex](http://jflex.de/)
+     - Build BNFC from the following commit or later: [BNFC/bnfc@7c9e859](BNFC/bnfc@7c9e859)
+    
 #### Node depends on the following subprojects: 
 
 1. comm

--- a/node/README.md
+++ b/node/README.md
@@ -27,10 +27,8 @@ In P2P mode, node will instantiate a peer-to-peer network. It will either connec
 * For Rholang
     - [CUP](http://www2.cs.tum.edu/projects/cup/install.php) 0.11b-2014-06-11 or later. See [Rholang README](https://github.com/rchain/rchain/blob/master/rholang/README.md) for notes on installation requirements.
      - [jflex](http://jflex.de/)
-     - Build [BNFC](http://bnfc.digitalgrammars.com/) from the following commit or later: BNFC/bnfc@7c9e859
- 
- 
-     
+     - Build [BNFC](http://bnfc.digitalgrammars.com/) from the following commit or later: [BNFC/bnfc@7c9e859](https://github.com/BNFC/bnfc/commit/7c9e859)
+      
 #### Node depends on the following subprojects: 
 
 1. comm


### PR DESCRIPTION
[CORE-372](https://rchain.atlassian.net/browse/CORE-372)

This adds a section of prerequisites for building RNode. Including a note on the BNFC requirement. Hopefully this will help resolve user errors reported in Discord.