### PR TITLE
CORE-568 - add openssl to docker/package dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val node = (project in file("node"))
         add(entry, entryTargetPath)
         run("apk", "update")
         run("apk", "add", "libsodium")
+        run("apk", "add", "openssl")
         entryPoint("/bin/main.sh")
       }
     },
@@ -156,7 +157,7 @@ lazy val node = (project in file("node"))
       Seq(packageMapping(file -> "/lib/systemd/system/rnode.service"), packageMapping(rholangExamples:_*))
     },
     /* Debian */
-    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
+   debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "openssl", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),
@@ -165,7 +166,7 @@ lazy val node = (project in file("node"))
     maintainerScripts in Rpm := maintainerScriptsAppendFromFile((maintainerScripts in Rpm).value)(
       RpmConstants.Post -> (sourceDirectory.value / "rpm" / "scriptlets" / "post")
     ),
-    rpmPrerequisites := Seq("libsodium >= 1.0.14-1", "java-1.8.0-openjdk-headless")
+    rpmPrerequisites := Seq("libsodium >= 1.0.14-1", "java-1.8.0-openjdk-headless", "openssl")
   )
   .dependsOn(casper, comm, crypto, rholang)
 

--- a/build.sbt
+++ b/build.sbt
@@ -157,7 +157,7 @@ lazy val node = (project in file("node"))
       Seq(packageMapping(file -> "/lib/systemd/system/rnode.service"), packageMapping(rholangExamples:_*))
     },
     /* Debian */
-   debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "openssl", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
+    debianPackageDependencies in Debian ++= Seq("openjdk-8-jre-headless", "openssl", "bash (>= 2.05a-11)", "libsodium18 (>= 1.0.8-5) | libsodium23 (>= 1.0.16-2)"),
     /* Redhat */
     rpmVendor := "rchain.coop",
     rpmUrl := Some("https://rchain.coop"),


### PR DESCRIPTION
## Overview
Add openssl as a dependency so it can by used by Scala to generate rnode keys. Eventually will go to pure java/scala but until then. 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-568

### Complete this checklist before you submit the PR
- [ x] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
I addded version requirements for openssl initially but then removed them as the one that is loaded default should work. There are a lot of "letters" out there for openssl versions. ghijk ... lmnop (just kidding on the last) That is why I didn't include things like "openssl(>= 1.0.2g)" in build.sbt. We can add that in later. I thought it was cleaner and more support with less. We can always change it if needed.
