### PR TITLE
CORE-666 Remove shortcut for `diagnostics` subcommand

### DIFF
--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -19,7 +19,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     opt[String](default = Some("localhost"),
                 descr = "Hostname or IP of node on which gRPC service is running.")
 
-  val diagnostics = new Subcommand("diagnostics", "d") {
+  val diagnostics = new Subcommand("diagnostics") {
     descr("Node diagnostics")
   }
   addSubcommand(diagnostics)


### PR DESCRIPTION
## Overview
Subcommands should be used with their full name

### Does this PR relate to an RChain JIRA issue? 
CORE-666 
