### PR TITLE
Add test for `OpXferLexToReg`

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/VirtualMachine.scala
@@ -798,7 +798,6 @@ object VirtualMachine {
         setCtxtReg(op.reg, e.slot(op.offset))(state)
       case None => die("OpXferLexToReg: Type mismatch")(state)
     }
-
   }
 
   def execute(op: OpXferGlobalToArg): VMTransition[Unit] =


### PR DESCRIPTION
In Rosette compiling the expression `(let [[x #t]] (let [[y #t]] (if x (if y 1 2) 3)))` results in the following `Code` object:
```
litvec:
   0:   {LetExpr}
   1:   {Template}
   2:   {Template}
codevec:
   0:   alloc 1
   1:   lit #t,arg[0]
   2:   nargs 1
   3:   extend 1
   4:   alloc 1
   5:   lit #t,arg[0]
   6:   nargs 1
   7:   extend 2
   8:   xfer lex[1,0],rslt
   9:   jf 16
  10:   xfer lex[0,0],rslt
  11:   jf 14
  12:   lit 1,rslt
  13:   rtn/nxt
  14:   lit 2,rslt
  15:   rtn/nxt
  16:   lit 3,rslt
  17:   rtn/nxt
```
Before `opXferLexToReg` comes to execution `opExtend` initialize environment with values from the `litvec`.
When `opXferLexToReg` is executed it transfer the value from environment to the specified register.
