### PR TITLE
rspace: add enrichment to derive Codec[T] from Serialize[T]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,6 +230,7 @@ lazy val rspace = (project in file("rspace"))
       lmdbjava,
       catsCore,
       scodecCore,
+      scodecCats,
       scodecBits
     ),
     /* Tutorial */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,6 +41,7 @@ object Dependencies {
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.0.3"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.10.3"
+  val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "0.6.0"
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.5"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.2"
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.+"

--- a/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
@@ -1,5 +1,11 @@
 package coop.rchain.rspace
 
+import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
+import scodec.bits.{BitVector, ByteVector}
+import scodec.codecs._
+import scodec.interop.cats._
+import cats.implicits._
+
 /**
   * Type class for serializing and deserializing values
   *
@@ -10,4 +16,31 @@ trait Serialize[A] {
   def encode(a: A): Array[Byte]
 
   def decode(bytes: Array[Byte]): Either[Throwable, A]
+}
+
+object Serialize {
+
+  implicit class RichSerialize[A](instance: Serialize[A]) {
+
+    def toCodec: Codec[A] = new Codec[A] {
+
+      private val sizeCodec = int64
+
+      private val codec = variableSizeBytesLong(sizeCodec, bytes)
+
+      def sizeBound: SizeBound = sizeCodec.sizeBound + bytes.sizeBound
+
+      def encode(value: A): Attempt[BitVector] =
+        codec.encode(ByteVector(instance.encode(value)))
+
+      def decode(bits: BitVector): Attempt[DecodeResult[A]] =
+        codec
+          .decode(bits)
+          .flatMap { (value: DecodeResult[ByteVector]) =>
+            Attempt.fromEither(value
+              .traverse[Either[Throwable, ?], A]((vec: ByteVector) => instance.decode(vec.toArray))
+              .leftMap((thw: Throwable) => Err(thw.getMessage)))
+          }
+    }
+  }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
@@ -1,0 +1,39 @@
+package coop.rchain.rspace
+
+import coop.rchain.rspace.examples.StringExamples.Pattern
+import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.test.ArbitraryInstances._
+import coop.rchain.rspace.test.roundTripCodec
+import org.scalacheck.Prop
+import org.scalactic.anyvals.PosInt
+import org.scalatest.prop.{Checkers, Configuration}
+import org.scalatest.{FlatSpec, Matchers}
+import scodec.DecodeResult
+
+class SerializeTests extends FlatSpec with Matchers with Checkers with Configuration {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = PosInt(1000))
+
+  "A String" should "round trip through a derived codec" in {
+
+    val propRoundTripCodec: Prop = Prop.forAll { (str: String) =>
+      roundTripCodec(str)(stringSerialize.toCodec)
+        .map((value: DecodeResult[String]) => value.value == str)
+        .getOrElse(default = false)
+    }
+
+    check(propRoundTripCodec)
+  }
+
+  "A Pattern" should "round trip through a derived codec" in {
+
+    val propRoundTripCodec: Prop = Prop.forAll { (pat: Pattern) =>
+      roundTripCodec(pat)(patternSerialize.toCodec)
+        .map((value: DecodeResult[Pattern]) => value.value == pat)
+        .getOrElse(default = false)
+    }
+
+    check(propRoundTripCodec)
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
@@ -1,11 +1,19 @@
 package coop.rchain.rspace.test
 
 import coop.rchain.rspace._
+import coop.rchain.rspace.examples.StringExamples.{Pattern, StringMatch, Wildcard}
 import coop.rchain.rspace.history._
 import org.scalacheck.{Arbitrary, Gen}
 import scodec.bits.ByteVector
 
 object ArbitraryInstances {
+
+  implicit val arbitraryPattern: Arbitrary[Pattern] = {
+    val genWildcard: Gen[Pattern] = Gen.const(Wildcard)
+    val genMatch: Gen[Pattern]    = Arbitrary.arbitrary[String].map((str: String) => StringMatch(str))
+    val genPattern: Gen[Pattern]  = Gen.oneOf(genWildcard, genMatch)
+    Arbitrary(genPattern)
+  }
 
   implicit val arbitraryBlake2b256Hash: Arbitrary[Blake2b256Hash] =
     Arbitrary(Arbitrary.arbitrary[Array[Byte]].map(bytes => Blake2b256Hash.create(bytes)))


### PR DESCRIPTION
## Overview
For the Trie implementation, I have chosen to use the [scodec](http://scodec.org/) library for serialization/deserialization of values of type `Trie[K, V]` to/from bytes stored in LMDB.

To store rspace `C`, `P`, `A`, and `K` (channel, pattern, data, continuation) values in the leaves of the Trie,  we need to be able to convert from instances of `Serialize` to instances of `Codec`.  

This PR provides an enrichment to instances of `Serialize` for this purpose.

### Does this PR relate to an RChain JIRA issue? 
Yes, it is related to CORE-{[534](https://rchain.atlassian.net/browse/CORE-534),[535](https://rchain.atlassian.net/browse/CORE-535),[536](https://rchain.atlassian.net/browse/CORE-536)}

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A