### PR TITLE
Add parens to disambiguate call to `position`

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
@@ -107,7 +107,7 @@ class Blake2b512Random private (private val digest: Blake2b512Block,
     }
 
   override def hashCode(): Int =
-    ((digest.hashCode * 31 + pathView.position) * 31 + position) * 31 + lastBlock.hashCode
+    ((digest.hashCode * 31 + pathView.position()) * 31 + position) * 31 + lastBlock.hashCode
 }
 
 object Blake2b512Random {
@@ -215,7 +215,7 @@ object Blake2b512Random {
     result.order(ByteOrder.LITTLE_ENDIAN).asLongBuffer().put(rand.countView.asReadOnlyBuffer())
     result.position(16)
     Blake2b512Block.fillByteBuffer(rand.digest, result)
-    result.put(rand.pathView.position.toByte)
+    result.put(rand.pathView.position().toByte)
     result.put(rand.position.toByte)
     val pathCopy = rand.pathView.duplicate
     pathCopy.flip()
@@ -258,7 +258,7 @@ object Blake2b512Random {
     val rotPosition = ((rand.position - 1) & 0x3f) + 1
     s"digest: ${Blake2b512Block.debugStr(rand.digest)}\n" +
       s"lastBlock: ${rand.lastBlock.array().mkString(", ")}\n" +
-      s"pathPosition: ${rand.pathView.position}\n" +
+      s"pathPosition: ${rand.pathView.position()}\n" +
       s"position: ${rand.position}\n" +
       s"rotPosition: ${rotPosition}\n" +
       s"remainder: ${rand.hashArray.slice(rotPosition, 64).mkString(", ")}\n"


### PR DESCRIPTION
## Overview
On Java 9, the `position` method of ByteBuffer moved to its superclass `Buffer`.  Travis uses Java 8.  I was using Java 10.  Adding parens disambiguates; this was already being done on line 213 of Blake2b512Random; this PR adds parens in three other places.

### Does this PR relate to an RChain JIRA issue? 
No.
