### PR TITLE
CORE-908 InMemoryTrieStore + lmdb-independent InMemoryStore

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
@@ -1,0 +1,84 @@
+package coop.rchain.rspace
+import scala.concurrent.SyncVar
+
+trait InMemTransaction[S] {
+  def commit(): Unit
+  def abort(): Unit
+  def close(): Unit
+  def readState[R](f: S => R): R
+  def writeState[R](f: S => (S, R)): R
+  def name: String
+}
+
+trait InMemoryOps[S] {
+
+  protected[rspace] type Transaction = InMemTransaction[S]
+
+  protected[rspace] type StateType = S
+
+  private[rspace] def emptyState: S
+
+  private[rspace] def updateGauges(): Unit
+
+  private[rspace] val stateRef: SyncVar[S] = {
+    val sv = new SyncVar[S]
+    sv.put(emptyState)
+    sv
+  }
+
+  private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R): R =
+    try {
+      val ret: R = f(txn)
+      txn.commit()
+      ret
+    } catch {
+      case ex: Throwable =>
+        txn.abort()
+        throw ex
+    } finally {
+      txn.close()
+    }
+
+  private[rspace] def createTxnRead(): InMemTransaction[S] = new InMemTransaction[S] {
+
+    val name: String = "read-" + Thread.currentThread().getId
+
+    private[this] val state = stateRef.get
+
+    override def commit(): Unit = {}
+
+    override def abort(): Unit = {}
+
+    override def close(): Unit = {}
+
+    override def readState[R](f: S => R): R = f(state)
+
+    override def writeState[R](f: S => (S, R)): R =
+      throw new RuntimeException("read txn cannot write")
+  }
+
+  private[rspace] def createTxnWrite(): InMemTransaction[S] =
+    new InMemTransaction[S] {
+      val name: String = "write-" + Thread.currentThread().getId
+
+      private[this] val initial = stateRef.take
+      private[this] var current = initial
+
+      override def commit(): Unit = {
+        stateRef.put(current)
+        updateGauges()
+      }
+
+      override def abort(): Unit = stateRef.put(initial)
+
+      override def close(): Unit = {}
+
+      override def readState[R](f: S => R): R = f(current)
+
+      override def writeState[R](f: S => (S, R)): R = {
+        val (newState, result) = f(current)
+        current = newState
+        result
+      }
+    }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
@@ -1,0 +1,117 @@
+package coop.rchain.rspace.history
+import coop.rchain.rspace.{Blake2b256Hash, InMemTransaction, InMemoryOps}
+import kamon.Kamon
+
+import scala.collection.immutable.Seq
+
+case class State[K, V](_dbTrie: Map[Blake2b256Hash, Trie[K, V]],
+                       _dbRoot: Map[Branch, Blake2b256Hash],
+                       _dbPastRoots: Map[Branch, Seq[Blake2b256Hash]]) {
+
+  def changeTrie(newTrie: Map[Blake2b256Hash, Trie[K, V]]): State[K, V] =
+    State(newTrie, _dbRoot, _dbPastRoots)
+
+  def changeRoot(newRoot: Map[Branch, Blake2b256Hash]): State[K, V] =
+    State(_dbTrie, newRoot, _dbPastRoots)
+
+  def chnagePastRoot(newPastRoots: Map[Branch, Seq[Blake2b256Hash]]): State[K, V] =
+    State(_dbTrie, _dbRoot, newPastRoots)
+}
+
+object State {
+  def empty[K, V]: State[K, V] = State[K, V](Map.empty, Map.empty, Map.empty)
+}
+
+class InMemoryTrieStore[K, V]
+    extends InMemoryOps[State[K, V]]
+    with ITrieStore[InMemTransaction[State[K, V]], K, V] {
+
+  override def emptyState: State[K, V] = State.empty
+
+  private[this] val refine       = Map("path" -> "inmemTrie")
+  private[this] val entriesGauge = Kamon.gauge("entries").refine(refine)
+
+  override private[rspace] def updateGauges(): Unit =
+    withTxn(createTxnRead())(_.readState { state =>
+      entriesGauge.set(state._dbTrie.size.toLong)
+    })
+
+  override private[rspace] def getRoot(txn: InMemTransaction[State[K, V]],
+                                       branch: Branch): Option[Blake2b256Hash] =
+    txn.readState(state => state._dbRoot.get(branch))
+
+  override private[rspace] def persistAndGetRoot(txn: InMemTransaction[State[K, V]],
+                                                 branch: Branch): Option[Blake2b256Hash] =
+    getRoot(txn, branch)
+      .map { currentRoot =>
+        val pastRoots = getPastRootsInBranch(txn, branch).filter(_ != currentRoot)
+        (currentRoot, currentRoot +: pastRoots)
+      }
+      .map {
+        case (currentRoot, updatedPastRoots) =>
+          txn.writeState(state =>
+            (state.chnagePastRoot(state._dbPastRoots + (branch -> updatedPastRoots)), ()))
+          currentRoot
+      }
+
+  private[this] def getPastRootsInBranch(txn: InMemTransaction[State[K, V]],
+                                         branch: Branch): Seq[Blake2b256Hash] =
+    txn.readState(state => state._dbPastRoots.getOrElse(branch, Seq.empty))
+
+  override private[rspace] def putRoot(txn: InMemTransaction[State[K, V]],
+                                       branch: Branch,
+                                       hash: Blake2b256Hash): Unit =
+    txn.writeState(state => (state.changeRoot(state._dbRoot + (branch -> hash)), ()))
+
+  override private[rspace] def getAllPastRoots(
+      txn: InMemTransaction[State[K, V]]): Seq[Blake2b256Hash] =
+    txn.readState(state =>
+      state._dbPastRoots.values.foldLeft(Seq.empty[Blake2b256Hash])((acc, value) => acc ++ value))
+
+  override private[rspace] def validateAndPutRoot(txn: InMemTransaction[State[K, V]],
+                                                  branch: Branch,
+                                                  hash: Blake2b256Hash): Unit =
+    getRoot(txn, branch)
+      .find(_ == hash)
+      .orElse {
+        getPastRootsInBranch(txn, branch)
+          .find(_ == hash)
+          .map { blake: Blake2b256Hash =>
+            putRoot(txn, branch, blake)
+            blake
+          }
+      }
+      .orElse {
+        getAllPastRoots(txn)
+          .find(_ == hash)
+          .map { blake: Blake2b256Hash =>
+            putRoot(txn, branch, blake)
+            blake
+          }
+      }
+      .getOrElse(throw new Exception(s"Unknown root."))
+
+  override private[rspace] def put(txn: InMemTransaction[State[K, V]],
+                                   key: Blake2b256Hash,
+                                   value: Trie[K, V]): Unit =
+    txn.writeState(state => (state.changeTrie(state._dbTrie + (key -> value)), ()))
+
+  override private[rspace] def get(txn: InMemTransaction[State[K, V]],
+                                   key: Blake2b256Hash): Option[Trie[K, V]] =
+    txn.readState(state => state._dbTrie.get(key))
+
+  override private[rspace] def toMap: Map[Blake2b256Hash, Trie[K, V]] =
+    withTxn(createTxnRead()) { txn =>
+      txn.readState(state => state._dbTrie)
+    }
+
+  override private[rspace] def clear(txn: InMemTransaction[State[K, V]]): Unit =
+    txn.writeState(_ => (State.empty, ()))
+
+  def close(): Unit = ()
+}
+
+object InMemoryTrieStore {
+  def create[K, V](): ITrieStore[InMemTransaction[State[K, V]], K, V] =
+    new InMemoryTrieStore[K, V]()
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -6,8 +6,10 @@ import com.google.common.collect.Multiset
 import com.typesafe.scalalogging.Logger
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
-import coop.rchain.rspace.history.Branch
+import coop.rchain.rspace.history.{Branch, InMemoryTrieStore}
+import coop.rchain.rspace.internal.GNAT
 import coop.rchain.rspace.trace.{COMM, Consume, IOEvent, Produce}
+import coop.rchain.shared.PathOps._
 import org.scalatest._
 
 import scala.Function.const
@@ -15,7 +17,7 @@ import scala.collection.{immutable, mutable}
 import scala.util.Random
 
 //noinspection ZeroIndexToHead,NameBooleanParameters
-class ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, String] {
+trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, String] {
 
   def consumeMany[C, P, A, R, K](
       space: ISpace[C, P, A, R, K],
@@ -821,12 +823,7 @@ class ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
     }
 }
 
-trait ReplayRSpaceTestsBase[C, P, A, K]
-    extends FlatSpec
-    with Matchers
-    with OptionValues
-    with BeforeAndAfterAll {
-
+trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionValues {
   val logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   override def withFixture(test: NoArgTest): Outcome = {
@@ -835,6 +832,15 @@ trait ReplayRSpaceTestsBase[C, P, A, K]
   }
 
   def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): S
+}
+
+trait LMDBReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+  override def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
@@ -852,7 +858,37 @@ trait ReplayRSpaceTestsBase[C, P, A, K]
       space.close()
       replaySpace.close()
       context.close()
+      dbDir.recursivelyDelete()
     }
   }
-
 }
+
+trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+  override def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]): S = {
+
+    val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
+    val space     = RSpace.createInMemory[C, P, A, A, K](trieStore, Branch.REPLAY)
+    val replaySpace =
+      ReplayRSpace.createInMemory[C, P, A, A, K](trieStore, Branch.REPLAY)
+
+    try {
+      f(space, replaySpace)
+    } finally {
+      space.close()
+      replaySpace.close()
+    }
+  }
+}
+
+class LMDBReplayRSpaceTests
+    extends LMDBReplayRSpaceTestsBase[String, Pattern, String, String]
+    with ReplayRSpaceTests {}
+
+class InMemoryRSpaceTests
+    extends InMemoryReplayRSpaceTestsBase[String, Pattern, String, String]
+    with ReplayRSpaceTests {}


### PR DESCRIPTION
## Overview
We need an in-memory implementation for 1) RSpace performance check 2) Possibility to run on WSL until mmap will be fixed 3) Testing 4) etc.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please 
https://rchain.atlassian.net/browse/CORE-908