### PR TITLE
CORE-914 Change CI to fail project when code is not formatted with scalafmt

### DIFF
--- a/scripts/build-subprojects.sh
+++ b/scripts/build-subprojects.sh
@@ -11,7 +11,7 @@ case "$SUBPROJECT" in "rosette")
 
 "core")
 
-    sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile coverage test coverageReport rspace:tut
+    sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile coverage scalafmtCheck test coverageReport rspace:tut
 
     for sub in block-storage casper crypto comm rholang roscala node rspace shared
     do


### PR DESCRIPTION
## Overview
Change CI to fail project when code is not formatted with scalafmt

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
