### PR TITLE
CORE-770/CORE-947 remove connections in rchain protocol when near max size

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -59,6 +59,7 @@ object CommError {
   def unexpectedMessage(msgStr: String): CommError       = UnexpectedMessage(msgStr)
   def senderNotAvailable: CommError                      = SenderNotAvailable
   def pongNotReceivedForPing(peer: PeerNode): CommError  = PongNotReceivedForPing(peer)
+  def timeout: CommError                                 = TimeOut
 
   def errorMessage(ce: CommError): String =
     ce match {

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -47,7 +47,7 @@ object Connect {
 
     for {
       connections <- ConnectionsCell[F].read
-      max         <- RPConfAsk[F].reader(_.maxNumOfConnections)
+      max         <- RPConfAsk[F].reader(_.clearConnections.maxNumOfConnections)
       cleared     <- if (connections.size > ((max * 2) / 3)) clear else 0.pure[F]
     } yield cleared
   }

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -53,9 +53,10 @@ object Connect {
         results <- toPing.traverse(peer =>
                     TransportLayer[F].roundTrip(peer, hb, timeout).map(r => (peer, r)))
         successfulPeers = results.filter(_._2.isRight).map(_._1)
+        failedPeers     = results.filter(_._2.isLeft).map(_._1)
         _ <- ConnectionsCell[F]
               .modify(p => (p.filter(conn => !toPing.contains(conn)) ++ successfulPeers).pure[F])
-      } yield results.size
+      } yield failedPeers.size
 
     for {
       connections <- ConnectionsCell[F].read

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -48,7 +48,7 @@ object Connect {
     for {
       connections <- ConnectionsCell[F].read
       max         <- RPConfAsk[F].reader(_.maxNumOfConnections)
-      cleared     <- if (connections.size > (max / 2)) clear else 0.pure[F]
+      cleared     <- if (connections.size > ((max * 2) / 3)) clear else 0.pure[F]
     } yield cleared
   }
 

--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -1,6 +1,7 @@
 package coop.rchain.comm.rp
 
-import Connect.ConnectionsCell
+import Connect.{Connections, ConnectionsCell}, Connections._
+
 import coop.rchain.p2p.effects._
 import coop.rchain.comm.discovery._
 import scala.concurrent.duration._
@@ -93,7 +94,7 @@ object HandleMessages {
     def handledHandshake(local: PeerNode): F[CommunicationResponse] =
       for {
         _ <- NodeDiscovery[F].addNode(peer)
-        _ <- ConnectionsCell[F].modify(cs => (cs + peer).pure[F])
+        _ <- ConnectionsCell[F].modify(_.addConn[F](peer))
         _ <- Log[F].info(s"Responded to protocol handshake request from $peer")
       } yield handledWithMessage(protocolHandshakeResponse(local))
 

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -1,0 +1,5 @@
+package coop.rchain.comm.rp
+
+case class RPConf(
+    maxNumOfConnections: Int
+)

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -1,5 +1,4 @@
 package coop.rchain.comm.rp
 
-case class RPConf(
-    maxNumOfConnections: Int
-)
+case class RPConf(clearConnections: ClearConnetionsConf)
+case class ClearConnetionsConf(maxNumOfConnections: Int, numOfConnectionsPinged: Int)

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -1,4 +1,6 @@
 package coop.rchain.comm.rp
 
-case class RPConf(clearConnections: ClearConnetionsConf)
+import scala.concurrent.duration._
+
+case class RPConf(defaultTimeout: FiniteDuration, clearConnections: ClearConnetionsConf)
 case class ClearConnetionsConf(maxNumOfConnections: Int, numOfConnectionsPinged: Int)

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -98,6 +98,20 @@ class ClearConnectionsSpec
         connections.read.size shouldBe (3)
         connections.read shouldEqual (List(peer("D"), peer("B"), peer("C")))
       }
+
+      it("should report number of connections that were removed") {
+        // given
+        implicit val connections = mkConnections(peer("A"), peer("B"), peer("C"), peer("D"))
+        implicit val max         = conf(maxNumOfConnections = 5, numOfConnectionsPinged = 3)
+        transport.setResponses({
+          case p if (p == peer("A")) => alwaysFail
+          case _                     => alwaysSuccess
+        })
+        // when
+        val cleared = Connect.clearConnections[Id]
+        // tehn
+        cleared shouldBe (1)
+      }
     }
   }
 

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -18,7 +18,8 @@ class ClearConnectionsSpec
   import ScalaTestCats._
 
   describe("Node when called to clear connectios") {
-    describe("if number of connectons is smaller or equal to 2/3 of number of maximum connectons allowed") {
+    describe(
+      "if number of connectons is smaller or equal to 2/3 of number of maximum connectons allowed") {
       it("should not clear any of existing connections") {
         // given
         implicit val connections = mkConnections(peer("A"), peer("B"))
@@ -41,9 +42,7 @@ class ClearConnectionsSpec
       }
     }
 
-    describe("if number of connectons is bigger then 2/3 of number of maximum connectons allowed") {
-
-    }
+    describe("if number of connectons is bigger then 2/3 of number of maximum connectons allowed") {}
   }
 
   private def peer(name: String): PeerNode =
@@ -55,6 +54,7 @@ class ClearConnectionsSpec
     })
 
   private def maxNumOfConnections(num: Int): RPConfAsk[Id] =
-    new ConstApplicativeAsk(RPConf(maxNumOfConnections = 5))
+    new ConstApplicativeAsk(
+      RPConf(ClearConnetionsConf(maxNumOfConnections = 5, numOfConnectionsPinged = num)))
 
 }

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -1,0 +1,60 @@
+package coop.rchain.comm.rp
+
+import Connect._, Connections._
+import coop.rchain.comm._
+
+import org.scalatest._
+import org.scalatest.enablers.Containing
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib._, Catscontrib._, ski._
+import coop.rchain.shared._
+
+class ClearConnectionsSpec
+    extends FunSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with AppendedClues {
+
+  import ScalaTestCats._
+
+  describe("Node when called to clear connectios") {
+    describe("if number of connectons is smaller or equal to 2/3 of number of maximum connectons allowed") {
+      it("should not clear any of existing connections") {
+        // given
+        implicit val connections = mkConnections(peer("A"), peer("B"))
+        implicit val max         = maxNumOfConnections(5)
+        // when
+        Connect.clearConnections[Id]
+        // then
+        connections.read.size shouldBe (2)
+        connections.read should contain(peer("A"))
+        connections.read should contain(peer("B"))
+      }
+      it("should report that 0 connections were cleared") {
+        // given
+        implicit val connections = mkConnections(peer("A"), peer("B"))
+        implicit val max         = maxNumOfConnections(5)
+        // when
+        val cleared = Connect.clearConnections[Id]
+        // then
+        cleared shouldBe (0)
+      }
+    }
+
+    describe("if number of connectons is bigger then 2/3 of number of maximum connectons allowed") {
+
+    }
+  }
+
+  private def peer(name: String): PeerNode =
+    PeerNode(NodeIdentifier(name.getBytes), Endpoint("host", 80, 80))
+
+  private def mkConnections(peers: PeerNode*): ConnectionsCell[Id] =
+    Cell.const[Id, Connections](peers.foldLeft(Connections.empty) {
+      case (acc, el) => acc.addConn[Id](el)
+    })
+
+  private def maxNumOfConnections(num: Int): RPConfAsk[Id] =
+    new ConstApplicativeAsk(RPConf(maxNumOfConnections = 5))
+
+}

--- a/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
@@ -45,7 +45,7 @@ class ConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach with App
         Connect.connect[Effect](remote, defaultTimeout)
         // then
         transportLayerEff.requests.size should be(1)
-        val Protocol(_, Protocol.Message.Upstream(upstream)) = transportLayerEff.requests(0)
+        val Protocol(_, Protocol.Message.Upstream(upstream)) = transportLayerEff.requests(0).msg
         upstream.unpack(ProtocolHandshake)
       }
       it("should then add remote node to communication layer") {

--- a/comm/src/test/scala/coop/rchain/comm/connect/ScalaTestCats.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ScalaTestCats.scala
@@ -1,0 +1,23 @@
+package coop.rchain.comm.rp
+
+import cats._, cats.data._, cats.implicits._
+import org.scalatest._
+import org.scalatest.enablers.Containing
+
+object ScalaTestCats {
+  implicit def idContaining[C](implicit C: Containing[C]): Containing[Id[C]] =
+    new Containing[Id[C]] {
+      def contains(container: cats.Id[C], element: Any): Boolean = {
+        val con: C = container
+        C.contains(con, element)
+      }
+      def containsNoneOf(container: cats.Id[C], elements: Seq[Any]): Boolean = {
+        val con: C = container
+        C.containsNoneOf(con, elements)
+      }
+      def containsOneOf(container: cats.Id[C], elements: Seq[Any]): Boolean = {
+        val con: C = container
+        C.containsOneOf(con, elements)
+      }
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -78,4 +78,6 @@ package object effects {
   def tcpConnections: Task[Cell[Task, TransportState]] = Cell.mvarCell(TransportState.empty)
   def rpConnections: Task[ConnectionsCell[Task]] =
     Cell.const[Task, Connections](Connections.empty).pure[Task] // noop for now
+
+  def rpConfAsk(conf: RPConf): ApplicativeAsk[Task, RPConf] = new ConstApplicativeAsk[Task, RPConf](conf)
 }

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -79,5 +79,6 @@ package object effects {
   def rpConnections: Task[ConnectionsCell[Task]] =
     Cell.const[Task, Connections](Connections.empty).pure[Task] // noop for now
 
-  def rpConfAsk(conf: RPConf): ApplicativeAsk[Task, RPConf] = new ConstApplicativeAsk[Task, RPConf](conf)
+  def rpConfAsk(conf: RPConf): ApplicativeAsk[Task, RPConf] =
+    new ConstApplicativeAsk[Task, RPConf](conf)
 }

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -303,6 +303,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
 
     /** create typeclass instances */
     tcpConnections <- effects.tcpConnections.toEffect
+    rpConfAsk = effects.rpConfAsk(RPConf(conf.server.maxNumOfConnections)).toEffect
     rpConnections  <- effects.rpConnections.toEffect
     log            = effects.log
     time           = effects.time

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -303,7 +303,10 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
 
     /** create typeclass instances */
     tcpConnections <- effects.tcpConnections.toEffect
-    rpConfAsk = effects.rpConfAsk(RPConf(conf.server.maxNumOfConnections)).toEffect
+    rpConfAsk      = effects.rpConfAsk(RPConf(ClearConnetionsConf(
+      conf.server.maxNumOfConnections,
+      numOfConnectionsPinged = 10) // TODO read from conf
+    )).toEffect
     rpConnections  <- effects.rpConnections.toEffect
     log            = effects.log
     time           = effects.time

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -128,7 +128,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
   private val storagePath       = conf.server.dataDir.resolve("rspace")
   private val casperStoragePath = storagePath.resolve("casper")
   private val storageSize       = conf.server.mapSize
-  private val defaultTimeout    = FiniteDuration(conf.server.defaultTimeout.toLong, MILLISECONDS)
+  private val defaultTimeout    = FiniteDuration(conf.server.defaultTimeout.toLong, MILLISECONDS) // TODO remove
 
   /** Final Effect + helper methods */
   type CommErrT[F[_], A] = EitherT[F, CommError, A]
@@ -303,13 +303,13 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
 
     /** create typeclass instances */
     tcpConnections <- effects.tcpConnections.toEffect
-    rpConfAsk      = effects.rpConfAsk(RPConf(ClearConnetionsConf(
-      conf.server.maxNumOfConnections,
-      numOfConnectionsPinged = 10) // TODO read from conf
-    )).toEffect
-    rpConnections  <- effects.rpConnections.toEffect
-    log            = effects.log
-    time           = effects.time
+    defaultTimeout = FiniteDuration(conf.server.defaultTimeout.toLong, MILLISECONDS)
+    rpClearConnConf = ClearConnetionsConf(conf.server.maxNumOfConnections,
+                                          numOfConnectionsPinged = 10) // TODO read from conf
+    rpConfAsk     = effects.rpConfAsk(RPConf(defaultTimeout, rpClearConnConf)).toEffect
+    rpConnections <- effects.rpConnections.toEffect
+    log           = effects.log
+    time          = effects.time
     sync = SyncInstances.syncEffect[CommError](commError => {
       new Exception(s"CommError: $commError")
     }, e => { UnknownCommError(e.getMessage) })

--- a/shared/src/main/scala/coop/rchain/shared/Cell.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Cell.scala
@@ -30,6 +30,13 @@ object Cell extends CellInstances0 {
     def modify(f: S => F[S]): F[Unit] = ().pure[F]
     def read: F[S]                    = const.pure[F]
   }
+
+  def id[S](init: S): Cell[Id, S] = new Cell[Id, S] {
+    var s: S = init
+    def modify(f: S => S): Unit =
+      s = f(s)
+    def read: S = s
+  }
 }
 
 trait CellInstances0 {

--- a/shared/src/main/scala/coop/rchain/shared/ConstApplicativeAsk.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ConstApplicativeAsk.scala
@@ -1,0 +1,11 @@
+package coop.rchain.shared
+
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib._, Catscontrib._, ski._
+import cats.mtl._
+
+class ConstApplicativeAsk[F[_]: Applicative, E](e: E) extends ApplicativeAsk[F, E] {
+  val applicative: Applicative[F] = Applicative[F]
+  def ask: F[E]                   = e.pure[F]
+  def reader[A](f: E => A): F[A]  = applicative.map(ask)(f)
+}


### PR DESCRIPTION
## Overview
RChain protocol connections can not grow infinitely. It needs to be cleared periodically.
Feature is implemented but not yet turned on.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/secure/RapidBoard.jspa?rapidView=7&projectKey=CORE&modal=detail&selectedIssue=CORE-947

