### PR TITLE
CORE-531: rspace: add PointerBlock

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
@@ -4,24 +4,33 @@ import scodec.Codec
 import scodec.Codec._
 import scodec.codecs._
 
-case class PointerBlock(toVector: Vector[Option[Blake2b256Hash]]) {
+class PointerBlock private (val toVector: Vector[Option[Blake2b256Hash]]) {
 
-  require(toVector.length == PointerBlock.length)
+  require(toVector.length == PointerBlock.length, "A PointerBlock's length must be 256")
 
   def updated(tuples: List[(Int, Option[Blake2b256Hash])]): PointerBlock =
-    PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
+    new PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
       vec.updated(curr._1, curr._2)
     })
 
   def children: Vector[(Int, Blake2b256Hash)] =
     toVector.zipWithIndex.collect { case (Some(hash), idx) => (idx, hash) }
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case pb: PointerBlock => pb.toVector == toVector
+    case _                => false
+  }
+
+  override def hashCode(): Int = toVector.hashCode()
 }
 
 object PointerBlock {
 
   val length = 256
 
-  def create(): PointerBlock = PointerBlock(Vector.fill(PointerBlock.length)(None))
+  def create(): PointerBlock = new PointerBlock(Vector.fill(length)(None))
+
+  def fromVector(vector: Vector[Option[Blake2b256Hash]]): PointerBlock = new PointerBlock(vector)
 
   implicit val codecPointerBlock: Codec[PointerBlock] =
     vectorOfN(

--- a/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
@@ -1,0 +1,31 @@
+package coop.rchain.rspace
+
+import scodec.Codec
+import scodec.Codec._
+import scodec.codecs._
+
+case class PointerBlock(toVector: Vector[Option[Blake2b256Hash]]) {
+
+  require(toVector.length == PointerBlock.length)
+
+  def updated(tuples: List[(Int, Option[Blake2b256Hash])]): PointerBlock =
+    PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
+      vec.updated(curr._1, curr._2)
+    })
+
+  def children: Vector[(Int, Blake2b256Hash)] =
+    toVector.zipWithIndex.collect { case (Some(hash), idx) => (idx, hash) }
+}
+
+object PointerBlock {
+
+  val length = 256
+
+  def create(): PointerBlock = PointerBlock(Vector.fill(PointerBlock.length)(None))
+
+  implicit val codecPointerBlock: Codec[PointerBlock] =
+    vectorOfN(
+      provide(256),
+      optional(ignore(size = 7) ~> bool, Blake2b256Hash.codecBlake2b256Hash)
+    ).as[PointerBlock]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/PointerBlock.scala
@@ -25,7 +25,7 @@ object PointerBlock {
 
   implicit val codecPointerBlock: Codec[PointerBlock] =
     vectorOfN(
-      provide(256),
+      provide(length),
       optional(ignore(size = 7) ~> bool, Blake2b256Hash.codecBlake2b256Hash)
     ).as[PointerBlock]
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/PointerBlockTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/PointerBlockTests.scala
@@ -1,0 +1,103 @@
+package coop.rchain.rspace
+
+import coop.rchain.rspace.PointerBlock._
+import coop.rchain.rspace.test.ArbitraryInstances._
+import coop.rchain.rspace.test.roundTripCodec
+import coop.rchain.shared.AttemptOps._
+import org.scalacheck.Prop
+import org.scalactic.anyvals.PosInt
+import org.scalatest.prop.{Checkers, Configuration}
+import org.scalatest.{FlatSpec, Matchers}
+import scodec.bits.BitVector
+import scodec.{Codec, DecodeResult}
+
+class PointerBlockTests extends FlatSpec with Matchers with Checkers with Configuration {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = PosInt(1000))
+
+  "A PointerBlock" should "be the same when round-tripped with scodec" in {
+
+    val propRoundTripCodec: Prop = Prop.forAll { (pb: PointerBlock) =>
+      roundTripCodec[PointerBlock](pb)
+        .map((value: DecodeResult[PointerBlock]) => value.value == pb)
+        .getOrElse(default = false)
+    }
+
+    check(propRoundTripCodec)
+  }
+
+  val emptyPb: PointerBlock = PointerBlock.create()
+
+  val emptyPbHash: Blake2b256Hash =
+    implicitly[Codec[PointerBlock]]
+      .encode(emptyPb)
+      .map((vector: BitVector) => Blake2b256Hash.create(vector.toByteArray))
+      .get
+
+  val helloHash: Blake2b256Hash = Blake2b256Hash.create("hello".getBytes())
+
+  val fullPb: PointerBlock = PointerBlock(Vector.fill(256)(Some(helloHash)))
+
+  "An empty PointerBlock" should "have the expected hash" in {
+
+    val expected = "2b69702a889248a4d6620475a105dccd5e0d4230aca8a492aaf6510e55d55b02"
+
+    emptyPbHash.bytes.toHex shouldBe expected
+  }
+
+  "A serialized empty PointerBlock" should "have the expected length" in {
+
+    val attemptedActual = implicitly[Codec[PointerBlock]]
+      .encode(emptyPb)
+      .map((vector: BitVector) => vector.bytes.length)
+
+    attemptedActual.get shouldBe PointerBlock.length
+  }
+
+  "A serialized full PointerBlock" should "have the expected length" in {
+
+    val attemptedActual = implicitly[Codec[PointerBlock]]
+      .encode(fullPb)
+      .map((vector: BitVector) => vector.bytes.length)
+
+    attemptedActual.get shouldBe (PointerBlock.length * (Blake2b256Hash.length + 1))
+  }
+
+  "A PointerBlock with a known item at index 1" should "have the expected hash" in {
+
+    val pb = emptyPb.updated(List((1, Some(helloHash))))
+
+    val attemptedActual = implicitly[Codec[PointerBlock]]
+      .encode(pb)
+      .map((vector: BitVector) => Blake2b256Hash.create(vector.bytes.toArray).bytes.toHex)
+
+    val expected = "b11665e990d461db27f850481ad538662cc5321d67f9688c3a6ae77fa4b63f03"
+
+    attemptedActual.get shouldBe expected
+  }
+
+  "A PointerBlock with a known item at index 42" should "have the expected hash" in {
+
+    val pb = emptyPb.updated(List((42, Some(helloHash))))
+
+    val attemptedActual = implicitly[Codec[PointerBlock]]
+      .encode(pb)
+      .map((vector: BitVector) => Blake2b256Hash.create(vector.bytes.toArray).bytes.toHex)
+
+    val expected = "bc50d1148e6c4197bc978a80e424d4a0b3f065496102d376ba6c138a2ed2c3a7"
+
+    attemptedActual.get shouldBe expected
+  }
+
+  "A PointerBlock with a known item at all indices" should "have the expected hash" in {
+
+    val attemptedActual = implicitly[Codec[PointerBlock]]
+      .encode(fullPb)
+      .map((vector: BitVector) => Blake2b256Hash.create(vector.bytes.toArray).bytes.toHex)
+
+    val expected = "2b5e43a142c6b5e1b2ff614185d76d1e215b0efe627e124b4244006f4da4ed64"
+
+    attemptedActual.get shouldBe expected
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/PointerBlockTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/PointerBlockTests.scala
@@ -37,7 +37,7 @@ class PointerBlockTests extends FlatSpec with Matchers with Checkers with Config
 
   val helloHash: Blake2b256Hash = Blake2b256Hash.create("hello".getBytes())
 
-  val fullPb: PointerBlock = PointerBlock(Vector.fill(256)(Some(helloHash)))
+  val fullPb: PointerBlock = PointerBlock.fromVector(Vector.fill(256)(Some(helloHash)))
 
   "An empty PointerBlock" should "have the expected hash" in {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
@@ -12,6 +12,6 @@ object ArbitraryInstances {
     Arbitrary(Gen.sized { _ =>
       Gen
         .listOfN(256, Arbitrary.arbitrary[Option[Blake2b256Hash]])
-        .map(maybeHashes => PointerBlock(maybeHashes.toVector))
+        .map(maybeHashes => PointerBlock.fromVector(maybeHashes.toVector))
     })
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
@@ -1,10 +1,17 @@
 package coop.rchain.rspace.test
 
-import coop.rchain.rspace.Blake2b256Hash
-import org.scalacheck.Arbitrary
+import coop.rchain.rspace.{Blake2b256Hash, PointerBlock}
+import org.scalacheck.{Arbitrary, Gen}
 
 object ArbitraryInstances {
 
   implicit val arbitraryBlake2b256Hash: Arbitrary[Blake2b256Hash] =
     Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(bytes => Blake2b256Hash.create(bytes)))
+
+  implicit val arbitraryPointerBlock: Arbitrary[PointerBlock] =
+    Arbitrary(Gen.sized { _ =>
+      Gen
+        .listOfN(256, Arbitrary.arbitrary[Option[Blake2b256Hash]])
+        .map(maybeHashes => new PointerBlock(maybeHashes.toVector))
+    })
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
@@ -12,6 +12,6 @@ object ArbitraryInstances {
     Arbitrary(Gen.sized { _ =>
       Gen
         .listOfN(256, Arbitrary.arbitrary[Option[Blake2b256Hash]])
-        .map(maybeHashes => new PointerBlock(maybeHashes.toVector))
+        .map(maybeHashes => PointerBlock(maybeHashes.toVector))
     })
 }


### PR DESCRIPTION
## Overview
This PR adds a `PointerBlock` type to rspace for use in the History Trie.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-531

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A