### PR TITLE
Core 480 - correct rnode.service file permissions

### DIFF
--- a/node/src/debian/DEBIAN/postinst
+++ b/node/src/debian/DEBIAN/postinst
@@ -18,6 +18,7 @@ else
     mkdir -p ${DIRECTORY}
     chown -R ${USERNAME}:${USERNAME} ${DIRECTORY}
 fi
-    chmod 0644 ${SYSTEMD_SERVICE_FILE} 
+
+chmod 0644 ${SYSTEMD_SERVICE_FILE} # Meets file permission criteria in Debian
 
 systemctl enable rnode.service

--- a/node/src/debian/DEBIAN/postinst
+++ b/node/src/debian/DEBIAN/postinst
@@ -4,6 +4,7 @@ set -e
 
 USERNAME="rnode"
 DIRECTORY="/var/lib/${USERNAME}"
+SYSTEMD_SERVICE_FILE="/lib/systemd/system/${USERNAME}.service"
 
 if id -u ${USERNAME} >/dev/null 2>&1; then
     echo "User ${USERNAME} already exists."
@@ -17,5 +18,6 @@ else
     mkdir -p ${DIRECTORY}
     chown -R ${USERNAME}:${USERNAME} ${DIRECTORY}
 fi
+    chmod 0644 ${SYSTEMD_SERVICE_FILE} 
 
 systemctl enable rnode.service


### PR DESCRIPTION
## Overview
Gives proper permission via post install for deb package. Complies with 0644 permissions in debian for /lib/systemd/system/xxxx.service files. Gets rid of information in logs telling you to do it. Fedora seems to not need have these permissions ...

### Does this PR relate to an RChain JIRA issue? 
CORE-480
https://rchain.atlassian.net/browse/CORE-480