### PR TITLE
Add logic and test for turning locked mbox into queue mbox

### DIFF
--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Actor.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Actor.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.Logger
 import coop.rchain.roscala.GlobalEnv
 import coop.rchain.roscala.Vm.State
 import coop.rchain.roscala.ob.Actor.logger
+import coop.rchain.roscala.ob.mbox.MboxOb
 
 class Actor extends MboxOb {
   val extension = new Extension()

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ob.scala
@@ -2,18 +2,19 @@ package coop.rchain.roscala.ob
 
 import com.typesafe.scalalogging.Logger
 
-import scala.collection.mutable
 import Ob.logger
 import coop.rchain.roscala.GlobalEnv
 import coop.rchain.roscala.Vm.State
-import java.util.concurrent.ConcurrentHashMap
 
-import coop.rchain.roscala.util.{LockedMap, Slot}
+import coop.rchain.roscala.ob.mbox.MboxOb
+import coop.rchain.roscala.util.Slot
 
 abstract class Ob {
   val slot       = Slot()
   var meta: Meta = _
   var parent: Ob = _
+
+  def accepts(msg: Ctxt): Boolean = false
 
   def dispatch(ctxt: Ctxt, state: State, globalEnv: GlobalEnv): Ob = Niv
 

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Queue.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Queue.scala
@@ -1,0 +1,15 @@
+package coop.rchain.roscala.ob
+
+import scala.collection.mutable
+
+class Queue(elems: mutable.Queue[Ob]) extends Ob {
+  def enqueue(value: Ob): Unit = elems.enqueue(value)
+
+  def dequeue(): Ob = elems.dequeue()
+}
+
+object Queue {
+  def apply(): Queue = new Queue(mutable.Queue.empty)
+
+  def apply(tuple: Tuple): Queue = new Queue(mutable.Queue(tuple.value: _*))
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala
@@ -4,6 +4,9 @@ class Tuple(val value: Array[Ob]) extends Ob {
 
   def apply(n: Int): Ob = value(n)
 
+  override def accepts(msg: Ctxt): Boolean =
+    value.exists(_.matches(msg))
+
   def becomeExtension(newMeta: Meta, newParent: Ob): Extension = {
     val extension = new Extension()
     extension.meta = newMeta
@@ -13,9 +16,9 @@ class Tuple(val value: Array[Ob]) extends Ob {
     extension
   }
 
-  def update(arg: Int, ob: Ob): Unit = value.update(arg, ob)
+  def elem(n: Int): Ob = value(n)
 
-  def accepts(msg: Ctxt): Boolean = this.value.exists(_.matches(msg))
+  def update(arg: Int, ob: Ob): Unit = value.update(arg, ob)
 
   def makeSlice(offset: Int, n: Int): Tuple = Tuple(n, this, offset, n)
 
@@ -50,9 +53,7 @@ class Tuple(val value: Array[Ob]) extends Ob {
             case (e, arg) => e == arg
           }
       }
-    } else {
-      false
-    }
+    } else false
   }
 
   def matches(msg: Tuple): Boolean = {

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/EmptyMbox.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/EmptyMbox.scala
@@ -1,0 +1,13 @@
+package coop.rchain.roscala.ob.mbox
+
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+import coop.rchain.roscala.ob.{Ctxt, Niv, Ob}
+
+class EmptyMbox extends Ob {
+  override def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    client.mbox = MboxOb.LockedMbox
+    client.schedule(task, state, globalEnv)
+    Niv
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/LockedMbox.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/LockedMbox.scala
@@ -1,0 +1,16 @@
+package coop.rchain.roscala.ob.mbox
+
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+import coop.rchain.roscala.ob.{Ctxt, Nil, Niv, Ob}
+
+class LockedMbox extends Ob {
+  override def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    MboxOb.logger.debug("Locked mailbox receives message")
+
+    val newMbox = QueueMbox(Nil)
+    newMbox.enqueue(task)
+    client.mbox = newMbox
+    Niv
+  }
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/MboxOb.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/MboxOb.scala
@@ -1,7 +1,9 @@
-package coop.rchain.roscala.ob
+package coop.rchain.roscala.ob.mbox
 
+import com.typesafe.scalalogging.Logger
 import coop.rchain.roscala.GlobalEnv
 import coop.rchain.roscala.Vm.State
+import coop.rchain.roscala.ob.{Ctxt, Ob}
 
 class MboxOb extends Ob {
   var mbox: Ob = MboxOb.LockedMbox
@@ -16,13 +18,7 @@ class MboxOb extends Ob {
 }
 
 object MboxOb {
-  val LockedMbox: Ob = Invalid
-}
+  val logger = Logger("Mailbox")
 
-class EmptyMbox extends Ob {
-  override def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
-    client.mbox = MboxOb.LockedMbox
-    client.schedule(task, state, globalEnv)
-    Niv
-  }
+  val LockedMbox: Ob = new LockedMbox
 }

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/MboxQueue.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/MboxQueue.scala
@@ -1,0 +1,11 @@
+package coop.rchain.roscala.ob.mbox
+
+import coop.rchain.roscala.ob.{Queue, Tuple}
+
+import scala.collection.mutable
+
+class MboxQueue(elems: Tuple) extends Queue(mutable.Queue(elems.value: _*))
+
+object MboxQueue {
+  def apply(): MboxQueue = new MboxQueue(Tuple())
+}

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/QueueMbox.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/QueueMbox.scala
@@ -1,0 +1,40 @@
+package coop.rchain.roscala.ob.mbox
+
+import coop.rchain.roscala.GlobalEnv
+import coop.rchain.roscala.Vm.State
+import coop.rchain.roscala.ob.{Ctxt, Niv, Ob}
+
+class QueueMbox(val enabledSet: Ob, val queue: MboxQueue) extends Ob {
+  var lockVal: Boolean = true
+
+  override def receiveMsg(client: MboxOb, task: Ctxt, state: State, globalEnv: GlobalEnv): Ob = {
+    MboxOb.logger.debug("Queue mailbox receives message")
+
+    if (isLocked || !enabledSet.accepts(task))
+      queue.enqueue(task)
+    else {
+      lock()
+      client.schedule(task, state, globalEnv)
+    }
+
+    Niv
+  }
+
+  def isLocked: Boolean = lockVal
+
+  def lock(): Unit = lockVal = true
+
+  def unlock(): Unit = lockVal = false
+
+  def enqueue(value: Ob): Unit = {
+    MboxOb.logger.debug(s"Enqueue $value")
+    queue.enqueue(value)
+  }
+}
+
+object QueueMbox {
+  def apply(enabledSet: Ob): QueueMbox = {
+    val queue = MboxQueue()
+    new QueueMbox(enabledSet, queue)
+  }
+}

--- a/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/ActorSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.roscala.CtxtRegName._
 import coop.rchain.roscala.VmLiteralName._
 import coop.rchain.roscala.ob.expr.TupleExpr
-import coop.rchain.roscala.ob.MboxOb.LockedMbox
+import coop.rchain.roscala.ob.mbox.{EmptyMbox, MboxOb, QueueMbox}
 
 class ActorSpec extends FlatSpec with Matchers {
 
@@ -106,7 +106,55 @@ class ActorSpec extends FlatSpec with Matchers {
 
     Vm.run(ctxt, fixture.globalEnv, Vm.State())
 
-    fixture.foo.mbox shouldBe LockedMbox
+    fixture.foo.mbox shouldBe MboxOb.LockedMbox
+  }
+
+  "Failing to unlock" should "turn a LockedMbox into a QueueMbox and enqueue the message" in {
+
+    /**
+      * Sending a messages to an `Actor` that does not unlock itself
+      * and has a `LockedMbox`, should turn the Actor's mailbox into a
+      * `QueueMbox`.
+      *
+      * (defOprn return-one)
+      * (defActor Foo
+      *   (method (return-one)
+      *     1
+      *   )
+      * )
+      * (define foo (new Foo))
+      *
+      * `mbox` gets locked and `return-one` method gets invoked when
+      * message is received.
+      * (return-one foo)
+      *
+      * `mbox` becomes a `QueueMbox`, message gets enqueued and
+      * nothing gets invoked.
+      * (return-one foo)
+      *
+      */
+    val fixture = defineActorWithoutUnlock
+
+    /** Bytecode for `(return-one foo)` */
+    val codevec = Seq(
+      OpAlloc(1),
+      OpXferGlobalToArg(global = 0, arg = 0),
+      OpXferGlobalToReg(global = 1, reg = trgt),
+      OpXmit(unwind = false, next = true, nargs = 1)
+    )
+
+    val code  = Code(litvec = Seq.empty, codevec = codevec)
+    val ctxt0 = Ctxt(code, Ctxt.empty, LocRslt)
+    val ctxt1 = ctxt0.clone()
+
+    Vm.run(ctxt0, fixture.globalEnv, Vm.State())
+    Vm.run(ctxt1, fixture.globalEnv, Vm.State())
+
+    fixture.foo.mbox shouldBe an[QueueMbox]
+
+    val message = fixture.foo.mbox.asInstanceOf[QueueMbox].queue.dequeue()
+    message shouldBe ctxt1
+    message.asInstanceOf[Ctxt].argvec.elem(0) shouldBe fixture.foo
   }
 
   "Dispatching a message" should "invoke a method" in {


### PR DESCRIPTION
## Overview
Provides a test case where a message gets send to a locked `Actor`. The mailbox of the `Actor` becomes a `QueueMbox` in which the sent message gets appended to its `MboxQueue` (`queue` field).

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
