### PR TITLE
CORE-633: make persistent produces remain available for matches

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -34,6 +34,8 @@ class RSpace[C, P, A, K](val store: IStore[C, P, A, K]) extends ISpace[C, P, A, 
         m.get(pattern, matchCandidate) match {
           case None =>
             findMatchingDataCandidate(channel, remaining, pattern, indexedDatum +: prefix)
+          case Some(mat) if persist =>
+            Some((DataCandidate(channel, Datum(mat, persist), dataIndex), data))
           case Some(mat) =>
             Some((DataCandidate(channel, Datum(mat, persist), dataIndex), prefix ++ remaining))
         }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -970,6 +970,28 @@ trait StorageActionsTests extends StorageTestsBase[String, Pattern, String, Stri
     store.eventsCounter.getProducesCount shouldBe 3
     store.eventsCounter.getConsumesCount shouldBe 4
   }
+
+  "A persistent produce" should "be available for multiple matches (CORE-633)" in withTestSpace {
+    space =>
+      val channel = "chan"
+
+      val r1 = space.produce(channel, data = "datum", persist = true)
+
+      r1 shouldBe None
+
+      val r2 = space.consume(
+        List(channel, channel),
+        List(Wildcard, Wildcard),
+        new StringsCaptor,
+        persist = false
+      )
+
+      r2 shouldBe defined
+
+      runK(r2)
+
+      getK(r2).results should contain(List("datum", "datum"))
+  }
 }
 
 class InMemoryStoreStorageActionsTests


### PR DESCRIPTION
## Overview
When matching, rspace was removing persistent produces (aka `Datum`s) from the list of remaining match candidates.  This behavior was incorrect.  This PR fixes that.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-633

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A