### PR TITLE
Rspace: Add parameter type for the result of match.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -55,7 +55,12 @@ trait Reduce[M[_]] {
 object Reduce {
 
   class DebruijnInterpreter[M[_]: InterpreterErrorsM: Capture, F[_]](
-      tupleSpace: PureRSpace[M, Channel, BindPattern, Seq[Channel], TaggedContinuation],
+      tupleSpace: PureRSpace[M,
+                             Channel,
+                             BindPattern,
+                             Seq[Channel],
+                             Seq[Channel],
+                             TaggedContinuation],
       dispatcher: => Dispatch[M, Seq[Channel], TaggedContinuation])(
       implicit parallel: cats.Parallel[M, F],
       fTell: FunctorTell[M, InterpreterError])

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -23,8 +23,12 @@ import scala.collection.immutable
 class Runtime private (
     val reducer: Reduce[Task],
     val replayReducer: Reduce[Task],
-    val space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-    val replaySpace: ReplayRSpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+    val space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+    val replaySpace: ReplayRSpace[Channel,
+                                  BindPattern,
+                                  Seq[Channel],
+                                  Seq[Channel],
+                                  TaggedContinuation],
     var errorLog: Runtime.ErrorLog) {
   def readAndClearErrorVector(): Vector[InterpreterError] = errorLog.readAndClearErrorVector()
   def close(): Unit                                       = space.close()
@@ -38,7 +42,7 @@ object Runtime {
   type Ref       = Long
 
   private def introduceSystemProcesses(
-      space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+      space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
       processes: immutable.Seq[(Name, Arity, Remainder, Ref)])
     : Seq[Option[(TaggedContinuation, Seq[Seq[Channel]])]] =
     processes.map {
@@ -96,18 +100,25 @@ object Runtime {
       mapSize
     )
 
-    val space = RSpace.create(context, Branch.MASTER)
+    val space = RSpace.create[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation](
+      context,
+      Branch.MASTER)
 
-    val replaySpace = ReplayRSpace.create(context, Branch.REPLAY)
+    val replaySpace =
+      ReplayRSpace.create[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation](
+        context,
+        Branch.REPLAY)
 
     val errorLog                                         = new ErrorLog()
     implicit val ft: FunctorTell[Task, InterpreterError] = errorLog
 
     lazy val dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation] =
-      RholangAndScalaDispatcher.create(space, dispatchTable)
+      RholangAndScalaDispatcher
+        .create(space, dispatchTable)
 
     lazy val replayDispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation] =
-      RholangAndScalaDispatcher.create(replaySpace, dispatchTable)
+      RholangAndScalaDispatcher
+        .create(replaySpace, dispatchTable)
 
     lazy val dispatchTable: Map[Ref, Seq[Seq[Channel]] => Task[Unit]] = Map(
       0L -> SystemProcesses.stdout,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -23,7 +23,7 @@ object SystemProcesses {
       Task(Console.println(prettyPrinter.buildString(arg)))
   }
 
-  def stdoutAck(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+  def stdoutAck(space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
                 dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(arg, ack)) =>
@@ -39,7 +39,7 @@ object SystemProcesses {
       Task(Console.err.println(prettyPrinter.buildString(arg)))
   }
 
-  def stderrAck(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+  def stderrAck(space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
                 dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(arg, ack)) =>
@@ -76,8 +76,9 @@ object SystemProcesses {
 //      }
 //  }
 
-  def ed25519Verify(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                    dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
+  def ed25519Verify(
+      space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack)) =>
       Task.fromTry(Try(Ed25519.verify(data, signature, pub))).flatMap { verified =>
@@ -90,8 +91,9 @@ object SystemProcesses {
         "ed25519Verify expects data, signature and public key (all as byte arrays) and ack channel as arguments")
   }
 
-  def sha256Hash(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                 dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
+  def sha256Hash(
+      space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(IsByteArray(input), ack)) =>
       Task.fromTry(Try(Sha256.hash(input))).flatMap { hash =>
@@ -103,8 +105,9 @@ object SystemProcesses {
       illegalArgumentException("sha256Hash expects byte array and return channel as arguments")
   }
 
-  def keccak256Hash(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                    dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
+  def keccak256Hash(
+      space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(IsByteArray(input), ack)) =>
       Task.fromTry(Try(Keccak256.hash(input))).flatMap { hash =>
@@ -116,8 +119,9 @@ object SystemProcesses {
       illegalArgumentException("keccak256Hash expects byte array and return channel as arguments")
   }
 
-  def blake2b256Hash(space: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                     dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
+  def blake2b256Hash(
+      space: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+      dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation])
     : Seq[Seq[Channel]] => Task[Unit] = {
     case Seq(Seq(IsByteArray(input), ack)) =>
       Task.fromTry(Try(Blake2b256.hash(input))).flatMap { hash =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -47,13 +47,14 @@ class RholangOnlyDispatcher[M[_]] private (_reducer: => Reduce[M])(implicit capt
 object RholangOnlyDispatcher {
 
   def create[M[_], F[_]](
-      tuplespace: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation])(
+      tuplespace: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation])(
       implicit
       intepreterErrorsM: InterpreterErrorsM[M],
       captureM: Capture[M],
       parallel: Parallel[M, F],
       ft: FunctorTell[M, InterpreterError]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
-    val pureSpace: PureRSpace[M, Channel, BindPattern, Seq[Channel], TaggedContinuation] =
+    val pureSpace
+      : PureRSpace[M, Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] =
       new PureRSpace(tuplespace)
     lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
       new RholangOnlyDispatcher(reducer)
@@ -88,14 +89,16 @@ class RholangAndScalaDispatcher[M[_]] private (
 
 object RholangAndScalaDispatcher {
 
-  def create[M[_], F[_]](tuplespace: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-                         dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], M[Unit]]])(
+  def create[M[_], F[_]](
+      tuplespace: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
+      dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], M[Unit]]])(
       implicit
       intepreterErrorsM: InterpreterErrorsM[M],
       captureM: Capture[M],
       parallel: Parallel[M, F],
       ft: FunctorTell[M, InterpreterError]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
-    val pureSpace: PureRSpace[M, Channel, BindPattern, Seq[Channel], TaggedContinuation] =
+    val pureSpace
+      : PureRSpace[M, Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] =
       new PureRSpace(tuplespace)
     lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
       new RholangAndScalaDispatcher(reducer, dispatchTable)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -23,8 +23,8 @@ object implicits {
       }
     }
 
-  implicit val matchListQuote: StorageMatch[BindPattern, Seq[Channel]] =
-    new StorageMatch[BindPattern, Seq[Channel]] {
+  implicit val matchListQuote: StorageMatch[BindPattern, Seq[Channel], Seq[Channel]] =
+    new StorageMatch[BindPattern, Seq[Channel], Seq[Channel]] {
 
       def get(pattern: BindPattern, data: Seq[Channel]): Option[Seq[Channel]] =
         foldMatch(data, pattern.patterns, pattern.remainder)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -30,12 +30,12 @@ import scala.concurrent.{Await, ExecutionException}
 
 trait PersistentStoreTester {
   def withTestSpace[R](
-      f: ISpace[Channel, BindPattern, Seq[Channel], TaggedContinuation] => R): R = {
+      f: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] => R): R = {
     val dbDir = Files.createTempDirectory("rchain-storage-test-")
     val store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation] =
       LMDBStore.create[Channel, BindPattern, Seq[Channel], TaggedContinuation](dbDir,
                                                                                1024 * 1024 * 1024)
-    val space = new RSpace(store, Branch("test"))
+    val space = new RSpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation](store, Branch("test"))
     try {
       f(space)
     } finally {

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -46,7 +46,7 @@ object BasicBench {
     val testStore: LMDBStore[String, Pattern, String, StringsCaptor] =
       LMDBStore.create[String, Pattern, String, StringsCaptor](dbDir, 1024 * 1024 * 1024)
 
-    val testSpace: RSpace[String, Pattern, String, StringsCaptor] =
-      new RSpace(testStore, Branch("bench"))
+    val testSpace: RSpace[String, Pattern, String, String, StringsCaptor] =
+      new RSpace[String, Pattern, String, String, StringsCaptor](testStore, Branch("bench"))
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Match.scala
@@ -5,8 +5,9 @@ package coop.rchain.rspace
   *
   * @tparam P A type representing patterns
   * @tparam A A type representing data
+  * @tparam R A type representing a match result
   */
-trait Match[P, A] {
+trait Match[P, A, R] {
 
-  def get(p: P, a: A): Option[A]
+  def get(p: P, a: A): Option[R]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -132,7 +132,7 @@ object AddressBookExample {
     /**
       * An instance of [[Match]] for [[Pattern]] and [[Entry]]
       */
-    implicit object matchPatternEntry extends Match[Pattern, Entry] {
+    implicit object matchPatternEntry extends Match[Pattern, Entry, Entry] {
       def get(p: Pattern, a: Entry): Option[Entry] =
         p match {
           case NameMatch(last) if a.name.last == last        => Some(a)
@@ -171,7 +171,7 @@ object AddressBookExample {
     val store: LMDBStore[Channel, Pattern, Entry, Printer] =
       LMDBStore.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
-    val space = new RSpace[Channel, Pattern, Entry, Printer](store, Branch.MASTER)
+    val space = new RSpace[Channel, Pattern, Entry, Entry, Printer](store, Branch.MASTER)
 
     Console.printf("\nExample One: Let's consume and then produce...\n")
 
@@ -205,7 +205,7 @@ object AddressBookExample {
     val store: LMDBStore[Channel, Pattern, Entry, Printer] =
       LMDBStore.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
-    val space = new RSpace[Channel, Pattern, Entry, Printer](store, Branch.MASTER)
+    val space = new RSpace[Channel, Pattern, Entry, Entry, Printer](store, Branch.MASTER)
 
     Console.printf("\nExample Two: Let's produce and then consume...\n")
 
@@ -277,13 +277,13 @@ object AddressBookExample {
     space.store.close()
   }
 
-  private[this] def withSpace(f: RSpace[Channel, Pattern, Entry, Printer] => Unit) = {
+  private[this] def withSpace(f: RSpace[Channel, Pattern, Entry, Entry, Printer] => Unit) = {
     // Here we define a temporary place to put the store's files
     val storePath = Files.createTempDirectory("rspace-address-book-example-")
     // Let's define our store
     val store = LMDBStore.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
-    f(new RSpace[Channel, Pattern, Entry, Printer](store, Branch.MASTER))
+    f(new RSpace[Channel, Pattern, Entry, Entry, Printer](store, Branch.MASTER))
   }
 
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -49,7 +49,7 @@ object StringExamples {
 
   object implicits {
 
-    implicit object stringMatch extends Match[Pattern, String] {
+    implicit object stringMatch extends Match[Pattern, String, String] {
       def get(p: Pattern, a: String): Option[String] = Some(a).filter(p.isMatch)
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -5,21 +5,21 @@ import coop.rchain.rspace._
 
 import scala.collection.immutable.Seq
 
-class PureRSpace[F[_], C, P, A, K](space: ISpace[C, P, A, K]) {
+class PureRSpace[F[_], C, P, A, R, K](space: ISpace[C, P, A, R, K]) {
 
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, A],
-      c: Capture[F]): F[Option[(K, Seq[A])]] =
+      implicit m: Match[P, A, R],
+      c: Capture[F]): F[Option[(K, Seq[R])]] =
     c.capture(space.consume(channels, patterns, continuation, persist))
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, A],
-      c: Capture[F]): F[Option[(K, Seq[A])]] =
+      implicit m: Match[P, A, R],
+      c: Capture[F]): F[Option[(K, Seq[R])]] =
     c.capture(space.install(channels, patterns, continuation))
 
   def produce(channel: C, data: A, persist: Boolean)(implicit
-                                                     m: Match[P, A],
-                                                     c: Capture[F]): F[Option[(K, Seq[A])]] =
+                                                     m: Match[P, A, R],
+                                                     c: Capture[F]): F[Option[(K, Seq[R])]] =
     c.capture(space.produce(channel, data, persist))
 
   def createCheckpoint()(c: Capture[F]): F[Checkpoint] = c.capture(space.createCheckpoint())

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -42,7 +42,7 @@ trait HistoryActionsTests
       joins: Map[Blake2b256Hash, Seq[Seq[String]]]
   )
 
-  def validateIndexedStates(space: ISpace[String, Pattern, String, StringsCaptor],
+  def validateIndexedStates(space: ISpace[String, Pattern, String, String, StringsCaptor],
                             indexedStates: Seq[(State, Int)]): Boolean = {
     val tests: Seq[Any] = indexedStates
       .map {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -17,25 +17,25 @@ import scala.util.Random
 //noinspection ZeroIndexToHead,NameBooleanParameters
 class ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, String] {
 
-  def consumeMany[C, P, A, K](
-      space: ISpace[C, P, A, K],
+  def consumeMany[C, P, A, R, K](
+      space: ISpace[C, P, A, R, K],
       range: Range,
       shuffle: Boolean,
       channelsCreator: Int => List[C],
       patterns: List[P],
       continuationCreator: Int => K,
-      persist: Boolean)(implicit matcher: Match[P, A]): List[Option[(K, Seq[A])]] =
+      persist: Boolean)(implicit matcher: Match[P, A, R]): List[Option[(K, Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
       space.consume(channelsCreator(i), patterns, continuationCreator(i), persist)
     }
 
-  def produceMany[C, P, A, K](
-      space: ISpace[C, P, A, K],
+  def produceMany[C, P, A, R, K](
+      space: ISpace[C, P, A, R, K],
       range: Range,
       shuffle: Boolean,
       channelCreator: Int => C,
       datumCreator: Int => A,
-      persist: Boolean)(implicit matcher: Match[P, A]): List[Option[(K, immutable.Seq[A])]] =
+      persist: Boolean)(implicit matcher: Match[P, A, R]): List[Option[(K, immutable.Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
       space.produce(channelCreator(i), datumCreator(i), persist)
     }
@@ -713,17 +713,17 @@ trait ReplayRSpaceTestsBase[C, P, A, K]
     super.withFixture(test)
   }
 
-  def withTestSpaces[R](f: (RSpace[C, P, A, K], ReplayRSpace[C, P, A, K]) => R)(
+  def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): R = {
+      sk: Serialize[K]): S = {
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.create[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
-    val space       = RSpace.create(context, Branch.MASTER)
-    val replaySpace = ReplayRSpace.create(context, Branch.REPLAY)
+    val space       = RSpace.create[C, P, A, A, K](context, Branch.MASTER)
+    val replaySpace = ReplayRSpace.create[C, P, A, A, K](context, Branch.REPLAY)
 
     try {
       f(space, replaySpace)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -280,7 +280,8 @@ class InMemoryStoreStorageExamplesTestsBase
 
   override def withTestSpace[R](f: T => R): R = {
     val testStore = InMemoryStore.create[Channel, Pattern, Entry, EntriesCaptor]
-    val testSpace = new RSpace[Channel, Pattern, Entry, EntriesCaptor](testStore, Branch.MASTER)
+    val testSpace =
+      new RSpace[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
     testStore.withTxn(testStore.createTxnWrite())(testStore.clear)
     try {
       f(testSpace)
@@ -305,7 +306,8 @@ class LMDBStoreStorageExamplesTestBase
 
   override def withTestSpace[R](f: T => R): R = {
     val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
-    val testSpace = new RSpace(testStore, Branch.MASTER)
+    val testSpace =
+      new RSpace[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
     try {
       testStore.withTxn(testStore.createTxnWrite())(txn => testStore.clear(txn))
       f(testSpace)


### PR DESCRIPTION
Note that the result match type does not need a Serialize instance, because it
only ever occurs post-deserialize. While not strictly necessary for passing the
random state along with the results, It is conceptually cleaner to separate the
match input type from the match output type.
