### PR TITLE
Rollback rspace changes after rholang evaluation errors in CLI & REPL

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -95,10 +95,12 @@ object Interpreter {
   def evaluate(runtime: Runtime, normalizedTerm: Par): Task[EvaluateResult] = {
     implicit val rand = Blake2b512Random(128)
     for {
+      checkpoint     <- Task.now(runtime.space.createCheckpoint())
       costAccounting <- CostAccountingAlg[Task](CostAccount.zero)
       _              <- runtime.reducer.inj(normalizedTerm)(rand, costAccounting)
-      errors         <- Task.now(runtime.readAndClearErrorVector)
+      errors         <- Task.now(runtime.readAndClearErrorVector())
       cost           <- costAccounting.getCost()
+      _              <- Task.now(if (errors.nonEmpty) runtime.space.reset(checkpoint.root))
     } yield EvaluateResult(cost, errors)
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -1,0 +1,52 @@
+package coop.rchain.rholang
+
+import java.io.StringReader
+import java.nio.file.Files
+
+import coop.rchain.rholang.interpreter.storage.StoragePrinter
+import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class InterpreterSpec extends FlatSpec with Matchers {
+  val mapSize     = 1024L * 1024L * 1024L
+  val tmpPrefix   = "rspace-store-"
+  val maxDuration = 5.seconds
+
+  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
+
+  "Interpreter" should "restore RSpace to its prior state after evaluation error" in {
+    val initStorage = storageContents()
+    val send        = "@{0}!(0)"
+    success(send)
+    val beforeError = storageContents()
+    assert(beforeError.contains(send))
+    failure("@1!(1) | @2!(3.noSuchMethod())")
+    assert(storageContents() == beforeError)
+    success("new stdout(`rho:io:stdout`) in { stdout!(42) }")
+    assert(storageContents() == beforeError)
+    success("for (_ <- @0) { Nil }")
+    assert(storageContents() == initStorage)
+  }
+
+  private def storageContents() =
+    StoragePrinter.prettyPrint(runtime.space.store)
+
+
+  private def success(rho: String): Unit =
+    execute(rho).swap.foreach(error => fail(s"""Execution failed for: $rho
+                                               |Cause:
+                                               |$error""".stripMargin))
+
+  private def failure(rho: String): Throwable =
+    execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))
+
+  private def execute(source: String) = {
+    val future = Interpreter.execute(runtime, new StringReader(source)).attempt.runAsync
+    Await.result(future, maxDuration)
+  }
+
+}


### PR DESCRIPTION
## Overview
Rollback rspace changes after rholang evaluation errors in CLI & REPL

### JIRA issue:
[RHOL-491 In the CLI and REPL, roll back the tuplespace on an error](https://rchain.atlassian.net/browse/RHOL-491)

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.