### PR TITLE
Implement a safe broadcast in the transport layer

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -13,6 +13,7 @@ import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
 
 class HashSetCasperTest extends FlatSpec with Matchers {
 
@@ -69,7 +70,6 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     val logMessages = List(
       "CASPER: Received Deploy",
       "CASPER: Beginning send of Block #1",
-      "CASPER: Sent",
       "CASPER: Added",
       "CASPER: New fork-choice tip is block"
     )
@@ -270,7 +270,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       .msgQueues(nodes(0).local)
       .clear // nodes(0) rejects normal adding process for blockThatPointsToInvalidBlock
     val signedInvalidBlockPacketMessage = packet(nodes(1).local, signedInvalidBlock.toByteString)
-    nodes(0).transportLayerEff.send(nodes(1).local, signedInvalidBlockPacketMessage)
+    nodes(0).transportLayerEff
+      .send(nodes(1).local, signedInvalidBlockPacketMessage, 1000.milliseconds)
     nodes(1).receive() // receives signedBlockThatPointsToInvalidBlock; attempts to add both blocks
 
     nodes(1).logEff.warns.count(_ startsWith "CASPER: Ignoring block ") should be(1)

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -6,10 +6,10 @@ import cats.implicits._
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.catscontrib._
 import coop.rchain.comm.CommError.{peerNodeNotFound, CommErr}
-import coop.rchain.comm.PeerNode
-
+import coop.rchain.comm.{CommError, PeerNode}
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.mutable
+
 import coop.rchain.comm.transport._
 
 class TransportLayerTestImpl[F[_]: Monad: Capture](
@@ -17,18 +17,27 @@ class TransportLayerTestImpl[F[_]: Monad: Capture](
     val msgQueues: collection.Map[PeerNode, mutable.Queue[Protocol]])
     extends TransportLayer[F] {
 
-  def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]] = ???
+  def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]] =
+    Capture[F].capture {
+      val maybeQ = msgQueues.get(peer)
+      maybeQ.fold[CommErr[Protocol]](Left(peerNodeNotFound(peer)))(q =>
+        Right(q.enqueue(msg)).map(_ => Protocol()))
+    }
 
   def local: F[PeerNode] = identity.pure[F]
 
-  def send(peer: PeerNode, msg: Protocol): F[Unit] = Capture[F].capture {
-    val maybeQ = msgQueues.get(peer)
+  def send(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[Unit] =
+    roundTrip(peer, msg, timeout).void
 
-    maybeQ.fold[CommErr[Unit]](Left(peerNodeNotFound(peer)))(q => Right(q.enqueue(msg)))
-  }
+  def broadcast(peers: Seq[PeerNode], msg: Protocol, timeout: FiniteDuration): F[Unit] =
+    peers.toList.traverse(send(_, msg, timeout)).void
 
-  def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Unit] =
-    Capture[F].capture(peers.map(send(_, msg)))
+  def safeBroadcast(peers: Seq[PeerNode],
+                    msg: Protocol,
+                    timeout: FiniteDuration): F[Map[PeerNode, Option[CommError]]] =
+    peers.toList
+      .traverse(p => roundTrip(p, msg, timeout).map(p -> _.swap.toOption))
+      .map(_.toMap)
 
   def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] =
     TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -3,6 +3,7 @@ package coop.rchain.comm.transport
 import scala.concurrent.duration.FiniteDuration
 
 import cats._, cats.data._, cats.implicits._
+import coop.rchain.comm.CommError
 import coop.rchain.comm.CommError.CommErr
 import coop.rchain.comm.{PeerNode, ProtocolHelper}
 import coop.rchain.shared._
@@ -13,8 +14,11 @@ trait TransportLayer[F[_]] {
   def local: F[PeerNode]
   def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]]
   // TODO remove ProtocolMessage, use raw messages from protocol
-  def send(peer: PeerNode, msg: Protocol): F[Unit]
-  def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Unit]
+  def send(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[Unit]
+  def broadcast(peers: Seq[PeerNode], msg: Protocol, timeout: FiniteDuration): F[Unit]
+  def safeBroadcast(peers: Seq[PeerNode],
+                    msg: Protocol,
+                    timeout: FiniteDuration): F[Map[PeerNode, Option[CommError]]]
   def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit]
   def disconnect(peer: PeerNode): F[Unit]
 
@@ -43,11 +47,18 @@ sealed abstract class TransportLayerInstances {
                     timeout: FiniteDuration): EitherT[F, E, CommErr[Protocol]] =
         EitherT.liftF(evF.roundTrip(peer, msg, timeout))
 
-      def send(peer: PeerNode, msg: Protocol): EitherT[F, E, Unit] =
-        EitherT.liftF(evF.send(peer, msg))
+      def send(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): EitherT[F, E, Unit] =
+        EitherT.liftF(evF.send(peer, msg, timeout))
 
-      def broadcast(peers: Seq[PeerNode], msg: Protocol): EitherT[F, E, Unit] =
-        EitherT.liftF(evF.broadcast(peers, msg))
+      def broadcast(peers: Seq[PeerNode],
+                    msg: Protocol,
+                    timeout: FiniteDuration): EitherT[F, E, Unit] =
+        EitherT.liftF(evF.broadcast(peers, msg, timeout))
+
+      def safeBroadcast(peers: Seq[PeerNode],
+                        msg: Protocol,
+                        timeout: FiniteDuration): EitherT[F, E, Map[PeerNode, Option[CommError]]] =
+        EitherT.liftF(evF.safeBroadcast(peers, msg, timeout))
 
       def receive(
           dispatch: Protocol => EitherT[F, E, CommunicationResponse]): EitherT[F, E, Unit] = {

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -69,12 +69,18 @@ object EffectsTestInstances {
       }
 
     def local: F[PeerNode] = src.pure[F]
-    def send(peer: PeerNode, msg: Protocol): F[Unit] =
+
+    def send(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[Unit] =
       Capture[F].capture {
         requests = requests :+ msg
         Right(())
       }
-    def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Unit] = ???
+
+    def broadcast(peers: Seq[PeerNode], msg: Protocol, timeout: FiniteDuration): F[Unit] = ???
+
+    def safeBroadcast(peers: Seq[PeerNode],
+                      msg: Protocol,
+                      timeout: FiniteDuration): F[Map[PeerNode, Option[CommError]]] = ???
 
     def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] = ???
 

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -34,7 +34,7 @@ import coop.rchain.comm.protocol.routing._
 import coop.rchain.crypto.codec.Base16
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.concurrent.duration._
 import coop.rchain.comm.transport.TcpTransportLayer.Connections
 
 class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
@@ -209,7 +209,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       peers <- nodeDiscoveryEffect.peers
       loc   <- transportLayerEffect.local
       msg   = ProtocolHelper.disconnect(loc)
-      _     <- transportLayerEffect.broadcast(peers, msg)
+      _     <- transportLayerEffect.broadcast(peers, msg, 500.milliseconds)
       // TODO remove that once broadcast and send reuse roundTrip
       _ <- IOUtil.sleep[Task](5000L)
     } yield ()).unsafeRunSync
@@ -227,7 +227,6 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   def startReportJvmMetrics: Task[Unit] =
     Task.delay {
-      import scala.concurrent.duration._
       scheduler.scheduleAtFixedRate(3.seconds, 3.second)(JvmMetrics.report[Task].unsafeRunSync)
     }
 


### PR DESCRIPTION
## Overview
Implement a safe broadcast in the transport layer. The safe roundtrip waits for the response of the remote peers and returns if applicable an error. However, one failed message doesn't fail the whole broadcast.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-751

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
