### PR TITLE
Clean store before making initial checkpoint in runtime manager

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -85,6 +85,7 @@ object RuntimeManager {
   type StateHash = ByteString
 
   def fromRuntime(active: Runtime): RuntimeManager = {
+    active.space.clear()
     val hash    = ByteString.copyFrom(active.space.createCheckpoint().root.bytes.toArray)
     val runtime = new SyncVar[Runtime]()
     runtime.put(active)


### PR DESCRIPTION
## Overview
Starting from an empty tuplespace prevents bugs involving remembering past state when creating the current initial checkpoint. This should prevent some problems with failure to reproduce tuplespace hashes when replaying trace logs.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-513

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
