### PR TITLE
ROS-384: Add test case for EmptyMbox to LockedMbox

### DIFF
--- a/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
@@ -5,10 +5,111 @@ import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.roscala.CtxtRegName._
 import coop.rchain.roscala.VmLiteralName._
 import coop.rchain.roscala.ob.expr.TupleExpr
+import coop.rchain.roscala.ob.MboxOb.LockedMbox
 
 class ActorSpec extends FlatSpec with Matchers {
 
-  "Dispatching a message to an actor" should "invoke a method" in {
+  def defineActorWithoutUnlock =
+    new {
+
+      /**
+        * (defOprn return-one)
+        * (defActor Foo
+        *   (method (return-one)
+        *     1
+        *   )
+        * )
+        * (define foo (new Foo))
+        */
+      val returnOneOprn = new Oprn
+      val foo           = new Actor
+
+      /**
+        * litvec:
+        *   0:   {StdMthd}
+        *   1:   {Template}
+        * codevec:
+        *   0:   extend 1
+        *   1:   lit 1,rslt
+        *   2:   rtn/nxt
+        *
+        * For some unknown reason the compiler wants to extend `env` (of
+        * the `Ctxt` that gets scheduled by the `return-one` method)
+        * with the mapping `Symbol(#self) -> foo`.
+        */
+      val keyMeta = Meta(extensible = false)
+      keyMeta.map.update(Symbol("#self"), LexVariable(0, 0, indirect = false))
+
+      val template = new Template(
+        keyTuple = Tuple(Symbol("#self")),
+        pat = new IdVecPattern(new TupleExpr(Seq(Symbol("#self")))),
+        keyMeta = keyMeta
+      )
+
+      val returnOneCode = Code(
+        litvec = Seq(Niv, template),
+        codevec = Seq(
+          OpExtend(1),
+          OpImmediateLitToReg(literal = `1`, reg = rslt),
+          OpRtn(next = true)
+        )
+      )
+
+      val returnOneMthd = Mthd(returnOneCode)
+
+      /**
+        * Create global environment with `foo` in the first position
+        * and the `return-one` operation in the second position.
+        */
+      val globalEnv = new GlobalEnv()
+      globalEnv.addSlot(Symbol("foo"), foo)
+      globalEnv.addSlot(Symbol("return-one"), returnOneOprn)
+
+      /**
+        * Add key-value pair to `foo` actor instance that maps the
+        * `return-one` operation to the `return-one` method of `Foo`.
+        */
+      foo.meta.add(foo, returnOneOprn, returnOneMthd, ctxt = null)(globalEnv)
+      foo.mbox = new EmptyMbox
+    }
+
+  "Failing to unlock" should "turn an EmptyMbox into a LockedMbox" in {
+
+    /**
+      * Sending a messages to an `Actor` that does not unlock itself,
+      * should turn the Actor's mailbox into a `LockedMbox`.
+      *
+      * (defOprn return-one)
+      * (defActor Foo
+      *   (method (return-one)
+      *     1
+      *   )
+      * )
+      * (define foo (new Foo))
+      *
+      * `mbox` gets locked and `return-one` method gets invoked.
+      * (return-one foo)
+      *
+      */
+    val fixture = defineActorWithoutUnlock
+
+    /** Bytecode for `(return-one foo)` */
+    val codevec = Seq(
+      OpAlloc(1),
+      OpXferGlobalToArg(global = 0, arg = 0),
+      OpXferGlobalToReg(global = 1, reg = trgt),
+      OpXmit(unwind = false, next = true, nargs = 1)
+    )
+
+    val code = Code(litvec = Seq.empty, codevec = codevec)
+    val ctxt = Ctxt(code, Ctxt.empty, LocRslt)
+
+    Vm.run(ctxt, fixture.globalEnv, Vm.State())
+
+    fixture.foo.mbox shouldBe LockedMbox
+  }
+
+  "Dispatching a message" should "invoke a method" in {
 
     /**
       * Send empty message to an `Actor` that in response invokes
@@ -51,56 +152,7 @@ class ActorSpec extends FlatSpec with Matchers {
       * altered with the code of the `return-one` method.
       * The altered `Ctxt` then gets scheduled.
       */
-    val returnOneOprn = new Oprn
-    val foo           = new Actor
-
-    /**
-      * litvec:
-      *   0:   {StdMthd}
-      *   1:   {Template}
-      * codevec:
-      *   0:   extend 1
-      *   1:   lit 1,rslt
-      *   2:   rtn/nxt
-      *
-      * For some unknown reason the compiler wants to extend `env` (of
-      * the `Ctxt` that gets scheduled by the `return-one` method)
-      * with the mapping `Symbol(#self) -> foo`.
-      */
-    val keyMeta = Meta(extensible = false)
-    keyMeta.map.update(Symbol("#self"), LexVariable(0, 0, indirect = false))
-
-    val template = new Template(
-      keyTuple = Tuple(Symbol("#self")),
-      pat = new IdVecPattern(new TupleExpr(Seq(Symbol("#self")))),
-      keyMeta = keyMeta
-    )
-
-    val returnOneCode = Code(
-      litvec = Seq(Niv, template),
-      codevec = Seq(
-        OpExtend(1),
-        OpImmediateLitToReg(literal = `1`, reg = rslt),
-        OpRtn(next = true)
-      )
-    )
-
-    val returnOneMthd = Mthd(returnOneCode)
-
-    /**
-      * Create global environment with `foo` in the first position
-      * and the `return-one` operation in the second position.
-      */
-    val globalEnv = new GlobalEnv()
-    globalEnv.addSlot(Symbol("foo"), foo)
-    globalEnv.addSlot(Symbol("return-one"), returnOneOprn)
-
-    /**
-      * Add key-value pair to `foo` actor instance that maps the
-      * `return-one` operation to the `return-one` method of `Foo`.
-      */
-    foo.meta.add(foo, returnOneOprn, returnOneMthd, ctxt = null)(globalEnv)
-    foo.mbox = new EmptyMbox
+    val fixture = defineActorWithoutUnlock
 
     /** Bytecode for `(return-one foo)` */
     val codevec = Seq(
@@ -115,7 +167,7 @@ class ActorSpec extends FlatSpec with Matchers {
     val code = Code(litvec = Seq.empty, codevec = codevec)
     val ctxt = Ctxt(code, rtnCtxt, LocRslt)
 
-    Vm.run(ctxt, globalEnv, Vm.State())
+    Vm.run(ctxt, fixture.globalEnv, Vm.State())
 
     rtnCtxt.rslt shouldBe Fixnum(1)
   }


### PR DESCRIPTION
## Overview
Adds a test case that asserts that an `Actor` changes its mailbox from an `EmptyMbox` to a `LockedMbox` when it receives a message. 
Also cleans up Actor tests by providing a fixture.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=6&projectKey=ROS&modal=detail&selectedIssue=ROS-384

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

