### PR TITLE
CORE-506: build binary tarball artifact for distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ deploy:
   file:
     - "node/target/*.deb"
     - "node/target/rpm/RPMS/noarch/*.rpm"
+    - "node/target/universal/*.tgz"
   skip_cleanup: true
   on:
     tags: true

--- a/scripts/build-subprojects.sh
+++ b/scripts/build-subprojects.sh
@@ -21,7 +21,10 @@ case "$SUBPROJECT" in "rosette")
 
 "test_artifact_creation")
 
-    sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/rpm:packageBin node/debian:packageBin
+    sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate \
+        node/rpm:packageBin \
+        node/debian:packageBin \
+        node/universal:packageZipTarball
     ;;
 
 "rnode-dockerhub-push")

--- a/scripts/create-artifacts.sh
+++ b/scripts/create-artifacts.sh
@@ -4,5 +4,9 @@ set -eo pipefail
 
 if [ "$SUBPROJECT" = "core" -a -n "$TRAVIS_TAG" ]
 then
-    sbt -Dsbt.log.noformat=true clean node/debian:packageBin node/rpm:packageBin
+    sbt -Dsbt.log.noformat=true clean \
+        rholang/bnfc:generate \
+        node/debian:packageBin \
+        node/rpm:packageBin \
+        node/universal:packageZipTarball
 fi


### PR DESCRIPTION
## Overview
This PR adds a binary tarball package to our distribution formats (alongside the deb and rpm packages).  This provides a binary package for users macOS, other distributions of Linux, and other Unixen.   The contents of the package is basically the same as the deb and rpm packages.  

Users of these packages will need to install `libsodium` themselves.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-506

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A