### PR TITLE
Add opfork and copy method for ctxt

### DIFF
--- a/roscala/src/main/scala/coop/rchain/roscala/Opcode.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Opcode.scala
@@ -2,6 +2,7 @@ package coop.rchain.roscala
 
 sealed trait Opcode
 case class OpAlloc(n: Int)                                                 extends Opcode
+case class OpFork(pc: Int)                                                 extends Opcode
 case class OpImmediateLitToArg(literal: Int, arg: Int)                     extends Opcode
 case class OpImmediateLitToReg(literal: Int, reg: Int)                     extends Opcode
 case class OpIndLitToArg(lit: Int, arg: Int)                               extends Opcode

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -104,7 +104,7 @@ object Vm {
         state.nextOpFlag = true
 
       case OpFork(pc) =>
-        val newCtxt = state.ctxt.copy()
+        val newCtxt = state.ctxt.clone()
         newCtxt.pc = pc
         state.strandPool.prepend(newCtxt)
         state.nextOpFlag = true

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -53,11 +53,11 @@ object Vm {
   def execute(opcode: Opcode, globalEnv: GlobalEnv, state: State): Unit =
     opcode match {
       case OpAlloc(n) =>
-        state.ctxt.argvec = Tuple(new Array[Ob](n))
+        state.ctxt.argvec = new Tuple(new Array[Ob](n))
         state.nextOpFlag = true
 
       case OpPushAlloc(n) =>
-        val t = Tuple(new Array[Ob](n))
+        val t = new Tuple(new Array[Ob](n))
         state.ctxt = Ctxt(t, state.ctxt)
         state.nextOpFlag = true
 
@@ -101,6 +101,12 @@ object Vm {
       case OpXferGlobalToArg(global, arg) =>
         val ob = globalEnv.values(global)
         state.ctxt.argvec.update(arg, ob)
+        state.nextOpFlag = true
+
+      case OpFork(pc) =>
+        val newCtxt = state.ctxt.copy()
+        newCtxt.pc = pc
+        state.strandPool.prepend(newCtxt)
         state.nextOpFlag = true
 
       case OpXmit(unwind, next, nargs) =>

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -53,11 +53,11 @@ object Vm {
   def execute(opcode: Opcode, globalEnv: GlobalEnv, state: State): Unit =
     opcode match {
       case OpAlloc(n) =>
-        state.ctxt.argvec = new Tuple(new Array[Ob](n))
+        state.ctxt.argvec = Tuple(new Array[Ob](n))
         state.nextOpFlag = true
 
       case OpPushAlloc(n) =>
-        val t = new Tuple(new Array[Ob](n))
+        val t = Tuple(new Array[Ob](n))
         state.ctxt = Ctxt(t, state.ctxt)
         state.nextOpFlag = true
 

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
@@ -20,8 +20,7 @@ class Ctxt(var tag: Location,
            var selfEnv: Ob,
            var rcvr: Ob,
            var monitor: Monitor)
-    extends Ob
-    with Cloneable {
+    extends Ob {
 
   def applyK(result: Ob, loc: Location, state: State): Boolean =
     // Make continuation receive `result` at `tag`

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
@@ -26,7 +26,7 @@ class Ctxt(var tag: Location,
     // Make continuation receive `result` at `tag`
     ctxt.rcv(result, loc, state)
 
-  def arg(n: Int): Ob = argvec.value(n)
+  def arg(n: Int): Ob = this.argvec.value(n)
 
   def copy(): Ctxt =
     new Ctxt(
@@ -36,7 +36,7 @@ class Ctxt(var tag: Location,
       pc = this.pc,
       rslt = this.rslt,
       trgt = this.trgt,
-      argvec = new Tuple(this.argvec.value.clone()),
+      argvec = Tuple(this.argvec.value.clone()),
       env = this.env,
       code = this.code,
       ctxt = this.ctxt,
@@ -101,7 +101,7 @@ object Ctxt {
       pc = 0,
       rslt = Niv,
       trgt = Niv,
-      argvec = new Tuple(new Array[Ob](0)),
+      argvec = Tuple(new Array[Ob](0)),
       env = Niv,
       code = code,
       ctxt = continuation,
@@ -139,7 +139,7 @@ object Ctxt {
     pc = 0,
     rslt = Niv,
     trgt = Niv,
-    argvec = new Tuple(new Array[Ob](i)),
+    argvec = Tuple(new Array[Ob](i)),
     env = Niv,
     code = Code(litvec = Seq.empty, codevec = Seq.empty),
     ctxt = null,
@@ -159,7 +159,7 @@ object Ctxt {
     pc = 0,
     rslt = Niv,
     trgt = Niv,
-    argvec = new Tuple(new Array[Ob](0)),
+    argvec = Tuple(new Array[Ob](0)),
     env = Niv,
     code = Code(litvec = Seq.empty, codevec = Seq.empty),
     ctxt = null,
@@ -179,7 +179,7 @@ object Ctxt {
     pc = 0,
     rslt = Niv,
     trgt = Niv,
-    argvec = new Tuple(new Array[Ob](0)),
+    argvec = Tuple(new Array[Ob](0)),
     env = Niv,
     code = Code(litvec = Seq.empty, codevec = Seq.empty),
     ctxt = null,

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
@@ -20,7 +20,8 @@ class Ctxt(var tag: Location,
            var selfEnv: Ob,
            var rcvr: Ob,
            var monitor: Monitor)
-    extends Ob {
+    extends Ob
+    with Cloneable {
 
   def applyK(result: Ob, loc: Location, state: State): Boolean =
     // Make continuation receive `result` at `tag`
@@ -28,7 +29,7 @@ class Ctxt(var tag: Location,
 
   def arg(n: Int): Ob = this.argvec.value(n)
 
-  def copy(): Ctxt =
+  override def clone(): Ctxt =
     new Ctxt(
       tag = this.tag,
       nargs = this.nargs,

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
@@ -6,20 +6,20 @@ import coop.rchain.roscala.Location._
 import coop.rchain.roscala.Vm.State
 import Ctxt.logger
 
-case class Ctxt(var tag: Location,
-                var nargs: Int,
-                var outstanding: Int,
-                var pc: Int,
-                var rslt: Ob,
-                var trgt: Ob,
-                var argvec: Tuple,
-                var env: Ob,
-                var code: Code,
-                var ctxt: Ctxt,
-                var self2: Ob,
-                var selfEnv: Ob,
-                var rcvr: Ob,
-                var monitor: Monitor)
+class Ctxt(var tag: Location,
+           var nargs: Int,
+           var outstanding: Int,
+           var pc: Int,
+           var rslt: Ob,
+           var trgt: Ob,
+           var argvec: Tuple,
+           var env: Ob,
+           var code: Code,
+           var ctxt: Ctxt,
+           var self2: Ob,
+           var selfEnv: Ob,
+           var rcvr: Ob,
+           var monitor: Monitor)
     extends Ob {
 
   def applyK(result: Ob, loc: Location, state: State): Boolean =
@@ -27,6 +27,24 @@ case class Ctxt(var tag: Location,
     ctxt.rcv(result, loc, state)
 
   def arg(n: Int): Ob = argvec.value(n)
+
+  def copy(): Ctxt =
+    new Ctxt(
+      tag = this.tag,
+      nargs = this.nargs,
+      outstanding = this.outstanding,
+      pc = this.pc,
+      rslt = this.rslt,
+      trgt = this.trgt,
+      argvec = new Tuple(this.argvec.value.clone()),
+      env = this.env,
+      code = this.code,
+      ctxt = this.ctxt,
+      self2 = this.self2,
+      selfEnv = this.selfEnv,
+      rcvr = this.rcvr,
+      monitor = this.monitor
+    )
 
   def rcv(result: Ob, loc: Location, state: State): Boolean =
     if (store(loc, this, result)) {
@@ -83,7 +101,7 @@ object Ctxt {
       pc = 0,
       rslt = Niv,
       trgt = Niv,
-      argvec = Tuple(null),
+      argvec = new Tuple(new Array[Ob](0)),
       env = Niv,
       code = code,
       ctxt = continuation,
@@ -121,7 +139,27 @@ object Ctxt {
     pc = 0,
     rslt = Niv,
     trgt = Niv,
-    argvec = Tuple(new Array[Ob](i)),
+    argvec = new Tuple(new Array[Ob](i)),
+    env = Niv,
+    code = Code(litvec = Seq.empty, codevec = Seq.empty),
+    ctxt = null,
+    self2 = Niv,
+    selfEnv = Niv,
+    rcvr = Niv,
+    monitor = null
+  )
+
+  /**
+    * Useful for testing.
+    */
+  def empty: Ctxt = new Ctxt(
+    tag = LocLimbo,
+    nargs = 0,
+    outstanding = 0,
+    pc = 0,
+    rslt = Niv,
+    trgt = Niv,
+    argvec = new Tuple(new Array[Ob](0)),
     env = Niv,
     code = Code(litvec = Seq.empty, codevec = Seq.empty),
     ctxt = null,
@@ -141,7 +179,7 @@ object Ctxt {
     pc = 0,
     rslt = Niv,
     trgt = Niv,
-    argvec = Tuple(null),
+    argvec = new Tuple(new Array[Ob](0)),
     env = Niv,
     code = Code(litvec = Seq.empty, codevec = Seq.empty),
     ctxt = null,

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
@@ -1,11 +1,15 @@
 package coop.rchain.roscala.ob
 
 class Tuple(val value: Array[Ob]) extends Ob {
-  def apply(i: Int): Ob = value(i)
+  def apply(n: Int): Ob = value(n)
 
   def update(arg: Int, ob: Ob): Unit = value.update(arg, ob)
 
-  def numberOfElements(): Int = value.size
+  def numberOfElements(): Int = value.length
+}
+
+object Tuple {
+  def apply(value: Array[Ob]): Tuple = new Tuple(value)
 }
 
 case object Nil extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
@@ -1,6 +1,6 @@
 package coop.rchain.roscala.ob
 
-case class Tuple(value: Array[Ob]) extends Ob {
+class Tuple(val value: Array[Ob]) extends Ob {
   def apply(i: Int): Ob = value(i)
 
   def update(arg: Int, ob: Ob): Unit = value.update(arg, ob)

--- a/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
@@ -20,7 +20,7 @@ class CtxtSpec extends FlatSpec with Matchers {
     val ob2 = Fixnum(2)
 
     val ctxt = Ctxt.empty
-    ctxt.argvec = new Tuple(new Array[Ob](1))
+    ctxt.argvec = Tuple(new Array[Ob](1))
     ctxt.argvec.update(0, ob)
 
     val copy = ctxt.copy()

--- a/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
@@ -1,0 +1,31 @@
+package coop.rchain.roscala
+
+import coop.rchain.roscala.ob.{Ctxt, Fixnum, Ob, Tuple}
+import org.scalatest.{FlatSpec, Matchers}
+
+class CtxtSpec extends FlatSpec with Matchers {
+
+  "copy()" should "should not reference the old program counter" in {
+    val ctxt = Ctxt.empty
+    ctxt.pc = 1
+
+    val copy = ctxt.copy()
+    copy.pc = 2
+
+    ctxt.pc shouldNot be(copy.pc)
+  }
+
+  "copy()" should "not reference the old argvec" in {
+    val ob  = Fixnum(1)
+    val ob2 = Fixnum(2)
+
+    val ctxt = Ctxt.empty
+    ctxt.argvec = new Tuple(new Array[Ob](1))
+    ctxt.argvec.update(0, ob)
+
+    val copy = ctxt.copy()
+    ctxt.argvec.update(0, ob2)
+
+    ctxt.arg(0) shouldNot be(copy.arg(0))
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CtxtSpec extends FlatSpec with Matchers {
 
-  "copy()" should "should not reference the old program counter" in {
+  "copy()" should "not reference the old program counter" in {
     val ctxt = Ctxt.empty
     ctxt.pc = 1
 

--- a/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/CtxtSpec.scala
@@ -5,17 +5,17 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class CtxtSpec extends FlatSpec with Matchers {
 
-  "copy()" should "not reference the old program counter" in {
+  "clone()" should "not reference the old program counter" in {
     val ctxt = Ctxt.empty
     ctxt.pc = 1
 
-    val copy = ctxt.copy()
-    copy.pc = 2
+    val clone = ctxt.clone()
+    clone.pc = 2
 
-    ctxt.pc shouldNot be(copy.pc)
+    ctxt.pc shouldNot be(clone.pc)
   }
 
-  "copy()" should "not reference the old argvec" in {
+  "clone()" should "not reference the old argvec" in {
     val ob  = Fixnum(1)
     val ob2 = Fixnum(2)
 
@@ -23,9 +23,9 @@ class CtxtSpec extends FlatSpec with Matchers {
     ctxt.argvec = Tuple(new Array[Ob](1))
     ctxt.argvec.update(0, ob)
 
-    val copy = ctxt.copy()
+    val clone = ctxt.clone()
     ctxt.argvec.update(0, ob2)
 
-    ctxt.arg(0) shouldNot be(copy.arg(0))
+    ctxt.arg(0) shouldNot be(clone.arg(0))
   }
 }


### PR DESCRIPTION
Port over test case for `OpFork`.
When a `Ctxt` is copied in `OpFork` it is important that the `argvec` is not just copied by reference since we want changes to the original `argvec` not to be reflected in the copied `argvec`.