### PR TITLE
CORE-565 Changed the default data directory to ~/.rnode.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -154,8 +154,8 @@ lazy val node = (project in file("node"))
         Cmd("WORKDIR", (defaultLinuxInstallLocation in Docker).value),
         Cmd("ADD", s"--chown=$daemon:$daemon opt /opt"),
         Cmd("USER", daemon),
-        ExecCmd("ENTRYPOINT", "bin/rnode", "--data_dir=/var/lib/rnode"),
-        ExecCmd("CMD")
+        ExecCmd("ENTRYPOINT", "bin/rnode"),
+        ExecCmd("CMD", "run", "--data_dir=/var/lib/rnode")
       )
     },
     mappings in Docker ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val node = (project in file("node"))
         Cmd("WORKDIR", (defaultLinuxInstallLocation in Docker).value),
         Cmd("ADD", s"--chown=$daemon:$daemon opt /opt"),
         Cmd("USER", daemon),
-        ExecCmd("ENTRYPOINT", "bin/rnode"),
+        ExecCmd("ENTRYPOINT", "bin/rnode", "--data_dir=/var/lib/rnode"),
         ExecCmd("CMD")
       )
     },

--- a/node-client/README.md
+++ b/node-client/README.md
@@ -20,14 +20,6 @@ solution:
 pip install -r requirements.txt
 ```
 
-### problem: NOENT when starting the server
-
-solution:
-
-```
-mkdir ~/.rnode
-```
-
 ### problem: UnsatisfiedLinkError when starting the server
 
 `Caused by: java.lang.UnsatisfiedLinkError: libsodium.so: cannot open shared object file: No such file or directory`

--- a/node-client/README.md
+++ b/node-client/README.md
@@ -25,8 +25,7 @@ pip install -r requirements.txt
 solution:
 
 ```
-sudo mkdir -p /var/lib/rnode
-sudo chown $USER /var/lib/rnode
+sudo mkdir -p ~/.rnode
 ```
 
 ### problem: UnsatisfiedLinkError when starting the server

--- a/node-client/README.md
+++ b/node-client/README.md
@@ -25,7 +25,7 @@ pip install -r requirements.txt
 solution:
 
 ```
-sudo mkdir -p ~/.rnode
+mkdir ~/.rnode
 ```
 
 ### problem: UnsatisfiedLinkError when starting the server

--- a/node/README.md
+++ b/node/README.md
@@ -147,10 +147,10 @@ Node exposes its API via gRPC services, which are exposed on `grpc-port`. To see
 Node needs to have read and write access to a folder called data directory. By default that folder is `$HOME/.rnode`. User can control that value by providing `--data_dir` flag. 
 Regardless of which path on the file system you choose for the data directory, please remember that node needs to have read and write access to that folder.
 
-Below is an example of creating folder for default location and giving it ownership to the current user.
+Below is an example of creating folder for default location. This should not be necessary as the server will try to create the `data_dir`.
 
 ```
-sudo mkdir -p ~/.rnode
+mkdir ~/.rnode
 ```
 
 #### 2.1.2 Running the Node

--- a/node/README.md
+++ b/node/README.md
@@ -147,12 +147,6 @@ Node exposes its API via gRPC services, which are exposed on `grpc-port`. To see
 Node needs to have read and write access to a folder called data directory. By default that folder is `$HOME/.rnode`. User can control that value by providing `--data_dir` flag. 
 Regardless of which path on the file system you choose for the data directory, please remember that node needs to have read and write access to that folder.
 
-Below is an example of creating folder for default location. This should not be necessary as the server will try to create the `data_dir`.
-
-```
-mkdir ~/.rnode
-```
-
 #### 2.1.2 Running the Node
 
 ##### 2.1.2.1 via Docker

--- a/node/README.md
+++ b/node/README.md
@@ -80,7 +80,7 @@ Subcommand: run
   -c, --certificate  <arg>      Path to node's X.509 certificate file, that is
                                 being used for identification
   -d, --data_dir  <arg>         Path to data directory. Defaults to
-                                /var/lib/rnode
+                                $HOME/.rnode
       --host  <arg>             Hostname or IP of this node.
   -h, --http-port  <arg>        HTTP port (deprecated - all API features will be
                                 ported to gRPC API).
@@ -144,14 +144,13 @@ Node exposes its API via gRPC services, which are exposed on `grpc-port`. To see
 
 #### 2.1.2 Data directory
 
-Node needs to have read and write access to a folder called data directory. By default that folder is `/var/lib/rnode/`. User can control that value by providing `--data_dir` flag. 
+Node needs to have read and write access to a folder called data directory. By default that folder is `$HOME/.rnode`. User can control that value by providing `--data_dir` flag. 
 Regardless of which path on the file system you choose for the data directory, please remember that node needs to have read and write access to that folder.
 
 Below is an example of creating folder for default location and giving it ownership to the current user.
 
 ```
-sudo mkdir -p /var/lib/rnode
-sudo chown $USER /var/lib/rnode
+sudo mkdir -p ~/.rnode
 ```
 
 #### 2.1.2 Running the Node

--- a/node/rnode.service
+++ b/node/rnode.service
@@ -3,7 +3,7 @@ Description=RChain Node
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/rnode
+ExecStart=/usr/bin/rnode --data_dir=/var/lib/rnode
 User=rnode
 
 [Install]

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -77,8 +77,8 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     val host = opt[String](default = None, descr = "Hostname or IP of this node.")
 
     val data_dir = opt[Path](required = false,
-                             descr = "Path to data directory. Defaults to /var/lib/rnode",
-                             default = Some(Paths.get("/var/lib/rnode")))
+                             descr = "Path to data directory. Defaults to $HOME/.rnode",
+                             default = Some(Paths.get(System.getProperty("user.home"), ".rnode")))
 
     val map_size = opt[Long](required = false,
                              descr = "Map size (in bytes)",

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -78,7 +78,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
     val data_dir = opt[Path](required = false,
                              descr = "Path to data directory. Defaults to $HOME/.rnode",
-                             default = Some(Paths.get(System.getProperty("user.home"), ".rnode")))
+                             default = Some(Paths.get(sys.props("user.home"), ".rnode")))
 
     val map_size = opt[Long](required = false,
                              descr = "Map size (in bytes)",

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -41,7 +41,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  val dataDirFile = conf.run.data_dir().toFile
+  private val dataDirFile = conf.run.data_dir().toFile
 
   if (!dataDirFile.exists()) {
     if (!dataDirFile.mkdir()) {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -41,12 +41,24 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
+  val dataDirFile = conf.run.data_dir().toFile
+
+  if (!dataDirFile.exists()) {
+    if (!dataDirFile.mkdir()) {
+      println(
+        s"The data dir must be a directory and have read and write permissions:\n${conf.run.data_dir()}")
+      System.exit(-1)
+    }
+  }
+
   // Check if data_dir has read/write access
-  if (!conf.run.data_dir().toFile.canRead
-      || !conf.run.data_dir().toFile.canWrite) {
-    println(s"The data dir must have read and write permissions:\n${conf.run.data_dir()}")
+  if (!dataDirFile.isDirectory || !dataDirFile.canRead || !dataDirFile.canWrite) {
+    println(
+      s"The data dir must be a directory and have read and write permissions:\n${conf.run.data_dir()}")
     System.exit(-1)
   }
+
+  println(s"Using data_dir: ${conf.run.data_dir()}")
 
   // Generate certificate if not provided as option or in the data dir
   if (conf.run.certificate.toOption.isEmpty


### PR DESCRIPTION
## Overview
Using `/var/lib/rnode` as the default data directory is terrible UX, so `$HOME/.rnode` was proposed as a replacement.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/projects/CORE/issues/CORE-565

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none.
