### PR TITLE
[RHOL-444]: Fix bug in if-else desugaring

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -234,7 +234,7 @@ object ProcNormalizeMatcher {
 
     def normalizeIfElse(valueProc: Proc,
                         trueBodyProc: Proc,
-                        falseBodyProc: Proc): M[ProcVisitOutputs] =
+                        falseBodyProc: Proc, input: ProcVisitInputs): M[ProcVisitOutputs] =
       for {
         targetResult <- normalizeMatch[M](valueProc, input)
         trueCaseBody <- normalizeMatch[M](
@@ -762,8 +762,18 @@ object ProcNormalizeMatcher {
           )
       }
 
-      case p: PIf     => normalizeIfElse(p.proc_1, p.proc_2, new PNil())
-      case p: PIfElse => normalizeIfElse(p.proc_1, p.proc_2, p.proc_3)
+      case p: PIf     =>
+        normalizeIfElse(p.proc_1, p.proc_2, new PNil(), input.copy(par = VectorPar()))
+          .map(normalized => ProcVisitOutputs(
+            input.par ++ normalized.par,
+            normalized.knownFree
+          ))
+      case p: PIfElse =>
+        normalizeIfElse(p.proc_1, p.proc_2, p.proc_3, input.copy(par = VectorPar()))
+          .map(normalized => ProcVisitOutputs(
+            input.par ++ normalized.par,
+            normalized.knownFree
+          ))
 
       case _ =>
         err.raiseError(UnrecognizedNormalizerError("Compilation of construct not yet supported."))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -764,16 +764,10 @@ object ProcNormalizeMatcher {
 
       case p: PIf     =>
         normalizeIfElse(p.proc_1, p.proc_2, new PNil(), input.copy(par = VectorPar()))
-          .map(normalized => ProcVisitOutputs(
-            input.par ++ normalized.par,
-            normalized.knownFree
-          ))
+          .map(n => n.copy(par = n.par ++ input.par))
       case p: PIfElse =>
         normalizeIfElse(p.proc_1, p.proc_2, p.proc_3, input.copy(par = VectorPar()))
-          .map(normalized => ProcVisitOutputs(
-            input.par ++ normalized.par,
-            normalized.knownFree
-          ))
+          .map(n => n.copy(par = n.par ++ input.par))
 
       case _ =>
         err.raiseError(UnrecognizedNormalizerError("Compilation of construct not yet supported."))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -638,6 +638,21 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.knownFree should be(inputs.knownFree)
   }
 
+  it should "not mix Par from the input with normalized one (RHOL-444)" in {
+    val rightProc = new PIf(new PGround(new GroundBool(new BoolTrue())), new PGround(new GroundInt(10)))
+
+    val input = inputs.copy(par = Par(exprs = Seq(GInt(7))))
+    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](rightProc, input).value
+
+    result.knownFree should be(inputs.knownFree)
+    result.par should be(
+      inputs.par.copy(
+        matches = Seq(Match(GBool(true), Seq(MatchCase(GBool(true), GInt(10)), MatchCase(GBool(false), Par())))),
+        exprs = Seq(GInt(7)))
+    )
+  }
+
+
   "PIfElse" should "Handle a more complicated if statement with an else clause" in {
     // if (47 == 47) { new x in { x!(47) } } else { new y in { y!(47) } }
     val condition = new PEq(new PGround(new GroundInt(47)), new PGround(new GroundInt(47)))


### PR DESCRIPTION
## Overview
`Par`s from the environment were concatenated inside the `if` condition instead of to the whole `if-else` expression.

### Does this PR relate to an RChain JIRA issue? 
[JIRA issue](https://rchain.atlassian.net/browse/RHOL-444).

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
None