### PR TITLE
Enable secp256k1 in rholang

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ lazy val projectSettings = Seq(
   organization := "coop.rchain",
   scalaVersion := "2.12.4",
   version := "0.1.0-SNAPSHOT",
-  resolvers += Resolver.sonatypeRepo("releases"),
+  resolvers ++= Seq(
+    Resolver.sonatypeRepo("releases"),
+    Resolver.sonatypeRepo("snapshots")), //Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
   scalafmtOnCompile := true
 )
 
@@ -83,11 +85,10 @@ lazy val crypto = (project in file("crypto"))
       guava,
       bouncyCastle,
       kalium,
-      jaxb
+      jaxb,
+      secp256k1Java
     ),
     fork := true,
-    unmanagedSourceDirectories in Compile += baseDirectory.value / "secp256k1/src/java",
-    javaOptions += "-Djava.library.path=secp256k1/.libs",
     doctestTestFramework := DoctestTestFramework.ScalaTest
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val projectSettings = Seq(
   version := "0.1.0-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots")), //Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
+    Resolver.sonatypeRepo("snapshots")),
   scalafmtOnCompile := true
 )
 

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -1,6 +1,6 @@
 package coop.rchain.crypto.signatures
 
-// import org.bitcoin._
+import org.bitcoin._
 
 object Secp256k1 {
 
@@ -26,10 +26,12 @@ object Secp256k1 {
     * boolean value of verification
     *
     */
-  // def verify(
-  // data: Array[Byte], signature: Array[Byte], pub: Array[Byte]
-  // ): Boolean =
-  // NativeSecp256k1.verify(data,signature,pub)
+  def verify(
+      data: Array[Byte],
+      signature: Array[Byte],
+      pub: Array[Byte]
+  ): Boolean =
+    NativeSecp256k1.verify(data, signature, pub)
 
   /**
     * libsecp256k1 Create an ECDSA signature.
@@ -52,10 +54,11 @@ object Secp256k1 {
     * byte array of signature
     *
   **/
-  // def sign(
-  // data: Array[Byte], sec: Array[Byte]
-  // ): Array[Byte] =
-  // NativeSecp256k1.sign(data,sec)
+  def sign(
+      data: Array[Byte],
+      sec: Array[Byte]
+  ): Array[Byte] =
+    NativeSecp256k1.sign(data, sec)
 
   /**
     * libsecp256k1 Seckey Verify - returns true if valid, false if invalid
@@ -73,8 +76,8 @@ object Secp256k1 {
     * Return value
     * Boolean of secret key verification
     */
-  // def secKeyVerify(seckey: Array[Byte]): Boolean =
-  // NativeSecp256k1.secKeyVerify(seckey)
+  def secKeyVerify(seckey: Array[Byte]): Boolean =
+    NativeSecp256k1.secKeyVerify(seckey)
 
   /**
     * libsecp256k1 Compute Pubkey - computes public key from secret key
@@ -91,7 +94,7 @@ object Secp256k1 {
     * Return values
     * @param pubkey ECDSA Public key, 33 or 65 bytes
     */
-  // def toPublic(seckey: Array[Byte]): Array[Byte] =
-  // NativeSecp256k1.computePubkey(seckey)
+  def toPublic(seckey: Array[Byte]): Array[Byte] =
+    NativeSecp256k1.computePubkey(seckey)
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,6 +51,7 @@ object Dependencies {
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.5"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.2"
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.+"
+  val secp256k1Java       = "coop.rchain"                 % "secp256k1-java"            % "0.1-SNAPSHOT"
 
   // format: on
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -117,9 +117,8 @@ object Runtime {
       4L -> SystemProcesses.ed25519Verify(space, dispatcher),
       5L -> SystemProcesses.sha256Hash(space, dispatcher),
       6L -> SystemProcesses.keccak256Hash(space, dispatcher),
-      7L -> SystemProcesses.blake2b256Hash(space, dispatcher)
-      //TODO: once we have secp256k1 packaged as jar
-//      9L -> SystemProcesses.secp256k1Verify(store, dispatcher)
+      7L -> SystemProcesses.blake2b256Hash(space, dispatcher),
+      9L -> SystemProcesses.secp256k1Verify(space, dispatcher)
     )
 
     val procDefs: immutable.Seq[(Name, Arity, Remainder, Ref)] = List(
@@ -130,9 +129,8 @@ object Runtime {
       ("ed25519Verify", 4, None, 4L),
       ("sha256Hash", 2, None, 5L),
       ("keccak256Hash", 2, None, 6L),
-      ("blake2b256Hash", 2, None, 7L)
-      //TODO: once we have secp256k1 packaged as jar
-//      ("secp256k1Verify", 4, None, 9L)
+      ("blake2b256Hash", 2, None, 7L),
+      ("secp256k1Verify", 4, None, 9L)
     )
 
     val res: Seq[Option[(TaggedContinuation, Seq[Seq[Channel]])]] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -64,17 +64,16 @@ object SystemProcesses {
 
   //  The following methods will be made available to contract authors.
 
-  //TODO(mateusz.gorski): we decided to look into delivering secp256k1 library (https://github.com/bitcoin-core/secp256k1)
-  // as separate jar in the future
-//  def secp256k1Verify(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-//                      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
-//    : Seq[Seq[Channel]] => Task[Unit] = {
-//    case Seq(Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack)) =>
-//      Task.fromTry(Try(Secp256k1.verify(data, signature, pub))).flatMap { verified =>
-//        space.produce(ack, Seq(Channel(Quote(Expr(GBool(verified))))), false)
-//          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
-//      }
-//  }
+  def secp256k1Verify(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+                      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
+    : Seq[Seq[Channel]] => Task[Unit] = {
+    case Seq(Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack)) =>
+      Task.fromTry(Try(Secp256k1.verify(data, signature, pub))).flatMap { verified =>
+        space
+          .produce(ack, Seq(Channel(Quote(Expr(GBool(verified))))), false)
+          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+      }
+  }
 
   def ed25519Verify(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
                     dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -4,9 +4,10 @@ import java.nio.file.Files
 
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.Capture
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.encryption.Curve25519
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
-import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
 import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray, GString}
 import coop.rchain.models.Var.VarInstance.Wildcard
@@ -126,38 +127,38 @@ class CryptoChannelsSpec
 
   "secp256k1Verify channel" should "verify integrity of the data and send result on ack channel" in {
     fixture =>
-      pending
-    //TODO: once we have secp256k1 packaged as jar
-//      val (reduce, store) = fixture
-//
-//      val secp256k1VerifyhashChannel = Quote(GString("secp256k1Verify"))
-//
-//      val (secKey, pubKey) = Secp256k1.newKeyPair
-//
-//      val ackChannel                                    = GString("x")
-//      implicit val emptyEnv                             = Env[Par]()
-//      val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel) _
-//
-//      forAll { (par: Par) =>
-//        val parByteArray: Array[Byte] = serialize(par)
-//
-//        val signature = Secp256k1.sign(parByteArray, secKey)
-//
-//        val serializedPar = byteArrayToExpr(parByteArray)
-//        val signaturePar  = byteArrayToExpr(signature)
-//        val pubKeyPar     = byteArrayToExpr(pubKey)
-//
-//        val refVerify = Secp256k1.verify(parByteArray, signature, pubKey)
-//        assert(refVerify === true)
-//
-//        val send = Send(secp256k1VerifyhashChannel,
-//                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
-//                        persistent = false,
-//                        BitSet())
-//        Await.result(reduce.eval(send).runAsync, 3.seconds)
-//        storeContainsTest(List[Channel](Quote(Expr(GBool(true)))))
-//        clearStore(store, reduce, ackChannel)
-//      }
+      val (reduce, store) = fixture
+
+      val secp256k1VerifyhashChannel = Quote(GString("secp256k1Verify"))
+
+      val pubKey = Base16.decode(
+        "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6")
+      val secKey = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+
+      val ackChannel                                    = GString("x")
+      implicit val emptyEnv                             = Env[Par]()
+      val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel) _
+
+      forAll { (par: Par) =>
+        val parByteArray: Array[Byte] = Keccak256.hash(serialize(par))
+
+        val signature = Secp256k1.sign(parByteArray, secKey)
+
+        val serializedPar = byteArrayToExpr(parByteArray)
+        val signaturePar  = byteArrayToExpr(signature)
+        val pubKeyPar     = byteArrayToExpr(pubKey)
+
+        val refVerify = Secp256k1.verify(parByteArray, signature, pubKey)
+        assert(refVerify === true)
+
+        val send = Send(secp256k1VerifyhashChannel,
+                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
+                        persistent = false,
+                        BitSet())
+        Await.result(reduce.eval(send).runAsync, 3.seconds)
+        storeContainsTest(List[Channel](Quote(Expr(GBool(true)))))
+        clearStore(store, reduce, ackChannel)
+      }
   }
 
   "ed25519Verify channel" should "verify integrity of the data and send result on ack channel" in {


### PR DESCRIPTION
## Overview
Adds dependency on `secp256k1-java` which will allow to use secp256k1 crypto in rholang.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.


### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
