### PR TITLE
Remove curve2559Encrypt from rholang

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -59,10 +59,9 @@ object Runtime {
       2L -> SystemProcesses.stderr,
       3L -> SystemProcesses.stderrAck(store, dispatcher),
       4L -> SystemProcesses.ed25519Verify(store, dispatcher),
-      5L -> SystemProcesses.curve25519Encrypt(store, dispatcher),
-      6L -> SystemProcesses.sha256Hash(store, dispatcher),
-      7L -> SystemProcesses.keccak256Hash(store, dispatcher),
-      8L -> SystemProcesses.blake2b256Hash(store, dispatcher)
+      5L -> SystemProcesses.sha256Hash(store, dispatcher),
+      6L -> SystemProcesses.keccak256Hash(store, dispatcher),
+      7L -> SystemProcesses.blake2b256Hash(store, dispatcher)
       //TODO: once we have secp256k1 packaged as jar
 //      9L -> SystemProcesses.secp256k1Verify(store, dispatcher)
     )
@@ -73,10 +72,9 @@ object Runtime {
       ("stderr", 1, None, 2L),
       ("stderrAck", 2, None, 3L),
       ("ed25519Verify", 4, None, 4L),
-      ("curve25519Encrypt", 5, None, 5L),
-      ("sha256Hash", 2, None, 6L),
-      ("keccak256Hash", 2, None, 7L),
-      ("blake2b256Hash", 2, None, 8L)
+      ("sha256Hash", 2, None, 5L),
+      ("keccak256Hash", 2, None, 6L),
+      ("blake2b256Hash", 2, None, 7L)
       //TODO: once we have secp256k1 packaged as jar
 //      ("secp256k1Verify", 4, None, 9L)
     )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -87,23 +87,6 @@ object SystemProcesses {
         "ed25519Verify expects data, signature and public key (all as byte arrays) and ack channel as arguments")
   }
 
-  def curve25519Encrypt(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                        dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
-    : Seq[Seq[Channel]] => Task[Unit] = {
-    case Seq(
-        Seq(IsByteArray(pub), IsByteArray(sec), IsByteArray(nonce), IsByteArray(message), ack)) =>
-      Task.fromTry(Try(Curve25519.encrypt(pub, sec, nonce, message))).flatMap { encrypted =>
-        produce(store,
-                ack,
-                Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(encrypted)))))),
-                false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
-      }
-    case _ =>
-      illegalArgumentException(
-        "curve25519Encrypt expects public key, private key, nonce, message (all as byte arrays) and ack channel as arguments")
-  }
-
   def sha256Hash(store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
                  dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -114,39 +114,6 @@ class CryptoChannelsSpec
   type Nonce      = Array[Byte]
   type Data       = Array[Byte]
 
-  "curve25519Encrypt channel" should "encrypt data and send result on ack channel" in { fixture =>
-    val (reduce, store) = fixture
-
-    val curve25519EncryptChannel = Quote(GString("curve25519Encrypt"))
-    val ackChannel               = GString("x")
-
-    val (secKey, pubKey) = Curve25519.newKeyPair
-
-    implicit val emptyEnv                             = Env[Par]()
-    val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel) _
-
-    forAll { (par: Par) =>
-      val parByteArray: Array[Byte] = serialize(par)
-      val nonce                     = Curve25519.newNonce
-      val encrypted                 = Curve25519.encrypt(pubKey, secKey, nonce, parByteArray)
-
-      val nonceExpr     = byteArrayToExpr(nonce)
-      val pubKeyExpr    = byteArrayToExpr(pubKey)
-      val secKeyExpr    = byteArrayToExpr(secKey)
-      val serializedPar = byteArrayToExpr(parByteArray)
-
-      val expecting = byteArrayToExpr(encrypted)
-
-      val send = Send(curve25519EncryptChannel,
-                      List(pubKeyExpr, secKeyExpr, nonceExpr, serializedPar, ackChannel),
-                      persistent = false,
-                      BitSet())
-      Await.result(reduce.eval(send).runAsync, 3.seconds)
-      storeContainsTest(List[Channel](Quote(expecting)))
-      clearStore(store, reduce, ackChannel)
-    }
-  }
-
   "secp256k1Verify channel" should "verify integrity of the data and send result on ack channel" in {
     fixture =>
       pending


### PR DESCRIPTION
## Overview
After brief discussion on cryptography channel on discord @pyrocto advised to remove `curve2559Encrypt` from rholang as we don't want to expose crypto primitives that require users to put their secrets on blockchain.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
