### PR TITLE
Include non-body BlockMessage fields into blockhash

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -77,11 +77,7 @@ object Validate {
     signatureVerifiers
       .get(b.sigAlgorithm)
       .map(verify => {
-        val justificationHash = ProtoUtil.protoSeqHash(b.justifications)
-        val sigData =
-          Blake2b256.hash(justificationHash.toByteArray ++ b.blockHash.toByteArray)
-
-        Try(verify(sigData, b.sig.toByteArray, b.sender.toByteArray)) match {
+        Try(verify(b.blockHash.toByteArray, b.sig.toByteArray, b.sender.toByteArray)) match {
           case Success(true) => true.pure[F]
           case _             => Log[F].warn(ignore(b, "signature is invalid.")).map(_ => false)
         }

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -190,15 +190,14 @@ object ProtoUtil {
         acc.updated(validator, block)
     }
 
-  def protoHash[A <: { def toByteArray: Array[Byte] }](proto: A): ByteString =
-    ByteString.copyFrom(Blake2b256.hash(proto.toByteArray))
+  def protoHash[A <: { def toByteArray: Array[Byte] }](protoSeq: A*): ByteString =
+    protoSeqHash(protoSeq)
 
-  def protoSeqHash[A <: { def toByteArray: Array[Byte] }](protoSeq: Seq[A]): ByteString = {
-    val bytes = protoSeq.foldLeft(Array.empty[Byte]) {
-      case (acc, proto) => acc ++ proto.toByteArray
-    }
-    ByteString.copyFrom(Blake2b256.hash(bytes))
-  }
+  def protoSeqHash[A <: { def toByteArray: Array[Byte] }](protoSeq: Seq[A]): ByteString =
+    hashBytes(protoSeq.map(_.toByteArray): _*)
+
+  def hashBytes(items: Array[Byte]*): ByteString =
+    ByteString.copyFrom(Blake2b256.hash(Array.concat(items: _*)))
 
   def blockHeader(body: Body,
                   parentHashes: Seq[ByteString],
@@ -215,12 +214,25 @@ object ProtoUtil {
 
   def unsignedBlockProto(body: Body,
                          header: Header,
-                         justifications: Seq[Justification]): BlockMessage =
+                         justifications: Seq[Justification]): BlockMessage = {
+    val hash = hashUnsignedBlock(header, justifications)
+
     BlockMessage()
-      .withBlockHash(protoHash(header))
+      .withBlockHash(hash)
       .withHeader(header)
       .withBody(body)
       .withJustifications(justifications)
+  }
+
+  def hashUnsignedBlock(header: Header, justifications: Seq[Justification]) = {
+    val items = header.toByteArray +: justifications.map(_.toByteArray)
+    hashBytes(items: _*)
+  }
+
+  def hashSignedBlock(header: Header, sender: ByteString, sigAlgorithm: String, seqNum: Int) = {
+    val headerBytes = header.toByteArray
+    hashBytes(headerBytes, sender.toByteArray, sigAlgorithm.getBytes, Array(seqNum.toByte))
+  }
 
   def signBlock(block: BlockMessage,
                 dag: BlockDag,
@@ -228,16 +240,26 @@ object ProtoUtil {
                 sk: Array[Byte],
                 sigAlgorithm: String,
                 signFunction: (Array[Byte], Array[Byte]) => Array[Byte]): BlockMessage = {
-    val justificationHash = ProtoUtil.protoSeqHash(block.justifications)
-    val sigData           = Blake2b256.hash(justificationHash.toByteArray ++ block.blockHash.toByteArray)
-    val sender            = ByteString.copyFrom(pk)
-    val sig               = ByteString.copyFrom(signFunction(sigData, sk))
-    val currSeqNum        = dag.currentSeqNum.getOrElse(sender, -1)
+
+    val header = {
+      //TODO refactor casper code to avoid the usage of Option fields in the block datastructures https://rchain.atlassian.net/browse/RHOL-572
+      assert(block.header.isDefined, "A block without a header doesn't make sense")
+      block.header.get
+    }
+
+    val sender = ByteString.copyFrom(pk)
+    val seqNum = dag.currentSeqNum.getOrElse(sender, -1) + 1
+
+    val blockHash = hashSignedBlock(header, sender, sigAlgorithm, seqNum)
+
+    val sig = ByteString.copyFrom(signFunction(blockHash.toByteArray, sk))
+
     val signedBlock = block
       .withSender(sender)
       .withSig(sig)
-      .withSeqNum(currSeqNum + 1)
+      .withSeqNum(seqNum)
       .withSigAlgorithm(sigAlgorithm)
+      .withBlockHash(blockHash)
 
     signedBlock
   }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -116,7 +116,6 @@ message ApprovedBlockRequest {
 // ------- End Signing Protocol --------
 
 // --------- Core Protocol  --------
-// TODO: Include non-body BlockMessage fields into blockhash (See RHOL-546)
 message BlockMessage {
   bytes                  blockHash      = 1; // obtained by hashing the information in the header
   Header                 header         = 2;


### PR DESCRIPTION

## Overview
Justifications, sender, seqNum, sigAlgorithm need to be included in the hash such that they cannot be faked

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-546

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
