### PR TITLE
Rholang: Add Blake2b512Random class and tests.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/crypto/Blake2b512Block.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/crypto/Blake2b512Block.scala
@@ -1,0 +1,152 @@
+package coop.rchain.rholang.crypto
+
+import coop.rchain.rspace.Serialize
+import org.bouncycastle.util.Pack
+
+/**
+Block oriented Blake2b512 class.
+
+Only supports hashes of data a positive number of whole blocks.
+  */
+class Blake2b512Block {
+  import Blake2b512Block._
+  val chainValue: Array[Long] = new Array[Long](CHAIN_VALUE_LENGTH)
+  private var t0: Long        = 0
+  private var t1: Long        = 0
+
+  // block must be 128 bytes long
+  def update(block: Array[Byte], offset: Int): Unit =
+    compress(block, offset, chainValue, false)
+
+  // gives the output as if block were the last block processed, but does not
+  // invalidate or modify internal state
+  def peekFinal(block: Array[Byte], inOffset: Int, output: Array[Byte], outOffset: Int): Unit = {
+    val tempChainValue: Array[Long] = new Array[Long](8)
+    compress(block, inOffset, tempChainValue, true)
+    Pack.longToLittleEndian(tempChainValue, output, outOffset)
+  }
+
+  private[this] def compress(msg: Array[Byte],
+                             offset: Int,
+                             newChainValue: Array[Long],
+                             peek: Boolean): Unit = {
+    val internalState: Array[Long] = new Array[Long](BLOCK_LENGTH_LONGS)
+    def g(m1: Long, m2: Long, posA: Int, posB: Int, posC: Int, posD: Int): Unit = {
+      def rotr64(x: Long, rot: Int): Long =
+        x >>> rot | (x << (64 - rot))
+      internalState(posA) = internalState(posA) + internalState(posB) + m1;
+      internalState(posD) = rotr64(internalState(posD) ^ internalState(posA), 32);
+      internalState(posC) = internalState(posC) + internalState(posD);
+      internalState(posB) = rotr64(internalState(posB) ^ internalState(posC), 24);
+      internalState(posA) = internalState(posA) + internalState(posB) + m2;
+      internalState(posD) = rotr64(internalState(posD) ^ internalState(posA), 16);
+      internalState(posC) = internalState(posC) + internalState(posD);
+      internalState(posB) = rotr64(internalState(posB) ^ internalState(posC), 63);
+    }
+
+    Array.copy(chainValue, 0, internalState, 0, CHAIN_VALUE_LENGTH)
+    Array.copy(IV, 0, internalState, CHAIN_VALUE_LENGTH, 4)
+    val f0    = if (peek) 0xffffffffffffffffL else 0x0L
+    val newT0 = t0 + BLOCK_LENGTH_BYTES
+    val newT1 = if (newT0 == 0) t1 + 1 else t1
+    internalState(12) = newT0 ^ IV(4)
+    internalState(13) = newT1 ^ IV(5)
+    internalState(14) = f0 ^ IV(6)
+    internalState(15) = IV(7)
+
+    val m: Array[Long] = new Array(BLOCK_LENGTH_LONGS)
+    0.until(BLOCK_LENGTH_LONGS).foreach { i =>
+      m(i) = Pack.littleEndianToLong(msg, offset + i * 8)
+    }
+
+    0.until(ROUNDS).foreach { round =>
+      // columns
+      g(m(SIGMA(round)(0).toInt), m(SIGMA(round)(1).toInt), 0, 4, 8, 12);
+      g(m(SIGMA(round)(2).toInt), m(SIGMA(round)(3).toInt), 1, 5, 9, 13);
+      g(m(SIGMA(round)(4).toInt), m(SIGMA(round)(5).toInt), 2, 6, 10, 14);
+      g(m(SIGMA(round)(6).toInt), m(SIGMA(round)(7).toInt), 3, 7, 11, 15);
+      // diagonals
+      g(m(SIGMA(round)(8).toInt), m(SIGMA(round)(9).toInt), 0, 5, 10, 15);
+      g(m(SIGMA(round)(10).toInt), m(SIGMA(round)(11).toInt), 1, 6, 11, 12);
+      g(m(SIGMA(round)(12).toInt), m(SIGMA(round)(13).toInt), 2, 7, 8, 13);
+      g(m(SIGMA(round)(14).toInt), m(SIGMA(round)(15).toInt), 3, 4, 9, 14);
+    }
+    if (!peek) {
+      t0 = newT0
+      t1 = newT1
+    }
+    0.until(CHAIN_VALUE_LENGTH).foreach { i =>
+      newChainValue(i) = chainValue(i) ^ internalState(i) ^ internalState(i + 8)
+    }
+  }
+
+}
+
+object Blake2b512Block {
+  def apply(): Blake2b512Block = {
+    val result = new Blake2b512Block
+    Array.copy(IV, 0, result.chainValue, 0, CHAIN_VALUE_LENGTH)
+    result.chainValue(0) ^= PARAM_VALUE
+    result
+  }
+
+  def apply(src: Blake2b512Block): Blake2b512Block = {
+    val result = new Blake2b512Block
+    Array.copy(src.chainValue, 0, result.chainValue, 0, CHAIN_VALUE_LENGTH)
+    result.t0 = src.t0
+    result.t1 = src.t1
+    result
+  }
+
+  implicit val serialize: Serialize[Blake2b512Block] = new Serialize[Blake2b512Block] {
+    override def encode(block: Blake2b512Block) = {
+      val result: Array[Byte] = new Array[Byte](80)
+      Pack.longToLittleEndian(block.chainValue, result, 0)
+      Pack.longToLittleEndian(block.t0, result, DIGEST_LENGTH_BYTES)
+      Pack.longToLittleEndian(block.t1, result, DIGEST_LENGTH_BYTES + 8)
+      result
+    }
+
+    override def decode(bytes: Array[Byte]): Either[Throwable, Blake2b512Block] =
+      if (bytes.length != 80)
+        Left(new Error("Invalid decode of Blake2b512Block"))
+      else {
+        val result = new Blake2b512Block
+        Pack.littleEndianToLong(bytes, 0, result.chainValue, 0, CHAIN_VALUE_LENGTH)
+        result.t0 = Pack.littleEndianToLong(bytes, DIGEST_LENGTH_BYTES)
+        result.t1 = Pack.littleEndianToLong(bytes, DIGEST_LENGTH_BYTES + 8)
+        Right(result)
+      }
+  }
+
+  // Produced from the square root of primes 2, 3, 5, 7, 11, 13, 17, 19.
+  // The same as SHA-512 IV.
+  val IV: Array[Long] = Array(0x6a09e667f3bcc908L, 0xbb67ae8584caa73bL, 0x3c6ef372fe94f82bL,
+    0xa54ff53a5f1d36f1L, 0x510e527fade682d1L, 0x9b05688c2b3e6c1fL, 0x1f83d9abfb41bd6bL,
+    0x5be0cd19137e2179L)
+
+  // Message word permutations:
+  val SIGMA: Array[Array[Byte]] =
+    Array(
+      Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      Array(14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3),
+      Array(11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4),
+      Array(7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8),
+      Array(9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13),
+      Array(2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9),
+      Array(12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11),
+      Array(13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10),
+      Array(6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5),
+      Array(10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0),
+      Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+      Array(14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3)
+    )
+
+  val ROUNDS: Int              = 12
+  val CHAIN_VALUE_LENGTH: Int  = 8
+  val BLOCK_LENGTH_BYTES: Int  = 128
+  val BLOCK_LENGTH_LONGS: Int  = 16
+  val DIGEST_LENGTH_BYTES: Int = 64
+  // Depth = 1, Fanout = 1, Keylength = 0, Digest length = 64 bytes
+  val PARAM_VALUE: Long = 0x01010040L
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/crypto/Blake2b512Random.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/crypto/Blake2b512Random.scala
@@ -1,0 +1,138 @@
+package coop.rchain.rholang.crypto
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.LongBuffer
+import org.bouncycastle.crypto.digests.Blake2bDigest
+import org.bouncycastle.util.Pack
+
+import coop.rchain.rspace.Serialize
+
+import coop.rchain.crypto.codec._
+
+class Blake2b512Random private (val digest: Blake2b512Block, val lastBlock: ByteBuffer) {
+  val pathView: ByteBuffer = lastBlock.duplicate()
+  pathView.limit(112)
+  val countView: LongBuffer = {
+    val lastDuplicate = lastBlock.duplicate()
+    lastDuplicate.position(112)
+    lastDuplicate.slice().order(ByteOrder.LITTLE_ENDIAN).asLongBuffer()
+  }
+
+  val hashArray: Array[Byte] = new Array[Byte](64)
+  var position: Int          = 0
+
+  private def addByte(index: Byte): Unit = {
+    if (pathView.position() == pathView.limit()) {
+      digest.update(lastBlock.array(), 0)
+      lastBlock.put(Blake2b512Random.BLANK_BLOCK.asReadOnlyBuffer())
+      lastBlock.rewind()
+      pathView.rewind()
+    }
+    pathView.put(index)
+  }
+
+  private[this] def copy(): Blake2b512Random = {
+    val cloneBlock = ByteBuffer.allocate(128)
+    cloneBlock.put(lastBlock.asReadOnlyBuffer())
+    cloneBlock.rewind()
+    val result = new Blake2b512Random(Blake2b512Block(digest), cloneBlock)
+    result.pathView.position(pathView.position)
+    result
+  }
+
+  def hash(): Unit = {
+    digest.peekFinal(lastBlock.array(), 0, hashArray, 0)
+    val low = countView.get(0)
+    if (low == -1) {
+      val high = countView.get(1)
+      countView.put(0, 0)
+      countView.put(1, high + 1)
+    } else {
+      countView.put(0, low + 1)
+    }
+  }
+
+  def next(): Array[Byte] =
+    if (position == 0) {
+      hash()
+      position = 32
+      hashArray.slice(0, 32)
+    } else {
+      position = 0
+      hashArray.slice(32, 64)
+    }
+
+  def splitByte(index: Byte): Blake2b512Random = {
+    val split = copy()
+    split.addByte(index)
+    split
+  }
+
+  def splitShort(index: Short): Blake2b512Random = {
+    val split  = copy()
+    val packed = new Array[Byte](2)
+    Pack.shortToLittleEndian(index, packed, 0)
+    split.addByte(packed(0))
+    split.addByte(packed(1))
+    split
+  }
+
+  def peek: ByteBuffer = lastBlock.asReadOnlyBuffer()
+}
+
+object Blake2b512Random {
+  def apply(init: Array[Byte], offset: Int, length: Int): Blake2b512Random = {
+    val result = new Blake2b512Random(Blake2b512Block(), ByteBuffer.allocate(128))
+    val range  = Range(offset, offset + length - 127, 128)
+    range.foreach { base =>
+      result.digest.update(init, base)
+    }
+    val partialBase =
+      if (range.isEmpty)
+        offset
+      else
+        range.last + 128
+
+    // If there is any remainder:
+    if (offset + length != partialBase) {
+      val padded = new Array[Byte](128)
+      Array.copy(init, partialBase, padded, 0, offset + length - partialBase)
+      result.digest.update(padded, 0)
+    }
+    result
+  }
+  def apply(init: Array[Byte]): Blake2b512Random =
+    apply(init, 0, init.length)
+
+  implicit val serialize: Serialize[Blake2b512Random] = new Serialize[Blake2b512Random] {
+    def encode(rand: Blake2b512Random): Array[Byte] = {
+      val remainderSize =
+        if (rand.position == 0)
+          0
+        else
+          64 - rand.position
+      val digestSize = 80
+      val totalSize  = digestSize + remainderSize + 4
+      val result     = new Array[Byte](totalSize)
+      Array.copy(Blake2b512Block.serialize.encode(rand.digest), 0, result, 0, digestSize)
+      Pack.intToLittleEndian(rand.position, result, digestSize)
+      if (remainderSize != 0)
+        Array.copy(rand.hashArray, rand.position, result, digestSize + 4, remainderSize)
+      result
+    }
+
+    override def decode(bytes: Array[Byte]): Either[Throwable, Blake2b512Random] =
+      Blake2b512Block.serialize
+        .decode(bytes.slice(0, 80))
+        .map(digest => {
+          val remainderPosition: Int = Pack.littleEndianToInt(bytes, 80)
+          val result                 = new Blake2b512Random(digest, ByteBuffer.allocate(128))
+          if (remainderPosition != 0)
+            Array.copy(bytes, 84, result.hashArray, remainderPosition, 64 - remainderPosition)
+          result
+        })
+  }
+
+  val BLANK_BLOCK = ByteBuffer.allocateDirect(128).asReadOnlyBuffer()
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/crypto/Blake2b512RandomTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/crypto/Blake2b512RandomTest.scala
@@ -1,0 +1,46 @@
+package coop.rchain.rholang.crypto
+
+import coop.rchain.crypto.codec._
+import org.scalatest._
+
+import java.nio.ByteBuffer
+
+class Blake2b512RandomSpec extends FlatSpec with Matchers {
+  val emptyMsg: Array[Byte] = new Array[Byte](0)
+  "Empty" should "give a predictable result" in {
+    val b2Random = Blake2b512Random(emptyMsg)
+    val res1     = b2Random.next()
+    val res2     = b2Random.next()
+    Base16.encode(res1) should be(
+      "865939e120e6805438478841afb739ae4250cf372653078a065cdcfffca4caf7")
+    Base16.encode(res2) should be(
+      "98e6d462b65d658fc165782640eded70963449ae1500fb0f24981d7727e22c41")
+  }
+  it should "roll over when enough byte-splits have occurred" in {
+    val b2Random = Blake2b512Random(emptyMsg)
+    val rollover = 0.to(112).foldLeft(b2Random) { (rand, n) =>
+      rand.splitByte(n.toByte)
+    }
+    val res1 = rollover.next()
+    val res2 = rollover.next()
+    Base16.encode(res1) should be(
+      "268bffba5e0b42f4102e39b5fc8db69f60d9af43f832d9799bb515bd7ff74bdf")
+    Base16.encode(res2) should be(
+      "b5c25ea9dcf50d6f71526a573e0b134e9b835e3821923f3ecaa5bf1d31cac912")
+  }
+  it should "correctly handle nexts that are then rolled over" in {
+    val b2Random           = Blake2b512Random(emptyMsg)
+    val result: ByteBuffer = ByteBuffer.allocate(128)
+    b2Random.next()
+    val rollover = 0.to(112).foldLeft(b2Random) { (rand, n) =>
+      rand.splitByte(n.toByte)
+    }
+    val res1 = rollover.next()
+    val res2 = rollover.next()
+
+    Base16.encode(res1) should be(
+      "0c6f966e2c1e1dc05173be1a94f0cb1c050015d670ac560f6f156baae3ce2bf4")
+    Base16.encode(res2) should be(
+      "438ad6889699497717dd4b05864b0e110888ce906b69944d2d9ca426c4baf9b2")
+  }
+}


### PR DESCRIPTION
Blake2b512Random is a specific purpose splittable random number generator. It
allows us to split along byte boundaries, and follows the basic design of
tf-random. In our case, we can only extract 256-bit sequences. We will be using
these sequences to generate predictable unforgeable names. All of the test
vectors were created by using a hex-editor to construct appopriate binary files
and then hashing them with b2sum.