### PR TITLE
Extract list of connected nodes via Communication typeclass

### DIFF
--- a/comm/src/main/scala/coop/rchain/p2p/effects/Communication.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/effects/Communication.scala
@@ -14,7 +14,7 @@ trait Communication[F[_]] {
   def addNode(node: PeerNode): F[Unit]
   def broadcast(msg: ProtocolMessage): F[Seq[CommErr[Unit]]]
   def findMorePeers(limit: Int): F[Seq[PeerNode]]
-  def countPeers: F[Int]
+  def peers: F[Seq[PeerNode]]
 }
 
 object Communication extends CommunicationInstances {
@@ -34,7 +34,7 @@ object Communication extends CommunicationInstances {
       def addNode(node: PeerNode): T[F, Unit]                       = C.addNode(node).liftM[T]
       def broadcast(msg: ProtocolMessage): T[F, Seq[CommErr[Unit]]] = C.broadcast(msg).liftM[T]
       def findMorePeers(limit: Int): T[F, Seq[PeerNode]]            = C.findMorePeers(limit).liftM[T]
-      def countPeers: T[F, Int]                                     = C.countPeers.liftM[T]
+      def peers: T[F, Seq[PeerNode]]                                = C.peers.liftM[T]
     }
 }
 

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -70,7 +70,7 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
         _              <- IOUtil.sleep[F](5000L)
         peers          <- Communication[F].findMorePeers(10)
         peersSuccedded <- peers.toList.traverse(connect[F](_, defaultTimeout).attempt)
-        thisCount      <- Communication[F].countPeers
+        thisCount      <- Communication[F].peers.map(_.size)
         _              <- (thisCount != lastCount).fold(Log[F].info(s"Peers: $thisCount."), ().pure[F])
       } yield thisCount)
 

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -58,7 +58,7 @@ object EffectsTestInstances {
     }
     def broadcast(msg: ProtocolMessage): F[Seq[CommErr[Unit]]] = ???
     def findMorePeers(limit: Int): F[Seq[PeerNode]]            = ???
-    def countPeers: F[Int]                                     = ???
+    def peers: F[Seq[PeerNode]]                                = ???
     def receiver: F[Unit]                                      = ???
   }
 

--- a/node/src/main/scala/coop/rchain/node/effects.scala
+++ b/node/src/main/scala/coop/rchain/node/effects.scala
@@ -181,9 +181,9 @@ object effects {
         Capture[F].capture {
           net.findMorePeers(limit)
         }
-      def countPeers: F[Int] =
+      def peers: F[Seq[PeerNode]] =
         Capture[F].capture {
-          net.table.peers.size
+          net.table.peers
         }
     }
 


### PR DESCRIPTION
## Overview
This PR adds new function `peers` to `Communication` API. 
Previous `countPeers` is build on that function. This API will be used by both CASPER and gRPC service (see CORE-352)

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=CORE-460

