### PR TITLE
nix/default.nix: update rchainPackages, add rchainEnv

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,9 +16,18 @@ let
 
   bnfcHEAD = pkgs.haskellPackages.callCabal2nix "bnfc-HEAD" bnfcSrc {};
 
-in {
+  jdk = pkgs.openjdk8;
+
+  sbt = pkgs.sbt.override { jre = jdk.jre; };
+
+in rec {
 
   bnfc = bnfcHEAD;
 
-  rchainPackages = with pkgs; [ bnfcHEAD jflex ];
+  rchainEnv = pkgs.buildFHSUserEnv {
+    name = "rchain";
+    targetPkgs = ps: rchainPackages;
+  };
+
+  rchainPackages = with pkgs; [ bnfcHEAD git jflex libsodium sbt jdk ];
 }


### PR DESCRIPTION
This PR adds `libsodium`, `sbt`, and the `openjdk` to the `rchainPackages` list.

It also adds a `FHSUserEnv`-based `rchainEnv` which creates a script to place a user in an FHS-compatible sandbox using linux namespaces.  When the script is invoked, a user will be dropped into a shell in the sandboxed environment.  This allows `libsodium` to found in `/usr/lib` rather than in `$HOME/.nix-profile/lib`.

To test the script:
```
nix-build nix/default.nix -A rchainEnv
./result/bin/rchain
sbt
```