### PR TITLE
Remove path deletion util from rspace

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -17,8 +17,8 @@ import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rspace.internal.{Datum, Row}
-import coop.rchain.rspace.test._
 import coop.rchain.rspace.{IStore, Serialize}
+import coop.rchain.shared.PathOps._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
@@ -212,7 +212,7 @@ class CryptoChannelsSpec
       test((runtime.reducer, runtime.space.store))
     } finally {
       runtime.close()
-      recursivelyDeletePath(dbDir)
+      dbDir.recursivelyDelete
     }
   }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -38,7 +38,7 @@ trait HistoryActionsTests
 
   /**
     * Helper for testing purposes only.
-   */
+    */
   private[this] def getRootHash(store: IStore[String, Pattern, String, StringsCaptor],
                                 branch: Branch): Blake2b256Hash =
     store.withTxn(store.createTxnRead()) { txn =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -8,6 +8,7 @@ import coop.rchain.rspace.history.{initialize, Branch, LMDBTrieStore}
 import coop.rchain.rspace.internal.{codecGNAT, GNAT}
 import coop.rchain.rspace.test.InMemoryStore
 import coop.rchain.rspace.util._
+import coop.rchain.shared.PathOps._
 import org.scalatest.BeforeAndAfterAll
 import scodec.Codec
 
@@ -309,7 +310,7 @@ class InMemoryStoreStorageExamplesTestsBase
   }
 
   override def afterAll(): Unit = {
-    test.recursivelyDeletePath(dbDir)
+    dbDir.recursivelyDelete
     super.afterAll()
   }
 }
@@ -342,7 +343,7 @@ class LMDBStoreStorageExamplesTestBase
   }
 
   override def afterAll(): Unit = {
-    test.recursivelyDeletePath(dbDir)
+    dbDir.recursivelyDelete
     super.afterAll()
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -9,6 +9,7 @@ import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.history.{initialize, Branch, ITrieStore, LMDBTrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.test._
+import coop.rchain.shared.PathOps._
 import org.lmdbjava.Txn
 import org.scalatest._
 import scodec.Codec
@@ -66,7 +67,7 @@ class InMemoryStoreTestsBase
   }
 
   override def afterAll(): Unit = {
-    test.recursivelyDeletePath(dbDir)
+    dbDir.recursivelyDelete
     super.afterAll()
   }
 }
@@ -106,5 +107,5 @@ class LMDBStoreTestsBase
   }
 
   override def afterAll(): Unit =
-    recursivelyDeletePath(dbDir)
+    dbDir.recursivelyDelete
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path}
 
 import coop.rchain.rspace.Context
 import coop.rchain.rspace.test._
+import coop.rchain.shared.PathOps._
 import org.lmdbjava.{Env, Txn}
 import org.scalacheck.Arbitrary
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -450,7 +451,7 @@ trait LMDBWithTestTrieStore[K]
   }
 
   override def afterAll(): Unit =
-    recursivelyDeletePath(dbDir)
+    dbDir.recursivelyDelete
 }
 
 class LMDBHistoryActionsTests

--- a/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -12,26 +12,6 @@ import scodec.{Attempt, Codec, DecodeResult}
 package object test {
 
   /**
-    * Makes a SimpleFileVisitor to delete files and the directories that contained them
-    *
-    * [[https://docs.oracle.com/javase/8/docs/api/java/nio/file/FileVisitor.html]]
-    */
-  private def makeDeleteFileVisitor: SimpleFileVisitor[Path] =
-    new SimpleFileVisitor[Path] {
-      override def visitFile(p: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        Files.delete(p)
-        FileVisitResult.CONTINUE
-      }
-      override def postVisitDirectory(p: Path, e: java.io.IOException): FileVisitResult = {
-        Files.delete(p)
-        FileVisitResult.CONTINUE
-      }
-    }
-
-  def recursivelyDeletePath(p: Path): Path =
-    Files.walkFileTree(p, makeDeleteFileVisitor)
-
-  /**
     * Converts specified byteBuffer to '-' separated string,
     * convenient during debugging
     */


### PR DESCRIPTION
## Overview
Remove path deletion util from rspace, and use the one from "shared". DRY

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-763

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
