### PR TITLE
[ROS-382][2/2] Address remaining compiler warning for roscala

### DIFF
--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -38,6 +38,7 @@ object CompilerSettings {
           Seq(
             "-Xlint:-unused,-adapted-args,-inaccessible,_",
             "-Ywarn-unused:implicits",
+            "-Ywarn-macros:after",
             "-Ywarn-unused:locals",
             "-Ywarn-unused:patvars",
             "-Ywarn-unused:privates"

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/rblstring.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/rblstring.scala
@@ -61,7 +61,6 @@ object rblstring {
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
       val elem = ctxt.argvec.elem
-      val n    = ctxt.nargs
       val init = ""
 
       Right(
@@ -170,8 +169,7 @@ object rblstring {
 
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, RblString] = {
-      val elem  = ctxt.argvec.elem
-      val nargs = ctxt.nargs
+      val elem = ctxt.argvec.elem
 
       for {
         n <- checkType[Fixnum](0, elem)
@@ -330,7 +328,7 @@ object rblstring {
       Left(IndexOutOfBounds(n, elem.size))
     } else {
       elem(n) match {
-        case e: T => Right(elem(n).asInstanceOf[T])
+        case _: T => Right(elem(n).asInstanceOf[T])
         case _    => Left(TypeMismatch(n, ct.runtimeClass.getName))
       }
     }

--- a/roscala/src/main/scala/coop/rchain/rosette/prim/tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/prim/tuple.scala
@@ -77,7 +77,6 @@ object tuple {
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
       val elem = ctxt.argvec.elem
-      val n    = ctxt.nargs
       val init = Tuple(Seq.empty)
 
       Right(
@@ -275,8 +274,7 @@ object tuple {
 
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, Tuple] = {
-      val elem  = ctxt.argvec.elem
-      val nargs = ctxt.nargs
+      val elem = ctxt.argvec.elem
 
       checkFixnum(1, elem).flatMap { n => // Ensure arg1 is a Fixnum
         if (n.value <= 0)
@@ -294,8 +292,7 @@ object tuple {
 
     @checkArgumentMismatch
     override def fnSimple(ctxt: Ctxt): Either[PrimError, RblBool] = {
-      val elem  = ctxt.argvec.elem
-      val nargs = ctxt.nargs
+      val elem = ctxt.argvec.elem
 
       checkTuple(0, elem).map { t =>
         RblBool(t.elem.exists(el => (el == elem(1))))

--- a/roscala/src/main/scala/coop/rchain/rosette/utils/package.scala
+++ b/roscala/src/main/scala/coop/rchain/rosette/utils/package.scala
@@ -4,11 +4,7 @@ import java.io.{File, PrintWriter}
 
 import shapeless.Lens
 
-package object utils {
-  def printToFile(f: File)(op: PrintWriter => Unit) {
-    val p = new PrintWriter(f)
-    try { op(p) } finally { p.close() }
-  }
+package utils {
 
   //this function exist only to use `asInstanceOf`-like casts at lens level
   //so normally when we use code like:
@@ -19,11 +15,18 @@ package object utils {
   class unsafeCastLens[B] {
     def apply[T, A](lens: Lens[T, A]): Lens[T, B] =
       new Lens[T, B] {
-        override def get(s: T): B       = lens.get(s).asInstanceOf[B]
+        override def get(s: T): B = lens.get(s).asInstanceOf[B]
+
         override def set(s: T)(b: B): T = lens.set(s)(b.asInstanceOf[A])
       }
   }
+}
 
+package object utils {
+  def printToFile(f: File)(op: PrintWriter => Unit): Unit = {
+    val p = new PrintWriter(f)
+    try { op(p) } finally { p.close() }
+  }
   object unsafeCastLens {
     def apply[B] = new unsafeCastLens[B]
   }


### PR DESCRIPTION
Since we use macro as checkTypeMismatch and checkArgumentMismatch, we should add the             "-Ywarn-macros:after" to CompilerSettings.scala, so that scala will then traverse the original tree of
macro expansions to witness usages, as https://github.com/scala/scala/pull/5876 and https://github.com/scala/bug/issues/10630 said. 

This PR reduce the number of compiler warning of roscala to 3, two of that are because "???" and another is because non-exhaustive match in VirtualMachine.scala:869. 

@tymm PTAL.
