### PR TITLE
Rspace/core 749/metrics from both stores in casper runtime

### DIFF
--- a/node/src/main/protobuf/diagnostics.proto
+++ b/node/src/main/protobuf/diagnostics.proto
@@ -77,30 +77,28 @@ message NodeCoreMetrics {
   int64 peers = 7;
 }
 
-message StoreUsageMetric {
+message RSpaceUsageMetric {
   int64 count = 1;
   double avgMilliseconds = 2;
   int32 peakRate = 3;
   int32 currentRate = 4;
 }
 
-// TODO: rename to StoreUsage
-message StoreUsageCount {
-  StoreUsageMetric rspaceConsumesCount = 1;
-  StoreUsageMetric rspaceProducesCount = 2;
-  StoreUsageMetric rspaceConsumesCommCount = 3;
-  StoreUsageMetric rspaceProducesCommCount = 4;
-  StoreUsageMetric rspaceInstallCommCount = 5;
+message RSpaceUsage {
+  RSpaceUsageMetric consumes = 1;
+  RSpaceUsageMetric produces = 2;
+  RSpaceUsageMetric consumesComm = 3;
+  RSpaceUsageMetric producesComm = 4;
+  RSpaceUsageMetric installComm = 5;
 }
 
-// TODO: rename to OverallStoreUsage
 message StoreUsage {
   int64 totalSizeOnDisk = 1;
   int64 rspaceSizeOnDisk = 2;
   int64 rspaceDataEntries = 3;
 
-  StoreUsageCount rspace = 4;
-  StoreUsageCount replayRspace = 5;
+  RSpaceUsage rspace = 4;
+  RSpaceUsage replayRSpace = 5;
 }
 
 service Diagnostics {

--- a/node/src/main/protobuf/diagnostics.proto
+++ b/node/src/main/protobuf/diagnostics.proto
@@ -77,23 +77,30 @@ message NodeCoreMetrics {
   int64 peers = 7;
 }
 
-message StoreUsageCount {
+message StoreUsageMetric {
   int64 count = 1;
   double avgMilliseconds = 2;
   int32 peakRate = 3;
   int32 currentRate = 4;
 }
 
+// TODO: rename to StoreUsage
+message StoreUsageCount {
+  StoreUsageMetric rspaceConsumesCount = 1;
+  StoreUsageMetric rspaceProducesCount = 2;
+  StoreUsageMetric rspaceConsumesCommCount = 3;
+  StoreUsageMetric rspaceProducesCommCount = 4;
+  StoreUsageMetric rspaceInstallCommCount = 5;
+}
+
+// TODO: rename to OverallStoreUsage
 message StoreUsage {
   int64 totalSizeOnDisk = 1;
   int64 rspaceSizeOnDisk = 2;
   int64 rspaceDataEntries = 3;
 
-  StoreUsageCount rspaceConsumesCount = 4;
-  StoreUsageCount rspaceProducesCount = 5;
-  StoreUsageCount rspaceConsumesCommCount = 6;
-  StoreUsageCount rspaceProducesCommCount = 7;
-  StoreUsageCount rspaceInstallCommCount = 8;
+  StoreUsageCount rspace = 4;
+  StoreUsageCount replayRspace = 5;
 }
 
 service Diagnostics {

--- a/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
@@ -41,21 +41,21 @@ object StoreMetrics extends StoreMetricsInstances {
         _ <- m.setGauge(name + "-avg-ms", value.map(_.avgMilliseconds.toLong).getOrElse(0))
       } yield ()
 
-    def reportStoreSize(storeSize: StoreUsage): List[F[Unit]] =
+    def reportStoreSize(storeUsage: StoreUsage): List[F[Unit]] =
       List(
-        g("total-size-on-disk", storeSize.totalSizeOnDisk),
-        g("rspace-size-on-disk", storeSize.rspaceSizeOnDisk),
-        g("rspace-data-entries", storeSize.rspaceDataEntries),
-        pc("rspace-consumes", storeSize.rspace.flatMap(_.consumes)),
-        pc("rspace-produces", storeSize.rspace.flatMap(_.produces)),
-        cm("rspace-consumes-COMM", storeSize.rspace.flatMap(_.consumesComm)),
-        cm("rspace-produces-COMM", storeSize.rspace.flatMap(_.producesComm)),
-        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.installComm)),
-        pc("replayrspace-consumes", storeSize.replayRSpace.flatMap(_.consumes)),
-        pc("replayrspace-produces", storeSize.replayRSpace.flatMap(_.produces)),
-        cm("replayrspace-consumes-COMM", storeSize.replayRSpace.flatMap(_.consumesComm)),
-        cm("replayrspace-produces-COMM", storeSize.replayRSpace.flatMap(_.producesComm)),
-        cm("replayrspace-install-COMM", storeSize.replayRSpace.flatMap(_.installComm))
+        g("total-size-on-disk", storeUsage.totalSizeOnDisk),
+        g("rspace-size-on-disk", storeUsage.rspaceSizeOnDisk),
+        g("rspace-data-entries", storeUsage.rspaceDataEntries),
+        pc("rspace-consumes", storeUsage.rspace.flatMap(_.consumes)),
+        pc("rspace-produces", storeUsage.rspace.flatMap(_.produces)),
+        cm("rspace-consumes-COMM", storeUsage.rspace.flatMap(_.consumesComm)),
+        cm("rspace-produces-COMM", storeUsage.rspace.flatMap(_.producesComm)),
+        cm("rspace-install-COMM", storeUsage.rspace.flatMap(_.installComm)),
+        pc("replayrspace-consumes", storeUsage.replayRSpace.flatMap(_.consumes)),
+        pc("replayrspace-produces", storeUsage.replayRSpace.flatMap(_.produces)),
+        cm("replayrspace-consumes-COMM", storeUsage.replayRSpace.flatMap(_.consumesComm)),
+        cm("replayrspace-produces-COMM", storeUsage.replayRSpace.flatMap(_.producesComm)),
+        cm("replayrspace-install-COMM", storeUsage.replayRSpace.flatMap(_.installComm))
       )
 
     def join(tasks: Seq[F[Unit]]*): F[List[Unit]] =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
@@ -50,7 +50,12 @@ object StoreMetrics extends StoreMetricsInstances {
         pc("rspace-produces", storeSize.rspace.flatMap(_.produces)),
         cm("rspace-consumes-COMM", storeSize.rspace.flatMap(_.consumesComm)),
         cm("rspace-produces-COMM", storeSize.rspace.flatMap(_.producesComm)),
-        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.installComm))
+        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.installComm)),
+        pc("replayrspace-consumes", storeSize.replayRSpace.flatMap(_.consumes)),
+        pc("replayrspace-produces", storeSize.replayRSpace.flatMap(_.produces)),
+        cm("replayrspace-consumes-COMM", storeSize.replayRSpace.flatMap(_.consumesComm)),
+        cm("replayrspace-produces-COMM", storeSize.replayRSpace.flatMap(_.producesComm)),
+        cm("replayrspace-install-COMM", storeSize.replayRSpace.flatMap(_.installComm))
       )
 
     def join(tasks: Seq[F[Unit]]*): F[List[Unit]] =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
@@ -28,14 +28,14 @@ object StoreMetrics extends StoreMetricsInstances {
     def g(name: String, value: Long): F[Unit] =
       m.setGauge(name, value)
 
-    def cm(name: String, value: Option[StoreUsageMetric]): F[Unit] =
+    def cm(name: String, value: Option[RSpaceUsageMetric]): F[Unit] =
       for {
         _ <- m.setGauge(name + "-count", value.map(_.count).getOrElse(0))
         _ <- m.setGauge(name + "-peak-rate", value.map(_.peakRate.toLong).getOrElse(0))
         _ <- m.setGauge(name + "-current-rate", value.map(_.currentRate.toLong).getOrElse(0))
       } yield ()
 
-    def pc(name: String, value: Option[StoreUsageMetric]): F[Unit] =
+    def pc(name: String, value: Option[RSpaceUsageMetric]): F[Unit] =
       for {
         _ <- cm(name, value)
         _ <- m.setGauge(name + "-avg-ms", value.map(_.avgMilliseconds.toLong).getOrElse(0))
@@ -46,11 +46,11 @@ object StoreMetrics extends StoreMetricsInstances {
         g("total-size-on-disk", storeSize.totalSizeOnDisk),
         g("rspace-size-on-disk", storeSize.rspaceSizeOnDisk),
         g("rspace-data-entries", storeSize.rspaceDataEntries),
-        pc("rspace-consumes", storeSize.rspace.flatMap(_.rspaceConsumesCount)),
-        pc("rspace-produces", storeSize.rspace.flatMap(_.rspaceProducesCount)),
-        cm("rspace-consumes-COMM", storeSize.rspace.flatMap(_.rspaceConsumesCommCount)),
-        cm("rspace-produces-COMM", storeSize.rspace.flatMap(_.rspaceProducesCommCount)),
-        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.rspaceInstallCommCount))
+        pc("rspace-consumes", storeSize.rspace.flatMap(_.consumes)),
+        pc("rspace-produces", storeSize.rspace.flatMap(_.produces)),
+        cm("rspace-consumes-COMM", storeSize.rspace.flatMap(_.consumesComm)),
+        cm("rspace-produces-COMM", storeSize.rspace.flatMap(_.producesComm)),
+        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.installComm))
       )
 
     def join(tasks: Seq[F[Unit]]*): F[List[Unit]] =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/StoreMetrics.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import coop.rchain.catscontrib.MonadTrans
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.metrics.Metrics
-import coop.rchain.node.model.diagnostics.{StoreUsage, StoreUsageCount}
+import coop.rchain.node.model.diagnostics._
 
 trait StoreMetrics[F[_]] {
   def storeUsage: F[StoreUsage]
@@ -28,14 +28,14 @@ object StoreMetrics extends StoreMetricsInstances {
     def g(name: String, value: Long): F[Unit] =
       m.setGauge(name, value)
 
-    def cm(name: String, value: Option[StoreUsageCount]): F[Unit] =
+    def cm(name: String, value: Option[StoreUsageMetric]): F[Unit] =
       for {
         _ <- m.setGauge(name + "-count", value.map(_.count).getOrElse(0))
         _ <- m.setGauge(name + "-peak-rate", value.map(_.peakRate.toLong).getOrElse(0))
         _ <- m.setGauge(name + "-current-rate", value.map(_.currentRate.toLong).getOrElse(0))
       } yield ()
 
-    def pc(name: String, value: Option[StoreUsageCount]): F[Unit] =
+    def pc(name: String, value: Option[StoreUsageMetric]): F[Unit] =
       for {
         _ <- cm(name, value)
         _ <- m.setGauge(name + "-avg-ms", value.map(_.avgMilliseconds.toLong).getOrElse(0))
@@ -46,11 +46,11 @@ object StoreMetrics extends StoreMetricsInstances {
         g("total-size-on-disk", storeSize.totalSizeOnDisk),
         g("rspace-size-on-disk", storeSize.rspaceSizeOnDisk),
         g("rspace-data-entries", storeSize.rspaceDataEntries),
-        pc("rspace-consumes", storeSize.rspaceConsumesCount),
-        pc("rspace-produces", storeSize.rspaceProducesCount),
-        cm("rspace-consumes-COMM", storeSize.rspaceConsumesCommCount),
-        cm("rspace-produces-COMM", storeSize.rspaceProducesCommCount),
-        cm("rspace-install-COMM", storeSize.rspaceInstallCommCount)
+        pc("rspace-consumes", storeSize.rspace.flatMap(_.rspaceConsumesCount)),
+        pc("rspace-produces", storeSize.rspace.flatMap(_.rspaceProducesCount)),
+        cm("rspace-consumes-COMM", storeSize.rspace.flatMap(_.rspaceConsumesCommCount)),
+        cm("rspace-produces-COMM", storeSize.rspace.flatMap(_.rspaceProducesCommCount)),
+        cm("rspace-install-COMM", storeSize.rspace.flatMap(_.rspaceInstallCommCount))
       )
 
     def join(tasks: Seq[F[Unit]]*): F[List[Unit]] =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
@@ -115,7 +115,7 @@ object Runtime {
        |""".stripMargin
 
   def showStoreUsage(storeUsage: StoreUsage): String = {
-    def writeCounts(name: String, value: Option[StoreUsageCount]): String =
+    def writeCounts(name: String, value: Option[StoreUsageMetric]): String =
       s"""
          |  + RSpace $name
          |    - Total Count: ${value.map(_.count).getOrElse(0)}
@@ -124,7 +124,7 @@ object Runtime {
          |    - Current Rate (events/sec): ${value.map(_.currentRate).getOrElse(0)}
           """
 
-    def writeCommCounts(name: String, value: Option[StoreUsageCount]): String =
+    def writeCommCounts(name: String, value: Option[StoreUsageMetric]): String =
       s"""
          |  + RSpace $name
          |    - Total Count: ${value.map(_.count).getOrElse(0)}
@@ -136,11 +136,11 @@ object Runtime {
        |  - Total Size On Disk: ${storeUsage.totalSizeOnDisk.toHumanReadableSize}
        |  - RSpace Size On Disk: ${storeUsage.rspaceSizeOnDisk.toHumanReadableSize}
        |  - RSpace Data Entries: ${storeUsage.rspaceDataEntries}
-       |  ${writeCounts("Consumes", storeUsage.rspaceConsumesCount)}
-       |  ${writeCounts("Produces", storeUsage.rspaceProducesCount)}
-       |  ${writeCommCounts("Consumes COMM", storeUsage.rspaceConsumesCommCount)}
-       |  ${writeCommCounts("Produces COMM", storeUsage.rspaceProducesCommCount)}
-       |  ${writeCommCounts("Install COMM", storeUsage.rspaceInstallCommCount)}
+       |  ${writeCounts("Consumes", storeUsage.rspace.flatMap(_.rspaceConsumesCount))}
+       |  ${writeCounts("Produces", storeUsage.rspace.flatMap(_.rspaceProducesCount))}
+       |  ${writeCommCounts("Consumes COMM", storeUsage.rspace.flatMap(_.rspaceConsumesCommCount))}
+       |  ${writeCommCounts("Produces COMM", storeUsage.rspace.flatMap(_.rspaceProducesCommCount))}
+       |  ${writeCommCounts("Install COMM", storeUsage.rspace.flatMap(_.rspaceInstallCommCount))}
        |""".stripMargin
   }
 }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
@@ -115,7 +115,7 @@ object Runtime {
        |""".stripMargin
 
   def showStoreUsage(storeUsage: StoreUsage): String = {
-    def writeCounts(name: String, value: Option[StoreUsageMetric]): String =
+    def writeCounts(name: String, value: Option[RSpaceUsageMetric]): String =
       s"""
          |  + RSpace $name
          |    - Total Count: ${value.map(_.count).getOrElse(0)}
@@ -124,7 +124,7 @@ object Runtime {
          |    - Current Rate (events/sec): ${value.map(_.currentRate).getOrElse(0)}
           """
 
-    def writeCommCounts(name: String, value: Option[StoreUsageMetric]): String =
+    def writeCommCounts(name: String, value: Option[RSpaceUsageMetric]): String =
       s"""
          |  + RSpace $name
          |    - Total Count: ${value.map(_.count).getOrElse(0)}
@@ -136,11 +136,11 @@ object Runtime {
        |  - Total Size On Disk: ${storeUsage.totalSizeOnDisk.toHumanReadableSize}
        |  - RSpace Size On Disk: ${storeUsage.rspaceSizeOnDisk.toHumanReadableSize}
        |  - RSpace Data Entries: ${storeUsage.rspaceDataEntries}
-       |  ${writeCounts("Consumes", storeUsage.rspace.flatMap(_.rspaceConsumesCount))}
-       |  ${writeCounts("Produces", storeUsage.rspace.flatMap(_.rspaceProducesCount))}
-       |  ${writeCommCounts("Consumes COMM", storeUsage.rspace.flatMap(_.rspaceConsumesCommCount))}
-       |  ${writeCommCounts("Produces COMM", storeUsage.rspace.flatMap(_.rspaceProducesCommCount))}
-       |  ${writeCommCounts("Install COMM", storeUsage.rspace.flatMap(_.rspaceInstallCommCount))}
+       |  ${writeCounts("Consumes", storeUsage.rspace.flatMap(_.consumes))}
+       |  ${writeCounts("Produces", storeUsage.rspace.flatMap(_.produces))}
+       |  ${writeCommCounts("Consumes COMM", storeUsage.rspace.flatMap(_.consumesComm))}
+       |  ${writeCommCounts("Produces COMM", storeUsage.rspace.flatMap(_.producesComm))}
+       |  ${writeCommCounts("Install COMM", storeUsage.rspace.flatMap(_.installComm))}
        |""".stripMargin
   }
 }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
@@ -161,8 +161,8 @@ package object diagnostics {
     }
 
   def storeMetrics[F[_]: Capture](store: IStore[_, _, _, _], data_dir: Path): StoreMetrics[F] = {
-    def convert(c: coop.rchain.rspace.StoreCount): Option[StoreUsageMetric] =
-      Some(StoreUsageMetric(c.count, c.avgMilliseconds, c.peakRate, c.currentRate))
+    def convert(c: coop.rchain.rspace.StoreCount): Option[RSpaceUsageMetric] =
+      Some(RSpaceUsageMetric(c.count, c.avgMilliseconds, c.peakRate, c.currentRate))
 
     new StoreMetrics[F] {
       def storeUsage: F[StoreUsage] =
@@ -174,14 +174,14 @@ package object diagnostics {
             rspaceSizeOnDisk = storeCounters.sizeOnDisk,
             rspaceDataEntries = storeCounters.dataEntries,
             rspace = Some(
-              StoreUsageCount(
-                rspaceConsumesCount = convert(storeCounters.consumesCount),
-                rspaceProducesCount = convert(storeCounters.producesCount),
-                rspaceConsumesCommCount = convert(storeCounters.consumesCommCount),
-                rspaceProducesCommCount = convert(storeCounters.producesCommCount),
-                rspaceInstallCommCount = convert(storeCounters.installCommCount)
+              RSpaceUsage(
+                consumes = convert(storeCounters.consumesCount),
+                produces = convert(storeCounters.producesCount),
+                consumesComm = convert(storeCounters.consumesCommCount),
+                producesComm = convert(storeCounters.producesCommCount),
+                installComm = convert(storeCounters.installCommCount)
               )),
-            replayRspace = None
+            replayRSpace = None
           )
         }
     }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
@@ -161,8 +161,8 @@ package object diagnostics {
     }
 
   def storeMetrics[F[_]: Capture](store: IStore[_, _, _, _], data_dir: Path): StoreMetrics[F] = {
-    def convert(c: coop.rchain.rspace.StoreCount): Option[StoreUsageCount] =
-      Some(StoreUsageCount(c.count, c.avgMilliseconds, c.peakRate, c.currentRate))
+    def convert(c: coop.rchain.rspace.StoreCount): Option[StoreUsageMetric] =
+      Some(StoreUsageMetric(c.count, c.avgMilliseconds, c.peakRate, c.currentRate))
 
     new StoreMetrics[F] {
       def storeUsage: F[StoreUsage] =
@@ -173,11 +173,15 @@ package object diagnostics {
             totalSizeOnDisk = totalSize,
             rspaceSizeOnDisk = storeCounters.sizeOnDisk,
             rspaceDataEntries = storeCounters.dataEntries,
-            rspaceConsumesCount = convert(storeCounters.consumesCount),
-            rspaceProducesCount = convert(storeCounters.producesCount),
-            rspaceConsumesCommCount = convert(storeCounters.consumesCommCount),
-            rspaceProducesCommCount = convert(storeCounters.producesCommCount),
-            rspaceInstallCommCount = convert(storeCounters.installCommCount)
+            rspace = Some(
+              StoreUsageCount(
+                rspaceConsumesCount = convert(storeCounters.consumesCount),
+                rspaceProducesCount = convert(storeCounters.producesCount),
+                rspaceConsumesCommCount = convert(storeCounters.consumesCommCount),
+                rspaceProducesCommCount = convert(storeCounters.producesCommCount),
+                rspaceInstallCommCount = convert(storeCounters.installCommCount)
+              )),
+            replayRspace = None
           )
         }
     }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
@@ -174,8 +174,8 @@ package object diagnostics {
           val totalSize           = data_dir.folderSize
           StoreUsage(
             totalSizeOnDisk = totalSize,
-            rspaceSizeOnDisk = storeCounters.sizeOnDisk,
-            rspaceDataEntries = storeCounters.dataEntries,
+            rspaceSizeOnDisk = storeCounters.sizeOnDisk, // + replayStoreCounters.sizeOnDisk,
+            rspaceDataEntries = storeCounters.dataEntries, // + replayStoreCounters.dataEntries,
             rspace = Some(
               RSpaceUsage(
                 consumes = convert(storeCounters.consumesCount),

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -185,7 +185,9 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
       grpcServer <- {
         implicit val casperEvidence: MultiParentCasper[Effect] = casperEffect
         implicit val storeMetrics =
-          diagnostics.storeMetrics[Effect](runtime.space.store, conf.run.data_dir().normalize)
+          diagnostics.storeMetrics[Effect](casperRuntime.space.store,
+                                           casperRuntime.replaySpace.store,
+                                           conf.run.data_dir().normalize)
         GrpcServer
           .acquireServer[Effect](conf.grpcPort(), runtime)
       }
@@ -236,7 +238,9 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
     Task.delay {
       import scala.concurrent.duration._
       implicit val storeMetrics: StoreMetrics[Task] =
-        diagnostics.storeMetrics[Task](resources.runtime.space.store, conf.run.data_dir().normalize)
+        diagnostics.storeMetrics[Task](resources.casperRuntime.space.store,
+                                       resources.casperRuntime.replaySpace.store,
+                                       conf.run.data_dir().normalize)
       scheduler.scheduleAtFixedRate(10.seconds, 10.second)(StoreMetrics.report[Task].unsafeRunSync)
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StoreEventsCounter.scala
@@ -16,7 +16,7 @@ case class StoreCounters(sizeOnDisk: Long,
                          installCommCount: StoreCount)
 
 /**
-  * Conters rspace produce and consume calls.
+  * Counts rspace produce and consume calls.
   * Returns counted number of cycles, avg times,
   * peak and current rate of events
   * Uses BigIntegers to accumulate total times


### PR DESCRIPTION
## Overview
Before: storage metrics from the rholang REPL runtime were reported. 
After: metrics from both Casper runtime storages (normal and replay) are going to be reported.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-749

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
