### PR TITLE
Core 769 v2

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -31,7 +31,7 @@ import coop.rchain.casper.helper.BlockGenerator.StateWithChain
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
 import monix.execution.Scheduler
-
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 import scala.collection.mutable
 import scala.util.Random
 
@@ -55,8 +55,9 @@ class HashSetCasperTestNode(name: String,
   implicit val blockStore        = InMemBlockStore.createWithId
   implicit val turanOracleEffect = SafetyOracle.turanOracle[Id]
 
-  val activeRuntime  = Runtime.create(storageDirectory, storageSize)
-  val runtimeManager = RuntimeManager.fromRuntime(activeRuntime)
+  val activeRuntime                  = Runtime.create(storageDirectory, storageSize)
+  val runtimeManager                 = RuntimeManager.fromRuntime(activeRuntime)
+  val defaultTimeout: FiniteDuration = FiniteDuration(1000, MILLISECONDS)
 
   val validatorId = ValidatorIdentity(Ed25519.toPublic(sk), sk, "ed25519")
 
@@ -71,7 +72,7 @@ class HashSetCasperTestNode(name: String,
     casperPacketHandler[Id]
   )
 
-  def receive(): Unit = tle.receive(dispatch[Id] _)
+  def receive(): Unit = tle.receive(p => dispatch[Id](p, defaultTimeout))
 
 }
 

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
@@ -9,10 +9,10 @@ option (scalapb.options) = {
   flat_package: true
 };
 
-message Disconnect {
+message Heartbeat {
 }
 
-message Hello {
+message HeartbeatResponse {
 }
 
 message ProtocolHandshake {
@@ -29,8 +29,8 @@ message Packet {
 
 message Protocol {
     oneof message {
-        Disconnect                  diconnect                     = 1;
-        Hello                       hello                         = 2;
+        Heartbeat                   heartbeat                     = 1;
+        HeartbeatResponse           heartbeat_response            = 2;
         ProtocolHandshake           protocol_handshake            = 3;
         ProtocolHandshakeResponse   protocol_handshake_response   = 4;
         Packet                      packet                        = 5;

--- a/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/connect/Connect.scala
@@ -85,13 +85,8 @@ object Connect {
       ph       = protocolHandshake(local)
       phsresp  <- TransportLayer[F].roundTrip(peer, ph, timeout) >>= errorHandler[F].fromEither
       _ <- Log[F].debug(
-            "Received protocol handshake response " +
-              s"from ${ProtocolHelper.sender(phsresp).map(_.toAddress).getOrElse("None")}.")
-      addedErr <- NodeDiscovery[F].addNode(peer)
-      _ <- addedErr.fold(
-            error => Log[F].error(s"Could not add $peerAddr, reason: ${error.message}"),
-            _ => ().pure[F]
-          )
+            s"Received protocol handshake response from ${ProtocolHelper.sender(phsresp)}.")
+      _   <- NodeDiscovery[F].addNode(peer)
       tsf <- Time[F].currentMillis
       _   <- Metrics[F].record("connect-time-ms", tsf - tss)
     } yield ()
@@ -122,28 +117,36 @@ object Connect {
   private def handleProtocolHandshake[
       F[_]: Monad: Time: TransportLayer: NodeDiscovery: Log: ErrorHandler](
       peer: PeerNode,
-      maybePh: Option[ProtocolHandshake]): F[CommunicationResponse] =
+      maybePh: Option[ProtocolHandshake],
+      defaultTimeout: FiniteDuration
+  ): F[CommunicationResponse] =
     for {
-      local    <- TransportLayer[F].local
-      peerAddr = peer.toAddress
-      _        <- getOrError[F, ProtocolHandshake](maybePh, parseError("ProtocolHandshake"))
-      phr      = protocolHandshakeResponse(local)
-      addedErr <- NodeDiscovery[F].addNode(peer)
-      commResponse <- addedErr.fold(
+      local  <- TransportLayer[F].local
+      _      <- getOrError[F, ProtocolHandshake](maybePh, parseError("ProtocolHandshake"))
+      hbrErr <- TransportLayer[F].roundTrip(peer, heartbeat(local), defaultTimeout)
+      commResponse <- hbrErr.fold(
                        error =>
-                         Log[F]
-                           .error(s"Could not add $peerAddr, reason: ${error.message}")
-                           .as(notHandled(error)),
+                         Log[F].warn(s"Not adding. Could receive Pong message back from $peer, reason: $error").as(notHandled(error)),
                        _ =>
-                         Log[F]
-                           .info(s"Responded to protocol handshake request from $peerAddr")
-                           .as(handledWithMessage(phr))
+                         NodeDiscovery[F].addNode(peer) *>
+                           Log[F]
+                             .info(s"Responded to protocol handshake request from $peer")
+                             .as(handledWithMessage(protocolHandshakeResponse(local)))
                      )
     } yield commResponse
 
+  private def handleHeartbeat[F[_]: Monad: TransportLayer: ErrorHandler](
+      peer: PeerNode,
+      maybeHeartbeat: Option[Heartbeat]): F[CommunicationResponse] =
+    for {
+      local <- TransportLayer[F].local
+      _     <- getOrError[F, Heartbeat](maybeHeartbeat, parseError("Heartbeat"))
+    } yield handledWithMessage(heartbeatResponse(local))
+
   def dispatch[
       F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler: PacketHandler](
-      protocol: RoutingProtocol): F[CommunicationResponse] = {
+      protocol: RoutingProtocol,
+      defaultTimeout: FiniteDuration): F[CommunicationResponse] = {
 
     def dispatchForUpstream(proto: RoutingProtocol, sender: PeerNode): F[CommunicationResponse] =
       proto.message.upstream
@@ -152,11 +155,16 @@ object Connect {
             usmsg.typeUrl match {
               // TODO interpolate this string to check if class exists
 
+              case "type.googleapis.com/coop.rchain.comm.protocol.rchain.Heartbeat" =>
+                handleHeartbeat[F](sender, toHeartbeat(proto).toOption)
+
               case "type.googleapis.com/coop.rchain.comm.protocol.rchain.Packet" =>
                 handlePacket[F](sender, toPacket(proto).toOption)
 
               case "type.googleapis.com/coop.rchain.comm.protocol.rchain.ProtocolHandshake" =>
-                handleProtocolHandshake[F](sender, toProtocolHandshake(proto).toOption)
+                handleProtocolHandshake[F](sender,
+                                           toProtocolHandshake(proto).toOption,
+                                           defaultTimeout)
 
               case _ =>
                 Log[F].error(s"Unexpected message type ${usmsg.typeUrl}") *> notHandled(

--- a/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
@@ -10,7 +10,7 @@ import coop.rchain.comm.{CommError, PeerNode, ProtocolHelper}, CommError.CommErr
 import coop.rchain.comm.protocol.routing._
 
 trait NodeDiscovery[F[_]] {
-  def addNode(node: PeerNode): F[CommErr[Unit]]
+  def addNode(node: PeerNode): F[Unit]
   def findMorePeers(limit: Int): F[Seq[PeerNode]]
   def peers: F[Seq[PeerNode]]
   def handleCommunications: Protocol => F[CommunicationResponse]
@@ -22,7 +22,7 @@ object NodeDiscovery extends NodeDiscoveryInstances {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
       implicit C: NodeDiscovery[F]): NodeDiscovery[T[F, ?]] =
     new NodeDiscovery[T[F, ?]] {
-      def addNode(node: PeerNode): T[F, CommErr[Unit]]   = C.addNode(node).liftM[T]
+      def addNode(node: PeerNode): T[F, Unit]            = C.addNode(node).liftM[T]
       def findMorePeers(limit: Int): T[F, Seq[PeerNode]] = C.findMorePeers(limit).liftM[T]
       def peers: T[F, Seq[PeerNode]]                     = C.peers.liftM[T]
       def handleCommunications: Protocol => T[F, CommunicationResponse] =

--- a/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
@@ -122,7 +122,7 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
     * If `peer` is already in the table, it becomes the most recently
     * seen entry at its distance.
     */
-  def observe[F[_]: Monad: Capture: Ping](peer: A): F[CommErr[Unit]] = {
+  def observe[F[_]: Monad: Capture: Ping](peer: A): F[Unit] = {
 
     def bucket: F[Option[mutable.ListBuffer[Entry]]] =
       Capture[F].capture(distance(home.key, peer.key).filter(_ < 8 * width).map(table.apply))
@@ -170,12 +170,7 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
         _     <- OptionT.liftF(pingAndUpdate(ps, older))
       } yield ()
 
-    for {
-      pingResponded <- Ping[F].ping(peer)
-      res <- if (pingResponded) upsert.value.as(Right(()))
-            else Left(pongNotReceivedForPing(peer)).pure[F]
-    } yield res
-
+    upsert.value.void
   }
 
   /**

--- a/comm/src/main/scala/coop/rchain/comm/transport/CommMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/CommMessages.scala
@@ -27,6 +27,22 @@ object CommMessages {
     ProtocolHelper.upstreamMessage(src, AnyProto.pack(phr))
   }
 
+  def heartbeat(src: PeerNode): routing.Protocol = {
+    val hb = Heartbeat()
+    ProtocolHelper.upstreamMessage(src, AnyProto.pack(hb))
+  }
+
+  def toHeartbeat(proto: routing.Protocol): CommErr[Heartbeat] =
+    proto.message match {
+      case routing.Protocol.Message.Upstream(upstream) => Right(upstream.unpack(Heartbeat))
+      case a                                           => Left(UnknownProtocolError(s"Was expecting Heartbeat, got $a"))
+    }
+
+  def heartbeatResponse(src: PeerNode): routing.Protocol = {
+    val hbr = HeartbeatResponse()
+    ProtocolHelper.upstreamMessage(src, AnyProto.pack(hbr))
+  }
+
   def packet(src: PeerNode, content: Array[Byte]): routing.Protocol =
     packet(src, ByteString.copyFrom(content))
 

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -49,7 +49,6 @@ class KademliaSpec extends FlatSpec with Matchers {
 
     val d = distance(peer0)
     table.distance(peer0) shouldBe Some(d)
-    pingedPeers shouldEqual Seq(peer0)
 
     val entries = table.table(d).map(_.entry)
     entries shouldEqual Seq(peer0)
@@ -73,7 +72,7 @@ class KademliaSpec extends FlatSpec with Matchers {
     table.distance(peer2) shouldBe Some(d)
     table.distance(peer3) shouldBe Some(d)
     table.distance(peer4) shouldBe Some(d)
-    pingedPeers shouldEqual Seq(peer1, peer2, peer3, peer4, peer1)
+    pingedPeers shouldEqual Seq(peer1)
 
     val entries = table.table(d).map(_.entry)
     entries shouldEqual Seq(peer2, peer3, peer1)
@@ -99,9 +98,10 @@ class KademliaSpec extends FlatSpec with Matchers {
     table.distance(peer2) shouldBe Some(d)
     table.distance(peer3) shouldBe Some(d)
     table.distance(peer4) shouldBe Some(d)
-    pingedPeers shouldEqual Seq(peer1, peer2, peer3, peer4, peer1)
+    pingedPeers shouldEqual Seq(peer1)
 
     val entries = table.table(d).map(_.entry)
     entries shouldEqual Seq(peer2, peer3, peer4)
   }
+
 }

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -39,9 +39,9 @@ object EffectsTestInstances {
     def reset(): Unit =
       nodes = List.empty[PeerNode]
 
-    def addNode(node: PeerNode): F[CommErr[Unit]] = Capture[F].capture {
+    def addNode(node: PeerNode): F[Unit] = Capture[F].capture {
       nodes = node :: nodes
-      Right(())
+      ()
     }
 
     def peers: F[Seq[PeerNode]] = Capture[F].capture {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -276,7 +276,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
 
     (pm: Protocol) =>
       NodeDiscovery[Effect].handleCommunications(pm) >>= {
-        case NotHandled(_) => Connect.dispatch[Effect](pm)
+        case NotHandled(_) => Connect.dispatch[Effect](pm, defaultTimeout)
         case handled       => handled.pure[Effect]
       }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/MatchTest.scala
@@ -426,9 +426,9 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     // "abc" ++ "def"
     val target = Expr(EPlusPlusBody(EPlusPlus(GString("abc"), GString("def"))))
     // x ++ y
-    val pattern = Expr(EPlusPlusBody(EPlusPlus(EVar(FreeVar(0)), EVar(FreeVar(1)))))
+    val pattern        = Expr(EPlusPlusBody(EPlusPlus(EVar(FreeVar(0)), EVar(FreeVar(1)))))
     val expectedResult = Some(Map[Int, Par](0 -> GString("abc"), 1 -> GString("def")))
-    val result  = spatialMatch(target, pattern).runS(emptyMap)
+    val result         = spatialMatch(target, pattern).runS(emptyMap)
     result should be(expectedResult)
   }
 
@@ -438,9 +438,9 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     // "${name}" %% {"name" : "a"}
     val target = Expr(EPercentPercentBody(EPercentPercent(GString("${name}"), map)))
     // x %% y
-    val pattern = Expr(EPercentPercentBody(EPercentPercent(EVar(FreeVar(0)), EVar(FreeVar(1)))))
+    val pattern        = Expr(EPercentPercentBody(EPercentPercent(EVar(FreeVar(0)), EVar(FreeVar(1)))))
     val expectedResult = Some(Map[Int, Par](0 -> GString("${name}"), 1 -> map))
-    val result  = spatialMatch(target, pattern).runS(emptyMap)
+    val result         = spatialMatch(target, pattern).runS(emptyMap)
     result should be(expectedResult)
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -963,7 +963,6 @@ trait StorageActionsTests
 
   "reset" should "change the state of the store, and reset the trie updates log" in withTestSpace {
     space =>
-
       val checkpoint0 = space.createCheckpoint()
 
       val store    = space.store


### PR DESCRIPTION
Overview
Remove Ping from addNode, call heartbeat explicitly in Rchain protocol

Kademlia constantly updates last seen peers. Calling Ping on
updateLastSeen was a mistake. This is a higher protocol concept thus
was moved to RChain protocol.

Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please
CORE-769