### PR TITLE
[NO_TICKET] Use sortable

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sort/BoolSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/BoolSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Expr.ExprInstance.GBool
 
-object BoolSortMatcher extends Sortable[GBool] {
+private[sort] object BoolSortMatcher extends Sortable[GBool] {
   def sortMatch(g: GBool): ScoredTerm[GBool] =
     if (g.value) {
       ScoredTerm(g, Leaves(Score.BOOL, 0))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Bundle
 
-object BundleSortMatcher extends Sortable[Bundle] {
+private[sort] object BundleSortMatcher extends Sortable[Bundle] {
   def sortMatch(b: Bundle): ScoredTerm[Bundle] = {
     val score: Int = if (b.writeFlag && b.readFlag) {
       Score.BUNDLE_READ_WRITE

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/BundleSortMatcher.scala
@@ -1,7 +1,6 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Bundle
-import coop.rchain.models.rholang.implicits._
 
 object BundleSortMatcher extends Sortable[Bundle] {
   def sortMatch(b: Bundle): ScoredTerm[Bundle] = {
@@ -14,7 +13,7 @@ object BundleSortMatcher extends Sortable[Bundle] {
     } else {
       Score.BUNDLE_EQUIV
     }
-    val sortedPar = ParSortMatcher
+    val sortedPar = Sortable
       .sortMatch(b.body)
     ScoredTerm(b.copy(body = sortedPar.term), Node(score, sortedPar.score))
   }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
@@ -8,10 +8,10 @@ object ChannelSortMatcher extends Sortable[Channel] {
   def sortMatch(channel: Channel): ScoredTerm[Channel] =
     channel.channelInstance match {
       case Quote(par) =>
-        val sortedPar = ParSortMatcher.sortMatch(par)
+        val sortedPar = Sortable.sortMatch(par)
         ScoredTerm(Quote(sortedPar.term.get), Node(Score.QUOTE, sortedPar.score))
       case ChanVar(par) =>
-        val sortedVar = VarSortMatcher.sortMatch(par)
+        val sortedVar = Sortable.sortMatch(par)
         ScoredTerm(ChanVar(sortedVar.term), Node(Score.CHAN_VAR, sortedVar.score))
       case Empty =>
         ScoredTerm(Empty, Leaf(Score.ABSENT))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ChannelSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.Channel
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Empty, Quote}
 import coop.rchain.models.rholang.implicits._
 
-object ChannelSortMatcher extends Sortable[Channel] {
+private[sort] object ChannelSortMatcher extends Sortable[Channel] {
   def sortMatch(channel: Channel): ScoredTerm[Channel] =
     channel.channelInstance match {
       case Quote(par) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
@@ -1,30 +1,22 @@
 package coop.rchain.models.rholang.sort
 
-import coop.rchain.models.Connective
-import coop.rchain.models.Connective.ConnectiveInstance.{
-  ConnAndBody,
-  ConnNotBody,
-  ConnOrBody,
-  Empty,
-  VarRefBody
-}
-import coop.rchain.models.VarRef
-import cats.implicits._
+import coop.rchain.models.Connective.ConnectiveInstance._
+import coop.rchain.models.{Connective, VarRef}
 import coop.rchain.models.rholang.implicits._
 
 object ConnectiveSortMatcher extends Sortable[Connective] {
   def sortMatch(c: Connective): ScoredTerm[Connective] =
     c.connectiveInstance match {
       case ConnAndBody(cb) =>
-        val pars = cb.ps.toList.map(par => ParSortMatcher.sortMatch(par))
+        val pars = cb.ps.toList.map(par => Sortable.sortMatch(par))
         ScoredTerm(Connective(ConnAndBody(cb.withPs(pars.map(_.term.get)))),
                    Node(Score.CONNECTIVE_AND, pars.map(_.score): _*))
       case ConnOrBody(cb) =>
-        val pars = cb.ps.toList.map(par => ParSortMatcher.sortMatch(par))
+        val pars = cb.ps.toList.map(par => Sortable.sortMatch(par))
         ScoredTerm(Connective(ConnOrBody(cb.withPs(pars.map(_.term.get)))),
                    Node(Score.CONNECTIVE_OR, pars.map(_.score): _*))
       case ConnNotBody(p) =>
-        val scoredPar = ParSortMatcher.sortMatch(p)
+        val scoredPar = Sortable.sortMatch(p)
         ScoredTerm(Connective(ConnNotBody(scoredPar.term.get)),
                    Node(Score.CONNECTIVE_NOT, scoredPar.score))
       case v @ VarRefBody(VarRef(index, depth)) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
@@ -4,7 +4,7 @@ import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.{Connective, VarRef}
 import coop.rchain.models.rholang.implicits._
 
-object ConnectiveSortMatcher extends Sortable[Connective] {
+private[sort] object ConnectiveSortMatcher extends Sortable[Connective] {
   def sortMatch(c: Connective): ScoredTerm[Connective] =
     c.connectiveInstance match {
       case ConnAndBody(cb) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 
-object ExprSortMatcher extends Sortable[Expr] {
+private[sort] object ExprSortMatcher extends Sortable[Expr] {
   private def sortBinaryOperation(p1: Par, p2: Par): (ScoredTerm[Par], ScoredTerm[Par]) =
     (Sortable.sortMatch(p1), Sortable.sortMatch(p2))
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
@@ -4,11 +4,10 @@ import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import cats.implicits._
 
 object ExprSortMatcher extends Sortable[Expr] {
   private def sortBinaryOperation(p1: Par, p2: Par): (ScoredTerm[Par], ScoredTerm[Par]) =
-    (ParSortMatcher.sortMatch(p1), ParSortMatcher.sortMatch(p2))
+    (Sortable.sortMatch(p1), Sortable.sortMatch(p2))
 
   def sortMatch(e: Expr): ScoredTerm[Expr] = {
     def constructExpr(exprInstance: ExprInstance, score: Tree[ScoreAtom]) =
@@ -16,16 +15,16 @@ object ExprSortMatcher extends Sortable[Expr] {
 
     e.exprInstance match {
       case ENegBody(en) =>
-        val sortedPar = ParSortMatcher.sortMatch(en.p)
+        val sortedPar = Sortable.sortMatch(en.p)
         constructExpr(ENegBody(ENeg(sortedPar.term)), Node(Score.ENEG, sortedPar.score))
       case EVarBody(ev) =>
-        val sortedVar = VarSortMatcher.sortMatch(ev.v)
+        val sortedVar = Sortable.sortMatch(ev.v)
         constructExpr(EVarBody(EVar(sortedVar.term)), Node(Score.EVAR, sortedVar.score))
       case EEvalBody(chan) =>
-        val sortedChan = ChannelSortMatcher.sortMatch(chan)
+        val sortedChan = Sortable.sortMatch(chan)
         constructExpr(EEvalBody(sortedChan.term), Node(Score.EEVAL, sortedChan.score))
       case ENotBody(en) =>
-        val sortedPar = ParSortMatcher.sortMatch(en.p)
+        val sortedPar = Sortable.sortMatch(en.p)
         constructExpr(ENotBody(ENot(sortedPar.term)), Node(Score.ENOT, sortedPar.score))
       case EMultBody(em) =>
         val (sortedPar1, sortedPar2) = sortBinaryOperation(em.p1, em.p2)
@@ -89,15 +88,15 @@ object ExprSortMatcher extends Sortable[Expr] {
         constructExpr(EPlusPlusBody(EPlusPlus(sortedPar1.term, sortedPar2.term)),
                       Node(Score.EPLUSPLUS, sortedPar1.score, sortedPar2.score))
       case EMethodBody(em) =>
-        val args         = em.arguments.toList.map(par => ParSortMatcher.sortMatch(par))
-        val sortedTarget = ParSortMatcher.sortMatch(em.target)
+        val args         = em.arguments.toList.map(par => Sortable.sortMatch(par))
+        val sortedTarget = Sortable.sortMatch(em.target)
         constructExpr(
           EMethodBody(em.withArguments(args.map(_.term.get)).withTarget(sortedTarget.term.get)),
           Node(
             Seq(Leaf(Score.EMETHOD), Leaf(em.methodName), sortedTarget.score) ++ args.map(_.score))
         )
       case eg =>
-        val sortedGround = GroundSortMatcher.sortMatch(eg)
+        val sortedGround = Sortable.sortMatch(eg)
         constructExpr(sortedGround.term, sortedGround.score)
     }
   }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{Par, ParMap, ParSet, SortedParHashSet}
 
-object GroundSortMatcher extends Sortable[ExprInstance] {
+private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
   def sortMatch(g: ExprInstance): ScoredTerm[ExprInstance] =
     g match {
       case gb: GBool   => ScoredTerm(g, Sortable.sortMatch(gb).score)

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -2,34 +2,30 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.{KeyValuePair, Par, SortedParHashSet}
-import cats.implicits._
-import cats.syntax._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.{ParMap, ParSet}
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.{Par, ParMap, ParSet, SortedParHashSet}
 
 object GroundSortMatcher extends Sortable[ExprInstance] {
   def sortMatch(g: ExprInstance): ScoredTerm[ExprInstance] =
     g match {
-      case gb: GBool   => ScoredTerm(g, BoolSortMatcher.sortMatch(gb).score)
+      case gb: GBool   => ScoredTerm(g, Sortable.sortMatch(gb).score)
       case gi: GInt    => ScoredTerm(g, Leaves(Score.INT, gi.value))
       case gs: GString => ScoredTerm(g, Node(Score.STRING, Leaf(gs.value)))
       case gu: GUri    => ScoredTerm(g, Node(Score.URI, Leaf(gu.value)))
       case EListBody(gl) =>
-        val sortedPars = gl.ps.toList.map(par => ParSortMatcher.sortMatch(par))
+        val sortedPars = gl.ps.toList.map(par => Sortable.sortMatch(par))
         ScoredTerm(EListBody(gl.withPs(sortedPars.map(_.term.get))),
                    Node(Score.ELIST, sortedPars.map(_.score): _*))
       case ETupleBody(gt) =>
         val sortedPars = gt.ps.toList
-          .map(par => ParSortMatcher.sortMatch(par))
+          .map(par => Sortable.sortMatch(par))
         ScoredTerm(ETupleBody(gt.withPs(sortedPars.map(_.term.get))),
                    Node(Score.ETUPLE, sortedPars.map(_.score): _*))
       // Note ESet and EMap rely on the stableness of Scala's sort
       // See https://github.com/scala/scala/blob/2.11.x/src/library/scala/collection/SeqLike.scala#L627
       case ESetBody(gs) =>
         val sortedPars = gs.ps.sortedPars
-          .map(par => ParSortMatcher.sortMatch(par))
+          .map(par => Sortable.sortMatch(par))
           .sorted
         ScoredTerm(ESetBody(
                      ParSet(SortedParHashSet(sortedPars.map(_.term.get)),
@@ -38,8 +34,8 @@ object GroundSortMatcher extends Sortable[ExprInstance] {
                    Node(Score.ESET, sortedPars.map(_.score): _*))
       case EMapBody(gm) =>
         def sortKeyValuePair(key: Par, value: Par): ScoredTerm[(Par, Par)] = {
-          val sortedKey   = ParSortMatcher.sortMatch(key)
-          val sortedValue = ParSortMatcher.sortMatch(value)
+          val sortedKey   = Sortable.sortMatch(key)
+          val sortedValue = Sortable.sortMatch(value)
           ScoredTerm((sortedKey.term, sortedValue.term), sortedKey.score)
         }
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.{Match, MatchCase}
 
-object MatchSortMatcher extends Sortable[Match] {
+private[sort] object MatchSortMatcher extends Sortable[Match] {
   def sortMatch(m: Match): ScoredTerm[Match] = {
     def sortCase(matchCase: MatchCase): ScoredTerm[MatchCase] = {
       val sortedPattern = Sortable.sortMatch(matchCase.pattern)

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
@@ -1,19 +1,17 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.{Match, MatchCase}
-import cats.implicits._
-import coop.rchain.models.rholang.implicits._
 
 object MatchSortMatcher extends Sortable[Match] {
   def sortMatch(m: Match): ScoredTerm[Match] = {
     def sortCase(matchCase: MatchCase): ScoredTerm[MatchCase] = {
-      val sortedPattern = ParSortMatcher.sortMatch(matchCase.pattern)
-      val sortedBody    = ParSortMatcher.sortMatch(matchCase.source)
+      val sortedPattern = Sortable.sortMatch(matchCase.pattern)
+      val sortedBody    = Sortable.sortMatch(matchCase.source)
       ScoredTerm(MatchCase(sortedPattern.term, sortedBody.term, matchCase.freeCount),
                  Node(Seq(sortedPattern.score) ++ Seq(sortedBody.score)))
     }
 
-    val sortedValue = ParSortMatcher.sortMatch(m.target)
+    val sortedValue = Sortable.sortMatch(m.target)
     val scoredCases = m.cases.toList.map(sortCase)
     ScoredTerm(Match(sortedValue.term, scoredCases.map(_.term), m.locallyFree, m.connectiveUsed),
                Node(Score.MATCH, Seq(sortedValue.score) ++ scoredCases.map(_.score): _*))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
@@ -1,11 +1,10 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.New
-import coop.rchain.models.rholang.implicits._
 
 object NewSortMatcher extends Sortable[New] {
   def sortMatch(n: New): ScoredTerm[New] = {
-    val sortedPar = ParSortMatcher.sortMatch(n.p)
+    val sortedPar = Sortable.sortMatch(n.p)
     ScoredTerm(New(bindCount = n.bindCount, p = sortedPar.term, locallyFree = n.locallyFree),
                Node(Score.NEW, Leaf(n.bindCount), sortedPar.score))
   }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/NewSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.New
 
-object NewSortMatcher extends Sortable[New] {
+private[sort] object NewSortMatcher extends Sortable[New] {
   def sortMatch(n: New): ScoredTerm[New] = {
     val sortedPar = Sortable.sortMatch(n.p)
     ScoredTerm(New(bindCount = n.bindCount, p = sortedPar.term, locallyFree = n.locallyFree),

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
@@ -1,18 +1,16 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Par
-import ordering._
-import cats.implicits._
 
 object ParSortMatcher extends Sortable[Par] {
   def sortMatch(par: Par): ScoredTerm[Par] = {
-    val sends       = par.sends.toList.map(s => SendSortMatcher.sortMatch(s)).sorted
-    val receives    = par.receives.toList.map(r => ReceiveSortMatcher.sortMatch(r)).sorted
-    val exprs       = par.exprs.toList.map(e => ExprSortMatcher.sortMatch(e)).sorted
-    val news        = par.news.toList.map(n => NewSortMatcher.sortMatch(n)).sorted
-    val matches     = par.matches.toList.map(m => MatchSortMatcher.sortMatch(m)).sorted
-    val bundles     = par.bundles.toList.map(b => BundleSortMatcher.sortMatch(b)).sorted
-    val connectives = par.connectives.toList.map(c => ConnectiveSortMatcher.sortMatch(c)).sorted
+    val sends       = par.sends.toList.map(s => Sortable.sortMatch(s)).sorted
+    val receives    = par.receives.toList.map(r => Sortable.sortMatch(r)).sorted
+    val exprs       = par.exprs.toList.map(e => Sortable.sortMatch(e)).sorted
+    val news        = par.news.toList.map(n => Sortable.sortMatch(n)).sorted
+    val matches     = par.matches.toList.map(m => Sortable.sortMatch(m)).sorted
+    val bundles     = par.bundles.toList.map(b => Sortable.sortMatch(b)).sorted
+    val connectives = par.connectives.toList.map(c => Sortable.sortMatch(c)).sorted
     val ids         = par.ids.map(g => ScoredTerm(g, Node(Score.PRIVATE, Leaf(g.id)))).sorted
     val sortedPar = Par(
       sends = sends.map(_.term),

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ParSortMatcher.scala
@@ -2,7 +2,7 @@ package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Par
 
-object ParSortMatcher extends Sortable[Par] {
+private[sort] object ParSortMatcher extends Sortable[Par] {
   def sortMatch(par: Par): ScoredTerm[Par] = {
     val sends       = par.sends.toList.map(s => Sortable.sortMatch(s)).sorted
     val receives    = par.receives.toList.map(r => Sortable.sortMatch(r)).sorted

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
@@ -1,19 +1,17 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.{Receive, ReceiveBind}
-import cats.implicits._
-import coop.rchain.models.rholang.implicits._
 
 object ReceiveSortMatcher extends Sortable[Receive] {
 
   def sortBind(bind: ReceiveBind): ScoredTerm[ReceiveBind] = {
     val patterns       = bind.patterns
     val source         = bind.source
-    val sortedPatterns = patterns.toList.map(channel => ChannelSortMatcher.sortMatch(channel))
-    val sortedChannel  = ChannelSortMatcher.sortMatch(source)
+    val sortedPatterns = patterns.toList.map(channel => Sortable.sortMatch(channel))
+    val sortedChannel  = Sortable.sortMatch(source)
     val sortedRemainder = bind.remainder match {
       case Some(bindRemainder) =>
-        val scoredVar = VarSortMatcher.sortMatch(bindRemainder)
+        val scoredVar = Sortable.sortMatch(bindRemainder)
         ScoredTerm(Some(scoredVar.term), scoredVar.score)
       case None => ScoredTerm(None, Leaf(Score.ABSENT))
     }
@@ -28,7 +26,7 @@ object ReceiveSortMatcher extends Sortable[Receive] {
   def sortMatch(r: Receive): ScoredTerm[Receive] = {
     val sortedBinds     = r.binds.toList.map(bind => sortBind(bind))
     val persistentScore = if (r.persistent) 1 else 0
-    val sortedBody      = ParSortMatcher.sortMatch(r.body)
+    val sortedBody      = Sortable.sortMatch(r.body)
     ScoredTerm(
       Receive(sortedBinds.map(_.term),
               sortedBody.term,

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
@@ -1,13 +1,12 @@
 package coop.rchain.models.rholang.sort
 
 import coop.rchain.models.Send
-import cats.implicits._
 import coop.rchain.models.rholang.implicits._
 
 object SendSortMatcher extends Sortable[Send] {
   def sortMatch(s: Send): ScoredTerm[Send] = {
-    val sortedChan = ChannelSortMatcher.sortMatch(s.chan)
-    val sortedData = s.data.toList.map(ParSortMatcher.sortMatch(_))
+    val sortedChan = Sortable.sortMatch(s.chan)
+    val sortedData = s.data.toList.map(Sortable.sortMatch(_))
     val sortedSend = Send(
       chan = sortedChan.term,
       data = sortedData.map(_.term.get),

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
@@ -3,7 +3,7 @@ package coop.rchain.models.rholang.sort
 import coop.rchain.models.Send
 import coop.rchain.models.rholang.implicits._
 
-object SendSortMatcher extends Sortable[Send] {
+private[sort] object SendSortMatcher extends Sortable[Send] {
   def sortMatch(s: Send): ScoredTerm[Send] = {
     val sortedChan = Sortable.sortMatch(s.chan)
     val sortedData = s.data.toList.map(Sortable.sortMatch(_))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/Sortable.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/Sortable.scala
@@ -10,6 +10,8 @@ trait Sortable[T] {
 object Sortable {
   def apply[T](implicit ev: Sortable[T]) = ev
 
+  def sortMatch[T : Sortable](term: T): ScoredTerm[T] = Sortable[T].sortMatch(term)
+
   implicit val boolSortable: Sortable[GBool]            = BoolSortMatcher
   implicit val bundleSortable: Sortable[Bundle]         = BundleSortMatcher
   implicit val channelSortable: Sortable[Channel]       = ChannelSortMatcher

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/VarSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/VarSortMatcher.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Var.VarInstance.{BoundVar, Empty, FreeVar, Wildcard}
 import cats.implicits._
 import cats.syntax._
 
-object VarSortMatcher extends Sortable[Var] {
+private[sort] object VarSortMatcher extends Sortable[Var] {
   def sortMatch(v: Var): ScoredTerm[Var] =
     v.varInstance match {
       case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level))

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ordering.scala
@@ -1,20 +1,19 @@
 package coop.rchain.models.rholang.sort
 
-import coop.rchain.models.{KeyValuePair, Par}
-import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.Par
 import coop.rchain.models.rholang.sort.ScoredTerm._
 
 object ordering {
 
   implicit class ListSortOps(ps: List[Par]) {
     def sort: List[Par] =
-      ps.map(par => ParSortMatcher.sortMatch(par)).sorted.map(_.term)
+      ps.map(par => Sortable.sortMatch(par)).sorted.map(_.term)
   }
 
   implicit class MapSortOps(ps: Map[Par, Par]) {
     def sortKeyValuePair(key: Par, value: Par): ScoredTerm[(Par, Par)] = {
-      val sortedKey   = ParSortMatcher.sortMatch(key)
-      val sortedValue = ParSortMatcher.sortMatch(value)
+      val sortedKey   = Sortable.sortMatch(key)
+      val sortedValue = Sortable.sortMatch(value)
       ScoredTerm((sortedKey.term, sortedValue.term), sortedKey.score)
     }
 

--- a/models/src/test/scala/coop/rchain/models/ParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/ParMapSpec.scala
@@ -3,9 +3,8 @@ package coop.rchain.models
 import coop.rchain.models.Channel.ChannelInstance.ChanVar
 import coop.rchain.models.Expr.ExprInstance.{EEvalBody, EMapBody, GInt, GString}
 import coop.rchain.models.Var.VarInstance.BoundVar
-import coop.rchain.models.rholang.sort.ParSortMatcher
-import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.models.rholang.implicits._
+import org.scalatest.{FlatSpec, Matchers}
 
 class ParMapSpec extends FlatSpec with Matchers {
 

--- a/models/src/test/scala/coop/rchain/models/ParSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/ParSetSpec.scala
@@ -1,12 +1,9 @@
 package coop.rchain.models
 
 import coop.rchain.models.Expr.ExprInstance.{ESetBody, GInt}
-import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Var.VarInstance.BoundVar
-import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.rholang.sort.ParSortMatcher
-import coop.rchain.models.rholang.sort.ordering._
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -8,7 +8,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sort._
 import org.scalatest._
-import coop.rchain.models.rholang.sort.ordering._
+
 import scala.collection.immutable.BitSet
 
 class ScoredTermSpec extends FlatSpec with Matchers {
@@ -61,7 +61,7 @@ class VarSortMatcherSpec extends FlatSpec with Matchers {
       locallyFree = BitSet(0, 1, 2),
       connectiveUsed = true
     )
-    val result = ParSortMatcher.sortMatch(parVars)
+    val result = Sortable.sortMatch(parVars)
     result.term should be(sortedParVars.get)
   }
 }
@@ -72,7 +72,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(GInt(2), GInt(1), GInt(-1), GInt(-2), GInt(0)))
     val sortedParGround: Option[Par] =
       Par(exprs = List(GInt(-2), GInt(-1), GInt(0), GInt(1), GInt(2)))
-    val result = ParSortMatcher.sortMatch(parGround)
+    val result = Sortable.sortMatch(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -81,7 +81,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(GUri("https://www.rchain.coop/"), GInt(47), GString("Hello"), GBool(true)))
     val sortedParGround: Option[Par] =
       Par(exprs = List(GBool(true), GInt(47), GString("Hello"), GUri("https://www.rchain.coop/")))
-    val result = ParSortMatcher.sortMatch(parGround)
+    val result = Sortable.sortMatch(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -104,7 +104,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           ParSet(Seq[Par](GInt(1), GInt(2)))
         )
       )
-    val result = ParSortMatcher.sortMatch(parGround)
+    val result = Sortable.sortMatch(parGround)
     result.term should be(sortedParGround)
   }
 
@@ -124,14 +124,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
              locallyFree = BitSet(),
              connectiveUsed = false)
 
-    val result = ParSortMatcher.sortMatch(parGround)
+    val result = Sortable.sortMatch(parGround)
     result.term should be(sortedParGround)
   }
 
   "Par" should "Keep order when adding numbers" in {
     val parExpr: Par =
       EPlus(EPlus(GInt(1), GInt(3)), GInt(2))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(parExpr.get)
   }
 
@@ -150,7 +150,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EPlus(GInt(1), GInt(3)),
           EMinus(GInt(4), GInt(3))
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -175,7 +175,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EEq(GInt(4), GInt(3)),
           ENeq(GInt(1), GInt(5))
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -194,7 +194,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EOr(EVar(BoundVar(3)), EVar(BoundVar(4))),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2))
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -215,7 +215,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2)),
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -236,7 +236,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Send(Quote(GInt(5)), List(GInt(3)), false, BitSet()),
           Send(Quote(GInt(5)), List(GInt(3)), true, BitSet())
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -299,7 +299,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
                   BitSet()),
           Receive(List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))), Par(), true, 0, BitSet())
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -326,7 +326,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
                 BitSet()),
           Match(GInt(5), List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))), BitSet())
         ))
-    val result = ParSortMatcher.sortMatch(parMatch)
+    val result = Sortable.sortMatch(parMatch)
     result.term should be(sortedParMatch.get)
   }
 
@@ -335,7 +335,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(EVar(FreeVar(2)), EVar(FreeVar(1)), EVar(BoundVar(2)), EVar(BoundVar(1))))
     val sortedParGround: Option[Par] =
       Par(exprs = List(EVar(BoundVar(1)), EVar(BoundVar(2)), EVar(FreeVar(1)), EVar(FreeVar(2))))
-    val result = ParSortMatcher.sortMatch(parGround)
+    val result = Sortable.sortMatch(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -358,7 +358,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EEq(GInt(4), GInt(3)),
           EOr(GBool(false), GBool(true))
         ))
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -383,7 +383,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
         ))
 
     val bundle = Bundle(parExpr)
-    val result = BundleSortMatcher.sortMatch(bundle)
+    val result = Sortable.sortMatch(bundle)
     result.term should be(Bundle(sortedParExpr))
   }
 
@@ -411,7 +411,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Bundle(Bundle(parExpr, writeFlag = true, readFlag = false),
              writeFlag = false,
              readFlag = true))
-    val result = BundleSortMatcher.sortMatch(nestedBundle)
+    val result = Sortable.sortMatch(nestedBundle)
     result.term should be(
       Bundle(
         Bundle(Bundle(sortedParExpr, writeFlag = true, readFlag = false),
@@ -448,7 +448,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
         ),
         connectiveUsed = true
       )
-    val result = ParSortMatcher.sortMatch(parExpr)
+    val result = Sortable.sortMatch(parExpr)
     result.term should be(sortedParExpr.get)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -7,17 +7,11 @@ import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
-import coop.rchain.models.rholang.sort.ParSortMatcher
+import coop.rchain.models.rholang.sort.Sortable
 import coop.rchain.rholang.interpreter.accounting.CostAccount
-import coop.rchain.rholang.interpreter.errors.{
-  InterpreterError,
-  SyntaxError,
-  TopLevelFreeVariablesNotAllowedError,
-  TopLevelWildcardsNotAllowedError,
-  UnrecognizedInterpreterError
-}
+import coop.rchain.rholang.interpreter.errors.{InterpreterError, SyntaxError, TopLevelFreeVariablesNotAllowedError, TopLevelWildcardsNotAllowedError, UnrecognizedInterpreterError}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.{Yylex, parser}
 import monix.eval.{Coeval, Task}
 
 private class FailingTask[T](task: Task[Either[Throwable, T]]) {
@@ -41,7 +35,7 @@ object Interpreter {
         inputs  = ProcVisitInputs(VectorPar(), IndexMapChain[VarSort](), DebruijnLevelMap[VarSort]())
         outputs <- normalizeTerm[Coeval](term, inputs)
         par <- Coeval.delay(
-                ParSortMatcher
+                Sortable
                   .sortMatch(outputs.par)
                   .term)
       } yield par

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -2,7 +2,6 @@ package coop.rchain.rholang.interpreter
 
 import cats.effect.Sync
 import cats.implicits._
-import cats.mtl.MonadState
 import cats.{Applicative, Monad}
 import coop.rchain.models.Channel.ChannelInstance
 import coop.rchain.models.Channel.ChannelInstance._
@@ -11,11 +10,9 @@ import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
+import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sort._
 import coop.rchain.rholang.interpreter.errors.SubstituteError
-import coop.rchain.models.rholang.implicits._
-import errors._
-import coop.rchain.models.rholang.sort.ordering._
 
 trait Substitute[M[_], A] {
   def substitute(term: A)(implicit depth: Int, env: Env[Par]): M[A]
@@ -128,7 +125,7 @@ object Substitute {
                          }
         } yield channelSubst
       override def substitute(term: Channel)(implicit depth: Int, env: Env[Par]): M[Channel] =
-        substituteNoSort(term).map(channelSubst => ChannelSortMatcher.sortMatch(channelSubst).term)
+        substituteNoSort(term).map(channelSubst => Sortable.sortMatch(channelSubst).term)
     }
 
   implicit def substitutePar[M[_]: Sync]: Substitute[M, Par] =
@@ -197,7 +194,7 @@ object Substitute {
             )
         } yield par
       override def substitute(term: Par)(implicit depth: Int, env: Env[Par]): M[Par] =
-        substituteNoSort(term).map(par => ParSortMatcher.sortMatch(par).term)
+        substituteNoSort(term).map(par => Sortable.sortMatch(par).term)
     }
 
   implicit def substituteSend[M[_]: Sync]: Substitute[M, Send] =
@@ -215,7 +212,7 @@ object Substitute {
           )
         } yield send
       override def substitute(term: Send)(implicit depth: Int, env: Env[Par]): M[Send] =
-        substituteNoSort(term).map(send => SendSortMatcher.sortMatch(send).term)
+        substituteNoSort(term).map(send => Sortable.sortMatch(send).term)
     }
 
   implicit def substituteReceive[M[_]: Sync]: Substitute[M, Receive] =
@@ -244,7 +241,7 @@ object Substitute {
           )
         } yield rec
       override def substitute(term: Receive)(implicit depth: Int, env: Env[Par]): M[Receive] =
-        substituteNoSort(term).map(rec => ReceiveSortMatcher.sortMatch(rec).term)
+        substituteNoSort(term).map(rec => Sortable.sortMatch(rec).term)
 
     }
 
@@ -256,7 +253,7 @@ object Substitute {
           neu    = New(term.bindCount, newSub, term.locallyFree.until(env.shift))
         } yield neu
       override def substitute(term: New)(implicit depth: Int, env: Env[Par]): M[New] =
-        substituteNoSort(term).map(newSub => NewSortMatcher.sortMatch(newSub).term)
+        substituteNoSort(term).map(newSub => Sortable.sortMatch(newSub).term)
     }
 
   implicit def substituteMatch[M[_]: Sync]: Substitute[M, Match] =
@@ -275,7 +272,7 @@ object Substitute {
           mat = Match(targetSub, casesSub, term.locallyFree.until(env.shift), term.connectiveUsed)
         } yield mat
       override def substitute(term: Match)(implicit depth: Int, env: Env[Par]): M[Match] =
-        substituteNoSort(term).map(mat => MatchSortMatcher.sortMatch(mat).term)
+        substituteNoSort(term).map(mat => Sortable.sortMatch(mat).term)
     }
 
   implicit def substituteExpr[M[_]: Sync]: Substitute[M, Expr] =


### PR DESCRIPTION
## Overview
Use the previously introduced `Sortable`, making it provide a single entry point to the sorting logic. Encapsulate `Sortable` instancs using `private[sort]`.

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.