### PR TITLE
Adds rholang method encodedToBytes

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -550,12 +550,12 @@ object Reduce {
         }
     }
 
-    private[this] def encodedToBytes: (Par, Seq[Par]) => Env[Par] => M[Par] = {
+    private[this] def hexToBytes: (Par, Seq[Par]) => Env[Par] => M[Par] = {
       (p: Par, args: Seq[Par]) => (env: Env[Par]) =>
         {
           if (args.nonEmpty) {
             interpreterErrorM[M].raiseError(
-              ReduceError("Error: encodedToBytes does not take arguments"))
+              ReduceError("Error: hexToBytes does not take arguments"))
           } else {
             p.singleExpr() match {
               case Some(Expr(GString(encoded))) =>
@@ -567,7 +567,7 @@ object Reduce {
                         x => interpreterErrorM[M].pure[Par](x))
               case _ =>
                 interpreterErrorM[M].raiseError(
-                  ReduceError("Error: encodedToBytes can be called only on single strings."))
+                  ReduceError("Error: hexToBytes can be called only on single strings."))
             }
           }
         }
@@ -575,10 +575,10 @@ object Reduce {
 
     def methodTable(method: String): Option[(Par, Seq[Par]) => Env[Par] => M[Par]] =
       method match {
-        case "nth"            => Some(nth)
-        case "toByteArray"    => Some(toByteArray)
-        case "encodedToBytes" => Some(encodedToBytes)
-        case _                => None
+        case "nth"         => Some(nth)
+        case "toByteArray" => Some(toByteArray)
+        case "hexToBytes"  => Some(hexToBytes)
+        case _             => None
       }
 
     def evalSingleExpr(p: Par)(implicit env: Env[Par]): M[Expr] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -82,7 +82,9 @@ object SystemProcesses {
         produce(store, ack, Seq(Channel(Quote(Expr(GBool(verified))))), false)
           .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
       }
-    case _ => illegalArgumentException("ed25519Verify expects data, signature and public key (all as byte arrays) and ack channel as arguments")
+    case _ =>
+      illegalArgumentException(
+        "ed25519Verify expects data, signature and public key (all as byte arrays) and ack channel as arguments")
   }
 
   def curve25519Encrypt(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
@@ -97,7 +99,9 @@ object SystemProcesses {
                 false)
           .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
       }
-    case _ => illegalArgumentException("curve25519Encrypt expects public key, private key, nonce, message (all as byte arrays) and ack channel as arguments")
+    case _ =>
+      illegalArgumentException(
+        "curve25519Encrypt expects public key, private key, nonce, message (all as byte arrays) and ack channel as arguments")
   }
 
   def sha256Hash(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
@@ -108,7 +112,8 @@ object SystemProcesses {
         produce(store, ack, Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))), false)
           .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
       }
-    case _ => illegalArgumentException("sha256Hash expects byte array and return channel as arguments")
+    case _ =>
+      illegalArgumentException("sha256Hash expects byte array and return channel as arguments")
   }
 
   def keccak256Hash(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
@@ -119,7 +124,8 @@ object SystemProcesses {
         produce(store, ack, Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))), false)
           .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
       }
-    case _ => illegalArgumentException("keccak256Hash expects byte array and return channel as arguments")
+    case _ =>
+      illegalArgumentException("keccak256Hash expects byte array and return channel as arguments")
   }
 
   def blake2b256Hash(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
@@ -130,7 +136,8 @@ object SystemProcesses {
         produce(store, ack, Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))), false)
           .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
       }
-    case _ => illegalArgumentException("blake2b256Hash expects byte array and return channel as arguments")
+    case _ =>
+      illegalArgumentException("blake2b256Hash expects byte array and return channel as arguments")
   }
 
   private def _dispatch(dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/implicits.scala
@@ -230,8 +230,8 @@ object implicits {
     def singleExpr(): Option[Expr] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.evals.isEmpty && p.news.isEmpty && p.matches.isEmpty && p.bundles.isEmpty) {
         p.exprs match {
-          case List(single) => Some(single)
-          case _            => None
+          case Seq(single) => Some(single)
+          case _           => None
         }
       } else {
         None

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -697,13 +697,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     }
   }
 
-  "eval of encodedToBytes" should "transform encoded string to byte array (not the rholang term)" in {
+  "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
     import coop.rchain.models.implicits._
     val testString                = "testing testing"
     val base16Repr                = Base16.encode(testString.getBytes)
     val proc: Par                 = GString(base16Repr)
     val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc))
-    val toByteArrayCall           = EMethod("encodedToBytes", proc, List[Par]())
+    val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestStore { store =>
       val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](store).reducer

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2,7 +2,9 @@ package coop.rchain.rholang.interpreter
 
 import java.nio.file.Files
 
+import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.Capture._
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
@@ -660,8 +662,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestStore { store =>
       val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](store).reducer
       val env         = Env[Par]()
-      val nthTask     = reducer.eval(wrapWithSend(toByteArrayCall))(env)
-      val inspectTask = for { _ <- nthTask } yield store.toMap
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env)
+      val inspectTask = for { _ <- task } yield store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
 
@@ -693,5 +695,33 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         runAndRethrowBoxedErrors(inspectTask)
       }
     }
+  }
+
+  "eval of encodedToBytes" should "transform encoded string to byte array (not the rholang term)" in {
+    import coop.rchain.models.implicits._
+    val testString                = "testing testing"
+    val base16Repr                = Base16.encode(testString.getBytes)
+    val proc: Par                 = GString(base16Repr)
+    val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc))
+    val toByteArrayCall           = EMethod("encodedToBytes", proc, List[Par]())
+    def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
+    val result = withTestStore { store =>
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](store).reducer
+      val env         = Env[Par]()
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env)
+      val inspectTask = for { _ <- task } yield store.toMap
+      Await.result(inspectTask.runAsync, 3.seconds)
+    }
+
+    result should be(
+      HashMap(
+        List(Channel(Quote(GString("result")))) ->
+          Row(List(
+                Datum[List[Channel]](
+                  List[Channel](Quote(Expr(GByteArray(ByteString.copyFrom(testString.getBytes))))),
+                  persist = false)),
+              List())
+      )
+    )
   }
 }


### PR DESCRIPTION
## Overview
Adds method `encodedToBytes` to rholang language allowing for turning raw encoded string into byte arrays (in contrary to `toByteArray()` that was transforming underlying rholang par ie `GString(_).toByteArray`). This method is necessary for usage of crypto functions like `verify` and `encrypt` because there was no way of introducing encoded strings into the rholang program.

#### Example usage:

1. Let's hash some rholang program and print out it in base16. In rholang:
```
new x,y in { 
   x!(@"name"!("Joe") | @"age"!(40)) |  // (1)
   for (@r <- x) { @"keccak256Hash"!(r.toByteArray(), *y) } |  // hash the program from (1)
   for (@h <- y) { @"stdout"!(h) }  // print out the keccak256 hash
}
```
This will print the hash of our program `(1)` : 
`a6da46a1dc7ed715d4cd6472a736249a4d11142d160dbef9f20ae493de908c4e`

2. We need pair of keys, let's generate some with `Ed25519` available in the project. In scala console:
```
import coop.rchain.crypto.signatures._
import coop.rchain.crypto.codec._

val keyPair = Ed25519.newKeyPair
val secKey = Base16.encode(keyPair._1)
// secKey: String = f6664a95992958bbfeb7e6f50bbca2aa7bfd015aec79820caf362a3c874e9247
val pubKey = Base16.encode(keyPair._2)
// pubKey: String = 288755c48c3951f89c5f0ffe885088dc0970fd935bc12adfdd81f81bb63d6219
```

3. Now we need to sign the hash we obtained in first step. Because we print out the base16 representation of underlying byte arrays for hashes we need to decode those strings.
```
val signature = Ed25519.sign(Base16.decode("a6da46a1dc7ed715d4cd6472a736249a4d11142d160dbef9f20ae493de908c4e"), Base16.decode(secKey))
val base16Repr = Base16.encode(signature)
// d0a909078ce8b8706a641b07a0d4fe2108064813ce42009f108f89c2a3f4864aa1a510d6dfccad3b62cd610db0bfe82bcecb08d813997fa7df14972f56017e0b
```

4. Now we can pass the signature and public key to our rholang program to verify it using crypto functions available. 

`ed25519Verify` channel expects four arguments as follows:
- data to verify. In our case this will be the keccak256 hash of our rholang program. The hash is represented in base16 so we need to call `encodedToBytes` on it to turn the string into byte array
- signature. Again we have hexadecimal string so we need to turn it into byte array (`encodedToBytes`)
- public key (same as for signature). 

So, in rholang:
```
new x in { 
  @"ed25519Verify"!("a6da46a1dc7ed715d4cd6472a736249a4d11142d160dbef9f20ae493de908c4e".encodedToBytes(), "d0a909078ce8b8706a641b07a0d4fe2108064813ce42009f108f89c2a3f4864aa1a510d6dfccad3b62cd610db0bfe82bcecb08d813997fa7df14972f56017e0b".encodedToBytes(),"288755c48c3951f89c5f0ffe885088dc0970fd935bc12adfdd81f81bb63d6219".encodedToBytes(), *x) | 
  for (@v <- x) { @"stdout"!(v) } 
} 

```
and we should see: 
```
@{true}
```

which means that our hash and signature match with public key.

If we for example pass in corrupted hash (the change is emphasized with ** - 71 changed to 61):
```
new x in { 
   @"ed25519Verify"!("a6da46a1dc7ed**61**5d4cd6472a736249a4d11142d160dbef9f20ae493de908c4e".encodedToBytes(), "d0a909078ce8b8706a641b07a0d4fe2108064813ce42009f108f89c2a3f4864aa1a510d6dfccad3b62cd610db0bfe82bcecb08d813997fa7df14972f56017e0b".encodedToBytes(),"288755c48c3951f89c5f0ffe885088dc0970fd935bc12adfdd81f81bb63d6219".encodedToBytes(), *x) | 
   for (@v <- x) { @"stdout"!(v) } 
} 
```

we will get:
```
@{false}
```

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
