### PR TITLE
CORE-560 Add Ubuntu 18.04 package deps support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val node = (project in file("node"))
       Seq(packageMapping(file -> "/lib/systemd/system/rnode.service"), packageMapping(rholangExamples:_*))
     },
     /* Debian */
-   debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
+    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),

--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val node = (project in file("node"))
       Seq(packageMapping(file -> "/lib/systemd/system/rnode.service"), packageMapping(rholangExamples:_*))
     },
     /* Debian */
-    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5)"),
+   debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),


### PR DESCRIPTION
## Overview
Add libsodium23 (version in 18.04 LTS vs libsodium18 in 16.04) to build.sbt via debianPackageDependencies "or"
This will allow for package installer to work on 18.04 LTS because it meets dependencies.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-560

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
