### PR TITLE
Update LMDBJava to 0.6.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
   val kalium              = "org.abstractj.kalium"        % "kalium"                    % "0.7.0"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
   val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % kamonVersion
-  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.0"
+  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val monix               = "io.monix"                   %% "monix"                     % "3.0.0-RC1"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.7.2"


### PR DESCRIPTION
## Overview
I used to get rare (once a day) strange unit-test failures on Ubuntu 18.04 VM with messages about disk space allocation failures. These errors disappear after updating to latest LMDBJava 0.6.1 (with native LMDB 0.9.22 inside).

### Notes
LMDBJava change log: https://github.com/lmdbjava/lmdbjava/wiki/Change-Log#061-25-apr-2018
LMDB change log: https://github.com/LMDB/lmdb/blob/LMDB_0.9.22/libraries/liblmdb/CHANGES