### PR TITLE
Update info on Github structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 * [Code Review Process](https://rchain.atlassian.net/wiki/spaces/DOC/pages/44040200/Code+Review+Process)
 * [Coding Standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards)
 * [Github Workflow](https://rchain.atlassian.net/wiki/spaces/DOC/pages/44007462/Github+Fork-n-Beans+Workflow)
-* [Github Structure](https://rchain.atlassian.net/wiki/spaces/DOC/pages/10616833/Github+structure)
+* Information about setting up your development environment and the structure of the RChain GitHub repository is available in [RChain/README.md](https://github.com/rchain/rchain/blob/master/README.md).
 
 If you're picking up someone else's pull request, then whatever you
 do must preserve the commit history. We're not going to squash commits


### PR DESCRIPTION
This PR updates the point to current information about the RChain GitHub structure.