### PR TITLE
CORE-478 diagnostics runtime

### DIFF
--- a/node/src/main/protobuf/rnode.proto
+++ b/node/src/main/protobuf/rnode.proto
@@ -16,7 +16,7 @@ message ListPeersRequest {
 }
 
 message Peers {
-  repeated Peer peer = 1;
+  repeated Peer peers = 1;
 }
 
 message Peer {

--- a/node/src/main/scala/coop/rchain/node/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/DiagnosticService.scala
@@ -3,10 +3,11 @@ package coop.rchain.node
 import java.util.concurrent.TimeUnit
 import io.grpc.{ManagedChannel, ManagedChannelBuilder, StatusRuntimeException}
 import coop.rchain.node.rnode._
+import coop.rchain.comm.{Endpoint, NodeIdentifier, PeerNode}
 import monix.eval.Task
 
 trait DiagnosticsService[F[_]] {
-  def listPeers: F[List[Peer]]
+  def listPeers: F[List[PeerNode]]
 }
 
 object DiagnosticsService {
@@ -19,7 +20,12 @@ class GrpcDiagnosticsService(host: String, port: Int) extends DiagnosticsService
     ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build
   private val blockingStub = DiagnosticsGrpc.blockingStub(channel)
 
-  def listPeers: Task[List[Peer]] = Task.delay {
-    blockingStub.listPeers(ListPeersRequest()).peer.toList
+  def listPeers: Task[List[PeerNode]] = Task.delay {
+    blockingStub
+      .listPeers(ListPeersRequest())
+      .peers
+      .toList
+      .map(p =>
+        new PeerNode(NodeIdentifier(p.key.toByteArray.toSeq), Endpoint(p.host, p.port, p.port)))
   }
 }

--- a/node/src/main/scala/coop/rchain/node/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/DiagnosticService.scala
@@ -1,0 +1,25 @@
+package coop.rchain.node
+
+import java.util.concurrent.TimeUnit
+import io.grpc.{ManagedChannel, ManagedChannelBuilder, StatusRuntimeException}
+import coop.rchain.node.rnode._
+import monix.eval.Task
+
+trait DiagnosticsService[F[_]] {
+  def listPeers: F[List[Peer]]
+}
+
+object DiagnosticsService {
+  def apply[F[_]](implicit ev: DiagnosticsService[F]): DiagnosticsService[F] = ev
+}
+
+class GrpcDiagnosticsService(host: String, port: Int) extends DiagnosticsService[Task] {
+
+  private val channel: ManagedChannel =
+    ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build
+  private val blockingStub = DiagnosticsGrpc.blockingStub(channel)
+
+  def listPeers: Task[List[Peer]] = Task.delay {
+    blockingStub.listPeers(ListPeersRequest()).peer.toList
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/DiagnosticsRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/DiagnosticsRuntime.scala
@@ -11,6 +11,6 @@ object DiagnosticsRuntime {
     for {
       _  <- ConsoleIO[F].println("List of peers:")
       ps <- DiagnosticsService[F].listPeers
-      _  <- ps.toList.traverse(p => ConsoleIO[F].println(p.toString))
+      _  <- ps.toList.traverse(p => ConsoleIO[F].println(p.toAddress))
     } yield ()
 }

--- a/node/src/main/scala/coop/rchain/node/DiagnosticsRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/DiagnosticsRuntime.scala
@@ -1,0 +1,16 @@
+package coop.rchain.node
+
+import java.util.concurrent.TimeUnit
+import io.grpc.{ManagedChannel, ManagedChannelBuilder, StatusRuntimeException}
+import coop.rchain.shared.StringOps._
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib._, Catscontrib._, ski.kp
+
+object DiagnosticsRuntime {
+  def diagnosticsProgram[F[_]: Monad: ConsoleIO: DiagnosticsService]: F[Unit] =
+    for {
+      _  <- ConsoleIO[F].println("List of peers:")
+      ps <- DiagnosticsService[F].listPeers
+      _  <- ps.toList.traverse(p => ConsoleIO[F].println(p.toString))
+    } yield ()
+}

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -27,11 +27,14 @@ object Main {
     implicit val consoleIO: ConsoleIO[Task] = new effects.JLineConsoleIO(console)
     implicit val replService: ReplService[Task] =
       new GrpcReplService(conf.grpcHost(), conf.grpcPort())
+    implicit val diagnosticsService: DiagnosticsService[Task] =
+      new GrpcDiagnosticsService(conf.grpcHost(), conf.grpcPort())
 
-    val exec: Task[Unit] = (conf.eval.toOption, conf.repl()) match {
-      case (Some(fileName), _) => new ReplRuntime(conf).evalProgram[Task](fileName)
-      case (None, true)        => new ReplRuntime(conf).replProgram[Task]
-      case (None, false) =>
+    val exec: Task[Unit] = conf.eval.toOption match {
+      case Some(fileName)               => new ReplRuntime(conf).evalProgram[Task](fileName)
+      case None if (conf.repl())        => new ReplRuntime(conf).replProgram[Task]
+      case None if (conf.diagnostics()) => DiagnosticsRuntime.diagnosticsProgram[Task]
+      case None =>
         new NodeRuntime(conf).nodeProgram.value.map {
           case Right(_) => ()
           case Left(commError) =>

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -42,6 +42,9 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val repl = opt[Boolean](default = Some(false),
                           short = 'r',
                           descr = "Start node with REPL (but without P2P network)")
+
+  val diagnostics = opt[Boolean](default = Some(false), short = 'd', descr = "Node diagnostics")
+
   val eval = opt[String](default = None,
                          descr = "Start node to evaluate rholang in file (but without P2P network)")
 

--- a/node/src/main/scala/coop/rchain/node/effects.scala
+++ b/node/src/main/scala/coop/rchain/node/effects.scala
@@ -212,6 +212,7 @@ object effects {
     }
     def println(str: String): Task[Unit] = Task.delay {
       console.println(str)
+      console.flush()
     }
     def updateCompletion(history: Set[String]): Task[Unit] = Task.delay {
       console.getCompleters.asScala.foreach(c => console.removeCompleter(c))


### PR DESCRIPTION
## Overview
This PR adds new little runtime called "diagnostics". Simply run node with `--diagnostics` flag to get list of all peers connected to node at the given moment.
This program is a thin-client and uses the gRPC API.

This PR also fixes bugs in `JLineConsoleIO` instance

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=CORE-478

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

