### PR TITLE
Assign specific scheduler to REPL

### DIFF
--- a/node/src/main/scala/coop/rchain/node/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/grpc.scala
@@ -57,32 +57,29 @@ object GrpcServer {
     }
   }
 
-  class ReplImpl(runtime: Runtime)(implicit scheduler: Scheduler) extends ReplGrpc.Repl {
+  class ReplImpl(runtime: Runtime) extends ReplGrpc.Repl {
     import RholangCLI.{buildNormalizedTerm, evaluate}
 
-    def exec(reader: Reader): Future[ReplResponse] = buildNormalizedTerm(reader) match {
-      case Left(er) =>
-        Future.successful(ReplResponse(s"Error: $er"))
-      case Right(term) =>
-        val evalAttempt: Either[Throwable, Unit] =
-          evaluate(runtime.reducer, term).attempt.unsafeRunSync
+    private[this] val io = Scheduler.fixedPool("rholang-cli", poolSize = 1)
 
-        Task
-          .pure(
-            evalAttempt match {
+    def exec(reader: Reader): Task[ReplResponse] =
+      buildNormalizedTerm(reader) match {
+        case Left(er) =>
+          Task.pure(ReplResponse(s"Error: $er"))
+        case Right(term) =>
+          evaluate(runtime.reducer, term).attempt
+            .map {
               case Left(ex) => s"Caught boxed exception: $ex"
               case Right(_) =>
                 s"Storage Contents:\n ${StoragePrinter.prettyPrint(runtime.store)}"
             }
-          )
-          .map(ReplResponse(_))
-          .runAsync
-    }
+            .map(ReplResponse(_))
+      }
 
     def run(request: CmdRequest): Future[ReplResponse] =
-      exec(new StringReader(request.line))
+      exec(new StringReader(request.line)).executeAsync.runAsync(io)
 
     def eval(request: EvalRequest): Future[ReplResponse] =
-      exec(RholangCLI.reader(request.fileName))
+      exec(RholangCLI.reader(request.fileName)).executeAsync.runAsync(io)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/sort.scala
@@ -133,16 +133,15 @@ object Score {
   final val QUOTE    = 203
   final val CHAN_VAR = 204
 
-  final val SEND    = 300
-  final val RECEIVE = 301
-  final val EVAL    = 302
-  final val NEW     = 303
-  final val MATCH   = 304
-  final val BUNDLE_EQUIV  = 305
-  final val BUNDLE_READ  = 306
-  final val BUNDLE_WRITE= 307
-  final val BUNDLE_READ_WRITE  = 308
-
+  final val SEND              = 300
+  final val RECEIVE           = 301
+  final val EVAL              = 302
+  final val NEW               = 303
+  final val MATCH             = 304
+  final val BUNDLE_EQUIV      = 305
+  final val BUNDLE_READ       = 306
+  final val BUNDLE_WRITE      = 307
+  final val BUNDLE_READ_WRITE = 308
 
   final val PAR = 999
 }
@@ -439,11 +438,11 @@ object MatchSortMatcher {
 object BundleSortMatcher {
   def sortMatch(b: Bundle): ScoredTerm[Bundle] = {
     val sortedPar = ParSortMatcher.sortMatch(b.body)
-    val score: Int = if(b.writeFlag && b.readFlag) {
+    val score: Int = if (b.writeFlag && b.readFlag) {
       Score.BUNDLE_READ_WRITE
-    } else if(b.writeFlag && !b.readFlag) {
+    } else if (b.writeFlag && !b.readFlag) {
       Score.BUNDLE_WRITE
-    } else if(!b.writeFlag && b.readFlag) {
+    } else if (!b.writeFlag && b.readFlag) {
       Score.BUNDLE_READ
     } else {
       Score.BUNDLE_EQUIV


### PR DESCRIPTION
## Overview
To avoid `Environment maxreaders reached` on the REPL server this PR attaches a specific `Scheduler` with `poolSize=1` to `RholangCLI` calls.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.