### PR TITLE
Enable deploy of rholang source files and forcing casper to propose a block via gRPC

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -25,7 +25,7 @@ trait Casper[F[_], A] {
   def deploy(d: Deploy): F[Unit]
   def estimator: F[A]
   def proposeBlock: F[Option[BlockMessage]]
-  def sendBlockWhenReady: F[Unit]
+  def sendBlockWhenReady(force: Boolean = false): F[Unit]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockMessage]]
@@ -42,8 +42,8 @@ sealed abstract class MultiParentCasperInstances {
       def deploy(r: Deploy): F[Unit]            = ().pure[F]
       def estimator: F[IndexedSeq[BlockMessage]] =
         Applicative[F].pure[IndexedSeq[BlockMessage]](Vector(BlockMessage()))
-      def proposeBlock: F[Option[BlockMessage]] = Applicative[F].pure[Option[BlockMessage]](None)
-      def sendBlockWhenReady: F[Unit]           = ().pure[F]
+      def proposeBlock: F[Option[BlockMessage]]               = Applicative[F].pure[Option[BlockMessage]](None)
+      def sendBlockWhenReady(force: Boolean = false): F[Unit] = ().pure[F]
     }
 
   //TODO: figure out Casper key management for validators
@@ -87,7 +87,7 @@ sealed abstract class MultiParentCasperInstances {
                 deployHist += d
               }
           _ <- Log[F].info(s"CASPER: Received ${PrettyPrinter.buildString(d)}")
-          _ <- sendBlockWhenReady
+          _ <- sendBlockWhenReady()
         } yield ()
 
       def estimator: F[IndexedSeq[BlockMessage]] =
@@ -174,13 +174,13 @@ sealed abstract class MultiParentCasperInstances {
         }
       }
 
-      def sendBlockWhenReady: F[Unit] =
+      def sendBlockWhenReady(force: Boolean = false): F[Unit] =
         for {
-          _ <- if (deployBuff.size < 10) {
-                Monad[F].pure(()) //nothing to do yet
-              } else {
+          _ <- if (force || deployBuff.size >= 10) {
                 val clearBuff = Capture[F].capture { deployBuff.clear() }
                 proposeBlock *> clearBuff
+              } else {
+                Monad[F].pure(()) //nothing to do yet
               }
         } yield ()
 

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -145,13 +145,24 @@ object ProtoUtil {
 
   def hashString(b: BlockMessage): String = Base16.encode(b.blockHash.toByteArray)
 
-  def basicDeploy(id: Int): Deploy = {
+  def basicDeployString(id: Int): DeployString = {
     val nonce = scala.util.Random.nextInt(10000)
-    val term  = InterpreterUtil.mkTerm(s"@${id}!($id)").right.get
+    val term  = s"@${id}!($id)"
 
-    Deploy()
+    DeployString()
       .withUser(ByteString.EMPTY)
       .withNonce(nonce)
       .withTerm(term)
+  }
+
+  def basicDeploy(id: Int): Deploy = {
+    val d    = basicDeployString(id)
+    val term = InterpreterUtil.mkTerm(d.term).right.get
+    Deploy(
+      user = d.user,
+      nonce = d.nonce,
+      term = Some(term),
+      sig = d.sig
+    )
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -2,24 +2,51 @@ package coop.rchain.casper.util.comm
 
 import cats.Monad
 import cats.implicits._
-import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.protocol.DeployString
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.catscontrib.{Capture, IOUtil, MonadOps}
 
-//Simulates user requests by randomly deploying things to Casper.
-//TODO: replace with proper service to handle deploy requests
+import scala.io.Source
+import scala.util.{Failure, Success, Try}
+
 object DeployRuntime {
-  def deployProgram[F[_]: Monad: Capture: DeployService]: F[Unit] =
+  //force Casper to propose a block
+  def forcePropose[F[_]: DeployService]: F[Unit] = DeployService[F].propose()
+
+  //Accepts a Rholang source file and deploys it to Casper
+  def deployFileProgram[F[_]: Monad: Capture: DeployService](file: String): F[Unit] =
+    Try(Source.fromFile(file).mkString) match {
+      case Success(code) =>
+        for {
+          //TODO: have the client track the nonce
+          nonce <- Capture[F].capture { scala.util.Random.nextInt(10000) }
+          //TODO: allow user to specify their public key
+          d        = DeployString().withNonce(nonce).withTerm(code)
+          response <- DeployService[F].deploy(d)
+          _ <- Capture[F].capture {
+                println(s"Response: ${response._2}")
+              }
+        } yield ()
+
+      case Failure(ex) =>
+        Capture[F].capture { println(s"Error with given file: \n${ex.getMessage()}") }
+    }
+
+  //Simulates user requests by randomly deploying things to Casper.
+  def deployDemoProgram[F[_]: Monad: Capture: DeployService]: F[Unit] =
     MonadOps.forever(singleDeploy[F])
 
   private def singleDeploy[F[_]: Monad: Capture: DeployService]: F[Unit] =
     for {
       id <- Capture[F].capture { scala.util.Random.nextInt(100) }
-      d  = ProtoUtil.basicDeploy(id)
+      d  = ProtoUtil.basicDeployString(id)
       _ <- Capture[F].capture {
-            println(s"Sending the following to Casper: ${PrettyPrinter.buildString(d)}")
+            println(s"Sending the following to Casper: ${d.term}")
           }
-      _ <- DeployService[F].deploy(d)
+      response <- DeployService[F].deploy(d)
+      _ <- Capture[F].capture {
+            println(s"Response: ${response._2}")
+          }
       _ <- IOUtil.sleep[F](4000L)
     } yield ()
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -1,11 +1,16 @@
 package coop.rchain.casper.util.comm
 
+import cats.implicits._
+
+import com.google.protobuf.empty.Empty
+
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
-import coop.rchain.casper.protocol.{Deploy, DeployServiceGrpc}
+import coop.rchain.casper.protocol.{DeployServiceGrpc, DeployString}
 import monix.eval.Task
 
 trait DeployService[F[_]] {
-  def deploy(d: Deploy): F[Boolean]
+  def deploy(d: DeployString): F[(Boolean, String)]
+  def propose(): F[Unit] //force Casper to propose a block
 }
 
 object DeployService {
@@ -18,8 +23,13 @@ class GrpcDeployService(host: String, port: Int) extends DeployService[Task] {
     ManagedChannelBuilder.forAddress(host, port).usePlaintext(true).build
   private val blockingStub = DeployServiceGrpc.blockingStub(channel)
 
-  def deploy(d: Deploy): Task[Boolean] = Task.delay {
+  def deploy(d: DeployString): Task[(Boolean, String)] = Task.delay {
     val response = blockingStub.doDeploy(d)
-    response.success
+    (response.success, response.message)
   }
+
+  def propose(): Task[Unit] =
+    Task.delay {
+      blockingStub.propose(Empty())
+    }.void
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package coop.rchain.casper.protocol;
 
+import "google/protobuf/empty.proto";
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
 
@@ -55,11 +56,19 @@ message Deploy {
   bytes sig   = 4; //signature of (hash(resource) + nonce) using private key
 }
 
+message DeployString {
+  bytes  user  = 1; //public key
+  int32  nonce = 2; //for uniqueness
+  string term  = 3; //rholang source code to deploy (will be parsed into `Par`)
+  bytes  sig   = 4; //signature of (hash(resource) + nonce) using private key
+}
 service DeployService {
-  rpc DoDeploy(Deploy) returns (DeployServiceResponse) {}
+  rpc DoDeploy(DeployString) returns (DeployServiceResponse) {}
+  rpc propose(google.protobuf.Empty) returns (google.protobuf.Empty) {}
 }
 message DeployServiceResponse {
-  bool success = 1;
+  bool   success = 1;
+  string message = 2;
 }
 
 message Justification {

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -42,7 +42,10 @@ object Main {
         implicit val consoleIO: ConsoleIO[Task] = new effects.JLineConsoleIO(createConsole)
         DiagnosticsRuntime.diagnosticsProgram[Task]
       }
-      case None if (conf.deployDemo()) => DeployRuntime.deployProgram[Task]
+      case None if (conf.deploy.toOption.isDefined) =>
+        DeployRuntime.deployFileProgram[Task](conf.deploy.toOption.get)
+      case None if (conf.deployDemo()) => DeployRuntime.deployDemoProgram[Task]
+      case None if (conf.propose())    => DeployRuntime.forcePropose[Task]
       case None =>
         new NodeRuntime(conf).nodeProgram.value.map {
           case Right(_) => ()

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -69,7 +69,19 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
   val deployDemo = opt[Boolean](
     default = Some(false),
-    descr = "Demo sending some placeholder Deploy operations to Casper at regular intervals")
+    descr =
+      "Demo sending some placeholder Deploy operations to Casper on an existing running node at regular intervals")
+
+  val deploy = opt[String](
+    default = None,
+    descr =
+      "Deploy a Rholang source file to Casper on an existing running node. The deploy will be packaged and sent as a block to the network depending on the configuration of the Casper instance."
+  )
+
+  val propose = opt[Boolean](
+    default = Some(false),
+    descr =
+      "Force Casper (on an existing running node) to propose a block based on its accumulated deploys.")
 
   def fetchHost(): String =
     host.toOption match {

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -75,7 +75,9 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   val deploy = opt[String](
     default = None,
     descr =
-      "Deploy a Rholang source file to Casper on an existing running node. The deploy will be packaged and sent as a block to the network depending on the configuration of the Casper instance."
+      "Deploy a Rholang source file to Casper on an existing running node. " +
+        "The deploy will be packaged and sent as a block to the network depending " +
+        "on the configuration of the Casper instance."
   )
 
   val propose = opt[Boolean](


### PR DESCRIPTION
## Overview
Users can supply a path to a Rholang source file (similar to `--eval`) and Casper will deploy it to the blockchain state. Block proposal (i.e. sending the deploys out to the network) still happens automatically after 10 deploys are accumulated, however the user can now also force Casper to send a block early with the `--propose` command line flag.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/RHOL-362

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
