### PR TITLE
Fix peers metrics for some edge cases

### DIFF
--- a/node/src/main/scala/coop/rchain/node/effects/TLNodeDiscovery.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/TLNodeDiscovery.scala
@@ -24,7 +24,7 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
   def addNode(peer: PeerNode): F[Unit] =
     for {
       _ <- updateLastSeen(peer)
-      _ <- Metrics[F].incrementGauge("peers")
+      _ <- Metrics[F].setGauge("peers", table.peers.length)
     } yield ()
 
   /**
@@ -109,7 +109,7 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
       _ <- Log[F].info(s"Forgetting about $sender.")
       _ <- Capture[F].capture(table.remove(sender.key))
       _ <- Metrics[F].incrementCounter("disconnect-recv-count")
-      _ <- Metrics[F].decrementGauge("peers")
+      _ <- Metrics[F].setGauge("peers", table.peers.length)
     } yield handledWitoutMessage
 
   private def lookup(key: Seq[Byte], remoteNode: ProtocolNode): F[Seq[PeerNode]] =


### PR DESCRIPTION
## Overview
Fixes `peers` metrics for the edge case when the bootstrap identifier is wrong. In this case, the node connects the bootstrap node, immediately disconnects and stops. The bootstrap node doesn't receive a disconnect message from this node. 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-577

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
