### PR TITLE
 Track log computed when merging multiple parents

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -333,8 +333,8 @@ sealed abstract class MultiParentCasperInstances {
         for {
           now         <- Time[F].currentMillis
           internalMap <- BlockStore[F].asMap()
-          Right((computedCheckpoint, _, deployWithCost)) = knownStateHashesContainer
-            .mapAndUpdate[(Checkpoint, Set[StateHash], Vector[DeployCost])](
+          Right((computedCheckpoint, mergeLog, _, deployWithCost)) = knownStateHashesContainer
+            .mapAndUpdate[(Checkpoint, Seq[protocol.Event], Set[StateHash], Vector[DeployCost])](
               InterpreterUtil.computeDeploysCheckpoint(p,
                                                        r,
                                                        genesis,
@@ -343,9 +343,9 @@ sealed abstract class MultiParentCasperInstances {
                                                        emptyStateHash,
                                                        _,
                                                        runtimeManager.computeState),
-              _._2)
+              _._3)
           computedStateHash = ByteString.copyFrom(computedCheckpoint.root.bytes.toArray)
-          serializedLog     = computedCheckpoint.log.map(EventConverter.toCasperEvent)
+          serializedLog     = mergeLog ++ computedCheckpoint.log.map(EventConverter.toCasperEvent)
           postState = RChainState()
             .withTuplespace(computedStateHash)
             .withBonds(bonds(p.head))


### PR DESCRIPTION
## Overview
The untraced comm event reported in RHOL-591 likely occurred because the fork-choice rule created a multi-parent block in which the parents' post-state was non-trivial (because it included the comm events from the respective parent blocks). The reason this produced an untraced comm event is because, prior to this change, the log reported in the block did not include anything about computing the parents' post-state, therefore when the parents' post-state was computed in replay mode all comm events were untraced. This change makes sure we track the log for the parents' post-state computation and includes it in the block.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-591

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
