### PR TITLE
Update default bootstrap rnode URI for peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ Invoking the above Docker image is simple enough (exit with `C-c`):
 08:30:32.710 [kamon.prometheus.PrometheusReporter] INFO  kamon.prometheus.PrometheusReporter - Started the embedded HTTP server on http://0.0.0.0:9095
 08:30:32.799 [main] INFO  logger - gRPC server started, listening on
 08:30:32.827 [main] INFO  logger - Listening for traffic on rnode://3afa77d09eb24a6caa25c0cb6a3e969f@172.17.0.2:30304.
-08:30:32.841 [main] INFO  logger - Bootstrapping from #{PeerNode 0f365f1016a54747b384b386b8e85352}.
-08:30:32.857 [main] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode 0f365f1016a54747b384b386b8e85352}
+08:30:32.841 [main] INFO  logger - Bootstrapping from #{PeerNode acd0b05a971c243817a0cfd469f5d1a238c60294}.
+08:30:32.857 [main] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode acd0b05a971c243817a0cfd469f5d1a238c60294}
 [...]
 ```
 

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -53,7 +53,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   )
 
   val bootstrap =
-    opt[String](default = Some("rnode://0f365f1016a54747b384b386b8e85352@216.83.154.106:30012"),
+    opt[String](default = Some("rnode://acd0b05a971c243817a0cfd469f5d1a238c60294@216.83.154.106:30304"),
                 short = 'b',
                 descr = "Bootstrap rnode address for initial seed.")
 


### PR DESCRIPTION
## Overview
We use to hard-code bootstrap rnode URI with --name option in boostrap standalone option. rnode URIs are now matched with private key of node so had to create a new key on bootstrap node. We also will have to change it in code default to match.

I changed port it was using from 30012 to 30304 while we were at it. That will make it more consistent with the rest of nodes. 30304 for all node p2p communications.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-576

### Complete this checklist before you submit the PR
- [ x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
