### PR TITLE
rspace: fix clear

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -35,17 +35,15 @@ trait PersistentStoreTester {
                 ListChannelWithRandom,
                 ListChannelWithRandom,
                 TaggedContinuation] => R): R = {
-    val dbDir = Files.createTempDirectory("rchain-storage-test-")
+    val dbDir = Files.createTempDirectory("rholang-interpreter-test-")
     val context = Context.create[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation](
       dbDir,
-      1024 * 1024 * 1024)
-    val store: IStore[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation] =
-      LMDBStore.create[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation](context)
+      mapSize = 1024L * 1024L * 1024L)
     val space = RSpace.create[Channel,
                               BindPattern,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
-                              TaggedContinuation](store, Branch("test"))
+                              TaggedContinuation](context, Branch("test"))
     try {
       f(space)
     } finally {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -208,11 +208,17 @@ object RSpace {
     implicit val codecA: Codec[A] = sa.toCodec
     implicit val codecK: Codec[K] = sk.toCodec
 
-    history.initialize(store.trieStore, branch)
-
     val space = new RSpace[C, P, A, R, K](store, branch)
 
-    val _ = space.createCheckpoint()
+    /*
+     * history.initialize returns true if the history trie contains no root (i.e. is empty).
+     *
+     * In this case, we create a checkpoint for the empty store so that we can reset
+     * to the empty store state with the clear method.
+     */
+    val _ = if (history.initialize(store.trieStore, branch)) {
+      space.createCheckpoint()
+    }
 
     space
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -210,6 +210,10 @@ object RSpace {
 
     history.initialize(store.trieStore, branch)
 
-    new RSpace[C, P, A, R, K](store, branch)
+    val space = new RSpace[C, P, A, R, K](store, branch)
+
+    val _ = space.createCheckpoint()
+
+    space
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -100,6 +100,8 @@ abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branc
       store.withTrieTxn(txn) { trieTxn =>
         store.trieStore.validateAndPutRoot(trieTxn, store.trieBranch, root)
         val leaves = store.trieStore.getLeaves(trieTxn, root)
+        eventLog.update(const(Seq.empty))
+        store.clearTrieUpdates()
         store.clear(txn)
         restoreInstalls(txn)
         store.bulkInsert(txn, leaves.map { case Leaf(k, v) => (k, v) })

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -351,6 +351,10 @@ object ReplayRSpace {
 
     val mainStore = LMDBStore.create[C, P, A, K](context, branch)
 
-    new ReplayRSpace[C, P, A, R, K](mainStore, branch)
+    val replaySpace = new ReplayRSpace[C, P, A, R, K](mainStore, branch)
+
+    val _ = replaySpace.createCheckpoint()
+
+    replaySpace
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -347,13 +347,19 @@ object ReplayRSpace {
     implicit val codecA: Codec[A] = sa.toCodec
     implicit val codecK: Codec[K] = sk.toCodec
 
-    history.initialize(context.trieStore, branch)
-
     val mainStore = LMDBStore.create[C, P, A, K](context, branch)
 
     val replaySpace = new ReplayRSpace[C, P, A, R, K](mainStore, branch)
 
-    val _ = replaySpace.createCheckpoint()
+    /*
+     * history.initialize returns true if the history trie contains no root (i.e. is empty).
+     *
+     * In this case, we create a checkpoint for the empty store so that we can reset
+     * to the empty store state with the clear method.
+     */
+    val _ = if (history.initialize(mainStore.trieStore, branch)) {
+      replaySpace.createCheckpoint()
+    }
 
     replaySpace
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -22,6 +22,8 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
+  private[rspace] def getAllPastRoots(txn: T): Seq[Blake2b256Hash]
+
   private[rspace] def validateAndPutRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -74,7 +74,7 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
   private[rspace] def putRoot(txn: Txn[ByteBuffer], branch: Branch, hash: Blake2b256Hash): Unit =
     _dbRoot.put(txn, branch, hash)(Codec[Branch], Codec[Blake2b256Hash])
 
-  private[this] def getAllPastRoots(txn: Txn[ByteBuffer]): Seq[Blake2b256Hash] =
+  private[rspace] def getAllPastRoots(txn: Txn[ByteBuffer]): Seq[Blake2b256Hash] =
     withResource(_dbPastRoots.iterate(txn)) { (it: CursorIterator[ByteBuffer]) =>
       it.asScala.foldLeft(Seq.empty[Blake2b256Hash]) { (acc, keyVal) =>
         acc ++ Codec[Seq[Blake2b256Hash]].decode(BitVector(keyVal.`val`())).map(_.value).get

--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -36,7 +36,7 @@ package object history {
 
   def initialize[T, K, V](store: ITrieStore[T, K, V], branch: Branch)(implicit
                                                                       codecK: Codec[K],
-                                                                      codecV: Codec[V]): Unit =
+                                                                      codecV: Codec[V]): Boolean =
     store.withTxn(store.createTxnWrite()) { txn =>
       store.getRoot(txn, branch) match {
         case None =>
@@ -45,8 +45,9 @@ package object history {
           store.put(txn, rootHash, root)
           store.putRoot(txn, branch, rootHash)
           logger.debug(s"workingRootHash: $rootHash")
+          true
         case Some(_) =>
-          ()
+          false
       }
     }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -746,6 +746,42 @@ class ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       replaySpace.produce(channel, datum, persist = false) shouldBe defined
   }
 
+  "reset" should
+    """|empty the replay store,
+       |reset the replay trie updates log,
+       |and reset the replay data""".stripMargin in
+    withTestSpaces { (space, replaySpace) =>
+      val channels     = List("ch1")
+      val patterns     = List(Wildcard)
+      val continuation = "continuation"
+      val datum        = "datum1"
+
+      val emptyPoint = space.createCheckpoint()
+
+      space.consume(channels, patterns, continuation, false) shouldBe None
+
+      val rigPoint = space.createCheckpoint()
+
+      replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+      replaySpace.consume(channels, patterns, continuation, false) shouldBe None
+
+      val replayStore = replaySpace.store
+
+      replayStore.isEmpty shouldBe false
+      replayStore.getTrieUpdates.length shouldBe 1
+      replayStore.getTrieUpdateCount shouldBe 1
+
+      replaySpace.reset(emptyPoint.root)
+      replayStore.isEmpty shouldBe true
+      replayStore.getTrieUpdates.length shouldBe 0
+      replayStore.getTrieUpdateCount shouldBe 0
+      replaySpace.replayData.get shouldBe empty
+
+      val checkpoint1 = replaySpace.createCheckpoint()
+      checkpoint1.log shouldBe empty
+    }
+
   "clear" should
     """|empty the replay store,
        |reset the replay event log,

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -961,6 +961,33 @@ trait StorageActionsTests
       getK(r2).results should contain(List("datum", "datum"))
   }
 
+  "reset" should "change the state of the store, and reset the trie updates log" in withTestSpace {
+    space =>
+
+      val checkpoint0 = space.createCheckpoint()
+
+      val store    = space.store
+      val key      = List("ch1")
+      val patterns = List(Wildcard)
+      val keyHash  = store.hashChannels(key)
+
+      val r = space.consume(key, patterns, new StringsCaptor, persist = false)
+
+      r shouldBe None
+      store.isEmpty shouldBe false
+      store.getTrieUpdates.length shouldBe 1
+      store.getTrieUpdateCount shouldBe 1
+
+      space.reset(checkpoint0.root)
+
+      store.isEmpty shouldBe true
+      store.getTrieUpdates.length shouldBe 0
+      store.getTrieUpdateCount shouldBe 0
+
+      val checkpoint1 = space.createCheckpoint()
+      checkpoint1.log shouldBe empty
+  }
+
   "clear" should "empty the store, reset the event log, and reset the trie updates log" in withTestSpace {
     space =>
       val store    = space.store

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -54,7 +54,7 @@ class InMemoryStoreTestsBase
         testStore.trieStore.clear(trieTxn)
       }
     }
-    initialize(trieStore, branch)
+    history.initialize(trieStore, branch)
     try {
       f(testSpace)
     } finally {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -48,8 +48,12 @@ class InMemoryStoreTestsBase
       LMDBTrieStore.create[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]](env, dbDir)
     val testStore = InMemoryStore.create[String, Pattern, String, StringsCaptor](trieStore, branch)
     val testSpace = RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, branch)
-    testStore.withTxn(testStore.createTxnWrite())(testStore.clear)
-    trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear)
+    testStore.withTxn(testStore.createTxnWrite()) { txn =>
+      testStore.withTrieTxn(txn) { trieTxn =>
+        testStore.clear(txn)
+        testStore.trieStore.clear(trieTxn)
+      }
+    }
     initialize(trieStore, branch)
     try {
       f(testSpace)
@@ -84,8 +88,10 @@ class LMDBStoreTestsBase
     val testSpace =
       RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, testBranch)
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
-      testStore.clear(txn)
-      testStore.trieStore.clear(txn)
+      testStore.withTrieTxn(txn) { trieTxn =>
+        testStore.clear(txn)
+        testStore.trieStore.clear(trieTxn)
+      }
     }
     history.initialize(testStore.trieStore, testBranch)
     try {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -55,6 +55,7 @@ class InMemoryStoreTestsBase
       }
     }
     history.initialize(trieStore, branch)
+    val _ = testSpace.createCheckpoint()
     try {
       f(testSpace)
     } finally {
@@ -94,6 +95,7 @@ class LMDBStoreTestsBase
       }
     }
     history.initialize(testStore.trieStore, testBranch)
+    val _ = testSpace.createCheckpoint()
     try {
       f(testSpace)
     } finally {


### PR DESCRIPTION
## Overview
This PR fixes the behavior the the `clear` method in ISpace, by making sure that the cleared store has the proper root hash for trie operations.  It essentially makes `clear` equivalent to `reset(emptyRootHash)`.

### Which JIRA issue does this PR relate to?
Potentially:
https://rchain.atlassian.net/browse/RHOL-500
https://rchain.atlassian.net/browse/RHOL-525

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
I did a wee bit of cleanup along the way.