### PR TITLE
CORE-534: rspace: add ITrieStore, refactor IStore

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -1,9 +1,8 @@
 package coop.rchain.rspace
 
-import coop.rchain.rspace.history.{Blake2b256Hash, Trie}
+import coop.rchain.rspace.internal._
 
 import scala.collection.immutable.Seq
-import coop.rchain.rspace.internal._
 
 /** The interface for the underlying store
   *
@@ -60,13 +59,6 @@ trait IStore[C, P, A, K] {
   private[rspace] def removeJoin(txn: T, channel: C, channels: Seq[C]): Unit
 
   private[rspace] def removeAllJoins(txn: T, channel: C): Unit
-
-  private[rspace] def putTrie(txn: T,
-                              key: Blake2b256Hash,
-                              value: Trie[Blake2b256Hash, GNAT[C, P, A, K]]): Unit
-
-  private[rspace] def getTrie(txn: T,
-                              key: Blake2b256Hash): Option[Trie[Blake2b256Hash, GNAT[C, P, A, K]]]
 
   def toMap: Map[Seq[C], Row[P, A, K]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -4,13 +4,9 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 
 import coop.rchain.crypto.hash.Blake2b256
-import coop.rchain.rspace.history.{Blake2b256Hash, Trie}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.internal.scodecs._
 import coop.rchain.rspace.util._
-import coop.rchain.rspace.history.Trie
-import coop.rchain.rspace.history.Blake2b256Hash._
-import coop.rchain.shared.AttemptOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
 import scodec.Codec
@@ -24,16 +20,15 @@ import scala.collection.immutable.Seq
   *
   * To create an instance, use [[LMDBStore.create]].
   */
-class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
+class LMDBStore[C, P, A, K] private (val env: Env[ByteBuffer],
                                      _dbKeys: Dbi[ByteBuffer],
                                      _dbWaitingContinuations: Dbi[ByteBuffer],
                                      _dbData: Dbi[ByteBuffer],
-                                     _dbJoins: Dbi[ByteBuffer],
-                                     _dbTrie: Dbi[ByteBuffer])(implicit
-                                                               sc: Serialize[C],
-                                                               sp: Serialize[P],
-                                                               sa: Serialize[A],
-                                                               sk: Serialize[K])
+                                     _dbJoins: Dbi[ByteBuffer])(implicit
+                                                                sc: Serialize[C],
+                                                                sp: Serialize[P],
+                                                                sa: Serialize[A],
+                                                                sk: Serialize[K])
     extends IStore[C, P, A, K]
     with ITestableStore[C, P] {
 
@@ -295,27 +290,6 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
         }.toMap
       }
     }
-
-  private[rspace] def putTrie(txn: Txn[ByteBuffer],
-                              key: Blake2b256Hash,
-                              value: Trie[Blake2b256Hash, GNAT[C, P, A, K]]): Unit = {
-    val encodedKey   = Codec[Blake2b256Hash].encode(key).get
-    val encodedValue = Codec[Trie[Blake2b256Hash, GNAT[C, P, A, K]]].encode(value).get
-    val keyBuff      = toByteBuffer(encodedKey)
-    val valBuff      = toByteBuffer(encodedValue)
-    _dbTrie.put(txn, keyBuff, valBuff)
-  }
-
-  private[rspace] def getTrie(
-      txn: Txn[ByteBuffer],
-      key: Blake2b256Hash): Option[Trie[Blake2b256Hash, GNAT[C, P, A, K]]] = {
-    val encodedKey = Codec[Blake2b256Hash].encode(key).get
-    val keyBuff    = toByteBuffer(encodedKey)
-    Option(_dbTrie.get(txn, keyBuff)).map { (buffer: ByteBuffer) =>
-      // ht: Yes, I want to throw an exception if deserialization fails
-      Codec[Trie[Blake2b256Hash, GNAT[C, P, A, K]]].decode(BitVector(buffer)).map(_.value).get
-    }
-  }
 }
 
 object LMDBStore {
@@ -323,7 +297,6 @@ object LMDBStore {
   private[this] val waitingContinuationsTableName: String = "WaitingContinuations"
   private[this] val dataTableName: String                 = "Data"
   private[this] val joinsTableName: String                = "Joins"
-  private[this] val trieTableName: String                 = "Trie"
 
   /**
     * Creates an instance of [[LMDBStore]]
@@ -353,12 +326,8 @@ object LMDBStore {
       env.openDbi(waitingContinuationsTableName, MDB_CREATE)
     val dbData: Dbi[ByteBuffer]  = env.openDbi(dataTableName, MDB_CREATE)
     val dbJoins: Dbi[ByteBuffer] = env.openDbi(joinsTableName, MDB_CREATE)
-    val dbTrie: Dbi[ByteBuffer]  = env.openDbi(trieTableName, MDB_CREATE)
 
-    new LMDBStore[C, P, A, K](env, dbKeys, dbWaitingContinuations, dbData, dbJoins, dbTrie)(sc,
-                                                                                            sp,
-                                                                                            sa,
-                                                                                            sk)
+    new LMDBStore[C, P, A, K](env, dbKeys, dbWaitingContinuations, dbData, dbJoins)(sc, sp, sa, sk)
   }
 
   private[rspace] def toByteVector[T](value: T)(implicit st: Serialize[T]): ByteVector =

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -1,0 +1,18 @@
+package coop.rchain.rspace.history
+
+import scala.concurrent.SyncVar
+
+trait ITrieStore[T, K, V] {
+
+  private[rspace] def createTxnRead(): T
+
+  private[rspace] def createTxnWrite(): T
+
+  private[rspace] def withTxn[R](txn: T)(f: T => R): R
+
+  private[rspace] val workingRootHash: SyncVar[Blake2b256Hash] = new SyncVar[Blake2b256Hash]()
+
+  private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit
+
+  private[rspace] def get(txn: T, key: Blake2b256Hash): Option[Trie[K, V]]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -1,0 +1,63 @@
+package coop.rchain.rspace.history
+
+import java.nio.ByteBuffer
+
+import coop.rchain.rspace.LMDBStore
+import coop.rchain.shared.AttemptOps._
+import org.lmdbjava.DbiFlags.MDB_CREATE
+import org.lmdbjava.{Dbi, Env, Txn}
+import scodec.Codec
+import scodec.bits.BitVector
+
+class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer], _dbTrie: Dbi[ByteBuffer])(
+    implicit
+    codecK: Codec[K],
+    codecV: Codec[V])
+    extends ITrieStore[Txn[ByteBuffer], K, V] {
+
+  private[rspace] def createTxnRead(): Txn[ByteBuffer] = env.txnRead
+
+  private[rspace] def createTxnWrite(): Txn[ByteBuffer] = env.txnWrite
+
+  private[rspace] def withTxn[R](txn: Txn[ByteBuffer])(f: Txn[ByteBuffer] => R): R =
+    try {
+      val ret: R = f(txn)
+      txn.commit()
+      ret
+    } catch {
+      case ex: Throwable =>
+        txn.abort()
+        throw ex
+    } finally {
+      txn.close()
+    }
+
+  private[rspace] def put(txn: Txn[ByteBuffer], key: Blake2b256Hash, value: Trie[K, V]): Unit = {
+    val encodedKey   = Codec[Blake2b256Hash].encode(key).get
+    val encodedValue = Codec[Trie[K, V]].encode(value).get
+    val keyBuff      = LMDBStore.toByteBuffer(encodedKey)
+    val valBuff      = LMDBStore.toByteBuffer(encodedValue)
+    _dbTrie.put(txn, keyBuff, valBuff)
+  }
+
+  private[rspace] def get(txn: Txn[ByteBuffer], key: Blake2b256Hash): Option[Trie[K, V]] = {
+    val encodedKey = Codec[Blake2b256Hash].encode(key).get
+    val keyBuff    = LMDBStore.toByteBuffer(encodedKey)
+    Option(_dbTrie.get(txn, keyBuff)).map { (buffer: ByteBuffer) =>
+      // ht: Yes, I want to throw an exception if deserialization fails
+      Codec[Trie[K, V]].decode(BitVector(buffer)).map(_.value).get
+    }
+  }
+}
+
+object LMDBTrieStore {
+
+  private[this] val trieTableName: String = "Trie"
+
+  def create[K, V](env: Env[ByteBuffer])(implicit
+                                         codecK: Codec[K],
+                                         codecV: Codec[V]): LMDBTrieStore[K, V] = {
+    val dbTrie: Dbi[ByteBuffer] = env.openDbi(trieTableName, MDB_CREATE)
+    new LMDBTrieStore[K, V](env, dbTrie)
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -18,7 +18,6 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     _waitingContinuations: mutable.HashMap[String, Seq[WaitingContinuation[P, K]]],
     _data: mutable.HashMap[String, Seq[Datum[A]]],
     _joinMap: mutable.MultiMap[C, String],
-    _trie: mutable.HashMap[Blake2b256Hash, Trie[Blake2b256Hash, GNAT[C, P, A, K]]]
 )(implicit sc: Serialize[C])
     extends IStore[C, P, A, K]
     with ITestableStore[C, P] {
@@ -159,15 +158,6 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
         val wks  = _waitingContinuations.getOrElse(hash, Seq.empty[WaitingContinuation[P, K]])
         (cs, Row(data, wks))
     }.toMap
-
-  private[rspace] def putTrie(txn: Unit,
-                              key: Blake2b256Hash,
-                              value: Trie[Blake2b256Hash, GNAT[C, P, A, K]]): Unit =
-    _trie.put(key, value)
-
-  private[rspace] def getTrie(txn: Unit,
-                              key: Blake2b256Hash): Option[Trie[Blake2b256Hash, GNAT[C, P, A, K]]] =
-    _trie.get(key)
 }
 
 object InMemoryStore {
@@ -189,7 +179,6 @@ object InMemoryStore {
       _keys = mutable.HashMap.empty[String, Seq[C]],
       _waitingContinuations = mutable.HashMap.empty[String, Seq[WaitingContinuation[P, K]]],
       _data = mutable.HashMap.empty[String, Seq[Datum[A]]],
-      _joinMap = new mutable.HashMap[C, mutable.Set[String]] with mutable.MultiMap[C, String],
-      _trie = mutable.HashMap.empty[Blake2b256Hash, Trie[Blake2b256Hash, GNAT[C, P, A, K]]]
+      _joinMap = new mutable.HashMap[C, mutable.Set[String]] with mutable.MultiMap[C, String]
     )
 }


### PR DESCRIPTION
## Overview
In the course of writing the Trie `insert` function, I decided that it would be simpler and cleaner for now to keep the notion of the `Trie` store decoupled from the current store.  This PR adds a new `ITrieStore` interface and the basic `LMDBTrieStore` interface.  

### Does this PR relate to an RChain JIRA issue? 
Yes, it is related to CORE-{[534](https://rchain.atlassian.net/browse/CORE-534),[535](https://rchain.atlassian.net/browse/CORE-535),[536](https://rchain.atlassian.net/browse/CORE-536)}

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
I recognize that there is a small amount of code duplication in `LMDBTrieStore` (namely `createTxnRead`, `createTxnWrite`, and `withTxn`).  Once this work has stabilized we can decide if and how we want to address this.

I haven't figured out if I want a separate `InMemoryTrieStore` implementation yet, which is why I haven't added it.