### PR TITLE
Object code export import additions fix

### DIFF
--- a/rosette/h/Code.h
+++ b/rosette/h/Code.h
@@ -33,10 +33,10 @@ class CodeBuf : public Ob {
     STD_DECLS(CodeBuf);
 
    protected:
-    void growCodevec(int = DefaultCodeVecSize);
     void deposit(Instr);
 
    public:
+    void growCodevec(int = DefaultCodeVecSize);
     CodeBuf();
 
     CodeVec* codevec;

--- a/rosette/src/BigBang.cc
+++ b/rosette/src/BigBang.cc
@@ -54,6 +54,7 @@
 #include "ModuleInit.h"
 
 #include "Export.h"
+#include "Import.h"
 
 int access(const char*, int);
 
@@ -471,12 +472,17 @@ static RblTable* GetEnvp(char** envp) {
 }
 
 static void LoadBootFiles() {
-    Reader* reader = Reader::create(FindBootFile());
-    PROTECT(reader);
 
-    Ob* expr = INVALID;
-    while ((expr = reader->readExpr()) != RBLEOF) {
-        vm->load(expr);
+    if ('\0' != *ImportFile) {
+        readImportCode();
+    } else {
+        Reader* reader = Reader::create(FindBootFile());
+        PROTECT(reader);
+
+        Ob* expr = INVALID;
+        while ((expr = reader->readExpr()) != RBLEOF) {
+            vm->load(expr);
+        }
     }
 }
 

--- a/rosette/src/CommandLine.cc
+++ b/rosette/src/CommandLine.cc
@@ -217,7 +217,6 @@ int ParseCommandLine(int argc, char** argv) {
         case 'c':
         {
             strncpy(ImportFile, optarg, MAXPATHLEN);    // Save the filename
-            readImportCode();   // temp debug
             break;
         }
 

--- a/rosette/src/Export.cc
+++ b/rosette/src/Export.cc
@@ -177,7 +177,74 @@ void stdExtensionObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodeP
 void expandedLocationObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
     ObjectCodePB::ExpandedLocation *exlocob = lvob->mutable_expanded_location();
     ExpandedLocation *el = (ExpandedLocation *)ob;
-    exlocob->set_value( BASE(el)->asCstring() );
+    Location loc;
+    loc.atom = el;
+    exlocob->set_value((uint32_t)loc.locfields);
+    exlocob->set_text( BASE(el)->asCstring() );
+
+    ObjectCodePB::ExpandedLocation_PBLocationType type = (ObjectCodePB::ExpandedLocation_PBLocationType)GET_GENERIC_TYPE(loc);
+    exlocob->set_type( type );
+    switch(type) {
+    case LT_CtxtRegister: {
+        ObjectCodePB::ExpandedLocation::LocCtxt * pbloc = exlocob->mutable_ctxt();
+        pbloc->set_reg( (ObjectCodePB::ExpandedLocation_LocCtxt_PBLocationCtxt)GET_CTXTREG_INDEX(loc) );
+        break;
+    }
+
+    case LT_ArgRegister: {
+        ObjectCodePB::ExpandedLocation::LocArg * pbloc = exlocob->mutable_arg();
+        pbloc->set_arg( GET_ARGREG_INDEX(loc) );
+        break;
+    }
+
+    case LT_LexVariable: {
+        ObjectCodePB::ExpandedLocation::LocLexVar * pbloc = exlocob->mutable_lexvar();
+        pbloc->set_indirect( GET_LEXVAR_IND(loc) );
+        pbloc->set_level( GET_LEXVAR_LEVEL(loc) );
+        pbloc->set_offset( GET_LEXVAR_OFFSET(loc) );
+        break;
+    }
+
+    case LT_AddrVariable: {
+        ObjectCodePB::ExpandedLocation::LocAddrVar * pbloc = exlocob->mutable_addrvar();
+        pbloc->set_indirect( GET_ADDRVAR_IND(loc) );
+        pbloc->set_level( GET_ADDRVAR_LEVEL(loc) );
+        pbloc->set_offset( GET_ADDRVAR_OFFSET(loc) );
+        break;
+    }
+
+    case LT_GlobalVariable: {
+        ObjectCodePB::ExpandedLocation::LocGlobalVar * pbloc = exlocob->mutable_globalvar();
+        pbloc->set_offset( GET_GLOBALVAR_OFFSET(loc) );
+        break;
+    }
+
+    case LT_BitField: {
+        ObjectCodePB::ExpandedLocation::LocBitField * pbloc = exlocob->mutable_bitfield();
+        pbloc->set_indirect( GET_BITFIELD_IND(loc) );
+        pbloc->set_signed_( GET_BITFIELD_SIGN(loc) );
+        pbloc->set_level( GET_BITFIELD_LEVEL(loc) );
+        pbloc->set_span( GET_BITFIELD_SPAN(loc) );
+        break;
+    }
+
+    case LT_BitField00: {
+        ObjectCodePB::ExpandedLocation::LocBitField00 * pbloc = exlocob->mutable_bitfield00();
+        pbloc->set_signed_( GET_BITFIELD00_SIGN(loc) );
+        pbloc->set_offset( GET_BITFIELD00_OFFSET(loc) );
+        pbloc->set_span( GET_BITFIELD00_SPAN(loc) );
+        break;
+    }
+
+    case LT_Limbo: {
+        ObjectCodePB::ExpandedLocation::LocLimbo * pbloc = exlocob->mutable_limbo();
+        break;
+    }
+
+    default: {
+        warning("Unknown Location Type during export.");
+    }
+    }
 }
 
 void freeExprObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
@@ -322,10 +389,6 @@ void quoteExprObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::
     populateObjectByType(qe->expr, expr);
 }
 
-void rblAtomExprObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
-    ObjectCodePB::RBLAtom *raob = lvob->mutable_rbl_atom();
-}
-
 void reflectiveMethodExprObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
     ObjectCodePB::ReflectiveMethodExpr *rmeob = lvob->mutable_reflective_method_expr();
     ReflectiveMethodExpr * rme = (ReflectiveMethodExpr *)ob;
@@ -421,17 +484,12 @@ void templateObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::O
     populateObjectByType(t->keymeta, keymeta);
 }
 
-void compoundPatternObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
-    ObjectCodePB::CompoundPattern *cpob = lvob->mutable_compound_pattern();
-    CompoundPattern * cp = (CompoundPattern *)ob;
-
-    ObjectCodePB::Object *expr = cpob->mutable_expr();
-    populateObjectByType(cp->expr, expr);
-}
-
 void complexPatternObjectHandler( ObjectCodePB::Object * lvob, pOb ob, ObjectCodePB::ObType pbtype ) {
     ObjectCodePB::ComplexPattern *cpob = lvob->mutable_complex_pattern();
     ComplexPattern * cp = (ComplexPattern *)ob;
+
+    ObjectCodePB::Object *expr = cpob->mutable_expr();
+    populateObjectByType(cp->expr, expr);
 
     ObjectCodePB::Object *patvec = cpob->mutable_patvec();
     populateObjectByType(cp->patvec, patvec);
@@ -521,7 +579,6 @@ std::map<ExportObjectKey, std::pair<ExportObjectHandler, ExportObjectType> >  ha
     {"BlockExpr",           {blockExprObjectHandler, ObjectCodePB::OT_BLOCK_EXPR} },
     {"Char",                {charObjectHandler,      ObjectCodePB::OT_CHAR} },
     {"Code",                {codeObjectHandler,      ObjectCodePB::OT_CODE} },
-    {"CompoundPattern",     {compoundPatternObjectHandler, ObjectCodePB::OT_COMPOUND_PATTERN} },
     {"ComplexPattern",      {complexPatternObjectHandler, ObjectCodePB::OT_COMPLEX_PATTERN} },
     {"ConstPattern",        {constPatternObjectHandler, ObjectCodePB::OT_CONST_PATTERN} },
     {"ExpandedLocation",    {expandedLocationObjectHandler, ObjectCodePB::OT_EXPANDED_LOCATION} },
@@ -543,7 +600,6 @@ std::map<ExportObjectKey, std::pair<ExportObjectHandler, ExportObjectType> >  ha
     {"Proc",                {procObjectHandler,      ObjectCodePB::OT_PROC} },
     {"ProcExpr",            {procExprObjectHandler,  ObjectCodePB::OT_PROC_EXPR} },
     {"QuoteExpr",           {quoteExprObjectHandler, ObjectCodePB::OT_QUOTE_EXPR} },
-    {"RblAtom",             {rblAtomExprObjectHandler, ObjectCodePB::OT_RBL_ATOM} },
     {"RblBool",             {rblboolObjectHandler,   ObjectCodePB::OT_RBL_BOOL} },
     {"RBLstring",           {rblstringObjectHandler, ObjectCodePB::OT_RBL_STRING} },
     {"RblTable",            {rblTableObjectHandler,  ObjectCodePB::OT_RBL_TABLE} },
@@ -603,7 +659,7 @@ void collectExportCode(Code *code) {
 
     // Save the binary opCodes from the codevec
     const char * code_binary = (char *)codevec->absolutize(0);
-    size_t code_size = codevec->numberOfWords() * sizeof(uint32_t);
+    size_t code_size = codevec->numberOfWords() * sizeof(Instr);
     ObjectCodePB::CodeVec * cv = cb->mutable_codevec();
     cv->set_opcodes( std::string(code_binary, code_size) );
 
@@ -628,7 +684,10 @@ void writeExportCode() {
     if (VerboseFlag) {
         std::string s;
         google::protobuf::TextFormat::PrintToString( objectCode, &s );
-        fprintf(stderr, "ObjectCode = \n%s\n", s.c_str());
+
+        fprintf(stderr, "*** Exported ObjectCode = \n%s\n", s.c_str());
+        fprintf(stderr, "object count = %d\n", objectCode.objects_size());
+        fprintf(stderr, "code count = %d\n", objectCode.code_block_size());
     }
 
     // Write the object code to disk.

--- a/rosette/src/Import.cc
+++ b/rosette/src/Import.cc
@@ -24,150 +24,359 @@ extern pOb NILmeta;
 extern CompoundPattern* NILpattern;
 
 ObjectCodePB::ObjectCode importObjectCode;
-typedef struct {
+class ObjectInfo {
+public:
+    ObjectInfo() : id(0), pbIndex(0), object(NULL) {}
     IdType id;
     int pbIndex;
     pOb object;
-} ObjectInfo;
+};
 
 std::map<IdType, ObjectInfo> objects;
+ObjectInfo * getObject(IdType id) {
+    auto oi = objects.find(id);
+    if (oi != objects.end()) {
+        return &oi->second;
+    }
 
-pOb createRosetteObject(const ObjectCodePB::Object & ob) {
+    warning("Unable to locate object %llu.", id);
+    return NULL;
+}
+
+pOb createRosetteObject(ObjectCodePB::Object * ob) {
 
     pOb retval = NULL;
+    ObjectInfo * oi = NULL;
 
-    switch(ob.type()) {
-    case ObjectCodePB::OT_ACTOR:
+    if (VerboseFlag) {
+        fprintf(stderr, "%s: Object=\n%s\n", __PRETTY_FUNCTION__, ob->DebugString().c_str());
+    }
+
+    // Is this a regular (not RblAtom) object
+    if (ob->object_id() != 0) {
+
+        // Find its info record
+        oi = getObject(ob->object_id());
+        if (oi->object != NULL) {
+            // It's there and already built, return the pointer
+            return oi->object;
+        }
+
+        if (ob->looped() == true) {  // Object referenced itself
+            return oi->object;
+        }
+    }
+
+    // If this is a reference, find the real object
+    if (ob->reference() != 0) {
+        ob = importObjectCode.mutable_objects(oi->pbIndex);
+        if (VerboseFlag) {
+            fprintf(stderr, " Referenced Object=\n%s\n", ob->DebugString().c_str());
+        }
+    }
+
+    // Create the object by type
+    switch(ob->type()) {
+
+    case ObjectCodePB::OT_ACTOR: {
+        ObjectCodePB::Actor * pbob = ob->mutable_actor();
         retval = Actor::create();
-        break;
-    case ObjectCodePB::OT_BLOCK_EXPR:
-        retval = BlockExpr::create(NULL);
-        break;
-    case ObjectCodePB::OT_CHAR:
-        retval = RBLCHAR(ob.char_().value());
-        break;
-    case ObjectCodePB::OT_CODE:
-        // Handled separately
-        break;
-    case ObjectCodePB::OT_EXPANDED_LOCATION:
-        // ???
-        break;
-    case ObjectCodePB::OT_FIXNUM:
-        retval = FIXNUM(ob.fixnum().value());
-        break;
-    case ObjectCodePB::OT_FLOAT:
-        retval = Float::create((double)ob.float_().value());
-        break;
-    case ObjectCodePB::OT_FREE_EXPR:
-        retval = FreeExpr::create(NULL, NULL);
-        break;
-    case ObjectCodePB::OT_GOTO_EXPR:
-        retval = GotoExpr::create(SYMBOL(ob.goto_expr().label().symbol().name().c_str()));
-        break;
-    case ObjectCodePB::OT_IF_EXPR:
-        retval = IfExpr::create(NULL, NULL);
-        break;
-    case ObjectCodePB::OT_LABEL_EXPR:
-        retval = LabelExpr::create(SYMBOL(ob.goto_expr().label().symbol().name().c_str()), NULL);
-        break;
-    case ObjectCodePB::OT_LET_EXPR:
-        retval = LetExpr::create(NULL, NULL);
-        break;
-    case ObjectCodePB::OT_LET_REC_EXPR:
-        retval = LetrecExpr::create(NULL, NULL);
-        break;
-    case ObjectCodePB::OT_METHOD_EXPR:
-        retval = MethodExpr::create(NULL, NULL, NULL);
-        break;
-    case ObjectCodePB::OT_PROC:
-        retval = Proc::create(NULL, NULL, NULL, NULL);
-        break;
-    case ObjectCodePB::OT_PROC_EXPR:
-        retval = ProcExpr::create(NULL, NULL, NULL);
-        break;
-    case ObjectCodePB::OT_QUOTE_EXPR:
-        retval = QuoteExpr::create(SYMBOL(ob.quote_expr().expr().symbol().name().c_str()));
-        break;
-    case ObjectCodePB::OT_RBL_STRING: {
-        retval = RBLstring::create((char *)ob.rbl_string().value().c_str());
+        // TODO: extension
         break;
     }
-    case ObjectCodePB::OT_REFLECTIVE_METHOD_EXPR:
-        retval = ReflectiveMethodExpr::create(NIV, NULL,
-                    SYMBOL(ob.reflective_method_expr().body().symbol().name().c_str()));
+
+    case ObjectCodePB::OT_BLOCK_EXPR: {
+        ObjectCodePB::BlockExpr * pbob = ob->mutable_block_expr();
+        retval = BlockExpr::create( (Tuple *)createRosetteObject(pbob->mutable_subexprs()),
+                                    createRosetteObject(pbob->mutable_implicit()) );
         break;
-    case ObjectCodePB::OT_REQUEST_EXPR:
-        retval = RequestExpr::create( SYMBOL(ob.request_expr().target().symbol().name().c_str()), NULL);
+    }
+
+    case ObjectCodePB::OT_CHAR:
+        retval = RBLCHAR(ob->char_().value());
         break;
-    case ObjectCodePB::OT_SEND_EXPR:
-        retval = SendExpr::create( SYMBOL(ob.send_expr().target().symbol().name().c_str()), NULL);
+
+    case ObjectCodePB::OT_CODE:
+        retval = oi->object;
         break;
-    case ObjectCodePB::OT_SEQ_EXPR:
-        retval = SeqExpr::create(NULL);
+
+    case ObjectCodePB::OT_EXPANDED_LOCATION: {
+        ObjectCodePB::ExpandedLocation * pbob = ob->mutable_expanded_location();
+        Location loc;
+
+        switch(pbob->type()) {
+        case LT_CtxtRegister: {
+            ObjectCodePB::ExpandedLocation::LocCtxt * ctxt = pbob->mutable_ctxt(); 
+            loc = CtxtReg( (CtxtRegName)ctxt->reg() );
+            break;
+        }
+
+        case LT_ArgRegister: {
+            ObjectCodePB::ExpandedLocation::LocArg * arg = pbob->mutable_arg(); 
+            loc = ArgReg( arg->arg() );
+            break;
+        }
+
+        case LT_LexVariable: {
+            ObjectCodePB::ExpandedLocation::LocLexVar * lex = pbob->mutable_lexvar(); 
+            loc = LexVar( lex->level(), lex->offset(), lex->indirect() );
+            break;
+        }
+
+        case LT_AddrVariable: {
+            ObjectCodePB::ExpandedLocation::LocAddrVar * addr = pbob->mutable_addrvar(); 
+            loc = AddrVar( addr->level(), addr->offset(), addr->indirect() );
+            break;
+        }
+
+        case LT_GlobalVariable: {
+            ObjectCodePB::ExpandedLocation::LocGlobalVar * lex = pbob->mutable_globalvar(); 
+            loc = GlobalVar( lex->offset() );
+            break;
+        }
+
+        case LT_BitField: {
+            ObjectCodePB::ExpandedLocation::LocBitField * bf = pbob->mutable_bitfield(); 
+            loc = BitField( bf->level(), bf->offset(), bf->span(), bf->indirect(), bf->signed_() );
+            break;
+        }
+
+        case LT_BitField00: {
+            ObjectCodePB::ExpandedLocation::LocBitField00 * bf = pbob->mutable_bitfield00(); 
+            loc = BitField00( bf->offset(), bf->span(), bf->signed_() );
+            break;
+        }
+
+        case LT_Limbo: {
+            ObjectCodePB::ExpandedLocation::LocLimbo * limbo = pbob->mutable_limbo(); 
+            loc = LocLimbo;
+            break;
+        }
+
+        default:
+            warning("Import expanded location");
+
+        }
+
+        ExpandedLocation * el = ExpandedLocation::create();
+        retval = valWrt(loc, el);;
         break;
-    case ObjectCodePB::OT_SET_EXPR:
-        retval = SetExpr::create( SYMBOL(ob.set_expr().trgt().symbol().name().c_str()), NULL);
+    }
+
+    case ObjectCodePB::OT_FIXNUM:
+        retval = FIXNUM(ob->fixnum().value());
         break;
-    case ObjectCodePB::OT_STD_METHOD:
-        retval = StdMthd::create(NULL, NULL, NULL);
+
+    case ObjectCodePB::OT_FLOAT:
+        retval = Float::create((double)ob->float_().value());
         break;
+
+    case ObjectCodePB::OT_FREE_EXPR: {
+        ObjectCodePB::FreeExpr * pbob = ob->mutable_free_expr();
+        retval = FreeExpr::create( (TupleExpr *)createRosetteObject(pbob->mutable_freeids()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_GOTO_EXPR:
+        retval = GotoExpr::create(SYMBOL(ob->goto_expr().label().symbol().name().c_str()));
+        break;
+
+    case ObjectCodePB::OT_IF_EXPR: {
+        ObjectCodePB::IfExpr * pbob = ob->mutable_if_expr();
+        retval = IfExpr::create(    createRosetteObject(pbob->mutable_condition()),
+                                    createRosetteObject(pbob->mutable_truebranch()),
+                                    createRosetteObject(pbob->mutable_falsebranch()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_LABEL_EXPR: {
+        ObjectCodePB::LabelExpr * pbob = ob->mutable_label_expr();
+        retval = LabelExpr::create( SYMBOL(pbob->label().symbol().name().c_str()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_LET_EXPR: {
+        ObjectCodePB::LetExpr * pbob = ob->mutable_let_expr();
+        retval = LetExpr::create( (TupleExpr *)createRosetteObject(pbob->mutable_bindings()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_LET_REC_EXPR:  {
+        ObjectCodePB::LetrecExpr * pbob = ob->mutable_let_rec_expr();
+        retval = LetrecExpr::create( (TupleExpr *)createRosetteObject(pbob->mutable_bindings()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_METHOD_EXPR: {
+        ObjectCodePB::MethodExpr * pbob = ob->mutable_method_expr();
+        retval = MethodExpr::create(    createRosetteObject(pbob->mutable_identity()),
+                                    createRosetteObject(pbob->mutable_formals()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_PROC: {
+        ObjectCodePB::Proc * pbob = ob->mutable_proc();
+        retval = Proc::create(    createRosetteObject(pbob->mutable_env()),
+                                    (Code *)createRosetteObject(pbob->mutable_code()),
+                                    createRosetteObject(pbob->mutable_id()),
+                                    createRosetteObject(pbob->mutable_source()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_PROC_EXPR: {
+        ObjectCodePB::ProcExpr * pbob = ob->mutable_proc_expr();
+        retval = ProcExpr::create(    createRosetteObject(pbob->mutable_identity()),
+                                    createRosetteObject(pbob->mutable_formals()),
+                                    createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_QUOTE_EXPR:
+        retval = QuoteExpr::create(SYMBOL(ob->quote_expr().expr().symbol().name().c_str()));
+        break;
+
+    case ObjectCodePB::OT_RBL_STRING: {
+        retval = RBLstring::create((char *)ob->rbl_string().value().c_str());
+        break;
+    }
+
+    case ObjectCodePB::OT_REFLECTIVE_METHOD_EXPR: {
+        ObjectCodePB::ReflectiveMethodExpr * pbob = ob->mutable_reflective_method_expr();
+        retval = ReflectiveMethodExpr::create(  createRosetteObject(pbob->mutable_identity()),
+                                                createRosetteObject(pbob->mutable_formals()),
+                                                createRosetteObject(pbob->mutable_body()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_REQUEST_EXPR: {
+        ObjectCodePB::RequestExpr * pbob = ob->mutable_request_expr();
+        retval = RequestExpr::create(
+                    SYMBOL(pbob->target().symbol().name().c_str()),
+                    (TupleExpr *)createRosetteObject( pbob->mutable_msg() ));
+        break;
+    }
+
+    case ObjectCodePB::OT_SEND_EXPR: {
+        ObjectCodePB::SendExpr * pbob = ob->mutable_send_expr();
+        retval = SendExpr::create(
+                    SYMBOL(pbob->target().symbol().name().c_str()),
+                    (TupleExpr *)createRosetteObject( pbob->mutable_msg() ));
+        break;
+    }
+
+    case ObjectCodePB::OT_SEQ_EXPR: {
+        ObjectCodePB::SeqExpr * pbob = ob->mutable_seq_expr();
+        retval = SeqExpr::create( (Tuple *)createRosetteObject(pbob->mutable_subexprs()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_SET_EXPR: {
+        ObjectCodePB::SetExpr * pbob = ob->mutable_set_expr();
+        retval = SetExpr::create( createRosetteObject(pbob->mutable_trgt()),
+                                    createRosetteObject(pbob->mutable_val()) );
+        break;
+    }
+
+    case ObjectCodePB::OT_STD_METHOD: {
+        ObjectCodePB::StdMthd * pbob = ob->mutable_std_mthd();
+        retval = StdMthd::create( (Code *)createRosetteObject(pbob->mutable_code()),
+                                    createRosetteObject(pbob->mutable_id()),
+                                    createRosetteObject(pbob->mutable_source()));
+        break;
+    }
+
     case ObjectCodePB::OT_SYMBOL:
-        retval = SYMBOL(ob.symbol().name().c_str());
+        retval = SYMBOL(ob->symbol().name().c_str());
         break;
-    case ObjectCodePB::OT_TBL_OBJECT:
+
+    case ObjectCodePB::OT_TBL_OBJECT: {
+        ObjectCodePB::TblObject * pbob = ob->mutable_tbl_object();
         retval = TblObject::create();
         break;
-    case ObjectCodePB::OT_TEMPLATE:
-        retval = Template::create(NIL, NILmeta, NILpattern);
+    }
+
+    case ObjectCodePB::OT_TEMPLATE: {
+        ObjectCodePB::Template * pbob = ob->mutable_template_();
+        retval = Template::create( (Tuple *)createRosetteObject(pbob->mutable_keytuple()),
+                                    createRosetteObject(pbob->mutable_pat()),
+                                    (CompoundPattern *)createRosetteObject(pbob->mutable_keymeta()) );
         break;
-    case ObjectCodePB::OT_TUPLE:
-        retval = Tuple::create();
-        break;
-    case ObjectCodePB::OT_TUPLE_EXPR:
-        retval = TupleExpr::create();
-        break;
+    }
+
+    case ObjectCodePB::OT_TUPLE: {
+        ObjectCodePB::Tuple * pbob = ob->mutable_tuple();
+        Tuple * tup = Tuple::create(pbob->elements().size(), INVALID);
+        for (int i = 0; i < pbob->elements().size(); i++) {
+            tup->setNth( i, createRosetteObject(pbob->mutable_elements(i)) );
+        }
+    }
+
+    case ObjectCodePB::OT_TUPLE_EXPR: {
+        ObjectCodePB::TupleExpr * pbob = ob->mutable_tuple_expr();
+        TupleExpr * tup = TupleExpr::create();
+        tup->rest = createRosetteObject( pbob->mutable_rest() );
+    }
+
     case ObjectCodePB::OT_RBL_BOOL:
-        retval = RBLBOOL(ob.rbl_bool().value());
+        retval = RBLBOOL(ob->rbl_bool().value());
         break;
+
     case ObjectCodePB::OT_NIV:
         retval = NIV;
         break;
-    case ObjectCodePB::OT_STD_EXTENSION:
-        retval = StdExtension::create( ob.std_extension().elements_size());
-        break;
-    case ObjectCodePB::OT_RBL_ATOM:
-        // ???
-        break;
+
+    case ObjectCodePB::OT_STD_EXTENSION: {
+        ObjectCodePB::StdExtension * pbob = ob->mutable_std_extension();
+        Tuple * tup = Tuple::create(pbob->elements().size(), INVALID);
+        for (int i = 0; i < pbob->elements().size(); i++) {
+            tup->setNth( i, createRosetteObject(pbob->mutable_elements(i)) );
+        }
+        retval = StdExtension::create( tup );
+    }
+
     case ObjectCodePB::OT_NULL_EXPR:
         retval = NullExpr::create();
         break;
-    case ObjectCodePB::OT_COMPOUND_PATTERN:
-        // ???
-        break;
-    case ObjectCodePB::OT_COMPLEX_PATTERN:
-        retval = ComplexPattern::create(NULL);
-        break;
+
+    case ObjectCodePB::OT_COMPLEX_PATTERN: {
+// TODO fix this
+        // ObjectCodePB::ComplexPattern * pbob = ob->mutable_complex_pattern();
+        // retval = ComplexPattern::create(
+        //     (TupleExpr *)createRosetteObject(pbob->mutable_expr()));
+        // break;
+    }
+
     case ObjectCodePB::OT_STD_META:
         retval = StdMeta::create(NIL);
         break;
+
     case ObjectCodePB::OT_ID_VEC_PATTERN:
         retval = IdVecPattern::create(NILexpr);
         break;
+
     case ObjectCodePB::OT_ID_AMPR_REST_PATTERN:
         retval = IdAmperRestPattern::create(NULL);
         break;
+
     case ObjectCodePB::OT_ID_PATTERN:
-        retval = IdPattern::create( SYMBOL(ob.id_pattern().symbol().symbol().name().c_str()) );
+        retval = IdPattern::create( SYMBOL(ob->id_pattern().symbol().symbol().name().c_str()) );
         break;
+
     case ObjectCodePB::OT_PRIM:
         retval =  Prim::create(
-            (char *)ob.prim().id().symbol().name().c_str(),
+            (char *)ob->prim().id().symbol().name().c_str(),
             NULL,
-            (int)ob.prim().minargs(),
-            (int)ob.prim().maxargs());
+            (int)ob->prim().minargs(),
+            (int)ob->prim().maxargs());
         break;
+
     case ObjectCodePB::OT_SYSVAL: {
-        std::string val = ob.sysval().value();
+        std::string val = ob->sysval().value();
 
         if (val == "#inv")
             retval = INVALID;
@@ -183,78 +392,46 @@ pOb createRosetteObject(const ObjectCodePB::Object & ob) {
             retval = DEADTHREAD;
         break;
     }
+
     case ObjectCodePB::OT_CONST_PATTERN:
-        retval = ConstPattern::create(FIXNUM(ob.const_pattern().val().fixnum().value()));
+        retval = ConstPattern::create(FIXNUM(ob->const_pattern().val().fixnum().value()));
         break;
+
     case ObjectCodePB::OT_RBL_TABLE:
         retval = RblTable::create();
         break;
+
     default:
-        warning("Import object type=%d not yet implemented!", ob.type());
+        warning("Import object type=%d not yet implemented!", ob->type());
     }
 
-    return retval;
-}
-
-pOb linkRosetteObject(ObjectInfo & obi) {
-
-    pOb retval = NULL;
-
-    ObjectCodePB::ObType type = importObjectCode.objects(obi.pbIndex).type();
-    switch(type) {
-    case ObjectCodePB::OT_ACTOR:
-    case ObjectCodePB::OT_BLOCK_EXPR:
-    case ObjectCodePB::OT_CHAR:
-    case ObjectCodePB::OT_CODE:
-    case ObjectCodePB::OT_EXPANDED_LOCATION:
-    case ObjectCodePB::OT_FIXNUM:
-    case ObjectCodePB::OT_FLOAT:
-    case ObjectCodePB::OT_FREE_EXPR:
-    case ObjectCodePB::OT_GOTO_EXPR:
-    case ObjectCodePB::OT_IF_EXPR:
-    case ObjectCodePB::OT_LABEL_EXPR:
-    case ObjectCodePB::OT_LET_EXPR:
-    case ObjectCodePB::OT_LET_REC_EXPR:
-    case ObjectCodePB::OT_METHOD_EXPR:
-    case ObjectCodePB::OT_PROC:
-    case ObjectCodePB::OT_PROC_EXPR:
-    case ObjectCodePB::OT_QUOTE_EXPR:
-    case ObjectCodePB::OT_RBL_STRING:
-    case ObjectCodePB::OT_REFLECTIVE_METHOD_EXPR:
-    case ObjectCodePB::OT_REQUEST_EXPR:
-    case ObjectCodePB::OT_SEND_EXPR:
-    case ObjectCodePB::OT_SEQ_EXPR:
-    case ObjectCodePB::OT_SET_EXPR:
-    case ObjectCodePB::OT_STD_METHOD:
-    case ObjectCodePB::OT_SYMBOL:
-    case ObjectCodePB::OT_TBL_OBJECT:
-    case ObjectCodePB::OT_TEMPLATE:
-    case ObjectCodePB::OT_TUPLE:
-    case ObjectCodePB::OT_TUPLE_EXPR:
-    case ObjectCodePB::OT_RBL_BOOL:
-    case ObjectCodePB::OT_NIV:
-    case ObjectCodePB::OT_STD_EXTENSION:
-    case ObjectCodePB::OT_RBL_ATOM:
-    case ObjectCodePB::OT_NULL_EXPR:
-    case ObjectCodePB::OT_COMPOUND_PATTERN:
-    case ObjectCodePB::OT_COMPLEX_PATTERN:
-    case ObjectCodePB::OT_STD_META:
-    case ObjectCodePB::OT_ID_VEC_PATTERN:
-    case ObjectCodePB::OT_ID_AMPR_REST_PATTERN:
-    case ObjectCodePB::OT_ID_PATTERN:
-    case ObjectCodePB::OT_PRIM:
-    case ObjectCodePB::OT_SYSVAL:
-    case ObjectCodePB::OT_CONST_PATTERN:
-    case ObjectCodePB::OT_RBL_TABLE:
-    default:
-        warning("Import object type=%d not yet implemented!", type);
+    // Save the result in the objects table so we don't create another next time this object is referenced.
+    if (oi != NULL) {
+        oi->object = retval;
     }
     return retval;
 }
 
-Code * createRosetteCode(const ObjectCodePB::CodeBlock & cb) {
 
-    return NULL;
+Code * createRosetteCode(ObjectCodePB::CodeBlock * cb) {
+fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+
+    // Create the CodeBuf and CodeVec objects, then copy in the opcodes. 
+    int codesize = cb->codevec().opcodes().size();   // In bytes
+    CodeBuf * cbuf = CodeBuf::create();
+    cbuf->growCodevec( codesize / sizeof(Instr) );  // Set the size in 16 bit words
+    char * code_binary = (char *)cbuf->codevec->absolutize(0);  // Pointer to the buffer to hold the code
+    memcpy(code_binary, cb->codevec().opcodes().data(), codesize);
+
+    // Create the LitVec object and populate it from the protobuf objects
+    Tuple * litvec = Tuple::create(cb->litvec().ob().size(), INVALID);
+    for (int i=0; i<cb->litvec().ob().size(); i++) {
+        ObjectCodePB::Object * pbob = cb->mutable_litvec()->mutable_ob(i);
+        litvec->setNth(i, createRosetteObject(pbob));
+    }
+
+    Code * code = Code::create(cbuf, litvec);
+    return code;
 }
 
 bool readImportCode() {
@@ -262,7 +439,9 @@ bool readImportCode() {
     if ('\0' == *ImportFile)
         return false;
 
-fprintf(stderr, "%s", __PRETTY_FUNCTION__);
+    if (VerboseFlag) {
+        fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+    }
 
     // Read the Object Code from disk
     std::fstream input(ImportFile, std::ios::in | std::ios::binary);
@@ -277,31 +456,34 @@ fprintf(stderr, "%s", __PRETTY_FUNCTION__);
     if (VerboseFlag) {
         std::string s;
         google::protobuf::TextFormat::PrintToString( importObjectCode, &s );
+
         fprintf(stderr, "*** Imported ObjectCode = \n%s\n", s.c_str());
         fprintf(stderr, "object count = %d\n", importObjectCode.objects_size());
         fprintf(stderr, "code count = %d\n", importObjectCode.code_block_size());
     }
 
-    // Make a map of the objects by id and create the initial top-level objects
+    // Make a map of the objects by id
     for (int i=0; i<importObjectCode.objects_size(); i++) {
         ObjectInfo obi;
         obi.id = importObjectCode.objects(i).object_id();
         obi.pbIndex = i;
-        obi.object = createRosetteObject(importObjectCode.objects(i));
+        obi.object = NULL;
+
         objects.insert(std::make_pair(obi.id, obi));
     } 
 
-    // Now do a deep dive to link them up
-    for (auto obi : objects) {
-        linkRosetteObject(obi.second);
-    }
-
     // Process the code blocks and link the litvecs to actual objects
-    for (const ObjectCodePB::CodeBlock& cb : importObjectCode.code_block()) {
-        Code * code = createRosetteCode(cb);
+    for (int i=0; i<importObjectCode.code_block_size(); i++) {
+        ObjectCodePB::CodeBlock * ob = importObjectCode.mutable_code_block(i);
+        Code * code = createRosetteCode(ob);
+
+        ObjectInfo obi;
+        obi.id = ob->object_id();
+        obi.pbIndex = -1;
+        obi.object = NULL;
+
+        objects.insert(std::make_pair(obi.id, obi));
     } 
-
-
 
     return true;
 }

--- a/rosette/src/Import.cc
+++ b/rosette/src/Import.cc
@@ -159,7 +159,8 @@ pOb createRosetteObject(ObjectCodePB::Object * ob) {
         }
 
         ExpandedLocation * el = ExpandedLocation::create();
-        retval = valWrt(loc, el);;
+// TODO: This isn't correct. Figure out the correct way to turn a loc into a ExpandedLocation Object
+//        retval = valWrt(loc, el);
         break;
     }
 
@@ -303,8 +304,8 @@ pOb createRosetteObject(ObjectCodePB::Object * ob) {
     case ObjectCodePB::OT_TEMPLATE: {
         ObjectCodePB::Template * pbob = ob->mutable_template_();
         retval = Template::create( (Tuple *)createRosetteObject(pbob->mutable_keytuple()),
-                                    createRosetteObject(pbob->mutable_pat()),
-                                    (CompoundPattern *)createRosetteObject(pbob->mutable_keymeta()) );
+                                    createRosetteObject(pbob->mutable_keymeta()),
+                                    (CompoundPattern *)createRosetteObject(pbob->mutable_pat()) );
         break;
     }
 

--- a/rosette/src/protobuf/Ob.proto
+++ b/rosette/src/protobuf/Ob.proto
@@ -56,15 +56,84 @@ message Code {
 message ComplexPattern {
     Object patvec = 1;
     Object offsetvec = 2;
-}
-message CompoundPattern {
-    Object expr = 1;
+    Object expr = 3;
 }
 message ConstPattern {
     Object val = 1;
 }
 message ExpandedLocation {
-    string value = 1;
+    string text = 1;
+    uint32 value = 2;
+
+    enum PBLocationType {
+        LT_CtxtRegister = 0;
+        LT_ArgRegister = 1;
+        LT_LexVariable = 2;
+        LT_GlobalVariable = 3;
+        LT_BitField = 4;
+        LT_Limbo = 5;
+        LT_BitField00 = 6;
+        LT_AddrVariable = 7;
+    }
+
+    PBLocationType type = 3;
+
+    message LocCtxt {
+        enum PBLocationCtxt {
+            LCT_RSLT = 0;
+            LCT_TRGT = 1;
+            LCT_ARGVEC = 2;
+            LCT_ENV = 3;
+            LCT_CODE = 4;
+            LCT_CTXT = 5;
+            LCT_SELF = 6;
+            LCT_SELFENV = 7;
+            LCT_RCVR = 8;
+            LCT_MONITOR = 9;
+        }
+        PBLocationCtxt reg = 1;
+    }
+    message LocArg {
+        uint32 arg = 1;
+    }
+    message LocLexVar {
+        bool indirect = 1;
+        uint32 level = 2;
+        uint32 offset = 3;
+    }
+    message LocAddrVar {
+        bool indirect = 1;
+        uint32 level = 2;
+        uint32 offset = 3;
+    }
+    message LocGlobalVar {
+        uint32 offset = 1;
+    }
+    message LocBitField {
+        bool indirect = 1;
+        bool signed = 2;
+        uint32 level = 3;
+        uint32 offset = 4;
+        uint32 span = 5;
+    }
+    message LocBitField00 {
+        bool signed = 1;
+        uint32 offset = 2;
+        uint32 span = 3;
+    }
+    message LocLimbo {
+    }
+
+    oneof loc {
+        LocCtxt ctxt = 4;
+        LocArg arg = 5;
+        LocLexVar lexvar = 6;
+        LocAddrVar addrvar = 7;
+        LocGlobalVar globalvar = 8;
+        LocBitField bitfield = 9;
+        LocBitField00 bitfield00 = 10;
+        LocLimbo limbo = 11;
+    }
 }
 message Fixnum {
     int32 value = 1;
@@ -134,8 +203,6 @@ message ProcExpr {
 }
 message QuoteExpr {
     Object expr = 1;
-}
-message RBLAtom {
 }
 message RBLBool {
     bool value = 1;
@@ -210,50 +277,50 @@ message TupleExpr {
 // The OT_ prefix avoids conflicts with various Rosette #define macros
 enum ObType {
     OT_NOT_SET = 0;
-    OT_BLOCK_EXPR = 1;
-    OT_CHAR = 2;
-    OT_CODE = 3;
-    OT_EXPANDED_LOCATION = 4;
-    OT_FIXNUM = 5;
-    OT_FLOAT = 6;
-    OT_FREE_EXPR = 7;
-    OT_GOTO_EXPR = 8;
-    OT_IF_EXPR = 9;
-    OT_LABEL_EXPR = 10;
-    OT_LET_EXPR = 11;
-    OT_LET_REC_EXPR = 12;
-    OT_METHOD_EXPR = 13;
-    OT_PROC = 14;
-    OT_PROC_EXPR = 15;
-    OT_QUOTE_EXPR = 16;
-    OT_RBL_STRING = 17;
-    OT_REFLECTIVE_METHOD_EXPR = 18;
-    OT_REQUEST_EXPR = 19;
-    OT_SEND_EXPR = 20;
-    OT_SEQ_EXPR = 21;
-    OT_SET_EXPR = 22;
-    OT_STD_METHOD = 23;
-    OT_SYMBOL = 24;
-    OT_TBL_OBJECT = 25;
-    OT_TEMPLATE = 26;
-    OT_TUPLE = 27;
-    OT_TUPLE_EXPR = 28;
-    OT_RBL_BOOL = 29;
-    OT_NIV = 30;
-    OT_STD_EXTENSION = 31;
-    OT_RBL_ATOM = 32;
-    OT_NULL_EXPR = 33;
-    OT_COMPOUND_PATTERN = 34;
-    OT_COMPLEX_PATTERN = 35;
-    OT_STD_META = 36;
-    OT_ID_VEC_PATTERN = 37;
-    OT_ID_AMPR_REST_PATTERN = 38;
-    OT_ID_PATTERN = 39;
-    OT_PRIM = 40;
-    OT_SYSVAL = 41;
-    OT_CONST_PATTERN = 42;
-    OT_RBL_TABLE = 43;
-    OT_ACTOR = 44;
+
+    OT_ACTOR = 1;
+    OT_BLOCK_EXPR = 2;
+    OT_CHAR = 3;
+    OT_CODE = 4;
+    OT_COMPLEX_PATTERN = 5;
+    OT_CONST_PATTERN = 6;
+    OT_EXPANDED_LOCATION = 7;
+    OT_FIXNUM = 8;
+    OT_FLOAT = 9;
+    OT_FREE_EXPR = 10;
+    OT_GOTO_EXPR = 11;
+    OT_ID_AMPR_REST_PATTERN = 12;
+    OT_ID_PATTERN = 13;
+    OT_ID_VEC_PATTERN = 14;
+    OT_IF_EXPR = 15;
+    OT_LABEL_EXPR = 16;
+    OT_LET_EXPR = 17;
+    OT_LET_REC_EXPR = 18;
+    OT_METHOD_EXPR = 19;
+    OT_NIV = 20;
+    OT_NULL_EXPR = 21;
+    OT_PRIM = 22;
+    OT_PROC = 23;
+    OT_PROC_EXPR = 24;
+    OT_QUOTE_EXPR = 25;
+    OT_RBL_BOOL = 26;
+    OT_RBL_STRING = 27;
+    OT_RBL_TABLE = 28;
+    OT_REFLECTIVE_METHOD_EXPR = 29;
+    OT_REQUEST_EXPR = 30;
+    OT_SEND_EXPR = 31;
+    OT_SEQ_EXPR = 32;
+    OT_SET_EXPR = 33;
+    OT_STD_EXTENSION = 34;
+    OT_STD_META = 35;
+    OT_STD_METHOD = 36;
+    OT_SYMBOL = 37;
+    OT_SYSVAL = 38;
+    OT_TBL_OBJECT = 39;
+    OT_TEMPLATE = 40;
+    OT_TUPLE = 41;
+    OT_TUPLE_EXPR = 42;
+
     OT_UNKNOWN = 999;
 }
 
@@ -272,45 +339,43 @@ message Object {
         BlockExpr block_expr = 11;
         Char char = 12;
         Code code = 13;
-        ExpandedLocation expanded_location = 14;
-        Fixnum fixnum = 15;
-        Float float = 16;
-        FreeExpr free_expr = 17;
-        GotoExpr goto_expr = 18;
-        IfExpr if_expr = 19;
-        LabelExpr label_expr = 20;
-        LetExpr let_expr = 21;
-        LetrecExpr let_rec_expr = 22;
-        MethodExpr method_expr = 23;
-        Niv niv = 24;
-        NullExpr null_expr = 25;
-        Proc proc = 26;
-        ProcExpr proc_expr = 27;
-        QuoteExpr quote_expr = 28;
-        RBLAtom rbl_atom = 29;
-        RBLstring rbl_string = 30;
-        RBLBool rbl_bool = 31;
-        ReflectiveMethodExpr reflective_method_expr = 32;
-        RequestExpr request_expr = 33;
-        SendExpr send_expr = 34;
-        SeqExpr seq_expr = 35;
-        SetExpr set_expr = 36;
-        StdExtension std_extension = 37;
-        StdMthd std_mthd = 38;
-        Symbol symbol = 39;
-        TblObject tbl_object = 40;
-        Template template = 41;
-        Tuple tuple = 42;
-        TupleExpr tuple_expr = 43;
-        CompoundPattern compound_pattern = 44;
-        ComplexPattern complex_pattern = 45;
-        StdMeta std_meta = 46;
-        IdVecPattern id_vec_pattern = 47;
-        IdAmprRestPattern id_ampr_rest_pattern = 48;
-        IdPattern id_pattern = 49;
-        Prim prim = 50;
-        Sysval sysval = 51;
-        ConstPattern const_pattern = 52;
-        RblTable rbl_table = 53;
+        ComplexPattern complex_pattern = 14;
+        ConstPattern const_pattern = 15;
+        ExpandedLocation expanded_location = 16;
+        Fixnum fixnum = 17;
+        Float float = 18;
+        FreeExpr free_expr = 19;
+        GotoExpr goto_expr = 20;
+        IdAmprRestPattern id_ampr_rest_pattern = 21;
+        IdPattern id_pattern = 22;
+        IdVecPattern id_vec_pattern = 23;
+        IfExpr if_expr = 24;
+        LabelExpr label_expr = 25;
+        LetExpr let_expr = 26;
+        LetrecExpr let_rec_expr = 27;
+        MethodExpr method_expr = 28;
+        Niv niv = 29;
+        NullExpr null_expr = 30;
+        Prim prim = 31;
+        Proc proc = 32;
+        ProcExpr proc_expr = 33;
+        QuoteExpr quote_expr = 34;
+        RBLBool rbl_bool = 35;
+        RBLstring rbl_string = 36;
+        RblTable rbl_table = 37;
+        ReflectiveMethodExpr reflective_method_expr = 38;
+        RequestExpr request_expr = 39;
+        SendExpr send_expr = 40;
+        SeqExpr seq_expr = 41;
+        SetExpr set_expr = 42;
+        StdExtension std_extension = 43;
+        StdMeta std_meta = 44;
+        StdMthd std_mthd = 45;
+        Symbol symbol = 46;
+        Sysval sysval = 47;
+        TblObject tbl_object = 48;
+        Template template = 49;
+        Tuple tuple = 50;
+        TupleExpr tuple_expr = 51;
     }
 }


### PR DESCRIPTION
## Overview
Cleanup, Additions and refactor Object Code Export/Import

- Import now subtitues for boot.rbl load
- Cleaned up Ob.proto by removing unused messages and renumbering fields
-- This will require previously exported code to be re-exported
- Added full support for ExtendedLocation object in export
- Corrected opcode export to use Instr (16-bit words) rather than uint32_t for size calculation
- ObjectInfo struct is now a class to allow for a constructor
- Import creates objects recursively by Code litvec. This is more similar to the way export is done to more closely mimic the just-in-time compile/execute used by rosette when loading boot.rbl
- Handle object references during import
- Remove some unused object that were causing import difficulties
- Support ExpandedLocation import
- Fully create objects rather than create with NULL pointers and try to fill in later.
- 

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/ROS-425
https://rchain.atlassian.net/browse/ROS-437

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Sorry for the huge PR. I've split it up into separate commits to help with reviewing.
