### PR TITLE
Catch exception when verifying signature and return false

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -57,7 +57,16 @@ object Ed25519 {
       signature: Array[Byte],
       pub: Array[Byte]
   ): Boolean =
-    new VerifyKey(pub).verify(data, signature)
+    try {
+      new VerifyKey(pub).verify(data, signature)
+    } catch {
+      case ex: RuntimeException =>
+        if (ex.getMessage contains "signature was forged or corrupted") {
+          false
+        } else {
+          throw ex
+        }
+    }
 
   /**
     * Create an Ed25519 signature.


### PR DESCRIPTION
## Overview
`Ed25519.verify`  would throw `RuntimeException` when signature was not valid. This PR catches it and on that specific error message returns `false`.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
