### PR TITLE
 Casper using Rholang Runtime to add deployed terms to state

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -7,6 +7,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Sha256
+import coop.rchain.models.Par
 
 import scala.annotation.tailrec
 
@@ -66,6 +67,21 @@ object ProtoUtil {
   def parents(b: BlockMessage): Seq[ByteString] =
     b.header.map(_.parentsHashList).getOrElse(List.empty[ByteString])
 
+  def deploys(b: BlockMessage): Seq[Deploy] =
+    b.body.map(_.newCode).getOrElse(List.empty[Deploy])
+
+  def bonds(b: BlockMessage): Seq[Bond] =
+    (for {
+      bd <- b.body
+      ps <- bd.postState
+    } yield ps.bonds).getOrElse(List.empty[Bond])
+
+  def blockNumber(b: BlockMessage): Long =
+    (for {
+      bd <- b.body
+      ps <- bd.postState
+    } yield ps.blockNumber).getOrElse(0L)
+
   //Two blocks conflict if they both use the same deploy in different histories
   def conflicts(b1: BlockMessage,
                 b2: BlockMessage,
@@ -73,7 +89,7 @@ object ProtoUtil {
                 dag: BlockDag): Boolean = {
     val gca = DagOperations.greatestCommonAncestor(b1, b2, genesis, dag)
     if (gca == b1 || gca == b2) {
-      //blocks which already in each other's chains do not conflict
+      //blocks which already exist in each other's chains do not conflict
       false
     } else {
       def getDeploys(b: BlockMessage) =
@@ -146,8 +162,13 @@ object ProtoUtil {
   def hashString(b: BlockMessage): String = Base16.encode(b.blockHash.toByteArray)
 
   def basicDeploy(id: Int): Deploy = {
+    val term = InterpreterUtil.mkTerm(s"@${id}!($id)").right.get
+
+    termDeploy(term)
+  }
+
+  def termDeploy(term: Par): Deploy = {
     val nonce = scala.util.Random.nextInt(10000)
-    val term  = InterpreterUtil.mkTerm(s"@${id}!($id)").right.get
 
     Deploy()
       .withUser(ByteString.EMPTY)

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -181,4 +181,14 @@ object ProtoUtil {
       sig = d.sig
     )
   }
+
+  def termDeploy(term: Par): Deploy = {
+    val d = basicDeployString(0)
+    Deploy(
+      user = d.user,
+      nonce = d.nonce,
+      term = Some(term),
+      sig = d.sig
+    )
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/Checkpoint.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/Checkpoint.scala
@@ -17,4 +17,14 @@ class Checkpoint(val hash: ByteString, val location: Path, val size: Long) {
 
     new Tuplespace(name, location, size)
   }
+
+  def toTuplespace: Tuplespace = {
+    val name       = Tuplespace.randomName
+    val tsLocation = location.resolve(name)
+
+    tsLocation.toFile.mkdir()
+    Tuplespace.copyDB(dbLocation, tsLocation)
+
+    new Tuplespace(name, location, size)
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -1,14 +1,138 @@
 package coop.rchain.casper.util.rholang
 
-import coop.rchain.models.Par
+import com.google.protobuf.ByteString
 
+import coop.rchain.casper.BlockDag
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.{DagOperations, ProtoUtil}
+import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.RholangCLI
 
 import java.io.StringReader
+import java.nio.file.Path
+
+import monix.execution.Scheduler
+
+import scala.collection.immutable.HashSet
 
 object InterpreterUtil {
 
   def mkTerm(s: String): Either[Throwable, Par] =
     RholangCLI.buildNormalizedTerm(new StringReader(s))
 
+  def computeParentsPostState(parents: Seq[BlockMessage],
+                              genesis: BlockMessage,
+                              dag: BlockDag,
+                              tsLocation: Path,
+                              tsSize: Long,
+                              checkpoints: Map[ByteString, Checkpoint])(
+      implicit scheduler: Scheduler): (Tuplespace, Map[ByteString, Checkpoint]) = {
+    val parentTuplespaces = parents
+      .flatMap(p => {
+        for {
+          bd <- p.body
+          ps <- bd.postState
+        } yield (p -> ps.tuplespace)
+      })
+
+    if (parentTuplespaces.isEmpty) {
+      //no parents to base off of -- start with new tuplespace
+      Tuplespace(tsLocation, tsSize) -> checkpoints
+    } else if (parentTuplespaces.size == 1) {
+      //For a single parent we look up its checkpoint
+      val (checkpoint, updatedMap) = checkpoints
+        .get(parentTuplespaces.head._2)
+        .map(_ -> checkpoints)
+        .getOrElse(
+          computeBlockCheckpoint(parentTuplespaces.head._1,
+                                 genesis,
+                                 dag,
+                                 tsLocation,
+                                 tsSize,
+                                 checkpoints))
+      checkpoint.toTuplespace -> updatedMap
+    } else {
+      //In the case of multiple parents we need
+      //to apply all of the deploys that have been
+      //made in all histories since the greatest
+      //common ancestor in order to reach the current
+      //state.
+      val gca =
+        parentTuplespaces
+          .map(_._1)
+          .reduce(DagOperations.greatestCommonAncestor(_, _, genesis, dag))
+
+      val (checkpoint, updatedMap) = (for {
+        bd <- gca.body
+        ps <- bd.postState
+        t  = ps.tuplespace
+        ch <- checkpoints.get(t)
+      } yield (ch -> checkpoints))
+        .getOrElse(computeBlockCheckpoint(gca, genesis, dag, tsLocation, tsSize, checkpoints))
+      val ts = checkpoint.toTuplespace
+
+      val deploys = DagOperations
+        .bfTraverse[BlockMessage](parentTuplespaces.map(_._1))(
+          ProtoUtil.parents(_).iterator.map(dag.blockLookup))
+        .takeWhile(_ != gca)
+        .flatMap(ProtoUtil.deploys(_).reverse)
+        .toIndexedSeq
+        .reverse
+      deploys.foreach(_.term.foreach(ts.addTerm(_)))
+      ts -> updatedMap
+    }
+  }
+
+  def computeDeploysCheckpoint(parents: Seq[BlockMessage],
+                               deploys: Seq[Deploy],
+                               genesis: BlockMessage,
+                               dag: BlockDag,
+                               tsLocation: Path,
+                               tsSize: Long,
+                               checkpoints: Map[ByteString, Checkpoint])(
+      implicit scheduler: Scheduler): (Checkpoint, Map[ByteString, Checkpoint]) = {
+    val (ts, updatedMap) =
+      computeParentsPostState(parents, genesis, dag, tsLocation, tsSize, checkpoints)
+
+    deploys.foreach(d => {
+      d.term.foreach(ts.addTerm(_))
+    })
+    val result = ts.checkpoint
+    ts.delete()
+    (result, updatedMap + (result.hash -> result))
+  }
+
+  def computeBlockCheckpoint(b: BlockMessage,
+                             genesis: BlockMessage,
+                             dag: BlockDag,
+                             tsLocation: Path,
+                             tsSize: Long,
+                             checkpoints: Map[ByteString, Checkpoint])(
+      implicit scheduler: Scheduler): (Checkpoint, Map[ByteString, Checkpoint]) = {
+
+    val preComputedCheckPoint = for {
+      bd <- b.body
+      ps <- bd.postState
+      ts = ps.tuplespace
+      ch <- checkpoints.get(ts)
+    } yield (ch -> checkpoints)
+
+    preComputedCheckPoint.getOrElse({
+      val parents = ProtoUtil
+        .parents(b)
+        .map(dag.blockLookup)
+
+      val deploys = ProtoUtil.deploys(b)
+
+      computeDeploysCheckpoint(
+        parents,
+        deploys,
+        genesis,
+        dag,
+        tsLocation,
+        tsSize,
+        checkpoints
+      )
+    })
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/Tuplespace.scala
@@ -38,6 +38,13 @@ class Tuplespace(val name: String, val location: Path, val size: Long) {
 
   def storageRepr: String =
     StoragePrinter.prettyPrint(runtime.store)
+
+  def delete(): Unit = {
+    runtime.store.close()
+    dbLocation.resolve("lock.mdb").toFile.delete()
+    dbLocation.resolve("data.mdb").toFile.delete()
+    dbLocation.toFile.delete()
+  }
 }
 
 object Tuplespace {
@@ -51,4 +58,9 @@ object Tuplespace {
     Files.copy(srcLock, destLock, StandardCopyOption.REPLACE_EXISTING)
     Files.copy(srcData, destData, StandardCopyOption.REPLACE_EXISTING)
   }
+
+  def randomName: String = "ts-" + (scala.util.Random.nextInt(10000)).formatted("%04d")
+
+  def apply(location: Path, size: Long): Tuplespace =
+    new Tuplespace(randomName, location, size)
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -1,0 +1,154 @@
+package coop.rchain.casper.util.rholang
+
+import com.google.protobuf.ByteString
+
+import InterpreterUtil._
+import coop.rchain.casper.{BlockDag, BlockGenerator}
+import coop.rchain.casper.BlockDagState._
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.ProtoUtil
+import org.scalatest.{FlatSpec, Matchers}
+
+import cats.Monad
+import cats.data.State
+import cats.implicits._
+import cats.mtl.implicits._
+
+import java.nio.file.Files
+
+import monix.execution.Scheduler.Implicits.global
+
+import scala.collection.immutable.HashMap
+
+class InterpreterUtilTest extends FlatSpec with Matchers with BlockGenerator {
+
+  type StateWithChain[A] = State[BlockDag, A]
+  val initState   = BlockDag().copy(currentId = -1)
+  val storageSize = 1024L * 1024
+
+  "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in {
+    val storageDirectory = Files.createTempDirectory("casper-interp-util-test")
+
+    val genesisDeploys = Vector(
+      "@1!(1)",
+      "@2!(2)",
+      "for(@a <- @1){ @123!(5 * a) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b1Deploys = Vector(
+      "@1!(1)",
+      "for(@a <- @2){ @456!(5 * a) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b2Deploys = Vector(
+      "for(@a <- @123; @b <- @456){ @1!(a + b) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b3Deploys = Vector(
+      "@7!(7)"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+    /*
+     * DAG Looks like this:
+     *
+     *          b3
+     *           |
+     *          b2
+     *           |
+     *          b1
+     *           |
+     *         genesis
+     */
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
+      for {
+        genesis <- createBlock[F](Seq.empty, deploys = genesisDeploys)
+        b1      <- createBlock[F](Seq(genesis.blockHash), deploys = b1Deploys)
+        b2      <- createBlock[F](Seq(b1.blockHash), deploys = b2Deploys)
+        b3      <- createBlock[F](Seq(b2.blockHash), deploys = b3Deploys)
+      } yield b3
+    val chain   = createChain[StateWithChain].runS(initState).value
+    val genesis = chain.idToBlocks(0)
+
+    val b1 = chain.idToBlocks(1)
+    val b3 = chain.idToBlocks(3)
+
+    val (genCh, genMap) = computeBlockCheckpoint(genesis,
+                                                 genesis,
+                                                 chain,
+                                                 storageDirectory,
+                                                 storageSize,
+                                                 Map.empty[ByteString, Checkpoint])
+    val genPostState = genCh.toTuplespace.storageRepr
+    genPostState.contains("@{2}!(2)") should be(true)
+    genPostState.contains("@{123}!(5)") should be(true)
+
+    val (b1Ch, b1Map) =
+      computeBlockCheckpoint(b1, genesis, chain, storageDirectory, storageSize, genMap)
+    val b1PostState = b1Ch.toTuplespace.storageRepr
+    b1PostState.contains("@{1}!(1)") should be(true)
+    b1PostState.contains("@{123}!(5)") should be(true)
+    b1PostState.contains("@{456}!(10)") should be(true)
+
+    //note skipping of b2 to force a test of the recursive aspect of computeBlockCheckpoint
+
+    val (b3Ch, _) =
+      computeBlockCheckpoint(b3, genesis, chain, storageDirectory, storageSize, b1Map)
+    val b3PostState = b3Ch.toTuplespace.storageRepr
+    b3PostState.contains("@{1}!(1)") should be(true)
+    b3PostState.contains("@{1}!(15)") should be(true)
+    b3PostState.contains("@{7}!(7)") should be(true)
+  }
+
+  "computeBlockCheckpoint" should "merge histories in case of multiple parents" in {
+    val storageDirectory = Files.createTempDirectory("casper-interp-util-test")
+
+    val genesisDeploys = Vector(
+      "@1!(1)",
+      "@2!(2)",
+      "for(@a <- @1){ @123!(5 * a) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b1Deploys = Vector(
+      "@5!(5)",
+      "for(@a <- @2){ @456!(5 * a) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b2Deploys = Vector(
+      "@6!(6)"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    val b3Deploys = Vector(
+      "for(@a <- @123; @b <- @456){ @1!(a + b) }"
+    ).flatMap(mkTerm(_).toOption).map(ProtoUtil.termDeploy)
+
+    /*
+     * DAG Looks like this:
+     *
+     *           b3
+     *          /  \
+     *        b1    b2
+     *         \    /
+     *         genesis
+     */
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
+      for {
+        genesis <- createBlock[F](Seq.empty, deploys = genesisDeploys)
+        b1      <- createBlock[F](Seq(genesis.blockHash), deploys = b1Deploys)
+        b2      <- createBlock[F](Seq(genesis.blockHash), deploys = b2Deploys)
+        b3      <- createBlock[F](Seq(b1.blockHash, b2.blockHash), deploys = b3Deploys)
+      } yield b3
+    val chain   = createChain[StateWithChain].runS(initState).value
+    val genesis = chain.idToBlocks(0)
+
+    val b3 = chain.idToBlocks(3)
+    val (b3Ch, _) = computeBlockCheckpoint(b3,
+                                           genesis,
+                                           chain,
+                                           storageDirectory,
+                                           storageSize,
+                                           Map.empty[ByteString, Checkpoint])
+    val b3PostState = b3Ch.toTuplespace.storageRepr
+    b3PostState.contains("@{1}!(15)") should be(true)
+    b3PostState.contains("@{5}!(5)") should be(true)
+    b3PostState.contains("@{6}!(6)") should be(true)
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -18,7 +18,7 @@ import coop.rchain.rholang.interpreter.Runtime
 import monix.eval.Task
 import monix.execution.Scheduler
 
-class NodeRuntime(conf: Conf) {
+class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   import ApplicativeError_._
 
@@ -72,7 +72,7 @@ class NodeRuntime(conf: Conf) {
                        httpServer: HttpServer,
                        runtime: Runtime)
 
-  def aquireResources(implicit scheduler: Scheduler): Effect[Resources] =
+  def aquireResources: Effect[Resources] =
     for {
       runtime <- Runtime.create(storagePath, storageSize).pure[Effect]
       grpcServer <- GrpcServer
@@ -107,7 +107,7 @@ class NodeRuntime(conf: Conf) {
   def addShutdownHook(resources: Resources): Task[Unit] =
     Task.delay(sys.addShutdownHook(clearResources(resources)))
 
-  def nodeProgram(implicit scheduler: Scheduler): Effect[Unit] =
+  def nodeProgram: Effect[Unit] =
     for {
       resources <- aquireResources
       _         <- startResources(resources)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -115,7 +115,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   private def exit0: Task[Unit] = Task.delay(System.exit(0))
 
-  private def unrecoverableNodeProgram(implicit scheduler: Scheduler): Effect[Unit] =
+  private def unrecoverableNodeProgram: Effect[Unit] =
     for {
       resources <- aquireResources
       _         <- startResources(resources)


### PR DESCRIPTION
## Overview
Casper using Rholang Runtime to add deployed terms to state and reduce to quiescence. Blocks contain hash of final result and what terms were deployed. This completes the move to using Rholang terms in Casper blocks instead of the simulated terms.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/RHOL-271

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
