### PR TITLE
CORE-905 Fix exceptions thrown from LMDB java wrapper on oo space.

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -14,6 +14,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.metrics.Metrics
 import org.lmdbjava._
 import org.lmdbjava.DbiFlags.MDB_CREATE
+import org.lmdbjava.Txn.NotReadyException
 
 class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks: Dbi[ByteBuffer])(
     implicit
@@ -43,7 +44,18 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
       }
     } {
       case (txn, ExitCase.Completed) => syncF.delay(txn.close())
-      case (txn, _)                  => syncF.delay { txn.abort(); txn.close() }
+      case (txn, t) =>
+        syncF.delay {
+          try {
+            txn.abort()
+          } catch {
+            case ex: NotReadyException =>
+              ex.printStackTrace()
+              TxnOps.manuallyAbortTxn(txn)
+            // vide: rchain/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+          }
+          txn.close()
+        }
     }
 
   private[this] def withWriteTxn(f: Txn[ByteBuffer] => Unit): F[Unit] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -44,7 +44,7 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
       }
     } {
       case (txn, ExitCase.Completed) => syncF.delay(txn.close())
-      case (txn, t) =>
+      case (txn, _) =>
         syncF.delay {
           try {
             txn.abort()

--- a/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
+++ b/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
@@ -1,0 +1,11 @@
+package org.lmdbjava
+import org.lmdbjava.Library.LIB
+
+object TxnOps {
+
+  /**
+    * a copy of rchain/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
+    */
+  def manuallyAbortTxn[T](txn: Txn[T]) =
+    LIB.mdb_txn_reset(txn.pointer())
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
@@ -10,7 +10,6 @@ import coop.rchain.shared.AttemptOps._
 import coop.rchain.shared.PathOps._
 import scodec.bits.BitVector
 import kamon._
-import org.lmdbjava.Library.LIB
 import org.lmdbjava.Txn.NotReadyException
 
 trait LMDBOps {
@@ -60,13 +59,13 @@ trait LMDBOps {
           case ex: NotReadyException =>
             ex.printStackTrace()
             TxnOps.manuallyAbortTxn(txn)
-            // due to the way LMDBjava tries to handle txn commit
-            // IF the DB runs out of space AND this occurs while trying to commit a txn (2)
-            // the internal java state (STATE in Txn) will be set to DONE (1) before the Txn is committed
-            // (the exception happens in the attempt to commit)
-            // the abort action will interpret this as an invalid state (3)
-            // A fix is to ignore this exception as the original one is a valid cause
-            // and it still will cause txn.close in the finally block
+          // due to the way LMDBjava tries to handle txn commit
+          // IF the DB runs out of space AND this occurs while trying to commit a txn (2)
+          // the internal java state (STATE in Txn) will be set to DONE (1) before the Txn is committed
+          // (the exception happens in the attempt to commit)
+          // the abort action will interpret this as an invalid state (3)
+          // A fix is to ignore this exception as the original one is a valid cause
+          // and it still will cause txn.close in the finally block
         }
         throw ex
     } finally {

--- a/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
+++ b/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
@@ -1,0 +1,8 @@
+package org.lmdbjava
+import org.lmdbjava.Library.LIB
+
+object TxnOps {
+  def manuallyAbortTxn[T](txn: Txn[T]) = {
+    LIB.mdb_txn_reset(txn.pointer())
+  }
+}

--- a/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
+++ b/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
@@ -2,7 +2,6 @@ package org.lmdbjava
 import org.lmdbjava.Library.LIB
 
 object TxnOps {
-  def manuallyAbortTxn[T](txn: Txn[T]) = {
+  def manuallyAbortTxn[T](txn: Txn[T]) =
     LIB.mdb_txn_reset(txn.pointer())
-  }
 }


### PR DESCRIPTION
## Overview
When stars align just right LMDB will throw an Exception (Environment mapsize reached (-30792)) when trying to `transaction commit`. This results in the internal transaction state of the java wrapper to be not sound.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/projects/CORE/issues/CORE-905

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none
