### PR TITLE
Enforce thread-safe atomic updates of Casper vars; Expose cmmand line API for examining blocks based on their hash

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -1,8 +1,8 @@
 package coop.rchain.casper.util.comm
 
-import cats.Monad
+import cats.{Functor, Monad}
 import cats.implicits._
-import coop.rchain.casper.protocol.DeployString
+import coop.rchain.casper.protocol.{BlockQuery, DeployString}
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.catscontrib.{Capture, IOUtil, MonadOps}
 
@@ -12,6 +12,9 @@ import scala.util.{Failure, Success, Try}
 object DeployRuntime {
   //force Casper to propose a block
   def forcePropose[F[_]: DeployService]: F[Unit] = DeployService[F].propose()
+
+  def showBlock[F[_]: Functor: DeployService](hash: String): F[Unit] =
+    DeployService[F].showBlock(BlockQuery(hash)).map(println(_))
 
   //Accepts a Rholang source file and deploys it to Casper
   def deployFileProgram[F[_]: Monad: Capture: DeployService](file: String): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -5,12 +5,13 @@ import cats.implicits._
 import com.google.protobuf.empty.Empty
 
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
-import coop.rchain.casper.protocol.{DeployServiceGrpc, DeployString}
+import coop.rchain.casper.protocol.{BlockQuery, DeployServiceGrpc, DeployString}
 import monix.eval.Task
 
 trait DeployService[F[_]] {
   def deploy(d: DeployString): F[(Boolean, String)]
   def propose(): F[Unit] //force Casper to propose a block
+  def showBlock(q: BlockQuery): F[String]
 }
 
 object DeployService {
@@ -32,4 +33,9 @@ class GrpcDeployService(host: String, port: Int) extends DeployService[Task] {
     Task.delay {
       blockingStub.propose(Empty())
     }.void
+
+  def showBlock(q: BlockQuery): Task[String] = Task.delay {
+    val response = blockingStub.showBlock(q)
+    response.desc
+  }
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -49,6 +49,13 @@ message Diff {
 
 //------------------------------------
 
+message BlockQuery {
+  string hash = 1;
+}
+message BlockInfo {
+  string desc = 1;
+}
+
 message Deploy {
   bytes user  = 1; //public key
   int32 nonce = 2; //for uniqueness
@@ -65,6 +72,7 @@ message DeployString {
 service DeployService {
   rpc DoDeploy(DeployString) returns (DeployServiceResponse) {}
   rpc propose(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+  rpc showBlock(BlockQuery) returns (BlockInfo) {}
 }
 message DeployServiceResponse {
   bool   success = 1;

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -46,6 +46,8 @@ object Main {
         DeployRuntime.deployFileProgram[Task](conf.deploy.toOption.get)
       case None if (conf.deployDemo()) => DeployRuntime.deployDemoProgram[Task]
       case None if (conf.propose())    => DeployRuntime.forcePropose[Task]
+      case None if (conf.showBlock.toOption.isDefined) =>
+        DeployRuntime.showBlock[Task](conf.showBlock.toOption.get)
       case None =>
         new NodeRuntime(conf).nodeProgram.value.map {
           case Right(_) => ()

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -80,6 +80,13 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
         "on the configuration of the Casper instance."
   )
 
+  val showBlock = opt[String](
+    default = None,
+    descr =
+      "View properties of a block known by Casper on an existing running node." +
+        "Output includes: parent hashes, storage contents of the tuplespace."
+  )
+
   val propose = opt[Boolean](
     default = Some(false),
     descr =

--- a/node/src/main/scala/coop/rchain/node/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/grpc.scala
@@ -6,10 +6,12 @@ import scala.concurrent.Future
 import cats._, cats.data._, cats.implicits._
 import com.google.protobuf.empty.Empty
 import coop.rchain.casper.MultiParentCasper
-import coop.rchain.casper.protocol.{Deploy, DeployServiceGrpc, DeployServiceResponse, DeployString}
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.catscontrib._, Catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.node.rnode._
 import coop.rchain.rholang.interpreter.{RholangCLI, Runtime}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
@@ -21,7 +23,7 @@ import java.io.{Reader, StringReader}
 
 object GrpcServer {
 
-  def acquireServer[F[_]: Capture: Applicative: MultiParentCasper: NodeDiscovery: Futurable](
+  def acquireServer[F[_]: Capture: Monad: MultiParentCasper: NodeDiscovery: Futurable](
       port: Int,
       runtime: Runtime)(implicit scheduler: Scheduler): F[Server] =
     Capture[F].capture {
@@ -48,7 +50,7 @@ object GrpcServer {
       }.toFuture
   }
 
-  class DeployImpl[F[_]: Applicative: MultiParentCasper: Futurable]
+  class DeployImpl[F[_]: Monad: MultiParentCasper: Futurable]
       extends DeployServiceGrpc.DeployService {
     override def doDeploy(d: DeployString): Future[DeployServiceResponse] =
       InterpreterUtil.mkTerm(d.term) match {
@@ -70,7 +72,49 @@ object GrpcServer {
       }
 
     override def propose(e: Empty): Future[Empty] =
-      (MultiParentCasper[F].sendBlockWhenReady(true) *> Applicative[F].pure(Empty())).toFuture
+      (MultiParentCasper[F].sendBlockWhenReady(true) *> Monad[F].pure(Empty())).toFuture
+
+    override def showBlock(q: BlockQuery): Future[BlockInfo] = {
+      val dag = MultiParentCasper[F].blockDag
+      val fullHash = dag.map(_.blockLookup.keys.find(h => {
+        Base16.encode(h.toByteArray).startsWith(q.hash)
+      }))
+      val fBlock = fullHash.flatMap(hash => {
+        hash.traverse(h => dag.map(_.blockLookup(h)))
+      })
+
+      fBlock
+        .flatMap[BlockInfo] {
+          case Some(block) =>
+            val parents =
+              ProtoUtil.parents(block).map(hash => "  " + Base16.encode(hash.toByteArray))
+            val ps     = block.body.flatMap(_.postState)
+            val tsHash = ps.map(_.tuplespace).getOrElse(ByteString.EMPTY)
+            MultiParentCasper[F]
+              .tsCheckpoint(tsHash)
+              .map(maybeCheckPoint => {
+                val tsDesc =
+                  maybeCheckPoint
+                    .map(checkpoint => {
+                      val ts     = checkpoint.toTuplespace
+                      val result = ts.storageRepr
+                      ts.delete()
+                      result
+                    })
+                    .getOrElse(s"Tuplespace hash ${Base16.encode(tsHash.toByteArray)} not found!")
+
+                val blockDesc =
+                  s"Parents:\n${parents.mkString("\n")}\n" +
+                    s"Tuplespace:\n${tsDesc}\n"
+
+                BlockInfo(blockDesc)
+              })
+
+          case None =>
+            BlockInfo(s"Block with hash ${q.hash} not found!").pure[F]
+        }
+        .toFuture
+    }
   }
 
   class ReplImpl(runtime: Runtime)(implicit scheduler: Scheduler) extends ReplGrpc.Repl {

--- a/shared/src/main/scala/coop/rchain/shared/AtomicSyncVar.scala
+++ b/shared/src/main/scala/coop/rchain/shared/AtomicSyncVar.scala
@@ -1,0 +1,30 @@
+package coop.rchain.shared
+
+import scala.concurrent.SyncVar
+import scala.util.{Failure, Success, Try}
+
+//A SyncVar which enforces the "consume/replace" model of
+//atomic updates (same as Rholang's for/! pattern with a
+//linear send).
+class AtomicSyncVar[A](init: A) {
+  private[this] val underlying: SyncVar[A] = new SyncVar()
+  underlying.put(init)
+
+  def get: A = underlying.get
+
+  //Use case: capture an intermediate result in the process of updating the var.
+  def mapAndUpdate[B](f: (A) => B, g: (B) => A): Either[Throwable, B] = {
+    val curr = underlying.take()
+
+    Try(f(curr))
+      .flatMap(value => Try(value -> g(value)))
+      .transform(
+        { case (value, updated) => underlying.put(updated); Success(value) },
+        (ex: Throwable) => { underlying.put(curr); Failure(ex) }
+      )
+      .toEither
+  }
+
+  def update(f: (A) => A): Either[Throwable, A] =
+    mapAndUpdate(f, identity[A])
+}


### PR DESCRIPTION
## Overview
@goral09 Pointed out that if another thread gets in between the `take`/`put` calls of a `SyncVar` then this could cause a problem, so I wrote a simple wrapper around `SyncVar` which guarantees atomic updates. I also exposed the `BlockDag` and `Checkpoints` map to a simple gRPC interface so that users can obtain out contents of blocks. I also added a command line parameter which accesses this interface.

### Does this PR relate to an RChain JIRA issue? 
It's the first steps towards a block explorer, I;m not sure if there is a particular ticket for this, but it's a requirement of node 0.5

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
