### PR TITLE
CORE-564 Bugfix and additional flags

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
@@ -22,11 +22,9 @@ import coop.rchain.comm.CommError.ErrorHandler
 
 object Connect {
 
-  val defaultTimeout: Duration = Duration(500, MILLISECONDS)
-
   def findAndConnect[
-      F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler]
-    : Int => F[Int] =
+      F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler](
+      defaultTimeout: Duration): Int => F[Int] =
     (lastCount: Int) =>
       for {
         _         <- IOUtil.sleep[F](5000L)
@@ -39,7 +37,8 @@ object Connect {
   def connectToBootstrap[
       F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler](
       bootstrapAddrStr: String,
-      maxNumOfAttempts: Int = 5): F[Unit] = {
+      maxNumOfAttempts: Int = 5,
+      defaultTimeout: Duration): F[Unit] = {
 
     def connectAttempt(attempt: Int, timeout: Duration, bootstrapAddr: PeerNode): F[Unit] =
       if (attempt > maxNumOfAttempts) for {

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -120,7 +120,7 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
       _   <- Metrics[F].incrementCounter("protocol-lookup-send")
       req = LookupMessage(ProtocolMessage.lookup(src, key), System.currentTimeMillis)
       r <- TransportLayer[F]
-            .roundTrip(req, remoteNode, 500.milliseconds)
+            .roundTrip(req, remoteNode, timeout)
             .map(_.toOption
               .map {
                 case LookupResponseMessage(proto, _) =>

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -11,7 +11,9 @@ import coop.rchain.comm.transport._, CommunicationResponse._
 import coop.rchain.comm.discovery._
 import coop.rchain.shared._
 
-class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](src: PeerNode)
+class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](
+    src: PeerNode,
+    timeout: Duration)
     extends NodeDiscovery[F] {
 
   private val table = PeerTable(src)

--- a/comm/src/main/scala/coop/rchain/comm/upnp.scala
+++ b/comm/src/main/scala/coop/rchain/comm/upnp.scala
@@ -7,38 +7,31 @@ import org.bitlet.weupnp.{GatewayDevice, GatewayDiscover}
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 import scala.util.Try
-import com.typesafe.scalalogging.Logger
 
 /**
   * Simple class that attempts to find and use a uPnP router for networking.
   *
-  * Registers the given port for UDP transmission through a NAT.
+  * Registers the given port for TCP transmission through a NAT.
   *
   * Cribbed from https://github.com/ScorexFoundation/Scorex/blob/503fda982d96707db8731f954ac6428b1d17e4e8/src/main/scala/scorex/core/network/UPnP.scala.
   */
-class UPnP(port: Int) {
-  val logger = Logger("upnp")
-
-  val gateway: Option[GatewayDevice] = {
+class UPnP {
+  lazy val gateway: Option[GatewayDevice] = {
     GatewayDevice.setHttpReadTimeout(5000)
     val discover = new GatewayDiscover
     discover.setTimeout(5000)
-
     discover.discover
-
     Option(discover.getValidGateway)
   }
 
   def localAddress: Option[InetAddress] = gateway.map(_.getLocalAddress)
   def externalAddress: Option[String]   = gateway.map(_.getExternalIPAddress)
 
-  addPort(port)
-
   def addPort(port: Int): Either[CommError, Boolean] =
     try {
       gateway match {
         case Some(device) =>
-          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "UDP", "RChain"))
+          Right(device.addPortMapping(port, port, localAddress.get.getHostAddress, "TCP", "RChain"))
         case None => Left(UnknownCommError("no gateway"))
       }
     } catch {
@@ -49,7 +42,7 @@ class UPnP(port: Int) {
     try {
       gateway match {
         case Some(device) =>
-          device.deletePortMapping(port, "UDP")
+          device.deletePortMapping(port, "TCP")
           Right(())
         case None => Left(UnknownCommError("no gateway"))
       }

--- a/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
@@ -12,12 +12,13 @@ import coop.rchain.comm.transport._, CommMessages._
 import coop.rchain.comm.discovery._
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared._
-import Connect.defaultTimeout
+import scala.concurrent.duration.{Duration, MILLISECONDS}
 
 class ConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
-  val src: PeerNode    = peerNode("src", 30300)
-  val remote: PeerNode = peerNode("remote", 30301)
+  val defaultTimeout: Duration = Duration(1, MILLISECONDS)
+  val src: PeerNode            = peerNode("src", 30300)
+  val remote: PeerNode         = peerNode("remote", 30301)
 
   type Effect[A] = CommErrT[Id, A]
 

--- a/comm/src/test/scala/coop/rchain/comm/connect/ConnectToBootstrap.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ConnectToBootstrap.scala
@@ -9,12 +9,15 @@ import coop.rchain.catscontrib._, ski._
 import coop.rchain.metrics.Metrics
 import coop.rchain.comm.transport._, CommMessages._
 import coop.rchain.p2p.EffectsTestInstances._
+import scala.concurrent.duration.{Duration, MILLISECONDS}
 
 class ConnectToBootstrapSpec
     extends FunSpec
     with Matchers
     with BeforeAndAfterEach
     with AppendedClues {
+
+  val timeout: Duration = Duration(1, MILLISECONDS)
 
   type Effect[A] = CommErrT[Id, A]
 
@@ -38,7 +41,7 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(failEverything))
       // when
-      val _ = Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val _ = Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.warns should equal(
         List(
@@ -54,7 +57,8 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(failEverything))
       // when
-      val result = Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val result =
+        Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.errors should equal(List("Failed to connect to bootstrap node, exiting..."))
       result.value should equal(Left(couldNotConnectToBootstrap))
@@ -64,7 +68,8 @@ class ConnectToBootstrapSpec
       // given
       transportLayerEff.setResponses(kp(alwaysSuccess))
       // when
-      val result = Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5)
+      val result =
+        Connect.connectToBootstrap[Effect](remote.toAddress, maxNumOfAttempts = 5, timeout)
       // then
       logEff.infos should contain(s"Bootstrapping from $remote.")
       logEff.infos should contain(s"Connected $remote.")

--- a/node/src/main/scala/coop/rchain/node/IpChecker.scala
+++ b/node/src/main/scala/coop/rchain/node/IpChecker.scala
@@ -1,0 +1,14 @@
+package coop.rchain.node
+
+import java.net._
+import java.io._
+import scala.util.Try
+
+object IpChecker {
+  def checkFrom(from: String): Option[String] =
+    Try {
+      val whatismyip         = new URL(from);
+      val in: BufferedReader = new BufferedReader(new InputStreamReader(whatismyip.openStream()))
+      InetAddress.getByName(in.readLine()).getHostAddress
+    }.toOption
+}

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -105,13 +105,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
       key.toOption
         .getOrElse(Paths.get(data_dir().toString, "node.key.pem"))
 
-    def fetchHost(): String =
-      host.toOption match {
-        case Some(host) => host
-        case None       => whoami(port()).fold("localhost")(_.getHostAddress)
-      }
-
-    lazy val localhost: String =
+    lazy val fetchHost: String =
       host.toOption match {
         case Some(host) => host
         case None       => whoami(port()).fold("localhost")(_.getHostAddress)

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -27,6 +27,10 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
   val run = new Subcommand("run") {
 
+    val defaultTimeout =
+      opt[Int](default = Some(1000),
+               descr = "Default timeout for roundtrip connections. Default 1 second.")
+
     val certificate =
       opt[Path](required = false,
                 short = 'c',

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.Logger
 import coop.rchain.comm.UPnP
 import coop.rchain.casper.CasperConf
 import org.rogach.scallop._
-
+import coop.rchain.catscontrib._, Catscontrib._, ski._
 import scala.collection.JavaConverters._
 
 final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
@@ -26,6 +26,8 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   addSubcommand(diagnostics)
 
   val run = new Subcommand("run") {
+
+    val noUpnp = opt[Boolean](default = Some(false), descr = "Use this flag to disable UpNp.")
 
     val defaultTimeout =
       opt[Int](default = Some(1000),
@@ -105,10 +107,10 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
       key.toOption
         .getOrElse(Paths.get(data_dir().toString, "node.key.pem"))
 
-    lazy val fetchHost: String =
+    def fetchHost(upnp: UPnP): String =
       host.toOption match {
         case Some(host) => host
-        case None       => whoami(port()).fold("localhost")(_.getHostAddress)
+        case None       => whoami(port(), upnp)
       }
   }
   addSubcommand(run)
@@ -162,36 +164,27 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
   }
   addSubcommand(propose)
 
-  private def whoami(port: Int): Option[InetAddress] = {
+  private def check(source: String, from: String): PartialFunction[Unit, (String, String)] =
+    Function.unlift(Unit => IpChecker.checkFrom(from).map(ip => (source, ip)))
 
-    val logger = Logger("conf")
-    val upnp   = new UPnP(port)
-
-    logger.info(s"uPnP: ${upnp.localAddress} -> ${upnp.externalAddress}")
-
-    upnp.localAddress match {
-      case Some(addy) => Some(addy)
-      case None => {
-        val ifaces = NetworkInterface.getNetworkInterfaces.asScala.map(_.getInterfaceAddresses)
-        val addresses = ifaces
-          .flatMap(_.asScala)
-          .map(_.getAddress)
-          .toList
-          .groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress || x.isSiteLocalAddress)
-        if (addresses.contains(false)) {
-          Some(addresses(false).head)
-        } else {
-          val locals = addresses(true).groupBy(x => x.isLoopbackAddress || x.isLinkLocalAddress)
-          if (locals.contains(false)) {
-            Some(locals(false).head)
-          } else if (locals.contains(true)) {
-            Some(locals(true).head)
-          } else {
-            None
-          }
-        }
+  private def checkAll: (String, String) = {
+    val func: PartialFunction[Unit, (String, String)] =
+      check("AmazonAWS service", "http://checkip.amazonaws.com") orElse
+        check("WhatIsMyIP service", "http://bot.whatismyipaddress.com") orElse {
+        case _ => ("failed to guess", "localhost")
       }
-    }
+
+    func.apply(())
+  }
+
+  private def whoami(port: Int, upnp: UPnP): String = {
+    println("INFO - flag --host was not provided, guessing your external IP address")
+
+    val (source, ip) = upnp.externalAddress
+      .map(addy => ("uPnP", InetAddress.getByName(addy).getHostAddress))
+      .getOrElse(checkAll)
+    println(s"INFO - guessed $ip from source: $source")
+    ip
   }
 
   def casperConf: CasperConf = CasperConf(

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -12,6 +12,7 @@ import coop.rchain.comm.transport._
 import coop.rchain.comm.discovery._
 import coop.rchain.shared._
 import scala.concurrent.duration.{Duration, MILLISECONDS}
+import java.io.File
 
 package object effects {
 
@@ -48,12 +49,12 @@ package object effects {
     }
 
   def tcpTranposrtLayer[
-      F[_]: Monad: Capture: Metrics: Futurable: TcpTransportLayer.ConnectionsState](conf: Conf)(
-      src: PeerNode)(implicit executionContext: ExecutionContext) =
-    new TcpTransportLayer[F](conf.run.fetchHost,
-                             conf.run.port(),
-                             conf.run.certificatePath.toFile,
-                             conf.run.keyPath.toFile)(src)
+      F[_]: Monad: Capture: Metrics: Futurable: TcpTransportLayer.ConnectionsState](
+      host: String,
+      port: Int,
+      cert: File,
+      key: File)(src: PeerNode)(implicit executionContext: ExecutionContext) =
+    new TcpTransportLayer[F](host, port, cert, key)(src)
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)
 

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -50,7 +50,7 @@ package object effects {
   def tcpTranposrtLayer[
       F[_]: Monad: Capture: Metrics: Futurable: TcpTransportLayer.ConnectionsState](conf: Conf)(
       src: PeerNode)(implicit executionContext: ExecutionContext) =
-    new TcpTransportLayer[F](conf.run.localhost,
+    new TcpTransportLayer[F](conf.run.fetchHost,
                              conf.run.port(),
                              conf.run.certificatePath.toFile,
                              conf.run.keyPath.toFile)(src)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -104,11 +104,32 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
     publicKeyHash.get
   }
 
+  /**
+    TODO FIX-ME This should not be here. Please fix this when working on rnode-0.5.x
+    This needs to be moved to node program! Part of execution. Effectful!
+    */
+  val upnpErrorMsg =
+    s"ERROR - Could not open the port via uPnP. Please open it manaually on your router!"
+  val upnp = new UPnP
+  if (!conf.run.noUpnp()) {
+    println("INFO - trying to open port using uPnP....")
+    upnp.addPort(conf.run.port()) match {
+      case Left(UnknownCommError("no gateway")) =>
+        println(s"INFO - [OK] no gateway found, no need to open any port.")
+      case Left(error)  => println(s"$upnpErrorMsg Reason: $error")
+      case Right(false) => println(s"$upnpErrorMsg")
+      case Right(true)  => println("INFO - uPnP port forwarding was most likely successful!")
+    }
+  }
+
   import ApplicativeError_._
 
   /** Configuration */
-  private val host                     = conf.run.fetchHost
-  private val address                  = s"rnode://$name@$host:${conf.run.port()}"
+  private val host                     = conf.run.fetchHost(upnp)
+  private val port                     = conf.run.port()
+  private val certificateFile          = conf.run.certificatePath.toFile
+  private val keyFile                  = conf.run.keyPath.toFile
+  private val address                  = s"rnode://$name@$host:$port"
   private val src                      = PeerNode.parse(address).right.get
   private val storagePath              = conf.run.data_dir().resolve("rspace")
   private val storageSize              = conf.run.map_size()
@@ -133,7 +154,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   implicit val nodeCoreMetricsEffect: NodeMetrics[Task]        = diagnostics.nodeCoreMetrics
   implicit val connectionsState: MonadState[Task, Connections] = effects.connectionsState[Task]
   implicit val transportLayerEffect: TransportLayer[Task] =
-    effects.tcpTranposrtLayer[Task](conf)(src)
+    effects.tcpTranposrtLayer[Task](host, port, certificateFile, keyFile)(src)
   implicit val pingEffect: Ping[Task] = effects.ping(src, defaultTimeout)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task] =
     new TLNodeDiscovery[Task](src, defaultTimeout)
@@ -162,7 +183,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       httpServer    <- HttpServer(conf.run.httpPort()).pure[Effect]
     } yield Resources(grpcServer, metricsServer, httpServer, runtime)
 
-  def startResources(resources: Resources): Effect[Unit] =
+ def startResources(resources: Resources): Effect[Unit] =
     for {
       _ <- resources.httpServer.start.toEffect
       _ <- resources.metricsServer.start.toEffect
@@ -180,6 +201,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       ts    <- timeEffect.currentMillis
       msg   = DisconnectMessage(ProtocolMessage.disconnect(loc), ts)
       _     <- transportLayerEffect.broadcast(msg, peers)
+      // TODO remove that once broadcast and send reuse roundTrip
+      _ <- IOUtil.sleep[Task](5000L)
     } yield ()).unsafeRunSync
     println("Shutting down metrics server...")
     resources.metricsServer.stop()

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -107,7 +107,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   import ApplicativeError_._
 
   /** Configuration */
-  private val host                     = conf.run.localhost
+  private val host                     = conf.run.fetchHost
   private val address                  = s"rnode://$name@$host:${conf.run.port()}"
   private val src                      = PeerNode.parse(address).right.get
   private val storagePath              = conf.run.data_dir().resolve("rspace")


### PR DESCRIPTION
## Overview
This PR will:
* push fixes done previously on #961 so that they are available on `dev`
* introduce `--no-upnp` flag as part of CORE-564

Changes:
* Introduce --default-timeout
* Rename localhost to fetchHost (back from weird naming)
* Introduce --no-upnp flag, change bahavior of --host flag, fix upnp
* upnp will now punch holes for TCP ports not UDP
* upnp is turned on by default and can only be turned of by --no-upnp
flag
* server will try to guess IP only if --host is not provided
* all calls use --default-timeout flag for all comm calls

### Does this PR relate to an RChain JIRA issue? 
CORE-564 