### PR TITLE
Fix RHOL-442 bug

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -404,7 +404,9 @@ object implicits {
   implicit val ReceiveBindLocallyFree: HasLocallyFree[ReceiveBind] =
     new HasLocallyFree[ReceiveBind] {
       def connectiveUsed(rb: ReceiveBind) =
-        ChannelLocallyFree.connectiveUsed(rb.source.get)
+        ChannelLocallyFree.connectiveUsed(rb.source.get) || rb.patterns.exists(
+          ChannelLocallyFree.connectiveUsed(_))
+
       def locallyFree(rb: ReceiveBind) =
         ChannelLocallyFree.locallyFree(rb.source.get)
     }

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -404,8 +404,7 @@ object implicits {
   implicit val ReceiveBindLocallyFree: HasLocallyFree[ReceiveBind] =
     new HasLocallyFree[ReceiveBind] {
       def connectiveUsed(rb: ReceiveBind) =
-        ChannelLocallyFree.connectiveUsed(rb.source.get) || rb.patterns.exists(
-          ChannelLocallyFree.connectiveUsed(_))
+        ChannelLocallyFree.connectiveUsed(rb.source.get)
 
       def locallyFree(rb: ReceiveBind) =
         ChannelLocallyFree.locallyFree(rb.source.get)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -55,8 +55,8 @@ case class PrettyPrinter(freeShift: Int,
         (buildString(p1) + " < " + buildString(p2)).wrapWithBraces
       case ELteBody(ELte(p1, p2)) =>
         (buildString(p1) + " <= " + buildString(p2)).wrapWithBraces
-      case EListBody(EList(s, _, _, _)) =>
-        "[" + buildSeq(s) + "]"
+      case EListBody(EList(s, _, _, remainderO)) =>
+        "[" + buildSeq(s) ++ remainderO.fold("")(v => "..." + buildString(v)) + "]"
       case ETupleBody(ETuple(s, _, _)) =>
         "(" + buildSeq(s) + ")"
       case ESetBody(ParSet(pars, _, _)) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -20,6 +20,7 @@ import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.models.rholang.implicits._
 
 import scala.collection.immutable.{BitSet, Vector}
+import scala.collection.convert.ImplicitConversionsToScala._
 import monix.eval.Coeval
 import coop.rchain.models.rholang.sort.ordering._
 
@@ -101,9 +102,10 @@ object CollectionNormalizeMatcher {
                acc._4 || result.par.connectiveUsed)
             }
         }
-        .map { folded =>
-          val resultKnownFree = folded._2
-          CollectVisitOutputs(constructor(folded._1.reverse, folded._3, folded._4), resultKnownFree)
+        .map {
+          case (ps, resultKnownFree, locallyFree, connectiveUsed) =>
+            CollectVisitOutputs(constructor(ps.reverse, locallyFree, connectiveUsed),
+                                resultKnownFree)
         }
     }
 
@@ -137,24 +139,31 @@ object CollectionNormalizeMatcher {
       case cl: CollectList =>
         RemainderNormalizeMatcher
           .normalizeMatchProc[M](cl.remainder_, input.knownFree)
-          .flatMap(remainderResult =>
-            foldMatch(remainderResult._2,
-                      cl.listproc_.asScala.toList,
-                      (ps, lf, wc) =>
-                        EList.apply(ps, lf, wc).update(_.optionalRemainder := remainderResult._1)))
+          .flatMap {
+            case (optionalRemainder, knownFree) =>
+              val constructor: Option[Var] => (Seq[Par], BitSet, Boolean) => EList =
+                optionalRemainder =>
+                  (ps, lf, cu) => {
+                    val tmpEList = EList(ps, lf, cu, optionalRemainder)
+                    tmpEList.withConnectiveUsed(
+                      tmpEList.connectiveUsed || optionalRemainder.isDefined)
+                }
+
+              foldMatch(knownFree, cl.listproc_.toList, constructor(optionalRemainder))
+          }
 
       case ct: CollectTuple =>
         val ps = ct.tuple_ match {
           case ts: TupleSingle   => Seq(ts.proc_)
-          case tm: TupleMultiple => Seq(tm.proc_) ++ tm.listproc_.asScala.toList
+          case tm: TupleMultiple => Seq(tm.proc_) ++ tm.listproc_.toList
         }
         foldMatch(input.knownFree, ps.toList, ETuple.apply)
       case cs: CollectSet =>
         val constructor: (Seq[Par], BitSet, Boolean) => ParSet =
           (pars, locallyFree, connectiveUsed) =>
             ParSet(SortedParHashSet(pars), connectiveUsed, Coeval.delay(locallyFree))
-        foldMatch(input.knownFree, cs.listproc_.asScala.toList, constructor)
-      case cm: CollectMap => foldMatchMap(cm.listkeyvaluepair_.asScala.toList)
+        foldMatch(input.knownFree, cs.listproc_.toList, constructor)
+      case cm: CollectMap => foldMatchMap(cm.listkeyvaluepair_.toList)
     }
   }
 }
@@ -385,7 +394,7 @@ object ProcNormalizeMatcher {
                      ProcVisitInputs(Par(), input.env, targetResult.knownFree),
                      BitSet(),
                      false)
-          argResults <- p.listproc_.asScala.toList.reverse.foldM(initAcc)((acc, e) => {
+          argResults <- p.listproc_.toList.reverse.foldM(initAcc)((acc, e) => {
                          normalizeMatch[M](e, acc._2).map(
                            procMatchResult =>
                              (procMatchResult.par :: acc._1,
@@ -439,7 +448,7 @@ object ProcNormalizeMatcher {
                      ProcVisitInputs(VectorPar(), input.env, nameMatchResult.knownFree),
                      BitSet(),
                      false)
-          dataResults <- p.listproc_.asScala.toList.reverse.foldM(initAcc)(
+          dataResults <- p.listproc_.toList.reverse.foldM(initAcc)(
                           (acc, e) =>
                             normalizeMatch[M](e, acc._2).map(
                               procMatchResult =>
@@ -478,7 +487,7 @@ object ProcNormalizeMatcher {
           // Note that we go over these in the order they were given and reverse
           // down below. This is because it makes more sense to number the free
           // variables in the order given, rather than in reverse.
-          formalsResults <- p.listname_.asScala.toList.foldM(initAcc)(
+          formalsResults <- p.listname_.toList.foldM(initAcc)(
                              (acc, n: Name) => {
                                NameNormalizeMatcher
                                  .normalizeMatch[M](n,
@@ -517,20 +526,19 @@ object ProcNormalizeMatcher {
       }
 
       case p: PInput => {
-        import scala.collection.JavaConverters._
         // To handle the most common case where we can sort the binds because
         // they're from different sources, Each channel's list of patterns starts its free variables at 0.
         // We check for overlap at the end after sorting. We could check before, but it'd be an extra step.
 
         // We split this into parts. First we process all the sources, then we process all the bindings.
-        def processSources(bindings: List[(List[Name], Name, NameRemainder)])
+        def processSources(sources: List[(List[Name], Name, NameRemainder)])
           : M[(Vector[(List[Name], Channel, NameRemainder)],
                DebruijnLevelMap[VarSort],
                BitSet,
                Boolean)] = {
           val initAcc =
             (Vector[(List[Name], Channel, NameRemainder)](), input.knownFree, BitSet(), false)
-          bindings
+          sources
             .foldM(initAcc)((acc, e) => {
               NameNormalizeMatcher
                 .normalizeMatch[M](e._2, NameVisitInputs(input.env, acc._2))
@@ -543,6 +551,7 @@ object ProcNormalizeMatcher {
             })
             .map(foldResult => (foldResult._1.reverse, foldResult._2, foldResult._3, foldResult._4))
         }
+
         def processBindings(bindings: Vector[(List[Name], Channel, NameRemainder)])
           : M[Vector[(Vector[Channel], Channel, Option[Var], DebruijnLevelMap[VarSort])]] =
           bindings.traverse {
@@ -554,59 +563,48 @@ object ProcNormalizeMatcher {
                     .normalizeMatch[M](n, NameVisitInputs(input.env.pushDown(), acc._2))
                     .map(result => (result.chan +: acc._1, result.knownFree))
                 })
-                .flatMap(formalsResults =>
-                  RemainderNormalizeMatcher
-                    .normalizeMatchName[M](nr, formalsResults._2)
-                    .map(remainderResult =>
-                      (formalsResults._1.reverse, chan, remainderResult._1, remainderResult._2)))
+                .flatMap {
+                  case (patterns, knownFree) =>
+                    RemainderNormalizeMatcher
+                      .normalizeMatchName[M](nr, knownFree)
+                      .map(remainderResult =>
+                        (patterns.reverse, chan, remainderResult._1, remainderResult._2))
+                }
             }
           }
+
         val resM = p.receipt_ match {
           case rl: ReceiptLinear =>
-            def bindingsReceiptLinear(
-                receipt: ReceiptLinearImpl): M[List[(List[Name], Name, NameRemainder)]] =
-              receipt match {
-                case ls: LinearSimple =>
-                  ls.listlinearbind_.asScala.toList.traverse {
+            rl.receiptlinearimpl_ match {
+              case ls: LinearSimple =>
+                ls.listlinearbind_.toList
+                  .traverse {
                     case lbi: LinearBindImpl =>
-                      (lbi.listname_.asScala.toList, lbi.name_, lbi.nameremainder_).pure[M]
-                    case _ =>
-                      err.raiseError(
-                        UnrecognizedNormalizerError("Unexpected LinearBind production."))
+                      (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
                   }
-                case _ =>
-                  err.raiseError(
-                    UnrecognizedNormalizerError("Unexpected LinearReceipt production."))
-              }
-            bindingsReceiptLinear(rl.receiptlinearimpl_).map(x => (x, false))
+                  .map(x => (x, false))
+            }
           case rl: ReceiptRepeated =>
-            def bindingsRepeatedReceipt(
-                receipt: ReceiptRepeatedImpl): M[List[(List[Name], Name, NameRemainder)]] =
-              receipt match {
-                case ls: RepeatedSimple =>
-                  ls.listrepeatedbind_.asScala.toList
-                    .traverse {
-                      case lbi: RepeatedBindImpl =>
-                        (lbi.listname_.asScala.toList, lbi.name_, lbi.nameremainder_).pure[M]
-                      case _ =>
-                        err.raiseError(
-                          UnrecognizedNormalizerError("Unexpected RepeatedBind production."))
-                    }
-                case _ =>
-                  err.raiseError(
-                    UnrecognizedNormalizerError("Unexpected RepeatedReceipt production."))
-              }
-            bindingsRepeatedReceipt(rl.receiptrepeatedimpl_).map(x => (x, true))
+            rl.receiptrepeatedimpl_ match {
+              case ls: RepeatedSimple =>
+                ls.listrepeatedbind_.toList
+                  .traverse {
+                    case lbi: RepeatedBindImpl =>
+                      (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
+                  }
+                  .map(x => (x, true))
+            }
         }
 
         for {
           res                                                              <- resM
-          (bindings, persistent)                                           = res
-          sourcesP                                                         <- processSources(bindings)
+          (bindingsRaw, persistent)                                        = res
+          sourcesP                                                         <- processSources(bindingsRaw)
           (sources, thisLevelFree, sourcesLocallyFree, sourcesConnectives) = sourcesP
-          bindingsSources                                                  <- processBindings(sources)
+          bindingsProcessed                                                <- processBindings(sources)
+          bindingsConnectiveUsed = bindingsProcessed.flatMap(_._1).exists(c => ChannelLocallyFree.connectiveUsed(c))
           receipts = ReceiveBindsSortMatcher
-            .preSortBinds[M, VarSort](bindingsSources)
+            .preSortBinds[M, VarSort](bindingsProcessed)
           mergedFrees <- receipts.toList.foldM[M, DebruijnLevelMap[VarSort]](
                           DebruijnLevelMap[VarSort]())((env, receipt) =>
                           env.merge(receipt._2) match {
@@ -626,7 +624,7 @@ object ProcNormalizeMatcher {
           updatedEnv = input.env.absorbFree(mergedFrees)._1
           bodyResult <- normalizeMatch[M](p.proc_,
                                           ProcVisitInputs(VectorPar(), updatedEnv, thisLevelFree))
-          connective = sourcesConnectives || bodyResult.par.connectiveUsed
+          connective = sourcesConnectives || bodyResult.par.connectiveUsed || bindingsConnectiveUsed
         } yield
           ProcVisitOutputs(
             input.par.prepend(
@@ -653,7 +651,7 @@ object ProcNormalizeMatcher {
       case p: PNew => {
         import scala.collection.JavaConverters._
         // TODO: bindings within a single new shouldn't have overlapping names.
-        val newBindings = p.listnamedecl_.asScala.toList.map {
+        val newBindings = p.listnamedecl_.toList.map {
           case n: NameDeclSimpl => (n.var_, NameSort, n.line_num, n.col_num)
         }
         val newEnv   = input.env.newBindings(newBindings)
@@ -723,7 +721,7 @@ object ProcNormalizeMatcher {
 
         for {
           targetResult <- normalizeMatch[M](p.proc_, input.copy(par = VectorPar()))
-          cases        <- p.listcase_.asScala.toList.traverse(liftCase)
+          cases        <- p.listcase_.toList.traverse(liftCase)
 
           initAcc = (Vector[MatchCase](), targetResult.knownFree, BitSet(), false)
           casesResult <- cases.foldM(initAcc)((acc, caseImpl) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -602,7 +602,9 @@ object ProcNormalizeMatcher {
           sourcesP                                                         <- processSources(bindingsRaw)
           (sources, thisLevelFree, sourcesLocallyFree, sourcesConnectives) = sourcesP
           bindingsProcessed                                                <- processBindings(sources)
-          bindingsConnectiveUsed = bindingsProcessed.flatMap(_._1).exists(c => ChannelLocallyFree.connectiveUsed(c))
+          bindingsConnectiveUsed = bindingsProcessed
+            .flatMap(_._1)
+            .exists(c => ChannelLocallyFree.connectiveUsed(c))
           receipts = ReceiveBindsSortMatcher
             .preSortBinds[M, VarSort](bindingsProcessed)
           mergedFrees <- receipts.toList.foldM[M, DebruijnLevelMap[VarSort]](

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
@@ -236,6 +236,19 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     parResult should be(expectedResult)
   }
 
+  "Matching a whole list with a remainder" should "capture the list." in {
+    // for (@[…a] <- @0) { … } | @0!([1,2,3])
+    val target: Expr   = EList(Seq(GInt(1), GInt(2), GInt(3)))
+    val pattern: Expr  = EList(remainder = Some(FreeVar(0)), connectiveUsed = true)
+    val result         = spatialMatch(target, pattern).runS(emptyMap)
+    val expectedResult = Some(Map[Int, Par](0 -> target))
+    result should be(expectedResult)
+    val targetPar: Par  = target
+    val patternPar: Par = pattern
+    val parResult = spatialMatch(targetPar, patternPar).runS(emptyMap)
+    parResult should be(expectedResult)
+  }
+
   "Matching inside bundles" should "not be possible" in {
     val target: Bundle = Bundle(
       Par()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
@@ -245,7 +245,7 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     result should be(expectedResult)
     val targetPar: Par  = target
     val patternPar: Par = pattern
-    val parResult = spatialMatch(targetPar, patternPar).runS(emptyMap)
+    val parResult       = spatialMatch(targetPar, patternPar).runS(emptyMap)
     parResult should be(expectedResult)
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -425,9 +425,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         List(
           ReceiveBind(List(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))), Quote(Par()), freeCount = 2)),
         Send(ChanVar(BoundVar(1)), List[Par](EEvalBody(ChanVar(BoundVar(0)))), false, BitSet(0, 1)),
-        false, // persistent
+        persistent = false,
         bindCount,
-        BitSet()
+        BitSet(),
+        connectiveUsed = true
       )))
     result.knownFree should be(inputs.knownFree)
   }
@@ -467,7 +468,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
                       freeCount = 2),
           ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))),
                       Quote(GInt(1)),
-                      freeCount = 2),
+                      freeCount = 2)
         ),
         Par().copy(
           sends = List(
@@ -476,9 +477,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
           ),
           locallyFree = BitSet(0, 1, 2, 3)
         ),
-        false, // persistent
+        persistent = false,
         bindCount,
-        BitSet()
+        BitSet(),
+        connectiveUsed = true
       )))
     result.knownFree should be(inputs.knownFree)
   }
@@ -595,20 +597,21 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val bindCount = 1
 
     val expectedResult =
-      inputs.par.copy(
-        sends = List(Send(Quote(Par()), List[Par](GInt(47)), false, BitSet())),
-        receives = List(
-          Receive(
-            List(ReceiveBind(List(Quote(EVar(FreeVar(0)))), Quote(Par()), freeCount = 1)),
-            Match(EVar(BoundVar(0)),
-                  List(MatchCase(GInt(42), Par()),
-                       MatchCase(EVar(FreeVar(0)), Par(), freeCount = 1)),
-                  BitSet(0)),
-            false,
-            bindCount,
-            BitSet()
-          ))
-      )
+      inputs.par
+        .prepend(Send(Quote(Par()), List[Par](GInt(47)), false, BitSet()))
+        .prepend(
+        Receive(
+          List(ReceiveBind(List(Quote(EVar(FreeVar(0)))), Quote(Par()), freeCount = 1)),
+          Match(EVar(BoundVar(0)),
+                List(MatchCase(GInt(42), Par()),
+                     MatchCase(EVar(FreeVar(0)), Par(), freeCount = 1)),
+                BitSet(0)),
+          persistent = false,
+          bindCount,
+          BitSet(),
+          connectiveUsed = true
+        ))
+
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }
@@ -736,8 +739,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val matchTarget = EVar(FreeVar(1)).prepend(EVar(FreeVar(0)))
     val expectedResult =
-      inputs.par.copy(
-        receives = List(
+      inputs.par.prepend(
           Receive(
             List(
               ReceiveBind(
@@ -746,10 +748,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
                 Quote(Par()),
                 freeCount = 2)),
             Par(),
-            false,
+            persistent = false,
             bindCount,
-          ))
-      )
+            connectiveUsed = true))
+
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -370,6 +370,60 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
+  "eval of Send | Receive" should "when whole list is bound to list remainder, meet in the tuplespace and proceed. (RHOL-422)" in {
+    // for(@[...a] <- @"channel") { … } | @"channel"!([7,8,9])
+    implicit val errorLog = new Runtime.ErrorLog()
+    val send =
+      Send(Quote(GString("channel")), List(Par(exprs = Seq(Expr(EListBody(EList(Seq(GInt(7), GInt(8), GInt(9)))))))), false, BitSet())
+    val receive = Receive(
+      Seq(
+        ReceiveBind(Seq(Quote(Par(exprs = Seq(EListBody(EList(connectiveUsed = true, remainder = Some(FreeVar(0)))))))),
+          Quote(GString("channel")),
+          freeCount = 1)),
+      Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
+      false,
+      1,
+      BitSet()
+    )
+    val sendFirstResult = withTestSpace { space =>
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      implicit val env = Env[Par]()
+      val inspectTaskSendFirst = for {
+        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)
+      } yield space.store.toMap
+      Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+    }
+
+    val channel = Channel(Quote(GString("result")))
+
+    sendFirstResult should be(
+      HashMap(
+        List(channel) ->
+          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+      )
+    )
+    errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
+
+    val receiveFirstResult = withTestSpace { space =>
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      implicit val env = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _ <- reducer.eval(receive)
+        _ <- reducer.eval(send)
+      } yield space.store.toMap
+      Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+    }
+
+    receiveFirstResult should be(
+      HashMap(
+        List(channel) ->
+          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+      )
+    )
+    errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
+  }
+
   "eval of Send on (7 + 8) | Receive on 15" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new Runtime.ErrorLog()
     val send =


### PR DESCRIPTION
## Overview
Fixes a bug when binding a list to a list remainder was not working properly.

Using only a list remainder as a binding pattern should set the `connectiveUsed` flag to `true`. If `connectiveUsed = false` then in the matcher target and pattern are compared using scala equality.

During this bug fix I've simplified some parts of the `normalize.scala` : 

* get rid of explicit `asScala` conversions in favor of implicit
* get rid of redundant `case _ => ` matches when there's only one type possible

### Does this PR relate to an RChain JIRA issue? 
[JIRA issue](https://rchain.atlassian.net/browse/RHOL-442).

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes

It's best to view the PR in the split diff version.