### PR TITLE
raise exception on line so integration tests fail properly

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -150,8 +150,7 @@ def main():
                 if check_network_convergence(container) != 0:
                     show_logs()
                     show_containers()
-                    print("FAIL: Network never converged. Check container logs for issues. One or more containers might have failed to start or connect.")
-                    sys.exit()
+                    raise Exception("FAIL: Network never converged. Check container logs for issues. One or more containers might have failed to start or connect.")
     if args.run_tests == True:
         run_tests()
         return


### PR DESCRIPTION
## Overview
integration tests did not fail properly as sys.exit() default exit code is 0. Just changing to raise Exception instead. Probably better.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-205

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
