### PR TITLE
Enforce sorted input- & expected-result-terms in spatial matching tests

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sort/BoolSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/BoolSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Expr.ExprInstance.GBool
 
-object BoolSortMatcher {
+object BoolSortMatcher extends Sortable[GBool] {
   def sortMatch(g: GBool): ScoredTerm[GBool] =
     if (g.value) {
       ScoredTerm(g, Leaves(Score.BOOL, 0))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
@@ -3,7 +3,7 @@ package coop.rchain.models.rholang.sort
 import coop.rchain.models.Bundle
 import coop.rchain.models.rholang.implicits._
 
-object BundleSortMatcher {
+object BundleSortMatcher extends Sortable[Bundle] {
   def sortMatch(b: Bundle): ScoredTerm[Bundle] = {
     val score: Int = if (b.writeFlag && b.readFlag) {
       Score.BUNDLE_READ_WRITE

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.Channel
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Empty, Quote}
 import coop.rchain.models.rholang.implicits._
 
-object ChannelSortMatcher {
+object ChannelSortMatcher extends Sortable[Channel] {
   def sortMatch(channel: Channel): ScoredTerm[Channel] =
     channel.channelInstance match {
       case Quote(par) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
@@ -12,7 +12,7 @@ import coop.rchain.models.VarRef
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
 
-object ConnectiveSortMatcher {
+object ConnectiveSortMatcher extends Sortable[Connective] {
   def sortMatch(c: Connective): ScoredTerm[Connective] =
     c.connectiveInstance match {
       case ConnAndBody(cb) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
@@ -6,7 +6,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import cats.implicits._
 
-object ExprSortMatcher {
+object ExprSortMatcher extends Sortable[Expr] {
   private def sortBinaryOperation(p1: Par, p2: Par): (ScoredTerm[Par], ScoredTerm[Par]) =
     (ParSortMatcher.sortMatch(p1), ParSortMatcher.sortMatch(p2))
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{ParMap, ParSet}
 import coop.rchain.models.rholang.sort.ordering._
 
-object GroundSortMatcher {
+object GroundSortMatcher extends Sortable[ExprInstance] {
   def sortMatch(g: ExprInstance): ScoredTerm[ExprInstance] =
     g match {
       case gb: GBool   => ScoredTerm(g, BoolSortMatcher.sortMatch(gb).score)

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.{Match, MatchCase}
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
 
-object MatchSortMatcher {
+object MatchSortMatcher extends Sortable[Match] {
   def sortMatch(m: Match): ScoredTerm[Match] = {
     def sortCase(matchCase: MatchCase): ScoredTerm[MatchCase] = {
       val sortedPattern = ParSortMatcher.sortMatch(matchCase.pattern)

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
@@ -3,7 +3,7 @@ package coop.rchain.models.rholang.sort
 import coop.rchain.models.New
 import coop.rchain.models.rholang.implicits._
 
-object NewSortMatcher {
+object NewSortMatcher extends Sortable[New] {
   def sortMatch(n: New): ScoredTerm[New] = {
     val sortedPar = ParSortMatcher.sortMatch(n.p)
     ScoredTerm(New(bindCount = n.bindCount, p = sortedPar.term, locallyFree = n.locallyFree),

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.Par
 import ordering._
 import cats.implicits._
 
-object ParSortMatcher {
+object ParSortMatcher extends Sortable[Par] {
   def sortMatch(par: Par): ScoredTerm[Par] = {
     val sends       = par.sends.toList.map(s => SendSortMatcher.sortMatch(s)).sorted
     val receives    = par.receives.toList.map(r => ReceiveSortMatcher.sortMatch(r)).sorted

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
@@ -4,7 +4,8 @@ import coop.rchain.models.{Receive, ReceiveBind}
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
 
-object ReceiveSortMatcher {
+object ReceiveSortMatcher extends Sortable[Receive] {
+
   def sortBind(bind: ReceiveBind): ScoredTerm[ReceiveBind] = {
     val patterns       = bind.patterns
     val source         = bind.source
@@ -24,7 +25,7 @@ object ReceiveSortMatcher {
 
   // The order of the binds must already be presorted by the time this is called.
   // This function will then sort the insides of the preordered binds.
-  def sortMatch[M[_]](r: Receive): ScoredTerm[Receive] = {
+  def sortMatch(r: Receive): ScoredTerm[Receive] = {
     val sortedBinds     = r.binds.toList.map(bind => sortBind(bind))
     val persistentScore = if (r.persistent) 1 else 0
     val sortedBody      = ParSortMatcher.sortMatch(r.body)

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.Send
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
 
-object SendSortMatcher {
+object SendSortMatcher extends Sortable[Send] {
   def sortMatch(s: Send): ScoredTerm[Send] = {
     val sortedChan = ChannelSortMatcher.sortMatch(s.chan)
     val sortedData = s.data.toList.map(ParSortMatcher.sortMatch(_))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/Sortable.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/Sortable.scala
@@ -1,0 +1,25 @@
+package coop.rchain.models.rholang.sort
+import coop.rchain.models.Expr.ExprInstance
+import coop.rchain.models.Expr.ExprInstance.GBool
+import coop.rchain.models._
+
+trait Sortable[T] {
+  def sortMatch(term: T): ScoredTerm[T]
+}
+
+object Sortable {
+  def apply[T](implicit ev: Sortable[T]) = ev
+
+  implicit val boolSortable: Sortable[GBool]            = BoolSortMatcher
+  implicit val bundleSortable: Sortable[Bundle]         = BundleSortMatcher
+  implicit val channelSortable: Sortable[Channel]       = ChannelSortMatcher
+  implicit val connectiveSortable: Sortable[Connective] = ConnectiveSortMatcher
+  implicit val exprSortable: Sortable[Expr]             = ExprSortMatcher
+  implicit val groundSortable: Sortable[ExprInstance]   = GroundSortMatcher
+  implicit val matchSortable: Sortable[Match]           = MatchSortMatcher
+  implicit val newSortable: Sortable[New]               = NewSortMatcher
+  implicit val parSortable: Sortable[Par]               = ParSortMatcher
+  implicit val receiveSortable: Sortable[Receive]       = ReceiveSortMatcher
+  implicit val sendSortable: Sortable[Send]             = SendSortMatcher
+  implicit val varSortable: Sortable[Var]               = VarSortMatcher
+}

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/VarSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/VarSortMatcher.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Var.VarInstance.{BoundVar, Empty, FreeVar, Wildcard}
 import cats.implicits._
 import cats.syntax._
 
-object VarSortMatcher {
+object VarSortMatcher extends Sortable[Var] {
   def sortMatch(v: Var): ScoredTerm[Var] =
     v.varInstance match {
       case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -318,7 +318,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
             for {
               p <- StateT.inspect[StreamT[State[CostAccount, ?], ?], FreeMap, Par]((m: FreeMap) =>
                     m.getOrElse(level, VectorPar()))
-              collectPar <- foldRemainder(rem, p)
+              collectPar <- foldRemainder(rem.reverse, p)
               _ <- StateT.modify[StreamT[State[CostAccount, ?], ?], FreeMap]((m: FreeMap) =>
                     m + (level -> collectPar))
             } yield Unit

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -17,9 +17,10 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   import coop.rchain.models.rholang.implicits._
 
   def assertSpatialMatch[T, P](target: T, pattern: P, expected: Option[FreeMap])(
-      implicit sm: SpatialMatcher[T, P]): Assertion =
-    assert(
-      spatialMatch(target, pattern).runS(emptyMap).value.run(CostAccount.zero).value._2 == expected)
+      implicit sm: SpatialMatcher[T, P]): Assertion = {
+    val result = spatialMatch(target, pattern).runS(emptyMap).value.run(CostAccount.zero).value._2
+    assert(result == expected)
+  }
 
   val wc = Wildcard(Var.WildcardMsg())
   "Matching ground with var" should "work" in {
@@ -400,8 +401,7 @@ class VarMatcherSpec extends FlatSpec with Matchers {
           body = Par(),
           persistent = false,
           bindCount = 0))))
-    val expectedResult = Some(Map.empty[Int, Par])
-    assertSpatialMatch(target, pattern, expectedResult)
+    assertSpatialMatch(target, pattern, Some(Map.empty[Int, Par]))
   }
 
   "Matching ++" should "work" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -7,6 +7,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
+import coop.rchain.models.rholang.sort.Sortable
 import coop.rchain.rholang.interpreter.accounting.CostAccount
 import org.scalatest._
 
@@ -16,10 +17,19 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   import SpatialMatcher._
   import coop.rchain.models.rholang.implicits._
 
-  def assertSpatialMatch[T, P](target: T, pattern: P, expected: Option[FreeMap])(
-      implicit sm: SpatialMatcher[T, P]): Assertion = {
+  def assertSpatialMatch[T: Sortable, P: Sortable](
+      target: T,
+      pattern: P,
+      expected: Option[FreeMap])(implicit sm: SpatialMatcher[T, P]): Assertion = {
+    assertSorted(target, "target")
+    assertSorted(pattern, "pattern")
+    expected.foreach(_.values.foreach((v: Par) => assertSorted(v, "expected captured term")))
     val result = spatialMatch(target, pattern).runS(emptyMap).value.run(CostAccount.zero).value._2
     assert(result == expected)
+  }
+
+  private def assertSorted[T: Sortable](term: T, termName: String): Assertion = {
+    assert(term == Sortable[T].sortMatch(term).term, s"Invalid test case - ${termName} is not sorted")
   }
 
   val wc = Wildcard(Var.WildcardMsg())
@@ -44,13 +54,13 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   "Matching 2 lists in parallel" should "work" in {
     // The second pattern will be checked first because of prepend.
     // It matches both targets, but the first pattern only matches one of the lists.
-    val target: Par = EList(List(GInt(7), GInt(8)), BitSet())
-      .prepend(EList(List(GInt(7), GInt(9)), BitSet()), 0)
-    val pattern: Par = EList(List(EVar(FreeVar(0)).withConnectiveUsed(true), GInt(8)), BitSet())
+    val target: Par = EList(List(GInt(7), GInt(9)), BitSet())
+      .prepend(EList(List(GInt(7), GInt(8)), BitSet()), 0)
+    val pattern: Par = EList(List(EVar(FreeVar(0)).withConnectiveUsed(true), GInt(9)), BitSet())
       .withConnectiveUsed(true)
       .prepend(EList(List(GInt(7), EVar(FreeVar(1)).withConnectiveUsed(true)), BitSet())
         .withConnectiveUsed(true), depth = 1)
-    assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(7), 1 -> GInt(9))))
+    assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(7), 1 -> GInt(8))))
   }
 
   "Matching a send's channel" should "work" in {
@@ -83,18 +93,19 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   }
 
   "Matching extras with free variable" should "work" in {
-    val target: Par  = GInt(7).prepend(GInt(8), depth = 0).prepend(GInt(9), depth = 0)
-    val pattern: Par = GInt(8).prepend(EVar(FreeVar(0)), depth = 1)
+    val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
+    val pattern: Par = EVar(FreeVar(0)).prepend(GInt(8), depth = 1)
     assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
   }
   "Matching extras with wildcard" should "work" in {
-    val target: Par  = GInt(7).prepend(GInt(8), depth = 0).prepend(GInt(9), depth = 0)
-    val pattern: Par = GInt(8).prepend(EVar(Wildcard(Var.WildcardMsg())), depth = 1)
+    val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
+    val pattern: Par = EVar(Wildcard(Var.WildcardMsg())).prepend(GInt(8), depth = 1)
     assertSpatialMatch(target, pattern, Some(Map.empty[Int, Par]))
   }
   "Matching extras with wildcard and free variable" should "capture in the free variable" in {
-    val target: Par  = GInt(7).prepend(GInt(8), depth = 0).prepend(GInt(9), depth = 0)
-    val pattern: Par = GInt(8).prepend(EVar(Wildcard(Var.WildcardMsg())), depth = 1).prepend(EVar(FreeVar(0)), depth = 1)
+    val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
+    val pattern: Par =
+      EVar(Wildcard(Var.WildcardMsg())).prepend(EVar(FreeVar(0)), depth = 1).prepend(GInt(8), depth = 1)
     assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
   }
   "Matching send with free variable in channel and variable position" should "capture both values" in {
@@ -155,8 +166,8 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     val target: New =
       New(2,
           Par()
-            .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), false))
-            .prepend(Send(ChanVar(BoundVar(0)), Seq(GInt(43)), false, locallyFree = BitSet(0))))
+            .prepend(Send(ChanVar(BoundVar(0)), Seq(GInt(43)), false, locallyFree = BitSet(0)))
+            .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), false)))
     val pattern: New =
       New(2,
           Par()
@@ -225,8 +236,8 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   "Matching inside bundles" should "not be possible" in {
     val target: Bundle = Bundle(
       Par()
-        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false))
-        .prepend(Send(Quote(GPrivate("0")), Seq(GInt(43)), persistent = false)))
+        .prepend(Send(Quote(GPrivate("0")), Seq(GInt(43)), persistent = false))
+        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false)))
     val pattern: Bundle = Bundle(
       Par()
         .prepend(Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), persistent = false))
@@ -246,8 +257,8 @@ class VarMatcherSpec extends FlatSpec with Matchers {
   it should "be possible to match on entire bundle" in {
     val target: Bundle = Bundle(
       Par()
-        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false))
-        .prepend(Send(Quote(GPrivate("0")), Seq(GInt(43)), persistent = false)))
+        .prepend(Send(Quote(GPrivate("0")), Seq(GInt(43)), persistent = false))
+        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false)))
 
     val pattern: Par = EVar(FreeVar(0))
 
@@ -352,22 +363,22 @@ class VarMatcherSpec extends FlatSpec with Matchers {
         Par()
           .addConnectives(nonNullConn, nonNullConn)
           .withConnectiveUsed(true)))
-    // ~{ ~Nil | ~Nil } & ~Nil
-    val prime: Connective = Connective(
-      ConnAndBody(
-        ConnectiveBody(Seq(nonNull, Par().addConnectives(singleFactor).withConnectiveUsed(true)))))
     // x /\ y!(7)
     val capture: Connective =
       Connective(
         ConnAndBody(ConnectiveBody(
           Seq(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), Seq(GInt(7))).withConnectiveUsed(true)))))
+    // ~{ ~Nil | ~Nil } & ~Nil
+    val prime: Connective = Connective(
+      ConnAndBody(
+        ConnectiveBody(Seq(nonNull, Par().addConnectives(singleFactor).withConnectiveUsed(true)))))
     // x!(7) \/ x!(8)
     val alternative: Connective = Connective(
       ConnOrBody(
         ConnectiveBody(Seq(Send(ChanVar(FreeVar(0)), Seq(GInt(7))).withConnectiveUsed(true),
                            Send(ChanVar(FreeVar(0)), Seq(GInt(8))).withConnectiveUsed(true)))))
-    // ~{ ~Nil | ~Nil } & ~Nil | x /\ y!(7) | x!(7) \/ x!(8)
-    val pattern: Par   = Par().addConnectives(prime, capture, alternative).withConnectiveUsed(true)
+    // x /\ y!(7) | ~{ ~Nil | ~Nil } & ~Nil | x!(7) \/ x!(8)
+    val pattern: Par   = Par().addConnectives(capture, prime, alternative).withConnectiveUsed(true)
     val expectedResult = Some(Map[Int, Par](0 -> Send(Quote(GInt(2)), Seq(GInt(7))), 1 -> GInt(2)))
     assertSpatialMatch(target, pattern, expectedResult)
 


### PR DESCRIPTION
## Overview

Also make the matcher output a sorted term for reminder.

Enforce sorted input- & expected-result-terms in spatial matching tests  …
This includes:
 - rearranging target, pattern, and expected capture terms
   in the spatial matcher's tests (so that they're sorted)
 - fixing two tests that started failing (because previously they were
   enforcing wrong behaviour), by reversing the remainder.
   The tests in question are:
    - "Matching extras with wildcard"
    - "Matching extras with wildcard and free variable"

### JIRA issue:
Discoverd during and needed for [RHOL-533 Use Stable Marriage algo for pattern matching in listMatch](https://rchain.atlassian.net/browse/RHOL-533)


### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.