### PR TITLE
Enable Casper to sign blocks

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -526,6 +526,8 @@ sealed abstract class MultiParentCasperInstances {
                 acc.updated(p, currChildren + hash)
             }
 
+            val newSeqNum = bd.currentSeqNum.updated(block.sender, block.seqNum)
+
             bd.copy(
               blockLookup = bd.blockLookup.updated(hash, block),
               //Assume that a non-equivocating validator must include
@@ -538,7 +540,8 @@ sealed abstract class MultiParentCasperInstances {
               latestMessagesOfLatestMessages =
                 bd.latestMessagesOfLatestMessages.updated(block.sender,
                                                           toLatestMessages(block.justifications)),
-              childMap = newChildMap
+              childMap = newChildMap,
+              currentSeqNum = newSeqNum
             )
           })
         }

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -1,0 +1,19 @@
+package coop.rchain.casper
+
+import coop.rchain.crypto.codec.Base16
+
+import java.nio.file.Path
+
+case class CasperConf(
+    pkBase16: Option[String],
+    skBase16: String,
+    sigAlgorithm: String,
+    bondsFile: Option[String],
+    numValidators: Int,
+    validatorsPath: Path,
+    storageLocation: Path,
+    storageSize: Long
+) {
+  val pk: Option[Array[Byte]] = pkBase16.map(Base16.decode)
+  val sk: Array[Byte]         = Base16.decode(skBase16)
+}

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -5,8 +5,8 @@ import coop.rchain.crypto.codec.Base16
 import java.nio.file.Path
 
 case class CasperConf(
-    pkBase16: Option[String],
-    skBase16: String,
+    publicKeyBase16: Option[String],
+    privateKeyBase16: Option[String],
     sigAlgorithm: String,
     bondsFile: Option[String],
     numValidators: Int,
@@ -14,6 +14,6 @@ case class CasperConf(
     storageLocation: Path,
     storageSize: Long
 ) {
-  val pk: Option[Array[Byte]] = pkBase16.map(Base16.decode)
-  val sk: Array[Byte]         = Base16.decode(skBase16)
+  val publicKey: Option[Array[Byte]]  = publicKeyBase16.map(Base16.decode)
+  val privateKey: Option[Array[Byte]] = privateKeyBase16.map(Base16.decode)
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -13,15 +13,10 @@ import scala.util.{Failure, Success, Try}
 
 object DeployRuntime {
 
-  //Propose a block, sign using given secret key with Ed25519.
-  //Note that this is just an example thin-client making use of the
-  //gRPC functionalities that are exposed. A node operator could easily
-  //write their own (e.g. in Python) if they wish to handle signing differently.
-  def propose[F[_]: DeployService: Monad](sk: Array[Byte]): F[Unit] =
+  def propose[F[_]: DeployService: Monad](): F[Unit] =
     DeployService[F].createBlock().flatMap {
       case Some(block) =>
-        val signedBlock = ProtoUtil.signBlock(block, sk)
-        DeployService[F].addBlock(signedBlock)
+        DeployService[F].addBlock(block)
 
       case None =>
         ().pure[F]

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -106,8 +106,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     val Some(block) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeploy(0)) *> MultiParentCasper[
       Id].createBlock
+    val invalidBlock = block.withSig(ByteString.EMPTY)
 
-    MultiParentCasper[Id].addBlock(block)
+    MultiParentCasper[Id].addBlock(invalidBlock)
 
     logEff.warns.head.contains("CASPER: Ignoring block") should be(true)
   }

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -26,7 +26,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "HashSetCasper" should "accept deploys" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._
 
     val deploy = ProtoUtil.basicDeploy(0)
@@ -37,7 +37,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "create blocks based on deploys" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._
 
     val deploy = ProtoUtil.basicDeploy(0)
@@ -56,14 +56,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "accept signed blocks" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._
 
     val deploy = ProtoUtil.basicDeploy(0)
     MultiParentCasper[Id].deploy(deploy)
 
-    val Some(block) = MultiParentCasper[Id].createBlock
-    val signedBlock = ProtoUtil.signBlock(block, validatorKeys.last)
+    val Some(signedBlock) = MultiParentCasper[Id].createBlock
 
     MultiParentCasper[Id].addBlock(signedBlock)
 
@@ -80,7 +79,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "be able to create a chain of blocks from different deploys" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._
 
     val deploys = Vector(
@@ -88,12 +87,10 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       "new unforgable in { @\"add\"!(5, 7, *unforgable) }"
     ).map(s => ProtoUtil.termDeploy(InterpreterUtil.mkTerm(s).right.get))
 
-    val Some(block1) = MultiParentCasper[Id].deploy(deploys.head) *> MultiParentCasper[Id].createBlock
-    val signedBlock1 = ProtoUtil.signBlock(block1, validatorKeys.last)
+    val Some(signedBlock1) = MultiParentCasper[Id].deploy(deploys.head) *> MultiParentCasper[Id].createBlock
     MultiParentCasper[Id].addBlock(signedBlock1)
 
-    val Some(block2) = MultiParentCasper[Id].deploy(deploys(1)) *> MultiParentCasper[Id].createBlock
-    val signedBlock2 = ProtoUtil.signBlock(block2, validatorKeys.head)
+    val Some(signedBlock2) = MultiParentCasper[Id].deploy(deploys(1)) *> MultiParentCasper[Id].createBlock
     MultiParentCasper[Id].addBlock(signedBlock2)
     val storage = blockTuplespaceContents(signedBlock2)
 
@@ -104,7 +101,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "reject unsigned blocks" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._
 
     val Some(block) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeploy(0)) *> MultiParentCasper[
@@ -116,12 +113,11 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "reject blocks not from bonded validators" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, otherSk)
     import node._
 
-    val Some(block) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeploy(0)) *> MultiParentCasper[
+    val Some(signedBlock) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeploy(0)) *> MultiParentCasper[
       Id].createBlock
-    val signedBlock = ProtoUtil.signBlock(block, otherSk)
 
     MultiParentCasper[Id].addBlock(signedBlock)
 
@@ -129,11 +125,10 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "propose blocks it adds to peers" in {
-    val nodes  = HashSetCasperTestNode.network(2, genesis)
+    val nodes  = HashSetCasperTestNode.network(validatorKeys.take(2), genesis)
     val deploy = ProtoUtil.basicDeploy(0)
 
-    val Some(block) = nodes(0).casperEff.deploy(deploy) *> nodes(0).casperEff.createBlock
-    val signedBlock = ProtoUtil.signBlock(block, validatorKeys.head)
+    val Some(signedBlock) = nodes(0).casperEff.deploy(deploy) *> nodes(0).casperEff.createBlock
 
     nodes(0).casperEff.addBlock(signedBlock)
     nodes(1).receive()
@@ -144,18 +139,16 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "ask peers for blocks it is missing" in {
-    val nodes   = HashSetCasperTestNode.network(3, genesis)
+    val nodes   = HashSetCasperTestNode.network(validatorKeys.take(3), genesis)
     val deploys = (0 until 3).map(i => ProtoUtil.basicDeploy(i))
 
-    val Some(block1) = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
-    val signedBlock1 = ProtoUtil.signBlock(block1.withSeqNum(0), validatorKeys.head)
+    val Some(signedBlock1) = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
 
     nodes(0).casperEff.addBlock(signedBlock1)
     nodes(1).receive()
     nodes(2).transportLayerEff.msgQueues(nodes(2).local).clear //nodes(2) misses this block
 
-    val Some(block2) = nodes(0).casperEff.deploy(deploys(1)) *> nodes(0).casperEff.createBlock
-    val signedBlock2 = ProtoUtil.signBlock(block2.withSeqNum(1), validatorKeys.head)
+    val Some(signedBlock2) = nodes(0).casperEff.deploy(deploys(1)) *> nodes(0).casperEff.createBlock
 
     nodes(0).casperEff.addBlock(signedBlock2)
     nodes(1).receive() //receives block2
@@ -173,13 +166,11 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "ignore adding equivocation blocks" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
 
     // Creates a pair that constitutes equivocation blocks
-    val Some(block1)      = node.casperEff.deploy(ProtoUtil.basicDeploy(0)) *> node.casperEff.createBlock
-    val signedBlock1      = ProtoUtil.signBlock(block1, validatorKeys.head)
-    val Some(block1Prime) = node.casperEff.deploy(ProtoUtil.basicDeploy(1)) *> node.casperEff.createBlock
-    val signedBlock1Prime = ProtoUtil.signBlock(block1Prime, validatorKeys.head)
+    val Some(signedBlock1)      = node.casperEff.deploy(ProtoUtil.basicDeploy(0)) *> node.casperEff.createBlock
+    val Some(signedBlock1Prime) = node.casperEff.deploy(ProtoUtil.basicDeploy(1)) *> node.casperEff.createBlock
 
     node.casperEff.addBlock(signedBlock1)
     node.casperEff.addBlock(signedBlock1Prime)
@@ -190,14 +181,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
   // See [[/docs/casper/images/minimal_equivocation_neglect.png]] but cross out genesis block
   it should "not ignore equivocation blocks that are required for parents of proper nodes" in {
-    val nodes   = HashSetCasperTestNode.network(3, genesis)
+    val nodes   = HashSetCasperTestNode.network(validatorKeys.take(3), genesis)
     val deploys = (0 to 5).map(i => ProtoUtil.basicDeploy(i))
 
     // Creates a pair that constitutes equivocation blocks
-    val Some(block1)      = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
-    val signedBlock1      = ProtoUtil.signBlock(block1.withSeqNum(0), validatorKeys.head)
-    val Some(block1Prime) = nodes(0).casperEff.deploy(deploys(1)) *> nodes(0).casperEff.createBlock
-    val signedBlock1Prime = ProtoUtil.signBlock(block1Prime.withSeqNum(0), validatorKeys.head)
+    val Some(signedBlock1) = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
+    val Some(signedBlock1Prime) = nodes(0).casperEff
+      .deploy(deploys(1)) *> nodes(0).casperEff.createBlock
 
     nodes(1).casperEff.addBlock(signedBlock1)
     nodes(0).transportLayerEff.msgQueues(nodes(0).local).clear //nodes(0) misses this block
@@ -212,10 +202,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     nodes(1).casperEff.contains(signedBlock1Prime) should be(false)
     nodes(2).casperEff.contains(signedBlock1Prime) should be(true)
 
-    val Some(block2) = nodes(1).casperEff.deploy(deploys(2)) *> nodes(1).casperEff.createBlock
-    val signedBlock2 = ProtoUtil.signBlock(block2.withSeqNum(0), validatorKeys(1))
-    val Some(block3) = nodes(2).casperEff.deploy(deploys(3)) *> nodes(2).casperEff.createBlock
-    val signedBlock3 = ProtoUtil.signBlock(block3.withSeqNum(0), validatorKeys(2))
+    val Some(signedBlock2) = nodes(1).casperEff.deploy(deploys(2)) *> nodes(1).casperEff.createBlock
+    val Some(signedBlock3) = nodes(2).casperEff.deploy(deploys(3)) *> nodes(2).casperEff.createBlock
 
     nodes(2).casperEff.addBlock(signedBlock3)
     nodes(1).casperEff.addBlock(signedBlock2)
@@ -227,8 +215,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     nodes(1).casperEff.contains(signedBlock3) should be(true)
     nodes(1).casperEff.contains(signedBlock1Prime) should be(true)
 
-    val Some(block4) = nodes(1).casperEff.deploy(deploys(4)) *> nodes(1).casperEff.createBlock
-    val signedBlock4 = ProtoUtil.signBlock(block4.withSeqNum(1), validatorKeys(1))
+    val Some(signedBlock4) = nodes(1).casperEff.deploy(deploys(4)) *> nodes(1).casperEff.createBlock
 
     nodes(1).casperEff.addBlock(signedBlock4)
 
@@ -247,11 +234,11 @@ class HashSetCasperTest extends FlatSpec with Matchers {
   }
 
   it should "prepare to slash an block that includes a invalid block pointer" in {
-    val nodes   = HashSetCasperTestNode.network(2, genesis)
+    val nodes   = HashSetCasperTestNode.network(validatorKeys.take(3), genesis)
     val deploys = (0 to 5).map(i => ProtoUtil.basicDeploy(i))
 
-    val Some(invalidBlock) = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
-    val signedInvalidBlock = ProtoUtil.signBlock(invalidBlock.withSeqNum(-2), validatorKeys.head) // Invalid seq num
+    val Some(signedBlock)  = nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
+    val signedInvalidBlock = signedBlock.withSeqNum(-2) // Invalid seq num
 
     val postState     = RChainState().withBonds(ProtoUtil.bonds(genesis)).withBlockNumber(2)
     val postStateHash = Blake2b256.hash(postState.toByteArray)
@@ -269,7 +256,12 @@ class HashSetCasperTest extends FlatSpec with Matchers {
                                                      serializedJustifications,
                                                      seqNum = 0)
     val signedBlockThatPointsToInvalidBlock =
-      ProtoUtil.signBlock(blockThatPointsToInvalidBlock, validatorKeys(1))
+      ProtoUtil.signBlock(blockThatPointsToInvalidBlock,
+                          nodes(1).casperEff.blockDag,
+                          validators(1),
+                          validatorKeys(1),
+                          "ed25519",
+                          Ed25519.sign _)
 
     nodes(1).casperEff.addBlock(signedBlockThatPointsToInvalidBlock)
     nodes(0).transportLayerEff

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -20,7 +20,7 @@ class RholangBuildTest extends FlatSpec with Matchers {
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "Our build system" should "allow import of rholang sources into scala code" in {
-    val node = HashSetCasperTestNode.standalone(genesis)
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.last)
     import node._
 
     val llDeploy = ProtoUtil.termDeploy(LinkedList.term)
@@ -30,9 +30,8 @@ class RholangBuildTest extends FlatSpec with Matchers {
       "for(@primes <- @\"primes\"){ @\"primes\"!(primes) | @[\"LinkedList\", \"map\"]!(primes, \"double\", \"dprimes\") }"
     ).map(s => ProtoUtil.termDeploy(InterpreterUtil.mkTerm(s).right.get))
 
-    val Some(block) = MultiParentCasper[Id].deploy(llDeploy) *> deploys.traverse(
+    val Some(signedBlock) = MultiParentCasper[Id].deploy(llDeploy) *> deploys.traverse(
       MultiParentCasper[Id].deploy) *> MultiParentCasper[Id].createBlock
-    val signedBlock = ProtoUtil.signBlock(block, validatorKeys.last)
     MultiParentCasper[Id].addBlock(signedBlock)
 
     val storage = HashSetCasperTest.blockTuplespaceContents(signedBlock)

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -66,7 +66,8 @@ class ValidateTest extends FlatSpec with Matchers with BeforeAndAfterEach with B
 
   def signedBlock(i: Int)(implicit chain: BlockDag, sk: Array[Byte]): BlockMessage = {
     val block = chain.idToBlocks(i)
-    ProtoUtil.signBlock(block, sk)
+    val pk    = Ed25519.toPublic(sk)
+    ProtoUtil.signBlock(block, chain, pk, sk, "ed25519", Ed25519.sign _)
   }
 
   implicit class ChangeBlockNumber(b: BlockMessage) {

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -54,14 +54,7 @@ object Main {
         DeployRuntime.deployFileProgram[Task](conf.deploy.location.toOption.get)
 
       case Some(conf.deployDemo) => DeployRuntime.deployDemoProgram[Task]
-      case Some(conf.propose) =>
-        conf.propose.secretKey.toOption match {
-          case Some(sk) => DeployRuntime.propose[Task](Base16.decode(sk))
-          case None =>
-            Task.delay {
-              println("Error: value of --secret-key must be specified to propose a block")
-            }
-        }
+      case Some(conf.propose)    => DeployRuntime.propose[Task]()
       case Some(conf.showBlock) =>
         DeployRuntime.showBlock[Task](conf.showBlock.hash.toOption.get)
       case Some(conf.showBlocks) =>

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -78,13 +78,13 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
                              descr = "Map size (in bytes)",
                              default = Some(1024L * 1024L * 1024L))
 
-    val validatorPK = opt[String](
+    val validatorPublicKey = opt[String](
       default = None,
       descr = "Base16 encoding of the public key to use for signing a proposed blocks. " +
         "Can be inferred from the private key for some signature algorithms."
     )
 
-    val validatorSK = opt[String](
+    val validatorPrivateKey = opt[String](
       default = None,
       descr = "Base16 encoding of the private key to use for signing a proposed blocks.")
 
@@ -197,8 +197,8 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   }
 
   def casperConf: CasperConf = CasperConf(
-    run.validatorPK.toOption,
-    run.validatorSK(),
+    run.validatorPublicKey.toOption,
+    run.validatorPrivateKey.toOption,
     run.validatorSigAlgorithm(),
     run.bondsFile.toOption,
     run.numValidators(),

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -14,6 +14,7 @@ import coop.rchain.casper.{MultiParentCasper, SafetyOracle}
 import coop.rchain.casper.genesis.Genesis.fromBondsFile
 import coop.rchain.casper.util.comm.CommUtil.casperPacketHandler
 import coop.rchain.comm._
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.Metrics
 import coop.rchain.node.diagnostics._
 import coop.rchain.p2p
@@ -130,13 +131,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   implicit val pingEffect: Ping[Task]                   = effects.ping(src)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task] = new TLNodeDiscovery[Task](src)
   implicit val turanOracleEffect: SafetyOracle[Effect]  = SafetyOracle.turanOracle[Effect]
-  implicit val casperEffect: MultiParentCasper[Effect] = MultiParentCasper.hashSetCasper[Effect](
-    storagePath.resolve("casper"),
-    storageSize,
-    fromBondsFile[Task](conf.run.bondsFile.toOption,
-                        conf.run.numValidators(),
-                        conf.run.data_dir().resolve("validators")).unsafeRunSync
-  )
+  implicit val casperEffect: MultiParentCasper[Effect] =
+    MultiParentCasper.fromConfig[Effect](conf.casperConf)
   implicit val packetHandlerEffect: PacketHandler[Effect] = PacketHandler.pf[Effect](
     casperPacketHandler[Effect]
   )


### PR DESCRIPTION
## Overview
Casper will keep the private key of the validator in memory. This allows it to track seq number correctly, and propose blocks on their behalf (e.g. when responding to a slashing condition). In the future we will not pass the private key to the node directly, but instead read from an encrypted file.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/RHOL-448

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
