### PR TITLE
[CORE-550] Bump rspace to 0.2.1-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ lazy val node = (project in file("node"))
       apiServerDependencies ++ commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
         catsCore,
         grpcNetty,
-        jline, 
+        jline,
         scallop,
         scalaUri,
         scalapbRuntimegGrpc
@@ -162,7 +162,7 @@ lazy val node = (project in file("node"))
     packageArchitecture in Rpm := "noarch",
     maintainerScripts in Rpm := maintainerScriptsAppendFromFile((maintainerScripts in Rpm).value)(
       RpmConstants.Post -> (sourceDirectory.value / "rpm" / "scriptlets" / "post")
-    ),    
+    ),
     rpmPrerequisites := Seq("libsodium >= 1.0.14-1")
   )
   .dependsOn(casper, comm, crypto, rholang)
@@ -225,7 +225,7 @@ lazy val rspace = (project in file("rspace"))
   .settings(commonSettings: _*)
   .settings(
     name := "rspace",
-    version := "0.1.1",
+    version := "0.2.1-SNAPSHOT",
     libraryDependencies ++= commonDependencies ++ Seq(
       lmdbjava,
       catsCore,


### PR DESCRIPTION
## Overview
The rspace version number is currently still 0.1.1. This is problematic because the released version has the same version number, but obviously there have been changes to rspace since then. It can also potentially cause issues if someone tries to use sbt rspace/publishLocal.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-550

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
