### PR TITLE
CORE-903/CORE-774 Cell typeclass

### DIFF
--- a/shared/src/main/scala/coop/rchain/shared/Cell.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Cell.scala
@@ -1,0 +1,26 @@
+package coop.rchain.shared
+
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib._, Catscontrib._
+
+trait Cell[F[_], S] {
+  def modify(f: S => S): F[Unit]
+}
+
+object Cell {
+  def apply[F[_], S](implicit ev: Cell[F, S]): Cell[F, S] = ev
+
+  def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans, S](implicit C: Cell[F, S]): Cell[T[F, ?], S] =
+    new Cell[T[F, ?], S] {
+      def modify(f: S => S): T[F, Unit] = C.modify(f).liftM[T]
+    }
+
+  class NOPCell[F[_]: Applicative, S] extends Cell[F, S] {
+    def modify(f: S => S): F[Unit] = ().pure[F]
+  }
+}
+
+object CellInstances0 {
+  implicit def eitherTCell[E, F[_]: Monad: Cell[?[_], S], S]: Cell[EitherT[F, E, ?], S] =
+    Cell.forTrans[F, EitherT[?[_], E, ?], S]
+}


### PR DESCRIPTION
## Overview
In TcpTransport layer we are using `MonadState` to hold open connections. This is not good enough, as it might hit race conditions when multipple threads try to manipulate the state.

This PR introduces a `Cell` typeclass - it is simplified version of `MonadState` that only holds single method `modify`. This way we can provide a thread-safe instance of it based on `monix.MVar`. Each thread will call `modify` but if other thread is running the modifications at the given moment, the `modify` will block until access is released by the second thread.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.

https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=CORE&modal=detail&selectedIssue=CORE-774