### PR TITLE
No ticket: Fixes variable reference substitution

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -3,6 +3,13 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.Channel.ChannelInstance
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
+import coop.rchain.models.Connective.ConnectiveInstance
+import coop.rchain.models.Connective.ConnectiveInstance.{
+  ConnAndBody,
+  ConnNotBody,
+  ConnOrBody,
+  VarRefBody
+}
 import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance
@@ -88,18 +95,16 @@ case class PrettyPrinter(freeShift: Int,
 
   def buildString(v: Var): String =
     v.varInstance match {
-      case FreeVar(level)  => s"$freeId${freeShift + level}"
-      case BoundVar(level) => s"$boundId${boundShift - level - 1}"
-      case Wildcard(_)     => "_"
-      // TODO: Figure out if we can prevent ScalaPB from generating
+      case FreeVar(level)    => s"$freeId${freeShift + level}"
+      case BoundVar(level)   => s"$boundId${boundShift - level - 1}"
+      case Wildcard(_)       => "_"
       case VarInstance.Empty => "@Nil"
     }
 
   def buildString(c: Channel): String =
     c.channelInstance match {
-      case Quote(p)    => "@{" + buildString(p) + "}"
-      case ChanVar(cv) => buildString(cv)
-      // TODO: Figure out if we can prevent ScalaPB from generating
+      case Quote(p)              => "@{" + buildString(p) + "}"
+      case ChanVar(cv)           => buildString(cv)
       case ChannelInstance.Empty => "@Nil"
     }
 
@@ -159,12 +164,28 @@ case class PrettyPrinter(freeShift: Int,
           } + " }"
 
       case g: GPrivate => g.id
+      case c: Connective =>
+        c.connectiveInstance match {
+          case ConnectiveInstance.Empty => ""
+          case ConnAndBody(value)       => value.ps.map(buildString).mkString("{", " /\\ ", "}")
+          case ConnOrBody(value)        => value.ps.map(buildString).mkString("{", " \\/ ", "}")
+          case ConnNotBody(value)       => "~{" ++ buildString(value) ++ "}"
+          case VarRefBody(value) =>
+            "=" + buildString(Var(FreeVar(value.index)))
+        }
 
       case par: Par =>
         if (isEmpty(par)) "Nil"
         else {
           val list =
-            List(par.bundles, par.sends, par.receives, par.news, par.exprs, par.matches, par.ids)
+            List(par.bundles,
+                 par.sends,
+                 par.receives,
+                 par.news,
+                 par.exprs,
+                 par.matches,
+                 par.ids,
+                 par.connectives)
           ((false, "") /: list) {
             case ((prevNonEmpty, string), items) =>
               if (items.nonEmpty) {
@@ -239,5 +260,6 @@ case class PrettyPrinter(freeShift: Int,
       p.exprs.isEmpty &
       p.matches.isEmpty &
       p.ids.isEmpty &
-      p.bundles.isEmpty
+      p.bundles.isEmpty &
+      p.connectives.isEmpty
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -3,6 +3,7 @@ package coop.rchain.rholang.interpreter
 import cats.implicits._
 import cats.{Applicative, Monad}
 import coop.rchain.models.Channel.ChannelInstance._
+import coop.rchain.models.Connective.ConnectiveInstance
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
@@ -77,7 +78,7 @@ object Substitute {
       env.get(term.index) match {
         case Some(par) => Applicative[M].pure(Right(par))
         case None =>
-          interpreterErrorM[M].raiseError(SubstituteError(s"Illegal VarRef [$term]"))
+          Applicative[M].pure(Left(term))
       }
 
   implicit def substituteQuote[M[_]: InterpreterErrorsM]: Substitute[M, Quote] =
@@ -370,6 +371,7 @@ object Substitute {
               .map(ps => Connective(ConnOrBody(ConnectiveBody(ps))))
           case ConnNotBody(p) =>
             substitutePar[M].substituteNoSort(p).map(p => Connective(ConnNotBody(p)))
+          case ConnectiveInstance.Empty => term.pure[M]
         }
       override def substitute(term: Connective)(implicit depth: Int, env: Env[Par]): M[Connective] =
         substituteNoSort(term).map(con => ConnectiveSortMatcher.sortMatch(con).term)


### PR DESCRIPTION
## Overview
When variable reference was referencing a variable in the receive pattern the substitution failed.

As part of the ticket I've also added `PrettyPrinter` cases for logical connectives although I wasn't able to write proper case for `VarRef`. I didn't want to postpone pushing the bugfix because of that.

### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
