### PR TITLE
Fix Kademlia issue with concurrency

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -17,7 +17,7 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
   private val table = PeerTable(src)
 
   private def updateLastSeen(peer: PeerNode): F[Unit] =
-    table.observe[F](peer, add = true)
+    table.observe[F](peer)
 
   private val id: NodeIdentifier = src.id
 

--- a/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable
 import scala.annotation.tailrec
 import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib.Capture
+import coop.rchain.shared._
 
 trait Keyed {
   def key: Seq[Byte]
@@ -109,22 +110,10 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
   private[discovery] def distance(otherKey: Seq[Byte]): Option[Int] = distance(home.key, otherKey)
   private[discovery] def distance(other: A): Option[Int]            = distance(other.key)
 
-  private def ping[F[_]: Functor: Ping](ps: mutable.ListBuffer[Entry],
-                                        older: Entry,
-                                        newer: A): F[Unit] =
-    Ping[F].ping(older.entry).map { response =>
-      val winner = if (response) older else new Entry(newer, _.key)
-      ps synchronized {
-        ps -= older
-        ps += winner
-        winner.pinging = false
-      }
-    }
-
   /** Update the last-seen time of `peer`, possibly adding it to the
     * routing table.
     *
-    * If `add` is true, and `peer` is not in the table, it is
+    * If the `peer` is not in the table, it is
     * added. If the table was already full at that distance, test the
     * least recently seen peer at that distance. If that peer
     * responds, discard `peer`; otherwise, discard the older entry and
@@ -133,39 +122,55 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
     * If `peer` is already in the table, it becomes the most recently
     * seen entry at its distance.
     */
-  def observe[F[_]: Applicative: Capture: Ping](peer: A, add: Boolean): F[Unit] =
-    distance(home.key, peer.key) match {
-      case Some(index) =>
-        if (index < 8 * width) {
-          val ps = table(index)
-          ps synchronized {
-            ps.find(_.key == peer.key) match {
-              case Some(entry) =>
-                Capture[F].capture {
-                  ps -= entry
-                  ps += entry
+  def observe[F[_]: Monad: Capture: Ping: Log](peer: A): F[Unit] = {
+
+    def bucket: F[Option[mutable.ListBuffer[Entry]]] =
+      Capture[F].capture(distance(home.key, peer.key).filter(_ < 8 * width).map(table.apply))
+
+    def addUpdateOrPickOldPeer(ps: mutable.ListBuffer[Entry]): F[Option[Entry]] =
+      Capture[F].capture {
+        ps synchronized {
+          ps.find(_.key == peer.key) match {
+            case Some(entry) =>
+              ps -= entry
+              ps += entry
+              None
+            case None =>
+              if (ps.size < k) {
+                ps += new Entry(peer, _.key)
+                None
+              } else {
+                // ping first (oldest) element that isn't already being
+                // pinged. If it responds, move it to back (newest
+                // position); if it doesn't respond, remove it and place
+                // a in back instead
+                ps.find(!_.pinging).map { candidate =>
+                  candidate.pinging = true
+                  candidate
                 }
-              case None if add =>
-                if (ps.size < k) {
-                  Capture[F].capture(ps += new Entry(peer, _.key))
-                } else {
-                  // ping first (oldest) element that isn't already being
-                  // pinged. If it responds, move it to back (newest
-                  // position); if it doesn't respond, remove it and place
-                  // a in back instead
-                  ps.find(!_.pinging)
-                    .map { candidate =>
-                      candidate.pinging = true
-                      ping[F](ps, candidate, peer)
-                    }
-                    .getOrElse(().pure[F])
-                }
-              case None => ().pure[F]
-            }
+              }
           }
-        } else ().pure[F]
-      case None => ().pure[F]
-    }
+        }
+      }
+
+    def ping(ps: mutable.ListBuffer[Entry], older: Entry): F[Unit] =
+      Ping[F].ping(older.entry).map { response =>
+        val winner = if (response) older else new Entry(peer, _.key)
+        ps synchronized {
+          ps -= older
+          ps += winner
+          winner.pinging = false
+        }
+      }
+
+    val result = for {
+      ps    <- OptionT(bucket)
+      older <- OptionT(addUpdateOrPickOldPeer(ps))
+      _     <- OptionT.liftF(ping(ps, older))
+    } yield ()
+
+    result.value.void
+  }
 
   /**
     * Remove a peer with the given key.

--- a/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
@@ -122,7 +122,7 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
     * If `peer` is already in the table, it becomes the most recently
     * seen entry at its distance.
     */
-  def observe[F[_]: Monad: Capture: Ping: Log](peer: A): F[Unit] = {
+  def observe[F[_]: Monad: Capture: Ping](peer: A): F[Unit] = {
 
     def bucket: F[Option[mutable.ListBuffer[Entry]]] =
       Capture[F].capture(distance(home.key, peer.key).filter(_ < 8 * width).map(table.apply))

--- a/comm/src/test/scala/coop/rchain/kademlia/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/kademlia/DistanceSpec.scala
@@ -97,7 +97,7 @@ class DistanceSpec extends FlatSpec with Matchers {
       val toAdd = oneOffs(kr).head
       val dist  = table.distance(toAdd).get
       for (i <- 1 to 10) {
-        table.observe[Id](PeerNode(NodeIdentifier(toAdd), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(toAdd), endpoint))
         table.table(dist).size should be(1)
       }
     }
@@ -105,7 +105,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     s"A table of width $width with peers at all distances" should "have no empty buckets" in {
       val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
       for (k <- oneOffs(kr.toArray)) {
-        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
       assert(table.table.forall(_.nonEmpty))
     }
@@ -113,7 +113,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should s"return min(k, ${8 * width}) peers on lookup" in {
       val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
       for (k <- oneOffs(kr.toArray)) {
-        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
       table.lookup(b.rand(width)).size should be(scala.math.min(table.k, 8 * width))
     }
@@ -121,7 +121,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should "not return sought peer on lookup" in {
       val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
       for (k <- oneOffs(kr.toArray)) {
-        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
       val target = table.table(table.width * 4)(0)
       val resp   = table.lookup(target.key)
@@ -131,7 +131,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should s"return ${8 * width} peers when sequenced" in {
       val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
       for (k <- oneOffs(kr.toArray)) {
-        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
       table.peers.size should be(8 * width)
     }
@@ -139,7 +139,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should "find each added peer" in {
       val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
       for (k <- oneOffs(kr.toArray)) {
-        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint), true)
+        table.observe[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
       for (k <- oneOffs(kr.toArray)) {
         table.find(k) should be(Some(PeerNode(NodeIdentifier(k), endpoint)))


### PR DESCRIPTION
## Overview
With refactoring Kademlia to MTL/TF a bug has been introduced with concurrency. Under some circumstances, a node has been added multiple times to the table of peers. The PR fixes this bug.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-587

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
We need to refactor Kademlia from imperative code to FP with `MonadState` and immutable data structures.