### PR TITLE
CORE-686 Enforcing checkpoint existence on reset.

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
@@ -2,9 +2,12 @@ package coop.rchain.rspace
 
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.rspace.internal.codecSeq
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
+
+import scala.collection.immutable.Seq
 
 /**
   * Represents a Blake2b256 Hash
@@ -47,4 +50,6 @@ object Blake2b256Hash {
 
   implicit val codecBlake2b256Hash: Codec[Blake2b256Hash] =
     fixedSizeBytes(length.toLong, bytes).as[Blake2b256Hash]
+
+  implicit def codecSeqBlake2b256Hash: Codec[Seq[Blake2b256Hash]] = codecSeq(codecBlake2b256Hash)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
@@ -51,5 +51,5 @@ object Blake2b256Hash {
   implicit val codecBlake2b256Hash: Codec[Blake2b256Hash] =
     fixedSizeBytes(length.toLong, bytes).as[Blake2b256Hash]
 
-  implicit def codecSeqBlake2b256Hash: Codec[Seq[Blake2b256Hash]] = codecSeq(codecBlake2b256Hash)
+  implicit val codecSeqBlake2b256Hash: Codec[Seq[Blake2b256Hash]] = codecSeq(codecBlake2b256Hash)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -184,7 +184,7 @@ trait ISpace[C, P, A, K] {
     */
   def reset(root: Blake2b256Hash): Unit =
     store.withTxn(store.createTxnWrite()) { txn =>
-      store.trieStore.putRoot(txn, branch, root)
+      store.trieStore.validateCheckpointAndPutRoot(txn, branch, root)
       val leaves: Seq[Leaf[Blake2b256Hash, GNAT[C, P, A, K]]] = store.trieStore.getLeaves(txn, root)
       store.clear(txn)
       store.bulkInsert(txn, leaves.map { case Leaf(k, v) => (k, v) })

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -184,7 +184,7 @@ trait ISpace[C, P, A, K] {
     */
   def reset(root: Blake2b256Hash): Unit =
     store.withTxn(store.createTxnWrite()) { txn =>
-      store.trieStore.validateCheckpointAndPutRoot(txn, branch, root)
+      store.trieStore.validateAndPutRoot(txn, branch, root)
       val leaves: Seq[Leaf[Blake2b256Hash, GNAT[C, P, A, K]]] = store.trieStore.getLeaves(txn, root)
       store.clear(txn)
       store.bulkInsert(txn, leaves.map { case Leaf(k, v) => (k, v) })

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -304,8 +304,10 @@ class LMDBStore[C, P, A, K] private (
       case TrieUpdate(_, Delete, channelsHash, gnat) =>
         history.delete(trieStore, trieBranch, channelsHash, canonicalize(gnat))
     }
-    withTxn(createTxnRead()) { txn =>
-      trieStore.getRoot(txn, trieBranch).getOrElse(throw new Exception("Could not get root hash"))
+    withTxn(createTxnWrite()) { txn =>
+      trieStore
+        .persistCheckpointAndGetRoot(txn, trieBranch)
+        .getOrElse(throw new Exception("Could not get root hash"))
     }
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -306,7 +306,7 @@ class LMDBStore[C, P, A, K] private (
     }
     withTxn(createTxnWrite()) { txn =>
       trieStore
-        .persistCheckpointAndGetRoot(txn, trieBranch)
+        .persistAndGetRoot(txn, trieBranch)
         .getOrElse(throw new Exception("Could not get root hash"))
     }
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -18,13 +18,13 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def getRoot(txn: T, branch: Branch): Option[Blake2b256Hash]
 
-  private[rspace] def persistCheckpointAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash]
+  private[rspace] def persistAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash]
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
-  private[rspace] def validateCheckpointAndPutRoot(txn: T,
-                                                   branch: Branch,
-                                                   hash: Blake2b256Hash): Unit
+  private[rspace] def validateAndPutRoot(txn: T,
+                                         branch: Branch,
+                                         hash: Blake2b256Hash): Unit
 
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -18,7 +18,13 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def getRoot(txn: T, branch: Branch): Option[Blake2b256Hash]
 
+  private[rspace] def persistCheckpointAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash]
+
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
+
+  private[rspace] def validateCheckpointAndPutRoot(txn: T,
+                                                   branch: Branch,
+                                                   hash: Blake2b256Hash): Unit
 
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -22,9 +22,7 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
-  private[rspace] def validateAndPutRoot(txn: T,
-                                         branch: Branch,
-                                         hash: Blake2b256Hash): Unit
+  private[rspace] def validateAndPutRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -14,12 +14,12 @@ import scodec.bits.BitVector
 import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
 
-class LMDBTrieStore[K, V] private(val env: Env[ByteBuffer],
-                                  _dbTrie: Dbi[ByteBuffer],
-                                  _dbRoot: Dbi[ByteBuffer],
-                                  _dbPastRoots: Dbi[ByteBuffer])(implicit
-                                                                 codecK: Codec[K],
-                                                                 codecV: Codec[V])
+class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
+                                   _dbTrie: Dbi[ByteBuffer],
+                                   _dbRoot: Dbi[ByteBuffer],
+                                   _dbPastRoots: Dbi[ByteBuffer])(implicit
+                                                                  codecK: Codec[K],
+                                                                  codecV: Codec[V])
     extends ITrieStore[Txn[ByteBuffer], K, V] {
 
   private[rspace] def createTxnRead(): Txn[ByteBuffer] = env.txnRead
@@ -94,8 +94,8 @@ class LMDBTrieStore[K, V] private(val env: Env[ByteBuffer],
       }
       .map {
         case (currentRoot, updatedPastRoots) =>
-          val encodedBranch          = Codec[Branch].encode(branch).get
-          val encodedBranchBuff      = encodedBranch.bytes.toDirectByteBuffer
+          val encodedBranch        = Codec[Branch].encode(branch).get
+          val encodedBranchBuff    = encodedBranch.bytes.toDirectByteBuffer
           val encodedPastRoots     = Codec[Seq[Blake2b256Hash]].encode(updatedPastRoots).get
           val encodedPastRootsBuff = encodedPastRoots.bytes.toDirectByteBuffer
           _dbPastRoots.put(txn, encodedBranchBuff, encodedPastRootsBuff)
@@ -120,7 +120,7 @@ class LMDBTrieStore[K, V] private(val env: Env[ByteBuffer],
     }
 
   private[this] def getPastRootsInBranch(txn: Txn[ByteBuffer],
-                                           branch: Branch): Seq[Blake2b256Hash] = {
+                                         branch: Branch): Seq[Blake2b256Hash] = {
     val encodedBranch     = Codec[Branch].encode(branch).get
     val encodedBranchBuff = encodedBranch.bytes.toDirectByteBuffer
     Option(_dbPastRoots.get(txn, encodedBranchBuff))
@@ -159,8 +159,8 @@ object LMDBTrieStore {
   def create[K, V](env: Env[ByteBuffer])(implicit
                                          codecK: Codec[K],
                                          codecV: Codec[V]): LMDBTrieStore[K, V] = {
-    val dbTrie: Dbi[ByteBuffer]        = env.openDbi("Trie", MDB_CREATE)
-    val dbRoots: Dbi[ByteBuffer]       = env.openDbi("Roots", MDB_CREATE)
+    val dbTrie: Dbi[ByteBuffer]      = env.openDbi("Trie", MDB_CREATE)
+    val dbRoots: Dbi[ByteBuffer]     = env.openDbi("Roots", MDB_CREATE)
     val dbPastRoots: Dbi[ByteBuffer] = env.openDbi("PastRoots", MDB_CREATE)
     new LMDBTrieStore[K, V](env, dbTrie, dbRoots, dbPastRoots)
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -1,24 +1,25 @@
 package coop.rchain.rspace.history
 
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 
 import coop.rchain.rspace.Blake2b256Hash
-import coop.rchain.shared.Resources.withResource
 import coop.rchain.shared.AttemptOps._
 import coop.rchain.shared.ByteVectorOps._
+import coop.rchain.shared.Resources.withResource
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
 import scodec.Codec
 import scodec.bits.BitVector
 
+import scala.collection.immutable.Seq
 import scala.collection.JavaConverters._
 
 class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
                                    _dbTrie: Dbi[ByteBuffer],
-                                   _dbRoot: Dbi[ByteBuffer])(implicit
-                                                             codecK: Codec[K],
-                                                             codecV: Codec[V])
+                                   _dbRoot: Dbi[ByteBuffer],
+                                   _dbCheckpoints: Dbi[ByteBuffer])(implicit
+                                                                    codecK: Codec[K],
+                                                                    codecV: Codec[V])
     extends ITrieStore[Txn[ByteBuffer], K, V] {
 
   private[rspace] def createTxnRead(): Txn[ByteBuffer] = env.txnRead
@@ -73,6 +74,7 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
   private[rspace] def clear(txn: Txn[ByteBuffer]): Unit = {
     _dbTrie.drop(txn)
     _dbRoot.drop(txn)
+    _dbCheckpoints.drop(txn)
   }
 
   private[rspace] def getRoot(txn: Txn[ByteBuffer], branch: Branch): Option[Blake2b256Hash] = {
@@ -83,6 +85,23 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
     }
   }
 
+  private[rspace] def persistCheckpointAndGetRoot(txn: Txn[ByteBuffer],
+                                                  branch: Branch): Option[Blake2b256Hash] =
+    getRoot(txn, branch)
+      .map { currentRoot =>
+        val checkpoints = getCheckpointsInBranch(txn, branch).filter(_ != currentRoot)
+        (currentRoot, currentRoot +: checkpoints)
+      }
+      .map {
+        case (currentRoot, updatedCheckpoints) =>
+          val encodedBranch          = Codec[Branch].encode(branch).get
+          val encodedBranchBuff      = encodedBranch.bytes.toDirectByteBuffer
+          val encodedCheckpoints     = Codec[Seq[Blake2b256Hash]].encode(updatedCheckpoints).get
+          val encodedCheckpointsBuff = encodedCheckpoints.bytes.toDirectByteBuffer
+          _dbCheckpoints.put(txn, encodedBranchBuff, encodedCheckpointsBuff)
+          currentRoot
+      }
+
   private[rspace] def putRoot(txn: Txn[ByteBuffer], branch: Branch, hash: Blake2b256Hash): Unit = {
     val encodedBranch     = Codec[Branch].encode(branch).get
     val encodedBranchBuff = encodedBranch.bytes.toDirectByteBuffer
@@ -92,6 +111,47 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
       throw new Exception(s"could not persist: $hash")
     }
   }
+
+  private[this] def getAllCheckpoints(txn: Txn[ByteBuffer]): Seq[Blake2b256Hash] =
+    withResource(_dbCheckpoints.iterate(txn)) { (it: CursorIterator[ByteBuffer]) =>
+      it.asScala.foldLeft(Seq.empty[Blake2b256Hash]) { (acc, keyVal) =>
+        acc ++ Codec[Seq[Blake2b256Hash]].decode(BitVector(keyVal.`val`())).map(_.value).get
+      }
+    }
+
+  private[this] def getCheckpointsInBranch(txn: Txn[ByteBuffer],
+                                           branch: Branch): Seq[Blake2b256Hash] = {
+    val encodedBranch     = Codec[Branch].encode(branch).get
+    val encodedBranchBuff = encodedBranch.bytes.toDirectByteBuffer
+    Option(_dbCheckpoints.get(txn, encodedBranchBuff))
+      .map { bytes =>
+        Codec[Seq[Blake2b256Hash]].decode(BitVector(bytes)).map(_.value).get
+      }
+      .getOrElse(Seq.empty)
+  }
+
+  private[rspace] def validateCheckpointAndPutRoot(txn: Txn[ByteBuffer],
+                                                   branch: Branch,
+                                                   hash: Blake2b256Hash): Unit =
+    getRoot(txn, branch)
+      .find(_ == hash)
+      .orElse {
+        getCheckpointsInBranch(txn, branch)
+          .find(_ == hash)
+          .map { blake: Blake2b256Hash =>
+            putRoot(txn, branch, blake)
+            blake
+          }
+      }
+      .orElse {
+        getAllCheckpoints(txn)
+          .find(_ == hash)
+          .map { blake: Blake2b256Hash =>
+            putRoot(txn, branch, blake)
+            blake
+          }
+      }
+      .getOrElse(throw new Exception(s"Unknown checkpoint."))
 }
 
 object LMDBTrieStore {
@@ -99,8 +159,9 @@ object LMDBTrieStore {
   def create[K, V](env: Env[ByteBuffer])(implicit
                                          codecK: Codec[K],
                                          codecV: Codec[V]): LMDBTrieStore[K, V] = {
-    val dbTrie: Dbi[ByteBuffer]  = env.openDbi("Trie", MDB_CREATE)
-    val dbRoots: Dbi[ByteBuffer] = env.openDbi("Roots", MDB_CREATE)
-    new LMDBTrieStore[K, V](env, dbTrie, dbRoots)
+    val dbTrie: Dbi[ByteBuffer]        = env.openDbi("Trie", MDB_CREATE)
+    val dbRoots: Dbi[ByteBuffer]       = env.openDbi("Roots", MDB_CREATE)
+    val dbCheckpoints: Dbi[ByteBuffer] = env.openDbi("Checkpoints", MDB_CREATE)
+    new LMDBTrieStore[K, V](env, dbTrie, dbRoots, dbCheckpoints)
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -268,6 +268,15 @@ trait HistoryActionsTests
       space.store.isEmpty shouldBe true
     }
 
+  "reset to an unknown checkpoint" should "result in an exception" in
+    withTestSpace { space =>
+      val unknownHash =
+        Blake2b256Hash.fromHex("ff3c5e70a028b7956791a6b3d8db00000f469e0088db22dd3afbc86997fe86a0")
+      the[Exception] thrownBy {
+        space.reset(unknownHash)
+      } should have message "Unknown checkpoint."
+    }
+
   "createCheckpoint, consume, createCheckpoint, reset to first checkpoint, reset to second checkpoint" should
     "result in a store that contains the consume and appropriate join map" in withTestSpace {
     space =>

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -274,7 +274,7 @@ trait HistoryActionsTests
         Blake2b256Hash.fromHex("ff3c5e70a028b7956791a6b3d8db00000f469e0088db22dd3afbc86997fe86a0")
       the[Exception] thrownBy {
         space.reset(unknownHash)
-      } should have message "Unknown checkpoint."
+      } should have message "Unknown root."
     }
 
   "createCheckpoint, consume, createCheckpoint, reset to first checkpoint, reset to second checkpoint" should

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -40,6 +40,21 @@ class ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       space.produce(channelCreator(i), datumCreator(i), persist)
     }
 
+  "reset to a checkpoint from a different branch" should "work" in withTestSpaces {
+    (space, replaySpace) =>
+      val root0 = replaySpace.createCheckpoint().root
+      replaySpace.store.isEmpty shouldBe true
+
+      space.produce("ch1", "datum1", false)
+      val root1 = space.createCheckpoint().root
+
+      replaySpace.reset(root1)
+      replaySpace.store.isEmpty shouldBe false
+
+      space.reset(root0)
+      space.store.isEmpty shouldBe true
+  }
+
   "Creating a COMM Event that is not contained in the trace log" should "throw a ReplayException" in
     withTestSpaces { (space, replaySpace) =>
       val ch1 = "ch1"

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
@@ -439,7 +439,7 @@ trait LMDBWithTestTrieStore[K]
       Env
         .create()
         .setMapSize(mapSize)
-        .setMaxDbs(2)
+        .setMaxDbs(3)
         .setMaxReaders(126)
         .open(dbDir.toFile)
     val testStore  = LMDBTrieStore.create[K, ByteVector](env)

--- a/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
@@ -15,11 +15,11 @@ class DummyTrieStore[T, K, V] extends ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit = ???
 
-  private[rspace] def validateCheckpointAndPutRoot(txn: T,
-                                                   branch: Branch,
-                                                   hash: Blake2b256Hash): Unit = ???
+  private[rspace] def validateAndPutRoot(txn: T,
+                                         branch: Branch,
+                                         hash: Blake2b256Hash): Unit = ???
 
-  private[rspace] def persistCheckpointAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash] =
+  private[rspace] def persistAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash] =
     ???
 
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit = ???

--- a/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
@@ -15,6 +15,13 @@ class DummyTrieStore[T, K, V] extends ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit = ???
 
+  private[rspace] def validateCheckpointAndPutRoot(txn: T,
+                                                   branch: Branch,
+                                                   hash: Blake2b256Hash): Unit = ???
+
+  private[rspace] def persistCheckpointAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash] =
+    ???
+
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit = ???
 
   private[rspace] def get(txn: T, key: Blake2b256Hash): Option[Trie[K, V]] = ???

--- a/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/DummyTrieStore.scala
@@ -15,9 +15,7 @@ class DummyTrieStore[T, K, V] extends ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit = ???
 
-  private[rspace] def validateAndPutRoot(txn: T,
-                                         branch: Branch,
-                                         hash: Blake2b256Hash): Unit = ???
+  private[rspace] def validateAndPutRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit = ???
 
   private[rspace] def persistAndGetRoot(txn: T, branch: Branch): Option[Blake2b256Hash] =
     ???


### PR DESCRIPTION
## Overview
After each `createCheckpoint` a checkpoint hash for the current `trieBranch` is preserved in LMDB.
On `reset` the hash needs to exist in any branch.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/projects/CORE/issues/CORE-686

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none
