### PR TITLE
removing p2p-test-network job from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,24 +60,6 @@ matrix:
           - haskell-platform
           - rpm
           - fakeroot
-  - language: scala
-    env: SUBPROJECT=p2p-test-network
-    scala: 2.12.4
-    sbt_args: -no-colors
-    install:
-      - ./scripts/install_secp.sh
-      - ./scripts/install_sodium.sh
-      - ./scripts/install_bnfc.sh
-    addons:
-      apt:
-        sources:
-          - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
-        packages:
-          - sbt
-          - jflex
-          - haskell-platform
-          - rpm
-          - fakeroot
   - language: nix 
     env: SUBPROJECT=rholang_more_tests
     install:


### PR DESCRIPTION
## Overview
Removing integration tests from Travis to free up worker cycles. These tests only run in Gitlab on rchain/rchain branches. If they break when merged we can notify devs to fix their issues.
You can also run these tests and more using the p2p-test-tool
https://rchain.atlassian.net/wiki/spaces/DOC/pages/463437825/RNode+Integration+Testing+Tool

### Does this PR relate to an RChain JIRA issue? 
No

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
