### PR TITLE
StreamT and bfTraverseF

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -149,11 +149,11 @@ sealed abstract class MultiParentCasperInstances {
         new mutable.HashSet[EquivocationRecord]()
       private val invalidBlockTracker: mutable.HashSet[BlockHash] =
         new mutable.HashSet[BlockHash]()
-      
+
       // TODO: Extract hardcoded fault tolerance threshold
       private val faultToleranceThreshold     = 0f
       private val lastFinalizedBlockContainer = Ref.unsafe[F, BlockMessage](genesis)
-      
+
       private val processingBlocks = new AtomicSyncVar(Set.empty[BlockHash])
 
       def addBlock(b: BlockMessage): F[BlockStatus] =

--- a/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
@@ -1,15 +1,36 @@
 package coop.rchain.casper.util
 
-import cats.Id
+import cats.{Eval, Monad}
+import cats.implicits._
+
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.BlockDag
 import coop.rchain.casper.Estimator.BlockHash
+import coop.rchain.shared.StreamT
 
 import scala.annotation.tailrec
-import scala.collection.immutable.HashSet
+import scala.collection.immutable.{HashSet, Queue}
 import scala.collection.mutable
 
 object DagOperations {
+
+  def bfTraverseF[F[_]: Monad, A](start: List[A])(neighbours: A => F[List[A]]): F[StreamT[F, A]] = {
+    def build(q: Queue[A], prevVisited: HashSet[A]): F[StreamT[F, A]] =
+      if (q.isEmpty) StreamT.empty[F, A].pure[F]
+      else {
+        val (curr, rest) = q.dequeue
+        if (prevVisited(curr)) build(rest, prevVisited)
+        else
+          for {
+            ns      <- neighbours(curr)
+            visited = prevVisited + curr
+            newQ    = rest.enqueue[A](ns.filterNot(visited))
+          } yield StreamT.cons(curr, Eval.later(build(newQ, visited)))
+      }
+
+    build(Queue.empty[A].enqueue[A](start), HashSet.empty[A])
+  }
+
   def bfTraverse[A](start: Iterable[A])(neighbours: (A) => Iterator[A]): Iterator[A] =
     new Iterator[A] {
       private val visited    = new mutable.HashSet[A]()

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -23,6 +23,11 @@ class DagOperationsTest
     with BlockStoreTestFixture {
   val initState = BlockDag().copy(currentId = -1)
 
+  "bfTraverseF" should "lazily breadth-first traverse a DAG with effectful neighbours" in {
+    val stream = DagOperations.bfTraverseF[Id, Int](List(1))(i => List(i * 2, i * 3))
+    stream.take(10).toList shouldBe List(1, 2, 3, 4, 6, 9, 8, 12, 18, 27)
+  }
+
   "Greatest common ancestor" should "be computed properly" in {
     /*
      * DAG Looks like this:

--- a/shared/src/main/scala/coop/rchain/shared/StreamT.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StreamT.scala
@@ -5,55 +5,199 @@ import cats.implicits._
 
 sealed abstract class StreamT[F[_], +A] { self =>
 
-  def ++[AA >: A](other: StreamT[F, AA]): StreamT[F, A] = ???
+  def ++[AA >: A](other: StreamT[F, AA])(implicit functor: Functor[F]): StreamT[F, AA] =
+    self match {
+      case SCons(curr, lazyTail) => StreamT.cons(curr, lazyTail.map(_.map(_ ++ other)))
+      case SLazy(lazyTail)       => StreamT.delay(lazyTail.map(_.map(_ ++ other)))
+      case _: SNil[F]            => other
+    }
 
-  def map[B](f: A => B)(implicit functor: Functor[F]): StreamT[F, B] = self match {
-    case Cons(head, tail) => StreamT.cons(f(head), tail.map(_.map(_.map(f))))
-    case _: Nil[F]        => StreamT.empty[F, B]
+  def drop(n: Int)(implicit functor: Functor[F]): StreamT[F, A] =
+    if (n > 0) self match {
+      case SCons(_, lazyTail) => StreamT.delay(lazyTail.map(_.map(_.drop(n - 1))))
+      case SLazy(lazyTail)    => StreamT.delay(lazyTail.map(_.map(_.drop(n))))
+      case _: SNil[F]         => StreamT.empty[F, A]
+    } else self
+
+  def find[AA >: A](p: A => Boolean)(implicit monad: Monad[F]): F[Option[AA]] = self match {
+    case SCons(curr, lazyTail) =>
+      if (p(curr)) monad.pure[Option[AA]](curr.some)
+      else lazyTail.value.flatMap(_.find(p))
+
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.find(p))
+
+    case _: SNil[F] => none[AA].pure[F]
+  }
+
+  def findF[AA >: A](p: A => F[Boolean])(implicit monad: Monad[F]): F[Option[AA]] = self match {
+    case SCons(curr, lazyTail) =>
+      p(curr).flatMap { found =>
+        if (found) monad.pure[Option[AA]](curr.some)
+        else lazyTail.value.flatMap(_.findF(p))
+      }
+
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.findF(p))
+
+    case _: SNil[F] => none[AA].pure[F]
   }
 
   def flatMap[B](f: A => StreamT[F, B])(implicit monad: Monad[F]): StreamT[F, B] = self match {
-    case Cons(head, lazyTail) =>
-      f(head) match {
-        case Cons(newHead, mappedLazyTail) =>
-          val newLazyTail: Eval[F[StreamT[F, B]]] = for {
-            tailF       <- lazyTail
-            mappedTailF <- mappedLazyTail
-          } yield
-            for {
-              mappedTail <- mappedTailF
-              tail       <- tailF
-            } yield mappedTail ++ tail.flatMap[B](f)
+    case SCons(curr, lazyTail) =>
+      f(curr) match {
+        case SCons(newHead, mappedLazyTail) =>
+          val newLazyTail = StreamT.flatMapHelper(f, lazyTail, mappedLazyTail)
           StreamT.cons(newHead, newLazyTail)
 
-        case _: Nil[F] => StreamT.skip(lazyTail.map(_.map(_.flatMap(f))))
+        case SLazy(mappedLazyTail) =>
+          StreamT.delay(StreamT.flatMapHelper(f, lazyTail, mappedLazyTail))
+
+        case _: SNil[F] => StreamT.delay(lazyTail.map(_.map(_.flatMap(f))))
       }
-    case _: Nil[F] => StreamT.empty[F, B]
+    case SLazy(lazyTail) => StreamT.delay(lazyTail.map(_.map(_.flatMap(f))))
+
+    case _: SNil[F] => StreamT.empty[F, B]
+  }
+
+  def foldLeft[B](b: B)(f: (B, A) => B)(implicit monad: Monad[F]): F[B] = self match {
+    case SCons(curr, lazyTail) =>
+      val newB = f(b, curr)
+      lazyTail.value.flatMap(_.foldLeft(newB)(f))
+
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.foldLeft(b)(f))
+
+    case _: SNil[F] => b.pure[F]
+  }
+
+  def foldRight[B](lb: Eval[B])(f: (A, Eval[F[B]]) => Eval[F[B]])(
+      implicit monad: Monad[F],
+      traverse: Traverse[F]): Eval[F[B]] = self match {
+    case SCons(curr, lazyTail) =>
+      val mappedLazyTail = lazyTail.flatMap { tailF =>
+        monad.map(tailF)(_.foldRight(lb)(f)).flatSequence
+      }
+      f(curr, mappedLazyTail)
+
+    case SLazy(lazyTail) =>
+      lazyTail.flatMap { tailF =>
+        monad.map(tailF)(_.foldRight(lb)(f)).flatSequence
+      }
+
+    case _: SNil[F] => lb.map(_.pure[F])
   }
 
   def foreach(f: A => F[Unit])(implicit monad: Monad[F]): F[Unit] = self match {
-    case Cons(head, tailF) =>
+    case SCons(curr, tailF) =>
       for {
-        _    <- f(head)
-        tail <- tailF.value
-        _    <- tail.foreach(f)
+        _        <- f(curr)
+        lazyTail <- tailF.value
+        _        <- lazyTail.foreach(f)
       } yield ()
 
-    case _: Nil[F] => ().pure[F]
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.foreach(f))
+
+    case _: SNil[F] => ().pure[F]
+  }
+
+  def head[AA >: A](implicit monadError: MonadError[F, Throwable]): F[AA] = self match {
+    case SCons(head, _)  => monadError.pure[AA](head)
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.head)
+    case _: SNil[F] =>
+      monadError.raiseError[AA](new Exception("Head on empty StreamT!"))
+  }
+
+  def map[B](f: A => B)(implicit functor: Functor[F]): StreamT[F, B] = self match {
+    case SCons(curr, lazyTail) => StreamT.cons(f(curr), lazyTail.map(_.map(_.map(f))))
+    case SLazy(lazyTail)       => StreamT.delay(lazyTail.map(_.map(_.map(f))))
+    case _: SNil[F]            => StreamT.empty[F, B]
+  }
+
+  def tail(implicit applicativeError: ApplicativeError[F, Throwable]): StreamT[F, A] = self match {
+    case SCons(_, lazyTail) => StreamT.delay(lazyTail)
+    case SLazy(lazyTail)    => StreamT.delay(lazyTail.map(_.map(_.tail)))
+    case _: SNil[F] =>
+      StreamT.delay(
+        Eval.now(
+          applicativeError.raiseError[StreamT[F, A]](new Exception("Tail on empty StreamT!"))))
   }
 
   def take(n: Int)(implicit functor: Functor[F]): StreamT[F, A] =
     if (n > 0) self match {
-      case Cons(head, tail) => StreamT.cons(head, tail.map(_.map(_.take(n - 1))))
-      case _: Nil[F]        => StreamT.empty[F, A]
+      case SCons(curr, lazyTail) => StreamT.cons(curr, lazyTail.map(_.map(_.take(n - 1))))
+      case SLazy(lazyTail)       => StreamT.delay(lazyTail.map(_.map(_.take(n))))
+      case _: SNil[F]            => StreamT.empty[F, A]
     } else StreamT.empty[F, A]
+
+  def toList[AA >: A](implicit monad: Monad[F]): F[List[AA]] = self match {
+    case SCons(curr, lazyTail) =>
+      for {
+        stail <- lazyTail.value
+        ltail <- stail.toList
+      } yield curr :: ltail
+
+    case SLazy(lazyTail) => lazyTail.value.flatMap(_.toList)
+
+    case _: SNil[F] => List.empty[AA].pure[F]
+  }
+
+  def zip[B](other: StreamT[F, B])(implicit monad: Monad[F]): StreamT[F, (A, B)] =
+    (self, other) match {
+      case (SCons(a, lazyTailA), SCons(b, lazyTailB)) =>
+        val tailB = StreamT.delay(lazyTailB)
+        StreamT.cons((a, b), lazyTailA.map(_.map(_.zip[B](tailB))))
+
+      case (streamA: SCons[F, A], SLazy(lazyTailB)) =>
+        StreamT.delay(lazyTailB.map(_.map(tailB => streamA.zip(tailB))))
+
+      case (SLazy(lazyTailA), streamB: SCons[F, B]) =>
+        StreamT.delay(lazyTailA.map(_.map(tailA => tailA.zip(streamB))))
+
+      case (SLazy(lazyTailA), SLazy(lazyTailB)) =>
+        StreamT.delay(
+          for {
+            tailAF <- lazyTailA
+            tailBF <- lazyTailB
+          } yield
+            for {
+              tailA <- tailAF
+              tailB <- tailBF
+            } yield tailA.zip(tailB)
+        )
+
+      case (_: SNil[F], _) => StreamT.empty[F, (A, B)]
+
+      case (_, _: SNil[F]) => StreamT.empty[F, (A, B)]
+    }
 }
-final case class Cons[F[_], A](head: A, tail: Eval[F[StreamT[F, A]]]) extends StreamT[F, A]
-final case class Skip[F[_], A](tail: Eval[F[StreamT[F, A]]])          extends StreamT[F, A]
-final class Nil[F[_]]                                                 extends StreamT[F, Nothing]
+final case class SCons[F[_], A](curr: A, lazyTail: Eval[F[StreamT[F, A]]]) extends StreamT[F, A]
+final case class SLazy[F[_], A](lazyTail: Eval[F[StreamT[F, A]]])          extends StreamT[F, A]
+final class SNil[F[_]]                                                     extends StreamT[F, Nothing]
 
 object StreamT {
-  def empty[F[_], A]: StreamT[F, A]                                       = new Nil[F]
-  def cons[F[_], A](head: A, tail: Eval[F[StreamT[F, A]]]): StreamT[F, A] = Cons(head, tail)
-  def skip[F[_], A](tail: Eval[F[StreamT[F, A]]]): StreamT[F, A]          = Skip(tail)
+  type STail[F[_], A] = Eval[F[StreamT[F, A]]]
+
+  def empty[F[_], A]: StreamT[F, A]                                = new SNil[F]
+  def cons[F[_], A](curr: A, lazyTail: STail[F, A]): StreamT[F, A] = SCons(curr, lazyTail)
+  def delay[F[_], A](lazyTail: STail[F, A]): StreamT[F, A]         = SLazy(lazyTail)
+
+  def fromList[F[_], A](listF: F[List[A]])(implicit applicative: Applicative[F]): StreamT[F, A] = {
+    def build(list: List[A]): StreamT[F, A] = list match {
+      case head :: tail => StreamT.cons(head, Eval.later(build(tail).pure[F]))
+      case Nil          => StreamT.empty[F, A]
+    }
+
+    StreamT.delay(Eval.now(listF.map(build(_))))
+  }
+
+  private def flatMapHelper[F[_], A, B, BB <: B](
+      f: A => StreamT[F, B],
+      lazyTail: STail[F, A],
+      mappedLazyTail: STail[F, BB])(implicit monad: Monad[F]): STail[F, B] =
+    for {
+      tailF       <- lazyTail
+      mappedTailF <- mappedLazyTail
+    } yield
+      for {
+        mappedTail <- mappedTailF
+        lazyTail   <- tailF
+      } yield mappedTail ++ lazyTail.flatMap[B](f)
 }

--- a/shared/src/main/scala/coop/rchain/shared/StreamT.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StreamT.scala
@@ -1,0 +1,59 @@
+package coop.rchain.shared
+
+import cats._
+import cats.implicits._
+
+sealed abstract class StreamT[F[_], +A] { self =>
+
+  def ++[AA >: A](other: StreamT[F, AA]): StreamT[F, A] = ???
+
+  def map[B](f: A => B)(implicit functor: Functor[F]): StreamT[F, B] = self match {
+    case Cons(head, tail) => StreamT.cons(f(head), tail.map(_.map(_.map(f))))
+    case _: Nil[F]        => StreamT.empty[F, B]
+  }
+
+  def flatMap[B](f: A => StreamT[F, B])(implicit monad: Monad[F]): StreamT[F, B] = self match {
+    case Cons(head, lazyTail) =>
+      f(head) match {
+        case Cons(newHead, mappedLazyTail) =>
+          val newLazyTail: Eval[F[StreamT[F, B]]] = for {
+            tailF       <- lazyTail
+            mappedTailF <- mappedLazyTail
+          } yield
+            for {
+              mappedTail <- mappedTailF
+              tail       <- tailF
+            } yield mappedTail ++ tail.flatMap[B](f)
+          StreamT.cons(newHead, newLazyTail)
+
+        case _: Nil[F] => StreamT.skip(lazyTail.map(_.map(_.flatMap(f))))
+      }
+    case _: Nil[F] => StreamT.empty[F, B]
+  }
+
+  def foreach(f: A => F[Unit])(implicit monad: Monad[F]): F[Unit] = self match {
+    case Cons(head, tailF) =>
+      for {
+        _    <- f(head)
+        tail <- tailF.value
+        _    <- tail.foreach(f)
+      } yield ()
+
+    case _: Nil[F] => ().pure[F]
+  }
+
+  def take(n: Int)(implicit functor: Functor[F]): StreamT[F, A] =
+    if (n > 0) self match {
+      case Cons(head, tail) => StreamT.cons(head, tail.map(_.map(_.take(n - 1))))
+      case _: Nil[F]        => StreamT.empty[F, A]
+    } else StreamT.empty[F, A]
+}
+final case class Cons[F[_], A](head: A, tail: Eval[F[StreamT[F, A]]]) extends StreamT[F, A]
+final case class Skip[F[_], A](tail: Eval[F[StreamT[F, A]]])          extends StreamT[F, A]
+final class Nil[F[_]]                                                 extends StreamT[F, Nothing]
+
+object StreamT {
+  def empty[F[_], A]: StreamT[F, A]                                       = new Nil[F]
+  def cons[F[_], A](head: A, tail: Eval[F[StreamT[F, A]]]): StreamT[F, A] = Cons(head, tail)
+  def skip[F[_], A](tail: Eval[F[StreamT[F, A]]]): StreamT[F, A]          = Skip(tail)
+}

--- a/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
@@ -1,0 +1,132 @@
+package coop.rchain.shared
+
+import cats._
+import cats.implicits._
+
+import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+import scala.util.{Failure, Success, Try}
+
+class StreamTSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+  import StreamTSpec._
+
+  describe("StreamT") {
+    it("should be able to be constructed from lists") {
+      forAll { (list: List[Int]) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.toList[Int] shouldBe list
+      }
+    }
+
+    it("should correctly compute heads") {
+      forAll { (list: List[Int]) =>
+        whenever(list.nonEmpty) {
+          val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+          stream.head[Int](mErrId) shouldBe list.head
+        }
+      }
+    }
+
+    it("should correctly compute tails") {
+      forAll { (list: List[Int]) =>
+        whenever(list.nonEmpty) {
+          val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+          stream.tail(mErrId).toList[Int] shouldBe list.tail
+        }
+      }
+    }
+
+    it("should be able to zip with other StreamTs") {
+      forAll { (listA: List[Int], listB: List[String]) =>
+        val streamA = StreamT.fromList[Id, Int](listA)
+        val streamB = StreamT.fromList[Id, String](listB)
+
+        listA.zip(listB) shouldBe streamA.zip(streamB).toList
+      }
+    }
+
+    it("should allow taking a finite number of terms") {
+      forAll { (list: List[Int], n: Int) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.take(n).toList[Int] shouldBe list.take(n)
+      }
+
+    }
+
+    it("should allow dropping a finite number of terms") {
+      forAll { (list: List[Int], n: Int) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.drop(n).toList[Int] shouldBe list.drop(n)
+      }
+
+    }
+
+    it("should find elements properly in") {
+      forAll { (list: List[Int]) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.find[Int](_ % 2 == 0) shouldBe list.find(_ % 2 == 0)
+      }
+    }
+
+    it("should foldLeft properly in") {
+      forAll { (list: List[Int]) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.foldLeft[Int](0)(_ + _) shouldBe list.sum
+      }
+    }
+
+    it("should map properly in") {
+      forAll { (list: List[Int]) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream.map(_ * 2).toList[Int] shouldBe list.map(_ * 2)
+      }
+    }
+
+    it("should flatMap properly in") {
+      forAll { (list: List[Int]) =>
+        val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
+
+        stream
+          .flatMap(i => StreamT.fromList[Id, Int](List(i + 1, i + 2, i + 3)))
+          .toList[Int] shouldBe list.flatMap(i => List(i + 1, i + 2, i + 3))
+      }
+    }
+    it("should be able lazily construct infinite sequences") {
+      lazy val fibs: StreamT[Id, Long] =
+        StreamT.cons(
+          0L,
+          Eval.now(pure(StreamT.cons(1L, Eval.later(pure(fibs.zip(fibs.tail(mErrId)).map {
+            case (a, b) => a + b
+          }))))))
+
+      fibs.take(8).toList[Long] shouldBe List(0L, 1L, 1L, 2L, 3L, 5L, 8L, 13L)
+    }
+  }
+
+  private def pure[A](value: A): Id[A] = Applicative[Id].pure(value)
+}
+
+object StreamTSpec {
+  val mErrId = unsafeMErr[Id]
+
+  def unsafeMErr[F[_]: Monad]: MonadError[F, Throwable] =
+    new MonadError[F, Throwable] {
+      def pure[A](x: A): F[A]                                 = Monad[F].pure(x)
+      def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]         = Monad[F].flatMap(fa)(f)
+      def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] = Monad[F].tailRecM(a)(f)
+      def raiseError[A](e: Throwable): F[A]                   = throw e
+      def handleErrorWith[A](fa: F[A])(f: Throwable => F[A]): F[A] = Try(fa) match {
+        case Success(x) => x
+        case Failure(e) => f(e)
+      }
+    }
+}


### PR DESCRIPTION
## Overview
Defines our own StreamT class and uses it to have a properly lazy `bfTraverseF` function, which will be needed in @KentShikama 's refactor of Casper to integrate the effectful block store properly (without the use of `asMap`).

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-554

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
