### PR TITLE
Core 658 connection bug

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -16,10 +16,10 @@ import com.typesafe.scalalogging.Logger
   *
   * Cribbed from https://github.com/ScorexFoundation/Scorex/blob/503fda982d96707db8731f954ac6428b1d17e4e8/src/main/scala/scorex/core/network/UPnP.scala.
   */
-class UPnP(port: Int) {
+class UPnP {
   val logger = Logger("upnp")
 
-  val gateway: Option[GatewayDevice] = {
+  lazy val gateway: Option[GatewayDevice] = {
     GatewayDevice.setHttpReadTimeout(5000)
     val discover = new GatewayDiscover
     discover.setTimeout(5000)
@@ -31,8 +31,6 @@ class UPnP(port: Int) {
 
   def localAddress: Option[InetAddress] = gateway.map(_.getLocalAddress)
   def externalAddress: Option[String]   = gateway.map(_.getExternalIPAddress)
-
-  addPort(port)
 
   def addPort(port: Int): Either[CommError, Boolean] =
     try {

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -38,7 +38,7 @@ class UPnP(port: Int) {
     try {
       gateway match {
         case Some(device) =>
-          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
+          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "TCP", "RChain"))
         case None => Left(UnknownCommError("no gateway"))
       }
     } catch {
@@ -49,7 +49,7 @@ class UPnP(port: Int) {
     try {
       gateway match {
         case Some(device) =>
-          device.deletePortMapping(port, "UDP")
+          device.deletePortMapping(port, "TCP")
           Right(())
         case None => Left(UnknownCommError("no gateway"))
       }

--- a/comm/src/test/scala/coop/rchain/p2p/ConnectToBootstrapSpec.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/ConnectToBootstrapSpec.scala
@@ -1,5 +1,6 @@
 package coop.rchain.p2p
 
+import scala.concurrent.duration.{Duration, MILLISECONDS}
 import org.scalatest._
 import com.google.common.io.BaseEncoding
 import coop.rchain.comm._, CommError._, NetworkProtocol._
@@ -15,6 +16,8 @@ class ConnectToBootstrapSpec
     with Matchers
     with BeforeAndAfterEach
     with AppendedClues {
+
+  val timeout: Duration = Duration(1, MILLISECONDS)
 
   val encoder = BaseEncoding.base16().lowerCase()
 
@@ -47,7 +50,7 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(failEverything))
       // when
-      val _ = Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val _ = Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.warns should equal(
         List(
@@ -63,7 +66,8 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(failEverything))
       // when
-      val result = Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val result =
+        Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.errors should equal(List("Failed to connect to bootstrap node, exiting..."))
       result.value should equal(Left(couldNotConnectToBootstrap))
@@ -73,7 +77,8 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(generateResponses(fstPhase, sndPhaseSucc)))
       // when
-      val result = Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val result =
+        Network.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.infos should contain(s"Bootstrapping from $remote.")
       logEff.infos should contain(s"Connected $remote.")

--- a/comm/src/test/scala/coop/rchain/p2p/ProtocolSpec.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/ProtocolSpec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.p2p
 
+import scala.concurrent.duration.{Duration, MILLISECONDS}
 import org.scalatest._
 import coop.rchain.comm.protocol.rchain._
 import com.google.common.io.BaseEncoding
-import coop.rchain.comm._, CommError._, NetworkProtocol._, Network.defaultTimeout
+import coop.rchain.comm._, CommError._, NetworkProtocol._
 import coop.rchain.p2p.effects._
 import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._, Catscontrib._, ski._, Encryption._
@@ -13,7 +14,8 @@ import EffectsTestInstances._
 
 class ProtocolSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
-  val encoder = BaseEncoding.base16().lowerCase()
+  val encoder                  = BaseEncoding.base16().lowerCase()
+  val defaultTimeout: Duration = Duration(1, MILLISECONDS)
 
   val src: ProtocolNode = protocolNode("src", 30300)
   val remote: PeerNode  = peerNode("remote", 30301)

--- a/node/src/main/scala/coop/rchain/node/IpChecker.scala
+++ b/node/src/main/scala/coop/rchain/node/IpChecker.scala
@@ -1,0 +1,15 @@
+package coop.rchain.node
+
+import java.net._
+import java.io._
+import scala.util.Try
+
+object IpChecker {
+  def checkFrom(from: String): Option[String] =
+    Try {
+      val whatismyip         = new URL(from);
+      val in: BufferedReader = new BufferedReader(new InputStreamReader(whatismyip.openStream()))
+      InetAddress.getByName(in.readLine()).getHostAddress
+    }.toOption
+
+}

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -27,7 +27,8 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
                 "Path to node's private key PEM file, that is being used for TLS communication")
 
   val defaultTimeout =
-    opt[Int](default = Some(1000), descr = "Default timeout for roundtrip connections. Default 1 second.")
+    opt[Int](default = Some(1000),
+             descr = "Default timeout for roundtrip connections. Default 1 second.")
 
   val port =
     opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -26,6 +26,9 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
               descr =
                 "Path to node's private key PEM file, that is being used for TLS communication")
 
+  val defaultTimeout =
+    opt[Int](default = Some(500), descr = "Default timeout for roundtrip connections")
+
   val port =
     opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")
 

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -134,9 +134,10 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
     logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
 
-    upnp.localAddress match {
-      case Some(addy) => Some(addy)
-      case None => {
+    (upnp.localAddress, upnp.externalAddress) match {
+      case (_, Some(addy)) => Some(InetAddress.getByName(addy))
+      case (Some(addy), _) => Some(addy)
+      case _ => {
         val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
         val addresses = ifaces
           .flatMap(_.asScala)

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -27,7 +27,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
                 "Path to node's private key PEM file, that is being used for TLS communication")
 
   val defaultTimeout =
-    opt[Int](default = Some(500), descr = "Default timeout for roundtrip connections")
+    opt[Int](default = Some(1000), descr = "Default timeout for roundtrip connections. Default 1 second.")
 
   val port =
     opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -113,7 +113,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     default = None,
     descr = "Base16 encoding of the Ed25519 private key to use for signing a proposed block.")
 
-  lazy val localhost: String =
+  lazy val fetchHost: String =
     host.toOption match {
       case Some(host) => host
       case None       => whoami(port()).fold("localhost")(_.getHostAddress)

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -6,7 +6,7 @@ import java.nio.file.{Path, Paths}
 import com.typesafe.scalalogging.Logger
 import coop.rchain.comm.UPnP
 import org.rogach.scallop._
-
+import coop.rchain.catscontrib._, Catscontrib._, ski._
 import scala.collection.JavaConverters._
 
 final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
@@ -122,7 +122,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   def fetchHost(upnp: UPnP): String =
     host.toOption match {
       case Some(host) => host
-      case None       => whoami(port(), upnp).fold("localhost")(_.getHostAddress)
+      case None       => whoami(port(), upnp)
     }
 
   def certificatePath: Path =
@@ -133,35 +133,26 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     certificate.toOption
       .getOrElse(Paths.get(data_dir().toString, "node.key.pem"))
 
-  private def whoami(port: Int, upnp: UPnP): Option[InetAddress] = {
+  def check(source: String, from: String): PartialFunction[Unit, (String, String)] =
+    Function.unlift(Unit => IpChecker.checkFrom(from).map(ip => (source, ip)))
 
-    val logger = Logger("conf")
-    logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
-
-    (upnp.localAddress, upnp.externalAddress) match {
-      case (_, Some(addy)) => Some(InetAddress.getByName(addy))
-      case (Some(addy), _) => Some(addy)
-      case _ => {
-        val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
-        val addresses = ifaces
-          .flatMap(_.asScala)
-          .map(_.getAddress)
-          .toList
-          .groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress || x.isSiteLocalAddress)
-        if (addresses.contains(false)) {
-          Some(addresses(false).head)
-        } else {
-          val locals = addresses(true).groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress)
-          if (locals.contains(false)) {
-            Some(locals(false).head)
-          } else if (locals.contains(true)) {
-            Some(locals(true).head)
-          } else {
-            None
-          }
-        }
+  def checkAll: (String, String) = {
+    val func: PartialFunction[Unit, (String, String)] =
+      check("AmazonAWS service", "http://checkip.amazonaws.com") orElse
+        check("WhatIsMyIP service", "http://bot.whatismyipaddress.com") orElse {
+        case _ => ("failed to guess", "localhost")
       }
-    }
+    func.apply(())
+  }
+
+  private def whoami(port: Int, upnp: UPnP): String = {
+    println("INFO - flag --host was not provided, guessing your external IP address")
+
+    val (source, ip) = upnp.externalAddress
+      .map(addy => ("uPnP", InetAddress.getByName(addy).getHostAddress))
+      .getOrElse(checkAll)
+    println(s"INFO - guessed $ip from source: $source")
+    ip
   }
 
   verify()

--- a/node/src/main/scala/coop/rchain/node/effects/TLNodeDiscovery.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/TLNodeDiscovery.scala
@@ -10,7 +10,9 @@ import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._, Catscontrib._, ski._, TaskContrib._
 import CommunicationResponse._
 
-class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](src: PeerNode)
+class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](
+    src: PeerNode,
+    timeout: Duration)
     extends NodeDiscovery[F] {
 
   private val local = ProtocolNode(src)
@@ -117,7 +119,7 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
       _   <- Metrics[F].incrementCounter("protocol-lookup-send")
       req = LookupMessage(ProtocolMessage.lookup(local, key), System.currentTimeMillis)
       r <- TransportLayer[F]
-            .roundTrip(req, remoteNode, 500.milliseconds)
+            .roundTrip(req, remoteNode, timeout)
             .map(_.toOption
               .map {
                 case LookupResponseMessage(proto, _) =>

--- a/node/src/main/scala/coop/rchain/node/effects/TcpTransportLayer.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/TcpTransportLayer.scala
@@ -71,12 +71,14 @@ class TcpTransportLayer[F[_]: Monad: Capture: Metrics: Futurable](
                 remote: ProtocolNode,
                 timeout: Duration): F[CommErr[ProtocolMessage]] =
     for {
-      tlResponseErr <- Capture[F].capture(
+      tlResponseErr <- Capture[F].capture {
                         Try(
-                          Await.result(
-                            withClient(remote.endpoint)(_.send(TLRequest(msg.proto.some))),
-                            timeout)
-                        ).toEither.leftMap(protocolException))
+                          Await
+                            .result(withClient(remote.endpoint)(_.send(TLRequest(msg.proto.some))),
+                                    timeout)
+                        ).toEither
+                          .leftMap(protocolException)
+                      }
       pmErr <- tlResponseErr
                 .flatMap(tlr =>
                   tlr.payload match {

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -143,7 +143,7 @@ package object effects {
 
   def tcpTranposrtLayer[F[_]: Monad: Capture: Metrics: Futurable](conf: Conf)(src: PeerNode)(
       implicit executionContext: ExecutionContext) =
-    new TcpTransportLayer[F](conf.localhost,
+    new TcpTransportLayer[F](conf.fetchHost,
                              conf.port(),
                              conf.certificatePath.toFile,
                              conf.keyPath.toFile)(src)

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -1,5 +1,6 @@
 package coop.rchain.node
 
+import scala.concurrent.duration.{Duration, MILLISECONDS}
 import coop.rchain.comm.protocol.rchain.Packet
 import coop.rchain.p2p, p2p.NetworkAddress
 import coop.rchain.p2p.effects._
@@ -130,14 +131,15 @@ package object effects {
         }).writeTo(new FileOutputStream(remoteKeysPath.toFile))
     }
 
-  def ping[F[_]: Monad: Capture: Metrics: TransportLayer](src: PeerNode): Ping[F] =
+  def ping[F[_]: Monad: Capture: Metrics: TransportLayer](src: PeerNode,
+                                                          timeout: Duration): Ping[F] =
     new Ping[F] {
       import scala.concurrent.duration._
       def ping(node: ProtocolNode): F[Boolean] =
         for {
           _   <- Metrics[F].incrementCounter("protocol-ping-sends")
           req = PingMessage(ProtocolMessage.ping(ProtocolNode(src)), System.currentTimeMillis)
-          res <- TransportLayer[F].roundTrip(req, node, 500.milliseconds).map(_.toOption)
+          res <- TransportLayer[F].roundTrip(req, node, timeout).map(_.toOption)
         } yield res.isDefined
     }
 

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -143,12 +143,12 @@ package object effects {
         } yield res.isDefined
     }
 
-  def tcpTranposrtLayer[F[_]: Monad: Capture: Metrics: Futurable](conf: Conf)(src: PeerNode)(
-      implicit executionContext: ExecutionContext) =
-    new TcpTransportLayer[F](conf.fetchHost,
-                             conf.port(),
-                             conf.certificatePath.toFile,
-                             conf.keyPath.toFile)(src)
+  def tcpTranposrtLayer[F[_]: Monad: Capture: Metrics: Futurable](
+      host: String,
+      port: Int,
+      cert: File,
+      key: File)(src: PeerNode)(implicit executionContext: ExecutionContext) =
+    new TcpTransportLayer[F](host, port, cert, key)(src)
 
   def udpTransportLayer(src: PeerNode)(implicit
                                        ev1: Log[Task],

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -89,6 +89,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   if (!conf.noUpnp()) {
     println("INFO - trying to open port using uPnP....")
     upnp.addPort(conf.port()) match {
+      case Left(UnknownCommError("no gateway")) =>
+        println(s"INFO - [OK] no gateway found, no need to open any port.")
       case Left(error)  => println(s"$upnpErrorMsg Reason: $error")
       case Right(false) => println(s"$upnpErrorMsg")
       case Right(true)  => println("INFO - uPnP port forwarding was most likely successful!")

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -87,7 +87,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   private val keysPath                 = conf.data_dir().resolve("keys").resolve(s"$name-rnode.keys")
   private val storagePath              = conf.data_dir().resolve("rspace")
   private val storageSize              = conf.map_size()
-  private val defaultTimeout: Duration = Duration(conf.defaultTimeout(), MILLISECONDS)
+  private val defaultTimeout: Duration = Duration(conf.defaultTimeout().toLong, MILLISECONDS)
 
   /** Final Effect + helper methods */
   type CommErrT[F[_], A] = EitherT[F, CommError, A]

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -80,7 +80,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   import ApplicativeError_._
 
   /** Configuration */
-  private val host           = conf.localhost
+  private val host           = conf.fetchHost
   private val address        = s"rnode://$name@$host:${conf.port()}"
   private val src            = p2p.NetworkAddress.parse(address).right.get
   private val remoteKeysPath = conf.data_dir().resolve("keys").resolve(s"$name-rnode-remote.keys")

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -190,6 +190,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       ts    <- timeEffect.currentMillis
       msg   = DisconnectMessage(ProtocolMessage.disconnect(loc), ts)
       _     <- transportLayerEffect.broadcast(msg, peers)
+      // TODO remove that once broadcast and send reuse roundTrip
+      _ <- IOUtil.sleep[Task](5000L)
     } yield ()).unsafeRunSync
     println("Shutting down metrics server...")
     resources.metricsServer.stop()

--- a/scripts/p2p-test-network.sh
+++ b/scripts/p2p-test-network.sh
@@ -68,9 +68,9 @@ EOF
    fi
 
     if [[ $i == 0 ]]; then
-      rnode_cmd="--port 30304 --standalone"
+      rnode_cmd="--port 30304 --standalone --host bootstrap0.${network_name}"
     else
-      rnode_cmd="--bootstrap rnode://23ea7ec9e3e42054c062c879d8c766a111f3ad37@169.254.1.2:30304"
+      rnode_cmd="--bootstrap rnode://23ea7ec9e3e42054c062c879d8c766a111f3ad37@169.254.1.2:30304 --host ${container_name}"
     fi
     sudo docker run -dit --name ${container_name} \
       -v ${var_lib_rnode_dir}:/var/lib/rnode \


### PR DESCRIPTION
## Overview
---> CORE-658 needs to be merge to master as hot bugfix and tagged&released as `0.4.2` <---

Things that were fixed:

1. UpNp was opening UDP ports, not TCP 🤦‍♂️ 
2. Local vs external network interface (+ UpNp & UDP dirty hacks)
* when `--host` flag was used, UpNp was functionality was being used
* when `--host` flag was not set, then two things would happen: UpNp was trying to open ports AND tried to GUESS a network interface (and IP address) which was being broadcast to other nodes during connection. Problem was that IP that was being broadcast was the INTERNAL one (like 192.168.x.y) not the external one! 🤷‍♂️  Why the hell it worked with `UdpTransportLayer` in the past then? Well UDP had a dirty little hack - whenever answering incoming message it would not used the IP address that it learned during connection (handshake protocol), it would use IP address from the incoming datagram 🤣 
3. roundTrip took default timeout 500 milliseconds, which is in most cased not enough. 
* for this release default timeout value was increased to 1 second and `--default-timeout` flag was added so that the timeout can be changed individually 
* for 0.5 we have do some radical changes: remove timeout from `roundTrip` method, so that `TransportLayer` can implement incremental backoff for every `PeerNode` it has a conversation with. This was we will be able to adjust to different topologies.