### PR TITLE
Add actor message dispatching

### DIFF
--- a/roscala/src/main/scala/coop/rchain/roscala/GlobalEnv.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/GlobalEnv.scala
@@ -5,5 +5,5 @@ import coop.rchain.roscala.ob.{Ob, TblObject}
 class GlobalEnv extends TblObject {
   def values(n: Int): Ob = extension.slot(n).get
 
-  override def numberOfSlots(): Int = extension.slot.size
+  override def numberOfSlots: Int = extension.slot.size
 }

--- a/roscala/src/main/scala/coop/rchain/roscala/Location.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Location.scala
@@ -56,7 +56,7 @@ object Location {
         ctxt.env.getLex(indirect, level, offset)
 
       case GlobalVar(offset) =>
-        if (offset < globalEnv.numberOfSlots())
+        if (offset < globalEnv.numberOfSlots)
           globalEnv.slot.unsafeGet(offset)
         else
           Invalid

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Actor.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Actor.scala
@@ -1,18 +1,34 @@
 package coop.rchain.roscala.ob
 
-import coop.rchain.roscala.util.syntax._
+import com.typesafe.scalalogging.Logger
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+import coop.rchain.roscala.ob.Actor.logger
 
-class Extension extends Ob
-
-class Actor extends Ob {
+class Actor extends MboxOb {
   val extension = new Extension()
   meta = Meta.empty
 
-  /**
-    * In Rosette `value` gets appended to the `extension` field and
-    * `key` is ignored.
-    */
   def addSlot(value: Ob): Int =
     extension.slot += value
 
+  override def lookupAndInvoke(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    logger.debug(s"$this receives message")
+    // TODO: Add handling of synchronous target
+    receive(ctxt, state, globalEnv)
+    Suspended
+  }
+
+  /**
+    * This is the code that is invoked when a message (the task formal)
+    * is removed from an actor's mailbox.
+    */
+  override def schedule(task: Ctxt, state: State, globalEnv: GlobalEnv): Unit = {
+    logger.debug("Schedule task on actor")
+    super.lookupAndInvoke(task, state, globalEnv)
+  }
+}
+
+object Actor {
+  val logger = Logger("Actor")
 }

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Extension.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Extension.scala
@@ -1,0 +1,3 @@
+package coop.rchain.roscala.ob
+
+class Extension extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/MboxOb.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/MboxOb.scala
@@ -1,0 +1,28 @@
+package coop.rchain.roscala.ob
+
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+
+class MboxOb extends Ob {
+  var mbox: Ob = MboxOb.LockedMbox
+
+  def receive(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    ctxt.rcvr = this
+    mbox.receiveMsg(this, ctxt, state, globalEnv)
+  }
+
+  def schedule(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Unit =
+    state.strandPool.append(ctxt)
+}
+
+object MboxOb {
+  val LockedMbox: Ob = Invalid
+}
+
+class EmptyMbox extends Ob {
+  override def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    client.mbox = MboxOb.LockedMbox
+    client.schedule(task, state, globalEnv)
+    Niv
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Mthd.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Mthd.scala
@@ -1,0 +1,24 @@
+package coop.rchain.roscala.ob
+
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+
+class Mthd(code: Code, id: Ob, source: Ob) extends Ob {
+  override def invoke(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    val surrogate = ctxt.arg(0)
+    ctxt.self2 = ctxt.arg(0)
+    ctxt.selfEnv = surrogate
+    ctxt.env = surrogate
+    ctxt.code = this.code
+    ctxt.rslt = Niv
+    ctxt.pc = 0
+    state.strandPool.append(ctxt)
+    Suspended
+  }
+
+}
+
+object Mthd {
+  def apply(code: Code, id: Ob = Qanon, source: Ob = Niv): Mthd =
+    new Mthd(code, id, source)
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
@@ -15,7 +15,9 @@ abstract class Ob {
   var meta: Meta = _
   var parent: Ob = _
 
-  def dispatch(state: State, globalEnv: GlobalEnv): Ob = Niv
+  def dispatch(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = Niv
+
+  def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = Niv
 
   def extendWith(keyMeta: Ob, argvec: Tuple): Ob =
     if (keyMeta == NilMeta)
@@ -23,16 +25,16 @@ abstract class Ob {
     else
       argvec.becomeExtension(keyMeta.asInstanceOf[Meta], this)
 
-  def invoke(state: State, globalEnv: GlobalEnv): Ob = Niv
+  def invoke(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = Niv
 
   /** Tries to lookup value for key and then invokes the value
     *
     * `ctxt.trgt` contains the key.
     */
-  def lookupAndInvoke(state: State, globalEnv: GlobalEnv): Ob = {
-    val fn = meta.lookupObo(this, state.ctxt.trgt)(globalEnv)
+  def lookupAndInvoke(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    val fn = meta.lookupObo(this, ctxt.trgt)(globalEnv)
     logger.debug(s"Lookup and invoke $fn")
-    fn.invoke(state, globalEnv)
+    fn.invoke(ctxt, state, globalEnv)
   }
 
   def lookup(key: Ob)(globalEnv: GlobalEnv): Ob = {
@@ -71,7 +73,7 @@ abstract class Ob {
     value
   }
 
-  def numberOfSlots = slot.size
+  def numberOfSlots: Int = slot.size
 }
 
 object Ob {
@@ -82,10 +84,12 @@ case class Monitor()             extends Ob
 case class Symbol(value: String) extends Ob
 
 case object Absent     extends Ob
-case object Suicide    extends Ob
-case object Invalid    extends Ob
-case object Upcall     extends Ob
 case object Deadthread extends Ob
+case object Invalid    extends Ob
 case object Niv        extends Ob
+case object Qanon      extends Ob
 case object RblFalse   extends Ob
 case object RblTrue    extends Ob
+case object Suicide    extends Ob
+case object Suspended  extends Ob
+case object Upcall     extends Ob

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Oprn.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Oprn.scala
@@ -5,11 +5,11 @@ import Oprn.logger
 import coop.rchain.roscala.GlobalEnv
 import coop.rchain.roscala.Vm.State
 
-case class Oprn() extends Actor {
-  override def dispatch(state: State, globalEnv: GlobalEnv): Ob =
+class Oprn extends Actor {
+  override def dispatch(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob =
     if (state.ctxt.nargs > 0) {
-      logger.debug("Dispatch")
-      state.ctxt.arg(0).lookupAndInvoke(state, globalEnv)
+      logger.debug(s"Dispatch to ${ctxt.arg(0)}")
+      ctxt.arg(0).lookupAndInvoke(ctxt, state, globalEnv)
     } else
       // TODO: Runtime error
       Niv

--- a/roscala/src/main/scala/coop/rchain/roscala/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/prim/Prim.scala
@@ -13,7 +13,7 @@ abstract class Prim extends Ob {
   def dispatchHelper(state: State, globalEnv: GlobalEnv): Ob =
     fn(state.ctxt, globalEnv)
 
-  override def dispatch(state: State, globalEnv: GlobalEnv): Ob = {
+  override def dispatch(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
     val result = dispatchHelper(state, globalEnv)
 
     if (result != Invalid && result != Upcall && result != Deadthread) {
@@ -23,8 +23,8 @@ abstract class Prim extends Ob {
     result
   }
 
-  override def invoke(state: State, globalEnv: GlobalEnv): Ob =
-    dispatch(state, globalEnv)
+  override def invoke(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob =
+    dispatch(ctxt, state, globalEnv)
 }
 
 object Prim {

--- a/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
@@ -1,0 +1,122 @@
+package coop.rchain.roscala
+
+import coop.rchain.roscala.ob._
+import org.scalatest.{FlatSpec, Matchers}
+import coop.rchain.roscala.CtxtRegName._
+import coop.rchain.roscala.VmLiteralName._
+import coop.rchain.roscala.ob.expr.TupleExpr
+
+class ActorSpec extends FlatSpec with Matchers {
+
+  "Dispatching a message to an actor" should "invoke a method" in {
+
+    /**
+      * Send empty message to an `Actor` that in response invokes
+      * a `Mthd` that schedules a `Ctxt` that returns `1`.
+      *
+      * (defOprn return-one)
+      * (defActor Foo
+      *   (method (return-one)
+      *     1
+      *   )
+      * )
+      * (define foo (new Foo))
+      *
+      * (return-one foo)
+      *
+      * litvec:
+      *   0:   {RequestExpr}
+      * codevec:
+      *   0:   alloc 1
+      *   1:   xfer global[foo],arg[0]
+      *   3:   xfer global[return-one],trgt
+      *   5:   xmit/nxt 1
+      *
+      * In `xmit/nxt 1` the VM calls `dispatch` on the `return-one`
+      * operation which will call `lookupAndInvoke` on `foo`.
+      *
+      * `foo.lookupAndInvoke` calls `MboxOb.receive` where the message
+      * is received. This also sets the `rcvr` field of the given
+      * `Ctxt` to the current `MboxOb`.
+      *
+      * In `EmptyMbox.receiveMsg` the `mbox` of `foo` is then set to
+      * `lockedMbox`. After that the actor processes the task by
+      * calling `foo.schedule`
+      *
+      * `foo.schedule` calls `Ob.lookupAndInvoke` which searches a
+      * value for the key `return-one` in `foo` (and in its meta object).
+      *
+      * The value, which is the `return-one` `Mthd`in this case, then
+      * gets invoked. In `Mthd.invoke` the passed in `Ctxt` gets
+      * altered with the code of the `return-one` method.
+      * The altered `Ctxt` then gets scheduled.
+      */
+    val returnOneOprn = new Oprn
+    val foo           = new Actor
+
+    /**
+      * litvec:
+      *   0:   {StdMthd}
+      *   1:   {Template}
+      * codevec:
+      *   0:   extend 1
+      *   1:   lit 1,rslt
+      *   2:   rtn/nxt
+      *
+      * For some unknown reason the compiler wants to extend `env` (of
+      * the `Ctxt` that gets scheduled by the `return-one` method)
+      * with the mapping `Symbol(#self) -> foo`.
+      */
+    val keyMeta = Meta(extensible = false)
+    keyMeta.map.update(Symbol("#self"), LexVariable(0, 0, indirect = false))
+
+    val template = new Template(
+      keyTuple = Tuple(Symbol("#self")),
+      pat = new IdVecPattern(new TupleExpr(Seq(Symbol("#self")))),
+      keyMeta = keyMeta
+    )
+
+    val returnOneCode = Code(
+      litvec = Seq(Niv, template),
+      codevec = Seq(
+        OpExtend(1),
+        OpImmediateLitToReg(literal = `1`, reg = rslt),
+        OpRtn(next = true)
+      )
+    )
+
+    val returnOneMthd = Mthd(returnOneCode)
+
+    /**
+      * Create global environment with `foo` in the first position
+      * and the `return-one` operation in the second position.
+      */
+    val globalEnv = new GlobalEnv()
+    globalEnv.addSlot(Symbol("foo"), foo)
+    globalEnv.addSlot(Symbol("return-one"), returnOneOprn)
+
+    /**
+      * Add key-value pair to `foo` actor instance that maps the
+      * `return-one` operation to the `return-one` method of `Foo`.
+      */
+    foo.meta.add(foo, returnOneOprn, returnOneMthd, ctxt = null)(globalEnv)
+    foo.mbox = new EmptyMbox
+
+    /** Bytecode for `(return-one foo)` */
+    val codevec = Seq(
+      OpAlloc(1),
+      OpXferGlobalToArg(global = 0, arg = 0),
+      OpXferGlobalToReg(global = 1, reg = trgt),
+      OpXmit(unwind = false, next = true, nargs = 1)
+    )
+
+    val rtnCtxt = Ctxt.outstanding(1)
+
+    val code = Code(litvec = Seq.empty, codevec = codevec)
+    val ctxt = Ctxt(code, rtnCtxt, LocRslt)
+
+    Vm.run(ctxt, globalEnv, Vm.State())
+
+    rtnCtxt.rslt shouldBe Fixnum(1)
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/roscala/VmSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/VmSpec.scala
@@ -8,8 +8,6 @@ import coop.rchain.roscala.prim.fixnum.fxPlus
 import coop.rchain.roscala.prim.rblfloat.flPlus
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.collection.mutable
-
 class VmSpec extends FlatSpec with Matchers {
 
   val globalEnv = new GlobalEnv()
@@ -20,7 +18,7 @@ class VmSpec extends FlatSpec with Matchers {
     * primitive for addition of `Fixnum`s.
     * And do the same for `RblFloat`.
     */
-  val addOprn = Oprn()
+  val addOprn = new Oprn
   Fixnum.fixnumSbo.meta.add(Fixnum.fixnumSbo, addOprn, fxPlus, ctxt = null)(globalEnv)
   RblFloat.rblFloatSbo.meta.add(RblFloat.rblFloatSbo, addOprn, flPlus, ctxt = null)(globalEnv)
 


### PR DESCRIPTION
Adds support to do the following:
```
(defOprn return-one)
(defActor Foo
  (method (return-one)
    1
  )
)
(define foo (new Foo))
(return-one foo)
```
In the test case we manually create the `Foo` actor instance and the code for the `return-one` method that returns `1`.
We then run the bytecode for `(return-one foo)`.