### PR TITLE
fix build error for base16 not importing

### DIFF
--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -25,9 +25,11 @@ import monix.execution.Scheduler
 import diagnostics.MetricsServer
 import coop.rchain.comm.transport._
 import coop.rchain.comm.discovery._
-import coop.rchain.shared._, ThrowableOps._
+import coop.rchain.shared._
+import ThrowableOps._
 import coop.rchain.node.api._
 import coop.rchain.comm.connect.Connect
+import coop.rchain.crypto.codec.Base16
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}


### PR DESCRIPTION
## Overview
There is a error showing：
`[error] /home/travis/build/rchain/rchain/node/src/main/scala/coop/rchain/node/node.scala:92:12: not found: value Base16`.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
