### PR TITLE
move artifact tests from travis config to gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,14 @@ test:integration-test-for-p2p-network:
     - sudo python3.6 -m pip install argparse docker pexpect requests
     - sudo ./scripts/p2p-test-tool.py -b -p 1
 
+test:integration-test-for-artifact-creation:
+  stage: test 
+  tags:
+    - preloaded-ubuntu1804 
+  script:
+    - ./scripts/install_bnfc.sh
+    - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate node/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball 
+
 deploy:deploy-rnode-to-dockerhub:
   stage: deploy 
   tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,24 +23,6 @@ matrix:
           - haskell-platform
           - rpm
           - fakeroot
-  - language: scala
-    env: SUBPROJECT=test_artifact_creation
-    scala: 2.12.4
-    sbt_args: -no-colors
-    install:
-      - ./scripts/install_secp.sh
-      - ./scripts/install_sodium.sh
-      - ./scripts/install.sh
-    addons:
-      apt:
-        sources:
-          - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
-        packages:
-          - sbt
-          - jflex
-          - haskell-platform
-          - rpm
-          - fakeroot
 
 script:
   - ./scripts/build-subprojects.sh


### PR DESCRIPTION
## Overview
Removes integration tests of artifact creation to gitlab-ci. These integration tests should stay out of unit tests. This will save on Travis CI cycles. 

### Does this PR relate to an RChain JIRA issue? 
Not really directly, just in general clean-up of Travis.

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes

