### PR TITLE
rspace: bump maxreaders to 126

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -309,7 +309,12 @@ object LMDBStore {
                                                     sk: Serialize[K]): LMDBStore[C, P, A, K] = {
 
     val env: Env[ByteBuffer] =
-      Env.create().setMapSize(mapSize).setMaxDbs(8).open(path.toFile)
+      Env
+        .create()
+        .setMapSize(mapSize)
+        .setMaxDbs(8)
+        .setMaxReaders(126)
+        .open(path.toFile)
 
     val dbKeys: Dbi[ByteBuffer] = env.openDbi(keysTableName, MDB_CREATE)
     val dbWaitingContinuations: Dbi[ByteBuffer] =


### PR DESCRIPTION
This is the default value for the C version, but lmdbjava sets it to 1.

Ref:
http://www.lmdb.tech/doc/group__readers.html#gadff1f7b4d4626610a8d616e0c6dbbea4