### PR TITLE
Rholang: Matcher: Add complete support for matching everything but expressions

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
@@ -381,4 +381,14 @@ object implicits {
         case Wildcard(_)     => BitSet()
       }
   }
+
+  implicit val ReceiveBindLocallyFree: HasLocallyFree[ReceiveBind] =
+    new HasLocallyFree[ReceiveBind] {
+      def wildcard(rb: ReceiveBind) =
+        ChannelLocallyFree.wildcard(rb.source.get)
+      def freeCount(rb: ReceiveBind) =
+        ChannelLocallyFree.freeCount(rb.source.get)
+      def locallyFree(rb: ReceiveBind) =
+        ChannelLocallyFree.locallyFree(rb.source.get)
+    }
 }


### PR DESCRIPTION
These commits round out matching support. The majority of the missing productions required shifting to DeBruijn Indices, and then they became straightforward.