### PR TITLE
Change Deferred Symbol Lookup to use a flag bit in the Lookup opCode

### DIFF
--- a/rosette/h/Compile.h
+++ b/rosette/h/Compile.h
@@ -63,6 +63,9 @@ class CompilationUnit : public BinaryOb {
     Tuple* litvec;
     LabelTable* labels;
 
+    static const int MaximumLitVecSize = 0x7f;
+    static const int LookupDeferMask = 0x80;
+
     static CompilationUnit* create(Ob*, Ob*, Ob*);
 
     int traversePtrs(PSOb__PSOb);

--- a/rosette/h/Opcode.h
+++ b/rosette/h/Opcode.h
@@ -78,10 +78,10 @@ jump/cut		     10nn nnnn nnnn m:8 x:8	pc <- n; cut m levels
 off env
 
 
-lookup to arg		0111 aaaa vvvv vvvv		arg[a] <-
-lookup(litvec[v])
-lookup to reg		1000 rrrr vvvv vvvv		reg[r] <-
-lookup(litvec[v])
+lookup to arg		0111 aaaa dvvv vvvv		arg[a] <-
+lookup(litvec[v]) with optional (d)efer
+lookup to reg		1000 rrrr dvvv vvvv		reg[r] <-
+lookup(litvec[v]) with optional (d)efer
 
 
 xfer lex to arg		1001 illl oooo aaaa		arg[a] <- lex[i,l,o]
@@ -193,7 +193,6 @@ enum Opcode {
 
     opImmediateLitToReg = 0xd0,
 
-    opDeferLookup = 0xe0,
 
     MaxOpcodes = 256
 };


### PR DESCRIPTION


## Overview
This PR refactors the Deferred Symbol Lookup feature to use a flag bit within the Lookup opCode
as opposed to a separate opCode that precedes and modifies the behavior of the Lookup opCode.

### Does this PR relate to an RChain JIRA issue?
https://rchain.atlassian.net/browse/ROS-360

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
