### PR TITLE
remove /var/lib/rnode from sbt docker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,6 @@ lazy val node = (project in file("node"))
         add(entry, entryTargetPath)
         run("apk", "update")
         run("apk", "add", "libsodium")
-        run("mkdir", "/var/lib/rnode")
         entryPoint("/bin/main.sh")
       }
     },


### PR DESCRIPTION
## Overview
remove /var/lib/rnode creation from sbt docker that I added in. 
