### PR TITLE
CORE-398: node: add rnode.service

### DIFF
--- a/node/rnode.service
+++ b/node/rnode.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=RChain Node
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/rnode
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ref:
https://rchain.atlassian.net/browse/CORE-398

This PR adds an initial systemd service definition for rnode.

Future PRs pertaining to this work should change this to:
- Run under a `rnode` user
- Explicitly & gracefully handle shutdown/stop