### PR TITLE
CORE-893 kademlia transport abstraction

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -9,9 +9,9 @@ import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._, Catscontrib._, ski._, TaskContrib._
 import coop.rchain.comm.transport._, CommunicationResponse._
 import coop.rchain.shared._
-import coop.rchain.comm.protocol.routing.{Ping => ProtocolPing, _}
+import coop.rchain.comm.protocol.routing._
 
-class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](
+class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: KademliaRPC](
     src: PeerNode,
     timeout: FiniteDuration)
     extends NodeDiscovery[F] {
@@ -56,7 +56,7 @@ class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportL
         val byteIndex    = dist / 8
         val differentBit = 1 << (dist % 8)
         target(byteIndex) = (target(byteIndex) ^ differentBit).toByte // A key at a distance dist from me
-        Ping[F]
+        KademliaRPC[F]
           .lookup(target, peerSet.head)
           .map { results =>
             potentials ++ results.filter(

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -113,19 +113,4 @@ class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportL
       _ <- Metrics[F].incrementCounter("disconnect-recv-count")
       _ <- Metrics[F].setGauge("peers", table.peers.length.toLong)
     } yield handledWitoutMessage
-
-  private def lookup(key: Seq[Byte], remoteNode: PeerNode): F[Seq[PeerNode]] =
-    for {
-      _   <- Metrics[F].incrementCounter("protocol-lookup-send")
-      req = ProtocolHelper.lookup(src, key)
-      r <- TransportLayer[F]
-            .roundTrip(remoteNode, req, timeout)
-            .map(_.toOption
-              .map {
-                case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
-                  lr.nodes.map(ProtocolHelper.toPeerNode)
-                case _ => Seq()
-              }
-              .getOrElse(Seq()))
-    } yield r
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -56,7 +56,8 @@ class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportL
         val byteIndex    = dist / 8
         val differentBit = 1 << (dist % 8)
         target(byteIndex) = (target(byteIndex) ^ differentBit).toByte // A key at a distance dist from me
-        lookup(target, peerSet.head)
+        Ping[F]
+          .lookup(target, peerSet.head)
           .map { results =>
             potentials ++ results.filter(
               r =>

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -11,7 +11,7 @@ import coop.rchain.comm.transport._, CommunicationResponse._
 import coop.rchain.shared._
 import coop.rchain.comm.protocol.routing.{Ping => ProtocolPing, _}
 
-class TLNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](
+class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: Ping](
     src: PeerNode,
     timeout: FiniteDuration)
     extends NodeDiscovery[F] {

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
@@ -8,22 +8,24 @@ import coop.rchain.catscontrib.{MonadTrans, _}
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.comm.PeerNode
 
-trait Ping[F[_]] {
+trait KademliaRPC[F[_]] {
   def ping(node: PeerNode): F[Boolean]
   def lookup(key: Seq[Byte], peer: PeerNode): F[Seq[PeerNode]]
 }
 
-object Ping extends PingInstances {
-  def apply[F[_]](implicit P: Ping[F]): Ping[F] = P
+object KademliaRPC extends KademliaRPCInstances {
+  def apply[F[_]](implicit P: KademliaRPC[F]): KademliaRPC[F] = P
 
-  def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit P: Ping[F]): Ping[T[F, ?]] =
-    new Ping[T[F, ?]] {
+  def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
+      implicit P: KademliaRPC[F]): KademliaRPC[T[F, ?]] =
+    new KademliaRPC[T[F, ?]] {
       def ping(node: PeerNode): T[F, Boolean]                         = P.ping(node).liftM[T]
       def lookup(key: Seq[Byte], peer: PeerNode): T[F, Seq[PeerNode]] = P.lookup(key, peer).liftM[T]
     }
 }
 
-sealed abstract class PingInstances {
-  implicit def eitherTPing[E, F[_]: Monad: Ping[?[_]]]: Ping[EitherT[F, E, ?]] =
-    Ping.forTrans[F, EitherT[?[_], E, ?]]
+sealed abstract class KademliaRPCInstances {
+  implicit def eitherTKademliaRPC[E, F[_]: Monad: KademliaRPC[?[_]]]
+    : KademliaRPC[EitherT[F, E, ?]] =
+    KademliaRPC.forTrans[F, EitherT[?[_], E, ?]]
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/Ping.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/Ping.scala
@@ -18,7 +18,7 @@ object Ping extends PingInstances {
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit P: Ping[F]): Ping[T[F, ?]] =
     new Ping[T[F, ?]] {
-      def ping(node: PeerNode): T[F, Boolean] = P.ping(node).liftM[T]
+      def ping(node: PeerNode): T[F, Boolean]                         = P.ping(node).liftM[T]
       def lookup(key: Seq[Byte], peer: PeerNode): T[F, Seq[PeerNode]] = P.lookup(key, peer).liftM[T]
     }
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/Ping.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/Ping.scala
@@ -10,6 +10,7 @@ import coop.rchain.comm.PeerNode
 
 trait Ping[F[_]] {
   def ping(node: PeerNode): F[Boolean]
+  def lookup(key: Seq[Byte], peer: PeerNode): F[Seq[PeerNode]]
 }
 
 object Ping extends PingInstances {
@@ -18,6 +19,7 @@ object Ping extends PingInstances {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit P: Ping[F]): Ping[T[F, ?]] =
     new Ping[T[F, ?]] {
       def ping(node: PeerNode): T[F, Boolean] = P.ping(node).liftM[T]
+      def lookup(key: Seq[Byte], peer: PeerNode): T[F, Seq[PeerNode]] = P.lookup(key, peer).liftM[T]
     }
 }
 

--- a/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/kademlia.scala
@@ -122,7 +122,7 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
     * If `peer` is already in the table, it becomes the most recently
     * seen entry at its distance.
     */
-  def observe[F[_]: Monad: Capture: Ping](peer: A): F[Unit] = {
+  def observe[F[_]: Monad: Capture: KademliaRPC](peer: A): F[Unit] = {
 
     def bucket: F[Option[mutable.ListBuffer[Entry]]] =
       Capture[F].capture(distance(home.key, peer.key).filter(_ < 8 * width).map(table.apply))
@@ -154,7 +154,7 @@ final class PeerTable[A <: PeerNode](home: A, private[discovery] val k: Int, alp
       }
 
     def pingAndUpdate(ps: mutable.ListBuffer[Entry], older: Entry): F[Unit] =
-      Ping[F].ping(older.entry).map { response =>
+      KademliaRPC[F].ping(older.entry).map { response =>
         val winner = if (response) older else new Entry(peer, _.key)
         ps synchronized {
           ps -= older

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -21,8 +21,11 @@ object b {
 
 class DistanceSpec extends FlatSpec with Matchers {
 
-  val endpoint                = Endpoint("", 0, 0)
-  implicit val ping: Ping[Id] = (_: PeerNode) => true
+  val endpoint = Endpoint("", 0, 0)
+  implicit val ping: Ping[Id] = new Ping[Id] {
+    def ping(node: PeerNode): Boolean                         = true
+    def lookup(key: Seq[Byte], peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
+  }
   implicit val capture: Capture[Id] = new Capture[Id] {
     def capture[A](a: => A): Id[A]       = a
     def unsafeUncapture[A](fa: Id[A]): A = fa

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -22,7 +22,7 @@ object b {
 class DistanceSpec extends FlatSpec with Matchers {
 
   val endpoint = Endpoint("", 0, 0)
-  implicit val ping: Ping[Id] = new Ping[Id] {
+  implicit val ping: KademliaRPC[Id] = new KademliaRPC[Id] {
     def ping(node: PeerNode): Boolean                         = true
     def lookup(key: Seq[Byte], peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
   }

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -103,14 +103,15 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   private def bucketEntriesAt(distance: Option[Int]): Seq[PeerNode] =
     distance.map(d => table.table(d).map(_.entry)).getOrElse(Seq.empty[PeerNode])
 
-  private val pingOk: Ping[Id] = (pn: PeerNode) => {
-    pingedPeers += pn
-    true
-  }
+  private val pingOk: Ping[Id]   = new PingMock(returns = true)
+  private val pingFail: Ping[Id] = new PingMock(returns = false)
 
-  private val pingFail: Ping[Id] = (pn: PeerNode) => {
-    pingedPeers += pn
-    false
+  private class PingMock(returns: Boolean) extends Ping[Id] {
+    def ping(peer: PeerNode): Boolean = {
+      pingedPeers += peer
+      returns
+    }
+    def lookup(key: Seq[Byte], peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
   }
 
 }

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -41,7 +41,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     describe("when adding a peer to an empty table") {
       it("should add it to a bucket according to its distance") {
         // given
-        implicit val ping: Ping[Id] = pingOk
+        implicit val ping: KademliaRPC[Id] = pingOk
         // when
         table.observe[Id](peer0)
         // then
@@ -50,7 +50,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
 
       it("should not ping the peer") {
         // given
-        implicit val ping: Ping[Id] = pingOk
+        implicit val ping: KademliaRPC[Id] = pingOk
         // when
         table.observe[Id](peer0)
         // then
@@ -61,7 +61,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     describe("when adding a peer to a table, where corresponding bucket is full") {
       it("should ping the oldest peer to check if it responds") {
         // given
-        implicit val ping: Ping[Id] = pingOk
+        implicit val ping: KademliaRPC[Id] = pingOk
         thatBucket4IsFull
         // when
         table.observe[Id](peer4)
@@ -72,7 +72,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       describe("and oldest peer IS responding to ping") {
         it("should drop the new peer") {
           // given
-          implicit val ping: Ping[Id] = pingOk
+          implicit val ping: KademliaRPC[Id] = pingOk
           thatBucket4IsFull
           // when
           table.observe[Id](peer4)
@@ -83,7 +83,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       describe("and oldest peer is NOT responding to ping") {
         it("should add the new peer and drop the oldest one") {
           // given
-          implicit val ping: Ping[Id] = pingFail
+          implicit val ping: KademliaRPC[Id] = pingFail
           thatBucket4IsFull
           // when
           table.observe[Id](peer4)
@@ -94,7 +94,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     }
   }
 
-  private def thatBucket4IsFull(implicit ev: Ping[Id]): Unit = {
+  private def thatBucket4IsFull(implicit ev: KademliaRPC[Id]): Unit = {
     table.observe[Id](peer1)
     table.observe[Id](peer2)
     table.observe[Id](peer3)
@@ -103,10 +103,10 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   private def bucketEntriesAt(distance: Option[Int]): Seq[PeerNode] =
     distance.map(d => table.table(d).map(_.entry)).getOrElse(Seq.empty[PeerNode])
 
-  private val pingOk: Ping[Id]   = new PingMock(returns = true)
-  private val pingFail: Ping[Id] = new PingMock(returns = false)
+  private val pingOk: KademliaRPC[Id]   = new KademliaRPCMock(returns = true)
+  private val pingFail: KademliaRPC[Id] = new KademliaRPCMock(returns = false)
 
-  private class PingMock(returns: Boolean) extends Ping[Id] {
+  private class KademliaRPCMock(returns: Boolean) extends KademliaRPC[Id] {
     def ping(peer: PeerNode): Boolean = {
       pingedPeers += peer
       returns

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -28,9 +28,10 @@ package object effects {
     }
   }
 
-  def ping[F[_]: Monad: Capture: Metrics: TransportLayer](src: PeerNode,
-                                                          timeout: FiniteDuration): Ping[F] =
-    new Ping[F] {
+  def kademliaRPC[F[_]: Monad: Capture: Metrics: TransportLayer](
+      src: PeerNode,
+      timeout: FiniteDuration): KademliaRPC[F] =
+    new KademliaRPC[F] {
       def ping(node: PeerNode): F[Boolean] =
         for {
           _   <- Metrics[F].incrementCounter("protocol-ping-sends")

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -13,6 +13,7 @@ import coop.rchain.comm.discovery._
 import coop.rchain.shared._
 import scala.concurrent.duration.FiniteDuration
 import java.io.File
+import coop.rchain.comm.protocol.routing.{Ping => _, _}
 
 package object effects {
 
@@ -42,14 +43,14 @@ package object effects {
           _   <- Metrics[F].incrementCounter("protocol-lookup-send")
           req = ProtocolHelper.lookup(src, key)
           r <- TransportLayer[F]
-          .roundTrip(remoteNode, req, timeout)
-          .map(_.toOption
-            .map {
-              case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
-                lr.nodes.map(ProtocolHelper.toPeerNode)
-              case _ => Seq()
-            }
-            .getOrElse(Seq()))
+                .roundTrip(remoteNode, req, timeout)
+                .map(_.toOption
+                  .map {
+                    case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
+                      lr.nodes.map(ProtocolHelper.toPeerNode)
+                    case _ => Seq()
+                  }
+                  .getOrElse(Seq()))
         } yield r
     }
 

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -13,7 +13,7 @@ import coop.rchain.comm.discovery._
 import coop.rchain.shared._
 import scala.concurrent.duration.FiniteDuration
 import java.io.File
-import coop.rchain.comm.protocol.routing.{Ping => _, _}
+import coop.rchain.comm.protocol.routing._
 
 package object effects {
 

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -36,6 +36,21 @@ package object effects {
           req = ProtocolHelper.ping(src)
           res <- TransportLayer[F].roundTrip(node, req, timeout)
         } yield res.toOption.isDefined
+
+      def lookup(key: Seq[Byte], remoteNode: PeerNode): F[Seq[PeerNode]] =
+        for {
+          _   <- Metrics[F].incrementCounter("protocol-lookup-send")
+          req = ProtocolHelper.lookup(src, key)
+          r <- TransportLayer[F]
+          .roundTrip(remoteNode, req, timeout)
+          .map(_.toOption
+            .map {
+              case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
+                lr.nodes.map(ProtocolHelper.toPeerNode)
+              case _ => Seq()
+            }
+            .getOrElse(Seq()))
+        } yield r
     }
 
   def tcpTransportLayer(host: String, port: Int, cert: File, key: File)(src: PeerNode)(

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -26,7 +26,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import diagnostics.MetricsServer
 import coop.rchain.comm.transport._
-import coop.rchain.comm.discovery.{Ping => NDPing, _}
+import coop.rchain.comm.discovery._
 import coop.rchain.shared._
 import ThrowableOps._
 import cats.effect.{Bracket, ExitCase, Sync}
@@ -177,7 +177,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   implicit val connectionsState: MonadState[Task, TransportState] = effects.connectionsState[Task]
   implicit val transportLayerEffect: TransportLayer[Task] =
     effects.tcpTransportLayer(host, port, certificateFile, keyFile)(src)
-  implicit val pingEffect: NDPing[Task] = effects.ping(src, defaultTimeout)
+  implicit val kademliaRPCEffect: KademliaRPC[Task] = effects.kademliaRPC(src, defaultTimeout)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task] =
     new KademliaNodeDiscovery[Task](src, defaultTimeout)
 

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -179,7 +179,7 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
     effects.tcpTransportLayer(host, port, certificateFile, keyFile)(src)
   implicit val pingEffect: NDPing[Task] = effects.ping(src, defaultTimeout)
   implicit val nodeDiscoveryEffect: NodeDiscovery[Task] =
-    new TLNodeDiscovery[Task](src, defaultTimeout)
+    new KademliaNodeDiscovery[Task](src, defaultTimeout)
 
   case class Resources(grpcServer: Server,
                        metricsServer: MetricsServer,


### PR DESCRIPTION
## Overview

In this PR:
1. `Ping` typeclass is renamed to `KademliaRPC`
2. `lookup` method is moved from `KademliaNodeDiscovery` to `KademliaRPC`

This way `KademliaNodeDiscovery` is *almost* ready to stop relying on `TransportLayer`. It will require to move `Disconnect` to Rchain protocol to completely remove dependency on `TransportLayer`

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=CORE&modal=detail&selectedIssue=CORE-893

