### PR TITLE
Generate an X.509 certificate for the node if none provided

### DIFF
--- a/node/src/main/scala/coop/rchain/node/CertificateHelper.scala
+++ b/node/src/main/scala/coop/rchain/node/CertificateHelper.scala
@@ -50,6 +50,10 @@ object CertificateHelper {
   }
 
   def generateKeyPair(): KeyPair = {
+    val p = Security.getProvider("SunEC")
+    val s = p.get("AlgorithmParameters.EC SupportedCurves")
+    println(System.getProperty("java.version"))
+    println(s)
     val kpg = KeyPairGenerator.getInstance("EC", "SunEC")
     kpg.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
     kpg.generateKeyPair

--- a/node/src/main/scala/coop/rchain/node/CertificateHelper.scala
+++ b/node/src/main/scala/coop/rchain/node/CertificateHelper.scala
@@ -2,10 +2,11 @@ package coop.rchain.node
 
 import java.io.{File, FileInputStream}
 import java.math.BigInteger
-import java.security.AlgorithmParameters
-import java.security.cert.{CertificateFactory, X509Certificate}
-import java.security.interfaces.ECPublicKey
+import java.security._
+import java.security.cert._
+import java.security.interfaces._
 import java.security.spec._
+import java.util.Base64
 
 import coop.rchain.crypto.hash.Keccak256
 
@@ -48,6 +49,47 @@ object CertificateHelper {
     cf.generateCertificate(is).asInstanceOf[X509Certificate]
   }
 
+  def generateKeyPair(): KeyPair = {
+    val kpg = KeyPairGenerator.getInstance("EC", "SunEC")
+    kpg.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom())
+    kpg.generateKeyPair
+  }
+
+  def generate(keyPair: KeyPair): X509Certificate = {
+    import sun.security.x509._
+
+    val privateKey  = keyPair.getPrivate
+    val publicKey   = keyPair.getPublic
+    val algorythm   = "SHA256withECDSA"
+    val algorithmId = new AlgorithmId(AlgorithmId.sha256WithECDSA_oid)
+
+    val info     = new X509CertInfo
+    val from     = new java.util.Date()
+    val to       = new java.util.Date(from.getTime + 365 * 86400000l)
+    val interval = new CertificateValidity(from, to)
+    val serial   = new BigInteger(64, new SecureRandom())
+    val owner    = new X500Name(s"CN=local, O=RChain Coop")
+
+    info.set(X509CertInfo.VALIDITY, interval)
+    info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(serial))
+    info.set(X509CertInfo.SUBJECT, owner)
+    info.set(X509CertInfo.ISSUER, owner)
+    info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey))
+    info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3))
+    info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithmId))
+
+    // Sign the cert to identify the algorithm that's used.
+    var cert = new X509CertImpl(info)
+    cert.sign(privateKey, algorythm)
+
+    // Update the algorith, and resign.
+    val algorithmId2 = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
+    info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algorithmId2)
+    cert = new X509CertImpl(info)
+    cert.sign(privateKey, algorythm)
+    cert
+  }
+
 }
 
 case class ParameterSpec(
@@ -63,4 +105,27 @@ case object ParameterSpec {
                   ecParamSpec.getGenerator,
                   ecParamSpec.getOrder,
                   ecParamSpec.getCofactor)
+}
+
+object CertificatePrinter {
+  import scala.annotation.tailrec
+
+  def print(certificate: X509Certificate): String = {
+    val str = Base64.getEncoder.encodeToString(certificate.getEncoded)
+    split(str).mkString("\n-----BEGIN CERTIFICATE-----\n", "\n", "\n-----END CERTIFICATE-----\n")
+  }
+
+  def printPrivateKey(privateKey: PrivateKey): String = {
+    val str = Base64.getEncoder.encodeToString(privateKey.getEncoded)
+    split(str).mkString("\n-----BEGIN PRIVATE KEY-----\n", "\n", "\n-----END PRIVATE KEY-----\n")
+  }
+
+  @tailrec
+  private def split(s: String, acc: List[String] = Nil): List[String] =
+    if (s.length == 0) acc.reverse
+    else {
+      val (a, b) = s.splitAt(64)
+      split(b, a :: acc)
+    }
+
 }

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -1,7 +1,7 @@
 package coop.rchain.node
 
 import java.net.{InetAddress, NetworkInterface}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Path, Paths}
 
 import com.typesafe.scalalogging.Logger
 import coop.rchain.comm.UPnP
@@ -19,6 +19,12 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
       required = false,
       short = 'c',
       descr = "Path to node's X.509 certificate file, that is being used for identification")
+
+  val key =
+    opt[Path](required = false,
+              short = 'k',
+              descr =
+                "Path to node's private key PEM file, that is being used for TLS communication")
 
   val port =
     opt[Int](default = Some(30304),
@@ -114,6 +120,14 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
       case Some(host) => host
       case None       => whoami(port()).fold("localhost")(_.getHostAddress)
     }
+
+  def certificatePath: Path =
+    certificate.toOption
+      .getOrElse(Paths.get(data_dir().toString, "node.certificate.pem"))
+
+  def keyPath: Path =
+    certificate.toOption
+      .getOrElse(Paths.get(data_dir().toString, "node.key.pem"))
 
   private def whoami(port: Int): Option[InetAddress] = {
 

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -34,12 +34,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       && !conf.certificatePath.toFile.exists()) {
     println(s"No certificate found at path ${conf.certificatePath}")
     println("Generating a X.509 certificate for the node")
-    val keyPair     = CertificateHelper.generateKeyPair()
-    val certificate = CertificateHelper.generate(keyPair)
-    val pem         = CertificatePrinter.print(certificate)
-    val pemPk       = CertificatePrinter.printPrivateKey(keyPair.getPrivate)
-    withResource(new PrintWriter(conf.certificatePath.toFile))(pw => pw.write(pem))
-    withResource(new PrintWriter(conf.keyPath.toFile))(pw => pw.write(pemPk))
+    CertificateHelper.generate(conf.data_dir().toString)
   }
 
   implicit class ThrowableOps(th: Throwable) {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -1,7 +1,6 @@
 package coop.rchain.node
 
 import java.io.{File, PrintWriter}
-import java.util.UUID
 import io.grpc.Server
 
 import cats._, cats.data._, cats.implicits._
@@ -18,6 +17,7 @@ import coop.rchain.p2p
 import coop.rchain.p2p.Network.KeysStore
 import coop.rchain.p2p.effects._
 import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.shared.Resources._
 import monix.eval.Task
 import monix.execution.Scheduler
 import diagnostics.MetricsServer
@@ -27,6 +27,20 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
+
+  // Generate certificate if not provided as option or in the data dir
+  if (conf.certificate.toOption.isEmpty
+      && conf.key.toOption.isEmpty
+      && !conf.certificatePath.toFile.exists()) {
+    println(s"No certificate found at path ${conf.certificatePath}")
+    println("Generating a X.509 certificate for the node")
+    val keyPair     = CertificateHelper.generateKeyPair()
+    val certificate = CertificateHelper.generate(keyPair)
+    val pem         = CertificatePrinter.print(certificate)
+    val pemPk       = CertificatePrinter.printPrivateKey(keyPair.getPrivate)
+    withResource(new PrintWriter(conf.certificatePath.toFile))(pw => pw.write(pem))
+    withResource(new PrintWriter(conf.keyPath.toFile))(pw => pw.write(pemPk))
+  }
 
   implicit class ThrowableOps(th: Throwable) {
     def containsMessageWith(str: String): Boolean =

--- a/scripts/p2p-test-network.sh
+++ b/scripts/p2p-test-network.sh
@@ -65,13 +65,6 @@ WuMwCgYIKoZIzj0EAwIDSQAwRgIhAMQsYq8J9V26Tarr1nfUfL0/aVoOetYDZ+c4
 QoU6g+xvAiEA1oTwyu+HHWCF8znOc6LpLaQvsqvfqgYc8s0qTi/p/5o=
 -----END CERTIFICATE-----
 EOF
-    else
-      openssl req -newkey ec:<(openssl ecparam -name secp256k1) -nodes \
-        -keyout ${var_lib_rnode_dir}/node.key.pem -x509 -days 365 \
-        -out ${var_lib_rnode_dir}/node.certificate.pem -subj "/CN=local"
-
-      cat ${var_lib_rnode_dir}/node.key.pem
-      cat ${var_lib_rnode_dir}/node.certificate.pem
    fi
 
     if [[ $i == 0 ]]; then


### PR DESCRIPTION
## Overview
In case no node certificate has been provided as an option and not found in the data dir then the node will generate an X.509 certificate.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-566

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
