### PR TITLE
CORE-661: Improve Serialize type class

### DIFF
--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -3,17 +3,19 @@ package coop.rchain.models.serialization
 import cats.implicits._
 import coop.rchain.models._
 import coop.rchain.rspace.Serialize
+import scodec.bits.ByteVector
+
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
 object implicits {
   def mkProtobufInstance[T <: GeneratedMessage with Message[T]](
       comp: GeneratedMessageCompanion[T]) = new Serialize[T] {
 
-    override def encode(a: T): Array[Byte] =
-      comp.toByteArray(a)
+    override def encode(a: T): ByteVector =
+      ByteVector.view(comp.toByteArray(a))
 
-    override def decode(bytes: Array[Byte]): Either[Throwable, T] =
-      Either.catchNonFatal(comp.parseFrom(bytes))
+    override def decode(bytes: ByteVector): Either[Throwable, T] =
+      Either.catchNonFatal(comp.parseFrom(bytes.toArray))
   }
 
   implicit val serializePar: Serialize[Par]         = mkProtobufInstance(Par)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -25,9 +25,11 @@ import monix.execution.Scheduler
 import diagnostics.MetricsServer
 import coop.rchain.comm.transport._
 import coop.rchain.comm.discovery._
-import coop.rchain.shared._, ThrowableOps._
+import coop.rchain.shared._
+import ThrowableOps._
 import coop.rchain.node.api._
 import coop.rchain.comm.connect.Connect
+import coop.rchain.crypto.codec.Base16
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -580,7 +580,7 @@ object Reduce {
     private[this] def toByteArray: MethodType = {
       def serialize(p: Par): Either[ReduceError, Array[Byte]] =
         Either
-          .fromTry(Try(Serialize[Par].encode(p)))
+          .fromTry(Try(Serialize[Par].encode(p).toArray))
           .leftMap(th =>
             ReduceError(s"Error: exception thrown when serializing $p." + th.getMessage))
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -234,7 +234,8 @@ object ProcNormalizeMatcher {
 
     def normalizeIfElse(valueProc: Proc,
                         trueBodyProc: Proc,
-                        falseBodyProc: Proc, input: ProcVisitInputs): M[ProcVisitOutputs] =
+                        falseBodyProc: Proc,
+                        input: ProcVisitInputs): M[ProcVisitOutputs] =
       for {
         targetResult <- normalizeMatch[M](valueProc, input)
         trueCaseBody <- normalizeMatch[M](
@@ -762,7 +763,7 @@ object ProcNormalizeMatcher {
           )
       }
 
-      case p: PIf     =>
+      case p: PIf =>
         normalizeIfElse(p.proc_1, p.proc_2, new PNil(), input.copy(par = VectorPar()))
           .map(n => n.copy(par = n.par ++ input.par))
       case p: PIfElse =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -8,6 +8,7 @@ import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.rholang.interpreter.SpatialMatcher._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
+import scodec.bits.ByteVector
 
 //noinspection ConvertExpressionToSAM
 object implicits {
@@ -57,11 +58,11 @@ object implicits {
   implicit val serializeChannels: Serialize[Seq[Channel]] =
     new Serialize[Seq[Channel]] {
 
-      override def encode(a: Seq[Channel]): Array[Byte] =
-        ListChannel.toByteArray(ListChannel(a))
+      override def encode(a: Seq[Channel]): ByteVector =
+        ByteVector.view(ListChannel.toByteArray(ListChannel(a)))
 
-      override def decode(bytes: Array[Byte]): Either[Throwable, Seq[Channel]] =
-        Either.catchNonFatal(ListChannel.parseFrom(bytes).channels.toList)
+      override def decode(bytes: ByteVector): Either[Throwable, Seq[Channel]] =
+        Either.catchNonFatal(ListChannel.parseFrom(bytes.toArray).channels.toList)
     }
 
   implicit val serializeTaggedContinuation: Serialize[TaggedContinuation] =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -40,7 +40,7 @@ class CryptoChannelsSpec
   implicit val serializeChannel: Serialize[Channel]       = storage.implicits.serializeChannel
   implicit val serializeChannels: Serialize[Seq[Channel]] = storage.implicits.serializeChannels
 
-  val serialize: Par => Array[Byte]                    = Serialize[Par].encode _
+  val serialize: Par => Array[Byte]                    = Serialize[Par].encode(_).toArray
   val byteArrayToByteString: Array[Byte] => ByteString = ba => ByteString.copyFrom(ba)
   val byteStringToExpr: ByteString => Expr             = bs => Expr(GByteArray(bs))
   val byteArrayToExpr                                  = byteArrayToByteString andThen byteStringToExpr

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -745,7 +745,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                        false,
                        1,
                        BitSet())
-    val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc))
+    val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc).toArray)
     val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>
@@ -799,7 +799,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val testString                = "testing testing"
     val base16Repr                = Base16.encode(testString.getBytes)
     val proc: Par                 = GString(base16Repr)
-    val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc))
+    val serializedProcess         = com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc).toArray)
     val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -8,6 +8,7 @@ import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.shared.Language.ignore
 import coop.rchain.rspace.util.runKs
+import scodec.bits.ByteVector
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable
@@ -80,20 +81,20 @@ object AddressBookExample {
       */
     implicit val serializeChannel: Serialize[Channel] = new Serialize[Channel] {
 
-      def encode(channel: Channel): Array[Byte] = {
+      def encode(channel: Channel): ByteVector = {
         val baos = new ByteArrayOutputStream()
         try {
           val oos = new ObjectOutputStream(baos)
           try { oos.writeObject(channel) } finally { oos.close() }
-          baos.toByteArray
+          ByteVector.view(baos.toByteArray)
         } finally {
           baos.close()
         }
       }
 
-      def decode(bytes: Array[Byte]): Either[Throwable, Channel] =
+      def decode(bytes: ByteVector): Either[Throwable, Channel] =
         try {
-          val bais = new ByteArrayInputStream(bytes)
+          val bais = new ByteArrayInputStream(bytes.toArray)
           try {
             val ois = new ObjectInputStream(bais)
             try { Right(ois.readObject.asInstanceOf[Channel]) } finally { ois.close() }

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets
 
 import coop.rchain.shared.Language.ignore
 import coop.rchain.rspace.{Match, Serialize}
+import scodec.bits.ByteVector
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -54,11 +55,11 @@ object StringExamples {
 
     implicit object stringSerialize extends Serialize[String] {
 
-      def encode(a: String): Array[Byte] =
-        a.getBytes(StandardCharsets.UTF_8)
+      def encode(a: String): ByteVector =
+        ByteVector.view(a.getBytes(StandardCharsets.UTF_8))
 
-      def decode(bytes: Array[Byte]): Either[Throwable, String] =
-        Right(new String(bytes, StandardCharsets.UTF_8))
+      def decode(bytes: ByteVector): Either[Throwable, String] =
+        Right(new String(bytes.toArray, StandardCharsets.UTF_8))
     }
 
     implicit val stringClosureSerialize: Serialize[StringsCaptor] =

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
@@ -4,23 +4,24 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 
 import cats.syntax.either._
 import coop.rchain.shared.Resources.withResource
+import scodec.bits.ByteVector
 
 package object examples {
 
   def makeSerializeFromSerializable[T <: Serializable]: Serialize[T] =
     new Serialize[T] {
 
-      def encode(a: T): Array[Byte] =
+      def encode(a: T): ByteVector =
         withResource(new ByteArrayOutputStream()) { baos =>
           withResource(new ObjectOutputStream(baos)) { (oos: ObjectOutputStream) =>
             oos.writeObject(a)
           }
-          baos.toByteArray
+          ByteVector.view(baos.toByteArray)
         }
 
-      def decode(bytes: Array[Byte]): Either[Throwable, T] =
+      def decode(bytes: ByteVector): Either[Throwable, T] =
         Either.catchNonFatal {
-          withResource(new ByteArrayInputStream(bytes)) { bais =>
+          withResource(new ByteArrayInputStream(bytes.toArray)) { bais =>
             withResource(new ObjectInputStream(bais)) { ois =>
               ois.readObject.asInstanceOf[T]
             }

--- a/rspace/src/main/tut/Tutorial.md
+++ b/rspace/src/main/tut/Tutorial.md
@@ -89,9 +89,9 @@ Here is the definition of the `Serialize` type class:
   */
 trait Serialize[A] {
 
-  def encode(a: A): Array[Byte]
+  def encode(a: A): ByteVector
 
-  def decode(bytes: Array[Byte]): Either[Throwable, A]
+  def decode(bytes: ByteVector): Either[Throwable, A]
 }
 ```
 
@@ -100,26 +100,27 @@ Let's try defining an instance of `Serialize` for `Channel` using Java serializa
 First we will need to import some more stuff.
 ```tut
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+import scodec.bits.ByteVector
 ```
 
 Now we define an instance of `Serialize`.
 ```tut
 implicit object serializeChannel extends Serialize[Channel] {
 
-  def encode(channel: Channel): Array[Byte] = {
+  def encode(channel: Channel): ByteVector = {
     val baos = new ByteArrayOutputStream()
     try {
       val oos = new ObjectOutputStream(baos)
       try { oos.writeObject(channel) } finally { oos.close() }
-      baos.toByteArray
+      ByteVector.view(baos.toByteArray)
     } finally {
       baos.close()
     }
   }
 
-  def decode(bytes: Array[Byte]): Either[Throwable, Channel] = {
+  def decode(bytes: ByteVector): Either[Throwable, Channel] = {
     try {
-      val bais = new ByteArrayInputStream(bytes)
+      val bais = new ByteArrayInputStream(bytes.toArray)
       try {
         val ois = new ObjectInputStream(bais)
         try { Right(ois.readObject.asInstanceOf[Channel]) } finally { ois.close() }


### PR DESCRIPTION
## Overview
The existing API isn't well suited to composability. You would have to copy out pieces to de-serialize the sub-parts. ByteVector has fast and rich API with views, slices, etc.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-661