### PR TITLE
Integrate Turan Oracle into Casper logs

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -108,12 +108,11 @@ sealed abstract class MultiParentCasperInstances {
           // TODO: Replace with getMainChainUntilLastFinalizedBlock
           forkchoice = getMainChain(dag, tip, IndexedSeq.empty[BlockMessage])
           forkchoiceSafety <- forkchoice.toList.traverse(block =>
-                               SafetyOracle[F].normalizedFaultTolerance(dag, block))
-          _ <- forkchoice.zip(forkchoiceSafety).toList.traverse {
-                case (block, faultTolerance) =>
-                  Log[F].info(s"CASPER: Block ${PrettyPrinter
-                    .buildString(block.blockHash)} has a fault tolerance of ${faultTolerance}.")
-              }
+                               SafetyOracle[F]
+                                 .normalizedFaultTolerance(dag, block)
+                                 .flatMap(faultTolerance =>
+                                   Log[F].info(s"CASPER: Block ${PrettyPrinter
+                                     .buildString(block.blockHash)} has a fault tolerance of ${faultTolerance}.")))
         } yield ()
 
       def contains(b: BlockMessage): F[Boolean] =

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -33,6 +33,9 @@ import scala.collection
 trait SafetyOracle[F[_]] {
 
   /**
+    * The normalizedFaultTolerance must be greater than the fault tolerance threshold t in order
+    * for a estimate to be safe.
+    *
     * @param estimate Block to detect safety on
     * @return normalizedFaultTolerance float between -1 and 1, where -1 means potentially orphaned
     */
@@ -46,10 +49,10 @@ object SafetyOracle extends SafetyOracleInstances {
 sealed abstract class SafetyOracleInstances {
   def turanOracle[F[_]: Applicative]: SafetyOracle[F] = new SafetyOracle[F] {
     def normalizedFaultTolerance(blockDag: BlockDag, estimate: BlockMessage): F[Float] = {
-      val blocks = blockDag.blockLookup
-      val faultTolerance = 2 * minMaxCliqueWeight(blockDag, estimate) - totalWeight(blocks,
-                                                                                    estimate)
-      val normalizedFaultTolerance = faultTolerance.toFloat / totalWeight(blocks, estimate)
+      val blocks                   = blockDag.blockLookup
+      val tw                       = totalWeight(blocks, estimate)
+      val faultTolerance           = 2 * minMaxCliqueWeight(blockDag, estimate) - tw
+      val normalizedFaultTolerance = faultTolerance.toFloat / tw
       normalizedFaultTolerance.pure[F]
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -34,7 +34,7 @@ trait SafetyOracle[F[_]] {
 
   /**
     * @param estimate Block to detect safety on
-    * @return normalizedFaultTolerance float between -1 and 1, where -1 means orphaned
+    * @return normalizedFaultTolerance float between -1 and 1, where -1 means potentially orphaned
     */
   def normalizedFaultTolerance(estimate: BlockMessage): F[Float]
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -20,26 +20,15 @@ object BlockAPI {
 
   def getBlocksResponse[F[_]: Monad: MultiParentCasper]: F[BlocksResponse] =
     for {
-      estimates                           <- MultiParentCasper[F].estimator
-      dag                                 <- MultiParentCasper[F].blockDag
-      tip                                 = estimates.head
-      mainChain: IndexedSeq[BlockMessage] = getMainChain(tip, dag, IndexedSeq.empty[BlockMessage])
-      blockInfos                          <- mainChain.toList.traverse(getBlockInfo[F])
+      estimates <- MultiParentCasper[F].estimator
+      dag       <- MultiParentCasper[F].blockDag
+      tip       = estimates.head
+      mainChain: IndexedSeq[BlockMessage] = ProtoUtil.getMainChain(dag,
+                                                                   tip,
+                                                                   IndexedSeq.empty[BlockMessage])
+      blockInfos <- mainChain.toList.traverse(getBlockInfo[F])
     } yield
       BlocksResponse(status = "Success", blocks = blockInfos, length = blockInfos.length.toLong)
-
-  @tailrec
-  private def getMainChain(estimate: BlockMessage,
-                           dag: BlockDag,
-                           acc: IndexedSeq[BlockMessage]): IndexedSeq[BlockMessage] = {
-    val parentsHashes       = ProtoUtil.parents(estimate)
-    val maybeMainParentHash = parentsHashes.headOption
-    maybeMainParentHash.flatMap(dag.blockLookup.get) match {
-      case Some(newEstimate) =>
-        getMainChain(newEstimate, dag, acc :+ estimate)
-      case None => acc :+ estimate
-    }
-  }
 
   def getBlockQueryResponse[F[_]: Monad: MultiParentCasper](q: BlockQuery): F[BlockQueryResponse] =
     for {

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -34,6 +34,19 @@ object ProtoUtil {
       }
     }
 
+  @tailrec
+  def getMainChain(blockDag: BlockDag,
+                   estimate: BlockMessage,
+                   acc: IndexedSeq[BlockMessage]): IndexedSeq[BlockMessage] = {
+    val parentsHashes       = ProtoUtil.parents(estimate)
+    val maybeMainParentHash = parentsHashes.headOption
+    maybeMainParentHash.flatMap(blockDag.blockLookup.get) match {
+      case Some(newEstimate) =>
+        getMainChain(blockDag, newEstimate, acc :+ estimate)
+      case None => acc :+ estimate
+    }
+  }
+
   def weightMap(blockMessage: BlockMessage): Map[ByteString, Int] =
     blockMessage.body match {
       case Some(block) =>

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -84,17 +84,14 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
 
     def runSafetyOracle[F[_]: Monad: SafetyOracle]: F[Unit] =
       for {
-        isGenesisSafe          <- SafetyOracle[F].isSafe(genesis, 1)
-        _                      = assert(isGenesisSafe)
-        isB2Safe               <- SafetyOracle[F].isSafe(b2, 1)
-        _                      = assert(isB2Safe)
-        isB3Safe               <- SafetyOracle[F].isSafe(b3, 1)
-        _                      = assert(!isB3Safe)
-        isB4SafeConservatively <- SafetyOracle[F].isSafe(b4, 1)
-        _                      = assert(!isB4SafeConservatively)
-        isB4SafeLessConservatively <- SafetyOracle[F]
-                                       .isSafe(b4, 0.2f) // Clique oracle would be safe
-        _ = assert(!isB4SafeLessConservatively)
+        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(genesis)
+        _                     = assert(genesisFaultTolerance == 1)
+        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b2)
+        _                     = assert(b2FaultTolerance == 1)
+        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b3)
+        _                     = assert(b3FaultTolerance == -1)
+        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b4)
+        _                     = assert(b4FaultTolerance == -0.2f) // Clique oracle would be 0.2f
       } yield ()
     runSafetyOracle[Task].unsafeRunSync
   }
@@ -165,14 +162,14 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
 
     def runSafetyOracle[F[_]: Monad: SafetyOracle]: F[Unit] =
       for {
-        isGenesisSafe <- SafetyOracle[F].isSafe(genesis, 0)
-        _             = assert(isGenesisSafe)
-        isB2Safe      <- SafetyOracle[F].isSafe(b2, 0)
-        _             = assert(!isB2Safe)
-        isB3Safe      <- SafetyOracle[F].isSafe(b3, 0)
-        _             = assert(!isB3Safe)
-        isB4Safe      <- SafetyOracle[F].isSafe(b4, 0)
-        _             = assert(!isB4Safe)
+        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(genesis)
+        _                     = assert(genesisFaultTolerance == 1)
+        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b2)
+        _                     = assert(b2FaultTolerance == -0.5f)
+        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b3)
+        _                     = assert(b3FaultTolerance == -1f)
+        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b4)
+        _                     = assert(b4FaultTolerance == -0.5f)
       } yield ()
     runSafetyOracle[Task].unsafeRunSync
   }

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -35,40 +35,40 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
     val v1Bond = Bond(v1, 2)
     val v2Bond = Bond(v2, 3)
     val bonds  = Seq(v1Bond, v2Bond)
-    val createChain =
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
       for {
-        genesis <- createBlock[StateWithChain](Seq(), ByteString.EMPTY, bonds)
-        b2 <- createBlock[StateWithChain](Seq(genesis.blockHash),
-                                          v2,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b3 <- createBlock[StateWithChain](Seq(genesis.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b4 <- createBlock[StateWithChain](Seq(b2.blockHash),
-                                          v2,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
-        b5 <- createBlock[StateWithChain](Seq(b2.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
-        _ <- createBlock[StateWithChain](Seq(b4.blockHash),
-                                         v2,
-                                         bonds,
-                                         HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b7 <- createBlock[StateWithChain](Seq(b4.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b8 <- createBlock[StateWithChain](Seq(b7.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
+        genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
+        b2 <- createBlock[F](Seq(genesis.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
+        b3 <- createBlock[F](Seq(genesis.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
+        b4 <- createBlock[F](Seq(b2.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
+        b5 <- createBlock[F](Seq(b2.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
+        _ <- createBlock[F](Seq(b4.blockHash),
+                            v2,
+                            bonds,
+                            HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
+        b7 <- createBlock[F](Seq(b4.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
+        b8 <- createBlock[F](Seq(b7.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
       } yield b8
 
-    val chain: BlockDag = createChain.runS(initState).value
+    val chain: BlockDag = createChain[StateWithChain].runS(initState).value
 
     val genesis = chain.idToBlocks(1)
     val b2      = chain.idToBlocks(2)
@@ -105,47 +105,44 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
     val v2Bond = Bond(v2, 20)
     val v3Bond = Bond(v3, 15)
     val bonds  = Seq(v1Bond, v2Bond, v3Bond)
-    val createChain =
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
       for {
-        genesis <- createBlock[StateWithChain](Seq(), ByteString.EMPTY, bonds)
-        b2 <- createBlock[StateWithChain](
+        genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
+        b2 <- createBlock[F](
                Seq(genesis.blockHash),
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
-        b3 <- createBlock[StateWithChain](
+        b3 <- createBlock[F](
                Seq(genesis.blockHash),
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
-        b4 <- createBlock[StateWithChain](
+        b4 <- createBlock[F](
                Seq(b2.blockHash),
                v3,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash))
-        b5 <- createBlock[StateWithChain](
+        b5 <- createBlock[F](
                Seq(b3.blockHash),
                v2,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash))
-        b6 <- createBlock[StateWithChain](
-               Seq(b4.blockHash),
-               v1,
-               bonds,
-               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
-        b7 <- createBlock[StateWithChain](
-               Seq(b5.blockHash),
-               v3,
-               bonds,
-               HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
-        b8 <- createBlock[StateWithChain](
-               Seq(b6.blockHash),
-               v2,
-               bonds,
-               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+        b6 <- createBlock[F](Seq(b4.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
+        b7 <- createBlock[F](Seq(b5.blockHash),
+                             v3,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+        b8 <- createBlock[F](Seq(b6.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
       } yield b8
 
-    val chain: BlockDag = createChain.runS(initState).value
+    val chain: BlockDag = createChain[StateWithChain].runS(initState).value
 
     val genesis = chain.idToBlocks(1)
     val b2      = chain.idToBlocks(2)

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -79,21 +79,20 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
 
     val latestBlocks = HashMap[Validator, BlockMessage](v1 -> b8, v2 -> b6)
 
-    implicit def turanOracleEffect: SafetyOracle[Task] =
-      new TuranOracle(chain.blockLookup, latestBlocks)
+    implicit val turanOracleEffect = SafetyOracle.turanOracle[Id]
 
     def runSafetyOracle[F[_]: Monad: SafetyOracle]: F[Unit] =
       for {
-        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(genesis)
+        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(chain, genesis)
         _                     = assert(genesisFaultTolerance == 1)
-        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b2)
+        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b2)
         _                     = assert(b2FaultTolerance == 1)
-        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b3)
+        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b3)
         _                     = assert(b3FaultTolerance == -1)
-        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b4)
+        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b4)
         _                     = assert(b4FaultTolerance == -0.2f) // Clique oracle would be 0.2f
       } yield ()
-    runSafetyOracle[Task].unsafeRunSync
+    runSafetyOracle[Id]
   }
 
   // See [[/docs/casper/images/no_finalizable_block_mistake_with_no_disagreement_check.png]]
@@ -154,20 +153,19 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator {
 
     val latestBlocks = HashMap[Validator, BlockMessage](v1 -> b6, v2 -> b8, v3 -> b7)
 
-    implicit def turanOracleEffect: SafetyOracle[Task] =
-      new TuranOracle(chain.blockLookup, latestBlocks)
+    implicit val turanOracleEffect = SafetyOracle.turanOracle[Id]
 
     def runSafetyOracle[F[_]: Monad: SafetyOracle]: F[Unit] =
       for {
-        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(genesis)
+        genesisFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(chain, genesis)
         _                     = assert(genesisFaultTolerance == 1)
-        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b2)
+        b2FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b2)
         _                     = assert(b2FaultTolerance == -0.5f)
-        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b3)
+        b3FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b3)
         _                     = assert(b3FaultTolerance == -1f)
-        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(b4)
+        b4FaultTolerance      <- SafetyOracle[F].normalizedFaultTolerance(chain, b4)
         _                     = assert(b4FaultTolerance == -0.5f)
       } yield ()
-    runSafetyOracle[Task].unsafeRunSync
+    runSafetyOracle[Id]
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
@@ -35,40 +35,40 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator {
     val v1Bond = Bond(v1, 2)
     val v2Bond = Bond(v2, 3)
     val bonds  = Seq(v1Bond, v2Bond)
-    val createChain =
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
       for {
-        genesis <- createBlock[StateWithChain](Seq(), ByteString.EMPTY, bonds)
-        b2 <- createBlock[StateWithChain](Seq(genesis.blockHash),
-                                          v2,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b3 <- createBlock[StateWithChain](Seq(genesis.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b4 <- createBlock[StateWithChain](Seq(b2.blockHash),
-                                          v2,
-                                          bonds,
-                                          HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
-        b5 <- createBlock[StateWithChain](Seq(b2.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
-        _ <- createBlock[StateWithChain](Seq(b4.blockHash),
-                                         v2,
-                                         bonds,
-                                         HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b7 <- createBlock[StateWithChain](Seq(b4.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b8 <- createBlock[StateWithChain](Seq(b7.blockHash),
-                                          v1,
-                                          bonds,
-                                          HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
+        genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
+        b2 <- createBlock[F](Seq(genesis.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
+        b3 <- createBlock[F](Seq(genesis.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
+        b4 <- createBlock[F](Seq(b2.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
+        b5 <- createBlock[F](Seq(b2.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
+        _ <- createBlock[F](Seq(b4.blockHash),
+                            v2,
+                            bonds,
+                            HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
+        b7 <- createBlock[F](Seq(b4.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
+        b8 <- createBlock[F](Seq(b7.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
       } yield b8
 
-    val chain: BlockDag = createChain.runS(initState).value
+    val chain: BlockDag = createChain[StateWithChain].runS(initState).value
 
     val genesis = chain.idToBlocks(1)
     val b6      = chain.idToBlocks(6)
@@ -90,47 +90,44 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator {
     val v2Bond = Bond(v2, 20)
     val v3Bond = Bond(v3, 15)
     val bonds  = Seq(v1Bond, v2Bond, v3Bond)
-    val createChain =
+    def createChain[F[_]: Monad: BlockDagState]: F[BlockMessage] =
       for {
-        genesis <- createBlock[StateWithChain](Seq(), ByteString.EMPTY, bonds)
-        b2 <- createBlock[StateWithChain](
+        genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
+        b2 <- createBlock[F](
                Seq(genesis.blockHash),
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
-        b3 <- createBlock[StateWithChain](
+        b3 <- createBlock[F](
                Seq(genesis.blockHash),
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
-        b4 <- createBlock[StateWithChain](
+        b4 <- createBlock[F](
                Seq(b2.blockHash),
                v3,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash))
-        b5 <- createBlock[StateWithChain](
+        b5 <- createBlock[F](
                Seq(b3.blockHash),
                v2,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash))
-        b6 <- createBlock[StateWithChain](
-               Seq(b4.blockHash),
-               v1,
-               bonds,
-               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
-        b7 <- createBlock[StateWithChain](
-               Seq(b5.blockHash),
-               v3,
-               bonds,
-               HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
-        b8 <- createBlock[StateWithChain](
-               Seq(b6.blockHash),
-               v2,
-               bonds,
-               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+        b6 <- createBlock[F](Seq(b4.blockHash),
+                             v1,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
+        b7 <- createBlock[F](Seq(b5.blockHash),
+                             v3,
+                             bonds,
+                             HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+        b8 <- createBlock[F](Seq(b6.blockHash),
+                             v2,
+                             bonds,
+                             HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
       } yield b8
 
-    val chain: BlockDag = createChain.runS(initState).value
+    val chain: BlockDag = createChain[StateWithChain].runS(initState).value
 
     val genesis = chain.idToBlocks(1)
     val b6      = chain.idToBlocks(6)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -63,7 +63,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       "CASPER: Received Deploy",
       "CASPER: Beginning send of Block #1",
       "CASPER: Added",
-      "CASPER: New fork-choice is block"
+      "CASPER: New fork-choice tip is block"
     )
 
     logEff.warns.isEmpty should be(true)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTestNode.scala
@@ -40,6 +40,7 @@ class HashSetCasperTestNode(name: String,
   implicit val keysStoreEff      = new Kvs.InMemoryKvs[Id, PeerNode, Encryption.Key]
   implicit val metricEff         = new Metrics.MetricsNOP[Id]
   implicit val errorHandlerEff   = errorHandler
+  implicit val turanOracleEffect = SafetyOracle.turanOracle[Id]
 
   implicit val casperEff =
     MultiParentCasper.hashSetCasper[Id](storageDirectory, storageSize, genesis)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -1,11 +1,16 @@
 package coop.rchain.node
 
 import java.io.{File, PrintWriter}
-import io.grpc.Server
 
-import cats._, cats.data._, cats.implicits._
-import coop.rchain.catscontrib._, Catscontrib._, ski._, TaskContrib._
-import coop.rchain.casper.MultiParentCasper
+import io.grpc.Server
+import cats._
+import cats.data._
+import cats.implicits._
+import coop.rchain.catscontrib._
+import Catscontrib._
+import ski._
+import TaskContrib._
+import coop.rchain.casper.{MultiParentCasper, SafetyOracle}
 import coop.rchain.casper.util.ProtoUtil.genesisBlock
 import coop.rchain.casper.util.comm.CommUtil.casperPacketHandler
 import coop.rchain.comm._
@@ -17,12 +22,12 @@ import coop.rchain.p2p
 import coop.rchain.p2p.Network.KeysStore
 import coop.rchain.p2p.effects._
 import coop.rchain.rholang.interpreter.Runtime
-
 import coop.rchain.shared.Resources._
 import monix.eval.Task
 import monix.execution.Scheduler
 import diagnostics.MetricsServer
 import coop.rchain.node.effects.TLNodeDiscovery
+
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
@@ -143,6 +148,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       })
     case None => newValidators
   }
+  implicit val turanOracleEffect: SafetyOracle[Effect] = SafetyOracle.turanOracle[Effect]
   implicit val casperEffect: MultiParentCasper[Effect] = MultiParentCasper.hashSetCasper[Effect](
     storagePath,
     storageSize,


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.

Relative to #879 

Runs turan oracle over the forkchoice everytime a new block is added (for now). The log output looks like follows:

```
15:29:24.151 [grpc-default-executor-0] INFO  logger - CASPER: Beginning send of Block #22 (47ee0a536e...) -- Sender ID a4b7a459ce... -- M Parent Hash d674ded414... -- Contents 4540b684eb... to peers...
15:29:24.151 [grpc-default-executor-0] INFO  logger - CASPER: Added 47ee0a536e...
15:29:24.153 [grpc-default-executor-0] INFO  logger - CASPER: New fork-choice tip is block 47ee0a536e....
15:29:24.222 [grpc-default-executor-0] INFO  logger - CASPER: Block 47ee0a536e... has a fault tolerance of -1.0.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block d674ded414... has a fault tolerance of -1.0.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block e49eefcc36... has a fault tolerance of -0.8666667.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block eb26664a20... has a fault tolerance of -0.8666667.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block a2bab7245b... has a fault tolerance of -0.8666667.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 25ebb5b5fa... has a fault tolerance of -0.8666667.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 8f7821c0b7... has a fault tolerance of -0.8666667.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block daf18ed7ac... has a fault tolerance of -0.6.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 4afc56b56d... has a fault tolerance of -0.6.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 5a20b858d7... has a fault tolerance of -0.6.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block def364fe35... has a fault tolerance of -0.6.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block e75d31f271... has a fault tolerance of -0.6.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 44c28730d4... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block a7509212bd... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 5fda723caf... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 75ad5d5fc1... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 2c4266bdd0... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 66f6a551f3... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 37c838bed2... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 8a099ce53b... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block daaecdeadc... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 0e0da5112c... has a fault tolerance of -0.2.
15:29:24.223 [grpc-default-executor-0] INFO  logger - CASPER: Block 7a4998626c... has a fault tolerance of -0.2.
```
The Turan Oracle works best when you have validators with equal weights.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

Part of https://rchain.atlassian.net/browse/RHOL-336

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
