### PR TITLE
Fix untraced comm event error

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -162,7 +162,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
             val otherErrors = errorLog.readAndClearErrorVector()
             val cost        = CostAccount.toProto(costAlg.getCost().unsafeRunSync)
             val deployCost  = DeployCost().withDeploy(deploy).withCost(cost)
-            Left((deploy, ex +: otherErrors, accCost :+ deployCost))
+            Left((deploy, otherErrors :+ ex, accCost :+ deployCost))
         }
       case Nil => Right(accCost)
     }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -155,14 +155,14 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
             val cost       = CostAccount.toProto(costAlg.getCost().unsafeRunSync)
             val deployCost = DeployCost().withDeploy(deploy).withCost(cost)
             if (errors.isEmpty)
-              eval(rest, reducer, errorLog, costAlg, deployCost +: accCost)
+              eval(rest, reducer, errorLog, costAlg, accCost :+ deployCost)
             else
-              Left((deploy, errors, accCost))
+              Left((deploy, errors, accCost :+ deployCost))
           case Failure(ex) =>
             val otherErrors = errorLog.readAndClearErrorVector()
             val cost        = CostAccount.toProto(costAlg.getCost().unsafeRunSync)
             val deployCost  = DeployCost().withDeploy(deploy).withCost(cost)
-            Left((deploy, ex +: otherErrors, deployCost +: accCost))
+            Left((deploy, ex +: otherErrors, accCost :+ deployCost))
         }
       case Nil => Right(accCost)
     }

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -144,6 +144,20 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     node.tearDown()
   }
 
+  it should "allow multiple deploys in a single block" in {
+    val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
+    import node._
+
+    val term    = InterpreterUtil.mkTerm(" for(@x <- @0){ @0!(x) } | @0!(0) ").right.get
+    val deploys = ProtoUtil.termDeploy(term) #:: ProtoUtil.termDeploy(term) #:: Stream.empty[Deploy]
+    deploys.foreach(MultiParentCasper[Id].deploy(_))
+    val block = MultiParentCasper[Id].createBlock.get
+    val _     = MultiParentCasper[Id].addBlock(block)
+
+    MultiParentCasper[Id].contains(block) shouldBe true
+    node.tearDown()
+  }
+
   it should "reject unsigned blocks" in {
     val node = HashSetCasperTestNode.standalone(genesis, validatorKeys.head)
     import node._


### PR DESCRIPTION
## Overview
Allows multiple deploys without crashing. The bug was actually caused by the deploys being stored in the block in reverse order due to the cost accounting accumulator prepending instead of appending. The fix was therefore very simple. I also added a unit test for the bug to prove it works.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-568

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
