### PR TITLE
CORE-848: use our forked kalium that contains native libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
     sbt_args: -no-colors
     install:
       - ./scripts/install_sbt.sh
-      - ./scripts/install_sodium.sh
       - ./scripts/install.sh
     addons:
       apt:

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -2,10 +2,6 @@
 
 `crypto` module provides cryptography functionalities for `node`.
 
-## Before you build it
-
-In order to be able to build `crypto` module, you need to have [The Sodium crypto library](https://github.com/jedisct1/libsodium) installed on your system. For details see [libsodium documentation](https://download.libsodium.org/doc/installation/) where different installation options are described
-
 ## Available functionality
 
 | Feature                                                                       | Description                               |

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
   val http4sDSL           = "org.http4s"                 %% "http4s-dsl"                % http4sVersion
   val jaxb                = "javax.xml.bind"              % "jaxb-api"                  % "2.1"
   val jline               = ("org.scala-lang"             % "jline"                      % "2.10.7").exclude("org.fusesource.jansi", "jansi")
-  val kalium              = "org.abstractj.kalium"        % "kalium"                    % "0.7.0"
+  val kalium              = "coop.rchain"                 % "kalium"                    % "0.8.1-SNAPSHOT"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
   val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % kamonVersion
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.1"

--- a/rholang/README.md
+++ b/rholang/README.md
@@ -14,7 +14,6 @@ Currently we have a working interpreter for the language. It should be considere
     * [sbt](http://www.scala-sbt.org/0.13/docs/Installing-sbt-on-Linux.html)
     * JFlex - install using apt 
     * BNFC - MUST be built from [git](https://github.com/BNFC/bnfc) b0252e5f666ed67a65b6e986748eccbfe802bc17 or later. If you use `cabal install` you will need to add your BNFC binary to the PATH.
-    * [libsodium](https://github.com/jedisct1/libsodium) - You can use the scripts/install_sodium.sh helper script
     * Scala
 4. Run `sbt rholang/bnfc:generate` to generate the lexer/parser. Re-run whenever you modify the grammar
 5. Run `sbt rholang/compile` to compile classes

--- a/scripts/install_sodium.sh
+++ b/scripts/install_sodium.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -eux
-
-cd crypto
-git clone https://github.com/jedisct1/libsodium --branch stable
-cd libsodium
-./configure
-make && make check
-sudo make install

--- a/scripts/rnode-docker-build-push-script.sh
+++ b/scripts/rnode-docker-build-push-script.sh
@@ -63,14 +63,6 @@ apt-get update -yqq
 #  apt-get install default-jdk -yqq # alternate jdk install 
 apt-get install openjdk-8-jdk -yqq
 
-## Build Needed Crypto
-# Build secp 
-apt-get install autoconf libtool -yqq
-
-# Build libsodium
-cd ${PROJECT_ROOT_DIR}
-./scripts/install_sodium.sh
-
 ## Install Haskell Platform
 # ref: https://www.haskell.org/platform/#linux-ubuntu
 # ref: https://www.haskell.org/platform/ # all platforms


### PR DESCRIPTION
## Overview
This PR swaps out the upstream [kalium](https://github.com/abstractj/kalium) dependency for our own version which packages the `libsodium` native libraries in its jar.

### Which JIRA issue does this PR relate to?
https://rchain.atlassian.net/browse/CORE-848

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Our fork:
https://github.com/rchain/kalium

This version of kalium includes jars produced from:
https://github.com/rchain/sodium-native
