### PR TITLE
Core 590 - use full path for rnode assembly command for dockerpy support

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -111,8 +111,7 @@ if len(sys.argv)==1:
 # Define globals
 args = parser.parse_args()
 client = docker.from_env()
-RNODE_CMD = 'java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar /rnode-assembly-*.jar'
-
+RNODE_CMD = 'java -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -jar /rnode-assembly-0.4.1.jar'
 
 
 def main():
@@ -212,6 +211,8 @@ def deploy_demo():
     for container in client.containers.list(all=True, filters={"name":f"peer\d.{args.network}"}):
         try:
             r = container.exec_run(cmd=cmd, detach=True)
+            if r.exit_code:
+                raise Exception(f"ERROR: There was an issue executing --demo-deploy command on {container.name}")
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
## Overview
dockerpy doesn't support passing wildcard "*" into command variable causing issues on some commands. See ticket for more info.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&modal=detail&selectedIssue=CORE-590

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
