### PR TITLE
Updated rholang-tutorial website to use rholangtut-0.3.md

### DIFF
--- a/rholang-tutorial/static.config.js
+++ b/rholang-tutorial/static.config.js
@@ -1,7 +1,10 @@
 import axios from 'axios'
 
-const sourceUrl = 'https://raw.githubusercontent.com/rchain/rchain/master/docs/rholang/rholangtut-0.2.md'
-const editUrl = 'https://github.com/rchain/rchain/blob/master/docs/rholang/rholangtut-0.2.md'
+const branch = 'dev'
+const path = 'docs/rholang/rholangtut-0.3.md'
+
+const sourceUrl = 'https://raw.githubusercontent.com/rchain/rchain/' + branch + '/' + path
+const editUrl = 'https://github.com/rchain/rchain/blob/' + branch + '/' + path
 
 // noinspection JSUnusedGlobalSymbols
 export default {


### PR DESCRIPTION
## Overview
This PR updates the rholang-tutorial website to use the `rholangtut-0.3.md` in the `dev` branch, as requested in [CORE-511](https://rchain.atlassian.net/browse/CORE-511).

The result of this commit can be seen here: http://rholang-tutorial.surge.sh/


### Does this PR relate to an RChain JIRA issue? 
[CORE-511](https://rchain.atlassian.net/browse/CORE-511)

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.