### PR TITLE
Rosette object code export/import additions and  bug fixes

### DIFF
--- a/rosette/h/Code.h
+++ b/rosette/h/Code.h
@@ -33,9 +33,9 @@ class CodeBuf : public Ob {
     STD_DECLS(CodeBuf);
 
    protected:
-    void deposit(Instr);
 
    public:
+    void deposit(Instr);
     void growCodevec(int = DefaultCodeVecSize);
     CodeBuf();
 

--- a/rosette/h/Pattern.h
+++ b/rosette/h/Pattern.h
@@ -120,10 +120,9 @@ class IdAmperRestPattern : public CompoundPattern {
 class ComplexPattern : public CompoundPattern {
     STD_DECLS(ComplexPattern);
 
-   protected:
-    ComplexPattern(TupleExpr*, Tuple*, Tuple*);
 
    public:
+    ComplexPattern(TupleExpr*, Tuple*, Tuple*);
     Tuple* patvec;
     Tuple* offsetvec;
 

--- a/rosette/h/Table.h
+++ b/rosette/h/Table.h
@@ -85,6 +85,7 @@ class RblTable : public BinaryOb {
 
     static RblTable* create(RblTableHitFn, int = DefaultTableSize);
     static RblTable* create(int = DefaultTableSize);
+    static RblTable* create(Tuple*);
 
     virtual int traversePtrs(PSOb__PSOb);
     virtual int traversePtrs(SI__PSOb);

--- a/rosette/src/Table.cc
+++ b/rosette/src/Table.cc
@@ -66,6 +66,11 @@ RblTable* RblTable::create(int max) {
     return new (loc) RblTable(max, tmp);
 }
 
+RblTable* RblTable::create(Tuple * tup) {
+    void* loc = PALLOC1(sizeof(RblTable), tup);
+    return new (loc) RblTable(SIZE(tup), tup);
+}
+
 RblTable::RblTable(int max, Tuple* tbl, RblTableHitFn rtabhfn)
     : BinaryOb(sizeof(RblTable), CLASS_META(RblTable), CLASS_SBO(RblTable)),
       maxEntries(max),

--- a/rosette/src/protobuf/Ob.proto
+++ b/rosette/src/protobuf/Ob.proto
@@ -23,7 +23,7 @@ message CodeBlock {
 // This message contains the actual executable opCodes
 message CodeVec {
     // Opcodes are serialized in binary
-    bytes opcodes = 1;
+    repeated uint32 opcodes = 1;
 }
 
 message LitVec {
@@ -272,6 +272,7 @@ message Tuple {
 }
 message TupleExpr {
     Object rest = 1;
+    repeated Object elements = 2;
 }
 
 // The OT_ prefix avoids conflicts with various Rosette #define macros


### PR DESCRIPTION
## Overview
    Flesh out TupleExpr
    Fixed StdExtension
    Export opcodes as Instr instead of flat binary
    Added comments
    Fixed handling of referenced Code objects
    Fixed ExpandedLocation
    Fixed Tuple
    Added missing "break" statements in createRosetteObject() big switch statement. (Grr rookie mistake...)
    Flesh out ComplexPattern
    Flesh out StdMeta
    Flesh out IdVecPattern
    Flesh out IdAmprRestPattern
    Flesh out RblTable
    Added a new RblTable::create(Tuple *) method
    Temporarily commented out code to show built Code objects until execution is in place.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/ROS-437

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
