### PR TITLE
CORE-641: rspace: support sharing a single history trie

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -15,7 +15,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.errors.InterpreterError
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.history.Branch
-import coop.rchain.rspace.{ISpace, LMDBStore, RSpace}
+import coop.rchain.rspace._
 import monix.eval.Task
 
 import scala.collection.immutable
@@ -88,11 +88,13 @@ object Runtime {
 
     if (Files.notExists(dataDir)) Files.createDirectories(dataDir)
 
-    val store =
-      LMDBStore
-        .create[Channel, BindPattern, Seq[Channel], TaggedContinuation](dataDir, mapSize)
+    val context = Context.create[Channel, BindPattern, Seq[Channel], TaggedContinuation](
+      dataDir,
+      mapSize
+    )
 
-    val space                                            = new RSpace(store, Branch.master)
+    val space = RSpace.create(context, Branch.master)
+
     val errorLog                                         = new ErrorLog()
     implicit val ft: FunctorTell[Task, InterpreterError] = errorLog
 

--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -1,0 +1,45 @@
+package coop.rchain.rspace
+
+import java.nio.ByteBuffer
+import java.nio.file.Path
+
+import coop.rchain.rspace.history.{ITrieStore, LMDBTrieStore}
+import coop.rchain.rspace.internal.GNAT
+import org.lmdbjava.{Env, EnvFlags, Txn}
+import scodec.Codec
+
+class Context[C, P, A, K] private (
+    val env: Env[ByteBuffer],
+    val path: Path,
+    val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]]
+)
+
+object Context {
+
+  def create[C, P, A, K](path: Path,
+                         mapSize: Long,
+                         flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS))(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): Context[C, P, A, K] = {
+
+    implicit val codecC: Codec[C] = sc.toCodec
+    implicit val codecP: Codec[P] = sp.toCodec
+    implicit val codecA: Codec[A] = sa.toCodec
+    implicit val codecK: Codec[K] = sk.toCodec
+
+    val env: Env[ByteBuffer] =
+      Env
+        .create()
+        .setMapSize(mapSize)
+        .setMaxDbs(8)
+        .setMaxReaders(126)
+        .open(path.toFile, flags: _*)
+
+    val trieStore = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env)
+
+    new Context(env, path, trieStore)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 
-import coop.rchain.rspace.history.{initialize, Branch, LMDBTrieStore}
+import coop.rchain.rspace.history.{initialize, Branch, ITrieStore, LMDBTrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util._
 import coop.rchain.shared.AttemptOps._
@@ -31,7 +31,7 @@ class LMDBStore[C, P, A, K] private (
     _dbJoins: Dbi[ByteBuffer],
     _trieUpdateCount: AtomicLong,
     _trieUpdates: SyncVar[Seq[TrieUpdate[C, P, A, K]]],
-    val trieStore: LMDBTrieStore[Blake2b256Hash, GNAT[C, P, A, K]],
+    val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
 )(implicit
   codecC: Codec[C],
@@ -318,29 +318,42 @@ class LMDBStore[C, P, A, K] private (
 }
 
 object LMDBStore {
-  private[this] val dataTableName: String  = "GNATs"
-  private[this] val joinsTableName: String = "Joins"
 
-  /**
-    * Creates an instance of [[LMDBStore]]
-    *
-    * @param path    Path to the database files
-    * @param mapSize Maximum size of the database, in bytes
-    * @tparam C A type representing a channel
-    * @tparam P A type representing a pattern
-    * @tparam A A type representing a piece of data
-    * @tparam K A type representing a continuation
-    */
+  def create[C, P, A, K](context: Context[C, P, A, K], branch: Branch)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): LMDBStore[C, P, A, K] = {
+    implicit val codecC: Codec[C] = sc.toCodec
+    implicit val codecP: Codec[P] = sp.toCodec
+    implicit val codecA: Codec[A] = sa.toCodec
+    implicit val codecK: Codec[K] = sk.toCodec
+
+    val dbGnats: Dbi[ByteBuffer] = context.env.openDbi(s"${branch.name}-gnats", MDB_CREATE)
+    val dbJoins: Dbi[ByteBuffer] = context.env.openDbi(s"${branch.name}-joins", MDB_CREATE)
+
+    val trieUpdateCount = new AtomicLong(0L)
+    val trieUpdates     = new SyncVar[Seq[TrieUpdate[C, P, A, K]]]()
+    trieUpdates.put(Seq.empty)
+
+    initialize(context.trieStore, branch)
+
+    new LMDBStore[C, P, A, K](context.env,
+                              context.path,
+                              dbGnats,
+                              dbJoins,
+                              trieUpdateCount,
+                              trieUpdates,
+                              context.trieStore,
+                              branch)
+  }
+
   def create[C, P, A, K](path: Path, mapSize: Long, noTls: Boolean = true)(
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]): LMDBStore[C, P, A, K] = {
-
-    implicit val codecC: Codec[C] = sc.toCodec
-    implicit val codecP: Codec[P] = sp.toCodec
-    implicit val codecA: Codec[A] = sa.toCodec
-    implicit val codecK: Codec[K] = sk.toCodec
 
     val flags =
       if (noTls)
@@ -348,33 +361,8 @@ object LMDBStore {
       else
         List.empty[EnvFlags]
 
-    val env: Env[ByteBuffer] =
-      Env
-        .create()
-        .setMapSize(mapSize)
-        .setMaxDbs(8)
-        .setMaxReaders(126)
-        .open(path.toFile, flags: _*)
+    val env = Context.create[C, P, A, K](path, mapSize, flags)
 
-    val dbGNATs: Dbi[ByteBuffer] = env.openDbi(dataTableName, MDB_CREATE)
-    val dbJoins: Dbi[ByteBuffer] = env.openDbi(joinsTableName, MDB_CREATE)
-
-    val trieUpdateCount = new AtomicLong(0L)
-    val trieUpdates     = new SyncVar[Seq[TrieUpdate[C, P, A, K]]]()
-    trieUpdates.put(Seq.empty)
-
-    val trieStore  = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env)
-    val trieBranch = Branch.master
-
-    initialize(trieStore, trieBranch)
-
-    new LMDBStore[C, P, A, K](env,
-                              path,
-                              dbGNATs,
-                              dbJoins,
-                              trieUpdateCount,
-                              trieUpdates,
-                              trieStore,
-                              trieBranch)
+    create(env, Branch.master)
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -333,3 +333,18 @@ class RSpace[C, P, A, K](val store: IStore[C, P, A, K], val branch: Branch)(
 
   def close(): Unit = store.close()
 }
+
+object RSpace {
+
+  def create[C, P, A, K](context: Context[C, P, A, K], branch: Branch)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): RSpace[C, P, A, K] = {
+
+    val mainStore = LMDBStore.create[C, P, A, K](context, branch)
+
+    new RSpace[C, P, A, K](mainStore, branch)
+  }
+}


### PR DESCRIPTION
## Overview
As mentioned in #949, in a `Runtime` there will be two reducer + rspace pairs, one for normal use, and one for deterministic replay.  The two rspaces will share the same history trie.  In this PR, we enable this by introducing `Context`, which contains the LMDB `Env` and a Trie store.  `RSpace` is constructed with a `Context` (and the upcoming `ReplaySpace` will be constructed from one too).

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-641

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
N/A