### PR TITLE
 Use in TCP transport layer a fiber non canceling timeout

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -103,7 +103,7 @@ class TcpTransportLayer(host: String, port: Int, cert: File, key: File)(src: Pee
                           peer: PeerNode,
                           timeout: FiniteDuration): Task[Either[CommError, TLResponse]] =
     innerSend(peer, request)
-      .timeout(timeout)
+      .nonCancelingTimeout(timeout)
       .attempt
       .map(_.leftMap {
         case _: TimeoutException => TimeOut

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -1,5 +1,6 @@
 package coop.rchain.catscontrib
 
+import java.util.concurrent.TimeoutException
 import monix.eval.Task
 import monix.execution.Scheduler
 import scala.concurrent.Await
@@ -10,5 +11,19 @@ object TaskContrib {
   implicit class TaskOps[A](task: Task[A])(implicit scheduler: Scheduler) {
     def unsafeRunSync: A =
       Await.result(task.runAsync, Duration.Inf)
+
+    def nonCancelingTimeout(after: FiniteDuration): Task[A] =
+      nonCancelingTimeoutTo(
+        after,
+        Task.raiseError(new TimeoutException(s"Task timed-out after $after of inactivity")))
+
+    def nonCancelingTimeoutTo[B >: A](after: FiniteDuration, backup: Task[B]): Task[B] =
+      Task.racePair(task, Task.unit.delayExecution(after)).flatMap {
+        case Left((a, _)) =>
+          Task.now(a)
+        case Right(_) =>
+          backup
+      }
+
   }
 }


### PR DESCRIPTION
## Overview
`Task.timout` is cancelling in case of a timeout the underlying fiber of the job. This resulted in stack traces in the gRPC subsystem.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-756

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.
