### PR TITLE
Point the wider audience to developer.rchain.coop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 The open-source RChain project is building a decentralized, economic, censorship-resistant, public compute infrastructure and blockchain. It will host and execute programs popularly referred to as “smart contracts”. It will be trustworthy, scalable, concurrent, with proof-of-stake consensus and content delivery.
 
-[RChain Developer](https://developer.rchain.coop/) is for building on top of the platform.
+[RChain Developer](https://developer.rchain.coop/) has a [Rholang tutorial](https://developer.rchain.coop/tutorial)
+and other information for building on top of the platform, including a roadmap of planned features and releases.
 This repository is the evolving platform itself.
 
 ### Communication

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 The open-source RChain project is building a decentralized, economic, censorship-resistant, public compute infrastructure and blockchain. It will host and execute programs popularly referred to as “smart contracts”. It will be trustworthy, scalable, concurrent, with proof-of-stake consensus and content delivery.
 
+[RChain Developer](https://developer.rchain.coop/) is for building on top of the platform.
+This repository is the evolving platform itself.
+
 ### Communication
 
 The `comm` subproject contains code for network related operations for RChain.


### PR DESCRIPTION
Andre Cronje's [code review](https://medium.com/@suchi.blackwing/cryptocurrency-code-review-rchain-ad77f74f74) article shows that it can be challenging to get oriented to the master branch.

So far, this PR is just a tweak to cite developer.rchain.coop and the Rholang tutorial and mention the roadmap.

But I could do a bit more... a lot of the info about setting up a development environment and building from source typically gets moved from README to CONTRIBUTING in due course. If you like, I can start doing that.

That might leave room for citing blog articles corresponding to the most recent one or two releases.

Another idea: I can move the Rosette README from 1993 out of the way and get github to show the modern stuff in README.txt .