### PR TITLE
CORE-575: rspace.history: add getLeaves

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -3,6 +3,9 @@ package coop.rchain.rspace
 import java.lang.{Byte => JByte}
 
 import cats.Eq
+import cats.syntax.traverse._
+import cats.instances.option._
+import cats.instances.vector._
 import cats.instances.byte._
 import cats.syntax.eq._
 import com.typesafe.scalalogging.Logger
@@ -37,6 +40,43 @@ package object history {
         case _             => throw new Exception(s"no node at $hash")
       }
     }
+
+  def getLeaves[T, K, V](store: ITrieStore[T, K, V]): Seq[Leaf[K, V]] = {
+    @tailrec
+    def loop(txn: T, ts: Seq[Trie[K, V]], ls: Seq[Leaf[K, V]]): Seq[Leaf[K, V]] =
+      ts match {
+        case Seq() =>
+          ls
+        case tries =>
+          val (next, acc) =
+            tries.foldLeft((Seq.empty[Trie[K, V]], ls)) {
+              case ((nexts, leaves), Node(pointerBlock)) =>
+                val children =
+                  pointerBlock.children
+                    .map(_._2)
+                    .traverse[Option, Trie[K, V]](hash => store.get(txn, hash))
+                    .getOrElse(throw new Exception("something went wrong"))
+                (nexts ++ children, leaves)
+              case ((nexts, leaves), leaf: Leaf[K, V]) =>
+                (nexts, leaves :+ leaf)
+            }
+          loop(txn, next, acc)
+      }
+    store.withTxn(store.createTxnRead()) { (txn: T) =>
+      val currentRoot =
+        store
+          .getRoot(txn)
+          .toRight(new Exception("could not get root hash"))
+          .flatMap { currentRootHash =>
+            store
+              .get(txn, currentRootHash)
+              .toRight(new Exception(s"could not get root at $currentRootHash "))
+          }
+          .toTry
+          .get
+      loop(txn, Seq(currentRoot), Seq.empty[Leaf[K, V]])
+    }
+  }
 
   def lookup[T, K, V](store: ITrieStore[T, K, V], key: K)(implicit codecK: Codec[K]): Option[V] = {
     val path = codecK.encode(key).map(_.bytes.toSeq).get

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
@@ -375,6 +375,43 @@ abstract class HistoryActionsTests[T] extends HistoryTestsBase[T, TestKey, ByteV
     }
   }
 
+  "getLeaves on an empty store" should "return an empty sequence" in
+    withTestTrieStore { store =>
+      getLeaves(store) shouldBe empty
+    }
+
+  "insert 6 things and getLeaves" should "return all of the leaves" in
+    withTestTrieStore { store =>
+      val expected: Vector[Leaf[TestKey, ByteVector]] = Vector(
+        Leaf(key1, val1),
+        Leaf(key2, val2),
+        Leaf(key3, val3),
+        Leaf(key4, val4),
+        Leaf(key5, val5),
+        Leaf(key6, val6)
+      )
+
+      insert(store, key1, val1)
+      insert(store, key2, val2)
+      insert(store, key3, val3)
+      insert(store, key4, val4)
+      insert(store, key5, val5)
+      insert(store, key6, val6)
+
+      val leaves = getLeaves(store)
+
+      leaves should contain allElementsOf expected
+    }
+
+  "insert a bunch of things and getLeaves" should "return all of the leaves" in
+    forAll { (kvs: Map[TestKey, ByteVector]) =>
+      withTestTrieStore { store =>
+        val expected = kvs.map { case (k, v) => Leaf(k, v) }
+        kvs.foreach { case (k, v) => insert(store, k, v) }
+        val leaves = getLeaves(store)
+        leaves should contain allElementsOf expected
+      }
+    }
 }
 
 object HistoryActionsTests {


### PR DESCRIPTION
## Overview
This PR adds `getLeaves` to the rspace `history` package.  It will be used when calling `reset` to extract all of the leaves so that we can insert them into the hot store. 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-575

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A