### PR TITLE
CORE-589 Test produce and consume in a multithreaded fashion

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -330,15 +330,22 @@ object LMDBStore {
     * @tparam A A type representing a piece of data
     * @tparam K A type representing a continuation
     */
-  def create[C, P, A, K](path: Path, mapSize: Long)(implicit sc: Serialize[C],
-                                                    sp: Serialize[P],
-                                                    sa: Serialize[A],
-                                                    sk: Serialize[K]): LMDBStore[C, P, A, K] = {
+  def create[C, P, A, K](path: Path, mapSize: Long, noTls: Boolean = true)(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): LMDBStore[C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
     implicit val codecA: Codec[A] = sa.toCodec
     implicit val codecK: Codec[K] = sk.toCodec
+
+    val flags =
+      if (noTls)
+        List(EnvFlags.MDB_NOTLS)
+      else
+        List.empty[EnvFlags]
 
     val env: Env[ByteBuffer] =
       Env
@@ -346,7 +353,7 @@ object LMDBStore {
         .setMapSize(mapSize)
         .setMaxDbs(8)
         .setMaxReaders(126)
-        .open(path.toFile)
+        .open(path.toFile, flags: _*)
 
     val dbGNATs: Dbi[ByteBuffer] = env.openDbi(dataTableName, MDB_CREATE)
     val dbJoins: Dbi[ByteBuffer] = env.openDbi(joinsTableName, MDB_CREATE)

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
@@ -87,9 +87,9 @@ private[rspace] class StoreEventsCounter(
       val now         = nanoTime
       val currentRate = eventsQueue.asScala.count(x => now - x <= registrationIntervalNanoseconds)
       val avgTimeMilliseconds = if (comm) {
-        exSum.avgTimeMilliseconds
-      } else {
         0.0
+      } else {
+        exSum.avgTimeMilliseconds
       }
       StoreCount(exSum.count, avgTimeMilliseconds, exSum.peakRate, currentRate)
     }

--- a/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -1,0 +1,195 @@
+package coop.rchain.rspace
+
+import coop.rchain.rspace.examples.AddressBookExample._
+import coop.rchain.rspace.examples.AddressBookExample.implicits._
+import coop.rchain.rspace.extended._
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import scala.concurrent.Await
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
+
+trait ConcurrencyTests extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor] {
+
+  def version: String
+
+  "CORE-589 produce and consume in a multithreaded fashion" should
+    "show high performance" in withTestSpace { space =>
+    val arrResults      = new Array[Long](Runtime.getRuntime.availableProcessors)
+    val iterationsCount = 500
+
+    def createThread(threadIndex: Int, iterations: Int): Thread =
+      new Thread(() => {
+        val channel = Channel("friends#" + threadIndex.toString)
+        val start   = System.nanoTime()
+
+        for (_ <- 1 to iterations) {
+          val r1 = space.consume(
+            List(channel, channel),
+            List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+            new EntriesCaptor,
+            persist = false
+          )
+
+          r1 shouldBe None
+
+          val r2 = space.produce(channel, bob, persist = false)
+
+          r2 shouldBe None
+
+          val r3 = space.produce(channel, bob, persist = false)
+
+          r3 shouldBe defined
+
+          runK(r3)
+          getK(r3).results shouldBe List(List(bob, bob))
+        }
+
+        val end  = System.nanoTime()
+        val diff = Math.max(end - start, 0)
+
+        arrResults(threadIndex) = math.max(arrResults(threadIndex), diff)
+      })
+
+    val throwMap = TrieMap[Thread, Throwable]()
+
+    //warm-up pass - short 10 iterations loop should be enough
+    val tWarmup = createThread(0, 10)
+    tWarmup.setUncaughtExceptionHandler((t, e) => throwMap += t -> e)
+    tWarmup.start()
+    tWarmup.join()
+    arrResults(0) = 0
+    //benchmark pass
+    val allThreads = arrResults.indices
+      .map(index => createThread(index, iterationsCount))
+      .map(thread => {
+        thread.setUncaughtExceptionHandler((t, e) => throwMap += t -> e)
+        thread.start()
+        thread
+      })
+      .toList
+
+    allThreads.foreach(_.join())
+
+    if (throwMap.nonEmpty) {
+      throwMap.values.toList match {
+        case ex :: tail =>
+          val throwEx = new Exception(ex)
+          tail.foreach(t => throwEx.addSuppressed(t))
+          throw throwEx
+        case _ => //impossible
+      }
+    }
+
+    val min = nsToMs(arrResults.min)
+    val max = nsToMs(arrResults.max)
+    val avg = arrResults.map(x => nsToMs(x) * (1.0 / arrResults.length)).sum
+
+    val counter = space.store.getStoreCounters
+
+    println(s"Finished $version: $iterationsCount iterations.")
+    println(
+      s"${counter.producesCount} produces, avg ${counter.producesCount.avgMilliseconds.formatted("%.2f")} ms per produce")
+    println(
+      s"${counter.consumesCount} consumes, avg ${counter.consumesCount.avgMilliseconds.formatted("%.2f")} ms per consume")
+
+    println(
+      s"Time per thread: avg: ${avg.formatted("%.2f")} ms; min: " +
+        s"${min.formatted("%.2f")} ms; max: ${max.formatted("%.2f")} ms")
+  }
+
+  "produce and consume with monix.Tasks" should "work" in withTestSpace { space =>
+    val tasksCount      = Runtime.getRuntime.availableProcessors
+    val iterationsCount = 500
+
+    def createTask(taskIndex: Int, iterations: Int): Task[Long] =
+      Task {
+        val channel = Channel("friends#" + taskIndex.toString)
+        val start   = System.nanoTime()
+
+        for (_ <- 1 to iterations) {
+          val r1 = space.produce(channel, bob, persist = false)
+
+          r1 shouldBe None
+
+          val r2 = space.produce(channel, bob, persist = false)
+
+          r2 shouldBe None
+
+          val r3 = space.consume(
+            List(channel, channel),
+            List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+            new EntriesCaptor,
+            persist = false
+          )
+
+          r3 shouldBe defined
+
+          runK(r3)
+          getK(r3).results shouldBe List(List(bob, bob))
+        }
+
+        val end  = System.nanoTime()
+        val diff = Math.max(end - start, 0)
+        diff
+      }
+    //warm-up pass - short 10 iterations loop should be enough
+    val tWarmup = createTask(0, iterationsCount)
+    val fWarmup = tWarmup.runAsync
+    Await.ready(fWarmup, Duration.Inf)
+    //benchmark pass
+    val tasks = (1 to tasksCount).map(idx => {
+      val task = createTask(idx, iterationsCount)
+      task.runAsync
+    })
+
+    val times = tasks.map(t => Await.result(t, Duration.Inf))
+    val min   = nsToMs(times.min)
+    val max   = nsToMs(times.max)
+    val avg   = times.map(x => nsToMs(x) * (1.0 / times.length)).sum
+
+    val counter = space.store.getStoreCounters
+
+    println(s"Finished $version: $iterationsCount iterations.")
+    println(
+      s"${counter.producesCount} produces, avg ${counter.producesCount.avgMilliseconds.formatted("%.2f")} ms per produce")
+    println(
+      s"${counter.consumesCount} consumes, avg ${counter.consumesCount.avgMilliseconds.formatted("%.2f")} ms per consume")
+
+    println(
+      s"Time per thread: avg: ${avg.formatted("%.2f")} ms; min: " +
+        s"${min.formatted("%.2f")} ms; max: ${max.formatted("%.2f")} ms")
+  }
+
+  def nsToMs(nanoseconds: Long): Double =
+    nanoseconds * (1.0 / 1000000.0)
+
+  val bob = Entry(name = Name("Bob", "Lahblah"),
+                  address = Address("1000 Main St", "Crystal Lake", "Idaho", "223322"),
+                  email = "blablah@tenex.net",
+                  phone = "698-555-1212")
+}
+
+class InMemoryStoreConcurrencyTests
+    extends InMemoryStoreStorageExamplesTestsBase
+    with ConcurrencyTests {
+  override def version: String = "InMemory"
+}
+
+class LMDBStoreConcurrencyTestsWithTls
+    extends LMDBStoreStorageExamplesTestBase
+    with ConcurrencyTests {
+  override def version: String = "LMDB with TLS"
+
+  override def noTls: Boolean = false
+}
+
+class LMDBStoreConcurrencyTestsNoTls
+    extends LMDBStoreStorageExamplesTestBase
+    with ConcurrencyTests {
+
+  override def version: String = "LMDB NO_TLS"
+
+  override def noTls: Boolean = true
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -274,7 +274,8 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
   }
 }
 
-class InMemoryStoreStorageExamplesTests extends StorageExamplesTests {
+class InMemoryStoreStorageExamplesTestsBase
+    extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor] {
 
   override def withTestSpace[R](f: T => R): R = {
     val testStore = InMemoryStore.create[Channel, Pattern, Entry, EntriesCaptor]
@@ -288,13 +289,21 @@ class InMemoryStoreStorageExamplesTests extends StorageExamplesTests {
   }
 }
 
-class LMDBStoreStorageExamplesTest extends StorageExamplesTests with BeforeAndAfterAll {
+class InMemoryStoreStorageExamplesTests
+    extends InMemoryStoreStorageExamplesTestsBase
+    with StorageExamplesTests
+
+class LMDBStoreStorageExamplesTestBase
+    extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor]
+    with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
   val mapSize: Long = 1024L * 1024L * 1024L
 
+  def noTls: Boolean = false
+
   override def withTestSpace[R](f: T => R): R = {
-    val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize)
+    val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testSpace = new RSpace(testStore)
     try {
       testStore.withTxn(testStore.createTxnWrite())(txn => testStore.clear(txn))
@@ -309,3 +318,7 @@ class LMDBStoreStorageExamplesTest extends StorageExamplesTests with BeforeAndAf
     super.afterAll()
   }
 }
+
+class LMDBStoreStorageExamplesTest
+    extends LMDBStoreStorageExamplesTestBase
+    with StorageExamplesTests


### PR DESCRIPTION
## Overview
The test launches 1000 iterations of one of RSpace examples (Address Book), and shows per-thread and produce/consume ops performance. Example is used as a ground since it better matches real store working conditions.

Also removed some code duplication by refactoring InMemoryStoreTestsBase and LMDBStoreTestsBase

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-589