### PR TITLE
added script for local machine rnode docker test-net build using deb package

### DIFF
--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # With Docker CE installed, this will build a simple private RChain P2P test network.
-# The test network contains a bootstrap server and two peers connecting to P2P network via bootstrap.
+# The test network contains a bootstrap server and two more peers connecting to P2P network via bootstrap.
 set -eo pipefail
 
 NETWORK_UID="1" # Unique identifier for network if you wanted to run multiple test networks
@@ -64,7 +64,7 @@ for i in {0..2}; do
   
   sudo docker exec ${container_name} bash -c "
     apt -y update;
-    apt -y iputils-ping vim nano iproute2;
+    apt -y iputils-ping vim nano curl iproute2;
     apt -y install ./rnode_${branch_name}_all.deb;
     ${rnode_cmd}
     " 
@@ -76,8 +76,12 @@ echo "To display standalone bootstrap server rnode log:"
 echo "sudo docker exec node0.${network_name} bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
 echo "To display node1 rnode log:"
-echo "sudo docker exec  node1.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
+echo "sudo docker exec node1.${network_name} bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
-echo "To go into your standalone docker container:"
+echo "To view rnode metrics of bootstrap container:"
+echo "sudo docker exec node0.${network_name} bash -c \"curl 127.0.0.1:9095\""
+echo "==============================================================="
+echo "To go into your bootstrap/standalone docker container:"
 echo "sudo docker exec -it node0.${network_name} /bin/bash"
 echo "==============================================================="
+

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -41,15 +41,15 @@ for i in {0..2}; do
     container_name="node${i}.${network_name}"
     echo $container_name
 
-	# If container exists force remove it.
-	if [[ $(sudo docker ps -aq -f name=${container_name}) ]]; then
-		sudo docker rm -f ${container_name}
-	fi
+    # If container exists force remove it.
+    if [[ $(sudo docker ps -aq -f name=${container_name}) ]]; then
+        sudo docker rm -f ${container_name}
+    fi
 
-        sudo docker run -dit --name ${container_name} \
-        -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
-        --network=${network_name} \
-        openjdk
+    sudo docker run -dit --name ${container_name} \
+    -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
+    --network=${network_name} \
+    openjdk
 
     # Ret rnode run command depending on node nubmer
     if [[ $i == 0 ]]; then

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -46,11 +46,11 @@ for i in {0..2}; do
 		sudo docker rm -f ${container_name}
 	fi
 
-	sudo docker run -dit --name ${container_name} \
+        sudo docker run -dit --name ${container_name} \
         -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
         --network=${network_name} \
         openjdk
-    
+
     # Ret rnode run command depending on node nubmer
     if [[ $i == 0 ]]; then
         rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -70,13 +70,14 @@ for i in {0..2}; do
     " 
 done
 
-echo "############################COMPLETED###########################"
+echo "#########################DOCKER NOTES##########################"
 echo "==============================================================="
 echo "To display standalone bootstrap server rnode log:"
-echo "sudo docker exec  node0.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
+echo "sudo docker exec node0.${network_name} bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
 echo "To display node1 rnode log:"
 echo "sudo docker exec  node1.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
 echo "To go into your standalone docker container:"
-echo "sudo docker exec -it node0.1.rnode.test.net /bin/bash"
+echo "sudo docker exec -it node0.${network_name} /bin/bash"
+echo "==============================================================="

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -10,7 +10,7 @@ if [[ $1 && $2 ]]; then
   branch_name=$2
   echo "Creating docker rnode test-net for ${git_repo} ${branch_name}"
 else
-  echo "Usage: $0 <repo url>> <branch name>"
+  echo "Usage: $0 <repo url> <branch name>"
   echo "Usage: $0 https://github.com/rchain/rchain dev"
   exit
 fi

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -67,7 +67,7 @@ for i in {0..2}; do
     apt -y iputils-ping bridge-utils iproute2;
     apt -y install ./rnode_${branch_name}_all.deb;
     ${rnode_cmd}
-  " 
+    " 
 done
 
 echo "############################COMPLETED###########################"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -15,7 +15,7 @@ fi
 
 network_name="${NETWORK_UID}.rnode.test.net"
 
-sudo echo "" # Ask for sudo auth early
+sudo echo "" # Ask for sudo early
 
 # Create debian package from git repo via sbt
 git_dir=$(mktemp -d /tmp/rchain-git.XXXXXXXX)
@@ -28,11 +28,11 @@ sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
 # Create docker network if it doesn't exist
 if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "${network_name}" ]]; then
     sudo docker network create \
-      --driver=bridge \
-      --subnet=10.1.1.0/24 \
-      --ip-range=10.1.1.0/24 \
-      --gateway=10.1.1.1 \
-      ${network_name}
+    --driver=bridge \
+    --subnet=10.1.1.0/24 \
+    --ip-range=10.1.1.0/24 \
+    --gateway=10.1.1.1 \
+    ${network_name}
 else
     echo "The network ${network_name} already exists."
 fi
@@ -59,7 +59,7 @@ for i in {0..2}; do
     fi
 
     branch_name="0.2.1"
-	sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; mkdir /var/lib/rnode; ${rnode_cmd}" 
+    sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; ${rnode_cmd}" 
 done
 
 echo "############################COMPLETE###########################"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -64,7 +64,7 @@ for i in {0..2}; do
   
   sudo docker exec ${container_name} bash -c "
     apt -y update;
-    apt -y iputils-ping bridge-utils iproute2;
+    apt -y iputils-ping vim nano iproute2;
     apt -y install ./rnode_${branch_name}_all.deb;
     ${rnode_cmd}
     " 

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+NETWORK_UID="1" # Unique identifier for network if you wanted to run multiple test networks
+
+if [[ $1 && $2 ]]; then
+    git_repo=$1
+    branch_name=$2
+    echo "Creating docker rnode test-net for ${git_repo} ${branch_name}"
+else
+    echo "Usage: $0 <repo url>> <branch name>"
+    echo "Usage: $0 https://github.com/rchain/rchain dev"
+    exit
+fi
+
+network_name="${NETWORK_UID}.rnode.test.net"
+
+sudo echo "" # Ask for sudo auth early
+
+# Create debian package from git repo via sbt
+git_dir=$(mktemp -d /tmp/rchain-git.XXXXXXXX)
+cd ${git_dir}
+git clone ${git_repo} 
+cd rchain
+git checkout ${branch_name}
+sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
+
+# Create docker network if it doesn't exist
+if [[ "$(sudo docker network list | grep ${network_name})" == "" ]]; then
+    sudo docker network create \
+      --driver=bridge \
+      --subnet=10.1.1.0/24 \
+      --ip-range=10.1.1.0/24 \
+      --gateway=10.1.1.1 \
+      ${network_name}
+else
+    echo "The network ${network_name} already exists."
+fi
+
+for i in {0..2}; do
+    container_name="node${i}.${network_name}"
+    echo $container_name
+
+	# If container exists force remove it.
+	if [[ $(sudo docker ps -aq -f name=${container_name}) ]]; then
+		sudo docker rm -f ${container_name}
+	fi
+
+	sudo docker run -dit --name ${container_name} \
+        -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
+        --network=${network_name} \
+        openjdk
+    
+    # Ret rnode run command depending on node nubmer
+    if [[ $i == 0 ]]; then
+        rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"
+    else
+        rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@10.1.1.2:30304 > /var/log/rnode.log 2>&1 &"
+    fi
+
+    branch_name="0.2.1"
+	sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; mkdir /var/lib/rnode; ${rnode_cmd}" 
+done
+
+echo "############################COMPLETE###########################"
+echo "==============================================================="
+echo "Run below to display standalone bootstrap server rnode log:"
+echo "sudo docker exec  node0.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
+echo "==============================================================="
+echo "Run below to display node1 rnode log:"
+echo "sudo docker exec  node1.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
+echo "==============================================================="
+echo "Run below to go into standaloner server and do things:"
+echo "sudo docker exec -it node0.1.rnode.test.net /bin/bash"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -6,13 +6,13 @@ set -eo pipefail
 NETWORK_UID="1" # Unique identifier for network if you wanted to run multiple test networks
 
 if [[ $1 && $2 ]]; then
-    git_repo=$1
-    branch_name=$2
-    echo "Creating docker rnode test-net for ${git_repo} ${branch_name}"
+  git_repo=$1
+  branch_name=$2
+  echo "Creating docker rnode test-net for ${git_repo} ${branch_name}"
 else
-    echo "Usage: $0 <repo url>> <branch name>"
-    echo "Usage: $0 https://github.com/rchain/rchain dev"
-    exit
+  echo "Usage: $0 <repo url>> <branch name>"
+  echo "Usage: $0 https://github.com/rchain/rchain dev"
+  exit
 fi
 
 network_name="${NETWORK_UID}.rnode.test.net"
@@ -29,39 +29,39 @@ sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
 
 # Create docker network if it doesn't exist
 if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "" ]]; then
-    sudo docker network create \
+  sudo docker network create \
     --driver=bridge \
     --subnet=10.1.1.0/24 \
     --ip-range=10.1.1.0/24 \
     --gateway=10.1.1.1 \
     ${network_name}
 else
-    echo "The network ${network_name} already exists."
+  echo "The network ${network_name} already exists."
 fi
 
 for i in {0..2}; do
-    container_name="node${i}.${network_name}"
-    echo $container_name
+  container_name="node${i}.${network_name}"
+  echo $container_name
 
-    # If container exists force remove it.
-    if [[ $(sudo docker ps -aq -f name=${container_name}) ]]; then
-        sudo docker rm -f ${container_name}
-    fi
+  # If container exists force remove it.
+  if [[ $(sudo docker ps -aq -f name=${container_name}) ]]; then
+    sudo docker rm -f ${container_name}
+  fi
 
-    sudo docker run -dit --name ${container_name} \
+  sudo docker run -dit --name ${container_name} \
     -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
     --network=${network_name} \
     openjdk
 
-    # Ret rnode run command depending on node nubmer
-    if [[ $i == 0 ]]; then
-        rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"
-    else
-        rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@10.1.1.2:30304 > /var/log/rnode.log 2>&1 &"
-    fi
+  # Ret rnode run command depending on node nubmer
+  if [[ $i == 0 ]]; then
+    rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"
+  else
+    rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@10.1.1.2:30304 > /var/log/rnode.log 2>&1 &"
+  fi
 
-    branch_name="0.2.1"
-    sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; ${rnode_cmd}" 
+  branch_name="0.2.1"
+  sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; ${rnode_cmd}" 
 done
 
 echo "############################COMPLETED###########################"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -61,7 +61,13 @@ for i in {0..2}; do
   fi
 
   branch_name="0.2.1"
-  sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; ${rnode_cmd}" 
+  
+  sudo docker exec ${container_name} bash -c "
+    apt -y update;
+    apt -y iputils-ping bridge-utils iproute2;
+    apt -y install ./rnode_${branch_name}_all.deb;
+    ${rnode_cmd}
+  " 
 done
 
 echo "############################COMPLETED###########################"

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -26,7 +26,7 @@ git checkout ${branch_name}
 sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
 
 # Create docker network if it doesn't exist
-if [[ "$(sudo docker network list | grep ${network_name})" == "" ]]; then
+if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "${network_name}" ]]; then
     sudo docker network create \
       --driver=bridge \
       --subnet=10.1.1.0/24 \

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -26,7 +26,7 @@ git checkout ${branch_name}
 sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
 
 # Create docker network if it doesn't exist
-if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "${network_name}" ]]; then
+if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "" ]]; then
     sudo docker network create \
     --driver=bridge \
     --subnet=10.1.1.0/24 \

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # With Docker CE installed, this will build a simple private RChain P2P test network.
 # The test network contains a bootstrap server and two more peers connecting to P2P network via bootstrap.
+
 set -eo pipefail
 
 NETWORK_UID="1" # Unique identifier for network if you wanted to run multiple test networks
@@ -27,17 +28,26 @@ cd rchain
 git checkout ${branch_name}
 sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/debian:packageBin
 
-# Create docker network if it doesn't exist
-if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" == "" ]]; then
-  sudo docker network create \
-    --driver=bridge \
-    --subnet=10.1.1.0/24 \
-    --ip-range=10.1.1.0/24 \
-    --gateway=10.1.1.1 \
-    ${network_name}
-else
-  echo "The network ${network_name} already exists."
+echo "done"
+exit
+
+# Remove docker containers related to a network 
+for i in $(docker container ps --format {{.Names}} | grep \.${network_name}$); do
+    echo "Force removing docker container $i"
+    sudo docker rm -f $i
+done
+
+if [[ "$(sudo docker network list --format {{.Name}} | grep ^${network_name}$)" != "" ]]; then
+  echo "Removing docker network ${network_name}"
+  sudo docker network rm ${network_name}
 fi
+
+sudo docker network create \
+  --driver=bridge \
+  --subnet=169.254.1.0/24 \
+  --ip-range=169.254.1.0/24 \
+  --gateway=169.254.1.1 \
+  ${network_name}
 
 for i in {0..2}; do
   container_name="node${i}.${network_name}"
@@ -51,20 +61,22 @@ for i in {0..2}; do
   sudo docker run -dit --name ${container_name} \
     -v $git_dir/rchain/node/target/rnode_0.2.1_all.deb:/rnode_0.2.1_all.deb \
     --network=${network_name} \
-    openjdk
+    ubuntu:16.04 
+  # phusion/baseimage-docker - alternate image
 
   # Ret rnode run command depending on node nubmer
   if [[ $i == 0 ]]; then
     rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"
   else
-    rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@10.1.1.2:30304 > /var/log/rnode.log 2>&1 &"
+    rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@169.254.1.2:30304 > /var/log/rnode.log 2>&1 &"
   fi
 
   branch_name="0.2.1"
   
   sudo docker exec ${container_name} bash -c "
     apt -y update;
-    apt -y iputils-ping vim nano curl iproute2;
+    mkdir -p /var/lib/rnode;
+    apt -y openjdk-8-jdk vim nano curl iproute2;
     apt -y install ./rnode_${branch_name}_all.deb;
     ${rnode_cmd}
     " 
@@ -84,4 +96,3 @@ echo "==============================================================="
 echo "To go into your bootstrap/standalone docker container:"
 echo "sudo docker exec -it node0.${network_name} /bin/bash"
 echo "==============================================================="
-

--- a/scripts/local-docker-rnode-p2p-test-net-builder.sh
+++ b/scripts/local-docker-rnode-p2p-test-net-builder.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# With Docker CE installed, this will build a simple private RChain P2P test network.
+# The test network contains a bootstrap server and two peers connecting to P2P network via bootstrap.
 set -eo pipefail
 
 NETWORK_UID="1" # Unique identifier for network if you wanted to run multiple test networks
@@ -62,13 +64,13 @@ for i in {0..2}; do
     sudo docker exec ${container_name} bash -c "apt -y update; apt -y iputils-ping bridge-utils iproute2; apt -y install ./rnode_${branch_name}_all.deb; ${rnode_cmd}" 
 done
 
-echo "############################COMPLETE###########################"
+echo "############################COMPLETED###########################"
 echo "==============================================================="
-echo "Run below to display standalone bootstrap server rnode log:"
+echo "To display standalone bootstrap server rnode log:"
 echo "sudo docker exec  node0.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
-echo "Run below to display node1 rnode log:"
+echo "To display node1 rnode log:"
 echo "sudo docker exec  node1.1.rnode.test.net bash -c \"tail -f /var/log/rnode.log\""
 echo "==============================================================="
-echo "Run below to go into standaloner server and do things:"
+echo "To go into your standalone docker container:"
 echo "sudo docker exec -it node0.1.rnode.test.net /bin/bash"


### PR DESCRIPTION
A simple script that will allow developers to easily build and rebuild rnode docker test network with boostrap server and a couple of peers based on the provided git repo.

This is kind of related to
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=CORE-392