### PR TITLE
Rholang: Fix freeCount for system processes.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -35,7 +35,8 @@ object Runtime {
           List(Channel(Quote(GString(name)))),
           List(
             BindPattern((0 until arity).map[Channel, Seq[Channel]](i => ChanVar(FreeVar(i))),
-                        remainder)),
+                        remainder,
+                        freeCount = arity)),
           TaggedContinuation(ScalaBodyRef(ref))
         )
     }


### PR DESCRIPTION
## Overview

The recent freeCount changes broke system processes. This is the straightforward
fix. We need to explicitly add the freeCount to the bindPattern. In this case,
it's simply the arity.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/RHOL-349
