### PR TITLE
Changed transactions in InMemoryStore to never timeout.

### DIFF
--- a/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -171,12 +171,11 @@ trait ConcurrencyTests extends StorageTestsBase[Channel, Pattern, Entry, Entries
                   phone = "698-555-1212")
 }
 
-//TODO: Uncomment when problem with InMemoryStore will be solved.
-//class InMemoryStoreConcurrencyTests
-//    extends InMemoryStoreStorageExamplesTestsBase
-//    with ConcurrencyTests {
-//  override def version: String = "InMemory"
-//}
+class InMemoryStoreConcurrencyTests
+    extends InMemoryStoreStorageExamplesTestsBase
+    with ConcurrencyTests {
+  override def version: String = "InMemory"
+}
 
 class LMDBStoreConcurrencyTestsWithTls
     extends LMDBStoreStorageExamplesTestBase

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -41,7 +41,6 @@ class InMemoryStore[C, P, A, K](
     val trieStore: ITrieStore[Transaction[State[C, P, A, K]], Blake2b256Hash, GNAT[C, P, A, K]]
 )(implicit sc: Serialize[C], sk: Serialize[K])
     extends IStore[C, P, A, K] {
-  val TRANSACTION_TIMEOUT = 100L
 
   private implicit val codecC: Codec[C] = sc.toCodec
   val eventsCounter: StoreEventsCounter = new StoreEventsCounter()
@@ -66,7 +65,7 @@ class InMemoryStore[C, P, A, K](
 
     val name: String = "read-" + Thread.currentThread().getId
 
-    private[this] val state = stateRef.get(TRANSACTION_TIMEOUT).get
+    private[this] val state = stateRef.get
 
     override def commit(): Unit = {}
     override def abort(): Unit  = {}
@@ -82,7 +81,7 @@ class InMemoryStore[C, P, A, K](
     new Transaction[StateType] {
       val name: String = "write-" + Thread.currentThread().getId
 
-      private[this] val initial = stateRef.take(TRANSACTION_TIMEOUT)
+      private[this] val initial = stateRef.take
       private[this] var current = initial
 
       override def commit(): Unit =


### PR DESCRIPTION
## Overview
LMDB does not timeout transactions. As we're striving for a close approximation of behaviour, the current solution is to allow infinite transactions.

### Does this PR relate to an RChain JIRA issue? 
no jira issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none