### PR TITLE
Add OpExtend

### DIFF
--- a/roscala/src/main/scala/coop/rchain/roscala/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Location.scala
@@ -2,7 +2,7 @@ package coop.rchain.roscala
 
 import coop.rchain.roscala.ob._
 
-sealed trait Location
+sealed trait Location                                              extends Ob
 case class ArgRegister(arg: Int)                                   extends Location
 case class GlobalVar(offset: Int)                                  extends Location
 case class LexVariable(level: Int, offset: Int, indirect: Boolean) extends Location
@@ -28,6 +28,9 @@ object Location {
           ctxt.argvec.update(arg, value)
           false
         }
+
+      case LexVariable(level, offset, indirect) =>
+        ctxt.env.setLex(indirect, level, offset, value) == Invalid
 
       case _ => true
     }

--- a/roscala/src/main/scala/coop/rchain/roscala/Opcode.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Opcode.scala
@@ -1,16 +1,21 @@
 package coop.rchain.roscala
 
 sealed trait Opcode
-case class OpAlloc(n: Int)                                                 extends Opcode
-case class OpFork(pc: Int)                                                 extends Opcode
-case class OpImmediateLitToArg(literal: Int, arg: Int)                     extends Opcode
-case class OpImmediateLitToReg(literal: Int, reg: Int)                     extends Opcode
-case class OpIndLitToArg(lit: Int, arg: Int)                               extends Opcode
-case class OpJmpFalse(pc: Int)                                             extends Opcode
-case class OpOutstanding(pc: Int, n: Int)                                  extends Opcode
-case class OpPushAlloc(n: Int)                                             extends Opcode
-case class OpRtn(next: Boolean)                                            extends Opcode
-case class OpXferGlobalToArg(global: Int, arg: Int)                        extends Opcode
-case class OpXferGlobalToReg(global: Int, reg: Int)                        extends Opcode
-case class OpXmit(unwind: Boolean, next: Boolean, nargs: Int)              extends Opcode
-case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int) extends Opcode
+case class OpAlloc(n: Int)                                                      extends Opcode
+case class OpExtend(lit: Int)                                                   extends Opcode
+case class OpFork(pc: Int)                                                      extends Opcode
+case class OpImmediateLitToArg(literal: Int, arg: Int)                          extends Opcode
+case class OpImmediateLitToReg(literal: Int, reg: Int)                          extends Opcode
+case class OpIndLitToArg(lit: Int, arg: Int)                                    extends Opcode
+case class OpJmp(pc: Int)                                                       extends Opcode
+case class OpJmpFalse(pc: Int)                                                  extends Opcode
+case class OpNargs(n: Int)                                                      extends Opcode
+case class OpOutstanding(pc: Int, n: Int)                                       extends Opcode
+case class OpPushAlloc(n: Int)                                                  extends Opcode
+case class OpRtn(next: Boolean)                                                 extends Opcode
+case class OpXferGlobalToArg(global: Int, arg: Int)                             extends Opcode
+case class OpXferGlobalToReg(global: Int, reg: Int)                             extends Opcode
+case class OpXferLexToReg(indirect: Boolean, level: Int, offset: Int, reg: Int) extends Opcode
+case class OpXferRsltToDest(lit: Int)                                           extends Opcode
+case class OpXmit(unwind: Boolean, next: Boolean, nargs: Int)                   extends Opcode
+case class OpXmitArg(unwind: Boolean, next: Boolean, nargs: Int, arg: Int)      extends Opcode

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -1,7 +1,8 @@
 package coop.rchain.roscala
 
-import coop.rchain.roscala.ob._
 import com.typesafe.scalalogging.Logger
+import coop.rchain.roscala.Location._
+import coop.rchain.roscala.ob._
 
 import scala.collection.mutable
 
@@ -56,10 +57,41 @@ object Vm {
         state.ctxt.argvec = Tuple(new Array[Ob](n))
         state.nextOpFlag = true
 
+      case OpNargs(n) =>
+        state.ctxt.nargs = n
+        state.nextOpFlag = true
+
       case OpPushAlloc(n) =>
         val t = Tuple(new Array[Ob](n))
         state.ctxt = Ctxt(t, state.ctxt)
         state.nextOpFlag = true
+
+      case OpExtend(lit) =>
+        val formals    = state.code.litvec(lit).asInstanceOf[Template]
+        val optActuals = formals.`match`(state.ctxt.argvec, state.ctxt.nargs)
+
+        optActuals match {
+          case Some(actuals) =>
+            /**
+              * Creates an `Extension` that maps from formals (e.g. `Symbol(x)`)
+              * to actuals (e.g. `Fixnum(1)`).
+              * Formals are given in `formals.keyMeta` and `actuals` is a `Tuple`.
+              * The current `env` becomes the parent of the newly created `Extension`.
+              */
+            val pairsStr = formals.keyMeta.map.keys
+              .zip(actuals.value)
+              .map { case (key, value) => s"$key -> $value" }
+              .mkString(", ")
+            logger.debug(s"Extend current env with: $pairsStr")
+
+            val extended = state.ctxt.env.extendWith(formals.keyMeta, actuals)
+            state.ctxt.env = extended
+            state.ctxt.nargs = 0
+            state.nextOpFlag = true
+
+          case None =>
+            state.doNextThreadFlag = true
+        }
 
       case OpOutstanding(pc, n) =>
         state.ctxt.pc = pc
@@ -77,6 +109,10 @@ object Vm {
 
       case OpImmediateLitToArg(literal, arg) =>
         state.ctxt.argvec.update(arg, vmLiterals(literal))
+        state.nextOpFlag = true
+
+      case OpJmp(pc) =>
+        state.pc = pc
         state.nextOpFlag = true
 
       case OpJmpFalse(pc) =>
@@ -102,6 +138,26 @@ object Vm {
         val ob = globalEnv.values(global)
         state.ctxt.argvec.update(arg, ob)
         state.nextOpFlag = true
+
+      case OpXferLexToReg(indirect, level, offset, reg) =>
+        var env = state.ctxt.env
+        for (_ <- 0 until level) env = env.parent
+
+        if (indirect) env = env.asInstanceOf[Actor].extension
+
+        logger.debug(s"Xfer ${env.slot(offset)} from lex[$level, $offset] to ${regName(reg)}")
+
+        state.ctxt.setReg(reg, env.slot(offset))
+        state.nextOpFlag = true
+
+      case OpXferRsltToDest(lit) =>
+        val loc = state.code.litvec(lit).asInstanceOf[Location]
+        logger.debug(s"Xfer ${state.ctxt.rslt} to $loc")
+
+        if (store(loc, state.ctxt, state.ctxt.rslt))
+          state.vmErrorFlag = true
+        else
+          state.nextOpFlag = true
 
       case OpFork(pc) =>
         val newCtxt = state.ctxt.clone()

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -68,7 +68,7 @@ object Vm {
 
       case OpExtend(lit) =>
         val formals    = state.code.litvec(lit).asInstanceOf[Template]
-        val optActuals = formals.`match`(state.ctxt.argvec, state.ctxt.nargs)
+        val optActuals = formals.matchPattern(state.ctxt.argvec, state.ctxt.nargs)
 
         optActuals match {
           case Some(actuals) =>

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Meta.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Meta.scala
@@ -84,3 +84,5 @@ case class Meta(map: mutable.Map[Ob, Location], var refCount: Int, var extensibl
 object Meta {
   def empty = Meta(map = mutable.Map(), 0, extensible = true)
 }
+
+object NilMeta extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
@@ -14,6 +14,12 @@ abstract class Ob {
 
   def dispatch(state: State, globalEnv: GlobalEnv): Ob = Niv
 
+  def extendWith(keyMeta: Ob, argvec: Tuple): Ob =
+    if (keyMeta == NilMeta)
+      this
+    else
+      argvec.becomeExtension(keyMeta.asInstanceOf[Meta], this)
+
   def invoke(state: State, globalEnv: GlobalEnv): Ob = Niv
 
   /** Tries to lookup value for key and then invokes the value
@@ -40,7 +46,7 @@ abstract class Ob {
   def getLex(indirect: Boolean, level: Int, offset: Int): Ob = {
     var p = this
 
-    for (_ <- 0 to level) p = p.parent
+    for (_ <- 0 until level) p = p.parent
 
     if (indirect) {
       p = p.asInstanceOf[Actor].extension
@@ -52,7 +58,7 @@ abstract class Ob {
   def setLex(indirect: Boolean, level: Int, offset: Int, value: Ob): Ob = {
     var p = this
 
-    for (_ <- 0 to level) p = p.parent
+    for (_ <- 0 until level) p = p.parent
 
     if (indirect) {
       p = p.asInstanceOf[Actor].extension

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Template.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Template.scala
@@ -1,0 +1,19 @@
+package coop.rchain.roscala.ob
+
+import coop.rchain.roscala.ob.expr.TupleExpr
+
+class Template(val keyTuple: Tuple, val pat: CompoundPattern, val keyMeta: Meta) extends Ob {
+  def `match`(argvec: Tuple, nargs: Int): Option[Tuple] =
+    pat.`match`(argvec, nargs)
+}
+
+abstract class CompoundPattern(expr: TupleExpr) {
+  def `match`(argvec: Tuple, nargs: Int): Option[Tuple]
+}
+
+class IdVecPattern(expr: TupleExpr) extends CompoundPattern(expr) {
+  override def `match`(argvec: Tuple, nargs: Int): Option[Tuple] = {
+    val need = expr.numberOfElements()
+    if (need == nargs) Some(argvec) else None
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Template.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Template.scala
@@ -3,16 +3,19 @@ package coop.rchain.roscala.ob
 import coop.rchain.roscala.ob.expr.TupleExpr
 
 class Template(val keyTuple: Tuple, val pat: CompoundPattern, val keyMeta: Meta) extends Ob {
-  def `match`(argvec: Tuple, nargs: Int): Option[Tuple] =
-    pat.`match`(argvec, nargs)
+  /* In Rosette this method is called `match` */
+  def matchPattern(argvec: Tuple, nargs: Int): Option[Tuple] =
+    pat.matchExpr(argvec, nargs)
 }
 
 abstract class CompoundPattern(expr: TupleExpr) {
-  def `match`(argvec: Tuple, nargs: Int): Option[Tuple]
+  /* In Rosette this method is called `match` */
+  def matchExpr(argvec: Tuple, nargs: Int): Option[Tuple]
 }
 
 class IdVecPattern(expr: TupleExpr) extends CompoundPattern(expr) {
-  override def `match`(argvec: Tuple, nargs: Int): Option[Tuple] = {
+  /* In Rosette this method is called `match` */
+  override def matchExpr(argvec: Tuple, nargs: Int): Option[Tuple] = {
     val need = expr.numberOfElements()
     if (need == nargs) Some(argvec) else None
   }

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
@@ -3,6 +3,15 @@ package coop.rchain.roscala.ob
 class Tuple(val value: Array[Ob]) extends Ob {
   def apply(n: Int): Ob = value(n)
 
+  def becomeExtension(newMeta: Meta, newParent: Ob): Extension = {
+    val extension = new Extension()
+    extension.meta = newMeta
+    extension.parent = newParent
+    extension.slot.appendAll(value)
+
+    extension
+  }
+
   def update(arg: Int, ob: Ob): Unit = value.update(arg, ob)
 
   def numberOfElements(): Int = value.length
@@ -10,6 +19,8 @@ class Tuple(val value: Array[Ob]) extends Ob {
 
 object Tuple {
   def apply(value: Array[Ob]): Tuple = new Tuple(value)
+
+  def apply(obs: Ob*): Tuple = new Tuple(obs.toArray[Ob])
 }
 
-case object Nil extends Ob
+object Nil extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/expr/Expr.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/expr/Expr.scala
@@ -1,0 +1,5 @@
+package coop.rchain.roscala.ob.expr
+
+import coop.rchain.roscala.ob.Ob
+
+class Expr extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/expr/TupleExpr.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/expr/TupleExpr.scala
@@ -1,0 +1,7 @@
+package coop.rchain.roscala.ob.expr
+
+import coop.rchain.roscala.ob.Ob
+
+class TupleExpr(elem: Seq[Ob], rest: Option[Ob] = None) extends Expr {
+  def numberOfElements(): Int = elem.size
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/package.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/package.scala
@@ -31,6 +31,21 @@ package object roscala {
     val monitor = 9
   }
 
+  def regName(reg: Int): String =
+    reg match {
+      case 0 => "rslt"
+      case 1 => "trgt"
+      case 2 => "argvec"
+      case 3 => "env"
+      case 4 => "code"
+      case 5 => "ctxt"
+      case 6 => "self"
+      case 7 => "selfEnv"
+      case 8 => "rcvr"
+      case 9 => "monitor"
+      case _ => "unknown"
+    }
+
   object VmLiteralName {
     val `0`   = 0
     val `1`   = 1

--- a/roscala/src/test/scala/coop/rchain/roscala/VmSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/VmSpec.scala
@@ -3,8 +3,11 @@ package coop.rchain.roscala
 import coop.rchain.roscala.CtxtRegName._
 import coop.rchain.roscala.VmLiteralName._
 import coop.rchain.roscala.ob._
+import coop.rchain.roscala.ob.expr.TupleExpr
 import coop.rchain.roscala.prim.fixnum.fxPlus
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable
 
 class VmSpec extends FlatSpec with Matchers {
 
@@ -133,5 +136,62 @@ class VmSpec extends FlatSpec with Matchers {
     Vm.run(ctxt, globalEnv, Vm.State())
 
     rtnCtxt.rslt shouldBe Fixnum(6)
+  }
+
+  "(let [[x #t]] (label l (if x (seq (set! x #f) (goto l)) 5)))" should "return 5" in {
+
+    /**
+      * litvec:
+      *    0:   {LetExpr}
+      *    1:   {Template}
+      *    2:   {Loc lex[0,0]}
+      * codevec:
+      *    0:   alloc 1
+      *    1:   lit #t,arg[0]
+      *    2:   nargs 1
+      *    3:   extend 1
+      *    4:   xfer lex[0,0],rslt
+      *    5:   jf 10
+      *    6:   lit #f,rslt
+      *    7:   xfer rslt,lex[0,0]
+      *    8:   xfer lex[0,0],rslt
+      *    9:   jmp 4
+      *   10:   lit 5,rslt
+      *   11:   rtn/nxt
+      */
+    val codevec = Seq(
+      OpAlloc(1),
+      OpImmediateLitToArg(literal = `#t`, arg = 0),
+      OpNargs(1),
+      OpExtend(1),
+      OpXferLexToReg(indirect = false, level = 0, offset = 0, reg = rslt),
+      OpJmpFalse(10),
+      OpImmediateLitToReg(literal = `#f`, reg = rslt),
+      OpXferRsltToDest(2),
+      OpXferLexToReg(indirect = false, level = 0, offset = 0, reg = rslt),
+      OpJmp(4),
+      OpImmediateLitToReg(literal = `5`, reg = rslt),
+      OpRtn(next = true)
+    )
+
+    val template = new Template(
+      keyTuple = Tuple(Symbol("x")),
+      pat = new IdVecPattern(new TupleExpr(Seq(Symbol("x")))),
+      keyMeta =
+        Meta(mutable.Map(Symbol("x") -> LexVariable(0, 0, indirect = false)), 0, extensible = false)
+    )
+
+    val lexVar = LexVariable(0, 0, indirect = false)
+
+    val rtnCtxt = Ctxt.outstanding(1)
+
+    val code = Code(litvec = Seq(Niv, template, lexVar), codevec = codevec)
+
+    val ctxt = Ctxt(code, rtnCtxt, LocRslt)
+    ctxt.env = new Extension()
+
+    Vm.run(ctxt, globalEnv, Vm.State())
+
+    rtnCtxt.rslt shouldBe Fixnum(5)
   }
 }


### PR DESCRIPTION
Add `OpExtend` test case and everything necessary to make it work.
We actually didn't get it right the first time because we were not aware of the details around `meta` and `StdExtension`.

The given `Template` provides a `meta` that contains the key (the formal) and a `Location` to the value (the actual).
The environment (`ctxt.env`) is then extended with this mapping from key to location to value.