### PR TITLE
CORE-360 bootsrap reattempts

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -16,6 +16,7 @@ final case class ParseError(msg: String)               extends CommError
 final case object EncryptionHandshakeIncorrectlySigned extends CommError
 final case object BootstrapNotProvided                 extends CommError
 final case class PeerNodeNotFound(peer: PeerNode)      extends CommError
+final case object CouldNotConnectToBootstrap           extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -29,4 +30,5 @@ object CommError {
   def headerNotAvailable: CommError                    = HeaderNotAvailable
   def peerNodeNotFound(peer: PeerNode): CommError      = PeerNodeNotFound(peer)
   def publicKeyNotAvailable(peer: PeerNode): CommError = PublicKeyNotAvailable(peer)
+  def couldNotConnectToBootstrap: CommError            = CouldNotConnectToBootstrap
 }

--- a/comm/src/main/scala/coop/rchain/p2p/effects/Communication.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/effects/Communication.scala
@@ -8,7 +8,7 @@ import coop.rchain.catscontrib._, Catscontrib._
 trait Communication[F[_]] {
   def roundTrip(msg: ProtocolMessage,
                 remote: ProtocolNode,
-                timeout: Duration = Duration(500, MILLISECONDS)): F[CommErr[ProtocolMessage]]
+                timeout: Duration): F[CommErr[ProtocolMessage]]
   def local: F[ProtocolNode]
   def commSend(msg: ProtocolMessage, peer: PeerNode): F[CommErr[Unit]]
   def addNode(node: PeerNode): F[Unit]

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -47,28 +47,108 @@ case object NetworkAddress {
 
 object Network extends ProtocolDispatcher[java.net.SocketAddress] {
 
-  type KeysStore[F[_]] = Kvs[F, PeerNode, Array[Byte]]
+  type KeysStore[F[_]]    = Kvs[F, PeerNode, Array[Byte]]
+  type ErrorHandler[F[_]] = ApplicativeError_[F, CommError]
 
   import NetworkProtocol._
   import Encryption._
 
+  val defaultTimeout: Duration = Duration(100, MILLISECONDS)
+
   def unsafeRoundTrip[F[_]: Capture: Communication]
     : (ProtocolMessage, ProtocolNode) => CommErr[ProtocolMessage] =
     (pm: ProtocolMessage, pn: ProtocolNode) => {
-      val result = Communication[F].roundTrip(pm, pn)
+      val result = Communication[F].roundTrip(pm, pn, defaultTimeout)
       Capture[F].unsafeUncapture(result)
     }
 
-  def connect[F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption](peer: PeerNode)(
-      implicit
-      keysStore: KeysStore[F],
-      err: ApplicativeError_[F, CommError]): F[Unit] = {
+  def findAndConnect[
+      F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption: KeysStore: ErrorHandler]
+    : Int => F[Int] =
+    (lastCount: Int) =>
+      (for {
+        _     <- IOUtil.sleep[F](5000L)
+        peers <- Communication[F].findMorePeers(10)
+        _ <- peers.toList
+              .traverse(p => errorHandler[F].attempt(connect[F](p, defaultTimeout)))
+              .map { attempts =>
+                attempts.filter {
+                  case Left(_) => false
+                  case _       => true
+                }
+              }
+        thisCount <- Communication[F].countPeers
+        _ <- if (thisCount != lastCount) Log[F].info(s"Peers: $thisCount.")
+            else ().pure[F]
+      } yield thisCount)
 
-    def fullHandshake: F[Unit] = firstPhase[F](peer) *> secondPhase[F](peer)
+  def connectToBootstrap[
+      F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption: KeysStore: ErrorHandler](
+      bootstrapAddrStr: String,
+      maxNumOfAttempts: Int = 5): F[Unit] = {
+
+    def connectAttempt(attempt: Int, timeout: Duration, bootstrapAddr: PeerNode): F[Unit] =
+      if (attempt > maxNumOfAttempts) for {
+        _ <- Log[F].error("Failed to connect to bootstrap node, exiting...")
+        _ <- errorHandler[F].raiseError[Unit](couldNotConnectToBootstrap)
+      } yield ()
+      else
+        for {
+          res <- connect[F](bootstrapAddr, timeout).attempt
+          _ <- res match {
+                case Left(err) =>
+                  val msg = s"Failed to connect to bootstrap (attempt $attempt / $maxNumOfAttempts)"
+                  Log[F].warn(msg) *> connectAttempt(attempt + 1,
+                                                     timeout + defaultTimeout,
+                                                     bootstrapAddr)
+                case Right(_) => ().pure[F]
+              }
+        } yield ()
+
+    for {
+      bootstrapAddr <- errorHandler[F].fromEither(NetworkAddress.parse(bootstrapAddrStr))
+      _             <- Log[F].info(s"Bootstrapping from $bootstrapAddr.")
+      _             <- connectAttempt(attempt = 1, defaultTimeout, bootstrapAddr)
+      _             <- Log[F].info(s"Connected $bootstrapAddr.")
+    } yield ()
+  }
+
+  def connect[
+      F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption: KeysStore: ErrorHandler](
+      peer: PeerNode,
+      timeout: Duration): F[Unit] = {
+
+    def firstPhase: F[ProtocolNode] =
+      for {
+        _            <- Log[F].info(s"Initialize first phase handshake (encryption handshake) to $peer")
+        keys         <- Encryption[F].fetchKeys
+        ts1          <- Time[F].currentMillis
+        local        <- Communication[F].local
+        ehs          = EncryptionHandshakeMessage(encryptionHandshake(local, keys), ts1)
+        remote       = ProtocolNode(peer, local, unsafeRoundTrip[F])
+        ehsrespmsg   <- Communication[F].roundTrip(ehs, remote, timeout) >>= (errorHandler[F].fromEither _)
+        ehsresp      <- errorHandler[F].fromEither(toEncryptionHandshakeResponse(ehsrespmsg.proto))
+        remotePubKey = ehsresp.publicKey.toByteArray
+        _            <- keysStore[F].put(peer, remotePubKey)
+        _            <- Log[F].debug(s"Received encryption response from ${ehsrespmsg.sender.get}.")
+      } yield remote
+
+    def secondPhase: F[Unit] =
+      for {
+        _       <- Log[F].info(s"Initialize second phase handshake (protocol handshake) to $peer")
+        local   <- Communication[F].local
+        remote  = ProtocolNode(peer, local, unsafeRoundTrip[F])
+        fm      <- frameMessage[F](remote, nonce => protocolHandshake(local, nonce))
+        phsresp <- Communication[F].roundTrip(fm, remote, timeout) >>= errorHandler[F].fromEither
+        _       <- Log[F].debug(s"Received protocol handshake response from ${phsresp.sender.get}.")
+        _       <- Communication[F].addNode(remote)
+      } yield ()
+
+    def fullHandshake: F[Unit] = firstPhase *> secondPhase
 
     def secondPhaseOrFull: F[Unit] =
       for {
-        res <- secondPhase[F](peer).attempt
+        res <- secondPhase.attempt
         _   <- res.fold(kp(fullHandshake), _.pure[F])
       } yield ()
 
@@ -76,56 +156,24 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
       tss      <- Time[F].currentMillis
       _        <- Log[F].debug(s"Connecting to $peer")
       _        <- Metrics[F].incrementCounter("connects")
-      maybeKey <- keysStore.get(peer)
+      maybeKey <- keysStore[F].get(peer)
       _        <- maybeKey.fold(fullHandshake)(kp(secondPhaseOrFull))
       tsf      <- Time[F].currentMillis
       _        <- Metrics[F].record("connect-time-ms", tsf - tss)
     } yield ()
   }
 
-  def firstPhase[F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption](
-      peer: PeerNode)(implicit
-                      keysStore: KeysStore[F],
-                      err: ApplicativeError_[F, CommError]): F[ProtocolNode] =
-    for {
-      _            <- Log[F].info(s"Initialize first phase handshake (encryption handshake) to $peer")
-      keys         <- Encryption[F].fetchKeys
-      ts1          <- Time[F].currentMillis
-      local        <- Communication[F].local
-      ehs          = EncryptionHandshakeMessage(encryptionHandshake(local, keys), ts1)
-      remote       = ProtocolNode(peer, local, unsafeRoundTrip[F])
-      ehsrespmsg   <- Communication[F].roundTrip(ehs, remote) >>= (err.fromEither _)
-      ehsresp      <- err.fromEither(toEncryptionHandshakeResponse(ehsrespmsg.proto))
-      remotePubKey = ehsresp.publicKey.toByteArray
-      _            <- keysStore.put(peer, remotePubKey)
-      _            <- Log[F].debug(s"Received encryption response from ${ehsrespmsg.sender.get}.")
-    } yield remote
-
-  def secondPhase[F[_]: Capture: Monad: Log: Time: Metrics: Communication: Encryption](
-      peer: PeerNode)(implicit
-                      keysStore: KeysStore[F],
-                      err: ApplicativeError_[F, CommError]): F[Unit] =
-    for {
-      _       <- Log[F].info(s"Initialize second phase handshake (protocol handshake) to $peer")
-      local   <- Communication[F].local
-      remote  = ProtocolNode(peer, local, unsafeRoundTrip[F])
-      fm      <- frameMessage[F](remote, nonce => protocolHandshake(local, nonce))
-      phsresp <- Communication[F].roundTrip(fm, remote) >>= err.fromEither
-      _       <- Log[F].debug(s"Received protocol handshake response from ${phsresp.sender.get}.")
-      _       <- Communication[F].addNode(remote)
-    } yield ()
-
   def handleEncryptionHandshake[
-      F[_]: Monad: Capture: Log: Time: Metrics: Communication: Encryption](
+      F[_]: Monad: Capture: Log: Time: Metrics: Communication: Encryption: KeysStore](
       sender: PeerNode,
-      msg: EncryptionHandshakeMessage)(implicit keysStore: KeysStore[F]): F[Unit] =
+      msg: EncryptionHandshakeMessage): F[Unit] =
     for {
       _            <- Metrics[F].incrementCounter("p2p-encryption-handshake-recv-count")
       local        <- Communication[F].local
       keys         <- Encryption[F].fetchKeys
       handshakeErr <- NetworkProtocol.toEncryptionHandshake(msg.proto).pure[F]
       _ <- handshakeErr.fold(kp(Log[F].error("could not fetch proto message")),
-                             hs => keysStore.put(sender, hs.publicKey.toByteArray))
+                             hs => keysStore[F].put(sender, hs.publicKey.toByteArray))
       responseErr <- msg.response[F](local, keys)
       result      <- responseErr.traverse(resp => Communication[F].commSend(resp, sender))
       _ <- result.traverse {
@@ -173,11 +221,10 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
       _      <- Communication[F].addNode(remote)
     } yield s"Responded to protocol handshake request from $remote"
 
-  override def dispatch[F[_]: Monad: Capture: Log: Time: Metrics: Communication: Encryption: Kvs[
-    ?[_],
-    PeerNode,
-    Array[Byte]]: ApplicativeError_[?[_], CommError]](sock: java.net.SocketAddress,
-                                                      msg: ProtocolMessage): F[Unit] = {
+  override def dispatch[
+      F[_]: Monad: Capture: Log: Time: Metrics: Communication: Encryption: KeysStore: ErrorHandler](
+      sock: java.net.SocketAddress,
+      msg: ProtocolMessage): F[Unit] = {
 
     val dispatchForSender: Option[F[Unit]] = msg.sender.map { sndr =>
       val sender =
@@ -261,4 +308,8 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
       maybeKey <- keysStore.get(remote)
       key      <- err.fromEither(maybeKey.toRight(publicKeyNotAvailable(remote)))
     } yield key
+
+  private def errorHandler[F[_]: ErrorHandler]: ErrorHandler[F] = ApplicativeError_[F, CommError]
+
+  private def keysStore[F[_]: KeysStore]: KeysStore[F] = Kvs[F, PeerNode, Array[Byte]]
 }

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -53,7 +53,7 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
   import NetworkProtocol._
   import Encryption._
 
-  val defaultTimeout: Duration = Duration(100, MILLISECONDS)
+  val defaultTimeout: Duration = Duration(500, MILLISECONDS)
 
   def unsafeRoundTrip[F[_]: Capture: Communication]
     : (ProtocolMessage, ProtocolNode) => CommErr[ProtocolMessage] =

--- a/comm/src/test/scala/coop/rchain/p2p/ProtocolSpec.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/ProtocolSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.p2p
 import org.scalatest._
 import coop.rchain.comm.protocol.rchain._
 import com.google.common.io.BaseEncoding
-import coop.rchain.comm._, CommError._, NetworkProtocol._
+import coop.rchain.comm._, CommError._, NetworkProtocol._, Network.defaultTimeout
 import coop.rchain.p2p.effects._
 import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._, Catscontrib._, ski._, Encryption._
@@ -45,7 +45,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           // given
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           val EncryptionHandshakeMessage(proto, _) = communicationEff.requests(0)
           val Right(EncryptionHandshake(pk))       = NetworkProtocol.toEncryptionHandshake(proto)
@@ -56,7 +56,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           // given
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           value(keysStoreEff.get(remote)).get should equal(remoteKeys.pub)
         }
@@ -65,7 +65,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           // given
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           val FrameMessage(proto, _) = communicationEff.requests(1)
           val Right(Frame(n, f))     = NetworkProtocol.toFrame(proto)
@@ -87,7 +87,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           // given
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           communicationEff.nodes should not be empty
         }
@@ -99,7 +99,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           keysStoreEff.put(remote, remoteKeys.pub)
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           communicationEff.requests(0) should not be an[EncryptionHandshakeMessage]
         }
@@ -108,7 +108,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           keysStoreEff.put(remote, remoteKeys.pub)
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           val FrameMessage(proto, _) = communicationEff.requests(0)
           val Right(Frame(n, f))     = NetworkProtocol.toFrame(proto)
@@ -131,7 +131,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
           keysStoreEff.put(remote, remoteKeys.pub)
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           communicationEff.nodes should not be empty
         }
@@ -141,7 +141,7 @@ class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with Ap
           communicationEff.setResponses(kp(generateResponses(fstPhase, sndPhaseFailure)))
           keysStoreEff.put(remote, remoteKeys.pub)
           // when
-          Network.connect[Effect](remote)
+          Network.connect[Effect](remote, defaultTimeout)
           // then
           communicationEff.requests(0) should be(an[FrameMessage])
           communicationEff.requests(1) should be(an[EncryptionHandshakeMessage])

--- a/node/src/main/scala/coop/rchain/node/effects.scala
+++ b/node/src/main/scala/coop/rchain/node/effects.scala
@@ -163,7 +163,7 @@ object effects {
 
       def roundTrip(msg: ProtocolMessage,
                     remote: ProtocolNode,
-                    timeout: Duration = Duration(500, MILLISECONDS)): F[CommErr[ProtocolMessage]] =
+                    timeout: Duration): F[CommErr[ProtocolMessage]] =
         net.roundTrip[F](msg, remote, timeout)
       def local: F[ProtocolNode] = net.local.pure[F]
       def commSend(msg: ProtocolMessage, peer: PeerNode): F[CommErr[Unit]] =


### PR DESCRIPTION
In this PR:

1. moved `connectToBootstrap` and `findAndConnect` to p2p.Network
2. now when connecting to bootstrap process is attempt few times before node surrenders and exits
3. Change findAndConnect - does not need filtering out the results of connect

Example of logs after the change:
```
11:07:24.027 [scala-execution-context-global-31] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode bootstrap}
11:07:24.067 [scala-execution-context-global-32] WARN  logger - Failed to connect to bootstrap (attempt 1 / 5)
11:07:24.068 [scala-execution-context-global-32] INFO  logger - Initialize second phase handshake (protocol handshake) to #{PeerNode bootstrap}
11:07:24.134 [scala-execution-context-global-31] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode bootstrap}
11:07:24.196 [scala-execution-context-global-31] WARN  logger - Failed to connect to bootstrap (attempt 2 / 5)
11:07:24.197 [scala-execution-context-global-31] INFO  logger - Initialize second phase handshake (protocol handshake) to #{PeerNode bootstrap}
11:07:24.289 [scala-execution-context-global-31] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode bootstrap}
11:07:24.330 [scala-execution-context-global-29] ERROR logger - Out-of-sequence message: UpstreamResponse(Protocol(Some(Header(Some(Node(<ByteString@74f8e9c1 size=9>,<ByteString@316dd90b size=13>,40000,40000)),1523437644285,1)),Some(ReturnHeader(1523437643975,1)),Upstream(Any(type.googleapis.com/coop.rchain.comm.protocol.rchain.Frame,<ByteString@586eca3b size=72>))),1523437644299)
11:07:24.331 [scala-execution-context-global-29] ERROR logger - Out-of-sequence message: UpstreamResponse(Protocol(Some(Header(Some(Node(<ByteString@224bf01c size=9>,<ByteString@28be8e3 size=13>,40000,40000)),1523437644310,2)),Some(ReturnHeader(1523437644034,2)),Upstream(Any(type.googleapis.com/coop.rchain.comm.protocol.rchain.EncryptionHandshakeResponse,<ByteString@501fe6a size=34>))),1523437644330)
11:07:24.332 [scala-execution-context-global-29] ERROR logger - Out-of-sequence message: UpstreamResponse(Protocol(Some(Header(Some(Node(<ByteString@674a41e size=9>,<ByteString@7b427fdc size=13>,40000,40000)),1523437644314,3)),Some(ReturnHeader(1523437644069,3)),Upstream(Any(type.googleapis.com/coop.rchain.comm.protocol.rchain.Frame,<ByteString@26d35ca7 size=72>))),1523437644331)
11:07:24.333 [scala-execution-context-global-29] ERROR logger - Out-of-sequence message: UpstreamResponse(Protocol(Some(Header(Some(Node(<ByteString@2c2b14b9 size=9>,<ByteString@fdc0176 size=13>,40000,40000)),1523437644318,4)),Some(ReturnHeader(1523437644135,4)),Upstream(Any(type.googleapis.com/coop.rchain.comm.protocol.rchain.EncryptionHandshakeResponse,<ByteString@678823ce size=34>))),1523437644332)
11:07:24.334 [scala-execution-context-global-29] ERROR logger - Out-of-sequence message: UpstreamResponse(Protocol(Some(Header(Some(Node(<ByteString@5b826dfc size=9>,<ByteString@2ff824e9 size=13>,40000,40000)),1523437644320,5)),Some(ReturnHeader(1523437644198,5)),Upstream(Any(type.googleapis.com/coop.rchain.comm.protocol.rchain.Frame,<ByteString@40c047d1 size=72>))),1523437644333)
11:07:24.342 [scala-execution-context-global-31] INFO  logger - Initialize second phase handshake (protocol handshake) to #{PeerNode bootstrap}
11:07:24.351 [scala-execution-context-global-31] INFO  logger - Connected #{PeerNode bootstrap}.
11:07:29.383 [scala-execution-context-global-31] INFO  logger - Peers: 1.
```