### PR TITLE
CORE-548 Change ProtcolDispatcher to become a typeclass and CORE-537

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -4,7 +4,6 @@ import java.net.{SocketAddress, SocketTimeoutException}
 import scala.collection.concurrent
 import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.{Duration, MILLISECONDS}
-import coop.rchain.comm.ProtocolDispatcher
 import coop.rchain.comm.protocol.routing.Header
 import coop.rchain.kademlia.PeerTable
 import coop.rchain.metrics.Metrics
@@ -21,7 +20,7 @@ import scala.util.Try
 /**
   * Implements the lower levels of the network protocol.
   */
-class UnicastNetwork(peer: PeerNode) extends ProtocolHandler {
+class UnicastNetwork(peer: PeerNode) {
 
   val logger = Logger("network-overlay")
 
@@ -203,7 +202,7 @@ class UnicastNetwork(peer: PeerNode) extends ProtocolHandler {
   /**
     * Broadcast a message to all peers in the Kademlia table.
     */
-  override def broadcast(msg: ProtocolMessage): Seq[Either[CommError, Unit]] = {
+  def broadcast(msg: ProtocolMessage): Seq[Either[CommError, Unit]] = {
     val bytes = msg.toByteSeq
     table.peers.par.map { p =>
       comm.send(bytes, p)
@@ -218,7 +217,7 @@ class UnicastNetwork(peer: PeerNode) extends ProtocolHandler {
     *
     * This method should be called in its own thread.
     */
-  override def roundTrip[G[_]: Capture: Monad](
+  def roundTrip[G[_]: Capture: Monad](
       msg: ProtocolMessage,
       remote: ProtocolNode,
       timeout: Duration = Duration(500, MILLISECONDS)): G[CommErr[ProtocolMessage]] = {

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -4,6 +4,7 @@ import java.net.{SocketAddress, SocketTimeoutException}
 import scala.collection.concurrent
 import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration.{Duration, MILLISECONDS}
+import coop.rchain.comm.ProtocolDispatcher
 import coop.rchain.comm.protocol.routing.Header
 import coop.rchain.kademlia.PeerTable
 import coop.rchain.metrics.Metrics
@@ -20,9 +21,7 @@ import scala.util.Try
 /**
   * Implements the lower levels of the network protocol.
   */
-class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddress]] = None)
-    extends ProtocolHandler
-    with ProtocolDispatcher[SocketAddress] {
+class UnicastNetwork(peer: PeerNode) extends ProtocolHandler {
 
   val logger = Logger("network-overlay")
 
@@ -42,18 +41,13 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
   val comm  = new UnicastComm(local)
   val table = PeerTable(local)
 
-  def receiver[
-      F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: Encryption: Kvs[
-        ?[_],
-        PeerNode,
-        Array[Byte]]: ApplicativeError_[?[_], CommError]: PacketHandler]: F[Unit] =
+  def receiver[F[_]: Monad: Capture: Log: Time: Metrics](
+      implicit protocolDispatcher: ProtocolDispatcher[F, SocketAddress]): F[Unit] =
     for {
       result <- Capture[F].capture(comm.recv)
       _ <- result match {
             case Right((sock, res)) =>
-              ProtocolMessage.parse(res).traverse { msg =>
-                dispatch[F](sock, msg)
-              }
+              ProtocolMessage.parse(res).traverse(msg => dispatch[F](sock, msg))
             // TODO flatten that pattern match
             case Left(err: CommError) =>
               err match {
@@ -66,9 +60,7 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
                 case DatagramException(ex) => Log[F].error(s"datgram error, ex: $ex")
                 case _                     => ().pure[F]
               }
-
           }
-
     } yield ()
 
   /**
@@ -111,13 +103,8 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
     potentials.toSeq
   }
 
-  def dispatch[
-      F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: Encryption: Kvs[
-        ?[_],
-        PeerNode,
-        Array[Byte]]: ApplicativeError_[?[_], CommError]: PacketHandler](
-      sock: SocketAddress,
-      msg: ProtocolMessage): F[Unit] = {
+  def dispatch[F[_]: Monad: Capture: Log: Time: Metrics](sock: SocketAddress, msg: ProtocolMessage)(
+      implicit protocolDispatcher: ProtocolDispatcher[F, SocketAddress]): F[Unit] = {
 
     val dispatchForSender: Option[F[Unit]] = msg.sender.map { sndr =>
       val sender =
@@ -129,10 +116,11 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
 
       // Update sender's last-seen time, adding it if there are no higher-level protocols.
       for {
-        ti <- Time[F].nanoTime
-        _ <- Capture[F].capture(
-              table.observe(ProtocolNode(sender, local, unsafeRoundTrip), next.isEmpty))
-        tf <- Time[F].nanoTime
+        ti     <- Time[F].nanoTime
+        exists <- protocolDispatcher.exists
+        doAdd  = !exists
+        _      <- Capture[F].capture(table.observe(ProtocolNode(sender, local, unsafeRoundTrip), doAdd))
+        tf     <- Time[F].nanoTime
         // Capture µs timing for roundtrips
         _ <- Metrics[F].record("network-roundtrip-micros", (tf - ti) / 1000)
         _ <- msg match {
@@ -140,7 +128,7 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
               case lookup @ LookupMessage(_, _)         => handleLookup[F](sender, lookup)
               case disconnect @ DisconnectMessage(_, _) => handleDisconnect[F](sender, disconnect)
               case resp: ProtocolResponse               => handleResponse[F](sock, sender, resp)
-              case _                                    => next.traverse(d => d.dispatch[F](sock, msg)).void
+              case _                                    => protocolDispatcher.dispatch(sock, msg)
             }
       } yield ()
 
@@ -156,20 +144,16 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
    * Handle a response to a message. If this message isn't one we were
    * expecting, propagate it to the next dispatcher.
    */
-  private def handleResponse[
-      F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: Encryption: Kvs[
-        ?[_],
-        PeerNode,
-        Array[Byte]]: ApplicativeError_[?[_], CommError]: PacketHandler](
-      sock: SocketAddress,
-      sender: PeerNode,
-      msg: ProtocolResponse): F[Unit] = {
+  private def handleResponse[F[_]: Monad: Capture: Log: Time: Metrics](sock: SocketAddress,
+                                                                       sender: PeerNode,
+                                                                       msg: ProtocolResponse)(
+      implicit protocolDispatcher: ProtocolDispatcher[F, SocketAddress]): F[Unit] = {
     val handleWithHeader: Option[F[Unit]] = msg.returnHeader.map { ret =>
       for {
         result <- Capture[F].capture(pending.get(PendingKey(sender.key, ret.timestamp, ret.seq)))
         _ <- result match {
               case Some(promise) => Capture[F].capture(promise.success(Right(msg)))
-              case None          => next.traverse(_.dispatch[F](sock, msg)).void
+              case None          => protocolDispatcher.dispatch(sock, msg)
             }
 
       } yield ()
@@ -178,8 +162,8 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
     handleWithHeader.getOrElse(Log[F].error("Could not handle response, header not available"))
   }
 
-  private def handlePing[F[_]: Functor: Capture: Log: Metrics](sender: PeerNode,
-                                                               ping: PingMessage): F[Unit] =
+  private def handlePing[F[_]: Monad: Capture: Log: Time: Metrics](sender: PeerNode,
+                                                                   ping: PingMessage): F[Unit] =
     ping
       .response(local)
       .map { pong =>
@@ -192,8 +176,9 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
     * Validate incoming LOOKUP message and return an answering
     * LOOKUP_RESPONSE.
     */
-  private def handleLookup[F[_]: Monad: Capture: Log: Metrics](sender: PeerNode,
-                                                               lookup: LookupMessage): F[Unit] =
+  private def handleLookup[F[_]: Monad: Capture: Log: Time: Metrics](
+      sender: PeerNode,
+      lookup: LookupMessage): F[Unit] =
     (for {
       id   <- lookup.lookupId
       resp <- lookup.response(local, table.lookup(id))
@@ -205,7 +190,7 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
   /**
     * Remove sending peer from table.
     */
-  private def handleDisconnect[F[_]: Monad: Capture: Log: Metrics](
+  private def handleDisconnect[F[_]: Monad: Capture: Log: Time: Metrics](
       sender: PeerNode,
       disconnect: DisconnectMessage): F[Unit] =
     for {
@@ -233,32 +218,32 @@ class UnicastNetwork(peer: PeerNode, next: Option[ProtocolDispatcher[SocketAddre
     *
     * This method should be called in its own thread.
     */
-  override def roundTrip[F[_]: Capture: Monad](
+  override def roundTrip[G[_]: Capture: Monad](
       msg: ProtocolMessage,
       remote: ProtocolNode,
-      timeout: Duration = Duration(500, MILLISECONDS)): F[CommErr[ProtocolMessage]] = {
+      timeout: Duration = Duration(500, MILLISECONDS)): G[CommErr[ProtocolMessage]] = {
 
-    def send(header: Header): CommErrT[F, ProtocolMessage] = {
-      val sendIt: F[CommErr[ProtocolMessage]] = for {
-        promise <- Capture[F].capture(Promise[Either[CommError, ProtocolMessage]])
+    def send(header: Header): CommErrT[G, ProtocolMessage] = {
+      val sendIt: G[CommErr[ProtocolMessage]] = for {
+        promise <- Capture[G].capture(Promise[Either[CommError, ProtocolMessage]])
         bytes   = msg.toByteSeq
         pend    = PendingKey(remote.key, header.timestamp, header.seq)
-        result <- Capture[F].capture {
+        result <- Capture[G].capture {
                    pending.put(pend, promise)
                    comm.send(bytes, remote)
                    Try(Await.result(promise.future, timeout)).toEither
                      .leftMap(protocolException)
                      .flatten
                  }
-        _ <- Capture[F].capture(pending.remove(pend))
+        _ <- Capture[G].capture(pending.remove(pend))
       } yield result
       EitherT(sendIt)
     }
 
-    def fetchHeader(maybeHeader: Option[Header]): CommErrT[F, Header] =
-      maybeHeader.fold[CommErrT[F, Header]](
-        EitherT(unknownProtocol("malformed message").asLeft[Header].pure[F]))(
-        _.pure[CommErrT[F, ?]])
+    def fetchHeader(maybeHeader: Option[Header]): CommErrT[G, Header] =
+      maybeHeader.fold[CommErrT[G, Header]](
+        EitherT(unknownProtocol("malformed message").asLeft[Header].pure[G]))(
+        _.pure[CommErrT[G, ?]])
 
     (for {
       header     <- fetchHeader(msg.header)

--- a/comm/src/main/scala/coop/rchain/comm/network.scala
+++ b/comm/src/main/scala/coop/rchain/comm/network.scala
@@ -161,8 +161,8 @@ class UnicastNetwork(peer: PeerNode) {
     handleWithHeader.getOrElse(Log[F].error("Could not handle response, header not available"))
   }
 
-  private def handlePing[F[_]: Monad: Capture: Log: Time: Metrics](sender: PeerNode,
-                                                                   ping: PingMessage): F[Unit] =
+  private def handlePing[F[_]: Functor: Capture: Log: Metrics](sender: PeerNode,
+                                                               ping: PingMessage): F[Unit] =
     ping
       .response(local)
       .map { pong =>
@@ -175,9 +175,8 @@ class UnicastNetwork(peer: PeerNode) {
     * Validate incoming LOOKUP message and return an answering
     * LOOKUP_RESPONSE.
     */
-  private def handleLookup[F[_]: Monad: Capture: Log: Time: Metrics](
-      sender: PeerNode,
-      lookup: LookupMessage): F[Unit] =
+  private def handleLookup[F[_]: Monad: Capture: Log: Metrics](sender: PeerNode,
+                                                               lookup: LookupMessage): F[Unit] =
     (for {
       id   <- lookup.lookupId
       resp <- lookup.response(local, table.lookup(id))
@@ -189,7 +188,7 @@ class UnicastNetwork(peer: PeerNode) {
   /**
     * Remove sending peer from table.
     */
-  private def handleDisconnect[F[_]: Monad: Capture: Log: Time: Metrics](
+  private def handleDisconnect[F[_]: Monad: Capture: Log: Metrics](
       sender: PeerNode,
       disconnect: DisconnectMessage): F[Unit] =
     for {

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -32,33 +32,6 @@ object ProtocolDispatcher {
   def apply[F[_], A](implicit pd: ProtocolDispatcher[F, A]): ProtocolDispatcher[F, A] = pd
 }
 
-/**
-  * Implements broadcasting and round-trip (request-response) messaging
-  * for higher level protocols.
-  */
-trait ProtocolHandler {
-
-  /**
-    * The node that anchors this handler; `local` becomes the source
-    * for outgoing communications.
-    */
-  def local: ProtocolNode
-
-  /**
-    * Send a message to a single, remote node, and wait up to the
-    * specified duration for a response.
-    */
-  def roundTrip[F[_]: Capture: Monad](
-      msg: ProtocolMessage,
-      remote: ProtocolNode,
-      timeout: Duration = Duration(500, MILLISECONDS)): F[Either[CommError, ProtocolMessage]]
-
-  /**
-    * Asynchronously broadcast a message to all known peers.
-    */
-  def broadcast(msg: ProtocolMessage): Seq[Either[CommError, Unit]]
-}
-
 object ProtocolNode {
 
   def apply(peer: PeerNode,

--- a/comm/src/main/scala/coop/rchain/comm/protocol.scala
+++ b/comm/src/main/scala/coop/rchain/comm/protocol.scala
@@ -17,20 +17,19 @@ import kamon._
 // generation. For reproducibility, this should be a passed-in value.
 
 // TODO REMOVE inheritance hierarchy for composition
-trait ProtocolDispatcher[A] {
+trait ProtocolDispatcher[F[_], A] {
 
   /**
     * Handle an incoming message. This function is intended to thread
     * levels of protocol together, such that inner protocols can
     * bubble unhandled messages up to outer levels.
     */
-  def dispatch[
-      F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: Encryption: Kvs[
-        ?[_],
-        PeerNode,
-        Array[Byte]]: ApplicativeError_[?[_], CommError]: PacketHandler](
-      extra: A,
-      msg: ProtocolMessage): F[Unit]
+  def dispatch(extra: A, msg: ProtocolMessage): F[Unit]
+  def exists: F[Boolean]
+}
+
+object ProtocolDispatcher {
+  def apply[F[_], A](implicit pd: ProtocolDispatcher[F, A]): ProtocolDispatcher[F, A] = pd
 }
 
 /**

--- a/comm/src/main/scala/coop/rchain/comm/unicast.scala
+++ b/comm/src/main/scala/coop/rchain/comm/unicast.scala
@@ -24,9 +24,7 @@ class UnicastComm(local: PeerNode) extends Comm[SocketAddress] {
   val socket = new DatagramSocket(local.endpoint.udpPort)
 
   /*
-   * Timeout for recv() calls; might need to be adjusted lower. This
-   * is unrelated to timeout configurable for round-trip messages in a
-   * ProtocolHandler.
+   * Timeout for recv() calls; might need to be adjusted lower.
    */
   socket.setSoTimeout(500) // 500 ms
 

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -103,7 +103,7 @@ object Network {
 
     for {
       bootstrapAddr <- errorHandler[F].fromEither(NetworkAddress.parse(bootstrapAddrStr))
-      _             <- Log[F].info(s"Bootstrapping from ${bootstrapAddr}.")
+      _             <- Log[F].info(s"Bootstrapping from $bootstrapAddr.")
       _             <- connectAttempt(attempt = 1, defaultTimeout, bootstrapAddr)
       _             <- Log[F].info(s"Connected $bootstrapAddr.")
     } yield ()

--- a/comm/src/main/scala/coop/rchain/p2p/p2p.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/p2p.scala
@@ -103,7 +103,7 @@ object Network {
 
     for {
       bootstrapAddr <- errorHandler[F].fromEither(NetworkAddress.parse(bootstrapAddrStr))
-      _             <- Log[F].info(s"Bootstrapping from ${bootstrapAddr.toAddress}.")
+      _             <- Log[F].info(s"Bootstrapping from ${bootstrapAddr}.")
       _             <- connectAttempt(attempt = 1, defaultTimeout, bootstrapAddr)
       _             <- Log[F].info(s"Connected $bootstrapAddr.")
     } yield ()

--- a/node/src/main/scala/coop/rchain/node/effects/RChainProtocolDispatcher.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/RChainProtocolDispatcher.scala
@@ -1,0 +1,19 @@
+package coop.rchain.node.effects
+
+import java.net.SocketAddress
+import coop.rchain.p2p.effects._
+import coop.rchain.comm._
+import coop.rchain.p2p.Network.{dispatch => networkDispatch, ErrorHandler, KeysStore}
+import coop.rchain.metrics.Metrics
+import coop.rchain.catscontrib.Capture
+import cats._, cats.data._, cats.implicits._
+
+object RChainProtocolDispatcher {
+  def get[
+      F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: Encryption: ErrorHandler: KeysStore: PacketHandler]
+    : ProtocolDispatcher[F, SocketAddress] = new ProtocolDispatcher[F, SocketAddress]() {
+    def dispatch(extra: SocketAddress, msg: ProtocolMessage): F[Unit] =
+      networkDispatch[F](extra, msg)
+    def exists: F[Boolean] = true.pure[F]
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -179,7 +179,8 @@ package object effects {
         }).writeTo(new FileOutputStream(remoteKeysPath.toFile))
     }
 
-  def nodeDiscovery[F[_]: Monad: Capture: Metrics](net: UnicastNetwork): NodeDiscovery[F] =
+  def nodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics](
+      net: UnicastNetwork): NodeDiscovery[F] =
     new NodeDiscovery[F] {
 
       def addNode(node: PeerNode): F[Unit] =
@@ -199,7 +200,8 @@ package object effects {
         }
     }
 
-  def transportLayer[F[_]: Monad: Capture: Metrics](net: UnicastNetwork): TransportLayer[F] =
+  def transportLayer[F[_]: Monad: Capture: Log: Time: Metrics](
+      net: UnicastNetwork): TransportLayer[F] =
     new TransportLayer[F] {
       import scala.concurrent.duration._
 

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -119,7 +119,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       resources <- aquireResources
       _         <- startResources(resources)
       _         <- addShutdownHook(resources).toEffect
-      _         <- Task.fork(MonadOps.forever(net.receiver[Effect].value.void)).start.toEffect
+      _         <- MonadOps.forever(net.receiver[Effect].value.void).executeAsync.start.toEffect
       _         <- Log[Effect].info(s"Listening for traffic on $address.")
       res <- ApplicativeError_[Effect, CommError].attempt(
               if (conf.standalone()) Log[Effect].info(s"Starting stand-alone node.")

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -59,6 +59,9 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   val net                                                 = new UnicastNetwork(src)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task]   = effects.nodeDiscovery[Task](net)
   implicit val transportLayerEffect: TransportLayer[Task] = effects.transportLayer[Task](net)
+  implicit val packetHandlerEffect: PacketHandler[Effect] = effects.packetHandler[Effect](
+    casperPacketHandler[Effect]
+  )
   implicit val protocolDispatcher: ProtocolDispatcher[Effect, SocketAddress] =
     effects.RChainProtocolDispatcher.get[Effect]
   implicit val casperEffect: MultiParentCasper[Effect] = MultiParentCasper.hashSetCasper[Effect](
@@ -66,10 +69,6 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
     com.google.protobuf.ByteString.copyFrom(Array((scala.util.Random.nextInt(10) + 1).toByte)),
     storagePath,
     storageSize
-  )
-
-  implicit val packetHandlerEffect: PacketHandler[Effect] = effects.packetHandler[Effect](
-    casperPacketHandler[Effect]
   )
 
   case class Resources(grpcServer: Server,

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -59,17 +59,17 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   val net                                                 = new UnicastNetwork(src)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task]   = effects.nodeDiscovery[Task](net)
   implicit val transportLayerEffect: TransportLayer[Task] = effects.transportLayer[Task](net)
-  implicit val packetHandlerEffect: PacketHandler[Effect] = effects.packetHandler[Effect](
-    casperPacketHandler[Effect]
-  )
-  implicit val protocolDispatcher: ProtocolDispatcher[Effect, SocketAddress] =
-    effects.RChainProtocolDispatcher.get[Effect]
   implicit val casperEffect: MultiParentCasper[Effect] = MultiParentCasper.hashSetCasper[Effect](
     //  TODO: figure out actual validator identities...
     com.google.protobuf.ByteString.copyFrom(Array((scala.util.Random.nextInt(10) + 1).toByte)),
     storagePath,
     storageSize
   )
+  implicit val packetHandlerEffect: PacketHandler[Effect] = effects.packetHandler[Effect](
+    casperPacketHandler[Effect]
+  )
+  implicit val protocolDispatcher: ProtocolDispatcher[Effect, SocketAddress] =
+    effects.RChainProtocolDispatcher.get[Effect]
 
   case class Resources(grpcServer: Server,
                        metricsServer: MetricsServer,


### PR DESCRIPTION
## Overview
Change ProtcolDispatcher to become a typeclass. This:
1. improvements code quality
2. gives us ability to abstract UnicastNetwork.receiver to a `TransportLayer`

### Does this PR relate to an RChain JIRA issue? 
CORE-548, CORE-537