### PR TITLE
OPS-137 Add docker-py library to repl loader and enabled active fails

### DIFF
--- a/scripts/build-subprojects.sh
+++ b/scripts/build-subprojects.sh
@@ -34,8 +34,8 @@ case "$SUBPROJECT" in "rosette")
 
 "p2p-test-network")
 
-    sudo apt-get -yq install python3-minimal python3-pexpect python3-pip
-    sudo pip3 install argparse
+    sudo apt-get -yq install python3-minimal python3-pip
+    sudo pip3 install pexpect argparse docker
     ./scripts/p2p-test-network.sh
     ;;
 

--- a/scripts/p2p-test-network.sh
+++ b/scripts/p2p-test-network.sh
@@ -226,7 +226,7 @@ run_tests_on_network() {
   if [[ $all_pass == false ]]; then
     echo "ERROR: Not all network checks passed."
     echo "Dumping metrics and logs"
-    # exit 1 # comment out this line to enable failures
+    exit 1 # comment out this line to enable failures
   elif [[ $all_pass == true ]]; then
     echo "SUCCESS: All checks passed"
   else

--- a/scripts/repl_load_runner.py
+++ b/scripts/repl_load_runner.py
@@ -2,7 +2,7 @@
 from pexpect import replwrap
 import subprocess
 import argparse
-import sys
+import docker
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-g", "--grpc-host", dest='grpc_host', default="node0.testnet1.rchain", help="set grpc host")
@@ -13,9 +13,12 @@ parser.add_argument("-m", "--memory", dest='memory', type=int, default=1024, hel
 parser.add_argument("-n", "--network", dest='network', type=str, default="testnet1.rchain", help="set docker memory for repl client node")
 args = parser.parse_args()
 
-result = subprocess.run(["docker", "volume", "create"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-volume_name = result.stdout.decode('ascii').rstrip('\r\n')
-print("creating tmp volume: {}".format(volume_name))
+client = docker.from_env()
+
+# Pre clean-up
+subprocess.call(["docker", "container", "rm", "-f", "rnode-repl.{}".format(args.network)], stderr=subprocess.DEVNULL)
+
+volume = client.volumes.create()
 
 # Delete rnode-repl on network if it exists
 # result = subprocess.run(["docker", "container", "ls", "--all", "--format", "{{.Names}}"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -25,15 +28,15 @@ print("creating tmp volume: {}".format(volume_name))
 #     print("removing {}".format(container))
 #     result = subprocess.run([ "docker", "container", "rm", "-f", container ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-# Run rnode-repl loader with replwrap
-cmd = "sudo docker run --rm -it -v {}:/var/lib/rnode --cpus=.5 --memory=1024m --name rnode-repl.{} --network {} coop.rchain/rnode --grpc-host node0.testnet1.rchain -r".format(volume_name, args.network, args.network)
+# Run rnode repl loader with replwrap
+cmd = "sudo docker run --rm -it -v {}:/var/lib/rnode --cpus=.5 --memory=1024m --name rnode-repl.{} --network {} coop.rchain/rnode --grpc-host node0.testnet1.rchain -r".format(volume.name, args.network, args.network)
 repl_cmds = ['5', '@"stdout"!("foo")']
 conn = replwrap.REPLWrapper(cmd, args.prompt, None)
 for i in range(args.repeat):
-  for repl_cmd in repl_cmds:
-    result = conn.run_command(repl_cmd) 
-    print("repetition: {} output: {}".format(i, result))
+    for repl_cmd in repl_cmds:
+        result = conn.run_command(repl_cmd) 
+        print("repetition: {} output: {}".format(i, result))
 
-# Clean up
-subprocess.run(["docker", "container", "rm", "-f", "rnode-repl.{}".format(args.network)])
-result = subprocess.run(["docker", "volume", "rm", volume_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+# Post clean-up
+subprocess.call(["docker", "container", "rm", "-f", "rnode-repl.{}".format(args.network)])
+client.volumes.prune()


### PR DESCRIPTION
## Overview
Introduces docker-py, https://github.com/docker/docker-py, to the CI mix in the REPL loader. I also enabled active failure if one of the tests fails in p2p-test-network. 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/OPS-137

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [ x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
