### PR TITLE
CORE-892 Clean up Kademlia tests

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -4,104 +4,90 @@ import scala.collection.mutable
 
 import cats.Id
 
-import coop.rchain.catscontrib.Capture
+import coop.rchain.catscontrib._, Catscontrib._
 import coop.rchain.comm._
 
 import org.scalatest._
 
-class KademliaSpec extends FlatSpec with Matchers {
+class KademliaSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   val endpoint = Endpoint("local", 0, 0)
   val local    = PeerNode(NodeIdentifier(Seq("00000001".b)), endpoint)
-  val peer0    = PeerNode(NodeIdentifier(Seq("00000010".b)), endpoint) // d = 6
-  val peer1    = PeerNode(NodeIdentifier(Seq("00001000".b)), endpoint) // d = 4
-  val peer2    = PeerNode(NodeIdentifier(Seq("00001001".b)), endpoint) // d = 4
-  val peer3    = PeerNode(NodeIdentifier(Seq("00001010".b)), endpoint) // d = 4
-  val peer4    = PeerNode(NodeIdentifier(Seq("00001100".b)), endpoint) // d = 4
+  val peer0    = PeerNode(NodeIdentifier(Seq("00000010".b)), endpoint)
+  val peer1    = PeerNode(NodeIdentifier(Seq("00001000".b)), endpoint)
+  val peer2    = PeerNode(NodeIdentifier(Seq("00001001".b)), endpoint)
+  val peer3    = PeerNode(NodeIdentifier(Seq("00001010".b)), endpoint)
+  val peer4    = PeerNode(NodeIdentifier(Seq("00001100".b)), endpoint)
 
-  implicit val capture: Capture[Id] = new Capture[Id] {
-    def capture[A](a: => A): Id[A]       = a
-    def unsafeUncapture[A](fa: Id[A]): A = fa
+  val DISTANCE_4 = Some(4)
+  val DISTANCE_6 = Some(6)
+
+  var table       = PeerTable(local, 3)
+  var pingedPeers = mutable.MutableList.empty[PeerNode]
+
+  override def beforeEach(): Unit = {
+    table = PeerTable(local, 3)
+    pingedPeers = mutable.MutableList.empty[PeerNode]
+
+    // peer1-4 distance is 4
+    table.distance(peer1) shouldBe DISTANCE_4
+    table.distance(peer2) shouldBe DISTANCE_4
+    table.distance(peer3) shouldBe DISTANCE_4
+    table.distance(peer4) shouldBe DISTANCE_4
+    // peer0 distance is 6
+    table.distance(peer0) shouldBe DISTANCE_6
   }
 
-  // Distance is the XOR sequence of 0s counted from the left
-  def distance(peer: PeerNode): Int = {
-    val l = local.id.key.head // local byte
-    val p = peer.id.key.head // peer byte
-    val d = l ^ p // XOR
-    // number of the most significant bit counted from the right
-    val s = (0 to 7).foldLeft(0) {
-      case (acc, i) =>
-        if (d >> i > 0) acc + 1
-        else acc
-    }
-    // count the distance from the left
-    8 - s
+  val pingOk: Ping[Id] = (pn: PeerNode) => {
+    pingedPeers += pn
+    true
   }
 
-  "A PeertTable with 1 byte addresses and k = 3" should "add new peer to the right bucket" in {
-    val table       = PeerTable(local, 3)
-    val pingedPeers = mutable.MutableList.empty[PeerNode]
-    implicit val ping: Ping[Id] = (pn: PeerNode) => {
-      pingedPeers += pn
-      true
+  val failSecondTime: Ping[Id] = new Ping[Id] {
+    var pinged = List.empty[PeerNode]
+    def ping(peer: PeerNode): Boolean = {
+      val result = !pinged.contains(peer)
+      pinged = peer :: pinged
+      result
     }
+  }
+
+  "A PeertTable with 1 byte addresses and k = 3" should "add new peer to the 6th bucket" in {
+    // given
+    implicit val ping: Ping[Id] = pingOk
+    // when
     table.observe[Id](peer0)
-
-    val d = distance(peer0)
-    table.distance(peer0) shouldBe Some(d)
-
-    val entries = table.table(d).map(_.entry)
-    entries shouldEqual Seq(peer0)
+    // then
+    table.distance(peer0) shouldBe DISTANCE_6
+    bucketEntriesAt(DISTANCE_6) shouldEqual Seq(peer0)
   }
 
   it should "drop new peer if the bucket is full and the oldest peer is responding to ping" in {
-    val table       = PeerTable(local, 3)
-    val pingedPeers = mutable.MutableList.empty[PeerNode]
-    implicit val ping: Ping[Id] = (pn: PeerNode) => {
-      pingedPeers += pn
-      true
-    }
+    // given
+    implicit val ping: Ping[Id] = pingOk
     table.observe[Id](peer1)
     table.observe[Id](peer2)
     table.observe[Id](peer3)
+    // when
     table.observe[Id](peer4)
-
-    val d = distance(peer1)
-    // peers 1-4 should have all the same distance to local
-    table.distance(peer1) shouldBe Some(d)
-    table.distance(peer2) shouldBe Some(d)
-    table.distance(peer3) shouldBe Some(d)
-    table.distance(peer4) shouldBe Some(d)
+    // then
     pingedPeers shouldEqual Seq(peer1)
-
-    val entries = table.table(d).map(_.entry)
-    entries shouldEqual Seq(peer2, peer3, peer1)
+    bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, peer1)
   }
 
   it should "drop oldest peer and add new peer if the bucket is full and the oldest peer is not responding to ping" in {
-    val table         = PeerTable(local, 3)
-    val pingedPeers   = mutable.MutableList.empty[PeerNode]
-    var failPingPeer1 = false
-    implicit val ping: Ping[Id] = (pn: PeerNode) => {
-      pingedPeers += pn
-      !(failPingPeer1 && pn == peer1)
-    }
+    // given
+    implicit val ping: Ping[Id] = failSecondTime
     table.observe[Id](peer1)
     table.observe[Id](peer2)
     table.observe[Id](peer3)
-    failPingPeer1 = true
+    // when
     table.observe[Id](peer4)
-
-    val d = distance(peer1)
-    // peers 1-4 should have all the same distance to local
-    table.distance(peer1) shouldBe Some(d)
-    table.distance(peer2) shouldBe Some(d)
-    table.distance(peer3) shouldBe Some(d)
-    table.distance(peer4) shouldBe Some(d)
+    // then
     pingedPeers shouldEqual Seq(peer1)
-
-    val entries = table.table(d).map(_.entry)
-    entries shouldEqual Seq(peer2, peer3, peer4)
+    bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, peer4)
   }
+
+  private def bucketEntriesAt(distance: Option[Int]): Seq[PeerNode] =
+    distance.map(d => table.table(d).map(_.entry)).getOrElse(Seq.empty[PeerNode])
 
 }


### PR DESCRIPTION
## Overview
This PR makes `KademliaSpec` tests more readable and maintainable for the future.
What was done:
1. removed elements which were not needed in the test (like `distance` function)
2. used `Capture[Id]` from shared
3. Change tests to have single point of failure. So once they fail we know exactly why that happened.

After running the tests it generates following output:

```
[info] KademliaSpec:
[info] A PeertTable with 1 byte addresses and k = 3
[info]   when adding a peer to an empty table
[info]   - should add it to a bucket according to its distance
[info]   - should not ping the peer
[info]   when adding a peer to a table, where corresponding bucket is full
[info]   - should ping the oldest peer to check if it responds
[info]     and oldest peer IS responding to ping
[info]     - should drop the new peer
[info]     and oldest peer is NOT responding to ping
[info]     - should add the new peer and drop the oldest one
```

@MParlikar FYI the above is what I've meant when talking about tests documenting the code. This should be part of the specification, generated automatically from testes.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=CORE&modal=detail&selectedIssue=CORE-892
