### PR TITLE
Rename roscala_macros to roscalaMacros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,7 +244,7 @@ lazy val rholangProtoBuild = (project in file("rholang-proto-build"))
   )
   .dependsOn(rholang)
 
-lazy val roscala_macros = (project in file("roscala/macros"))
+lazy val roscalaMacros = (project in file("roscala/macros"))
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= commonDependencies ++ Seq(
@@ -261,7 +261,7 @@ lazy val roscala = (project in file("roscala"))
     inThisBuild(
       List(addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))),
     libraryDependencies ++= commonDependencies
-  ).dependsOn(roscala_macros)
+  ).dependsOn(roscalaMacros)
 
 lazy val blockStorage = (project in file("block-storage"))
   .settings(commonSettings: _*)


### PR DESCRIPTION
This change keeps the naming convention consistent. Also my sbt-mode
on Emacs does not freak out :)