### PR TITLE
Rholang: Matcher: Add logical connectives.

### DIFF
--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -22,13 +22,13 @@ _. Proc16 ::= "{" Proc "}" ;
 -- In general the expression style processes are higher precedence.
 -- Expression style is anything that necessary resolves to a single ground value
 -- or a collection.
-PNegation.    Proc16 ::= "~" Proc16 ;
-PConjunction. Proc15 ::= Proc15 "/\\" Proc16 ;
-PDisjunction. Proc14 ::= Proc14 "\\/" Proc15 ;
-PGround.      Proc13 ::= Ground ;
-PCollect.     Proc13 ::= Collection ;
-PVar.         Proc13 ::= ProcVar ;
-PNil.         Proc13 ::= "Nil" ;
+PGround.      Proc16 ::= Ground ;
+PCollect.     Proc16 ::= Collection ;
+PVar.         Proc16 ::= ProcVar ;
+PNil.         Proc16 ::= "Nil" ;
+PNegation.    Proc15 ::= "~" Proc15 ;
+PConjunction. Proc14 ::= Proc14 "/\\" Proc15 ;
+PDisjunction. Proc13 ::= Proc13 "\\/" Proc14 ;
 PEval.        Proc12 ::= "*" Name ;
 PMethod.      Proc11 ::= Proc11 "." Var "(" [Proc] ")" ;
 PNot.         Proc10 ::= "not" Proc10 ;

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
@@ -139,6 +139,9 @@ object implicits {
       connectiveUsed = false
     )
 
+  def apply(c: Connective): Par =
+    new Par(connectives = Vector(c), connectiveUsed = true)
+
   implicit def fromSend(s: Send): Par                             = apply(s)
   implicit def fromReceive(r: Receive): Par                       = apply(r)
   implicit def fromEval[T](e: T)(implicit toEval: T => Eval): Par = apply(e)
@@ -147,6 +150,7 @@ object implicits {
   implicit def fromMatch(m: Match): Par                           = apply(m)
   implicit def fromGPrivate(g: GPrivate): Par                     = apply(g)
   implicit def fromBundle(b: Bundle): Par                         = apply(b)
+  implicit def fromConnective(c: Connective): Par                 = apply(c)
 
   object VectorPar {
     def apply(): Par = new Par(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
@@ -98,14 +98,14 @@ object SpatialMatcher {
 
   def emptyMap: FreeMap = Map.empty[Int, Par]
 
-  case class ParCount(val sends: Int = 0,
-                      val receives: Int = 0,
-                      val evals: Int = 0,
-                      val news: Int = 0,
-                      val exprs: Int = 0,
-                      val matches: Int = 0,
-                      val ids: Int = 0,
-                      val bundles: Int = 0) {
+  case class ParCount(sends: Int = 0,
+                      receives: Int = 0,
+                      evals: Int = 0,
+                      news: Int = 0,
+                      exprs: Int = 0,
+                      matches: Int = 0,
+                      ids: Int = 0,
+                      bundles: Int = 0) {
     def binOp(op: (Int, Int) => Int, other: ParCount): ParCount =
       ParCount(
         sends = op(sends, other.sends),

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/match.scala
@@ -3,7 +3,9 @@ package coop.rchain.rholang.interpreter
 import cats.data._
 import cats.implicits._
 import cats.{Eval => _}
+import cats.Foldable
 import coop.rchain.models.Channel.ChannelInstance._
+import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
@@ -95,6 +97,274 @@ object SpatialMatcher {
     }
 
   def emptyMap: FreeMap = Map.empty[Int, Par]
+
+  case class ParCount(val sends: Int = 0,
+                      val receives: Int = 0,
+                      val evals: Int = 0,
+                      val news: Int = 0,
+                      val exprs: Int = 0,
+                      val matches: Int = 0,
+                      val ids: Int = 0,
+                      val bundles: Int = 0) {
+    def binOp(op: (Int, Int) => Int, other: ParCount): ParCount =
+      ParCount(
+        sends = op(sends, other.sends),
+        receives = op(receives, other.receives),
+        evals = op(evals, other.evals),
+        news = op(news, other.news),
+        exprs = op(exprs, other.exprs),
+        matches = op(matches, other.matches),
+        ids = op(ids, other.ids),
+        bundles = op(bundles, other.bundles)
+      )
+    def min(other: ParCount): ParCount = binOp(math.min, other)
+    def max(other: ParCount): ParCount = binOp(math.max, other)
+    def +(other: ParCount): ParCount   = binOp(saturatingAdd, other)
+    // Only saturates going from positive to negative
+    def saturatingAdd(l: Int, r: Int): Int = {
+      val res = l + r
+      (res | -(if (res < l) 1 else 0)) & ~Int.MinValue
+    }
+  }
+
+  private[this] def noFrees(exprs: Seq[Expr]): Seq[Expr] =
+    exprs.filter({ (expr) =>
+      expr.exprInstance match {
+        case EVarBody(EVar(Some((v)))) =>
+          v.varInstance match {
+            case FreeVar(_)  => false
+            case Wildcard(_) => false
+            case _           => true
+          }
+        case _ => true
+      }
+    })
+
+  private[this] def noFrees(par: Par): Par =
+    par.withExprs(noFrees(par.exprs))
+
+  object ParCount {
+    def apply(par: Par): ParCount =
+      ParCount(
+        sends = par.sends.size,
+        receives = par.receives.size,
+        evals = par.evals.size,
+        news = par.news.size,
+        matches = par.matches.size,
+        exprs = par.exprs.size,
+        ids = par.ids.size,
+        bundles = par.bundles.size
+      )
+    def max: ParCount =
+      ParCount(
+        sends = Int.MaxValue,
+        receives = Int.MaxValue,
+        evals = Int.MaxValue,
+        news = Int.MaxValue,
+        matches = Int.MaxValue,
+        exprs = Int.MaxValue,
+        ids = Int.MaxValue,
+        bundles = Int.MaxValue
+      )
+
+    def minMax(par: Par): (ParCount, ParCount) = {
+      val pc = ParCount(noFrees(par))
+      val wildcard: Boolean = par.exprs.exists { expr =>
+        expr.exprInstance match {
+          case EVarBody(EVar(Some(v))) =>
+            v.varInstance match {
+              case Wildcard(_) => true
+              case FreeVar(_)  => true
+              case _           => false
+            }
+          case _ => false
+        }
+      }
+      val minInit = pc
+      val maxInit = if (wildcard) ParCount.max else pc
+
+      par.connectives.foldLeft((minInit, maxInit)) {
+        case ((min, max), con) =>
+          val (cmin, cmax) = minMax(con)
+          (min + cmin, max + cmax)
+      }
+    }
+
+    def min(par: Par): ParCount =
+      par.connectives.foldLeft(ParCount(par)) { (acc, con) =>
+        acc + min(con)
+      }
+
+    def max(par: Par): ParCount =
+      par.connectives.foldLeft(ParCount(par)) { (acc, con) =>
+        acc + max(con)
+      }
+
+    def min(con: Connective): ParCount =
+      con.connectiveInstance match {
+        case ConnAndBody(ConnectiveBody(ps)) =>
+          ps.map(min).foldLeft(ParCount())(_ max _)
+        case ConnOrBody(ConnectiveBody(ps)) =>
+          ps.map(min).foldLeft(ParCount())(_ min _)
+        case ConnNotBody(_) => ParCount()
+      }
+
+    def max(con: Connective): ParCount =
+      con.connectiveInstance match {
+        case ConnAndBody(ConnectiveBody(ps)) =>
+          ps.map(max).foldLeft(ParCount())(_ min _)
+        case ConnOrBody(ConnectiveBody(ps)) =>
+          ps.map(max).foldLeft(ParCount())(_ max _)
+        case ConnNotBody(_) =>
+          ParCount(
+            sends = Int.MaxValue,
+            receives = Int.MaxValue,
+            evals = Int.MaxValue,
+            news = Int.MaxValue,
+            matches = Int.MaxValue,
+            exprs = Int.MaxValue,
+            ids = Int.MaxValue,
+            bundles = Int.MaxValue
+          )
+      }
+
+    def minMax(con: Connective): (ParCount, ParCount) =
+      con.connectiveInstance match {
+        case ConnAndBody(ConnectiveBody(ps)) =>
+          val pMinMax = ps.map(minMax)
+          (pMinMax.foldLeft(ParCount())(_ max _._1), pMinMax.foldLeft(ParCount.max)(_ min _._2))
+        case ConnOrBody(ConnectiveBody(ps)) =>
+          val pMinMax = ps.map(minMax)
+          (pMinMax.foldLeft(ParCount.max)(_ min _._1), pMinMax.foldLeft(ParCount())(_ max _._2))
+        case ConnNotBody(_) =>
+          (ParCount(),
+           ParCount(
+             sends = Int.MaxValue,
+             receives = Int.MaxValue,
+             evals = Int.MaxValue,
+             news = Int.MaxValue,
+             matches = Int.MaxValue,
+             exprs = Int.MaxValue,
+             ids = Int.MaxValue,
+             bundles = Int.MaxValue
+           ))
+      }
+  }
+
+  def subPars(par: Par,
+              min: ParCount,
+              max: ParCount,
+              minPrune: ParCount,
+              maxPrune: ParCount): Stream[(Par, Par)] = {
+
+    val sendMax    = math.min(max.sends, par.sends.size - minPrune.sends)
+    val receiveMax = math.min(max.receives, par.receives.size - minPrune.receives)
+    val evalMax    = math.min(max.evals, par.evals.size - minPrune.evals)
+    val newMax     = math.min(max.news, par.news.size - minPrune.news)
+    val exprMax    = math.min(max.exprs, par.exprs.size - minPrune.exprs)
+    val matchMax   = math.min(max.matches, par.matches.size - minPrune.matches)
+    val idMax      = math.min(max.ids, par.ids.size - minPrune.ids)
+    val bundleMax  = math.min(max.bundles, par.bundles.size - minPrune.bundles)
+
+    val sendMin    = math.max(min.sends, par.sends.size - maxPrune.sends)
+    val receiveMin = math.max(min.receives, par.receives.size - maxPrune.receives)
+    val evalMin    = math.max(min.evals, par.evals.size - maxPrune.evals)
+    val newMin     = math.max(min.news, par.news.size - maxPrune.news)
+    val exprMin    = math.max(min.exprs, par.exprs.size - maxPrune.exprs)
+    val matchMin   = math.max(min.matches, par.matches.size - maxPrune.matches)
+    val idMin      = math.max(min.ids, par.ids.size - maxPrune.ids)
+    val bundleMin  = math.max(min.bundles, par.bundles.size - maxPrune.bundles)
+
+    for {
+      subSends    <- minMaxSubsets(par.sends, sendMin, sendMax)
+      subReceives <- minMaxSubsets(par.receives, receiveMin, receiveMax)
+      subEvals    <- minMaxSubsets(par.evals, evalMin, evalMax)
+      subNews     <- minMaxSubsets(par.news, newMin, newMax)
+      subExprs    <- minMaxSubsets(par.exprs, exprMin, exprMax)
+      subMatches  <- minMaxSubsets(par.matches, matchMin, matchMax)
+      subIds      <- minMaxSubsets(par.ids, idMin, idMax)
+      subBundles  <- minMaxSubsets(par.bundles, bundleMin, bundleMax)
+    } yield
+      (Par(subSends._1,
+           subReceives._1,
+           subEvals._1,
+           subNews._1,
+           subExprs._1,
+           subMatches._1,
+           subIds._1,
+           subBundles._1),
+       Par(subSends._2,
+           subReceives._2,
+           subEvals._2,
+           subNews._2,
+           subExprs._2,
+           subMatches._2,
+           subIds._2,
+           subBundles._2))
+  }
+
+  def minMaxSubsets[A](as: Seq[A], minSize: Int, maxSize: Int): Stream[(Seq[A], Seq[A])] = {
+    def countedMaxSubsets(as: Seq[A], maxSize: Int): Stream[(Seq[A], Seq[A], Int)] =
+      as match {
+        case Nil => Stream((as, as, 0))
+        case head +: rem =>
+          (as.slice(0, 0), as, 0) #::
+            (for {
+            countedTail               <- countedMaxSubsets(rem, maxSize)
+            (tail, complement, count) = countedTail
+            result <- {
+              if (count == maxSize)
+                Stream((tail, head +: complement, count))
+              else if (tail.isEmpty)
+                Stream((head +: tail, complement, 1))
+              else
+                Stream((tail, head +: complement, count), (head +: tail, complement, count + 1))
+            }
+          } yield result)
+      }
+    def worker(as: Seq[A], minSize: Int, maxSize: Int): Stream[(Seq[A], Seq[A], Int)] =
+      if (maxSize < 0)
+        Stream.empty
+      else if (minSize > maxSize)
+        Stream.empty
+      else if (minSize <= 0)
+        if (maxSize == 0)
+          Stream((as.slice(0, 0), as, 0))
+        else
+          countedMaxSubsets(as, maxSize)
+      else
+        as match {
+          case Nil => Stream.empty
+          case hd +: rem =>
+            val decr = minSize - 1
+            for {
+              countedTail               <- worker(rem, decr, maxSize)
+              (tail, complement, count) = countedTail
+              result <- {
+                if (count == maxSize)
+                  Stream((tail, hd +: complement, count))
+                else if (count == decr)
+                  Stream((hd +: tail, complement, minSize))
+                else
+                  Stream((tail, hd +: complement, count), (hd +: tail, complement, count + 1))
+              }
+            } yield result
+        }
+    worker(as, minSize, maxSize).map(x => (x._1, x._2))
+  }
+
+  def interleave[A](streams: Stream[A]*): Stream[A] = interleaveInternal(streams, Seq())
+  def interleaveInternal[A](left: Seq[Stream[A]], right: Seq[Stream[A]]): Stream[A] =
+    (left, right) match {
+      // If both sequences of streams are empty, then so is the result stream.
+      case (Nil, Nil) => Stream.Empty
+      case (Nil, r)   => interleaveInternal(r, Nil)
+      case (lh +: lrem, r) =>
+        lh match {
+          case lhh #:: lht  => lhh #:: interleaveInternal(lrem, lht +: r)
+          case Stream.Empty => interleaveInternal(lrem, r)
+        }
+    }
 
   // This helper function is useful in several productions
   def foldMatch[T, P](tlist: Seq[T], plist: Seq[P], remainder: Option[Var] = None)(
@@ -306,56 +576,69 @@ object SpatialMatcher {
           }
         }
 
-        def NoFrees(exprs: Seq[Expr]): Seq[Expr] =
-          exprs.filter({ (expr) =>
-            expr.exprInstance match {
-              case EVarBody(EVar(Some((v)))) =>
-                v.varInstance match {
-                  case FreeVar(_)  => false
-                  case Wildcard(_) => false
-                  case _           => true
-                }
-              case _ => true
-            }
-          })
+        val filteredPattern  = pattern.withExprs(noFrees(pattern.exprs))
+        val pc               = ParCount(filteredPattern)
+        val minRem           = pc
+        val maxRem           = if (wildcard || !varLevel.isEmpty) ParCount.max else pc
+        val individualBounds = filteredPattern.connectives.map(ParCount.minMax)
+        val remainderBounds = individualBounds
+          .scanRight((minRem, maxRem)) { (bounds, acc) =>
+            val result = (bounds._1 + acc._1, bounds._2 + acc._2)
+            result
+          }
+          .tail
+        val connectivesWithBounds =
+          (filteredPattern.connectives, individualBounds, remainderBounds).zipped.toList
 
+        def matchConnectiveWithBounds(
+            target: Par,
+            labeledConnective: (Connective, (ParCount, ParCount), (ParCount, ParCount)))
+          : NonDetFreeMap[Par] = {
+          val (con, bounds, remainders) = labeledConnective
+          for {
+            sp <- StateT.liftF(subPars(target, bounds._1, bounds._2, remainders._1, remainders._2))
+            _  <- nonDetMatch(sp._1, con)
+          } yield sp._2
+        }
         for {
-          _ <- listMatchSingleNonDet[Send](target.sends,
+          remainder <- Foldable[List].foldM(connectivesWithBounds, target)(
+                        matchConnectiveWithBounds)
+          _ <- listMatchSingleNonDet[Send](remainder.sends,
                                            pattern.sends,
                                            (p, s) => p.withSends(s +: p.sends),
                                            varLevel,
                                            wildcard)
-          _ <- listMatchSingleNonDet[Receive](target.receives,
+          _ <- listMatchSingleNonDet[Receive](remainder.receives,
                                               pattern.receives,
                                               (p, s) => p.withReceives(s +: p.receives),
                                               varLevel,
                                               wildcard)
-          _ <- listMatchSingleNonDet[Eval](target.evals,
+          _ <- listMatchSingleNonDet[Eval](remainder.evals,
                                            pattern.evals,
                                            (p, s) => p.withEvals(s +: p.evals),
                                            varLevel,
                                            wildcard)
-          _ <- listMatchSingleNonDet[New](target.news,
+          _ <- listMatchSingleNonDet[New](remainder.news,
                                           pattern.news,
                                           (p, s) => p.withNews(s +: p.news),
                                           varLevel,
                                           wildcard)
-          _ <- listMatchSingleNonDet[Expr](target.exprs,
-                                           NoFrees(pattern.exprs),
+          _ <- listMatchSingleNonDet[Expr](remainder.exprs,
+                                           noFrees(pattern.exprs),
                                            (p, e) => p.withExprs(e +: p.exprs),
                                            varLevel,
                                            wildcard)
-          _ <- listMatchSingleNonDet[Match](target.matches,
+          _ <- listMatchSingleNonDet[Match](remainder.matches,
                                             pattern.matches,
                                             (p, e) => p.withMatches(e +: p.matches),
                                             varLevel,
                                             wildcard)
-          _ <- listMatchSingleNonDet[Bundle](target.bundles,
+          _ <- listMatchSingleNonDet[Bundle](remainder.bundles,
                                              pattern.bundles,
                                              (p, b) => p.withBundles(b +: p.bundles),
                                              varLevel,
                                              wildcard)
-          _ <- listMatchSingleNonDet[GPrivate](target.ids,
+          _ <- listMatchSingleNonDet[GPrivate](remainder.ids,
                                                pattern.ids,
                                                (p, i) => p.withIds(i +: p.ids),
                                                varLevel,
@@ -509,4 +792,36 @@ object SpatialMatcher {
         spatialMatch(target.source.get, pattern.source.get)
     }
 
+  // This matches a single logical connective against a Par. If it can match
+  // more ways than one, we don't care, as we care about what went into the
+  // match, and not about how it matched inside. The tricky part goes into
+  // the par/par matcher.
+  implicit val connectiveMatcher: SpatialMatcher[Par, Connective] =
+    fromFunction[Par, Connective] { (target, pattern) =>
+      pattern.connectiveInstance match {
+        case ConnAndBody(ConnectiveBody(ps)) =>
+          ps.toList.traverse_(p => spatialMatch(target, p))
+        case ConnOrBody(ConnectiveBody(ps)) => {
+          def firstMatch(target: Par, patterns: Seq[Par]): OptionalFreeMap[Unit] =
+            patterns match {
+              case Nil => StateT.pure(Unit)
+              case p +: rem =>
+                StateT[Option, FreeMap, Unit]((s: FreeMap) => {
+                  spatialMatch(target, p).run(s) match {
+                    case None            => firstMatch(target, rem).run(s)
+                    case Some((_, unit)) => Some((s, unit))
+                  }
+                })
+            }
+          firstMatch(target, ps)
+        }
+        case ConnNotBody(p) =>
+          StateT[Option, FreeMap, Unit]((s: FreeMap) => {
+            spatialMatch(target, p).run(s) match {
+              case None         => Some((s, Unit))
+              case Some((_, _)) => None
+            }
+          })
+      }
+    }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
@@ -277,7 +277,8 @@ class VarMatcherSpec extends FlatSpec with Matchers {
 
   "Matching a single and" should "match both sides" in {
     // @7!(8)
-    val target: Par = Send(Quote(GInt(7)), Seq(GInt(8)), persistent = false)
+    val target: Par     = Send(Quote(GInt(7)), Seq(GInt(8)), persistent = false)
+    val failTarget: Par = Send(Quote(GInt(7)), Seq(GInt(9)), persistent = false)
     // @7!(x) /\ @y!(8)
     val pattern: Connective = Connective(
       ConnAndBody(ConnectiveBody(Seq(
@@ -292,11 +293,17 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     val patternPar: Par = pattern
     val parResult       = spatialMatch(target, patternPar).runS(emptyMap)
     parResult should be(expectedResult)
+
+    val failResult    = spatialMatch(failTarget, pattern).runS(emptyMap)
+    val failParResult = spatialMatch(failTarget, patternPar).runS(emptyMap)
+    failResult should be(None)
+    failParResult should be(None)
   }
 
   "Matching a single or" should "match some side" in {
     // @7!(8)
-    val target: Par = Send(Quote(GInt(7)), Seq(GInt(8)), persistent = false)
+    val target: Par     = Send(Quote(GInt(7)), Seq(GInt(8)), persistent = false)
+    val failTarget: Par = Send(Quote(GInt(7)), Seq(GInt(9)), persistent = false)
     // @9!(x) \/ @x!(8)
     val pattern: Connective = Connective(
       ConnOrBody(ConnectiveBody(Seq(
@@ -311,6 +318,11 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     val patternPar: Par = pattern
     val parResult       = spatialMatch(target, patternPar).runS(emptyMap)
     parResult should be(expectedResult)
+
+    val failResult    = spatialMatch(failTarget, pattern).runS(emptyMap)
+    val failParResult = spatialMatch(failTarget, patternPar).runS(emptyMap)
+    failResult should be(None)
+    failParResult should be(None)
   }
 
   "Matching negation" should "work" in {
@@ -357,6 +369,12 @@ class VarMatcherSpec extends FlatSpec with Matchers {
       Send(Quote(GInt(3)), Seq(GInt(8)), persistent = false)
     )
 
+    val failTarget: Par = Par().addSends(
+      Send(Quote(GInt(1)), Seq(GInt(6)), persistent = false),
+      Send(Quote(GInt(2)), Seq(GInt(9)), persistent = false),
+      Send(Quote(GInt(3)), Seq(GInt(8)), persistent = false)
+    )
+
     // ~Nil
     val nonNullConn: Connective = Connective(ConnNotBody(Par()))
     val nonNull: Par            = nonNullConn
@@ -386,5 +404,8 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     val expectedResult = Some(Map[Int, Par](0 -> Send(Quote(GInt(2)), Seq(GInt(7))), 1 -> GInt(2)))
     val result         = spatialMatch(target, pattern).runS(emptyMap)
     result should be(expectedResult)
+
+    val failResult = spatialMatch(failTarget, pattern).runS(emptyMap)
+    failResult should be(None)
   }
 }


### PR DESCRIPTION
## Overview

This allows the matching of And, Or, and Not for complicated spatial types. Note
that using Not is expensive at the moment, so we may want to add some things
that are expressible with Not as expressions in themselves. Two examples are
`~Nil` and `~{~Nil | ~Nil} /\ ~Nil`. The first being any non-nil term and the second
being any atomic term that cannot be split into 2 things in parallel. The
matching uses backtracking, but we try to be smart and compute bounds on how
many of each atomic term must be in the piece that we match, and how many must
be left for the remaining logical connectives.

### Does this PR relate to an RChain JIRA issue? 

https://rchain.atlassian.net/browse/RHOL-320