### PR TITLE
CORE-864 - Disallow sending RChain protocol messages to peers that are not connected via Rchain protocol handshake

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -41,6 +41,7 @@ import monix.eval.Task
 class HashSetCasperTestNode(name: String,
                             val local: PeerNode,
                             tle: TransportLayerTestImpl[Id],
+                            connCell: ConnectionsCell[Id],
                             val genesis: BlockMessage,
                             sk: Array[Byte],
                             storageSize: Long = 1024L * 1024,
@@ -52,7 +53,7 @@ class HashSetCasperTestNode(name: String,
 
   implicit val logEff            = new LogStub[Id]
   implicit val timeEff           = new LogicalTime[Id]
-  implicit val connectionsCell   = Cell.id[Connections](Connect.Connections.empty)
+  implicit val connectionsCell   = connCell
   implicit val transportLayerEff = tle
   implicit val metricEff         = new Metrics.MetricsNOP[Id]
   implicit val errorHandlerEff   = errorHandler
@@ -101,8 +102,9 @@ object HashSetCasperTestNode {
     val identity = peerNode(name, 40400)
     val tle =
       new TransportLayerTestImpl[Id](identity, Map.empty[PeerNode, mutable.Queue[Protocol]])
+    val connCell = Cell.id[Connections](Connect.Connections.empty)
 
-    new HashSetCasperTestNode(name, identity, tle, genesis, sk)
+    new HashSetCasperTestNode(name, identity, tle, connCell, genesis, sk)
   }
 
   def network(sks: IndexedSeq[Array[Byte]], genesis: BlockMessage)(
@@ -115,8 +117,9 @@ object HashSetCasperTestNode {
     val nodes =
       names.zip(peers).zip(sks).map {
         case ((n, p), sk) =>
-          val tle = new TransportLayerTestImpl[Id](p, msgQueues)
-          new HashSetCasperTestNode(n, p, tle, genesis, sk)
+          val tle      = new TransportLayerTestImpl[Id](p, msgQueues)
+          val connCell = Cell.id[Connections](Connect.Connections.empty)
+          new HashSetCasperTestNode(n, p, tle, connCell, genesis, sk)
       }
 
     import Connections._

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -29,6 +29,7 @@ final case object UpstreamNotAvailable                   extends CommError
 final case class UnexpectedMessage(msgStr: String)       extends CommError
 final case object SenderNotAvailable                     extends CommError
 final case class PongNotReceivedForPing(peer: PeerNode)  extends CommError
+final case class NotConnectedToPeer(peer: PeerNode)      extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -59,6 +60,7 @@ object CommError {
   def unexpectedMessage(msgStr: String): CommError       = UnexpectedMessage(msgStr)
   def senderNotAvailable: CommError                      = SenderNotAvailable
   def pongNotReceivedForPing(peer: PeerNode): CommError  = PongNotReceivedForPing(peer)
+  def notConnectedToPeer(peer: PeerNode): CommError      = NotConnectedToPeer(peer)
   def timeout: CommError                                 = TimeOut
 
   def errorMessage(ce: CommError): String =

--- a/comm/src/test/scala/coop/rchain/comm/connect/HandlePacketSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/HandlePacketSpec.scala
@@ -1,0 +1,101 @@
+package coop.rchain.comm.rp
+
+import coop.rchain.comm.protocol.rchain.Packet
+import coop.rchain.p2p.effects.PacketHandler
+import Connect._, Connections._
+import coop.rchain.comm.transport.BlockMessage
+import com.google.protobuf.ByteString
+import coop.rchain.comm._, CommError._, protocol.routing._
+import coop.rchain.p2p.EffectsTestInstances._
+import coop.rchain.metrics.Metrics
+import scala.concurrent.duration._
+import org.scalatest._
+import org.scalatest.enablers.Containing
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib._, Catscontrib._, ski._
+import coop.rchain.shared._
+import coop.rchain.comm.transport._, CommMessages._
+
+class HandlePacketSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+
+  import ScalaTestCats._
+
+  type Effect[A] = EitherT[Id, CommError, A]
+
+  val src: PeerNode              = peer("src")
+  val remote: PeerNode           = peer("remote")
+  val deftimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS)
+  val packetInProtocol           = packet(remote, BlockMessage, ByteString.copyFromUtf8("content"))
+  val thePacket                  = toPacket(packetInProtocol).right.get
+  implicit val transport         = new TransportLayerStub[Id]
+  implicit val log               = new Log.NOPLog[Id]
+  implicit val time              = new LogicalTime[Id]
+  implicit val metric            = new Metrics.MetricsNOP[Id]
+  implicit val nodeDiscovery     = new NodeDiscoveryStub[Effect]()
+  implicit val rpConf            = conf(defaultTimeout = deftimeout)
+  implicit val packetHandler: PacketHandler[Id] =
+    (peer: PeerNode, packet: Packet) => {
+      packetsProcessed = packet :: packetsProcessed
+      Some(packet)
+    }
+
+  var packetsProcessed: List[Packet] = List.empty[Packet]
+
+  override def beforeEach(): Unit =
+    packetsProcessed = List.empty[Packet]
+
+  describe("When Node receives a Packet message") {
+    describe("and remote peer sending the Packet went through the protocol handshake") {
+      it("then packet is processed") {
+        // given
+        implicit val connections = mkConnections(remote)
+        // when
+        HandleMessages.handlePacket[Effect](remote, Some(thePacket))
+        // then
+        packetsProcessed should contain(thePacket)
+      }
+    }
+
+    describe("and remote peer sending the Packet did NOT went through the protocol handshake") {
+      it("then packet is not processed") {
+        // given
+        implicit val connections = mkConnections()
+        // when
+        HandleMessages.handlePacket[Effect](remote, Some(thePacket))
+        // then
+        packetsProcessed should not contain (thePacket)
+      }
+      it("should return not handled response") {
+        // given
+        implicit val connections = mkConnections()
+        // when
+        val result = HandleMessages.handlePacket[Effect](remote, Some(thePacket)).value
+        // then
+        result shouldBe (Right(NotHandled(NotConnectedToPeer(remote))))
+      }
+    }
+  }
+
+  private def peer(name: String): PeerNode =
+    PeerNode(NodeIdentifier(name.getBytes), Endpoint("host", 80, 80))
+
+  private def mkConnections(peers: PeerNode*): ConnectionsCell[Id] =
+    Cell.id[Connections](peers.reverse.foldLeft(Connections.empty) {
+      case (acc, el) => acc.addConn[Id](el)
+    })
+
+  private def conf(
+      maxNumOfConnections: Int = 5,
+      numOfConnectionsPinged: Int = 5,
+      defaultTimeout: FiniteDuration
+  ): RPConfAsk[Id] =
+    new ConstApplicativeAsk(
+      RPConf(clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
+             defaultTimeout = defaultTimeout,
+             local = peer("src"))
+    )
+
+  implicit def eiterTrpConfAsk: RPConfAsk[Effect] =
+    new EitherTApplicativeAsk[Id, RPConf, CommError]
+
+}


### PR DESCRIPTION
## Overview
Disallow handling packets if remote that send is not connected with node

Integration test passing
```
=================TEST SUMMARY RESULTS======================
PASS: peer1.rchain.coop: Metrics API http/tcp/40403 is available.
PASS: peer0.rchain.coop: Metrics API http/tcp/40403 is available.
PASS: peer1.rchain.coop: Peers count correct in node logs.
PASS: peer0.rchain.coop: Peers count correct in node logs.
PASS: peer1.rchain.coop: Rholang evaluation of files performed correctly.
PASS: peer0.rchain.coop: Rholang evaluation of files performed correctly.
PASS: peer0.rchain.coop: REPL loader success!
PASS: peer1.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: peer0.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: bootstrap.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: peer1.rchain.coop: No errors defined by "ERROR" in logs.
PASS: peer0.rchain.coop: No errors defined by "ERROR" in logs.
PASS: peer1.rchain.coop: No text of "RuntimeException" in logs.
PASS: peer0.rchain.coop: No text of "RuntimeException" in logs.
PASS ALL: All tests successfully passed
===========================================================
===========================================================
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-864