### PR TITLE
CORE-545: create parent directories in Runtime

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -43,7 +43,7 @@ object Runtime {
 
   def create(dataDir: Path, mapSize: Long): Runtime = {
 
-    if (Files.notExists(dataDir)) Files.createDirectory(dataDir)
+    if (Files.notExists(dataDir)) Files.createDirectories(dataDir)
 
     val store =
       LMDBStore


### PR DESCRIPTION
## Overview
This PR fixes a bug where `Runtime` attempts to create a directory when the parent directories don't exist and fails.  

It uses `java.nio.file.Files.createDirectories` which creates all nonexistent parent directories first (like `mkdir -p`).

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-545

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A