### PR TITLE
OPS-160 change how sbt is installed due to Travis-CI apt key issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ matrix:
     scala: 2.12.4
     sbt_args: -no-colors
     install:
+      - ./scripts/install_sbt.sh
       - ./scripts/install_sodium.sh
       - ./scripts/install.sh
     addons:
       apt:
-        sources:
-          - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
         packages:
-          - sbt
           - jflex
           - haskell-platform
           - rpm

--- a/scripts/install_sbt.sh
+++ b/scripts/install_sbt.sh
@@ -1,0 +1,4 @@
+echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+sudo apt-get update
+sudo apt-get -yq install sbt


### PR DESCRIPTION
## Overview
Removed sourceline sbt install and changed sbt to be installed by script due to Travis-CI apt key issues causing sbt install errors. We might change back when Travis gets it worked out. This is perfectly fine solution as well. a few more lines.


### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/OPS-160

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
