### PR TITLE
rspace: remove vestigial parameter bounds from InMemoryStore

### DIFF
--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -13,7 +13,7 @@ import javax.xml.bind.DatatypeConverter.printHexBinary
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 
-class InMemoryStore[C, P, A, K <: Serializable] private (
+class InMemoryStore[C, P, A, K] private (
     _keys: mutable.HashMap[String, Seq[C]],
     _waitingContinuations: mutable.HashMap[String, Seq[WaitingContinuation[P, K]]],
     _data: mutable.HashMap[String, Seq[Datum[A]]],


### PR DESCRIPTION
## Overview
This PR removes the leftover parameter bounds in `InMemoryStore`, finishing the work in #836.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/projects/CORE/issues/CORE-559

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A