### PR TITLE
Rholang: Substitute: sorting sorts the entire term, so only do it once.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -19,17 +19,11 @@ object Substitute {
 
   def substitute2[M[_]: Monad, A, B, C](termA: A, termB: B)(
       f: (A, B) => C)(implicit evA: Substitute[M, A], evB: Substitute[M, B], env: Env[Par]): M[C] =
-    for {
-      aSub <- evA.substitute(termA)
-      bSub <- evB.substitute(termB)
-    } yield f(aSub, bSub)
+    (evA.substitute(termA), evB.substitute(termB)).mapN(f)
 
   def substituteNoSort2[M[_]: Monad, A, B, C](termA: A, termB: B)(
       f: (A, B) => C)(implicit evA: Substitute[M, A], evB: Substitute[M, B], env: Env[Par]): M[C] =
-    for {
-      aSub <- evA.substituteNoSort(termA)
-      bSub <- evB.substituteNoSort(termB)
-    } yield f(aSub, bSub)
+    (evA.substituteNoSort(termA), evB.substituteNoSort(termB)).mapN(f)
 
   def apply[M[_], A](implicit ev: Substitute[M, A]): Substitute[M, A] = ev
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -12,6 +12,7 @@ import errors._
 
 trait Substitute[M[_], A] {
   def substitute(term: A)(implicit env: Env[Par]): M[A]
+  def substituteNoSort(term: A)(implicit env: Env[Par]): M[A]
 }
 
 object Substitute {
@@ -21,6 +22,13 @@ object Substitute {
     for {
       aSub <- evA.substitute(termA)
       bSub <- evB.substitute(termB)
+    } yield f(aSub, bSub)
+
+  def substituteNoSort2[M[_]: Monad, A, B, C](termA: A, termB: B)(
+      f: (A, B) => C)(implicit evA: Substitute[M, A], evB: Substitute[M, B], env: Env[Par]): M[C] =
+    for {
+      aSub <- evA.substituteNoSort(termA)
+      bSub <- evB.substituteNoSort(termB)
     } yield f(aSub, bSub)
 
   def apply[M[_], A](implicit ev: Substitute[M, A]): Substitute[M, A] = ev
@@ -48,7 +56,7 @@ object Substitute {
   def maybeSubstitute[M[_]: InterpreterErrorsM](term: Eval)(
       implicit env: Env[Par]): M[Either[Eval, Par]] =
     term.channel.get.channelInstance match {
-      case Quote(p) => substitutePar[M].substitute(p).map(Right(_))
+      case Quote(p) => substitutePar[M].substituteNoSort(p).map(Right(_))
       case ChanVar(v) =>
         maybeSubstitute[M](v).map {
           case Left(v)    => Left(Eval(ChanVar(v)))
@@ -60,6 +68,8 @@ object Substitute {
     new Substitute[M, Quote] {
       override def substitute(term: Quote)(implicit env: Env[Par]): M[Quote] =
         substitutePar[M].substitute(term.value).map(Quote(_))
+      override def substituteNoSort(term: Quote)(implicit env: Env[Par]): M[Quote] =
+        substitutePar[M].substituteNoSort(term.value).map(Quote(_))
     }
 
   implicit def substituteBundle[M[_]: InterpreterErrorsM]: Substitute[M, Bundle] =
@@ -73,11 +83,18 @@ object Substitute {
             case None        => term.copy(body = subBundle)
           }
         }
+      override def substituteNoSort(term: Bundle)(implicit env: Env[Par]): M[Bundle] =
+        substitutePar[M].substituteNoSort(term.body.get).map { subBundle =>
+          subBundle.singleBundle() match {
+            case Some(value) => term.merge(value)
+            case None        => term.copy(body = subBundle)
+          }
+        }
     }
 
   implicit def substituteChannel[M[_]: InterpreterErrorsM]: Substitute[M, Channel] =
     new Substitute[M, Channel] {
-      override def substitute(term: Channel)(implicit env: Env[Par]): M[Channel] =
+      override def substituteNoSort(term: Channel)(implicit env: Env[Par]): M[Channel] =
         for {
           channelSubst <- term.channelInstance match {
                            case Quote(p) => substitutePar[M].substitute(p).map(Quote(_))
@@ -87,7 +104,11 @@ object Substitute {
                                case Right(p) => Quote(p)
                              }
                          }
-          sortedChan <- ChannelSortMatcher.sortMatch[M](channelSubst)
+        } yield channelSubst
+      override def substitute(term: Channel)(implicit env: Env[Par]): M[Channel] =
+        for {
+          channelSubst <- substituteNoSort(term)
+          sortedChan   <- ChannelSortMatcher.sortMatch[M](channelSubst)
         } yield sortedChan.term
     }
 
@@ -101,7 +122,7 @@ object Substitute {
                 case Left(_e)    => par.prepend(_e)
                 case Right(_par) => _par ++ par
               }
-            case _ => substituteExpr[M].substitute(expr).map(par.prepend(_))
+            case _ => substituteExpr[M].substituteNoSort(expr).map(par.prepend(_))
           }
         }
 
@@ -113,15 +134,15 @@ object Substitute {
           }
         }
 
-      override def substitute(term: Par)(implicit env: Env[Par]): M[Par] =
+      override def substituteNoSort(term: Par)(implicit env: Env[Par]): M[Par] =
         for {
           exprs    <- subExp(term.exprs)
           evals    <- subEval(term.evals)
-          sends    <- term.sends.toList.traverse(substituteSend[M].substitute(_))
-          bundles  <- term.bundles.toList.traverse(substituteBundle[M].substitute(_))
-          receives <- term.receives.toList.traverse(substituteReceive[M].substitute(_))
-          news     <- term.news.toList.traverse(substituteNew[M].substitute(_))
-          matches  <- term.matches.toList.traverse(substituteMatch[M].substitute(_))
+          sends    <- term.sends.toList.traverse(substituteSend[M].substituteNoSort(_))
+          bundles  <- term.bundles.toList.traverse(substituteBundle[M].substituteNoSort(_))
+          receives <- term.receives.toList.traverse(substituteReceive[M].substituteNoSort(_))
+          news     <- term.news.toList.traverse(substituteNew[M].substituteNoSort(_))
+          matches  <- term.matches.toList.traverse(substituteMatch[M].substituteNoSort(_))
           par = exprs ++
             evals ++
             Par(
@@ -136,19 +157,20 @@ object Substitute {
               locallyFree = term.locallyFree.until(env.shift),
               connectiveUsed = term.connectiveUsed
             )
-          // This may be a minor thing, but sorting this par causes all of the insides to be sorted.
-          // Maybe we want to split substitute so that there's an external API that sorts and an internal API that doesn't
+        } yield par
+      override def substitute(term: Par)(implicit env: Env[Par]): M[Par] =
+        for {
+          par       <- substituteNoSort(term)
           sortedPar <- ParSortMatcher.sortMatch[M](par)
         } yield sortedPar.term.get
-
     }
 
   implicit def substituteSend[M[_]: InterpreterErrorsM]: Substitute[M, Send] =
     new Substitute[M, Send] {
-      override def substitute(term: Send)(implicit env: Env[Par]): M[Send] =
+      override def substituteNoSort(term: Send)(implicit env: Env[Par]): M[Send] =
         for {
-          channelsSub <- substituteChannel[M].substitute(term.chan.get)
-          parsSub     <- term.data.toList.traverse(substitutePar[M].substitute(_))
+          channelsSub <- substituteChannel[M].substituteNoSort(term.chan.get)
+          parsSub     <- term.data.toList.traverse(substitutePar[M].substituteNoSort(_))
           send = Send(
             chan = channelsSub,
             data = parsSub,
@@ -156,21 +178,25 @@ object Substitute {
             locallyFree = term.locallyFree.until(env.shift),
             connectiveUsed = term.connectiveUsed
           )
+        } yield send
+      override def substitute(term: Send)(implicit env: Env[Par]): M[Send] =
+        for {
+          send       <- substituteNoSort(term)
           sortedSend <- SendSortMatcher.sortMatch[M](send)
         } yield sortedSend.term
     }
 
   implicit def substituteReceive[M[_]: InterpreterErrorsM]: Substitute[M, Receive] =
     new Substitute[M, Receive] {
-      override def substitute(term: Receive)(implicit env: Env[Par]): M[Receive] =
+      override def substituteNoSort(term: Receive)(implicit env: Env[Par]): M[Receive] =
         for {
           bindsSub <- term.binds.toList.traverse {
                        case ReceiveBind(xs, Some(chan), rem, freeCount) =>
-                         substituteChannel[M].substitute(chan).map { (subChannel: Channel) =>
+                         substituteChannel[M].substituteNoSort(chan).map { (subChannel: Channel) =>
                            ReceiveBind(xs, subChannel, rem, freeCount)
                          }
                      }
-          bodySub <- substitutePar[M].substitute(term.body.get)(env.shift(term.bindCount))
+          bodySub <- substitutePar[M].substituteNoSort(term.body.get)(env.shift(term.bindCount))
           rec = Receive(
             binds = bindsSub,
             body = bodySub,
@@ -179,6 +205,10 @@ object Substitute {
             locallyFree = term.locallyFree.until(env.shift),
             connectiveUsed = term.connectiveUsed
           )
+        } yield rec
+      override def substitute(term: Receive)(implicit env: Env[Par]): M[Receive] =
+        for {
+          rec           <- substituteNoSort(term)
           sortedReceive <- ReceiveSortMatcher.sortMatch[M](rec)
         } yield sortedReceive.term
 
@@ -186,83 +216,89 @@ object Substitute {
 
   implicit def substituteNew[M[_]: InterpreterErrorsM]: Substitute[M, New] =
     new Substitute[M, New] {
+      override def substituteNoSort(term: New)(implicit env: Env[Par]): M[New] =
+        for {
+          newSub <- substitutePar[M].substituteNoSort(term.p.get)(env.shift(term.bindCount))
+          neu    = New(term.bindCount, newSub, term.locallyFree.until(env.shift))
+        } yield neu
       override def substitute(term: New)(implicit env: Env[Par]): M[New] =
         for {
-          newSub <- substitutePar[M].substitute(term.p.get)(env.shift(term.bindCount))
-          sortedMatch <- NewSortMatcher
-                          .sortMatch[M](
-                            New(term.bindCount, newSub, term.locallyFree.until(env.shift)))
+          newSub      <- substituteNoSort(term)
+          sortedMatch <- NewSortMatcher.sortMatch[M](newSub)
         } yield sortedMatch.term
     }
 
   implicit def substituteMatch[M[_]: InterpreterErrorsM]: Substitute[M, Match] =
     new Substitute[M, Match] {
-      override def substitute(term: Match)(implicit env: Env[Par]): M[Match] =
+      override def substituteNoSort(term: Match)(implicit env: Env[Par]): M[Match] =
         for {
-          targetSub <- substitutePar[M].substitute(term.target.get)
+          targetSub <- substitutePar[M].substituteNoSort(term.target.get)
           casesSub <- term.cases.toList.traverse {
                        case MatchCase(_case, Some(_par), freeCount) =>
                          substitutePar[M]
-                           .substitute(_par)(env.shift(freeCount))
+                           .substituteNoSort(_par)(env.shift(freeCount))
                            .map(par => MatchCase(_case, par, freeCount))
                      }
-          sortedMatch <- MatchSortMatcher
-                          .sortMatch[M](
-                            Match(targetSub,
-                                  casesSub,
-                                  term.locallyFree.until(env.shift),
-                                  term.connectiveUsed))
+          mat = Match(targetSub, casesSub, term.locallyFree.until(env.shift), term.connectiveUsed)
+        } yield mat
+      override def substitute(term: Match)(implicit env: Env[Par]): M[Match] =
+        for {
+          mat         <- substituteNoSort(term)
+          sortedMatch <- MatchSortMatcher.sortMatch[M](mat)
         } yield sortedMatch.term
     }
 
   implicit def substituteExpr[M[_]: InterpreterErrorsM]: Substitute[M, Expr] =
     new Substitute[M, Expr] {
-      override def substitute(term: Expr)(implicit env: Env[Par]): M[Expr] =
+      private[this] def substituteDelegate(
+          term: Expr,
+          s1: Par => M[Par],
+          s2: (Par, Par) => ((Par, Par) => Expr) => M[Expr])(implicit env: Env[Par]): M[Expr] =
         term.exprInstance match {
-          case ENotBody(ENot(par)) => substitutePar[M].substitute(par.get).map(ENot(_))
-          case ENegBody(ENeg(par)) => substitutePar[M].substitute(par.get).map(ENeg(_))
+          case ENotBody(ENot(par)) => s1(par.get).map(ENot(_))
+          case ENegBody(ENeg(par)) => s1(par.get).map(ENeg(_))
           case EMultBody(EMult(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EMult(_, _))
+            s2(par1.get, par2.get)(EMult(_, _))
           case EDivBody(EDiv(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EDiv(_, _))
+            s2(par1.get, par2.get)(EDiv(_, _))
           case EPlusBody(EPlus(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EPlus(_, _))
+            s2(par1.get, par2.get)(EPlus(_, _))
           case EMinusBody(EMinus(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EMinus(_, _))
+            s2(par1.get, par2.get)(EMinus(_, _))
           case ELtBody(ELt(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(ELt(_, _))
+            s2(par1.get, par2.get)(ELt(_, _))
           case ELteBody(ELte(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(ELte(_, _))
+            s2(par1.get, par2.get)(ELte(_, _))
           case EGtBody(EGt(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EGt(_, _))
+            s2(par1.get, par2.get)(EGt(_, _))
           case EGteBody(EGte(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EGte(_, _))
+            s2(par1.get, par2.get)(EGte(_, _))
           case EEqBody(EEq(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EEq(_, _))
+            s2(par1.get, par2.get)(EEq(_, _))
           case ENeqBody(ENeq(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(ENeq(_, _))
+            s2(par1.get, par2.get)(ENeq(_, _))
           case EAndBody(EAnd(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EAnd(_, _))
+            s2(par1.get, par2.get)(EAnd(_, _))
           case EOrBody(EOr(par1, par2)) =>
-            substitute2[M, Par, Par, Expr](par1.get, par2.get)(EOr(_, _))
+            s2(par1.get, par2.get)(EOr(_, _))
           case EListBody(EList(ps, locallyFree, connectiveUsed, rem)) =>
             for {
               pss <- ps.toList
-                      .traverse(p => substitutePar[M].substitute(p))
+                      .traverse(p => s1(p))
               newLocallyFree = locallyFree.until(env.shift)
             } yield Expr(exprInstance = EListBody(EList(pss, newLocallyFree, connectiveUsed, rem)))
 
           case ETupleBody(ETuple(ps, locallyFree, connectiveUsed)) =>
             for {
               pss <- ps.toList
-                      .traverse(p => substitutePar[M].substitute(p))
+                      .traverse(p => s1(p))
               newLocallyFree = locallyFree.until(env.shift)
             } yield Expr(exprInstance = ETupleBody(ETuple(pss, newLocallyFree, connectiveUsed)))
 
           case ESetBody(ESet(ps, locallyFree, connectiveUsed)) =>
             for {
               pss <- ps.toList
-                      .traverse(p => substitutePar[M].substitute(p))
+                      .traverse(p => s1(p))
               newLocallyFree = locallyFree.until(env.shift)
             } yield Expr(exprInstance = ESetBody(ESet(pss, newLocallyFree, connectiveUsed)))
 
@@ -272,13 +308,19 @@ object Substitute {
                        .traverse {
                          case KeyValuePair(p1, p2) =>
                            for {
-                             pk1 <- substitutePar[M].substitute(p1.get)
-                             pk2 <- substitutePar[M].substitute(p2.get)
+                             pk1 <- s1(p1.get)
+                             pk2 <- s1(p2.get)
                            } yield KeyValuePair(pk1, pk2)
                        }
               newLocallyFree = locallyFree.until(env.shift)
             } yield Expr(exprInstance = EMapBody(EMap(kvps, newLocallyFree, connectiveUsed)))
           case g @ _ => Applicative[M].pure(term)
         }
+      override def substitute(term: Expr)(implicit env: Env[Par]): M[Expr] =
+        substituteDelegate(term, substitutePar[M].substitute, substitute2[M, Par, Par, Expr])
+      override def substituteNoSort(term: Expr)(implicit env: Env[Par]): M[Expr] =
+        substituteDelegate(term,
+                           substitutePar[M].substituteNoSort,
+                           substituteNoSort2[M, Par, Par, Expr])
     }
 }


### PR DESCRIPTION
## Overview
Sorting sorts the entire term, so rather than sorting things that have already
been sorted, we have 2 substitute functions, substitute and substituteNoSort.
Substitute always calls substituteNoSort for the all the things it needs to
delegate. All tests continue to pass.

