### PR TITLE
node: rejigger data directory, persist keys there

### DIFF
--- a/node/src/main/scala/coop/rchain/node/effects.scala
+++ b/node/src/main/scala/coop/rchain/node/effects.scala
@@ -5,6 +5,7 @@ import coop.rchain.p2p, p2p.NetworkAddress, p2p.Network.KeysStore
 import coop.rchain.p2p.effects._
 import coop.rchain.comm._, CommError._
 import java.io.{File, FileInputStream, FileOutputStream, PrintWriter}
+import java.nio.file.{Files, Path}
 
 import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._
@@ -12,7 +13,11 @@ import Catscontrib._, ski._, TaskContrib._
 import monix.eval.Task
 
 object effects {
-  def encryption(nodeName: String): Encryption[Task] = new Encryption[Task] {
+
+  private def createDirectoryIfNotExists(path: Path): Path =
+    if (Files.notExists(path)) Files.createDirectory(path) else path
+
+  def encryption(keysPath: Path): Encryption[Task] = new Encryption[Task] {
     import Encryption._
     import coop.rchain.crypto.encryption.Curve25519
     import com.google.common.io.BaseEncoding
@@ -24,13 +29,12 @@ object effects {
       PublicPrivateKeys(pub, sec)
     }
 
-    val storePath = System.getProperty("user.home") + File.separator + s".${nodeName}-rnode.keys"
-
     private def storeToFS: PublicPrivateKeys => Task[Unit] =
       keys =>
         Task
           .delay {
-            val pw = new PrintWriter(new File(storePath))
+            createDirectoryIfNotExists(keysPath.getParent)
+            val pw = new PrintWriter(keysPath.toFile)
             pw.println(encoder.encode(keys.pub))
             pw.println(encoder.encode(keys.priv))
             pw.close
@@ -41,7 +45,7 @@ object effects {
     private def fetchFromFS: Task[Option[PublicPrivateKeys]] =
       Task
         .delay {
-          val lines  = scala.io.Source.fromFile(storePath).getLines.toList
+          val lines  = scala.io.Source.fromFile(keysPath.toFile).getLines.toList
           val pubKey = encoder.decode(lines(0))
           val secKey = encoder.decode(lines(1))
           PublicPrivateKeys(pubKey, secKey)
@@ -120,7 +124,7 @@ object effects {
     }
   }
 
-  def remoteKeysKvs(path: String): Kvs[Task, PeerNode, Array[Byte]] =
+  def remoteKeysKvs(remoteKeysPath: Path): Kvs[Task, PeerNode, Array[Byte]] =
     new Kvs[Task, PeerNode, Array[Byte]] {
       import com.google.protobuf.ByteString
       var m: Map[PeerNode, Array[Byte]] = fetch()
@@ -138,7 +142,8 @@ object effects {
       }
 
       private def fetch(): Map[PeerNode, Array[Byte]] = {
-        val file = new File(path)
+        createDirectoryIfNotExists(remoteKeysPath.getParent)
+        val file = remoteKeysPath.toFile
         file.createNewFile()
         KeysStore
           .parseFrom(new FileInputStream(file))
@@ -155,7 +160,7 @@ object effects {
       private def store(): Unit =
         KeysStore(m.map {
           case (k, v) => (k.toAddress, ByteString.copyFrom(v))
-        }).writeTo(new FileOutputStream(new File(path)))
+        }).writeTo(new FileOutputStream(remoteKeysPath.toFile))
     }
 
   def communication[F[_]: Monad: Capture: Metrics](net: UnicastNetwork): Communication[F] =

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -38,7 +38,7 @@ class NodeRuntime(conf: Conf) {
   val http = HttpServer(conf.httpPort())
   http.start
 
-  val runtime: Runtime = Runtime.create(conf.data_dir(), conf.map_size())
+  val runtime: Runtime = Runtime.create(conf.data_dir().resolve("rspace"), conf.map_size())
 
   val grpc = new GrpcServer(ExecutionContext.global, conf.grpcPort(), runtime)
   grpc.start()

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -28,7 +28,8 @@ class NodeRuntime(conf: Conf) {
   private val name           = conf.name.toOption.fold(UUID.randomUUID.toString.replaceAll("-", ""))(id)
   private val address        = s"rnode://$name@$host:${conf.port()}"
   private val src            = p2p.NetworkAddress.parse(address).right.get
-  private val remoteKeysPath = System.getProperty("user.home") + File.separator + s".${name}-rnode-remote.keys"
+  private val remoteKeysPath = conf.data_dir().resolve("keys").resolve(s"${name}-rnode-remote.keys")
+  private val keysPath       = conf.data_dir().resolve("keys").resolve(s"${name}-rnode.keys")
 
   /** Run services */
   /** TODO all services should be defined in terms of `nodeProgram` */
@@ -56,7 +57,7 @@ class NodeRuntime(conf: Conf) {
   }
 
   /** Capabilities for Effect */
-  implicit val encryptionEffect: Encryption[Task]        = effects.encryption(name)
+  implicit val encryptionEffect: Encryption[Task]        = effects.encryption(keysPath)
   implicit val logEffect: Log[Task]                      = effects.log
   implicit val timeEffect: Time[Task]                    = effects.time
   implicit val metricsEffect: Metrics[Task]              = effects.metrics

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.interpreter
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
 import coop.rchain.models.Expr.ExprInstance.GString
@@ -36,6 +36,9 @@ object Runtime {
     }
 
   def create(dataDir: Path, mapSize: Long): Runtime = {
+
+    if (Files.notExists(dataDir)) Files.createDirectory(dataDir)
+
     val store =
       LMDBStore.create[Channel, Seq[Channel], Seq[Channel], TaggedContinuation](dataDir, mapSize)
 


### PR DESCRIPTION
## Overview
This PR updates node to do two things:
1. It stores node keys a "keys" sub-directory of the data directory instead of $HOME
2. It stores rspace db files in an "rspace" sub-directory of the data directory

### Does this PR relate to an RChain JIRA issue? 
No.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A