### PR TITLE
Moved some functions to the "shared" project. Added unit-tests.

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -6,7 +6,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 import coop.rchain.rspace.history.{initialize, Branch, ITrieStore, LMDBTrieStore}
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.util._
+import coop.rchain.shared.SeqOps._
+import coop.rchain.shared.Resources.withResource
 import coop.rchain.shared.AttemptOps._
 import coop.rchain.shared.ByteVectorOps._
 import coop.rchain.shared.PathOps._

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -6,7 +6,8 @@ import java.nio.file.{Files, Path}
 import cats.implicits._
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
-import coop.rchain.rspace.util.{ignore, runKs}
+import coop.rchain.shared.Language.ignore
+import coop.rchain.rspace.util.runKs
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -2,7 +2,7 @@ package coop.rchain.rspace.examples
 
 import java.nio.charset.StandardCharsets
 
-import coop.rchain.rspace.util._
+import coop.rchain.shared.Language.ignore
 import coop.rchain.rspace.{Match, Serialize}
 
 import scala.collection.mutable

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
@@ -3,7 +3,7 @@ package coop.rchain.rspace
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import cats.syntax.either._
-import coop.rchain.rspace.util.withResource
+import coop.rchain.shared.Resources.withResource
 
 package object examples {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import coop.rchain.rspace.Blake2b256Hash
-import coop.rchain.rspace.util.withResource
+import coop.rchain.shared.Resources.withResource
 import coop.rchain.shared.AttemptOps._
 import coop.rchain.shared.ByteVectorOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -5,46 +5,6 @@ import scala.collection.immutable.Seq
 package object util {
 
   /**
-    * Runs a computation for its side-effects, discarding its value
-    *
-    * @param a A computation to run
-    */
-  def ignore[A](a: => A): Unit = {
-    val _: A = a
-    ()
-  }
-
-  /**
-    * Executes a function `f` with a given [[AutoCloseable]] `a` as its argument,
-    * returning the result of the function and closing the `a`
-    *
-    * Compare to Java's "try-with-resources"
-    *
-    * @param a A given resource implementing [[AutoCloseable]]
-    * @param f A function that takes this resource as its argument
-    */
-  def withResource[A <: AutoCloseable, B](a: A)(f: A => B): B =
-    try {
-      f(a)
-    } finally {
-      a.close()
-    }
-
-  /** Drops the 'i'th element of a list.
-    */
-  def dropIndex[T](xs: Seq[T], n: Int): Seq[T] = {
-    val (l1, l2) = xs splitAt n
-    l1 ++ (l2 drop 1)
-  }
-
-  /** Removes the first occurrence of an element that matches the given predicate.
-    */
-  def removeFirst[T](xs: Seq[T])(p: T => Boolean): Seq[T] = {
-    val (l1, l2) = xs.span(x => !p(x))
-    l1 ++ (l2 drop 1)
-  }
-
-  /**
     * Extracts a continuation from a produce result
     */
   def getK[A, K](t: Option[(K, A)]): K =

--- a/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/InMemoryStore.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.util.{dropIndex, removeFirst}
+import coop.rchain.shared.SeqOps.{dropIndex, removeFirst}
 import coop.rchain.shared.AttemptOps._
 import scodec.Codec
 import scodec.bits.BitVector

--- a/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import coop.rchain.rspace.util.ignore
+import coop.rchain.shared.Language.ignore
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, DecodeResult}
 

--- a/shared/src/main/scala/coop/rchain/shared/Language.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Language.scala
@@ -1,0 +1,14 @@
+package coop.rchain.shared
+
+object Language {
+
+  /**
+    * Runs a computation for its side-effects, discarding its value
+    *
+    * @param a A computation to run
+    */
+  def ignore[A](a: => A): Unit = {
+    val _: A = a
+    ()
+  }
+}

--- a/shared/src/main/scala/coop/rchain/shared/Resources.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Resources.scala
@@ -2,6 +2,15 @@ package coop.rchain.shared
 
 object Resources {
 
+  /**
+    * Executes a function `f` with a given [[AutoCloseable]] `a` as its argument,
+    * returning the result of the function and closing the `a`
+    *
+    * Compare to Java's "try-with-resources"
+    *
+    * @param a A given resource implementing [[AutoCloseable]]
+    * @param f A function that takes this resource as its argument
+    */
   def withResource[A <: AutoCloseable, B](a: A)(f: A => B): B =
     try {
       f(a)

--- a/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
@@ -1,0 +1,20 @@
+package coop.rchain.shared
+
+import scala.collection.immutable.Seq
+
+object SeqOps {
+
+  /** Drops the 'i'th element of a list.
+    */
+  def dropIndex[T](xs: Seq[T], n: Int): Seq[T] = {
+    val (l1, l2) = xs splitAt n
+    l1 ++ (l2 drop 1)
+  }
+
+  /** Removes the first occurrence of an element that matches the given predicate.
+    */
+  def removeFirst[T](xs: Seq[T])(p: T => Boolean): Seq[T] = {
+    val (l1, l2) = xs.span(x => !p(x))
+    l1 ++ (l2 drop 1)
+  }
+}

--- a/shared/src/test/scala/coop/rchain/shared/SeqOpsTest.scala
+++ b/shared/src/test/scala/coop/rchain/shared/SeqOpsTest.scala
@@ -1,0 +1,49 @@
+package coop.rchain.shared
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.collection.immutable.Seq
+import coop.rchain.shared.SeqOps._
+
+class SeqOpsTest extends FlatSpec with Matchers {
+
+  "dropIndex" should "remove first element" in {
+    dropIndex(Seq(1, 2, 3), 0) shouldBe Seq(2, 3)
+  }
+
+  "dropIndex" should "remove single element" in {
+    dropIndex(Seq(1), 0) shouldBe Seq.empty[Int]
+  }
+
+  "dropIndex " should "remove last element" in {
+    dropIndex(Seq(1, 2, 3), 2) shouldBe Seq(1, 2)
+  }
+
+  "dropIndex " should "remove element in the middle of sequence" in {
+    dropIndex(Seq(1, 2, 3), 1) shouldBe Seq(1, 3)
+  }
+
+  "dropIndex" should "ignore invalid indexes" in {
+    dropIndex(Seq(1, 2, 3), 10) shouldBe Seq(1, 2, 3)
+  }
+
+  "removeFirst" should "remove first element" in {
+    removeFirst(Seq(1, 2, 3))(_ => false) shouldBe Seq(1, 2, 3)
+  }
+
+  "removeFirst" should "remove single element" in {
+    removeFirst(Seq(1))(_ => true) shouldBe Seq.empty[Int]
+  }
+
+  "removeFirst" should "remove first matched element" in {
+    removeFirst(Seq(1, 2, 3))(_ => true) shouldBe Seq(2, 3)
+  }
+
+  "removeFirst" should "remove only the first element that matches the predicate" in {
+    removeFirst(Seq(1, 2, 3, 2))(_ == 2) shouldBe Seq(1, 3, 2)
+  }
+
+  "removeFirst" should "work on empty collections" in {
+    removeFirst(Seq.empty[Int])(_ => true) shouldBe Seq.empty[Int]
+    removeFirst(Seq.empty[Int])(_ => false) shouldBe Seq.empty[Int]
+  }
+}


### PR DESCRIPTION
## Overview
Moved reusable library functions from the RSpace.util to the "shared" project. 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-621

### Notes
There is a behavior that looks wrong. Please take a look into <<"dropIndex" should "ignore invalid indexes">> unit-test and let me know what do you think about it.