### PR TITLE
CORE-774/CORE-904 Replace MonadState with Cell in TcpTransportLayer

### DIFF
--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -68,14 +68,11 @@ package object effects {
 
   def tcpTransportLayer(host: String, port: Int, cert: File, key: File)(src: PeerNode)(
       implicit scheduler: Scheduler,
-      connections: TcpTransportLayer.State,
+      connections: TcpTransportLayer.TransportCell[Task],
       log: Log[Task]) =
     new TcpTransportLayer(host, port, cert, key)(src)
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)
 
-  def connectionsState[F[_]: Monad: Capture]: MonadState[F, TransportState] = {
-    val state = AtomicAny(TransportState())
-    new AtomicMonadState[F, TransportState](state)
-  }
+  def tcpConnections: Task[Cell[Task, TransportState]] = Cell.mvarCell(TransportState.empty)
 }

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -334,15 +334,14 @@ class NodeRuntime(conf: Conf)(implicit scheduler: Scheduler) {
   val main: Effect[Unit] = for {
 
     /** create typeclass instances */
-    connectionsState <- effects.connectionsState[Task].pure[Effect]
-    log              = effects.log
-    time             = effects.time
-    sync             = SyncInstances.syncEffect
-    metrics          = diagnostics.metrics[Task]
-    transport = effects.tcpTransportLayer(host, port, certificateFile, keyFile)(src)(
-      scheduler,
-      connectionsState,
-      log)
+    tcpConnections <- effects.tcpConnections.toEffect
+    log            = effects.log
+    time           = effects.time
+    sync           = SyncInstances.syncEffect
+    metrics        = diagnostics.metrics[Task]
+    transport = effects.tcpTransportLayer(host, port, certificateFile, keyFile)(src)(scheduler,
+                                                                                     tcpConnections,
+                                                                                     log)
     kademliaRPC = effects.kademliaRPC(src, defaultTimeout)(metrics, transport)
     nodeDiscovery = effects.nodeDiscovery(src, defaultTimeout)(log,
                                                                time,


### PR DESCRIPTION

## Overview
Previously when using `MonadState` we could have race conditions when
creating or removing grpc connections. Example would be two threads
calling `connection` function, creating new ManagedConnection and
storing them to map. During race, only one thread would store its
connection to map, leaving the other with leaking resources.

With Cell we can have thread-safe state modifications while applying
effects (creating connections). This has adventage over using Ref and
its compareAndSet/transform function. While using `Ref` is in general
considered better approach (as it is almost non-blocking), it has its
limits when state modification wants to apply external effect.
Cell typeclass does not have this limitation. Cons of using Cell is
the fact that whole `modify` is a blocking function.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=CORE&modal=detail&selectedIssue=CORE-774


