### PR TITLE
ROS-399 Port Ob.cc Primitives

### DIFF
--- a/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/RblAtom.scala
@@ -2,6 +2,13 @@ package coop.rchain.rosette
 
 trait RblAtom extends Ob
 
+case class RblSymbol(value: Symbol) extends RblAtom {
+  override val meta   = null
+  override val parent = null
+
+  override def toString = s"RblSymbol($value)"
+}
+
 case class RblBool(value: Boolean) extends RblAtom {
   override val meta   = null
   override val parent = null

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/ob.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rosette.prim
 
-import coop.rchain.rosette.{Ctxt, Ob, RblString}
+import coop.rchain.rosette.{Ctxt, Ob, RblString, RblSymbol}
 import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
 import coop.rchain.rosette.prim.Prim._
 
@@ -12,12 +12,11 @@ object ob {
     * e.g. (object->string 1)   ==> "1"
     *      (object->string fx+) ==> "{Prim}"
     */
-  object objectString extends Prim {
+  object objectToString extends Prim {
     override val name: String = "object->string"
     override val minArgs: Int = 1
     override val maxArgs: Int = MaxArgs
 
-    @checkTypeMismatch[Ob]
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
@@ -25,8 +24,7 @@ object ob {
       val init = ""
 
       Right(
-        RblString(
-          elem.foldLeft(init)((acc: String, el: Ob) => (acc ++ el.toString)))
+        RblString(elem.foldLeft(init)((acc: String, el: Ob) => (acc ++ el.toString)))
       )
     }
   }
@@ -37,6 +35,21 @@ object ob {
     * e.g. (object->symbol 1)   ==> '1
     *      (object->symbol fx+) ==> '{Prim}
     */
-  // TODO: Implement objectSymbol primitive
+  object objectToSymbol extends Prim {
+    override val name: String = "object->symbol"
+    override val minArgs: Int = 1
+    override val maxArgs: Int = MaxArgs
+
+    @checkArgumentMismatch
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblSymbol] = {
+      val elem = ctxt.argvec.elem
+      val n    = ctxt.nargs
+      val init = ""
+
+      Right(
+        RblSymbol(Symbol(elem.foldLeft(init)((acc: String, el: Ob) => (acc ++ el.toString))))
+      )
+    }
+  }
 
 }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/ob.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/ob.scala
@@ -1,0 +1,42 @@
+package coop.rchain.rosette.prim
+
+import coop.rchain.rosette.{Ctxt, Ob, RblString}
+import coop.rchain.rosette.macros.{checkArgumentMismatch, checkTypeMismatch}
+import coop.rchain.rosette.prim.Prim._
+
+object ob {
+
+  /**
+    * Define the object->string primitive.
+    * Returns the string representation of the supplied arguments.
+    * e.g. (object->string 1)   ==> "1"
+    *      (object->string fx+) ==> "{Prim}"
+    */
+  object objectString extends Prim {
+    override val name: String = "object->string"
+    override val minArgs: Int = 1
+    override val maxArgs: Int = MaxArgs
+
+    @checkTypeMismatch[Ob]
+    @checkArgumentMismatch
+    override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
+      val elem = ctxt.argvec.elem
+      val n    = ctxt.nargs
+      val init = ""
+
+      Right(
+        RblString(
+          elem.foldLeft(init)((acc: String, el: Ob) => (acc ++ el.toString)))
+      )
+    }
+  }
+
+  /**
+    * Define the object->symbol primitive.
+    * Returns the symbol representation of the supplied arguments.
+    * e.g. (object->symbol 1)   ==> '1
+    *      (object->symbol fx+) ==> '{Prim}
+    */
+  // TODO: Implement objectSymbol primitive
+
+}

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/ObSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/ObSpec.scala
@@ -1,0 +1,35 @@
+package coop.rchain.rosette.prim
+
+import coop.rchain.rosette.prim.ob._
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, RblBool, RblString, Tuple}
+import org.scalatest._
+
+class ObSpec extends FlatSpec with Matchers {
+  val ctxt = Ctxt(
+    tag = null,
+    nargs = 1,
+    outstanding = 0,
+    pc = PC.PLACEHOLDER,
+    rslt = null,
+    trgt = null,
+    argvec = Tuple(1, Fixnum(1)),
+    env = null,
+    code = null,
+    ctxt = null,
+    self2 = null,
+    selfEnv = null,
+    rcvr = null,
+    monitor = null,
+  )
+
+  "objectString" should "convert an object into its string representation" in {
+    val newCtxt = ctxt.copy(argvec = Tuple(1, Fixnum(5)))
+    objectString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)")))
+  }
+
+  "objectString" should "convert multiple objects into their string representations" in {
+    val args    = Seq(Fixnum(5), RblBool(true))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(args))
+    objectString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)RblBool(true)")))
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/rosette/prim/ObSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/rosette/prim/ObSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rosette.prim
 
 import coop.rchain.rosette.prim.ob._
-import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, RblBool, RblString, Tuple}
+import coop.rchain.rosette.{Ctxt, Fixnum, Ob, PC, RblBool, RblString, RblSymbol, Tuple}
 import org.scalatest._
 
 class ObSpec extends FlatSpec with Matchers {
@@ -22,14 +22,25 @@ class ObSpec extends FlatSpec with Matchers {
     monitor = null,
   )
 
-  "objectString" should "convert an object into its string representation" in {
+  "objectToString" should "convert an object into its string representation" in {
     val newCtxt = ctxt.copy(argvec = Tuple(1, Fixnum(5)))
-    objectString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)")))
+    objectToString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)")))
   }
 
-  "objectString" should "convert multiple objects into their string representations" in {
+  "objectToString" should "convert multiple objects into their string representations" in {
     val args    = Seq(Fixnum(5), RblBool(true))
     val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(args))
-    objectString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)RblBool(true)")))
+    objectToString.fnSimple(newCtxt) should be(Right(RblString("Fixnum(5)RblBool(true)")))
+  }
+
+  "objectToSymbol" should "convert an object into its symbol representation" in {
+    val newCtxt = ctxt.copy(argvec = Tuple(1, Fixnum(5)))
+    objectToSymbol.fnSimple(newCtxt) should be(Right(RblSymbol(Symbol("Fixnum(5)"))))
+  }
+
+  "objectToSymbol" should "convert multiple objects into their symbol representations" in {
+    val args    = Seq(Fixnum(5), RblBool(true))
+    val newCtxt = ctxt.copy(nargs = 2, argvec = Tuple(args))
+    objectToSymbol.fnSimple(newCtxt) should be(Right(RblSymbol(Symbol("Fixnum(5)RblBool(true)"))))
   }
 }


### PR DESCRIPTION
Ports over the `object->string` primitive from the rosette vm. There is still quite a bit of work left to do but opening up PR for comments. 

Listing some TODOs:
- [x] Add test cases for `object->string`
- [x] Implement `object->symbol`
- [x] Add test cases for `object->symbol`

Unrelated questions:
- Need some help understanding how the `TypeMismatchMacro` works. I've tried looking up how `whitebox.Context`'s `macroApplication.filter` works (It's used here:https://github.com/rchain/rchain/pull/68/files#diff-1188bbd754795ad1979dd4dadf615c60R45) but I can't find anything except for a comment in the scala reflection docs [here](http://www.scala-lang.org/api/2.12.x/scala-reflect/scala/reflect/macros/blackbox/Context.html). 
