### PR TITLE
Add deterministic unforgeable names.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -262,9 +262,12 @@ object ProtoUtil {
     )
   }
 
-  def termDeploy(term: Par): Deploy =
+  def termDeploy(term: Par): Deploy = {
+    val timestamp = System.currentTimeMillis()
     Deploy(
       term = Some(term),
-      raw = None
+      raw = Some(
+        DeployString(user = ByteString.EMPTY, timestamp = timestamp, term = term.toProtoString))
     )
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -61,7 +61,7 @@ object InterpreterUtil {
       dag: BlockDag,
       defaultStateHash: StateHash,
       knownStateHashes: Set[StateHash],
-      computeState: (StateHash, List[Par]) => Either[Throwable, Checkpoint])(
+      computeState: (StateHash, Seq[Deploy]) => Either[Throwable, Checkpoint])(
       implicit scheduler: Scheduler): (Checkpoint, Set[StateHash]) = {
     val (postStateHash, updatedStateHashes) =
       computeParentsPostState(parents,
@@ -71,7 +71,7 @@ object InterpreterUtil {
                               knownStateHashes,
                               computeState)
 
-    val Right(postDeploysCheckpoint) = computeState(postStateHash, deploys.flatMap(_.term).toList)
+    val Right(postDeploysCheckpoint) = computeState(postStateHash, deploys)
     val postDeploysStateHash         = ByteString.copyFrom(postDeploysCheckpoint.root.bytes.toArray)
     (postDeploysCheckpoint, updatedStateHashes + postDeploysStateHash)
   }
@@ -82,7 +82,7 @@ object InterpreterUtil {
       dag: BlockDag,
       defaultStateHash: StateHash,
       knownStateHashes: Set[StateHash],
-      computeState: (StateHash, List[Par]) => Either[Throwable, Checkpoint])(
+      computeState: (StateHash, Seq[Deploy]) => Either[Throwable, Checkpoint])(
       implicit scheduler: Scheduler): (StateHash, Set[StateHash]) = {
 
     val blockStateHash = ProtoUtil.tuplespace(b).get
@@ -107,7 +107,7 @@ object InterpreterUtil {
       dag: BlockDag,
       defaultStateHash: StateHash,
       knownStateHashes: Set[StateHash],
-      computeState: (StateHash, List[Par]) => Either[Throwable, Checkpoint])(
+      computeState: (StateHash, Seq[Deploy]) => Either[Throwable, Checkpoint])(
       implicit scheduler: Scheduler): (StateHash, Set[StateHash]) = {
     val parentTuplespaces = parents.flatMap(p => ProtoUtil.tuplespace(p).map(p -> _))
 
@@ -161,7 +161,7 @@ object InterpreterUtil {
 
       //TODO: figure out what casper should do with errors in deploys
       val Right(resultStateCheckpoint) =
-        computeState(computedGcaStateHash, deploys.flatMap(_.term).toList)
+        computeState(computedGcaStateHash, deploys)
       val resultStateHash = ByteString.copyFrom(resultStateCheckpoint.root.bytes.toArray)
       (resultStateHash, knownStateHashes + resultStateHash)
     }
@@ -173,7 +173,7 @@ object InterpreterUtil {
       dag: BlockDag,
       defaultStateHash: StateHash,
       knownStateHashes: Set[StateHash],
-      computeState: (StateHash, List[Par]) => Either[Throwable, Checkpoint])(
+      computeState: (StateHash, Seq[Deploy]) => Either[Throwable, Checkpoint])(
       implicit scheduler: Scheduler): (Checkpoint, Set[StateHash]) = {
     val parents = ProtoUtil
       .parents(b)

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -71,7 +71,6 @@ class RuntimeManager private (runtimeContainer: SyncVar[Runtime]) {
       implicit scheduler: Scheduler): Option[Throwable] =
     terms match {
       case deploy +: rest =>
-        val deployBytes = DeployString.toByteArray(deploy.raw.get)
         implicit val rand: Blake2b512Random = Blake2b512Random(
           DeployString.toByteArray(deploy.raw.get))
         Try(reducer.inj(deploy.term.get).unsafeRunSync) match {

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -1,7 +1,10 @@
 package coop.rchain.casper.util.rholang
 
 import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.Deploy
+import coop.rchain.casper.protocol.DeployString
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.{Reduce, Runtime}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
@@ -17,8 +20,8 @@ import monix.eval.Task
 class RuntimeManager private (runtimeContainer: SyncVar[Runtime]) {
 
   def replayComputeState(log: trace.Log)(
-      implicit scheduler: Scheduler): (StateHash, List[Par]) => Either[Throwable, Checkpoint] = {
-    (hash: StateHash, terms: List[Par]) =>
+      implicit scheduler: Scheduler): (StateHash, Seq[Deploy]) => Either[Throwable, Checkpoint] = {
+    (hash: StateHash, terms: Seq[Deploy]) =>
       {
         val runtime   = runtimeContainer.take()
         val blakeHash = Blake2b256Hash.fromByteArray(hash.toByteArray)
@@ -36,7 +39,7 @@ class RuntimeManager private (runtimeContainer: SyncVar[Runtime]) {
       }
   }
 
-  def computeState(hash: StateHash, terms: List[Par])(
+  def computeState(hash: StateHash, terms: Seq[Deploy])(
       implicit scheduler: Scheduler): Either[Throwable, Checkpoint] = {
     val resetRuntime: Runtime = getResetRuntime(hash)
     val error                 = eval(terms, resetRuntime.reducer)
@@ -64,11 +67,14 @@ class RuntimeManager private (runtimeContainer: SyncVar[Runtime]) {
     }
   }
 
-  private def eval(terms: List[Par], reducer: Reduce[Task])(
+  private def eval(terms: Seq[Deploy], reducer: Reduce[Task])(
       implicit scheduler: Scheduler): Option[Throwable] =
     terms match {
-      case term :: rest =>
-        Try(reducer.inj(term).unsafeRunSync) match {
+      case deploy +: rest =>
+        val deployBytes = DeployString.toByteArray(deploy.raw.get)
+        implicit val rand: Blake2b512Random = Blake2b512Random(
+          DeployString.toByteArray(deploy.raw.get))
+        Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
           case Success(_)  => eval(rest, reducer)
           case Failure(ex) => Some(ex)
         }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -10,7 +10,6 @@ import coop.rchain.rholang.collection.LinkedList
 import coop.rchain.rholang.unittest.TestSet
 
 import java.nio.file.Files
-import java.security.SecureRandom
 
 import monix.execution.Scheduler
 
@@ -38,9 +37,7 @@ object TestSetUtil {
   def runTests(tests: Par, otherLibs: Seq[Par], runtime: Runtime)(
       implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
-    val bytes = new Array[Byte](128)
-    new SecureRandom().nextBytes(bytes)
-    val rand = Blake2b512Random(bytes)
+    val rand = Blake2b512Random(128)
     eval_term(LinkedList.term, runtime)(implicitly, rand.splitShort(0))
     eval_term(TestSet.term, runtime)(implicitly, rand.splitShort(1))
 

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
@@ -58,7 +58,7 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
 
     check(propRoundTripTypeMapper)
 
-    val zeroPositionRand = Arbitrary.arbitrary[Blake2b512Random] suchThat (_.position == 0)
+    val zeroPositionRand = Arbitrary.arbitrary[Blake2b512Random] suchThat (_.getPosition == 0)
     val propNextNotSame: Prop = Prop.forAll(zeroPositionRand) { (rand: Blake2b512Random) =>
       val tm       = Blake2b512Random.typeMapper
       val randCopy = rand.copy()

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -25,9 +25,14 @@ message Par {
 
 message TaggedContinuation {
     oneof tagged_cont {
-        Par par_body = 1;
+        ParWithRandom par_body = 1;
         int64 scala_body_ref = 2;
     }
+}
+
+message ParWithRandom {
+    Par body = 1 [(scalapb.field).no_box = true];
+    bytes randomState = 2 [(scalapb.field).type = "coop.rchain.crypto.hash.Blake2b512Random"];
 }
 
 message Channel {
@@ -37,8 +42,9 @@ message Channel {
     }
 }
 
-message ListChannel {
+message ListChannelWithRandom {
     repeated Channel channels = 1;
+    bytes randomState = 2 [(scalapb.field).type = "coop.rchain.crypto.hash.Blake2b512Random"];
 }
 
 // While we use vars in both positions, when producing the normalized

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -293,5 +293,5 @@ message ConnectiveBody {
 // These should only occur as the program is being evaluated. There is no way in
 // the grammar to construct them.
 message GPrivate {
-    string id = 1;
+    bytes id = 1;
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -10,6 +10,7 @@ import coop.rchain.models.Var.VarInstance
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
 
+import com.google.protobuf.ByteString
 import scala.collection.immutable.{BitSet, Vector}
 
 object implicits {
@@ -166,8 +167,10 @@ object implicits {
   }
 
   object GPrivate {
-    def apply(): GPrivate          = new GPrivate(java.util.UUID.randomUUID.toString)
-    def apply(s: String): GPrivate = new GPrivate(s)
+    def apply(): GPrivate =
+      new GPrivate(ByteString.copyFromUtf8(java.util.UUID.randomUUID.toString))
+    def apply(s: String): GPrivate     = new GPrivate(ByteString.copyFromUtf8(s))
+    def apply(b: ByteString): GPrivate = new GPrivate(b)
   }
 
   implicit class ParExtension[T](p: T)(implicit toPar: T => Par) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -1,7 +1,6 @@
 package coop.rchain.rholang.interpreter
 
 import java.io.Reader
-import java.security.SecureRandom
 
 import cats.MonadError
 import cats.implicits._
@@ -92,9 +91,7 @@ object Interpreter {
     } yield (result)
 
   def evaluate(runtime: Runtime, normalizedTerm: Par): Task[Vector[InterpreterError]] = {
-    val bytes = new Array[Byte](128)
-    new SecureRandom().nextBytes(bytes)
-    implicit val rand = Blake2b512Random(bytes)
+    implicit val rand = Blake2b512Random(128)
     for {
       _      <- runtime.reducer.inj(normalizedTerm)
       errors <- Task.now(runtime.readAndClearErrorVector)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -163,7 +163,7 @@ case class PrettyPrinter(freeShift: Int,
               }
           } + " }"
 
-      case g: GPrivate => g.id
+      case g: GPrivate => "Unforgeable(0x" + Base16.encode(g.id.toByteArray) + ")"
       case c: Connective =>
         c.connectiveInstance match {
           case ConnectiveInstance.Empty => ""

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -7,24 +7,26 @@ import cats.mtl.FunctorTell
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
 import coop.rchain.models.Expr.ExprInstance._
+import coop.rchain.models.ListChannelWithRandom
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.rholang.sort.ordering._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.{Match, MatchCase, GPrivate => _, _}
 import coop.rchain.rholang.interpreter.Substitute._
 import coop.rchain.rholang.interpreter.errors._
-import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.Serialize
 import coop.rchain.rspace.pure.PureRSpace
 
 import scala.collection.immutable.BitSet
 import scala.util.Try
-import coop.rchain.models.rholang.sort.ordering._
 import monix.eval.Coeval
 
 // Notes: Caution, a type annotation is often needed for Env.
@@ -35,14 +37,16 @@ import monix.eval.Coeval
   */
 trait Reduce[M[_]] {
 
-  def produce(chan: Quote, data: Seq[Par], persistent: Boolean)(implicit env: Env[Par]): M[Unit]
+  def produce(chan: Quote, data: Seq[Par], persistent: Boolean)(implicit env: Env[Par],
+                                                                rand: Blake2b512Random): M[Unit]
 
   def consume(binds: Seq[(BindPattern, Quote)], body: Par, persistent: Boolean)(
-      implicit env: Env[Par]): M[Unit]
+      implicit env: Env[Par],
+      rand: Blake2b512Random): M[Unit]
 
-  def eval(par: Par)(implicit env: Env[Par]): M[Unit]
+  def eval(par: Par)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit]
 
-  def inj(par: Par): M[Unit]
+  def inj(par: Par)(implicit rand: Blake2b512Random): M[Unit]
 
   /**
     * Evaluate any top level expressions in @param Par .
@@ -58,10 +62,10 @@ object Reduce {
       tupleSpace: PureRSpace[M,
                              Channel,
                              BindPattern,
-                             Seq[Channel],
-                             Seq[Channel],
+                             ListChannelWithRandom,
+                             ListChannelWithRandom,
                              TaggedContinuation],
-      dispatcher: => Dispatch[M, Seq[Channel], TaggedContinuation])(
+      dispatcher: => Dispatch[M, ListChannelWithRandom, TaggedContinuation])(
       implicit parallel: cats.Parallel[M, F],
       fTell: FunctorTell[M, InterpreterError])
       extends Reduce[M] {
@@ -78,9 +82,10 @@ object Reduce {
       * @return  An optional continuation resulting from a match in the tuplespace.
       */
     override def produce(chan: Quote, data: Seq[Par], persistent: Boolean)(
-        implicit env: Env[Par]): M[Unit] = {
+        implicit env: Env[Par],
+        rand: Blake2b512Random): M[Unit] = {
       // TODO: Handle the environment in the store
-      def go(res: Option[(TaggedContinuation, Seq[Seq[Channel]])]) =
+      def go(res: Option[(TaggedContinuation, Seq[ListChannelWithRandom])]) =
         res match {
           case Some((continuation, dataList)) =>
             if (persistent) {
@@ -96,8 +101,10 @@ object Reduce {
       for {
         substData <- data.toList.traverse(
                       substitutePar[M].substitute(_)(0, env).map(p => Channel(Quote(p))))
-        res <- tupleSpace.produce(Channel(chan), substData, persist = persistent)
-        _   <- go(res)
+        res <- tupleSpace.produce(Channel(chan),
+                                  ListChannelWithRandom(substData, rand),
+                                  persist = persistent)
+        _ <- go(res)
       } yield ()
     }
 
@@ -113,7 +120,8 @@ object Reduce {
       *          will be @param body if the continuation is not None.
       */
     override def consume(binds: Seq[(BindPattern, Quote)], body: Par, persistent: Boolean)(
-        implicit env: Env[Par]): M[Unit] =
+        implicit env: Env[Par],
+        rand: Blake2b512Random): M[Unit] =
       binds match {
         case Nil => interpreterErrorM[M].raiseError(ReduceError("Error: empty binds"))
         case _ =>
@@ -121,7 +129,7 @@ object Reduce {
           tupleSpace
             .consume(sources.map(q => Channel(q)).toList,
                      patterns.toList,
-                     TaggedContinuation(ParBody(body)),
+                     TaggedContinuation(ParBody(ParWithRandom(body, rand))),
                      persist = persistent)
             .flatMap {
               case Some((continuation, dataList)) =>
@@ -148,56 +156,77 @@ object Reduce {
       * @param par
       * @return
       */
-    override def eval(par: Par)(implicit env: Env[Par]): M[Unit] = {
-      def handle[A](eval: (A => M[Unit]))(a: A): M[Unit] =
-        eval(a).handleError((e: InterpreterError) => {
+    override def eval(par: Par)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] = {
+      val filteredExprs = par.exprs.filter { expr =>
+        expr.exprInstance match {
+          case _: EVarBody    => true
+          case _: EEvalBody   => true
+          case _: EMethodBody => true
+          case _              => false
+        }
+      }
+      val starts = Vector(par.sends.size,
+                          par.receives.size,
+                          par.news.size,
+                          par.matches.size,
+                          par.bundles.size,
+                          filteredExprs.size)
+        .scanLeft(0)(_ + _)
+      def handle[A](eval: (A => (Env[Par], Blake2b512Random) => M[Unit]), start: Int)(
+          ta: (A, Int)): M[Unit] = {
+        val newRand =
+          if (starts(6) == 1)
+            rand
+          else if (starts(6) > 256)
+            rand.splitShort((start + ta._2).toShort)
+          else
+            rand.splitByte((start + ta._2).toByte)
+        eval(ta._1)(env, newRand).handleError((e: InterpreterError) => {
           fTell.tell(e)
         })
+      }
       List(
-        Parallel.parTraverse(par.sends.toList)(handle(eval)),
-        Parallel.parTraverse(par.receives.toList)(handle(eval)),
-        Parallel.parTraverse(par.news.toList)(handle(eval)),
-        Parallel.parTraverse(par.matches.toList)(handle(eval)),
-        Parallel.parTraverse(par.bundles.toList)(handle(eval)),
-        Parallel.parTraverse(par.exprs.filter { expr =>
-          expr.exprInstance match {
-            case _: EVarBody    => true
-            case _: EEvalBody   => true
-            case _: EMethodBody => true
-            case _              => false
-          }
-        }.toList)(expr =>
+        Parallel.parTraverse(par.sends.zipWithIndex.toList)(handle(evalExplicit, starts(0))),
+        Parallel.parTraverse(par.receives.zipWithIndex.toList)(handle(evalExplicit, starts(1))),
+        Parallel.parTraverse(par.news.zipWithIndex.toList)(handle(evalExplicit, starts(2))),
+        Parallel.parTraverse(par.matches.zipWithIndex.toList)(handle(evalExplicit, starts(3))),
+        Parallel.parTraverse(par.bundles.zipWithIndex.toList)(handle(evalExplicit, starts(4))),
+        Parallel.parTraverse(filteredExprs.zipWithIndex.toList)(texpr => {
+          val (expr, idx) = texpr
+          val newRand =
+            if (starts(6) == 1)
+              rand
+            else if (starts(6) > 256)
+              rand.splitShort((starts(5) + idx).toShort)
+            else
+              rand.splitByte((starts(5) + idx).toByte)
           expr.exprInstance match {
             case EVarBody(EVar(v)) =>
               (for {
                 varref <- eval(v.get)
-                _      <- eval(varref)
+                _      <- eval(varref)(env, newRand)
               } yield ()).handleError((e: InterpreterError) => fTell.tell(e))
             case e: EEvalBody =>
               (for {
                 p <- evalExprToPar(Expr(e))
-                _ <- eval(p)
+                _ <- eval(p)(env, newRand)
               } yield ()).handleError((e: InterpreterError) => fTell.tell(e))
             case e: EMethodBody =>
               (for {
                 p <- evalExprToPar(Expr(e))
-                _ <- eval(p)
+                _ <- eval(p)(env, newRand)
               } yield ()).handleError((e: InterpreterError) => fTell.tell(e))
             case _ => Applicative[M].pure(())
+          }
         })
       ).parSequence.map(_ => ())
     }
 
-    override def inj(par: Par): M[Unit] =
-      for { _ <- eval(par)(Env[Par]()) } yield ()
+    override def inj(par: Par)(implicit rand: Blake2b512Random): M[Unit] =
+      for { _ <- eval(par)(Env[Par](), rand) } yield ()
 
-    def debug(msg: String): Unit = {
-      val now = java.time.format.DateTimeFormatter.ISO_INSTANT
-        .format(java.time.Instant.now)
-        .substring(11, 23)
-      val thread = Thread.currentThread.getName
-      println(s"$now [$thread]" + "\n" + msg)
-    }
+    def evalExplicit(send: Send)(env: Env[Par], rand: Blake2b512Random): M[Unit] =
+      eval(send)(env, rand)
 
     /** Algorithm as follows:
       *
@@ -212,7 +241,7 @@ object Reduce {
       * @param env An execution context
       * @return
       */
-    def eval(send: Send)(implicit env: Env[Par]): M[Unit] =
+    def eval(send: Send)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
       for {
         quote <- eval(send.chan)
         data  <- send.data.toList.traverse(x => evalExpr(x))
@@ -231,7 +260,9 @@ object Reduce {
         _ <- produce(unbundled, data, send.persistent)
       } yield ()
 
-    def eval(receive: Receive)(implicit env: Env[Par]): M[Unit] =
+    def evalExplicit(receive: Receive)(env: Env[Par], rand: Blake2b512Random): M[Unit] =
+      eval(receive)(env, rand)
+    def eval(receive: Receive)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
       for {
         binds <- receive.binds.toList
                   .traverse(rb =>
@@ -241,8 +272,10 @@ object Reduce {
                                         substituteChannel[M].substitute(pattern)(1, env))
                     } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q))
         // TODO: Allow for the environment to be stored with the body in the Tuplespace
-        substBody <- substitutePar[M].substitute(receive.body.get)(0, env.shift(receive.bindCount))
-        _         <- consume(binds, substBody, receive.persistent)
+        substBody <- substitutePar[M].substituteNoSort(receive.body.get)(
+                      0,
+                      env.shift(receive.bindCount))
+        _ <- consume(binds, substBody, receive.persistent)
       } yield ()
 
     /**
@@ -302,7 +335,9 @@ object Reduce {
           interpreterErrorM[M].raiseError(ReduceError("Impossible channel instance EMPTY"))
       }
 
-    def eval(mat: Match)(implicit env: Env[Par]): M[Unit] = {
+    def evalExplicit(mat: Match)(env: Env[Par], rand: Blake2b512Random): M[Unit] =
+      eval(mat)(env, rand)
+    def eval(mat: Match)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] = {
       def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
         Range(0, freeCount).foldLeft(env)(
           (acc, e) =>
@@ -330,7 +365,7 @@ object Reduce {
                   case None => Applicative[M].pure(Left((target, caseRem)))
                   case Some(freeMap) => {
                     val newEnv: Env[Par] = addToEnv(env, freeMap, singleCase.freeCount)
-                    eval(singleCase.source.get)(newEnv).map(Right(_))
+                    eval(singleCase.source.get)(newEnv, implicitly).map(Right(_))
                   }
                 }
               }
@@ -355,14 +390,16 @@ object Reduce {
       * @param neu
       * @return
       */
-    def eval(neu: New)(implicit env: Env[Par]): M[Unit] = {
+    def evalExplicit(neu: New)(env: Env[Par], rand: Blake2b512Random): M[Unit] =
+      eval(neu)(env, rand)
+    def eval(neu: New)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] = {
       def alloc(level: Int): Env[Par] =
         (env /: (0 until level).toList) { (_env, _) =>
-          val addr: Par = GPrivate()
+          val addr: Par = GPrivate(ByteString.copyFrom(rand.next()))
           _env.put(addr)
         }
 
-      eval(neu.p.get)(alloc(neu.bindCount))
+      eval(neu.p.get)(alloc(neu.bindCount), rand)
     }
 
     private[this] def unbundleReceive(rb: ReceiveBind)(implicit env: Env[Par]): M[Quote] =
@@ -383,7 +420,9 @@ object Reduce {
                  }
       } yield unbndl
 
-    def eval(bundle: Bundle)(implicit env: Env[Par]): M[Unit] =
+    def evalExplicit(bundle: Bundle)(env: Env[Par], rand: Blake2b512Random): M[Unit] =
+      eval(bundle)(env, rand)
+    def eval(bundle: Bundle)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
       eval(bundle.body.get)
 
     def evalExprToPar(expr: Expr)(implicit env: Env[Par]): M[Par] =
@@ -806,7 +845,7 @@ object Reduce {
       }
 
     def evalSingleExpr(p: Par)(implicit env: Env[Par]): M[Expr] =
-      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty)
+      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         interpreterErrorM[M].raiseError(
           ReduceError("Error: parallel or non expression found where expression expected."))
       else
@@ -817,7 +856,7 @@ object Reduce {
         }
 
     def evalToInt(p: Par)(implicit env: Env[Par]): M[Int] =
-      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty)
+      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         interpreterErrorM[M].raiseError(
           ReduceError("Error: parallel or non expression found where expression expected."))
       else
@@ -844,7 +883,7 @@ object Reduce {
         }
 
     def evalToBool(p: Par)(implicit env: Env[Par]): M[Boolean] =
-      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty)
+      if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         interpreterErrorM[M].raiseError(
           ReduceError("Error: parallel or non expression found where expression expected."))
       else
@@ -875,7 +914,8 @@ object Reduce {
           par.receives.foldLeft(BitSet())((acc, receive) => acc | receive.locallyFree) |
           par.news.foldLeft(BitSet())((acc, newProc) => acc | newProc.locallyFree) |
           par.exprs.foldLeft(BitSet())((acc, expr) => acc | ExprLocallyFree.locallyFree(expr)) |
-          par.matches.foldLeft(BitSet())((acc, matchProc) => acc | matchProc.locallyFree)
+          par.matches.foldLeft(BitSet())((acc, matchProc) => acc | matchProc.locallyFree) |
+          par.bundles.foldLeft(BitSet())((acc, bundleProc) => acc | bundleProc.locallyFree)
       par.copy(locallyFree = resultLocallyFree)
     }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -5,7 +5,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeoutException
 
 import coop.rchain.catscontrib.Capture._
-import coop.rchain.models.{BindPattern, Channel, Par, TaggedContinuation}
+import coop.rchain.models.{BindPattern, Channel, ListChannelWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rspace.IStore
@@ -71,7 +71,7 @@ object RholangCLI {
   }
 
   private def printStorageContents(
-      store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation]): Unit = {
+      store: IStore[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation]): Unit = {
     Console.println("\nStorage Contents:")
     Console.println(StoragePrinter.prettyPrint(store))
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -3,9 +3,10 @@ package coop.rchain.rholang.interpreter
 import cats.Parallel
 import cats.mtl.FunctorTell
 import coop.rchain.catscontrib.Capture
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
-import coop.rchain.models.{BindPattern, Channel, Par, TaggedContinuation}
+import coop.rchain.models.{BindPattern, Channel, ListChannelWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, InterpreterErrorsM}
 import coop.rchain.rspace.ISpace
 import coop.rchain.rspace.pure.PureRSpace
@@ -20,23 +21,27 @@ trait Dispatch[M[_], A, K] {
 object Dispatch {
 
   // TODO: Make this function total
-  def buildEnv(dataList: Seq[Seq[Channel]]): Env[Par] =
-    Env.makeEnv(dataList.flatten.map({
-      case Channel(Quote(p)) => p
-      case Channel(_)        => Par() // Should never happen
-    }): _*)
+  def buildEnv(dataList: Seq[ListChannelWithRandom]): Env[Par] =
+    Env.makeEnv(
+      dataList
+        .flatMap(_.channels)
+        .map({
+          case Channel(Quote(p)) => p
+          case Channel(_)        => Par() // Should never happen
+        }): _*)
 }
 
 class RholangOnlyDispatcher[M[_]] private (_reducer: => Reduce[M])(implicit captureM: Capture[M])
-    extends Dispatch[M, Seq[Channel], TaggedContinuation] {
+    extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   val reducer: Reduce[M] = _reducer
 
-  def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): M[Unit] =
+  def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     continuation.taggedCont match {
-      case ParBody(par) =>
-        val env = Dispatch.buildEnv(dataList)
-        reducer.eval(par)(env)
+      case ParBody(parWithRand) =>
+        val env     = Dispatch.buildEnv(dataList)
+        val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
+        reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
       case ScalaBodyRef(_) =>
         captureM.apply(())
       case Empty =>
@@ -46,17 +51,25 @@ class RholangOnlyDispatcher[M[_]] private (_reducer: => Reduce[M])(implicit capt
 
 object RholangOnlyDispatcher {
 
-  def create[M[_], F[_]](
-      tuplespace: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation])(
+  def create[M[_], F[_]](tuplespace: ISpace[Channel,
+                                            BindPattern,
+                                            ListChannelWithRandom,
+                                            ListChannelWithRandom,
+                                            TaggedContinuation])(
       implicit
       intepreterErrorsM: InterpreterErrorsM[M],
       captureM: Capture[M],
       parallel: Parallel[M, F],
-      ft: FunctorTell[M, InterpreterError]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
-    val pureSpace
-      : PureRSpace[M, Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] =
+      ft: FunctorTell[M, InterpreterError])
+    : Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
+    val pureSpace: PureRSpace[M,
+                              Channel,
+                              BindPattern,
+                              ListChannelWithRandom,
+                              ListChannelWithRandom,
+                              TaggedContinuation] =
       new PureRSpace(tuplespace)
-    lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
+    lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangOnlyDispatcher(reducer)
     lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](pureSpace, dispatcher)
@@ -66,17 +79,18 @@ object RholangOnlyDispatcher {
 
 class RholangAndScalaDispatcher[M[_]] private (
     _reducer: => Reduce[M],
-    _dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], M[Unit]]])(
+    _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
     implicit captureM: Capture[M])
-    extends Dispatch[M, Seq[Channel], TaggedContinuation] {
+    extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   val reducer: Reduce[M] = _reducer
 
-  def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): M[Unit] =
+  def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     continuation.taggedCont match {
-      case ParBody(par) =>
-        val env = Dispatch.buildEnv(dataList)
-        reducer.eval(par)(env)
+      case ParBody(parWithRand) =>
+        val env     = Dispatch.buildEnv(dataList)
+        val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
+        reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
       case ScalaBodyRef(ref) =>
         _dispatchTable.get(ref) match {
           case Some(f) => f(dataList)
@@ -90,17 +104,26 @@ class RholangAndScalaDispatcher[M[_]] private (
 object RholangAndScalaDispatcher {
 
   def create[M[_], F[_]](
-      tuplespace: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation],
-      dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], M[Unit]]])(
+      tuplespace: ISpace[Channel,
+                         BindPattern,
+                         ListChannelWithRandom,
+                         ListChannelWithRandom,
+                         TaggedContinuation],
+      dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
       implicit
       intepreterErrorsM: InterpreterErrorsM[M],
       captureM: Capture[M],
       parallel: Parallel[M, F],
-      ft: FunctorTell[M, InterpreterError]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
-    val pureSpace
-      : PureRSpace[M, Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] =
+      ft: FunctorTell[M, InterpreterError])
+    : Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
+    val pureSpace: PureRSpace[M,
+                              Channel,
+                              BindPattern,
+                              ListChannelWithRandom,
+                              ListChannelWithRandom,
+                              TaggedContinuation] =
       new PureRSpace(tuplespace)
-    lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
+    lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangAndScalaDispatcher(reducer, dispatchTable)
     lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](pureSpace, dispatcher)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rholang.interpreter.storage
 
 import cats.implicits._
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
@@ -8,7 +9,6 @@ import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.rholang.interpreter.SpatialMatcher._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
-import scodec.bits.ByteVector
 
 //noinspection ConvertExpressionToSAM
 object implicits {
@@ -23,11 +23,12 @@ object implicits {
       }
     }
 
-  implicit val matchListQuote: StorageMatch[BindPattern, Seq[Channel], Seq[Channel]] =
-    new StorageMatch[BindPattern, Seq[Channel], Seq[Channel]] {
+  implicit val matchListQuote
+    : StorageMatch[BindPattern, ListChannelWithRandom, ListChannelWithRandom] =
+    new StorageMatch[BindPattern, ListChannelWithRandom, ListChannelWithRandom] {
 
-      def get(pattern: BindPattern, data: Seq[Channel]): Option[Seq[Channel]] =
-        foldMatch(data, pattern.patterns, pattern.remainder)
+      def get(pattern: BindPattern, data: ListChannelWithRandom): Option[ListChannelWithRandom] =
+        foldMatch(data.channels, pattern.patterns, pattern.remainder)
           .run(emptyMap)
           .map {
             case (freeMap: FreeMap, caughtRem: Seq[Channel]) =>
@@ -43,7 +44,7 @@ object implicits {
                   freeMap + (level -> VectorPar().addExprs(EList(flatRem.toVector)))
                 case _ => freeMap
               }
-              toChannels(remainderMap, pattern.freeCount)
+              ListChannelWithRandom(toChannels(remainderMap, pattern.freeCount), data.randomState)
           }
     }
 
@@ -55,15 +56,8 @@ object implicits {
   implicit val serializeChannel: Serialize[Channel] =
     mkProtobufInstance(Channel)
 
-  implicit val serializeChannels: Serialize[Seq[Channel]] =
-    new Serialize[Seq[Channel]] {
-
-      override def encode(a: Seq[Channel]): ByteVector =
-        ByteVector.view(ListChannel.toByteArray(ListChannel(a)))
-
-      override def decode(bytes: ByteVector): Either[Throwable, Seq[Channel]] =
-        Either.catchNonFatal(ListChannel.parseFrom(bytes.toArray).channels.toList)
-    }
+  implicit val serializeChannels: Serialize[ListChannelWithRandom] =
+    mkProtobufInstance(ListChannelWithRandom)
 
   implicit val serializeTaggedContinuation: Serialize[TaggedContinuation] =
     mkProtobufInstance(TaggedContinuation)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -6,7 +6,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.encryption.Curve25519
-import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
+import coop.rchain.crypto.hash.{Blake2b256, Blake2b512Random, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
 import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray, GString}
@@ -36,10 +36,12 @@ class CryptoChannelsSpec
     with TripleEqualsSupport {
   behavior of "Crypto channels"
 
-  type Store = IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation]
+  implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
+  type Store = IStore[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation]
 
-  implicit val serializeChannel: Serialize[Channel]       = storage.implicits.serializeChannel
-  implicit val serializeChannels: Serialize[Seq[Channel]] = storage.implicits.serializeChannels
+  implicit val serializeChannel: Serialize[Channel] = storage.implicits.serializeChannel
+  implicit val serializeChannels: Serialize[ListChannelWithRandom] =
+    storage.implicits.serializeChannels
 
   val serialize: Par => Array[Byte]                    = Serialize[Par].encode(_).toArray
   val byteArrayToByteString: Array[Byte] => ByteString = ba => ByteString.copyFrom(ba)
@@ -60,14 +62,14 @@ class CryptoChannelsSpec
     Await.ready(reduce.eval(consume).runAsync, 3.seconds)
   }
 
-  def assertStoreContains(store: Store)(ackChannel: GString)(data: Seq[Channel])(
+  def assertStoreContains(store: Store)(ackChannel: GString)(data: ListChannelWithRandom)(
       implicit
       serializeChannel: Serialize[Channel],
-      serializeChannels: Serialize[Seq[Channel]]): Assertion = {
+      serializeChannels: Serialize[ListChannelWithRandom]): Assertion = {
     val channel = Channel(Quote(ackChannel))
     store.toMap(List(channel)) should be(
       Row(
-        List(Datum.create[Channel, Seq[Channel]](channel, data, false)),
+        List(Datum.create[Channel, ListChannelWithRandom](channel, data, false)),
         List()
       )
     )
@@ -75,9 +77,10 @@ class CryptoChannelsSpec
 
   def hashingChannel(channelName: String,
                      hashFn: Array[Byte] => Array[Byte],
-                     fixture: FixtureParam)(implicit
-                                            serializeChannel: Serialize[Channel],
-                                            serializeChannels: Serialize[Seq[Channel]]): Any = {
+                     fixture: FixtureParam)(
+      implicit
+      serializeChannel: Serialize[Channel],
+      serializeChannels: Serialize[ListChannelWithRandom]): Any = {
     val (reduce, store) = fixture
 
     val serializeAndHash: (Array[Byte] => Array[Byte]) => Par => Array[Byte] =
@@ -89,7 +92,8 @@ class CryptoChannelsSpec
     val ackChannel        = GString("x")
     implicit val emptyEnv = Env[Par]()
 
-    val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel)(_)
+    val storeContainsTest: ListChannelWithRandom => Assertion =
+      assertStoreContains(store)(ackChannel)(_)
 
     forAll { (par: Par) =>
       val byteArrayToSend = Expr(GByteArray(par.toByteString))
@@ -101,7 +105,7 @@ class CryptoChannelsSpec
       // 2. hash input array
       // 3. send result on supplied ack channel
       Await.result(reduce.eval(send).runAsync, 3.seconds)
-      storeContainsTest(List[Channel](Quote(expected)))
+      storeContainsTest(ListChannelWithRandom(Seq(Quote(expected)), rand))
       clearStore(store, reduce, ackChannel)
     }
   }
@@ -135,9 +139,10 @@ class CryptoChannelsSpec
         "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6")
       val secKey = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
 
-      val ackChannel                                    = GString("x")
-      implicit val emptyEnv                             = Env[Par]()
-      val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel) _
+      val ackChannel        = GString("x")
+      implicit val emptyEnv = Env[Par]()
+      val storeContainsTest: ListChannelWithRandom => Assertion =
+        assertStoreContains(store)(ackChannel) _
 
       forAll { (par: Par) =>
         val parByteArray: Array[Byte] = Keccak256.hash(serialize(par))
@@ -156,7 +161,7 @@ class CryptoChannelsSpec
                         persistent = false,
                         BitSet())
         Await.result(reduce.eval(send).runAsync, 3.seconds)
-        storeContainsTest(List[Channel](Quote(Expr(GBool(true)))))
+        storeContainsTest(ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand))
         clearStore(store, reduce, ackChannel)
       }
   }
@@ -165,12 +170,15 @@ class CryptoChannelsSpec
     fixture =>
       val (reduce, store) = fixture
 
+      implicit val rand = Blake2b512Random(Array.empty[Byte])
+
       val ed25519VerifyChannel = Quote(GString("ed25519Verify"))
       val (secKey, pubKey)     = Ed25519.newKeyPair
 
-      val ackChannel                                    = GString("x")
-      implicit val emptyEnv                             = Env[Par]()
-      val storeContainsTest: List[Channel] => Assertion = assertStoreContains(store)(ackChannel) _
+      val ackChannel        = GString("x")
+      implicit val emptyEnv = Env[Par]()
+      val storeContainsTest: ListChannelWithRandom => Assertion =
+        assertStoreContains(store)(ackChannel) _
 
       forAll { (par: Par) =>
         val parByteArray: Array[Byte] = serialize(par)
@@ -189,7 +197,7 @@ class CryptoChannelsSpec
                         persistent = false,
                         BitSet())
         Await.result(reduce.eval(send).runAsync, 3.seconds)
-        storeContainsTest(List[Channel](Quote(Expr(GBool(true)))))
+        storeContainsTest(ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand))
         clearStore(store, reduce, ackChannel)
       }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -99,7 +99,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       ids = Seq(GPrivate("4"), GPrivate("5"))
     )
     val result = PrettyPrinter().buildString(source)
-    val target = "0 | true | \"2\" | `www.3cheese.com` | 4 | 5"
+    val target = "0 | true | \"2\" | `www.3cheese.com` | Unforgeable(0x34) | Unforgeable(0x35)"
     result shouldBe target
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -6,6 +6,7 @@ import cats.mtl.FunctorTell
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.Capture._
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance._
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
@@ -30,14 +31,12 @@ import scala.concurrent.{Await, ExecutionException}
 
 trait PersistentStoreTester {
   def withTestSpace[R](
-      f: ISpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation] => R): R = {
+      f: ISpace[Channel, BindPattern, ListChannelWithRandom, ListChannelWithRandom, TaggedContinuation] => R): R = {
     val dbDir = Files.createTempDirectory("rchain-storage-test-")
-    val store: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation] =
-      LMDBStore.create[Channel, BindPattern, Seq[Channel], TaggedContinuation](dbDir,
+    val store: IStore[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation] =
+      LMDBStore.create[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation](dbDir,
                                                                                1024 * 1024 * 1024)
-    val space = new RSpace[Channel, BindPattern, Seq[Channel], Seq[Channel], TaggedContinuation](
-      store,
-      Branch("test"))
+    val space = new RSpace[Channel, BindPattern, ListChannelWithRandom, ListChannelWithRandom, TaggedContinuation](store, Branch("test"))
     try {
       f(space)
     } finally {
@@ -47,6 +46,8 @@ trait PersistentStoreTester {
 }
 
 class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
+  implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
+
   "evalExpr" should "handle simple addition" in {
     implicit val errorLog = new Runtime.ErrorLog()
     val result = withTestSpace { space =>
@@ -107,13 +108,14 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Bundle" should "evaluate contents of bundle" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val bundleSend =
         Bundle(Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet()))
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(bundleSend)
+      val resultTask   = interpreter.eval(bundleSend)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -128,7 +130,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           Row(
             List(
               Datum.create(channel,
-                           Seq[Channel](Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))),
+                           ListChannelWithRandom(Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))), splitRand),
                            false)),
             List()
           )
@@ -174,13 +176,14 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send" should "place something in the tuplespace." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val send =
         Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(send)
+      val resultTask   = interpreter.eval(send)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -195,7 +198,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           Row(
             List(
               Datum.create(channel,
-                           Seq[Channel](Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))),
+                           ListChannelWithRandom(Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))), splitRand),
                            false)),
             List()
           )
@@ -205,6 +208,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "verify that Bundle is writeable before sending on Bundle " in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     /* @bundle+ { x } !(7) -> x!(7)
      */
     val x = GString("channel")
@@ -214,20 +218,21 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
-      val task         = reducer.eval(send).map(_ => space.store.toMap)
+      val task         = reducer.eval(send)(env, splitRand).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
 
     val channel = Channel(Quote(x))
 
     result should be(
-      HashMap(List(channel) -> Row(List(Datum.create(channel, Seq[Channel](Quote(GInt(7))), false)),
+      HashMap(List(channel) -> Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GInt(7))), splitRand), false)),
                                    List())))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
   "eval of single channel Receive" should "place something in the tuplespace." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val receive =
         Receive(Seq(
@@ -240,7 +245,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(receive)
+      val resultTask   = interpreter.eval(receive)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -263,7 +268,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                                      Channel(ChanVar(FreeVar(1))),
                                      Channel(ChanVar(FreeVar(2)))),
                                 None)),
-                  TaggedContinuation(ParBody(Par())),
+                  TaggedContinuation(ParBody(ParWithRandom(Par(), splitRand))),
                   false
                 )
             )
@@ -274,6 +279,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "verify that bundle is readable if receiving on Bundle" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(1)
     /* for (@Nil <- @bundle- { y } ) { }  -> for (n <- y) { }
      */
 
@@ -288,7 +294,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
-      val task         = reducer.eval(receive).map(_ => space.store.toMap)
+      val task         = reducer.eval(receive)(env, splitRand).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
 
@@ -303,7 +309,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               WaitingContinuation.create[Channel, BindPattern, TaggedContinuation](
                 channels,
                 List(BindPattern(List(Channel(Quote(Par()))), None)),
-                TaggedContinuation(ParBody(Par())),
+                TaggedContinuation(ParBody(ParWithRandom(Par(), splitRand))),
                 false))
           )
       ))
@@ -312,6 +318,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send | Receive" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand0 = rand.splitByte(0)
+    val splitRand1 = rand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val send =
       Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive = Receive(
@@ -328,8 +337,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)
-        _ <- reducer.eval(receive)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -339,7 +348,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -348,8 +357,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -357,7 +366,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -366,6 +375,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   "eval of Send | Receive" should "when whole list is bound to list remainder, meet in the tuplespace and proceed. (RHOL-422)" in {
     // for(@[...a] <- @"channel") { … } | @"channel"!([7,8,9])
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand0 = rand.splitByte(0)
+    val splitRand1 = rand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     // format: off
     val send =
       Send(Quote(GString("channel")), List(Par(exprs = Seq(Expr(EListBody(EList(Seq(GInt(7), GInt(8), GInt(9)))))))), false, BitSet())
@@ -384,8 +396,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)
-        _ <- reducer.eval(receive)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -395,7 +407,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -404,8 +416,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -413,7 +425,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -421,6 +433,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send on (7 + 8) | Receive on 15" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand0 = rand.splitByte(0)
+    val splitRand1 = rand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val send =
       Send(Quote(EPlus(GInt(7), GInt(8))), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive = Receive(
@@ -438,8 +453,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)
-        _ <- reducer.eval(receive)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -449,7 +464,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -458,15 +473,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -474,6 +489,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send of Receive | Receive" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val baseRand = rand.splitByte(2)
+    val splitRand0 = baseRand.splitByte(0)
+    val splitRand1 = baseRand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val simpleReceive = Receive(
       Seq(ReceiveBind(Seq(Quote(GInt(2))), Quote(GInt(2)))),
       Par(),
@@ -496,14 +515,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val interpreter  = reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- interpreter.eval(send)
-        _ <- interpreter.eval(receive)
+        _ <- interpreter.eval(send)(env, splitRand0)
+        _ <- interpreter.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
 
     val channels = List(Channel(Quote(GInt(2))))
 
+    // Because they are evaluated separately, nothing is split.
     sendFirstResult should be(
       HashMap(
         channels ->
@@ -513,7 +533,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               WaitingContinuation.create[Channel, BindPattern, TaggedContinuation](
                 channels,
                 List(BindPattern(List(Quote(GInt(2))))),
-                TaggedContinuation(ParBody(Par())),
+                TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
                 false)
             )
           )
@@ -525,8 +545,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -539,7 +559,31 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               WaitingContinuation.create[Channel, BindPattern, TaggedContinuation](
                 channels,
                 List(BindPattern(List(Quote(GInt(2))))),
-                TaggedContinuation(ParBody(Par())),
+                TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
+                false))
+          )
+      )
+    )
+    errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
+
+    val bothResult = withTestSpace { space =>
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      implicit val env = Env[Par]()
+      val inspectTaskReceiveFirst = for {
+        _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env, baseRand)
+      } yield space.store.toMap
+      Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+    }
+    bothResult should be(
+      HashMap(
+        channels ->
+          Row(
+            List(),
+            List(
+              WaitingContinuation.create[Channel, BindPattern, TaggedContinuation](
+                channels,
+                List(BindPattern(List(Quote(GInt(2))))),
+                TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
                 false))
           )
       )
@@ -549,6 +593,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Simple match" should "capture and add to the environment." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val pattern = Send(ChanVar(FreeVar(0)), List(GInt(7), EVar(FreeVar(1))), false, BitSet())
         .withConnectiveUsed(true)
@@ -569,7 +614,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       )
       implicit val env = Env.makeEnv[Par](GPrivate("one"), GPrivate("zero"))
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
-      val matchTask    = reducer.eval(matchTerm)
+      val matchTask    = reducer.eval(matchTerm)(env, splitRand)
       val inspectTask = for {
         _ <- matchTask
       } yield space.store.toMap
@@ -584,7 +629,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           Row(
             List(
               Datum.create(channel,
-                           Seq[Channel](Quote(GPrivate("one")), Quote(GPrivate("zero"))),
+                           ListChannelWithRandom(Seq(Quote(GPrivate("one")), Quote(GPrivate("zero"))), splitRand),
                            false)),
             List()
           )
@@ -595,6 +640,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send | Send | Receive join" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand0 = rand.splitByte(0)
+    val splitRand1 = rand.splitByte(1)
+    val splitRand2 = rand.splitByte(2)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand2, splitRand0, splitRand1))
     val send1 =
       Send(Quote(GString("channel1")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val send2 =
@@ -617,9 +666,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send1)
-        _ <- reducer.eval(send2)
-        _ <- reducer.eval(receive)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(send2)(env, splitRand1)
+        _ <- reducer.eval(receive)(env, splitRand2)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -629,7 +678,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -638,16 +687,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send1)
-        _ <- reducer.eval(send2)
+        _ <- reducer.eval(receive)(env, splitRand2)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(send2)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -656,16 +705,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val inspectTaskInterleaved = for {
-        _ <- reducer.eval(send1)
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send2)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand2)
+        _ <- reducer.eval(send2)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskInterleaved.runAsync, 3.seconds)
     }
     interleavedResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -673,6 +722,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send with remainder receive" should "capture the remainder." in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand0 = rand.splitByte(0)
+    val splitRand1 = rand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val send =
       Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive =
@@ -683,8 +735,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
       val task = for {
-        _ <- reducer.eval(receive)
-        _ <- reducer.eval(send)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(task.runAsync, 3.seconds)
     }
@@ -696,7 +748,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List(channel) ->
           Row(List(
                 Datum.create(channel,
-                             Seq[Channel](Quote(EList(List(GInt(7), GInt(8), GInt(9))))),
+                             ListChannelWithRandom(Seq(Quote(EList(List(GInt(7), GInt(8), GInt(9))))), mergeRand),
                              false)),
               List())
       )
@@ -706,6 +758,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of nth method" should "pick out the nth item from a list" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val nthCall: Expr =
       EMethod("nth", EList(List(GInt(7), GInt(8), GInt(9), GInt(10))), List[Par](GInt(2)))
     val directResult: Par = withTestSpace { space =>
@@ -728,7 +781,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val indirectResult = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
-      val nthTask      = reducer.eval(nthCallEvalToSend)
+      val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand)
       val inspectTask = for {
         _ <- nthTask
       } yield space.store.toMap
@@ -740,7 +793,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     indirectResult should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("Success"))), false)), List())
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("Success"))), splitRand), false)), List())
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -748,6 +801,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of nth method in send position" should "change what is sent" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val nthCallEvalToSend: Expr =
       EMethod("nth",
               EList(
@@ -761,7 +815,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       implicit val env = Env[Par]()
-      val nthTask      = reducer.eval(send)
+      val nthTask      = reducer.eval(send)(env, splitRand)
       val inspectTask = for {
         _ <- nthTask
       } yield space.store.toMap
@@ -777,8 +831,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             List(
               Datum.create(
                 channel,
-                Seq[Channel](
-                  Quote(Send(Quote(GString("result")), List(GString("Success")), false, BitSet()))),
+                ListChannelWithRandom(Seq(
+                  Quote(Send(Quote(GString("result")), List(GString("Success")), false, BitSet()))), splitRand),
                 false)),
             List())
       )
@@ -788,6 +842,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of `toByteArray` method on any process" should "return that process serialized" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     import coop.rchain.models.serialization.implicits._
     val proc = Receive(Seq(ReceiveBind(Seq(ChanVar(FreeVar(0))), Quote(GString("channel")))),
                        Par(),
@@ -801,7 +856,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val env         = Env[Par]()
-      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env)
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -813,7 +868,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List(channel) ->
           Row(List(
                 Datum.create(channel,
-                             Seq[Channel](Quote(Expr(GByteArray(serializedProcess)))),
+                             ListChannelWithRandom(Seq(Quote(Expr(GByteArray(serializedProcess)))), splitRand),
                              persist = false)),
               List())
       )
@@ -846,6 +901,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
     import coop.rchain.models.serialization.implicits._
     implicit val errorLog         = new Runtime.ErrorLog()
+    val splitRand = rand.splitByte(0)
     val testString                = "testing testing"
     val base16Repr                = Base16.encode(testString.getBytes)
     val proc: Par                 = GString(base16Repr)
@@ -854,7 +910,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val env         = Env[Par]()
-      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env)
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -867,7 +923,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List(channel) ->
           Row(List(
                 Datum.create(channel,
-                  Seq[Channel](Quote(Expr(GByteArray(ByteString.copyFrom(testString.getBytes))))),
+                  ListChannelWithRandom(Seq(Quote(Expr(GByteArray(ByteString.copyFrom(testString.getBytes))))), splitRand),
                   persist = false)),
               List())
       )
@@ -878,7 +934,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "variable references" should "be substituted before being used." in {
     implicit val errorLog = new Runtime.ErrorLog()
-
+    val splitRandResult = rand.splitByte(3)
+    val splitRandSrc = rand.splitByte(3)
+    splitRandResult.next()
+    val mergeRand = Blake2b512Random.merge(Seq(splitRandResult.splitByte(1), splitRandResult.splitByte(0)))
     val proc = New(
       bindCount = 1,
       p = Par(
@@ -902,7 +961,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new Runtime.ErrorLog()
       val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val env               = Env[Par]()
-      val task              = reducer.eval(proc)(env)
+      val task              = reducer.eval(proc)(env, splitRandSrc)
       val inspectTask       = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -912,7 +971,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("true"))), persist = false)),
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand), persist = false)),
               List())
       )
     )
@@ -922,7 +981,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "be substituted before being used in a match." in {
     implicit val errorLog = new Runtime.ErrorLog()
-
+    val splitRandResult = rand.splitByte(4)
+    val splitRandSrc = rand.splitByte(4)
+    splitRandResult.next()
     val proc = New(
       bindCount = 1,
       p = Match(
@@ -937,7 +998,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new Runtime.ErrorLog()
       val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val env               = Env[Par]()
-      val task              = reducer.eval(proc)(env)
+      val task              = reducer.eval(proc)(env, splitRandSrc)
       val inspectTask       = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -947,7 +1008,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("true"))), persist = false)),
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("true"))), splitRandResult), persist = false)),
               List())
       )
     )
@@ -957,6 +1018,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "reference a variable that comes from a match in tuplespace" in {
     implicit val errorLog = new Runtime.ErrorLog()
+    val baseRand = rand.splitByte(7)
+    val splitRand0 = baseRand.splitByte(0)
+    val splitRand1 = baseRand.splitByte(1)
+    val mergeRand = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val proc = Par(
       sends = List(Send(chan = Quote(GInt(7)), data = List(GInt(10)))),
       receives = List(
@@ -983,7 +1048,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new Runtime.ErrorLog()
       val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
       val env               = Env[Par]()
-      val task              = reducer.eval(proc)(env)
+      val task              = reducer.eval(proc)(env, baseRand)
       val inspectTask       = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -993,7 +1058,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(Datum.create(channel, Seq[Channel](Quote(GString("true"))), persist = false)),
+          Row(List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand), persist = false)),
               List())
       )
     )


### PR DESCRIPTION
## Overview
Adds deterministic unforgeable names by using a splittable, mergeable, random number generator.
We take advantage of the sort order on pars to deterministically split the random number generator.
We use the merging so that we can get unique names even on replicated for's without worrying about sequencing.
