### PR TITLE
{,rholang/}README.md: remove mention of CUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Assuming you have Docker running on your system, use the following pull command 
 * [sbt](https://www.scala-sbt.org/download.html)
 * For crypto, the [Sodium crypto library](https://github.com/jedisct1/libsodium)
 * For Rholang
-    - [CUP](http://www2.cs.tum.edu/projects/cup/install.php) 0.11b-2014-06-11 or later. See [Rholang README](https://github.com/rchain/rchain/blob/master/rholang/README.md) for notes on installation requirements.
      - [jflex](http://jflex.de/)
      - Build [BNFC](http://bnfc.digitalgrammars.com/) from the following commit or later: [BNFC/bnfc@7c9e859](https://github.com/BNFC/bnfc/commit/7c9e859). Use the installation command `cabal install bnfc --global`.
      

--- a/rholang/README.md
+++ b/rholang/README.md
@@ -12,18 +12,6 @@ Currently we have a working interpreter for the language. It should be considere
 1. Clone the repository
 2. Configure/fetch dependencies
     * [sbt](http://www.scala-sbt.org/0.13/docs/Installing-sbt-on-Linux.html)
-    * [CUP](http://www2.cs.tum.edu/projects/cup/install.php) - cannot be installed using apt.
-        * Must be cup 0.11b-2014-06-11 or later. Cup does not generate a shell script on install.
-        * Use something like the following (for me it lives in $HOME/.local/bin):
-			```
-			#! /bin/sh
-
-			CLASSPATH="$CLASSPATH:$HOME/.local/share/java/java-cup-11b.jar"
-			CLASSPATH="$CLASSPATH:$HOME/.local/share/java/java-cup-11b-runtime.jar"
-			export CLASSPATH
-
-			exec /usr/bin/java java_cup.Main "$@"
-			```
     * JFlex - install using apt 
     * BNFC - MUST be built from [git](https://github.com/BNFC/bnfc) b0252e5f666ed67a65b6e986748eccbfe802bc17 or later. If you use `cabal install` you will need to add your BNFC binary to the PATH.
     * [libsodium](https://github.com/jedisct1/libsodium) - You can use the scripts/install_sodium.sh helper script


### PR DESCRIPTION
## Overview
The CUP jar is vendored in rholang/lib.  sbt finds it there and add its to the classpath automatically. 
Therefore, it does not need to be installed separately.

### Does this PR relate to an RChain JIRA issue? 
No.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
