### PR TITLE
CORE-585a -  bind graphing services and pull for metrics on localhost interface

### DIFF
--- a/docker/node/docker-compose.yml
+++ b/docker/node/docker-compose.yml
@@ -5,37 +5,13 @@ volumes:
     grafana_data_storage: {}
     rnode_data_storage: {}
 
-networks:
-  rchain:
-    driver: bridge
-  metrics:
-    driver: bridge
-
 services:
-  rchain-node:
-    image: rchain/rnode:latest
-    volumes:
-      - rnode_data_storage:/var/lib/rnode
-      - ../../rholang/examples:/tmp/examples
-    ports:
-      - 40403:40403
-      - 40400:40400
-    networks:
-      - rchain
-    command: run -s -p 60000
   prometheus-pushgateway:
     image: prom/pushgateway
-    ports:
-      - 9091:9091
-    networks:
-      - rchain
+    network_mode: "host"
   prometheus-server:
     image: prom/prometheus:v2.3.2
-    ports:
-      - 9090:9090
-    networks:
-      - rchain
-      - metrics
+    network_mode: "host"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data_storage:/prometheus
@@ -46,12 +22,7 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
   grafana-ui:
     image: grafana/grafana:5.2.1
-    ports:
-      - 3000:3000
-    networks:
-      - metrics
-    #environment:
-    #  - GF_SECURITY_ADMIN_PASSWORD=secret
+    network_mode: "host"
     env_file:
       - ./grafana/grafana.conf
     volumes:

--- a/docker/node/grafana/provisioning/dashboards/rnode-metric-counters.json
+++ b/docker/node/grafana/provisioning/dashboards/rnode-metric-counters.json
@@ -26,7 +26,7 @@
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": "5.0.0"
+      "version": "2.3.2"
     }
   ],
   "annotations": {

--- a/docker/node/prometheus/prometheus.yml
+++ b/docker/node/prometheus/prometheus.yml
@@ -1,7 +1,7 @@
 global:
-  scrape_interval:     15s
-  scrape_timeout:      5s
-  evaluation_interval: 15s
+  scrape_interval:     30s
+  scrape_timeout:      10s
+  evaluation_interval: 1m 
 
   # Attach labels to time series or alerts when communicating with
   # external systems like alert manager or remote storage.
@@ -10,7 +10,7 @@ global:
 
 # Load and evaluate rules in file every evaluation_interval.
 rule_files:
-  # - "some.rules"
+  # - "some.rules" # add if wanted
 
 scrape_configs:
 
@@ -20,12 +20,11 @@ scrape_configs:
 
   - job_name: 'prometheus-pushgateway'
     static_configs:
-      - targets: ['prometheus-pushgateway:9091']
+      - targets: ['localhost:9091']
 
   - job_name: 'rchain-node'
-    scrape_interval:     1s
-    scrape_timeout:      1s
+    scrape_interval:     1m 
 
     metrics_path: "/"
     static_configs:
-      - targets: ['rchain-node:40403']
+      - targets: ['localhost:40403']


### PR DESCRIPTION
## Overview
This fixes/updates metrics to actually pull from your localhost network interface. It was using virtual bridges before. Made simpler and bound all metric services directly to localhost interface. Removed docker-compose rnode service as that will be started separately. May add in later if wanted for docker default bootup

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/CORE-585

### Complete this checklist before you submit the PR
- [x ] This PR contains no more than 200 lines of code, excluding test code.
- [x ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
