### PR TITLE
remove rholang integration tests from Travis CI config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ deploy:deploy-rnode-to-dockerhub:
   script:
     - ./scripts/install_bnfc.sh
     - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/docker
-    - docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
-    - docker tag  coop.rchain/rnode:latest rchain/rnode:${CI_COMMIT_REF_NAME}
-    - docker push rchain/rnode:${CI_COMMIT_REF_NAME} 
+    - sudo docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+    - sudo docker tag  coop.rchain/rnode:latest rchain/rnode:${CI_COMMIT_REF_NAME}
+    - sudo docker push rchain/rnode:${CI_COMMIT_REF_NAME} 
   only:
     - master
     - dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ matrix:
           - haskell-platform
           - rpm
           - fakeroot
-  - language: nix 
-    env: SUBPROJECT=rholang_more_tests
-    install:
-      - ./scripts/install_sodium.sh
 
 script:
   - ./scripts/build-subprojects.sh


### PR DESCRIPTION
## Overview
Removing integration tests from Travis. These integration tests will be ran outside in integration test environment. I added sudo to some docker commands in this as to not load Travis as much.

### Does this PR relate to an RChain JIRA issue? 
Not really

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
