### PR TITLE
CORE-830 Display the git commit hash as part of the node version prin…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,7 @@ lazy val node = (project in file("node"))
       PB.gens.java                        -> (sourceManaged in Compile).value / "protobuf",
       scalapb.gen(javaConversions = true) -> (sourceManaged in Compile).value / "protobuf"
     ),
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "coop.rchain.node",
     mainClass in assembly := Some("coop.rchain.node.Main"),
     assemblyMergeStrategy in assembly := {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -275,7 +275,8 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
   private def unrecoverableNodeProgram: Effect[Unit] =
     for {
-      _         <- Log[Effect].info(s"RChain Node ${BuildInfo.version}")
+      _ <- Log[Effect].info(
+            s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})")
       resources <- acquireResources
       _         <- startResources(resources)
       _         <- addShutdownHook(resources).toEffect


### PR DESCRIPTION
## Overview
As part of the RNode printout info about the git hash used to build the version is available.

```
19:54:43.912 [main] INFO  coop.rchain.node.NodeRuntime - RChain Node 0.4.2 (42cfbfc57bf9e98fd5b0216256611d05cd042318)
```

### Does this PR relate to an RChain JIRA issue? 
https://rchain.atlassian.net/projects/CORE/issues/CORE-830

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none.
