### PR TITLE
CORE-591: rspace: add 'trace' package and classes

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
@@ -1,4 +1,4 @@
-package coop.rchain.rspace.history
+package coop.rchain.rspace
 
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
@@ -10,8 +10,6 @@ import scodec.codecs._
   * Represents a Blake2b256 Hash
   *
   * The default constructor is private to prevent construction means other than [[create]]
-  *
-  * TODO: Restrict access
   */
 class Blake2b256Hash private (val bytes: ByteVector) {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rspace
 
-import coop.rchain.rspace.history.{Blake2b256Hash, ITrieStore}
+import coop.rchain.rspace.history.ITrieStore
 import coop.rchain.rspace.internal._
 
 import scala.collection.immutable.Seq

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 
-import coop.rchain.rspace.history.{initialize, Blake2b256Hash, LMDBTrieStore}
+import coop.rchain.rspace.history.{LMDBTrieStore, initialize}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util._
 import coop.rchain.shared.AttemptOps._

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -3,6 +3,7 @@ package coop.rchain.rspace.history
 import cats.instances.option._
 import cats.instances.vector._
 import cats.syntax.traverse._
+import coop.rchain.rspace.Blake2b256Hash
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -3,6 +3,7 @@ package coop.rchain.rspace.history
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.util.withResource
 import coop.rchain.shared.AttemptOps._
 import coop.rchain.shared.ByteVectorOps._

--- a/rspace/src/main/scala/coop/rchain/rspace/history/PointerBlock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/PointerBlock.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace.history
 
+import coop.rchain.rspace.Blake2b256Hash
 import scodec.Codec
 import scodec.Codec._
 import scodec.codecs._

--- a/rspace/src/main/scala/coop/rchain/rspace/history/Trie.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Trie.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace.history
 
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.shared.AttemptOps._
 import scodec.Codec
 import scodec.bits.BitVector

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rspace
 
-import coop.rchain.rspace.history.Blake2b256Hash
 import coop.rchain.scodec.codecs.seqOfN
 import scodec.Codec
 import scodec.bits.ByteVector

--- a/rspace/src/main/scala/coop/rchain/rspace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/package.scala
@@ -3,7 +3,7 @@ package coop.rchain
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
 import coop.rchain.catscontrib._
-import coop.rchain.rspace.history.{Blake2b256Hash, Leaf}
+import coop.rchain.rspace.history.Leaf
 import coop.rchain.rspace.internal._
 
 import scala.annotation.tailrec

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -1,0 +1,91 @@
+package coop.rchain.rspace.trace
+
+import cats.implicits._
+import coop.rchain.rspace.{Blake2b256Hash, Serialize}
+import coop.rchain.shared.AttemptOps._
+import scodec.bits.BitVector
+import scodec.interop.cats._
+import scodec.{Attempt, Codec}
+import coop.rchain.rspace.internal._
+import coop.rchain.scodec.codecs._
+import scala.collection.immutable.Seq
+
+/**
+  * Broadly speaking, there are two kinds of events in RSpace,
+  *
+  *   1. [[IOEvent]]s, which are represented as [[Produce]] and [[Consume]]s
+  *   2. [[COMM]] Events, which consist of a single [[Consume]] and one or more [[Produce]]s
+  */
+sealed trait Event
+case class COMM(consume: Consume, produces: Seq[Produce]) extends Event
+
+sealed trait IOEvent extends Event
+
+class Produce private (val hash: Blake2b256Hash) extends IOEvent {
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case produce: Produce => produce.hash == hash
+    case _                => false
+  }
+
+  override def hashCode(): Int = hash.hashCode()
+
+  override def toString: String = s"Produce(hash: ${hash.toString})"
+
+  def unapply(arg: Produce): Option[Blake2b256Hash] = Some(arg.hash)
+}
+
+object Produce {
+
+  def apply[C, A](channel: C, datum: A)(implicit
+                                        serializeC: Serialize[C],
+                                        serializeA: Serialize[A]): Produce = {
+    implicit val codecC: Codec[C] = serializeC.toCodec
+    implicit val codecA: Codec[A] = serializeA.toCodec
+
+    val hash: Blake2b256Hash =
+      List(Codec[C].encode(channel), Codec[A].encode(datum))
+        .sequence[Attempt, BitVector]
+        .map((vectors: List[BitVector]) => Blake2b256Hash.create(vectors.combineAll.toByteArray))
+        .get
+
+    new Produce(hash)
+  }
+}
+
+class Consume private (val hash: Blake2b256Hash) extends IOEvent {
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case consume: Consume => consume.hash == hash
+    case _                => false
+  }
+
+  override def hashCode(): Int = hash.hashCode()
+
+  override def toString: String = s"Consume(hash: ${hash.toString})"
+
+  def unapply(arg: Consume): Option[Blake2b256Hash] = Some(arg.hash)
+}
+
+object Consume {
+
+  def apply[C, P, K](channels: Seq[C], patterns: Seq[P], continuation: K)(
+      implicit
+      serializeC: Serialize[C],
+      serializeP: Serialize[P],
+      serializeK: Serialize[K]): Consume = {
+    implicit val codecC: Codec[C] = serializeC.toCodec
+    implicit val codecA: Codec[P] = serializeP.toCodec
+    implicit val codecK: Codec[K] = serializeK.toCodec
+
+    val hash: Blake2b256Hash =
+      List(Codec[Seq[C]].encode(channels),
+           Codec[Seq[P]].encode(patterns),
+           Codec[K].encode(continuation))
+        .sequence[Attempt, BitVector]
+        .map((vectors: List[BitVector]) => Blake2b256Hash.create(vectors.combineAll.toByteArray))
+        .get
+
+    new Consume(hash)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
@@ -1,0 +1,8 @@
+package coop.rchain.rspace
+
+package object trace {
+
+  type Log = Seq[Event]
+
+  type ReplayData = Map[IOEvent, COMM]
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
@@ -3,6 +3,7 @@ package coop.rchain.rspace.history
 import java.util.Arrays
 
 import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec
 import org.scalacheck.Prop

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryTestsBase.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rspace.history
 
 import com.typesafe.scalalogging.Logger
+import coop.rchain.rspace.Blake2b256Hash
 import org.scalactic.anyvals.PosInt
 import org.scalatest.prop.{Configuration, GeneratorDrivenPropertyChecks}
 import org.scalatest.{FlatSpec, Matchers, OptionValues, Outcome}

--- a/rspace/src/test/scala/coop/rchain/rspace/history/PointerBlockTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/PointerBlockTests.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace.history
 
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec
 import coop.rchain.shared.AttemptOps._

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
@@ -2,6 +2,7 @@ package coop.rchain.rspace.history
 
 import java.nio.ByteBuffer
 
+import coop.rchain.rspace.Blake2b256Hash
 import org.lmdbjava.Txn
 import scodec.Codec
 import scodec.bits.ByteVector

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieTests.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace.history
 
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.history.Trie.codecTrie
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec

--- a/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rspace.test
 
-import coop.rchain.rspace.history.{Blake2b256Hash, ITrieStore, Trie}
+import coop.rchain.rspace.Blake2b256Hash
+import coop.rchain.rspace.history.{ITrieStore, Trie}
 
 class DummyTrieStore[T, K, V] extends ITrieStore[T, K, V] {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rspace.test
 
 import cats.implicits._
-import coop.rchain.rspace.history.{Blake2b256Hash, ITrieStore}
+import coop.rchain.rspace.history.ITrieStore
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.{dropIndex, removeFirst}
 import coop.rchain.rspace._

--- a/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
@@ -1,0 +1,61 @@
+package coop.rchain.rspace.trace
+
+import cats.implicits._
+import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.examples.StringExamples.{Pattern, StringsCaptor}
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.test.ArbitraryInstances._
+import coop.rchain.rspace.{Blake2b256Hash, Serialize}
+import coop.rchain.shared.AttemptOps._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import scodec.bits.BitVector
+import scodec.interop.cats._
+import scodec.{Attempt, Codec}
+
+import scala.collection.immutable.Seq
+
+class EventTests extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  implicit val codecString: Codec[String]        = implicitly[Serialize[String]].toCodec
+  implicit val codecPattern: Codec[Pattern]      = implicitly[Serialize[Pattern]].toCodec
+  implicit val codecCaptor: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
+
+  "A Produce" should "contain the expected hash" in {
+    forAll { (channel: String, data: String) =>
+      val actual = Produce(channel, data)
+
+      val expectedHash =
+        List(Codec[String].encode(channel), Codec[String].encode(data))
+          .sequence[Attempt, BitVector]
+          .map { (vectors: List[BitVector]) =>
+            Blake2b256Hash.create(vectors.toArray.flatMap(_.toByteArray))
+          }
+          .get
+
+      actual.hash shouldBe expectedHash
+    }
+  }
+
+  "A Consume" should "contain the expected hash" in {
+    forAll { (channelPatterns: List[(String, Pattern)]) =>
+      val (channels, patterns) = channelPatterns.unzip
+
+      val continuation = new StringsCaptor
+
+      val actual = Consume(channels, patterns, continuation)
+
+      val expectedHash =
+        List(Codec[Seq[String]].encode(channels),
+             Codec[Seq[Pattern]].encode(patterns),
+             Codec[StringsCaptor].encode(continuation))
+          .sequence[Attempt, BitVector]
+          .map { (vectors: List[BitVector]) =>
+            Blake2b256Hash.create(vectors.toArray.flatMap(_.toByteArray))
+          }
+          .get
+
+      actual.hash shouldBe expectedHash
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR introduces the `Event` trait and various related subtypes.  A trace log is envisaged to be represented as follows (also found in the `trace` package):

```scala
type Log = Seq[Event]
```

Also moved the `Blake2b256Hash` type out to the main `rspace` package, and removed the TODO about controlling its access, as it is now expected that clients of rspace will be using this type when dealing with trace logs.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-591

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
As is somewhat the norm for rspace, I was fairly aggressive about privatizing the default constructors and using smart constructors instead.  This is why the `Consume` and `Produce` classes are "almost" case classes, but not actually...