### PR TITLE
OPS 143 - Removing P2P test network update from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,24 +78,6 @@ matrix:
           - haskell-platform
           - rpm
           - fakeroot
-  - language: scala
-    env: SUBPROJECT=cloud-p2p-test-network
-    scala: 2.12.4
-    sbt_args: -no-colors
-    install:
-      - ./scripts/install_secp.sh
-      - ./scripts/install_sodium.sh
-      - ./scripts/install_bnfc.sh
-    addons:
-      apt:
-        sources:
-          - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
-        packages:
-          - sbt
-          - jflex
-          - haskell-platform
-          - rpm
-          - fakeroot
   - language: nix 
     env: SUBPROJECT=rholang_more_tests
     install:


### PR DESCRIPTION
## Overview
Removing p2p test network update on dev commit from CI in order improve CI completion time. Offloading this to just a shared dev environment/sandbox.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/OPS-143

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [ x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes

