### PR TITLE
Bugix: decrement peers metric on node disconnect

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -211,7 +211,7 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
       _ <- Log[F].info(s"Forgetting about $sender.")
       _ <- Capture[F].capture(table.remove(sender.key))
       _ <- Metrics[F].incrementCounter("disconnect-recv-count")
-      _ <- Metrics[F].incrementCounter("peers", -1L)
+      _ <- Metrics[F].decrementGauge("peers")
     } yield ()
 
   /**

--- a/comm/src/main/scala/coop/rchain/p2p/effects/Metrics.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/effects/Metrics.scala
@@ -14,6 +14,10 @@ trait Metrics[F[_]] {
   // Gauge
   def setGauge(name: String, value: Long): F[Unit]
 
+  def incrementGauge(name: String, delta: Long = 1): F[Unit]
+
+  def decrementGauge(name: String, delta: Long = 1): F[Unit]
+
   // Histogram
   def record(name: String, value: Long, count: Long = 1): F[Unit]
 }
@@ -27,6 +31,8 @@ object Metrics extends MetricsInstances {
       def incrementSampler(name: String, delta: Long)    = M.incrementSampler(name, delta).liftM[T]
       def sample(name: String)                           = M.sample(name).liftM[T]
       def setGauge(name: String, value: Long)            = M.setGauge(name, value).liftM[T]
+      def incrementGauge(name: String, delta: Long)      = M.incrementGauge(name, delta).liftM[T]
+      def decrementGauge(name: String, delta: Long)      = M.decrementGauge(name, delta).liftM[T]
       def record(name: String, value: Long, count: Long) = M.record(name, value, count).liftM[T]
     }
 
@@ -35,6 +41,8 @@ object Metrics extends MetricsInstances {
     def incrementSampler(name: String, delta: Long = 1): F[Unit]    = ().pure[F]
     def sample(name: String): F[Unit]                               = ().pure[F]
     def setGauge(name: String, value: Long): F[Unit]                = ().pure[F]
+    def incrementGauge(name: String, delta: Long): F[Unit]          = ().pure[F]
+    def decrementGauge(name: String, delta: Long): F[Unit]          = ().pure[F]
     def record(name: String, value: Long, count: Long = 1): F[Unit] = ().pure[F]
   }
 

--- a/node/src/main/scala/coop/rchain/node/effects.scala
+++ b/node/src/main/scala/coop/rchain/node/effects.scala
@@ -98,31 +98,43 @@ object effects {
 
     def incrementCounter(name: String, delta: Long): Task[Unit] = Task.delay {
       m.getOrElseUpdate(name, { Kamon.counter(name) }) match {
-        case (c: metric.Counter) => c.increment(delta)
+        case c: metric.Counter => c.increment(delta)
       }
     }
 
     def incrementSampler(name: String, delta: Long): Task[Unit] = Task.delay {
       m.getOrElseUpdate(name, { Kamon.rangeSampler(name) }) match {
-        case (c: metric.RangeSampler) => c.increment(delta)
+        case c: metric.RangeSampler => c.increment(delta)
       }
     }
 
     def sample(name: String): Task[Unit] = Task.delay {
       m.getOrElseUpdate(name, { Kamon.rangeSampler(name) }) match {
-        case (c: metric.RangeSampler) => c.sample
+        case c: metric.RangeSampler => c.sample
       }
     }
 
     def setGauge(name: String, value: Long): Task[Unit] = Task.delay {
       m.getOrElseUpdate(name, { Kamon.gauge(name) }) match {
-        case (c: metric.Gauge) => c.set(value)
+        case c: metric.Gauge => c.set(value)
+      }
+    }
+
+    def incrementGauge(name: String, delta: Long): Task[Unit] = Task.delay {
+      m.getOrElseUpdate(name, { Kamon.gauge(name) }) match {
+        case c: metric.Gauge => c.increment(delta)
+      }
+    }
+
+    def decrementGauge(name: String, delta: Long): Task[Unit] = Task.delay {
+      m.getOrElseUpdate(name, { Kamon.gauge(name) }) match {
+        case c: metric.Gauge => c.decrement(delta)
       }
     }
 
     def record(name: String, value: Long, count: Long = 1): Task[Unit] = Task.delay {
       m.getOrElseUpdate(name, { Kamon.histogram(name) }) match {
-        case (c: metric.Histogram) => c.record(value, count)
+        case c: metric.Histogram => c.record(value, count)
       }
     }
   }
@@ -172,7 +184,7 @@ object effects {
       def addNode(node: PeerNode): F[Unit] =
         for {
           _ <- Capture[F].capture(net.add(node))
-          _ <- Metrics[F].incrementCounter("peers")
+          _ <- Metrics[F].incrementGauge("peers")
         } yield ()
 
       def findMorePeers(limit: Int): F[Seq[PeerNode]] =


### PR DESCRIPTION
## Overview
Kamon `peers` counter can't be decremented. Changed to `peers` gauge which can be incremented and decremented.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-479

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
@jeremybusk: This has an impact on the (`PrometheusReporter`) metrics API. The reported value changes from `peers_total` to `peers`.
