### PR TITLE
Core 720 heartbeat

### DIFF
--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -62,6 +62,7 @@ message TLRequest {
 }
 
 message InternalServerError {
+  bytes error = 1;
 }
 
 message NoResponse {

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -75,13 +75,13 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
 
   def handleCommunications: Protocol => F[CommunicationResponse] =
     protocol =>
-      ProtocolHelper.sender(protocol).fold(notHandled.pure[F]) { sender =>
+      ProtocolHelper.sender(protocol).fold(notHandled(senderNotAvailable).pure[F]) { sender =>
         updateLastSeen(sender) >>= kp(protocol match {
           case Protocol(_, Protocol.Message.Ping(_))        => handlePing
           case Protocol(_, Protocol.Message.Lookup(lookup)) => handleLookup(sender, lookup)
           case Protocol(_, Protocol.Message.Disconnect(disconnect)) =>
             handleDisconnect(sender, disconnect)
-          case _ => notHandled.pure[F]
+          case _ => notHandled(unexpectedMessage(protocol.toString)).pure[F]
         })
     }
 

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -18,18 +18,18 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
 
   private val table = PeerTable(src)
 
-  private def updateLastSeen(peer: PeerNode): F[Unit] =
+  private def updateLastSeen(peer: PeerNode): F[CommErr[Unit]] =
     table.observe[F](peer)
 
   private val id: NodeIdentifier = src.id
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  def addNode(peer: PeerNode): F[Unit] =
+  def addNode(peer: PeerNode): F[CommErr[Unit]] =
     for {
-      _ <- updateLastSeen(peer)
-      _ <- Metrics[F].setGauge("peers", table.peers.length.toLong)
-    } yield ()
+      res <- updateLastSeen(peer)
+      _   <- Metrics[F].setGauge("peers", table.peers.length.toLong)
+    } yield res
 
   /**
     * Return up to `limit` candidate peers.
@@ -76,13 +76,14 @@ class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: 
   def handleCommunications: Protocol => F[CommunicationResponse] =
     protocol =>
       ProtocolHelper.sender(protocol).fold(notHandled(senderNotAvailable).pure[F]) { sender =>
-        updateLastSeen(sender) >>= kp(protocol match {
-          case Protocol(_, Protocol.Message.Ping(_))        => handlePing
-          case Protocol(_, Protocol.Message.Lookup(lookup)) => handleLookup(sender, lookup)
+        protocol match {
+          case Protocol(_, Protocol.Message.Ping(_)) => handlePing
+          case Protocol(_, Protocol.Message.Lookup(lookup)) =>
+            updateLastSeen(sender) >>= kp(handleLookup(sender, lookup))
           case Protocol(_, Protocol.Message.Disconnect(disconnect)) =>
             handleDisconnect(sender, disconnect)
           case _ => notHandled(unexpectedMessage(protocol.toString)).pure[F]
-        })
+        }
     }
 
   private def handlePing: F[CommunicationResponse] =

--- a/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
@@ -6,11 +6,11 @@ import cats.Monad
 import cats.data.EitherT
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.{MonadTrans, _}
-import coop.rchain.comm.{PeerNode, ProtocolHelper}
+import coop.rchain.comm.{CommError, PeerNode, ProtocolHelper}, CommError.CommErr
 import coop.rchain.comm.protocol.routing._
 
 trait NodeDiscovery[F[_]] {
-  def addNode(node: PeerNode): F[Unit]
+  def addNode(node: PeerNode): F[CommErr[Unit]]
   def findMorePeers(limit: Int): F[Seq[PeerNode]]
   def peers: F[Seq[PeerNode]]
   def handleCommunications: Protocol => F[CommunicationResponse]
@@ -22,7 +22,7 @@ object NodeDiscovery extends NodeDiscoveryInstances {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
       implicit C: NodeDiscovery[F]): NodeDiscovery[T[F, ?]] =
     new NodeDiscovery[T[F, ?]] {
-      def addNode(node: PeerNode): T[F, Unit]            = C.addNode(node).liftM[T]
+      def addNode(node: PeerNode): T[F, CommErr[Unit]]   = C.addNode(node).liftM[T]
       def findMorePeers(limit: Int): T[F, Seq[PeerNode]] = C.findMorePeers(limit).liftM[T]
       def peers: T[F, Seq[PeerNode]]                     = C.peers.liftM[T]
       def handleCommunications: Protocol => T[F, CommunicationResponse] =

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -22,6 +22,10 @@ final case class MalformedMessage(pm: Protocol)          extends CommError
 final case object CouldNotConnectToBootstrap             extends CommError
 final case class InternalCommunicationError(msg: String) extends CommError
 final case object TimeOut                                extends CommError
+final case object NoResponseForRequest                   extends CommError
+final case object UpstreamNotAvailable                   extends CommError
+final case class UnexpectedMessage(msgStr: String)       extends CommError
+final case object SenderNotAvailable                     extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -41,4 +45,8 @@ object CommError {
   def couldNotConnectToBootstrap: CommError              = CouldNotConnectToBootstrap
   def internalCommunicationError(msg: String): CommError = InternalCommunicationError(msg)
   def malformedMessage(pm: Protocol): CommError          = MalformedMessage(pm)
+  def noResponseForRequest: CommError                    = NoResponseForRequest
+  def upstreamNotAvailable: CommError                    = UpstreamNotAvailable
+  def unexpectedMessage(msgStr: String): CommError       = UnexpectedMessage(msgStr)
+  def senderNotAvailable: CommError                      = SenderNotAvailable
 }

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -26,6 +26,7 @@ final case object NoResponseForRequest                   extends CommError
 final case object UpstreamNotAvailable                   extends CommError
 final case class UnexpectedMessage(msgStr: String)       extends CommError
 final case object SenderNotAvailable                     extends CommError
+final case class PongNotReceivedForPing(peer: PeerNode)  extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -49,4 +50,5 @@ object CommError {
   def upstreamNotAvailable: CommError                    = UpstreamNotAvailable
   def unexpectedMessage(msgStr: String): CommError       = UnexpectedMessage(msgStr)
   def senderNotAvailable: CommError                      = SenderNotAvailable
+  def pongNotReceivedForPing(peer: PeerNode): CommError  = PongNotReceivedForPing(peer)
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/CommunicationResponse.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/CommunicationResponse.scala
@@ -1,14 +1,15 @@
 package coop.rchain.comm.transport
 
 import coop.rchain.comm.protocol.routing.Protocol
+import coop.rchain.comm.CommError
 
 sealed trait CommunicationResponse
 case class HandledWithMessage(pm: Protocol) extends CommunicationResponse
 case object HandledWitoutMessage            extends CommunicationResponse
-case object NotHandled                      extends CommunicationResponse
+case class NotHandled(error: CommError)     extends CommunicationResponse
 
 object CommunicationResponse {
   def handledWithMessage(protocol: Protocol): CommunicationResponse = HandledWithMessage(protocol)
   def handledWitoutMessage: CommunicationResponse                   = HandledWitoutMessage
-  def notHandled: CommunicationResponse                             = NotHandled
+  def notHandled(error: CommError): CommunicationResponse           = NotHandled(error)
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -120,8 +120,8 @@ class TcpTransportLayer(host: String, port: Int, cert: File, key: File)(src: Pee
                     case p if p.isProtocol => Right(tlr.getProtocol)
                     case p if p.isNoResponse =>
                       Left(internalCommunicationError("Was expecting message, nothing arrived"))
-                    case p if p.isInternalServerError =>
-                      Left(internalCommunicationError("crap"))
+                    case TLResponse.Payload.InternalServerError(ise) =>
+                      Left(internalCommunicationError(ise.error.toStringUtf8))
                 })
                 .pure[Task]
     } yield pmErr
@@ -163,7 +163,7 @@ class TransportLayerImpl(dispatch: Protocol => Task[CommunicationResponse])(
     request.protocol
       .fold(internalServerError("protocol not available in request").pure[Task]) { protocol =>
         dispatch(protocol) map {
-          case NotHandled                   => internalServerError(s"Message ${protocol} was not handled!")
+          case NotHandled(error)            => internalServerError(s"$error")
           case HandledWitoutMessage         => noResponse
           case HandledWithMessage(response) => returnProtocol(response)
         }
@@ -175,7 +175,9 @@ class TransportLayerImpl(dispatch: Protocol => Task[CommunicationResponse])(
 
   // TODO InternalServerError should take msg in constructor
   private def internalServerError(msg: String): TLResponse =
-    TLResponse(TLResponse.Payload.InternalServerError(InternalServerError()))
+    TLResponse(
+      TLResponse.Payload.InternalServerError(
+        InternalServerError(ProtocolHelper.toProtocolBytes(msg))))
 
   private def noResponse: TLResponse =
     TLResponse(TLResponse.Payload.NoResponse(NoResponse()))

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -3,7 +3,7 @@ package coop.rchain.comm.transport
 import scala.concurrent.duration.FiniteDuration
 
 import cats._, cats.data._, cats.implicits._
-import coop.rchain.comm.CommError.CommErr
+import coop.rchain.comm.CommError, CommError.CommErr
 import coop.rchain.comm.{PeerNode, ProtocolHelper}
 import coop.rchain.shared._
 import coop.rchain.comm.protocol.routing._
@@ -31,35 +31,36 @@ sealed abstract class TransportLayerInstances {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  implicit def eitherTTransportLayer[E, F[_]: Monad: Log](
-      implicit evF: TransportLayer[F]): TransportLayer[EitherT[F, E, ?]] =
-    new TransportLayer[EitherT[F, E, ?]] {
+  implicit def eitherTTransportLayer[F[_]: Monad: Log](
+      implicit evF: TransportLayer[F]): TransportLayer[EitherT[F, CommError, ?]] =
+    new TransportLayer[EitherT[F, CommError, ?]] {
 
-      def local: EitherT[F, E, PeerNode] =
+      def local: EitherT[F, CommError, PeerNode] =
         EitherT.liftF(evF.local)
 
       def roundTrip(peer: PeerNode,
                     msg: Protocol,
-                    timeout: FiniteDuration): EitherT[F, E, CommErr[Protocol]] =
+                    timeout: FiniteDuration): EitherT[F, CommError, CommErr[Protocol]] =
         EitherT.liftF(evF.roundTrip(peer, msg, timeout))
 
-      def send(peer: PeerNode, msg: Protocol): EitherT[F, E, Unit] =
+      def send(peer: PeerNode, msg: Protocol): EitherT[F, CommError, Unit] =
         EitherT.liftF(evF.send(peer, msg))
 
-      def broadcast(peers: Seq[PeerNode], msg: Protocol): EitherT[F, E, Unit] =
+      def broadcast(peers: Seq[PeerNode], msg: Protocol): EitherT[F, CommError, Unit] =
         EitherT.liftF(evF.broadcast(peers, msg))
 
-      def receive(
-          dispatch: Protocol => EitherT[F, E, CommunicationResponse]): EitherT[F, E, Unit] = {
+      def receive(dispatch: Protocol => EitherT[F, CommError, CommunicationResponse])
+        : EitherT[F, CommError, Unit] = {
         val dis: Protocol => F[CommunicationResponse] = msg =>
           dispatch(msg).value.flatMap {
             case Left(err) =>
-              Log[F].error(s"Error while handling message. Error: $err") *> notHandled.pure[F]
+              Log[F].error(s"Error while handling message. Error: $err") *> notHandled(err).pure[F]
             case Right(m) => m.pure[F]
         }
         EitherT.liftF(evF.receive(dis))
       }
 
-      def disconnect(peer: PeerNode): EitherT[F, E, Unit] = EitherT.liftF(evF.disconnect(peer))
+      def disconnect(peer: PeerNode): EitherT[F, CommError, Unit] =
+        EitherT.liftF(evF.disconnect(peer))
     }
 }

--- a/comm/src/test/scala/coop/rchain/comm/connect/ConnectToBootstrap.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ConnectToBootstrap.scala
@@ -46,11 +46,11 @@ class ConnectToBootstrapSpec
       // then
       logEff.warns should equal(
         List(
-          "Failed to connect to bootstrap (attempt 1 / 5)",
-          "Failed to connect to bootstrap (attempt 2 / 5)",
-          "Failed to connect to bootstrap (attempt 3 / 5)",
-          "Failed to connect to bootstrap (attempt 4 / 5)",
-          "Failed to connect to bootstrap (attempt 5 / 5)"
+          "Failed to connect to bootstrap (attempt 1 / 5). Reason: UnknownProtocolError(unknown)",
+          "Failed to connect to bootstrap (attempt 2 / 5). Reason: UnknownProtocolError(unknown)",
+          "Failed to connect to bootstrap (attempt 3 / 5). Reason: UnknownProtocolError(unknown)",
+          "Failed to connect to bootstrap (attempt 4 / 5). Reason: UnknownProtocolError(unknown)",
+          "Failed to connect to bootstrap (attempt 5 / 5). Reason: UnknownProtocolError(unknown)"
         ))
     }
 

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -37,8 +37,9 @@ object EffectsTestInstances {
     def reset(): Unit =
       nodes = List.empty[PeerNode]
 
-    def addNode(node: PeerNode): F[Unit] = Capture[F].capture {
+    def addNode(node: PeerNode): F[CommErr[Unit]] = Capture[F].capture {
       nodes = node :: nodes
+      Right(())
     }
 
     def peers: F[Seq[PeerNode]] = Capture[F].capture {

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -46,8 +46,8 @@ package object effects {
         for {
           _   <- Metrics[F].incrementCounter("protocol-ping-sends")
           req = ProtocolHelper.ping(src)
-          res <- TransportLayer[F].roundTrip(node, req, timeout).map(_.toOption)
-        } yield res.isDefined
+          res <- TransportLayer[F].roundTrip(node, req, timeout)
+        } yield res.toOption.isDefined
     }
 
   def tcpTranposrtLayer(host: String, port: Int, cert: File, key: File)(src: PeerNode)(

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -252,8 +252,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
     (pm: Protocol) =>
       NodeDiscovery[Effect].handleCommunications(pm) >>= {
-        case NotHandled => Connect.dispatch[Effect](pm)
-        case handled    => handled.pure[Effect]
+        case NotHandled(_) => Connect.dispatch[Effect](pm)
+        case handled       => handled.pure[Effect]
       }
   }
 


### PR DESCRIPTION
## Overview
Best to follow this PR commit by commit.

Originally this PR was suppose to be about providing heartbeat. Eventually I:

1. upgraded Kademlia's `table.observe` to `Ping` remotes each time `updateLastSeen` is called
2. fixed Kademlia issues (when adding a node that already extis in a tabkle, routing information was not updated, peer was not `Ping`ed

After this PR is merged, when two nodes are connected to each other we have 100% guarantee  that they can exchange messages with each other (both sending and receiving). 

Also: `NotHandled` was given `CommError` to propagate. `InternalServerError` response pushes that back to the caller via `String` - this has to be handled better in a future.

During the work on this issue, some additional Kademlia issues were spotted, like:

1. Kademlia.observe - consider returning an result of action taken (added, updated, older update instead)
2. Potential bug: we ignore ping request to update the kademlai table
3. Potenatial BUG: when disconnecting from network other nodes (even though they've learned about disconnect) continue on sending PING messages

Overall we need to focus on writing unit tests for Kademlia.

### Does this PR relate to an RChain JIRA issue? 
CORE-720