### PR TITLE
Fixed Docker commands containing "coop"

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -124,14 +124,18 @@ sudo chown $USER /var/lib/rnode
 
 ##### 2.1.2.1 via Docker
 
-By far the simplest way to run this code is by using Docker and the official image at Docker Hub. You can also [build a docker image yourself](#building-via-docker) and then run it.
+By far the simplest way to run this code is by using Docker. Use this pull command in Docker to get the current version of RNode
+
+```docker pull rchain/rnode```
+
+You can also [build a docker image yourself](#building-via-docker) and then run it.
 
 __Note__ The port used has to be mapped to the proper host port for the node to be able to advertise itself to the network
 properly. This may happen automatically, and it may not; it completely depends on how your computer and network are configured. Some monkeying with `docker run` options may be required, and the `--host` and `--port` options to this system may also help.
 
 
 ```
-$ docker run -ti coop.rchain/rnode
+$ docker run -ti rchain/rnode
 17:12:21.938 [main] INFO main - uPnP: Some(/192.168.1.123) -> Some(93.158.233.123)
 17:12:22.450 [kamon.prometheus.PrometheusReporter] INFO kamon.prometheus.PrometheusReporter - Started the embedded HTTP server on http://0.0.0.0:9095
 17:12:22.850 [main] INFO org.http4s.blaze.channel.nio1.NIO1SocketServerGroup - Service bound to address /127.0.0.1:8080
@@ -174,10 +178,10 @@ In REPL mode users have the ability to execute Rholang commands in REPL environm
 
 
 #### 2.2.1 Running via Docker
-By far the simplest way to run this code is by using Docker and the official image at Docker Hub. You can also [build docker image yourself](#building-via-docker) and then run it.
+Assuming you have a RNode running in Docker, use the command below to run the node in REPL mode.
 
 ```
-$ docker run -ti coop.rchain/rnode --repl
+$ docker run -ti rchain/rnode --repl
 ```
 
 #### 2.2.2. Running via Java
@@ -191,9 +195,7 @@ $ java -jar ./node/target/scala-2.12/rnode-assembly-0.1.3.jar --repl
 When running the program with `--eval`, it will fire up a thin program that will connect to running node instance via gRPC to evaluate Rholang code that is stored in a plain text file on the node itself.
 
 ### 2.3.1 Running via Docker
-By far the simplest way to run this code is by using Docker and the official image at Docker Hub. You can also [build docker image yourself](#building-via-docker) and then run it.
-
-To run Rholang that is stored in a plain text file (filename.rho), use
+This assumes you have a RNode running in Docker. To run Rholang that is stored in a plain text file (filename.rho), use
 
 '''
 docker run -it --mount type=bind,source="$(pwd)"/file_directory,target=/tmp rchain/rnode --eval /tmp/filename.rho


### PR DESCRIPTION
Docker commands to run RNode containing "coop" no longer work. This PR updates the commands in the following sections:
* 2.1.2.1
* 2.2.1
* 2.3.1

## Overview
Provide a brief description of what this PR does, and why it's needed.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [X ] This PR contains no more than 200 lines of code, excluding test code.
- [ X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
