### PR TITLE
[WIP] Add bonds cache validation over proof of stake stub

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -26,3 +26,4 @@ case object JustificationRegression extends InvalidBlock with Slashable
 case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
 case object NeglectedEquivocation   extends InvalidBlock with Slashable
 case object InvalidTransaction      extends InvalidBlock with Slashable
+case object InvalidBondsCache       extends InvalidBlock with Slashable

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -1,17 +1,29 @@
 package coop.rchain.casper
 
+import java.nio.file.Files
+
 import cats.{Id, Monad}
 import cats.implicits._
 import cats.mtl.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
+import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.genesis.contracts.{ProofOfStake, Rev}
 import coop.rchain.casper.helper.BlockGenerator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.casper.util.ProtoUtil.termDeploy
+import coop.rchain.casper.util.rholang.{InterpreterUtil, RuntimeManager}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.models.Par
 import coop.rchain.p2p.EffectsTestInstances.LogStub
+import coop.rchain.rholang.collection.LinkedList
+import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.math.NonNegativeNumber
+import coop.rchain.rholang.mint.MakeMint
+import coop.rchain.rholang.wallet.BasicWallet
 import coop.rchain.shared.Time
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
@@ -337,5 +349,34 @@ class ValidateTest extends FlatSpec with Matchers with BeforeAndAfterEach with B
     Validate.justificationRegressions[Id](blockWithJustificationRegression, b0, chain) should be(
       Left(JustificationRegression))
     log.warns.size should be(1)
+  }
+
+  "Bonds cache validation" should "succeed on a valid block and fail on modified bonds" in {
+    val (_, validators)   = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
+    val bonds             = validators.zipWithIndex.map { case (v, i) => v -> (2 * i + 1) }.toMap
+    val initial           = Genesis.withoutContracts(bonds = bonds, version = 0L, timestamp = 0L)
+    val storageDirectory  = Files.createTempDirectory(s"hash-set-casper-test-genesis")
+    val storageSize: Long = 1024L * 1024
+    val activeRuntime     = Runtime.create(storageDirectory, storageSize)
+    val runtimeManager    = RuntimeManager.fromRuntime(activeRuntime)
+    val initStateHash     = runtimeManager.initStateHash
+
+    val proofOfStakeStub    = s"""
+                           @"proofOfStake"!({"validatorOne" : 1, "validatorTwo" : 2})
+                           """
+    val proofOfStakeStubPar = InterpreterUtil.mkTerm(proofOfStakeStub).right.get
+    val genesis = Genesis.withContracts(List(ProtoUtil.termDeploy(proofOfStakeStubPar)),
+                                        initial,
+                                        Nil,
+                                        initStateHash,
+                                        runtimeManager)
+
+    Validate.bondsCache[Id](genesis, runtimeManager) should be(Right(Valid))
+
+    val modifiedBonds     = Seq.empty[Bond]
+    val modifiedPostState = genesis.body.get.postState.get.withBonds(modifiedBonds)
+    val modifiedBody      = genesis.body.get.withPostState(modifiedPostState)
+    val modifiedGenesis   = genesis.withBody(modifiedBody)
+    Validate.bondsCache[Id](modifiedGenesis, runtimeManager) should be(Left(InvalidBondsCache))
   }
 }


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.

We enforce that the bonds cache in the block corresponds to the bonds map in the proof of stake contract. This is preparation of the insertion of the proof of stake contract.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

https://rchain.atlassian.net/browse/RHOL-405

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
