### PR TITLE
Use Base16 for byte address encoding to String

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/PeerNode.scala
+++ b/comm/src/main/scala/coop/rchain/comm/PeerNode.scala
@@ -3,10 +3,12 @@ package coop.rchain.comm
 import java.net.InetSocketAddress
 import com.netaporter.uri.Uri
 import scala.util.control.NonFatal
+import coop.rchain.crypto.codec.Base16
 
 // TODO: Add Show instance
 final case class NodeIdentifier(key: Seq[Byte]) {
-  override def toString: String = key.map("%02x".format(_)).mkString
+  private val keyString         = Base16.encode(key.toArray)
+  override def toString: String = keyString
 }
 
 object NodeIdentifier {

--- a/comm/src/test/scala/coop/rchain/kademlia/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/kademlia/DistanceSpec.scala
@@ -1,14 +1,12 @@
 package coop.rchain.comm.discovery
 
 import org.scalatest._
-import scala.util.{Success, Try}
-import scala.concurrent.duration.{Duration, MILLISECONDS}
 
 import cats._
 
 import coop.rchain.catscontrib.Capture
 import coop.rchain.comm._
-import coop.rchain.comm.discovery._
+import coop.rchain.crypto.codec.Base16
 
 object b {
   val rand                   = new scala.util.Random(System.currentTimeMillis)
@@ -60,7 +58,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     def keyString(key: Seq[Byte]): String =
-      key.map("%02x".format(_)).mkString
+      Base16.encode(key.toArray)
 
     val k0 = Array.fill(width)(b(0))
     s"A node with key all zeroes (${keyString(k0)})" should "compute distance correctly" in {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -89,14 +89,16 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       case _ => None
     }
 
-    Base16.encode(
-      publicKey
-        .flatMap(CertificateHelper.publicAddress)
-        .getOrElse {
-          println("Certificate must contain a secp256r1 EC Public Key")
-          System.exit(1)
-          Array[Byte]()
-        })
+    val publicKeyHash = publicKey
+      .flatMap(CertificateHelper.publicAddress)
+      .map(Base16.encode)
+
+    if (publicKeyHash.isEmpty) {
+      println("Certificate must contain a secp256r1 EC Public Key")
+      System.exit(1)
+    }
+
+    publicKeyHash.get
   }
 
   import ApplicativeError_._

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -89,15 +89,14 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       case _ => None
     }
 
-    publicKey
-      .flatMap(CertificateHelper.publicAddress)
-      .getOrElse {
-        println("Certificate must contain a secp256r1 EC Public Key")
-        System.exit(1)
-        Array[Byte]()
-      }
-      .map("%02x".format(_))
-      .mkString
+    Base16.encode(
+      publicKey
+        .flatMap(CertificateHelper.publicAddress)
+        .getOrElse {
+          println("Certificate must contain a secp256r1 EC Public Key")
+          System.exit(1)
+          Array[Byte]()
+        })
   }
 
   import ApplicativeError_._


### PR DESCRIPTION
## Overview
Use `coop.rchain.crypto.codec.Base16` instead of `map("%02x".format(_))`

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-671

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
