### PR TITLE
add Traverse instance for immutable.Seq

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -259,6 +259,7 @@ lazy val rspace = (project in file("rspace"))
       )
     )
   )
+  .dependsOn(shared)
 
 lazy val rspaceBench = (project in file("rspace-bench"))
   .settings(commonSettings, libraryDependencies ++= commonDependencies)

--- a/rspace/src/main/scala/coop/rchain/rspace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/package.scala
@@ -2,11 +2,11 @@ package coop.rchain
 
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
+import coop.rchain.catscontrib._
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.util.{removeFirst, sequence}
 
-import scala.collection.immutable.Seq
 import scala.annotation.tailrec
+import scala.collection.immutable.Seq
 import scala.util.Random
 
 package object rspace {
@@ -93,7 +93,7 @@ package object rspace {
       c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
     }.toMap
 
-    sequence(extractDataCandidatesLoop(channels.zip(patterns), channelToIndexedData, Nil))
+    extractDataCandidatesLoop(channels.zip(patterns), channelToIndexedData, Nil).sequence
   }
 
   /** Finds matching data candidates in the store.
@@ -121,7 +121,7 @@ package object rspace {
       c -> { if (c == batChannel) (data, -1) +: as else as }
     }.toMap
 
-    sequence(extractDataCandidatesLoop(channels.zip(patterns), channelToIndexedData, Nil))
+    extractDataCandidatesLoop(channels.zip(patterns), channelToIndexedData, Nil).sequence
   }
 
   /** Searches the store for data matching all the given patterns at the given channels.

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -1,4 +1,5 @@
 package coop.rchain.rspace
+
 import scala.collection.immutable.Seq
 
 package object util {
@@ -42,16 +43,4 @@ package object util {
     val (l1, l2) = xs.span(x => !p(x))
     l1 ::: l2.drop(1)
   }
-
-  /**
-    * scala cats sequence
-    * returns None if any element in the list is None, and return Some of values in the list otherwise
-    */
-  def sequence[T](xs: Seq[Option[T]]): Option[Seq[T]] =
-    //return is bad operator, however fold and recursive implementations
-    //generate enormous memory traffic due to Seq concatenations
-    Some(xs.map {
-      case None    => return None
-      case Some(x) => x
-    })
 }

--- a/shared/src/main/scala/coop/rchain/catscontrib/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/package.scala
@@ -5,3 +5,4 @@ package object catscontrib
     with EitherTInstances
     with WriterTInstances
     with ApplicativeError_Instances
+    with SeqInstances

--- a/shared/src/main/scala/coop/rchain/catscontrib/seq.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/seq.scala
@@ -1,0 +1,30 @@
+package coop.rchain.catscontrib
+
+import cats.{Always, Applicative, Eval, Traverse}
+
+import scala.collection.immutable.Seq
+
+object seq extends SeqInstances
+
+trait SeqInstances {
+
+  implicit val traverseSeq: Traverse[Seq] = new Traverse[Seq] {
+
+    def traverse[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Seq[B]] =
+      foldRight[A, G[Seq[B]]](fa, Always(G.pure(Seq.empty[B]))) { (a, acc) =>
+        G.map2Eval(f(a), acc)(_ +: _)
+      }.value
+
+    def foldLeft[A, B](fa: Seq[A], b: B)(f: (B, A) => B): B =
+      fa.foldLeft(b)(f)
+
+    def foldRight[A, B](fa: Seq[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
+      def loop(as: Seq[A]): Eval[B] =
+        as match {
+          case Nil    => lb
+          case h +: t => f(h, Eval.defer(loop(t)))
+        }
+      Eval.defer(loop(fa))
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds a `Traverse` instance for `scala.collection.immutable.Seq`, and then puts it to use in `rspace`.

### Does this PR relate to an RChain JIRA issue? 

No.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes

N/A