### PR TITLE
Correct rpm package service file permissions for systemd

### DIFF
--- a/node/src/debian/DEBIAN/postinst
+++ b/node/src/debian/DEBIAN/postinst
@@ -17,8 +17,7 @@ if [ -d ${DIRECTORY} ] ; then
 else
     mkdir -p ${DIRECTORY}
     chown -R ${USERNAME}:${USERNAME} ${DIRECTORY}
+    chmod 0644 ${SYSTEMD_SERVICE_FILE}
 fi
-
-chmod 0644 ${SYSTEMD_SERVICE_FILE} # Meets file permission criteria in Debian
 
 systemctl enable rnode.service

--- a/node/src/rpm/scriptlets/post
+++ b/node/src/rpm/scriptlets/post
@@ -4,6 +4,7 @@ set -e
 
 USERNAME="rnode"
 DIRECTORY="/var/lib/${USERNAME}"
+SYSTEMD_SERVICE_FILE="/lib/systemd/system/${USERNAME}.service"
 
 if id -u ${USERNAME} >/dev/null 2>&1; then
     echo "User ${USERNAME} already exists."
@@ -16,6 +17,7 @@ if [ -d ${DIRECTORY} ] ; then
 else
     mkdir -p ${DIRECTORY}
     chown -R ${USERNAME}:${USERNAME} ${DIRECTORY}
+    chmod 0644 ${SYSTEMD_SERVICE_FILE}
 fi
 
 systemctl enable rnode.service


### PR DESCRIPTION
## Overview
Sets rpm permissions in /lib/systemd/system/rnode.service to 0644 which is correct setting.
