### PR TITLE
Add run subcommand in systemd service description

### DIFF
--- a/node/rnode.service
+++ b/node/rnode.service
@@ -3,7 +3,7 @@ Description=RChain Node
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/rnode
+ExecStart=/usr/bin/rnode run
 User=rnode
 
 [Install]


### PR DESCRIPTION
## Overview
When trying to run rnode as systemd process, system was not booting
up. The reason was related with recent changes of adding subcommands (CORE-496). 

Subcommands were added in CORE-496 as a bounty feature. Docker and documentation were updated, however systemd configuration was was not updated.

This PR was created against dev (not master), as I'm not 100% sure how we want to approach it regarding to 0.4.2 release.

There is also a bigger interesting issue: currently users who use systemd to run the rnode can not really control the flags that are available.

### Does this PR relate to an RChain JIRA issue? 
CORE-711