### PR TITLE
CORE-793 rNode port defaults need to be a contiguous range of port numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Invoking the above Docker image is simple enough (exit with `C-c`):
 08:30:32.647 [main] INFO  org.http4s.server.blaze.BlazeBuilder - http4s v0.18.0 on blaze v0.12.11 started at http://127.0.0.1:8080/
 08:30:32.710 [kamon.prometheus.PrometheusReporter] INFO  kamon.prometheus.PrometheusReporter - Started the embedded HTTP server on http://0.0.0.0:9095
 08:30:32.799 [main] INFO  logger - gRPC server started, listening on
-08:30:32.827 [main] INFO  logger - Listening for traffic on rnode://3afa77d09eb24a6caa25c0cb6a3e969f@172.17.0.2:30304.
+08:30:32.827 [main] INFO  logger - Listening for traffic on rnode://3afa77d09eb24a6caa25c0cb6a3e969f@172.17.0.2:30300.
 08:30:32.841 [main] INFO  logger - Bootstrapping from #{PeerNode acd0b05a971c243817a0cfd469f5d1a238c60294}.
 08:30:32.857 [main] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode acd0b05a971c243817a0cfd469f5d1a238c60294}
 [...]
@@ -227,13 +227,13 @@ In a new terminal:
 08:38:11.298 [main] INFO  org.http4s.server.blaze.BlazeBuilder - http4s v0.18.0 on blaze v0.12.11 started at http://127.0.0.1:8080/
 08:38:11.358 [kamon.prometheus.PrometheusReporter] INFO  kamon.prometheus.PrometheusReporter - Started the embedded HTTP server on http://0.0.0.0:9095
 08:38:11.436 [main] INFO  logger - gRPC server started, listening on
-08:38:11.460 [main] INFO  logger - Listening for traffic on rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30304.
+08:38:11.460 [main] INFO  logger - Listening for traffic on rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30300.
 08:38:11.463 [main] INFO  logger - Starting stand-alone node.
 ```
 
 Note this line (listening address):
 ```bash
-Listening for traffic on rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30304.
+Listening for traffic on rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30300.
 ```
 
 A repl instance can be invoked this way:
@@ -260,7 +260,7 @@ Evaluating:
 
 A peer node can be started with the following command (note that `--bootstrap` takes the listening address of `rnode0`):
 ```bash
-> docker run -v $HOME/tmp:/var/lib/rnode -it --name rnode-client --network rnode-net coop.rchain/rnode:latest --bootstrap rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30304
+> docker run -v $HOME/tmp:/var/lib/rnode -it --name rnode-client --network rnode-net coop.rchain/rnode:latest --bootstrap rnode://ee00a5357f2f4cb58b08a8a4c949da1b@172.18.0.2:30300
 08:58:34.595 [main] INFO  conf - uPnP: None -> None
 08:58:36.053 [main] INFO  o.h.b.c.nio1.NIO1SocketServerGroup - Service bound to address /127.0.0.1:8080
 08:58:36.054 [main] INFO  org.http4s.server.blaze.BlazeBuilder -   _   _   _        _ _
@@ -271,7 +271,7 @@ A peer node can be started with the following command (note that `--bootstrap` t
 08:58:36.098 [main] INFO  org.http4s.server.blaze.BlazeBuilder - http4s v0.18.0 on blaze v0.12.11 started at http://127.0.0.1:8080/
 08:58:36.139 [kamon.prometheus.PrometheusReporter] INFO  kamon.prometheus.PrometheusReporter - Started the embedded HTTP server on http://0.0.0.0:9095
 08:58:36.241 [main] INFO  logger - gRPC server started, listening on
-08:58:36.267 [main] INFO  logger - Listening for traffic on rnode://29d77e8cfd924db49e715d4cf4eeb28d@172.18.0.4:30304.
+08:58:36.267 [main] INFO  logger - Listening for traffic on rnode://29d77e8cfd924db49e715d4cf4eeb28d@172.18.0.4:30300.
 08:58:36.279 [main] INFO  logger - Bootstrapping from #{PeerNode ee00a5357f2f4cb58b08a8a4c949da1b}.
 08:58:36.294 [main] INFO  logger - Initialize first phase handshake (encryption handshake) to #{PeerNode ee00a5357f2f4cb58b08a8a4c949da1b}
 08:58:36.816 [repl-io-29] INFO  logger - Initialize second phase handshake (protocol handshake) to #{PeerNode ee00a5357f2f4cb58b08a8a4c949da1b}

--- a/docker/node/docker-compose.yml
+++ b/docker/node/docker-compose.yml
@@ -17,8 +17,7 @@ services:
     volumes: 
       - rnode_data_storage:/var/lib/rnode
     ports:
-      - 9095:9095
-      - 30304:30304
+      - 30300:30330
     networks:
       - rchain 
   prometheus-pushgateway:

--- a/node/README.md
+++ b/node/README.md
@@ -172,7 +172,7 @@ $ docker run -ti rchain/rnode
 17:12:22.852 [main] INFO org.http4s.server.blaze.BlazeBuilder -  |_||_\__|\__| .__/ |_|/__/
 17:12:22.852 [main] INFO org.http4s.server.blaze.BlazeBuilder -              |_|
 17:12:22.889 [main] INFO org.http4s.server.blaze.BlazeBuilder - http4s v0.18.0 on blaze v0.12.11 started at http://127.0.0.1:8080/
-17:12:22.963 [main] INFO main - Listening for traffic on rnode://6403d6e9f0874d31940a654f3f52a830@192.168.1.123:30304.
+17:12:22.963 [main] INFO main - Listening for traffic on rnode://6403d6e9f0874d31940a654f3f52a830@192.168.1.123:30300.
 17:12:22.970 [main] INFO main - Bootstrapping from #{PeerNode 0f365f1016a54747b384b386b8e85352}.
 17:12:22.975 [main] DEBUG main - Connecting to #{PeerNode 0f365f1016a54747b384b386b8e85352}
 (...)
@@ -203,7 +203,7 @@ $ java -jar ./node/target/scala-2.12/rnode-assembly-0.1.3.jar
 17:12:22.852 [main] INFO org.http4s.server.blaze.BlazeBuilder -  |_||_\__|\__| .__/ |_|/__/
 17:12:22.852 [main] INFO org.http4s.server.blaze.BlazeBuilder -              |_|
 17:12:22.889 [main] INFO org.http4s.server.blaze.BlazeBuilder - http4s v0.18.0 on blaze v0.12.11 started at http://127.0.0.1:8080/
-17:12:22.963 [main] INFO main - Listening for traffic on rnode://6403d6e9f0874d31940a654f3f52a830@192.168.1.123:30304.
+17:12:22.963 [main] INFO main - Listening for traffic on rnode://6403d6e9f0874d31940a654f3f52a830@192.168.1.123:30300.
 17:12:22.970 [main] INFO main - Bootstrapping from #{PeerNode 0f365f1016a54747b384b386b8e85352}.
 17:12:22.975 [main] DEBUG main - Connecting to #{PeerNode 0f365f1016a54747b384b386b8e85352}
 (...)
@@ -248,10 +248,10 @@ This command will run the node in interpreter mode and will make a directory on 
 The system attempts to find a gateway device with Universal Plug-and-Play enabled. If that fails, the system tries to guess a good IP address and a reasonable UDP port that other nodes can use to communicate with this one. If it does not guess a usable pair, they may be specified on the command line using the `--host` and `--port` options:
 
 ```
---host 1.2.3.4 --port 30304
+--host 1.2.3.4 --port 30300
 ```
 
-By default it uses UDP port 30304. This is also how more than one node may be run on a single machine: just pick different
+By default it uses UDP port 30300. This is also how more than one node may be run on a single machine: just pick different
 ports. Remember that if using Docker, ports may have to be properly mapped and forwarded. For example, if we want to connect on the test net on UDP port 12345 and our machine's public IP address is 1.2.3.4, we could do it like so:
 
 ```

--- a/node/src/main/scala/coop/rchain/node/conf.scala
+++ b/node/src/main/scala/coop/rchain/node/conf.scala
@@ -32,7 +32,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
     .map(Profile.profiles.getOrElse(_, Profile.default))
 
   val grpcPort =
-    opt[Int](default = Some(50000), descr = "Port used for gRPC API.")
+    opt[Int](default = Some(30301), descr = "Port used for gRPC API.")
 
   val grpcHost =
     opt[String](default = Some("localhost"),
@@ -64,14 +64,14 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
                   "Path to node's private key PEM file, that is being used for TLS communication")
 
     val port =
-      opt[Int](default = Some(30304), short = 'p', descr = "Network port to use.")
+      opt[Int](default = Some(30300), short = 'p', descr = "Network port to use.")
 
     val httpPort =
-      opt[Int](default = Some(8080),
+      opt[Int](default = Some(30302),
                descr = "HTTP port (deprecated - all API features will be ported to gRPC API).")
 
     val metricsPort =
-      opt[Int](default = Some(9095), descr = "Port used by metrics API.")
+      opt[Int](default = Some(30303), descr = "Port used by metrics API.")
 
     val numValidators = opt[Int](default = Some(5), descr = "Number of validators at genesis.")
     val bondsFile = opt[String](
@@ -98,7 +98,7 @@ final case class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 
     val bootstrap =
       opt[String](default =
-                    Some("rnode://acd0b05a971c243817a0cfd469f5d1a238c60294@52.119.8.109:30304"),
+                    Some("rnode://acd0b05a971c243817a0cfd469f5d1a238c60294@52.119.8.109:30300"),
                   short = 'b',
                   descr = "Bootstrap rnode address for initial seed.")
 


### PR DESCRIPTION
## Overview
rNode port defaults need to be a contiguous range of port numbers

### Does this PR relate to an RChain JIRA issue? 
CORE-793

@jeremybusk please not potential places where change is still needed for integration tests:

`scripts/p2p-test-tool.py`
```
parser.add_argument("--bootstrap-command",
                    dest='bootstrap_command',
                    type=str,
                    default="run --port 30304 --standalone",
                    help="bootstrap container run command")
```

```
parser.add_argument("--peer-command",
                    dest='peer_command',
                    type=str,
                    default="run --bootstrap rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.rchain.coop:30304",
                    help="peer container run command")
```


`scripts/cloud-p2p-test-network.sh`
```
    if [[ $i == 1 ]]; then
      rnode_cmd="rnode --port 30304 --standalone --name 0f365f1016a54747b384b386b8e85352 > /var/log/rnode.log 2>&1 &"
    else
      rnode_cmd="rnode --bootstrap rnode://0f365f1016a54747b384b386b8e85352@10.1.1.2:30304 > /var/log/rnode.log 2>&1 &"
    fi
```