### PR TITLE
CORE-693 - Trivial wrappers for getData and getWaitingContinuations

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -53,6 +53,16 @@ trait ISpace[C, P, A, K] {
         }
     }
 
+  def getData(channel: C): Seq[Datum[A]] =
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getData(txn, Seq(channel))
+    }
+
+  def getWaitingContinuations(channels: Seq[C]): Seq[WaitingContinuation[P, K]] =
+    store.withTxn(store.createTxnRead()) { txn =>
+      store.getWaitingContinuation(txn, channels)
+    }
+
   /** Iterates through (channel, pattern) pairs looking for matching data.
     *
     * Potential match candidates are supplied by the `channelToIndexedData` cache.


### PR DESCRIPTION
## Overview
Trivial wrappers with read transactions around the existing methods in IStore. Required for Casper PoS.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-693