### PR TITLE
CORE-676 Introduce LogSource to extend functionality of logger

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -15,7 +15,7 @@ import coop.rchain.p2p.effects._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.comm.transport._
 import coop.rchain.comm.discovery._
-import coop.rchain.shared.{AtomicSyncVar, Log, Time}
+import coop.rchain.shared.{AtomicSyncVar, Log, LogSource, Time}
 
 import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
@@ -51,6 +51,9 @@ object MultiParentCasper extends MultiParentCasperInstances {
 }
 
 sealed abstract class MultiParentCasperInstances {
+
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def noOpsCasper[F[_]: Applicative]: MultiParentCasper[F] =
     new MultiParentCasper[F] {
       def addBlock(b: BlockMessage): F[Unit]    = ().pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -8,11 +8,13 @@ import coop.rchain.casper.protocol.{BlockMessage, Justification}
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.shared.Log
+import coop.rchain.shared.{Log, LogSource}
 
 import scala.util.Try
 
 object Validate {
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def ignore(b: BlockMessage, reason: String): String =
     s"CASPER: Ignoring block ${PrettyPrinter.buildString(b.blockHash)} because $reason"
 

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -11,7 +11,7 @@ import coop.rchain.casper.util.ProtoUtil.{blockHeader, unsignedBlockProto}
 import coop.rchain.casper.util.Sorting
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.shared.Log
+import coop.rchain.shared.{Log, LogSource}
 
 import java.io.{File, PrintWriter}
 import java.nio.file.Path
@@ -20,6 +20,8 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 object Genesis {
+
+  private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def fromBondsFile[F[_]: Monad: Capture: Log](maybePath: Option[String],
                                                numValidators: Int,

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -19,6 +19,8 @@ import scala.util.Try
 
 object CommUtil {
 
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def sendBlock[F[_]: Monad: NodeDiscovery: TransportLayer: Log: Time: ErrorHandler](
       b: BlockMessage): F[Unit] = {
     val serializedBlock = b.toByteString

--- a/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
@@ -22,7 +22,8 @@ import coop.rchain.comm.CommError.ErrorHandler
 
 object Connect {
 
-  val defaultTimeout: Duration = Duration(500, MILLISECONDS)
+  val defaultTimeout: Duration              = Duration(500, MILLISECONDS)
+  private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def findAndConnect[
       F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler]

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -21,6 +21,8 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
 
   private val id: NodeIdentifier = src.id
 
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def addNode(peer: PeerNode): F[Unit] =
     for {
       _ <- updateLastSeen(peer)

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -32,6 +32,8 @@ sealed abstract class TransportLayerInstances {
 
   import CommunicationResponse._
 
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   implicit def eitherTTransportLayer[E, F[_]: Monad: Log](
       implicit evF: TransportLayer[F]): TransportLayer[EitherT[F, E, ?]] =
     new TransportLayer[EitherT[F, E, ?]] {

--- a/comm/src/main/scala/coop/rchain/p2p/effects/PacketHandler.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/effects/PacketHandler.scala
@@ -11,6 +11,8 @@ trait PacketHandler[F[_]] {
 }
 
 object PacketHandler extends PacketHandlerInstances {
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def apply[F[_]: PacketHandler]: PacketHandler[F] = implicitly[PacketHandler[F]]
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -93,16 +93,16 @@ object EffectsTestInstances {
       warns = List.empty[String]
       errors = List.empty[String]
     }
-    def debug(msg: String): F[Unit] = ().pure[F]
-    def info(msg: String): F[Unit] = {
+    def debug(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
+    def info(msg: String)(implicit ev: LogSource): F[Unit] = {
       infos = infos :+ msg
       ().pure[F]
     }
-    def warn(msg: String): F[Unit] = {
+    def warn(msg: String)(implicit ev: LogSource): F[Unit] = {
       warns = warns :+ msg
       ().pure[F]
     }
-    def error(msg: String): F[Unit] = {
+    def error(msg: String)(implicit ev: LogSource): F[Unit] = {
       errors = errors :+ msg
       ().pure[F]
     }

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -35,6 +35,8 @@ import coop.rchain.shared._
 
 object GrpcServer {
 
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   def acquireServer[
       F[_]: Capture: Monad: MultiParentCasper: NodeDiscovery: StoreMetrics: JvmMetrics: NodeMetrics: Futurable: SafetyOracle](
       port: Int,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -21,12 +21,14 @@ package object effects {
   def log: Log[Task] = new Log[Task] {
     import com.typesafe.scalalogging.Logger
 
-    val logger = Logger("logger")
-
-    def debug(msg: String): Task[Unit] = Task.delay(logger.debug(msg))
-    def info(msg: String): Task[Unit]  = Task.delay(logger.info(msg))
-    def warn(msg: String): Task[Unit]  = Task.delay(logger.warn(msg))
-    def error(msg: String): Task[Unit] = Task.delay(logger.error(msg))
+    def debug(msg: String)(implicit ev: LogSource): Task[Unit] =
+      Task.delay(Logger(ev.clazz).debug(msg))
+    def info(msg: String)(implicit ev: LogSource): Task[Unit] =
+      Task.delay(Logger(ev.clazz).info(msg))
+    def warn(msg: String)(implicit ev: LogSource): Task[Unit] =
+      Task.delay(Logger(ev.clazz).warn(msg))
+    def error(msg: String)(implicit ev: LogSource): Task[Unit] =
+      Task.delay(Logger(ev.clazz).error(msg))
   }
 
   def time: Time[Task] = new Time[Task] {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -34,6 +34,8 @@ import scala.util.{Failure, Success, Try}
 
 class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
   // Generate certificate if not provided as option or in the data dir
   if (conf.run.certificate.toOption.isEmpty
       && !conf.run.certificatePath.toFile.exists()) {


### PR DESCRIPTION
## Overview
Uptil now logger was logging with source set to "main". This was
problematic when working with logs as each message
loged (INFO/WARN/ERROR/DEBUG) were listed as if they were coming from
the same file.

With this change this is no longer a case. Each class that needs to
use Log[F] has to provide an evidence (only once) for a
`LogSource`. This way each time Log[F] method is called, the logger
can be created with the source set correctly

### Does this PR relate to an RChain JIRA issue? 
CORE-676