### PR TITLE
CORE-529 RSpace produce/consume counters

### DIFF
--- a/node/src/main/protobuf/diagnostics.proto
+++ b/node/src/main/protobuf/diagnostics.proto
@@ -81,6 +81,12 @@ message StoreUsage {
   int64 totalSizeOnDisk = 1;
   int64 rspaceSizeOnDisk = 2;
   int64 rspaceDataEntries = 3;
+
+  int64 rspaceConsumesCount = 4;
+  double rspaceConsumeAvgMilliseconds = 5;
+
+  int64 rspaceProducesCount = 6;
+  double rspaceProduceAvgMilliseconds = 7;
 }
 
 service Diagnostics {

--- a/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
@@ -32,7 +32,11 @@ object StoreMetrics extends StoreMetricsInstances {
       List(
         g("total-size-on-disk", storeSize.totalSizeOnDisk),
         g("rspace-size-on-disk", storeSize.rspaceSizeOnDisk),
-        g("rspace-data-entries", storeSize.rspaceDataEntries)
+        g("rspace-data-entries", storeSize.rspaceDataEntries),
+        g("rspace-consumes-count", storeSize.rspaceConsumesCount),
+        g("rspace-consume-avg-ms", storeSize.rspaceConsumeAvgMilliseconds.toLong),
+        g("rspace-produces-count", storeSize.rspaceProducesCount),
+        g("rspace-produces-avg-ms", storeSize.rspaceProduceAvgMilliseconds.toLong)
       )
 
     def join(tasks: Seq[F[Unit]]*): F[List[Unit]] =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
@@ -115,8 +115,12 @@ object Runtime {
 
   def showStoreUsage(storeUsage: StoreUsage): String =
     s"""Store metrics:
-       | - Total Size On Disk: ${storeUsage.totalSizeOnDisk.toHumanReadableSize}
-       | - RSpace Size On Disk: ${storeUsage.rspaceSizeOnDisk.toHumanReadableSize}
-       | - RSpace Data Entries: ${storeUsage.rspaceDataEntries}
+       |  - Total Size On Disk: ${storeUsage.totalSizeOnDisk.toHumanReadableSize}
+       |  - RSpace Size On Disk: ${storeUsage.rspaceSizeOnDisk.toHumanReadableSize}
+       |  - RSpace Data Entries: ${storeUsage.rspaceDataEntries}
+       |  - RSpace Consumes Count: ${storeUsage.rspaceConsumesCount}
+       |  - RSpace Avg Consume(ms): ${storeUsage.rspaceConsumeAvgMilliseconds.formatted("%.2f")}
+       |  - RSpace Produces Count: ${storeUsage.rspaceProducesCount}
+       |  - RSpace Avg Produce(ms): ${storeUsage.rspaceProduceAvgMilliseconds.formatted("%.2f")}
        |""".stripMargin
 }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
@@ -164,12 +164,17 @@ package object diagnostics {
     new StoreMetrics[F] {
       def storeUsage: F[StoreUsage] =
         Capture[F].capture {
-          val storeSize = store.getStoreSize
-          val totalSize = data_dir.folderSize
-          StoreUsage()
-            .withTotalSizeOnDisk(totalSize)
-            .withRspaceSizeOnDisk(storeSize.sizeOnDisk)
-            .withRspaceDataEntries(storeSize.dataEntries)
+          val storeCounters = store.getStoreCounters
+          val totalSize     = data_dir.folderSize
+          StoreUsage(
+            totalSizeOnDisk = totalSize,
+            rspaceSizeOnDisk = storeCounters.sizeOnDisk,
+            rspaceDataEntries = storeCounters.dataEntries,
+            rspaceConsumesCount = storeCounters.consumesCount,
+            rspaceConsumeAvgMilliseconds = storeCounters.consumeAvgMilliseconds,
+            rspaceProducesCount = storeCounters.producesCount,
+            rspaceProduceAvgMilliseconds = storeCounters.produceAvgMilliseconds
+          )
         }
     }
 

--- a/rholang/examples/performance/loop_recursive.rho
+++ b/rholang/examples/performance/loop_recursive.rho
@@ -1,0 +1,17 @@
+// This benchmark example runs N iterations recursively.
+// Useful to measure RSpace performance.
+
+new LoopRecursive in {
+  contract LoopRecursive(@count) = {  	
+    match count {
+    0 => @"stdout"!("Done!")
+    x => {
+        @"stdout"!("Step")
+         | LoopRecursive!(x - 1)
+      }
+    }  
+  } |
+  new myChannel in {
+    LoopRecursive!(10000)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -70,5 +70,7 @@ trait IStore[C, P, A, K] {
 
   def close(): Unit
 
-  def getStoreSize: StoreSize
+  def getStoreCounters: StoreCounters
+
+  private[rspace] val eventsCounter: StoreEventsCounter
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -255,13 +255,15 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
     collectGarbage(txn, joinKey)
   }
 
-  private[rspace] def clear(): Unit =
+  private[rspace] def clear(): Unit = {
     withTxn(createTxnWrite()) { txn =>
       _dbKeys.drop(txn)
       _dbData.drop(txn)
       _dbWaitingContinuations.drop(txn)
       _dbJoins.drop(txn)
     }
+    eventsCounter.reset()
+  }
 
   def close(): Unit = {
     _dbKeys.close()

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -45,6 +45,8 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
 
   private[rspace] type T = Txn[ByteBuffer]
 
+  val eventsCounter: StoreEventsCounter = new StoreEventsCounter()
+
   private[rspace] def hashChannels(channels: Seq[C])(implicit st: Serialize[C]): H =
     hashBytes(toByteBuffer(channels)(st))
 
@@ -269,8 +271,8 @@ class LMDBStore[C, P, A, K] private (env: Env[ByteBuffer],
     env.close()
   }
 
-  def getStoreSize: StoreSize =
-    StoreSize(databasePath.folderSize, env.stat().entries)
+  def getStoreCounters: StoreCounters =
+    eventsCounter.createCounters(databasePath.folderSize, env.stat().entries)
 
   def isEmpty: Boolean =
     withTxn(createTxnRead()) { txn =>

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
@@ -35,10 +35,9 @@ private[rspace] class StoreEventsCounter {
     consumesSumTime.set(0)
   }
 
-  /**
-    * @return a tuple (producesCount, consumesCount) just for unit-tests
-    */
-  private[rspace] def getCounts: (Long, Long) = (producesCount.get, consumesCount.get)
+  private[rspace] def getConsumesCount: Long = consumesCount.get
+
+  private[rspace] def getProducesCount: Long = producesCount.get
 
   // for nano-time pitfalls please read
   // https://shipilev.net/blog/2014/nanotrusting-nanotime/

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
@@ -27,6 +27,19 @@ private[rspace] class StoreEventsCounter {
   private[this] val consumesCount   = new AtomicLong
   private[this] val consumesSumTime = new AtomicReference[BigInt](BigInt(0))
 
+  private[rspace] def reset(): Unit = {
+    producesCount.set(0)
+    producesSumTime.set(0)
+
+    consumesCount.set(0)
+    consumesSumTime.set(0)
+  }
+
+  /**
+    * @return a tuple (producesCount, consumesCount) just for unit-tests
+    */
+  private[rspace] def getCounts: (Long, Long) = (producesCount.get, consumesCount.get)
+
   // for nano-time pitfalls please read
   // https://shipilev.net/blog/2014/nanotrusting-nanotime/
   def registerProduce[T](f: => T): T = {

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
@@ -1,0 +1,93 @@
+package coop.rchain.rspace
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import scala.annotation.tailrec
+
+case class StoreCounters(sizeOnDisk: Long,
+                         dataEntries: Long,
+                         consumesCount: Long,
+                         consumeAvgMilliseconds: Double,
+                         producesCount: Long,
+                         produceAvgMilliseconds: Double)
+
+/**
+  * Conters rspace produce and consume calls.
+  * Returns counted number of cycles and avg times
+  * Uses BigIntegers to accumulate total times
+  * w/o rounding errors
+  *
+  * Lock-free. Non wait-free.
+  *
+  * For percentiles here is an algorithm that will not drain
+  * memory: http://www.cs.wustl.edu/~jain/papers/ftp/psqr.pdf,
+  */
+private[rspace] class StoreEventsCounter {
+  private[this] val producesCount   = new AtomicLong
+  private[this] val producesSumTime = new AtomicReference[BigInt](BigInt(0))
+
+  private[this] val consumesCount   = new AtomicLong
+  private[this] val consumesSumTime = new AtomicReference[BigInt](BigInt(0))
+
+  // for nano-time pitfalls please read
+  // https://shipilev.net/blog/2014/nanotrusting-nanotime/
+  def registerProduce[T](f: => T): T = {
+    val start = System.nanoTime()
+    try {
+      f
+    } finally {
+      val end  = System.nanoTime()
+      val diff = Math.max(end - start, 0)
+      //addAtomic can is times slower than incrementAndGet
+      //run it first to minimize possible avg error
+      addAtomic(producesSumTime, diff)
+      producesCount.getAndIncrement()
+    }
+  }
+
+  def registerConsume[T](f: => T): T = {
+    val start = System.nanoTime()
+    try {
+      f
+    } finally {
+      val end  = System.nanoTime()
+      val diff = Math.max(end - start, 0)
+      //addAtomic can is times slower than incrementAndGet
+      //run it first to minimize possible avg error
+      addAtomic(consumesSumTime, diff)
+      consumesCount.getAndIncrement()
+    }
+  }
+
+  @tailrec
+  private[this] def addAtomic(value: AtomicReference[BigInt], add: BigInt): Unit = {
+    val exInt = value.get
+    if (!value.compareAndSet(exInt, exInt + add))
+      addAtomic(value, add)
+  }
+
+  def createCounters(sizeOnDisk: Long, dataEntries: Long): StoreCounters = {
+    //since producesCount and producesSumTime updated separately
+    //we may have average a bit non-precise (lower) sometimes,
+    //anyway that's better then waste speed on synchronization or locking
+    val producesTotal = producesCount.get
+    val produceAvgTime =
+      if (producesTotal > 0)
+        (BigDecimal(producesSumTime.get) / (producesTotal * 1000000)).toDouble
+      else
+        0
+
+    val consumesTotal = consumesCount.get
+    val consumeAvgTime =
+      if (consumesTotal > 0)
+        (BigDecimal(consumesSumTime.get) / (consumesTotal * 1000000)).toDouble
+      else
+        0
+
+    StoreCounters(sizeOnDisk,
+                  dataEntries,
+                  consumesTotal,
+                  consumeAvgTime,
+                  producesTotal,
+                  produceAvgTime)
+  }
+
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreSize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreSize.scala
@@ -1,3 +1,0 @@
-package coop.rchain.rspace
-
-case class StoreSize(sizeOnDisk: Long, dataEntries: Long)

--- a/rspace/src/main/scala/coop/rchain/rspace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/package.scala
@@ -103,56 +103,57 @@ package object rspace {
                           channels: Seq[C],
                           patterns: Seq[P],
                           continuation: K,
-                          persist: Boolean)(implicit m: Match[P, A]): Option[(K, Seq[A])] = {
-    if (channels.length =!= patterns.length) {
-      val msg = "channels.length must equal patterns.length"
-      logger.error(msg)
-      throw new IllegalArgumentException(msg)
-    }
-    store.withTxn(store.createTxnWrite()) { txn =>
-      logger.debug(s"""|consume: searching for data matching <patterns: $patterns> 
-                       |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-      /*
-       * Here, we create a cache of the data at each channel as `channelToIndexedData`
-       * which is used for finding matches.  When a speculative match is found, we can
-       * remove the matching datum from the remaining data candidates in the cache.
-       *
-       * Put another way, this allows us to speculatively remove matching data without
-       * affecting the actual store contents.
-       */
+                          persist: Boolean)(implicit m: Match[P, A]): Option[(K, Seq[A])] =
+    store.eventsCounter.registerConsume {
+      if (channels.length =!= patterns.length) {
+        val msg = "channels.length must equal patterns.length"
+        logger.error(msg)
+        throw new IllegalArgumentException(msg)
+      }
+      store.withTxn(store.createTxnWrite()) { txn =>
+        logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
+              |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+        /*
+         * Here, we create a cache of the data at each channel as `channelToIndexedData`
+         * which is used for finding matches.  When a speculative match is found, we can
+         * remove the matching datum from the remaining data candidates in the cache.
+         *
+         * Put another way, this allows us to speculatively remove matching data without
+         * affecting the actual store contents.
+         */
 
-      val channelToIndexedData = channels.map { (c: C) =>
-        c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-      }.toMap
+        val channelToIndexedData = channels.map { (c: C) =>
+          c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
+        }.toMap
 
-      val options: Option[Seq[DataCandidate[C, A]]] =
-        extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+        val options: Option[Seq[DataCandidate[C, A]]] =
+          extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
 
-      options match {
-        case None =>
-          store.putWaitingContinuation(txn,
-                                       channels,
-                                       WaitingContinuation(patterns, continuation, persist))
-          for (channel <- channels) store.addJoin(txn, channel, channels)
-          logger.debug(s"""|consume: no data found,
-                           |storing <(patterns, continuation): ($patterns, $continuation)>
-                           |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-          None
-        case Some(dataCandidates) =>
-          dataCandidates
-            .sortBy(_.datumIndex)(Ordering[Int].reverse)
-            .foreach {
-              case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex)
-                  if !persistData =>
-                store.removeDatum(txn, candidateChannel, dataIndex)
-              case _ =>
-                ()
-            }
-          logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
-          Some((continuation, dataCandidates.map(_.datum.a)))
+        options match {
+          case None =>
+            store.putWaitingContinuation(txn,
+                                         channels,
+                                         WaitingContinuation(patterns, continuation, persist))
+            for (channel <- channels) store.addJoin(txn, channel, channels)
+            logger.debug(s"""|consume: no data found,
+                  |storing <(patterns, continuation): ($patterns, $continuation)>
+                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+            None
+          case Some(dataCandidates) =>
+            dataCandidates
+              .sortBy(_.datumIndex)(Ordering[Int].reverse)
+              .foreach {
+                case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex)
+                    if !persistData =>
+                  store.removeDatum(txn, candidateChannel, dataIndex)
+                case _ =>
+                  ()
+              }
+            logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
+            Some((continuation, dataCandidates.map(_.datum.a)))
+        }
       }
     }
-  }
 
   def install[C, P, A, K](store: IStore[C, P, A, K],
                           channels: Seq[C],
@@ -258,72 +259,76 @@ package object rspace {
     */
   def produce[C, P, A, K](store: IStore[C, P, A, K], channel: C, data: A, persist: Boolean)(
       implicit m: Match[P, A]): Option[(K, Seq[A])] =
-    store.withTxn(store.createTxnWrite()) { txn =>
-      val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
-      logger.debug(s"""|produce: searching for matching continuations
-                       |at <groupedChannels: $groupedChannels>""".stripMargin.replace('\n', ' '))
+    store.eventsCounter.registerProduce {
+      store.withTxn(store.createTxnWrite()) { txn =>
+        val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
+        logger.debug(s"""|produce: searching for matching continuations
+              |at <groupedChannels: $groupedChannels>""".stripMargin.replace('\n', ' '))
 
-      /*
-       * Find produce candidate
-       *
-       * Could also be implemented with a lazy `foldRight`.
-       */
-      @tailrec
-      def extractProduceCandidate(groupedChannels: Seq[Seq[C]],
-                                  batChannel: C,
-                                  data: Datum[A]): Option[ProduceCandidate[C, P, A, K]] =
-        groupedChannels match {
-          case Nil => None
-          case channels :: remaining =>
-            val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
-              store.getWaitingContinuation(txn, channels).zipWithIndex
-            /*
-             * Here, we create a cache of the data at each channel as `channelToIndexedData`
-             * which is used for finding matches.  When a speculative match is found, we can
-             * remove the matching datum from the remaining data candidates in the cache.
-             *
-             * Put another way, this allows us to speculatively remove matching data without
-             * affecting the actual store contents.
-             *
-             * In this version, we also add the produced data directly to this cache.
-             */
-            val channelToIndexedData: Map[C, Seq[(Datum[A], Int)]] = channels.map { (c: C) =>
-              val as = Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-              c -> { if (c == batChannel) (data, -1) +: as else as }
-            }.toMap
-            extractFirstMatch(channels, Random.shuffle(matchCandidates), channelToIndexedData) match {
-              case None             => extractProduceCandidate(remaining, batChannel, data)
-              case produceCandidate => produceCandidate
-            }
-        }
-
-      extractProduceCandidate(groupedChannels, channel, Datum(data, persist)) match {
-        case Some(
-            ProduceCandidate(channels,
-                             WaitingContinuation(_, continuation, persistK),
-                             continuationIndex,
-                             dataCandidates)) =>
-          if (!persistK) {
-            store.removeWaitingContinuation(txn, channels, continuationIndex)
-          }
-          dataCandidates
-            .sortBy(_.datumIndex)(Ordering[Int].reverse)
-            .foreach {
-              case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex) =>
-                if (!persistData && dataIndex >= 0) {
-                  store.removeDatum(txn, candidateChannel, dataIndex)
+        /*
+         * Find produce candidate
+         *
+         * Could also be implemented with a lazy `foldRight`.
+         */
+        @tailrec
+        def extractProduceCandidate(groupedChannels: Seq[Seq[C]],
+                                    batChannel: C,
+                                    data: Datum[A]): Option[ProduceCandidate[C, P, A, K]] =
+          groupedChannels match {
+            case Nil => None
+            case channels :: remaining =>
+              val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
+                store.getWaitingContinuation(txn, channels).zipWithIndex
+              /*
+               * Here, we create a cache of the data at each channel as `channelToIndexedData`
+               * which is used for finding matches.  When a speculative match is found, we can
+               * remove the matching datum from the remaining data candidates in the cache.
+               *
+               * Put another way, this allows us to speculatively remove matching data without
+               * affecting the actual store contents.
+               *
+               * In this version, we also add the produced data directly to this cache.
+               */
+              val channelToIndexedData: Map[C, Seq[(Datum[A], Int)]] = channels.map { (c: C) =>
+                val as = Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
+                c -> {
+                  if (c == batChannel) (data, -1) +: as else as
                 }
-                store.removeJoin(txn, candidateChannel, channels)
-              case _ =>
-                ()
+              }.toMap
+              extractFirstMatch(channels, Random.shuffle(matchCandidates), channelToIndexedData) match {
+                case None             => extractProduceCandidate(remaining, batChannel, data)
+                case produceCandidate => produceCandidate
+              }
+          }
+
+        extractProduceCandidate(groupedChannels, channel, Datum(data, persist)) match {
+          case Some(
+              ProduceCandidate(channels,
+                               WaitingContinuation(_, continuation, persistK),
+                               continuationIndex,
+                               dataCandidates)) =>
+            if (!persistK) {
+              store.removeWaitingContinuation(txn, channels, continuationIndex)
             }
-          logger.debug(s"produce: matching continuation found at <channels: $channels>")
-          Some(continuation, dataCandidates.map(_.datum.a))
-        case None =>
-          logger.debug(s"produce: no matching continuation found")
-          store.putDatum(txn, Seq(channel), Datum(data, persist))
-          logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
-          None
+            dataCandidates
+              .sortBy(_.datumIndex)(Ordering[Int].reverse)
+              .foreach {
+                case DataCandidate(candidateChannel, Datum(_, persistData), dataIndex) =>
+                  if (!persistData && dataIndex >= 0) {
+                    store.removeDatum(txn, candidateChannel, dataIndex)
+                  }
+                  store.removeJoin(txn, candidateChannel, channels)
+                case _ =>
+                  ()
+              }
+            logger.debug(s"produce: matching continuation found at <channels: $channels>")
+            Some(continuation, dataCandidates.map(_.datum.a))
+          case None =>
+            logger.debug(s"produce: no matching continuation found")
+            store.putDatum(txn, Seq(channel), Datum(data, persist))
+            logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
+            None
+        }
       }
     }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -28,6 +28,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     r shouldBe None
     //store is not empty - we have 'A' stored
     store.isEmpty shouldBe false
+
+    store.eventsCounter.getCounts shouldBe (1, 0)
   }
 
   "producing twice on the same channel" should
@@ -60,6 +62,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     r2 shouldBe None
     //store is not empty - we have 2 As stored
     store.isEmpty shouldBe false
+
+    store.eventsCounter.getCounts shouldBe (2, 0)
   }
 
   "consuming on one channel" should
@@ -80,6 +84,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     r shouldBe None
     //there is a continuation stored in the storage
     store.isEmpty shouldBe false
+
+    store.eventsCounter.getCounts shouldBe (0, 1)
   }
 
   "consuming with a list of patterns that is a different length than the list of channels" should
@@ -88,6 +94,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       consume(store, List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (0, 1)
   }
 
   "consuming on three channels" should
@@ -108,6 +116,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     r shouldBe None
     //continuation is left in the storage
     store.isEmpty shouldBe false
+
+    store.eventsCounter.getCounts shouldBe (0, 1)
   }
 
   "producing and then consuming on the same channel" should
@@ -144,6 +154,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r2).results should contain theSameElementsAs List(List("datum"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (1, 1)
   }
 
   "producing three times then doing consuming three times" should "work" in withTestStore { store =>
@@ -174,6 +186,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r6).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (3, 3)
   }
 
   "producing on channel, consuming on that channel and another, and then producing on the other channel" should
@@ -238,6 +252,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r3).results should contain theSameElementsAs List(List("datum1", "datum2"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (2, 1)
   }
 
   "producing on three different channels and then consuming once on all three" should
@@ -301,6 +317,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r4).results should contain theSameElementsAs List(List("datum1", "datum2", "datum3"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (3, 1)
   }
 
   "producing three times on the same channel then consuming three times on the same channel" should
@@ -339,6 +357,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
                                                          List("datum1"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (3, 3)
   }
 
   "consuming three times on the same channel, then producing three times on that channel" should
@@ -367,6 +387,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       getK(r2).results shouldNot contain theSameElementsAs getK(r3).results
 
       store.isEmpty shouldBe true
+
+      store.eventsCounter.getCounts shouldBe (3, 3)
   }
 
   "consuming three times on the same channel with non-trivial matches, then producing three times on that channel" should
@@ -390,6 +412,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r3).results shouldBe List(List("datum3"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (3, 3)
   }
 
   "consuming on two channels, producing on one, then producing on the other" should
@@ -411,6 +435,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r3).results should contain theSameElementsAs List(List("datum1", "datum2"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (2, 1)
   }
 
   "A joined consume with the same channel given twice followed by a produce" should
@@ -434,6 +460,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r3).results shouldBe List(List("datum1", "datum1"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (2, 1)
   }
 
   "consuming twice on the same channels with different patterns, and then producing on those channels" should
@@ -469,6 +497,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r6).results should contain theSameElementsAs List(List("datum1", "datum2"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (4, 2)
   }
 
   "consuming and producing with non-trivial matches" should
@@ -498,6 +528,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     }
 
     store.isEmpty shouldBe false
+
+    store.eventsCounter.getCounts shouldBe (1, 1)
   }
 
   "consuming twice and producing twice with non-trivial matches" should
@@ -520,6 +552,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     getK(r4).results should contain theSameElementsAs List(List("datum2"))
 
     store.isEmpty shouldBe true
+
+    store.eventsCounter.getCounts shouldBe (2, 2)
   }
 
   "consuming on two channels, consuming on one of those channels, and then producing on both of those channels separately" should
@@ -556,6 +590,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       }
 
       store.isEmpty shouldBe false
+
+      store.eventsCounter.getCounts shouldBe (2, 2)
     }
 
   /* Persist tests */
@@ -598,6 +634,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     }
 
     r3 shouldBe None
+
+    store.eventsCounter.getCounts shouldBe (1, 2)
   }
 
   "producing, doing a persistent consume, and producing again on the same channel" should
@@ -654,6 +692,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       runK(r4)
 
       getK(r4).results should contain theSameElementsAs List(List("datum2"))
+
+      store.eventsCounter.getCounts shouldBe (2, 2)
   }
 
   "doing a persistent consume and producing multiple times" should "work" in withTestStore {
@@ -692,6 +732,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       runK(r3)
 
       getK(r3).results should contain theSameElementsAs List(List("datum2"))
+
+      store.eventsCounter.getCounts shouldBe (2, 1)
   }
 
   "consuming and doing a persistient produce" should "work" in withTestStore { store =>
@@ -719,6 +761,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       store.getData(txn, List("ch1")) shouldBe List(Datum("datum1", persist = true))
       store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
     }
+
+    store.eventsCounter.getCounts shouldBe (2, 1)
   }
 
   "consuming, doing a persistient produce, and consuming again" should "work" in withTestStore {
@@ -761,6 +805,7 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       getK(r4).results should contain theSameElementsAs List(List("datum1"))
 
+      store.eventsCounter.getCounts shouldBe (2, 2)
   }
 
   "doing a persistent produce and consuming twice" should "work" in withTestStore { store =>
@@ -798,6 +843,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     runK(r3)
 
     getK(r3).results should contain theSameElementsAs List(List("datum1"))
+
+    store.eventsCounter.getCounts shouldBe (1, 2)
   }
 
   "producing three times and doing a persistent consume" should "work" in withTestStore { store =>
@@ -865,6 +912,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     }
 
     r7 shouldBe None
+
+    store.eventsCounter.getCounts shouldBe (3, 4)
   }
 }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -29,7 +29,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     //store is not empty - we have 'A' stored
     store.isEmpty shouldBe false
 
-    store.eventsCounter.getCounts shouldBe (1, 0)
+    store.eventsCounter.getProducesCount shouldBe 1
+    store.eventsCounter.getConsumesCount shouldBe 0
   }
 
   "producing twice on the same channel" should
@@ -63,7 +64,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     //store is not empty - we have 2 As stored
     store.isEmpty shouldBe false
 
-    store.eventsCounter.getCounts shouldBe (2, 0)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 0
   }
 
   "consuming on one channel" should
@@ -85,7 +87,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     //there is a continuation stored in the storage
     store.isEmpty shouldBe false
 
-    store.eventsCounter.getCounts shouldBe (0, 1)
+    store.eventsCounter.getProducesCount shouldBe 0
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming with a list of patterns that is a different length than the list of channels" should
@@ -95,7 +98,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (0, 1)
+    store.eventsCounter.getProducesCount shouldBe 0
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming on three channels" should
@@ -117,7 +121,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     //continuation is left in the storage
     store.isEmpty shouldBe false
 
-    store.eventsCounter.getCounts shouldBe (0, 1)
+    store.eventsCounter.getProducesCount shouldBe 0
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "producing and then consuming on the same channel" should
@@ -155,7 +160,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (1, 1)
+    store.eventsCounter.getProducesCount shouldBe 1
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "producing three times then doing consuming three times" should "work" in withTestStore { store =>
@@ -187,7 +193,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (3, 3)
+    store.eventsCounter.getProducesCount shouldBe 3
+    store.eventsCounter.getConsumesCount shouldBe 3
   }
 
   "producing on channel, consuming on that channel and another, and then producing on the other channel" should
@@ -253,7 +260,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (2, 1)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "producing on three different channels and then consuming once on all three" should
@@ -318,7 +326,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (3, 1)
+    store.eventsCounter.getProducesCount shouldBe 3
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "producing three times on the same channel then consuming three times on the same channel" should
@@ -358,7 +367,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (3, 3)
+    store.eventsCounter.getProducesCount shouldBe 3
+    store.eventsCounter.getConsumesCount shouldBe 3
   }
 
   "consuming three times on the same channel, then producing three times on that channel" should
@@ -388,7 +398,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       store.isEmpty shouldBe true
 
-      store.eventsCounter.getCounts shouldBe (3, 3)
+      store.eventsCounter.getProducesCount shouldBe 3
+      store.eventsCounter.getConsumesCount shouldBe 3
   }
 
   "consuming three times on the same channel with non-trivial matches, then producing three times on that channel" should
@@ -413,7 +424,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (3, 3)
+    store.eventsCounter.getProducesCount shouldBe 3
+    store.eventsCounter.getConsumesCount shouldBe 3
   }
 
   "consuming on two channels, producing on one, then producing on the other" should
@@ -436,7 +448,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (2, 1)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "A joined consume with the same channel given twice followed by a produce" should
@@ -461,7 +474,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (2, 1)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming twice on the same channels with different patterns, and then producing on those channels" should
@@ -498,7 +512,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (4, 2)
+    store.eventsCounter.getProducesCount shouldBe 4
+    store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "consuming and producing with non-trivial matches" should
@@ -529,7 +544,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe false
 
-    store.eventsCounter.getCounts shouldBe (1, 1)
+    store.eventsCounter.getProducesCount shouldBe 1
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming twice and producing twice with non-trivial matches" should
@@ -553,7 +569,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     store.isEmpty shouldBe true
 
-    store.eventsCounter.getCounts shouldBe (2, 2)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "consuming on two channels, consuming on one of those channels, and then producing on both of those channels separately" should
@@ -591,7 +608,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       store.isEmpty shouldBe false
 
-      store.eventsCounter.getCounts shouldBe (2, 2)
+      store.eventsCounter.getProducesCount shouldBe 2
+      store.eventsCounter.getConsumesCount shouldBe 2
     }
 
   /* Persist tests */
@@ -635,7 +653,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     r3 shouldBe None
 
-    store.eventsCounter.getCounts shouldBe (1, 2)
+    store.eventsCounter.getProducesCount shouldBe 1
+    store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "producing, doing a persistent consume, and producing again on the same channel" should
@@ -693,7 +712,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       getK(r4).results should contain theSameElementsAs List(List("datum2"))
 
-      store.eventsCounter.getCounts shouldBe (2, 2)
+      store.eventsCounter.getProducesCount shouldBe 2
+      store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "doing a persistent consume and producing multiple times" should "work" in withTestStore {
@@ -733,7 +753,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       getK(r3).results should contain theSameElementsAs List(List("datum2"))
 
-      store.eventsCounter.getCounts shouldBe (2, 1)
+      store.eventsCounter.getProducesCount shouldBe 2
+      store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming and doing a persistient produce" should "work" in withTestStore { store =>
@@ -762,7 +783,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
       store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
     }
 
-    store.eventsCounter.getCounts shouldBe (2, 1)
+    store.eventsCounter.getProducesCount shouldBe 2
+    store.eventsCounter.getConsumesCount shouldBe 1
   }
 
   "consuming, doing a persistient produce, and consuming again" should "work" in withTestStore {
@@ -805,7 +827,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
       getK(r4).results should contain theSameElementsAs List(List("datum1"))
 
-      store.eventsCounter.getCounts shouldBe (2, 2)
+      store.eventsCounter.getProducesCount shouldBe 2
+      store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "doing a persistent produce and consuming twice" should "work" in withTestStore { store =>
@@ -844,7 +867,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     getK(r3).results should contain theSameElementsAs List(List("datum1"))
 
-    store.eventsCounter.getCounts shouldBe (1, 2)
+    store.eventsCounter.getProducesCount shouldBe 1
+    store.eventsCounter.getConsumesCount shouldBe 2
   }
 
   "producing three times and doing a persistent consume" should "work" in withTestStore { store =>
@@ -913,7 +937,8 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
 
     r7 shouldBe None
 
-    store.eventsCounter.getCounts shouldBe (3, 4)
+    store.eventsCounter.getProducesCount shouldBe 3
+    store.eventsCounter.getConsumesCount shouldBe 4
   }
 }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -155,6 +155,7 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     _waitingContinuations.clear()
     _data.clear()
     _joinMap.clear()
+    eventsCounter.reset()
   }
 
   def getStoreCounters: StoreCounters =

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -7,7 +7,7 @@ import coop.rchain.rspace.examples._
 import coop.rchain.rspace.history.{Blake2b256Hash, Trie}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.dropIndex
-import coop.rchain.rspace.{IStore, ITestableStore, Serialize, StoreSize}
+import coop.rchain.rspace.{IStore, ITestableStore, Serialize, StoreCounters, StoreEventsCounter}
 import javax.xml.bind.DatatypeConverter.printHexBinary
 
 import scala.collection.immutable.Seq
@@ -25,6 +25,8 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
   private[rspace] type H = String
 
   private[rspace] type T = Unit
+
+  val eventsCounter: StoreEventsCounter = new StoreEventsCounter()
 
   private[rspace] def hashChannels(cs: Seq[C])(implicit sc: Serialize[C]): H =
     printHexBinary(InMemoryStore.hashBytes(cs.flatMap(sc.encode).toArray))
@@ -155,8 +157,10 @@ class InMemoryStore[C, P, A, K <: Serializable] private (
     _joinMap.clear()
   }
 
-  def getStoreSize: StoreSize =
-    StoreSize(0, (_keys.size + _waitingContinuations.size + _data.size + _joinMap.size).toLong)
+  def getStoreCounters: StoreCounters =
+    eventsCounter.createCounters(
+      0,
+      (_keys.size + _waitingContinuations.size + _data.size + _joinMap.size).toLong)
 
   def isEmpty: Boolean =
     _waitingContinuations.isEmpty && _data.isEmpty && _keys.isEmpty && _joinMap.isEmpty

--- a/shared/src/main/scala/coop/rchain/shared/LongOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/LongOps.scala
@@ -16,8 +16,9 @@ object LongOps {
       if (value < 1024) {
         value + " B"
       } else {
-        val z = 63 - numberOfLeadingZeros(value)
-        "%.1f %sB".formatLocal(Locale.US, value.toDouble / (1L << z), " KMGTPE".charAt(z / 10))
+        //division and then multiplication by 10 resets trailing bits
+        val z: Int = (63 - numberOfLeadingZeros(value)) / 10
+        "%.1f %sB".formatLocal(Locale.US, value.toDouble / (1L << (z * 10)), " KMGTPE".charAt(z))
       }
   }
 }


### PR DESCRIPTION
## Overview
With this commit RSpace will track and reports (via metrics) counts of produces, consumes and average time of calls. Tested on recursive contract "loop_recursive.rho"

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-529
