### PR TITLE
Check for index bounds in coop.rchain.shared.SeqOps.dropIndex

### DIFF
--- a/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
@@ -7,6 +7,10 @@ object SeqOps {
   /** Drops the 'i'th element of a list.
     */
   def dropIndex[T](xs: Seq[T], n: Int): Seq[T] = {
+    if((n < 0) || (n >= xs.size)) {
+      throw new IndexOutOfBoundsException(s"Index $n is outside the sequence bounds 0..${xs.size}")
+    }
+
     val (l1, l2) = xs splitAt n
     l1 ++ (l2 drop 1)
   }


### PR DESCRIPTION
## Overview
It's good idea to validate index bounds in coop.rchain.shared.SeqOps.dropIndex

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-621

