### PR TITLE
rspace: use BLAKE2b256 in existing store

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -2,9 +2,9 @@ package coop.rchain.rspace
 
 import java.nio.ByteBuffer
 import java.nio.file.Path
-import java.security.MessageDigest
 import scala.collection.immutable.Seq
 
+import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.internal.scodecs._
 import coop.rchain.rspace.util._
@@ -394,7 +394,7 @@ object LMDBStore {
   }
 
   private[rspace] def hashBytes(bytes: Array[Byte]): ByteBuffer = {
-    val dataArr    = MessageDigest.getInstance("SHA-256").digest(bytes)
+    val dataArr    = Blake2b256.hash(bytes)
     val byteBuffer = ByteBuffer.allocateDirect(dataArr.length)
     byteBuffer.put(dataArr).flip()
     byteBuffer

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -1,8 +1,8 @@
 package coop.rchain.rspace.test
 
 import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 
+import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.rspace.examples._
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.dropIndex
@@ -168,7 +168,7 @@ object InMemoryStore {
   }
 
   def hashBytes(bs: Array[Byte]): Array[Byte] =
-    MessageDigest.getInstance("SHA-256").digest(bs)
+    Blake2b256.hash(bs)
 
   def hashString(s: String): Array[Byte] =
     hashBytes(s.getBytes(StandardCharsets.UTF_8))


### PR DESCRIPTION
## Overview
We were using SHA-256 a few places internally in the store.  In order to stay consistent with the upcoming Trie and Trace implementations, we should switch to using BLAKE2b256.

### Does this PR relate to an RChain JIRA issue? 
No.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A