### PR TITLE
[RHOL-NOTICKET]: Extract interaction with tuplespace in Reducer.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -1,14 +1,13 @@
 package coop.rchain.rholang.interpreter
 
-import cats.{effect, ApplicativeError, Parallel}
+import cats.Parallel
 import cats.effect.Sync
 import cats.mtl.FunctorTell
-import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
-import coop.rchain.models.{BindPattern, Channel, ListChannelWithRandom, Par, TaggedContinuation}
-import coop.rchain.rholang.interpreter.errors.{InterpreterError, InterpreterErrorsM}
+import coop.rchain.models._
+import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rspace.ISpace
 import coop.rchain.rspace.pure.PureRSpace
 
@@ -68,10 +67,11 @@ object RholangOnlyDispatcher {
                               ListChannelWithRandom,
                               TaggedContinuation] =
       new PureRSpace(tuplespace)
+    lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangOnlyDispatcher(reducer)
     lazy val reducer: Reduce[M] =
-      new Reduce.DebruijnInterpreter[M, F](pureSpace, dispatcher)
+      new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg)
     dispatcher
   }
 }
@@ -120,10 +120,11 @@ object RholangAndScalaDispatcher {
                               ListChannelWithRandom,
                               TaggedContinuation] =
       new PureRSpace(tuplespace)
+    lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangAndScalaDispatcher(reducer, dispatchTable)
     lazy val reducer: Reduce[M] =
-      new Reduce.DebruijnInterpreter[M, F](pureSpace, dispatcher)
+      new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg)
     dispatcher
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
@@ -1,0 +1,81 @@
+package coop.rchain.rholang.interpreter.storage
+
+import cats.Parallel
+import cats.effect.Sync
+import coop.rchain.models.Channel.ChannelInstance.Quote
+import coop.rchain.models._
+import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
+import coop.rchain.rholang.interpreter.Dispatch
+import coop.rchain.rholang.interpreter.errors.ReduceError
+import coop.rchain.rspace.pure.PureRSpace
+import cats.implicits._
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.interpreter.storage.implicits._
+
+trait TuplespaceAlg[F[_]] {
+  def produce(chan: Channel, data: ListChannelWithRandom, persistent: Boolean): F[Unit]
+  def consume(binds: Seq[(BindPattern, Quote)], body: ParWithRandom, persistent: Boolean): F[Unit]
+}
+
+object TuplespaceAlg {
+  def rspaceTuplespace[F[_], M[_]](
+      pureRSpace: PureRSpace[F,
+                             Channel,
+                             BindPattern,
+                             ListChannelWithRandom,
+                             ListChannelWithRandom,
+                             TaggedContinuation],
+      dispatcher: => Dispatch[F, ListChannelWithRandom, TaggedContinuation])(
+      implicit F: Sync[F],
+      P: Parallel[F, M]): TuplespaceAlg[F] = new TuplespaceAlg[F] {
+    override def produce(channel: Channel,
+                         data: ListChannelWithRandom,
+                         persistent: Boolean): F[Unit] = {
+      // TODO: Handle the environment in the store
+      def go(res: Option[(TaggedContinuation, Seq[ListChannelWithRandom])]): F[Unit] =
+        res match {
+          case Some((continuation, dataList)) =>
+            if (persistent) {
+              Parallel.parSequence_[List, F, M, Unit](
+                List(dispatcher.dispatch(continuation, dataList),
+                     produce(channel, data, persistent)))
+            } else {
+              dispatcher.dispatch(continuation, dataList)
+            }
+          case None =>
+            F.unit
+        }
+
+      for {
+        res <- pureRSpace.produce(channel, data, persist = persistent)
+        _   <- go(res)
+      } yield ()
+    }
+
+    override def consume(binds: Seq[(BindPattern, Quote)],
+                         body: ParWithRandom,
+                         persistent: Boolean): F[Unit] =
+      binds match {
+        case Nil => F.raiseError(ReduceError("Error: empty binds"))
+        case _ =>
+          val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
+          pureRSpace
+            .consume(sources.map(q => Channel(q)).toList,
+                     patterns.toList,
+                     TaggedContinuation(ParBody(body)),
+                     persist = persistent)
+            .flatMap {
+              case Some((continuation, dataList)) =>
+                dispatcher.dispatch(continuation, dataList)
+                if (persistent) {
+                  List(dispatcher.dispatch(continuation, dataList),
+                       consume(binds, body, persistent)).parSequence
+                    .as(())
+                } else {
+                  dispatcher.dispatch(continuation, dataList)
+                }
+              case None => F.unit
+            }
+      }
+  }
+}


### PR DESCRIPTION
## Overview
Extract `consume` and `produce` mehods from `Reduce` trait to `TuplespaceAlg`. Now `DebruijnInterpreter` doesn't know about `dispatch` and only interacts with tuplespace.

This is preliminary work for cost accounting - this approach should reduce the noise incurred by adding new responsibilities to the reducer (interacting with tuplespace, cost accounting).


### Does this PR relate to an RChain JIRA issue? 
If applicable, add link to corresponding JIRA issue.

None.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
