### PR TITLE
CORE-170: rspace.util: update removeFirst

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -39,8 +39,8 @@ package object util {
 
   /** Removes the first occurrence of an element that matches the given predicate.
     */
-  def removeFirst[T](xs: List[T])(p: T => Boolean): List[T] = {
+  def removeFirst[T](xs: Seq[T])(p: T => Boolean): Seq[T] = {
     val (l1, l2) = xs.span(x => !p(x))
-    l1 ::: l2.drop(1)
+    l1 ++ (l2 drop 1)
   }
 }


### PR DESCRIPTION
## Overview
Just a simple refactor of `removeFirst` to make it work with `Seq`s and bring it a little closer to `dropIndex` in its implementation.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-170

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A