### PR TITLE
Create simple, temporary version of history/rollback

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val casper = (project in file("casper"))
       scalapb.gen() -> (sourceManaged in Compile).value
     )
   )
-  .dependsOn(comm % "compile->compile;test->test", shared, crypto) // TODO: Add models, rspace
+  .dependsOn(comm % "compile->compile;test->test", shared, crypto, models, rspace, rholang)
 
 lazy val comm = (project in file("comm"))
   .settings(commonSettings: _*)

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/Checkpoint.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/Checkpoint.scala
@@ -1,0 +1,20 @@
+package coop.rchain.casper.util.rholang
+
+import com.google.protobuf.ByteString
+
+import coop.rchain.crypto.codec.Base16
+
+import java.nio.file.Path
+
+class Checkpoint(val hash: ByteString, val location: Path, val size: Long) {
+  val dbLocation: Path = location.resolve(Base16.encode(hash.toByteArray))
+
+  def toTuplespace(name: String): Tuplespace = {
+    val tsLocation = location.resolve(name)
+
+    tsLocation.toFile.mkdir()
+    Tuplespace.copyDB(dbLocation, tsLocation)
+
+    new Tuplespace(name, location, size)
+  }
+}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -5,22 +5,10 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.RholangCLI
 
 import java.io.StringReader
-import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 
 object InterpreterUtil {
 
   def mkTerm(s: String): Either[Throwable, Par] =
     RholangCLI.buildNormalizedTerm(new StringReader(s))
-
-  def copyDB(source: Path, dest: Path): Unit = {
-    val srcLock = Paths.get(source.toString + "/lock.mdb")
-    val srcData = Paths.get(source.toString + "/data.mdb")
-
-    val destLock = Paths.get(dest.toString + "/lock.mdb")
-    val destData = Paths.get(dest.toString + "/data.mdb")
-
-    Files.copy(srcLock, destLock, StandardCopyOption.REPLACE_EXISTING)
-    Files.copy(srcData, destData, StandardCopyOption.REPLACE_EXISTING)
-  }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -1,0 +1,26 @@
+package coop.rchain.casper.util.rholang
+
+import coop.rchain.models.Par
+
+import coop.rchain.rholang.interpreter.RholangCLI
+
+import java.io.StringReader
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
+
+object InterpreterUtil {
+
+  def mkTerm(s: String): Either[Throwable, Par] =
+    RholangCLI.buildNormalizedTerm(new StringReader(s))
+
+  def copyDB(source: Path, dest: Path): Unit = {
+    val srcLock = Paths.get(source.toString + "/lock.mdb")
+    val srcData = Paths.get(source.toString + "/data.mdb")
+
+    val destLock = Paths.get(dest.toString + "/lock.mdb")
+    val destData = Paths.get(dest.toString + "/data.mdb")
+
+    Files.copy(srcLock, destLock, StandardCopyOption.REPLACE_EXISTING)
+    Files.copy(srcData, destData, StandardCopyOption.REPLACE_EXISTING)
+  }
+
+}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
@@ -4,33 +4,51 @@ import com.google.protobuf.ByteString
 
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Sha256
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 
-import java.nio.file.Path
+import java.nio.file.{Files, Path, StandardCopyOption}
 
 import monix.execution.Scheduler
 
-class Tuplespace(val location: Path, val size: Long) {
-  val runtime = Runtime.create(location, size)
+class Tuplespace(val name: String, val location: Path, val size: Long) {
+  val dbLocation: Path = location.resolve(name)
+  val runtime: Runtime = Runtime.create(dbLocation, size)
 
-  def withTerm(term: Par, dest: Path)(implicit scheduler: Scheduler): Tuplespace = {
-    InterpreterUtil.copyDB(location, dest)
-    val result = new Tuplespace(dest, size)
-    Tuplespace.updateInPlace(result, term)
-  }
+  def addTerm(term: Par)(implicit scheduler: Scheduler): Unit =
+    runtime.reducer.inj(term).unsafeRunSync
 
-  def hash: ByteString = {
+  def hash: Array[Byte] = {
     val bytes = ByteString.copyFromUtf8(StoragePrinter.prettyPrint(runtime.store))
-    val hsh   = Sha256.hash(bytes.toByteArray)
-    ByteString.copyFrom(hsh)
+    Sha256.hash(bytes.toByteArray)
   }
+
+  def checkpoint: Checkpoint = {
+    val hsh        = hash
+    val hashString = Base16.encode(hsh)
+    val dest       = location.resolve(hashString)
+
+    dest.toFile.mkdir()
+    Tuplespace.copyDB(dbLocation, dest)
+
+    new Checkpoint(ByteString.copyFrom(hsh), location, size)
+  }
+
+  def storageRepr: String =
+    StoragePrinter.prettyPrint(runtime.store)
 }
 
 object Tuplespace {
-  def updateInPlace(source: Tuplespace, term: Par)(implicit scheduler: Scheduler): Tuplespace = {
-    source.runtime.reducer.inj(term).unsafeRunSync
-    source
+  def copyDB(source: Path, dest: Path): Unit = {
+    val srcLock = source.resolve("lock.mdb")
+    val srcData = source.resolve("data.mdb")
+
+    val destLock = dest.resolve("lock.mdb")
+    val destData = dest.resolve("data.mdb")
+
+    Files.copy(srcLock, destLock, StandardCopyOption.REPLACE_EXISTING)
+    Files.copy(srcData, destData, StandardCopyOption.REPLACE_EXISTING)
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
@@ -1,0 +1,36 @@
+package coop.rchain.casper.util.rholang
+
+import com.google.protobuf.ByteString
+
+import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.crypto.hash.Sha256
+import coop.rchain.models.Par
+import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.storage.StoragePrinter
+
+import java.nio.file.Path
+
+import monix.execution.Scheduler
+
+class Tuplespace(val location: Path, val size: Long) {
+  val runtime = Runtime.create(location, size)
+
+  def withTerm(term: Par, dest: Path)(implicit scheduler: Scheduler): Tuplespace = {
+    InterpreterUtil.copyDB(location, dest)
+    val result = new Tuplespace(dest, size)
+    Tuplespace.updateInPlace(result, term)
+  }
+
+  def hash: ByteString = {
+    val bytes = ByteString.copyFromUtf8(StoragePrinter.prettyPrint(runtime.store))
+    val hsh   = Sha256.hash(bytes.toByteArray)
+    ByteString.copyFrom(hsh)
+  }
+}
+
+object Tuplespace {
+  def updateInPlace(source: Tuplespace, term: Par)(implicit scheduler: Scheduler): Tuplespace = {
+    source.runtime.reducer.inj(term).unsafeRunSync
+    source
+  }
+}


### PR DESCRIPTION
## Overview
A temporary version of history/rollback allows us to work towards sending rholang terms in blocks. This works by simply copying the lmdb files to a separate directory named based on the content hash.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/RHOL-361

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
