### PR TITLE
Use protobuf serialization for approved block signature data

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperConstructor.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperConstructor.scala
@@ -8,7 +8,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.catscontrib._
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
+import coop.rchain.casper.protocol.{ApprovedBlock, ApprovedBlockCandidate, BlockMessage}
 import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.transport._
 import coop.rchain.comm.discovery._
@@ -67,7 +67,7 @@ sealed abstract class MultiParentCasperConstructorInstances {
             MultiParentCasper.hashSetCasper[F](
               runtimeManager,
               validatorId,
-              g.block.get
+              g.candidate.get.block.get
           ))
 
       override def receive(a: ApprovedBlock): F[Boolean] =
@@ -104,7 +104,8 @@ sealed abstract class MultiParentCasperConstructorInstances {
                                              conf.genesisPath,
                                              conf.walletsFile,
                                              runtimeManager)
-        approved    = ApprovedBlock(block = Some(genesis)) //TODO: do actual approval protocol
+        candidate   = ApprovedBlockCandidate(block = Some(genesis), requiredSigs = 0)
+        approved    = ApprovedBlock(candidate = Some(candidate)) //TODO: do actual approval protocol
         validatorId <- ValidatorIdentity.fromConfig[G](conf)
         casper      = MultiParentCasper.hashSetCasper[F](runtimeManager, validatorId, genesis)
       } yield successCasperConstructor[F](approved, casper)

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -240,21 +240,6 @@ object ProtoUtil {
 
   def hashString(b: BlockMessage): String = Base16.encode(b.blockHash.toByteArray)
 
-  /**
-    * Interprets the byte array as a large positive number, adds the
-    * given integer by usual addition, then turns the result back into
-    * a byte array.
-    * @param n Byte array to interpret as large positive number
-    * @param m Integer to add to `n`
-    * @return Result of the addition, changes back to a byte array.
-    */
-  def add(n: Array[Byte], m: Int): Array[Byte] = {
-    val num = BigInt(Base16.encode(n), 16)
-    val sum = num + m
-
-    Base16.decode(sum.toString(16))
-  }
-
   def stringToByteString(string: String): ByteString =
     ByteString.copyFrom(Base16.decode(string))
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -198,7 +198,7 @@ object CommUtil {
 
   private def packetToApprovedBlock(msg: Packet): Option[ApprovedBlock] =
     Try(ApprovedBlock.parseFrom(msg.content.toByteArray)).toOption
-      .filter(_.block.nonEmpty)
+      .filter(_.candidate.nonEmpty)
 
   private def packetToApprovedBlockRequest(msg: Packet): Option[ApprovedBlockRequest] =
     Try(ApprovedBlockRequest.parseFrom(msg.content.toByteArray)).toOption

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -60,7 +60,9 @@ class HashSetCasperTestNode(name: String,
   implicit val casperEff =
     MultiParentCasper.hashSetCasper[Id](runtimeManager, Some(validatorId), genesis)
   implicit val constructor = MultiParentCasperConstructor
-    .successCasperConstructor[Id](ApprovedBlock(block = Some(genesis)), casperEff)
+    .successCasperConstructor[Id](
+      ApprovedBlock(candidate = Some(ApprovedBlockCandidate(block = Some(genesis)))),
+      casperEff)
 
   implicit val packetHandlerEff = PacketHandler.pf[Id](
     casperPacketHandler[Id]

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -77,11 +77,15 @@ message BlockInfo {
 // --------- End DeployService  --------
 
 // ---------- Signing Protocol ---------
-message UnapprovedBlock {
-  BlockMessage candidate    = 1;
+message ApprovedBlockCandidate {
+  BlockMessage block        = 1;
   int32        requiredSigs = 2;
-  int64        timestamp    = 3;
-  int64        duration     = 4;
+}
+
+message UnapprovedBlock {
+  ApprovedBlockCandidate candidate = 1; 
+  int64                  timestamp = 2;
+  int64                  duration  = 3;
 }
 
 message Signature {
@@ -91,9 +95,8 @@ message Signature {
 }
 
 message ApprovedBlock  {
-  BlockMessage       block        = 1;
-  int32              requiredSigs = 2;
-  repeated Signature sigs         = 3;
+  ApprovedBlockCandidate candidate = 1; 
+  repeated Signature     sigs      = 2;
 }
 
 message ApprovedBlockRequest {


### PR DESCRIPTION
## Overview
Use protobuf serialization to combine block hash and required number of signatures for approved blocks. This fixes the bug involving attempting to interpret a large number with an odd number of hex digits as a byte array. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-521

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
