### PR TITLE
Fixes the code to make node assembly plugin able to merge on deduplication

### DIFF
--- a/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
+++ b/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
@@ -2,10 +2,6 @@ package org.lmdbjava
 import org.lmdbjava.Library.LIB
 
 object TxnOps {
-
-  /**
-    * a copy of rchain/rspace/src/main/scala/org/lmdbjava/TxnOps.scala
-    */
   def manuallyAbortTxn[T](txn: Txn[T]) =
     LIB.mdb_txn_reset(txn.pointer())
 }


### PR DESCRIPTION
## Overview
The node assembly plugin is not able to deduplicate the `TxnOps` files if they are not identical.

```
[error] java.lang.RuntimeException: deduplicate: different file contents found in the following:
[error] org/lmdbjava/TxnOps$.class
[error] org/lmdbjava/TxnOps$.class
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
no link

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none
