### PR TITLE
Get block passing working with comms

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -1,8 +1,12 @@
 package coop.rchain.casper
 
-import cats.Applicative, cats.implicits._
-
+import cats.{Applicative, Monad}
+import cats.implicits._
 import coop.rchain.casper.protocol.{BlockMessage, Resource}
+import coop.rchain.casper.util.comm.CommUtil
+import coop.rchain.catscontrib.{Capture, IOUtil}
+import coop.rchain.p2p.Network.{ErrorHandler, KeysStore}
+import coop.rchain.p2p.effects._
 
 trait Casper[F[_], A] {
   def addBlock(b: BlockMessage): F[Unit]
@@ -10,6 +14,7 @@ trait Casper[F[_], A] {
   def deploy(r: Resource): F[Unit]
   def estimator: F[A]
   def proposeBlock: F[Option[BlockMessage]]
+  def shouldSendBlock: F[Unit]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockMessage]]
@@ -19,12 +24,30 @@ object MultiParentCasper extends MultiParentCasperInstances {
 }
 
 sealed abstract class MultiParentCasperInstances {
-  def noCasper[F[_]: Applicative]: MultiParentCasper[F] = new MultiParentCasper[F] {
+  def noCasper[F[_]: Applicative]: MultiParentCasper[F] =
+    new MultiParentCasper[F] {
+      def addBlock(b: BlockMessage): F[Unit]    = ().pure[F]
+      def contains(b: BlockMessage): F[Boolean] = false.pure[F]
+      def deploy(r: Resource): F[Unit]          = ().pure[F]
+      def estimator: F[IndexedSeq[BlockMessage]] =
+        Applicative[F].pure[IndexedSeq[BlockMessage]](Vector(BlockMessage()))
+      def proposeBlock: F[Option[BlockMessage]] = Applicative[F].pure[Option[BlockMessage]](None)
+      def shouldSendBlock: F[Unit]              = ().pure[F]
+    }
+
+  def simpleCasper[
+      F[_]: Monad: Capture: Applicative: NodeDiscovery: TransportLayer: Log: Time: Encryption: KeysStore: ErrorHandler]
+    : MultiParentCasper[F] = new MultiParentCasper[F] {
     def addBlock(b: BlockMessage): F[Unit]    = ().pure[F]
     def contains(b: BlockMessage): F[Boolean] = false.pure[F]
     def deploy(r: Resource): F[Unit]          = ().pure[F]
     def estimator: F[IndexedSeq[BlockMessage]] =
       Applicative[F].pure[IndexedSeq[BlockMessage]](Vector(BlockMessage()))
     def proposeBlock: F[Option[BlockMessage]] = Applicative[F].pure[Option[BlockMessage]](None)
+    def shouldSendBlock: F[Unit] =
+      for {
+        _ <- IOUtil.sleep[F](5000L)
+        _ <- CommUtil.sendBlock[F](BlockMessage.defaultInstance)
+      } yield ()
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -2,23 +2,28 @@ package coop.rchain.casper.util.comm
 
 import cats.{Applicative, Monad}
 import cats.implicits._
-
 import coop.rchain.casper.MultiParentCasper
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.comm.ProtocolMessage
 import coop.rchain.comm.protocol.rchain.Packet
-import coop.rchain.p2p.effects.{Log, NodeDiscovery, TransportLayer}
+import coop.rchain.p2p.effects._
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.p2p.Network.{frameMessage, ErrorHandler, KeysStore}
+import coop.rchain.p2p.NetworkProtocol
+
 import scala.util.Try
 
 object CommUtil {
-  def sendBlock[F[_]: Monad: NodeDiscovery: TransportLayer: Log](b: BlockMessage): F[Unit] = {
-    val packet = blockMessageToPacket(b)
-    val msg    = framePacket(packet)
-
+  def sendBlock[
+      F[_]: Monad: NodeDiscovery: TransportLayer: Log: Time: Encryption: KeysStore: ErrorHandler](
+      b: BlockMessage): F[Unit] = {
+    val serializedBlock = b.toByteString
     for {
       peers <- NodeDiscovery[F].peers
-      sends <- peers.toList.traverse(peer => TransportLayer[F].commSend(msg, peer).map(_ -> peer))
+      sends <- peers.toList.traverse { peer =>
+                frameMessage[F](peer, nonce => NetworkProtocol.framePacket(peer, serializedBlock))
+                  .flatMap(msg => TransportLayer[F].commSend(msg, peer).map(_ -> peer))
+              }
       _ <- sends.traverse {
             case (Left(err), _)   => Log[F].error(s"$err")
             case (Right(_), peer) => Log[F].info(s"Sent block ${hashString(b)} to $peer")
@@ -26,7 +31,8 @@ object CommUtil {
     } yield ()
   }
 
-  def casperPacketHandler[F[_]: Monad: MultiParentCasper: NodeDiscovery: TransportLayer: Log]
+  def casperPacketHandler[
+      F[_]: Monad: MultiParentCasper: NodeDiscovery: TransportLayer: Log: Time: Encryption: KeysStore: ErrorHandler]
     : PartialFunction[Packet, F[String]] =
     Function.unlift(packetToBlockMessage).andThen {
       case b: BlockMessage =>
@@ -40,7 +46,8 @@ object CommUtil {
         } yield logMessage
     }
 
-  private def handleNewBlock[F[_]: Monad: MultiParentCasper: NodeDiscovery: TransportLayer: Log](
+  private def handleNewBlock[
+      F[_]: Monad: MultiParentCasper: NodeDiscovery: TransportLayer: Log: Time: Encryption: KeysStore: ErrorHandler](
       b: BlockMessage): F[String] =
     for {
       _          <- MultiParentCasper[F].addBlock(b)
@@ -51,12 +58,6 @@ object CommUtil {
   private def hashString(b: BlockMessage): String =
     Base16.encode(b.blockHash.toByteArray)
 
-  private def blockMessageToPacket(msg: BlockMessage): Packet =
-    Packet().withContent(msg.toByteString)
-
   private def packetToBlockMessage(msg: Packet): Option[BlockMessage] =
     Try(BlockMessage.parseFrom(msg.content.toByteArray)).toOption
-
-  //TODO: Ask Pawel to provide a method somewhere in Comm that does the framing
-  private def framePacket(p: Packet): ProtocolMessage = ???
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -37,11 +37,11 @@ object CommUtil {
     Function.unlift(packetToBlockMessage).andThen {
       case b: BlockMessage =>
         for {
-          isNewBlock <- MultiParentCasper[F].contains(b)
-          logMessage <- if (isNewBlock) {
-                         handleNewBlock[F](b)
-                       } else {
+          isOldBlock <- MultiParentCasper[F].contains(b)
+          logMessage <- if (isOldBlock) {
                          s"Received block ${hashString(b)} again.".pure[F]
+                       } else {
+                         handleNewBlock[F](b)
                        }
         } yield logMessage
     }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -53,7 +53,7 @@ object CommUtil {
       _          <- MultiParentCasper[F].addBlock(b)
       forkchoice <- MultiParentCasper[F].estimator.map(_.head)
       _          <- sendBlock[F](b)
-    } yield s"Received block ${hashString(b)}; new fork-choice is ${hashString(forkchoice)}."
+    } yield s"Received block ${hashString(b)}. New fork-choice is TODO. ${hashString(forkchoice)}"
 
   private def hashString(b: BlockMessage): String =
     Base16.encode(b.blockHash.toByteArray)

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -1,15 +1,24 @@
 package coop.rchain.p2p
 
 import coop.rchain.p2p.effects._
+
 import scala.concurrent.duration.{Duration, MILLISECONDS}
 import com.google.protobuf.any.{Any => AnyProto}
-import coop.rchain.comm.protocol.routing, routing.Header
-import coop.rchain.comm._, CommError._
+import coop.rchain.comm.protocol.routing
+import routing.Header
+import coop.rchain.comm._
+import CommError._
 import com.netaporter.uri.Uri
 import coop.rchain.comm.protocol.rchain._
+
 import scala.util.control.NonFatal
-import cats._, cats.data._, cats.implicits._
-import coop.rchain.catscontrib._, Catscontrib._, ski._
+import cats._
+import cats.data._
+import cats.implicits._
+import coop.rchain.catscontrib._
+import Catscontrib._
+import com.google.protobuf.ByteString
+import ski._
 
 /*
  * Inspiration from ethereum:
@@ -279,10 +288,10 @@ object Network extends ProtocolDispatcher[java.net.SocketAddress] {
       err: ApplicativeError_[F, CommError]): F[A] =
     oa.fold[F[A]](err.raiseError[A](error))(_.pure[F])
 
-  private def frameMessage[F[_]: Monad: Time: TransportLayer: Encryption](
-      remote: PeerNode,
-      frameable: Nonce => Frameable)(implicit keysStore: KeysStore[F],
-                                     err: ApplicativeError_[F, CommError]): F[FrameMessage] =
+  def frameMessage[F[_]: Monad: Time: TransportLayer: Encryption](remote: PeerNode,
+                                                                  frameable: Nonce => Frameable)(
+      implicit keysStore: KeysStore[F],
+      err: ApplicativeError_[F, CommError]): F[FrameMessage] =
     frameIt[F](remote, frameable, (local, nonce, f) => frame(local, nonce, f))
 
   private def frameResponseMessage[F[_]: Monad: Time: TransportLayer: Encryption](

--- a/comm/src/main/scala/coop/rchain/p2p/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/protocol.scala
@@ -69,6 +69,11 @@ object NetworkProtocol {
     Frameable(
       Frameable.Message.ProtocolHandshakeResponse(
         ProtocolHandshakeResponse(ByteString.copyFrom(nonce))))
+
+  def framePacket(src: PeerNode, content: ByteString): Frameable =
+    Frameable(
+      Frameable.Message.Packet(Packet(content))
+    )
 }
 
 final case class EncryptionHandshakeMessage(proto: routing.Protocol, timestamp: Long)


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.

Note this PR needs a lot of clean up but can be merged into #623 

Example output

```
$ java -jar target/scala-2.12/rnode-assembly-0.2.1.jar --bootstrap "rnode://87184a84fd9e4ef9825349701feb93ae@159.203.84.29:30304"
...
01:22:12.171 [scala-execution-context-global-25] INFO  logger - Sent block 3ffde56587264a9fdc30c83507d7e2d757603877453576693d41d4ac782fad99 to #{PeerNode 87184a84fd9e4ef9825349701feb93ae}
01:22:12.171 [scala-execution-context-global-25] INFO  logger - Received block 3ffde56587264a9fdc30c83507d7e2d757603877453576693d41d4ac782fad99. New fork-choice is TODO.
01:22:12.173 [scala-execution-context-global-25] INFO  logger - Sent block 714fbcf2e84da8ca2677bafde9309d2fb46e5e76fa9b09771e57bcabf9022323 to #{PeerNode 87184a84fd9e4ef9825349701feb93ae}
01:22:12.173 [scala-execution-context-global-25] INFO  logger - Received block 714fbcf2e84da8ca2677bafde9309d2fb46e5e76fa9b09771e57bcabf9022323. New fork-choice is TODO.
01:22:12.179 [scala-execution-context-global-25] INFO  logger - Sent block 4c333d10fae134670cec5b86dd259a023b37957a4abe034d19e39678ce453aab to #{PeerNode 87184a84fd9e4ef9825349701feb93ae}
01:22:12.179 [scala-execution-context-global-25] INFO  logger - Received block 4c333d10fae134670cec5b86dd259a023b37957a4abe034d19e39678ce453aab. New fork-choice is TODO.
01:22:12.184 [scala-execution-context-global-23] INFO  logger - Sent block 38ec36de6bd8e7ba20a7e9ca500de12a14ad0fd5cb962e3b22abd9e56214c708 to #{PeerNode 87184a84fd9e4ef9825349701feb93ae}
01:22:12.184 [scala-execution-context-global-23] INFO  logger - Received block 38ec36de6bd8e7ba20a7e9ca500de12a14ad0fd5cb962e3b22abd9e56214c708. New fork-choice is TODO.
01:22:12.188 [scala-execution-context-global-23] INFO  logger - Sent block 2deb2f8c613ba35b539c0bc1a9a216b46c0675cf809ce6d0ff34ef2ee45ef828 to #{PeerNode 87184a84fd9e4ef9825349701feb93ae}
01:22:12.189 [scala-execution-context-global-23] INFO  logger - Received block 2deb2f8c613ba35b539c0bc1a9a216b46c0675cf809ce6d0ff34ef2ee45ef828. New fork-choice is TODO.
Goodbye.
```

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

This is for the Node v0.3 release.

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
