### PR TITLE
Rholang: Matcher: Match everything in a par.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
@@ -377,12 +377,24 @@ object implicits {
     def locallyFree(v: Var)    = VarInstanceLocallyFree.locallyFree(v.varInstance)
   }
 
+  implicit val ReceiveLocallyFree: HasLocallyFree[Receive] =
+    new HasLocallyFree[Receive] {
+      def connectiveUsed(r: Receive) = r.connectiveUsed
+      def locallyFree(r: Receive)    = r.locallyFree
+    }
+
   implicit val ReceiveBindLocallyFree: HasLocallyFree[ReceiveBind] =
     new HasLocallyFree[ReceiveBind] {
       def connectiveUsed(rb: ReceiveBind) =
         ChannelLocallyFree.connectiveUsed(rb.source.get)
       def locallyFree(rb: ReceiveBind) =
         ChannelLocallyFree.locallyFree(rb.source.get)
+    }
+
+  implicit val MatchLocallyFree: HasLocallyFree[Match] =
+    new HasLocallyFree[Match] {
+      def connectiveUsed(m: Match) = m.connectiveUsed
+      def locallyFree(m: Match)    = m.locallyFree
     }
 
   implicit val MatchCaseLocallyFree: HasLocallyFree[MatchCase] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
@@ -12,11 +12,15 @@ import coop.rchain.rholang.interpreter.implicits.{
   fromEList,
   fromExpr,
   BundleLocallyFree,
+  EvalLocallyFree,
   ExprLocallyFree,
   GPrivateLocallyFree,
   MatchCaseLocallyFree,
+  MatchLocallyFree,
+  NewLocallyFree,
   ParLocallyFree,
   ReceiveBindLocallyFree,
+  ReceiveLocallyFree,
   SendLocallyFree,
   VectorPar
 }
@@ -280,21 +284,41 @@ object SpatialMatcher {
                                      (p, s) => p.withSends(s +: p.sends),
                                      varLevel,
                                      wildcard)
+          _ <- listMatchSingle[Receive](target.receives,
+                                        pattern.receives,
+                                        (p, s) => p.withReceives(s +: p.receives),
+                                        varLevel,
+                                        wildcard)
+          _ <- listMatchSingle[Eval](target.evals,
+                                     pattern.evals,
+                                     (p, s) => p.withEvals(s +: p.evals),
+                                     varLevel,
+                                     wildcard)
+          _ <- listMatchSingle[New](target.news,
+                                    pattern.news,
+                                    (p, s) => p.withNews(s +: p.news),
+                                    varLevel,
+                                    wildcard)
           _ <- listMatchSingle[Expr](target.exprs,
                                      NoFrees(pattern.exprs),
                                      (p, e) => p.withExprs(e +: p.exprs),
                                      varLevel,
                                      wildcard)
-          _ <- listMatchSingle[GPrivate](target.ids,
-                                         pattern.ids,
-                                         (p, i) => p.withIds(i +: p.ids),
-                                         varLevel,
-                                         wildcard)
+          _ <- listMatchSingle[Match](target.matches,
+                                      pattern.matches,
+                                      (p, e) => p.withMatches(e +: p.matches),
+                                      varLevel,
+                                      wildcard)
           _ <- listMatchSingle[Bundle](target.bundles,
                                        pattern.bundles,
                                        (p, b) => p.withBundles(b +: p.bundles),
                                        varLevel,
                                        wildcard)
+          _ <- listMatchSingle[GPrivate](target.ids,
+                                         pattern.ids,
+                                         (p, i) => p.withIds(i +: p.ids),
+                                         varLevel,
+                                         wildcard)
         } yield Unit
       }
   }


### PR DESCRIPTION
## Overview
This completes the work done earlier to have matchers for everything. We also
take advantage of all the existing tests and make sure that the spatial match
for par delegates and gets the same results.
