### PR TITLE
CORE-534: rspace: add {put,get}Trie to IStore (and a touch of cleanup)

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rspace
 
+import coop.rchain.rspace.history.{Blake2b256Hash, Trie}
+
 import scala.collection.immutable.Seq
 import coop.rchain.rspace.internal._
 
@@ -58,6 +60,13 @@ trait IStore[C, P, A, K] {
   private[rspace] def removeJoin(txn: T, channel: C, channels: Seq[C]): Unit
 
   private[rspace] def removeAllJoins(txn: T, channel: C): Unit
+
+  private[rspace] def putTrie(txn: T,
+                              key: Blake2b256Hash,
+                              value: Trie[Blake2b256Hash, GNAT[C, P, A, K]]): Unit
+
+  private[rspace] def getTrie(txn: T,
+                              key: Blake2b256Hash): Option[Trie[Blake2b256Hash, GNAT[C, P, A, K]]]
 
   def toMap: Map[Seq[C], Row[P, A, K]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -51,16 +51,12 @@ trait IStore[C, P, A, K] {
 
   private[rspace] def removeAll(txn: T, channels: Seq[C]): Unit
 
-  // compare to store.joinMap.addBinding
   private[rspace] def addJoin(txn: T, channel: C, channels: Seq[C]): Unit
 
-  // compare to store.joinMap.get(c).toList.flatten
   private[rspace] def getJoin(txn: T, channel: C): Seq[Seq[C]]
 
-  // compare to store.joinMap.removeBinding
   private[rspace] def removeJoin(txn: T, channel: C, channels: Seq[C]): Unit
 
-  // compare to store.joinMap.remove
   private[rspace] def removeAllJoins(txn: T, channel: C): Unit
 
   def toMap: Map[Seq[C], Row[P, A, K]]

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -2,18 +2,22 @@ package coop.rchain.rspace
 
 import java.nio.ByteBuffer
 import java.nio.file.Path
-import scala.collection.immutable.Seq
 
 import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.rspace.history.{Blake2b256Hash, Trie}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.internal.scodecs._
 import coop.rchain.rspace.util._
+import coop.rchain.rspace.history.Trie
+import coop.rchain.rspace.history.Blake2b256Hash._
+import coop.rchain.shared.AttemptOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
 import scodec.Codec
 import scodec.bits._
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 
 /**
   * The main store class.
@@ -24,13 +28,21 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
                                      _dbKeys: Dbi[ByteBuffer],
                                      _dbWaitingContinuations: Dbi[ByteBuffer],
                                      _dbData: Dbi[ByteBuffer],
-                                     _dbJoins: Dbi[ByteBuffer])(implicit
-                                                                sc: Serialize[C],
-                                                                sp: Serialize[P],
-                                                                sa: Serialize[A],
-                                                                sk: Serialize[K])
+                                     _dbJoins: Dbi[ByteBuffer],
+                                     _dbTrie: Dbi[ByteBuffer])(implicit
+                                                               sc: Serialize[C],
+                                                               sp: Serialize[P],
+                                                               sa: Serialize[A],
+                                                               sk: Serialize[K])
     extends IStore[C, P, A, K]
     with ITestableStore[C, P] {
+
+  private implicit val codecC: Codec[C] = sc.toCodec
+  private implicit val codecP: Codec[P] = sp.toCodec
+  private implicit val codecA: Codec[A] = sa.toCodec
+  private implicit val codecK: Codec[K] = sk.toCodec
+
+  private val codecHistory: Codec[Trie[Blake2b256Hash, GNAT[C, P, A, K]]] = Trie.codecTrie
 
   import coop.rchain.rspace.LMDBStore._
 
@@ -285,6 +297,25 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
         }.toMap
       }
     }
+
+  private[rspace] def putTrie(txn: Txn[ByteBuffer],
+                              key: Blake2b256Hash,
+                              value: Trie[Blake2b256Hash, GNAT[C, P, A, K]]): Unit = {
+    val encodedValue = codecHistory.encode(value).get
+    val keyBuff      = toByteBuffer(key.bytes)
+    val valBuff      = toByteBuffer(encodedValue)
+    _dbTrie.put(txn, keyBuff, valBuff)
+  }
+
+  private[rspace] def getTrie(
+      txn: Txn[ByteBuffer],
+      key: Blake2b256Hash): Option[Trie[Blake2b256Hash, GNAT[C, P, A, K]]] = {
+    val keyBuff = toByteBuffer(key.bytes)
+    Option(_dbTrie.get(txn, keyBuff)).map { (buffer: ByteBuffer) =>
+      // ht: Yes, I want to throw an exception if deserialization fails
+      codecHistory.decode(BitVector(buffer)).map(_.value).get
+    }
+  }
 }
 
 object LMDBStore {
@@ -292,6 +323,7 @@ object LMDBStore {
   private[this] val waitingContinuationsTableName: String = "WaitingContinuations"
   private[this] val dataTableName: String                 = "Data"
   private[this] val joinsTableName: String                = "Joins"
+  private[this] val trieTableName: String                 = "Trie"
 
   /**
     * Creates an instance of [[LMDBStore]]
@@ -321,8 +353,12 @@ object LMDBStore {
       env.openDbi(waitingContinuationsTableName, MDB_CREATE)
     val dbData: Dbi[ByteBuffer]  = env.openDbi(dataTableName, MDB_CREATE)
     val dbJoins: Dbi[ByteBuffer] = env.openDbi(joinsTableName, MDB_CREATE)
+    val dbTrie: Dbi[ByteBuffer]  = env.openDbi(trieTableName, MDB_CREATE)
 
-    new LMDBStore[C, P, A, K](env, dbKeys, dbWaitingContinuations, dbData, dbJoins)(sc, sp, sa, sk)
+    new LMDBStore[C, P, A, K](env, dbKeys, dbWaitingContinuations, dbData, dbJoins, dbTrie)(sc,
+                                                                                            sp,
+                                                                                            sa,
+                                                                                            sk)
   }
 
   private[rspace] def toByteVector[T](value: T)(implicit st: Serialize[T]): ByteVector =
@@ -340,13 +376,15 @@ object LMDBStore {
   private[rspace] def toByteBuffer[T](values: Seq[T])(implicit st: Serialize[T]): ByteBuffer =
     toByteBuffer(toBitVector(toByteVectorSeq(values), byteVectorsCodec))
 
-  private[rspace] def toByteBuffer(vector: BitVector): ByteBuffer = {
-    val bytes          = vector.bytes
-    val bb: ByteBuffer = ByteBuffer.allocateDirect(bytes.size.toInt)
-    bytes.copyToBuffer(bb)
-    bb.flip()
-    bb
+  private[rspace] def toByteBuffer(byteVector: ByteVector): ByteBuffer = {
+    val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size.toInt)
+    byteVector.copyToBuffer(buffer)
+    buffer.flip()
+    buffer
   }
+
+  private[rspace] def toByteBuffer(bitVector: BitVector): ByteBuffer =
+    toByteBuffer(bitVector.bytes)
 
   private[rspace] def toByteVectorSeq[T](values: Seq[T])(
       implicit st: Serialize[T]): Seq[ByteVector] =

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -29,8 +29,6 @@ object internal {
       wks: Seq[WaitingContinuation[P, K]]
   )
 
-  object codecs {}
-
   private[rspace] object scodecs {
 
     import scodec.{Attempt, Codec, DecodeResult}

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -1,6 +1,8 @@
 package coop.rchain.rspace
 
 import coop.rchain.shared.AttemptOps._
+import scodec.{Attempt, Codec, DecodeResult, SizeBound}
+import scodec.bits.BitVector
 
 import scala.collection.immutable.Seq
 
@@ -18,6 +20,16 @@ object internal {
                                                 dataCandidates: Seq[DataCandidate[C, A]])
 
   case class Row[P, A, K](data: Seq[Datum[A]], wks: Seq[WaitingContinuation[P, K]])
+
+  /** [[GNAT]] is not a `Tuple3`
+    */
+  case class GNAT[C, P, A, K](
+      channels: Seq[C],
+      data: Seq[Datum[A]],
+      wks: Seq[WaitingContinuation[P, K]]
+  )
+
+  object codecs {}
 
   private[rspace] object scodecs {
 
@@ -60,6 +72,25 @@ object internal {
 
     def fromBitVector[T](vector: BitVector, codec: Codec[T]): T =
       fromAttempt(codec.decode(vector))
-  }
 
+    /* A new approach */
+
+    implicit def codecDatum[A](implicit codecA: Codec[A]): Codec[Datum[A]] =
+      (codecA :: bool).as[Datum[A]]
+
+    implicit def codecWaitingContinuation[P, K](
+        implicit
+        codecP: Codec[P],
+        codecK: Codec[K]): Codec[WaitingContinuation[P, K]] =
+      (seqOfN(int32, codecP) :: codecK :: bool).as[WaitingContinuation[P, K]]
+
+    implicit def codecGNAT[C, P, A, K](implicit
+                                       codecC: Codec[C],
+                                       codecP: Codec[P],
+                                       codecA: Codec[A],
+                                       codecK: Codec[K]): Codec[GNAT[C, P, A, K]] =
+      (seqOfN(int32, codecC) ::
+        seqOfN(int32, codecDatum(codecA)) ::
+        seqOfN(int32, codecWaitingContinuation(codecP, codecK))).as[GNAT[C, P, A, K]]
+  }
 }


### PR DESCRIPTION
## Overview
This PR adds two methods to `IStore`: `putTrie` and `getTrie`.  These are intended for use in the construction and access of the history Trie.  It adds also adds implementations for them in `LMDBStore` and `InMemoryStore`, along with a place to store the Trie (a new sub-database and a hash map, respectively).

### Does this PR relate to an RChain JIRA issue? 
Yes, it is related to CORE-{[534](https://rchain.atlassian.net/browse/CORE-534),[535](https://rchain.atlassian.net/browse/CORE-535),[536](https://rchain.atlassian.net/browse/CORE-536)}

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
See #747 for the work that proceeded this.  

I think the work in that PR and the way of using the derived `Codec`s in this PR provide an example of how we could refactor and simplify `LMDBStore`.