### PR TITLE
Create a PR template for the RChain project

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,7 +5,7 @@ Provide a brief description of what this PR does, and why it's needed.
 If applicable, add link to corresponding JIRA issue.
 
 ### Complete this checklist before you submit the PR
-- [ ] This PR contains no more than 200 lines of code.
+- [ ] This PR contains no more than 200 lines of code, excluding test code.
 - [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
 - [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+## Overview
+Provide a brief description of what this PR does, and why it's needed.
+
+### Does this PR relate to an RChain JIRA issue? 
+If applicable, add link to corresponding JIRA issue.
+
+### Complete this checklist before you submit the PR
+- [ ] This PR contains no more than 200 lines of code.
+- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
+- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.
+
+### Notes
+Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.


### PR DESCRIPTION
Using a standard template for RChain PRs will help assure PRs meet adopted coding standards.

@MParlikar, do you want to add other items to the checklist related to testing, integration, or documentation?