### PR TITLE
CORE-170: shared: add ByteVectorOps

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -7,6 +7,7 @@ import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.internal.scodecs._
 import coop.rchain.rspace.util._
+import coop.rchain.shared.ByteVectorOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
 import scodec.Codec
@@ -348,20 +349,10 @@ object LMDBStore {
     }
 
   private[rspace] def toByteBuffer[T](value: T, codec: Codec[T]): ByteBuffer =
-    toByteBuffer(toBitVector(value, codec))
+    toBitVector(value, codec).bytes.toDirectByteBuffer
 
   private[rspace] def toByteBuffer[T](values: Seq[T])(implicit st: Serialize[T]): ByteBuffer =
-    toByteBuffer(toBitVector(toByteVectorSeq(values), byteVectorsCodec))
-
-  private[rspace] def toByteBuffer(byteVector: ByteVector): ByteBuffer = {
-    val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size.toInt)
-    byteVector.copyToBuffer(buffer)
-    buffer.flip()
-    buffer
-  }
-
-  private[rspace] def toByteBuffer(bitVector: BitVector): ByteBuffer =
-    toByteBuffer(bitVector.bytes)
+    toBitVector(toByteVectorSeq(values), byteVectorsCodec).bytes.toDirectByteBuffer
 
   private[rspace] def toByteVectorSeq[T](values: Seq[T])(
       implicit st: Serialize[T]): Seq[ByteVector] =

--- a/shared/src/main/scala/coop/rchain/shared/ByteVectorOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteVectorOps.scala
@@ -1,0 +1,18 @@
+package coop.rchain.shared
+
+import java.nio.ByteBuffer
+
+import scodec.bits.ByteVector
+
+object ByteVectorOps {
+
+  implicit class RichByteVector(byteVector: ByteVector) {
+
+    def toDirectByteBuffer: ByteBuffer = {
+      val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size.toInt)
+      byteVector.copyToBuffer(buffer)
+      buffer.flip()
+      buffer
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This adds an enrichment to scodec `ByteVector`s to allow them to be converted to a Direct `ByteBuffer`.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-170

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A