### PR TITLE
Add macOS installer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,6 +165,7 @@ lazy val node = (project in file("node"))
          .map { case (f, p) => f -> s"$base/$p" }
      },
     /* Packaging */
+    mappings in packageZipTarball in Universal += baseDirectory.value / "macos_install.sh" -> "macos_install.sh",
     linuxPackageMappings ++= {
       val file = baseDirectory.value / "rnode.service"
       val rholangExamples = directory((baseDirectory in rholang).value / "examples")

--- a/node/macos_install.sh
+++ b/node/macos_install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Check if Homebrew is installed, install if we don't have it, update if we do
+homebrew() {
+  if [[ $(command -v brew) == "" ]]; then
+    echo "Installing Homebrew.. "
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  else
+    echo "Updating Homebrew.. "
+    brew update
+  fi
+}
+
+
+# RUN
+homebrew
+brew install libsodium


### PR DESCRIPTION
## Overview
Add macOS installer. The installer checks if Homebrew is installed and if not instals it. Then it's using Homebrew to install the libsodium library.

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/browse/CORE-798

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Command Line Tools (CLT) for Xcode must be installed on the system