### PR TITLE
OPS-140 - Add git libsodium install to subproject for dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,8 @@ matrix:
           - fakeroot
   - language: nix 
     env: SUBPROJECT=rholang_more_tests
+    install:
+      - ./scripts/install_sodium.sh
 
 script:
   - ./scripts/build-subprojects.sh


### PR DESCRIPTION
## Overview
Added libsodium install (git version) for libsodium.so dependency. nix libsodium wasn't cutting it.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=OPS-140

### Complete this checklist before you submit the PR
- [ x] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
For some reason java had issues linking/finding nix libsodium so file.
