### PR TITLE
CORE-948 Move Disconnect message from Kademlia to RChain protocol

### DIFF
--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
@@ -28,6 +28,9 @@ message Packet {
   bytes  content = 2;
 }
 
+message Disconnect {
+}
+
 message Protocol {
     oneof message {
         Heartbeat                   heartbeat                     = 1;
@@ -35,5 +38,6 @@ message Protocol {
         ProtocolHandshake           protocol_handshake            = 3;
         ProtocolHandshakeResponse   protocol_handshake_response   = 4;
         Packet                      packet                        = 5;
+        Disconnect                  disconnect                    = 6;
     }
 }

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -36,20 +36,15 @@ message LookupResponse {
     repeated Node nodes = 1;
 }
 
-message Disconnect {
-}
-
 message Protocol {
     Header header                           = 1;
 
     oneof message {
         google.protobuf.Any upstream        = 2;
-
         Ping                ping            = 3;
         Pong                pong            = 4;
         Lookup              lookup          = 5;
         LookupResponse      lookup_response = 6;
-        Disconnect          disconnect      = 7;
     }
 }
 

--- a/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
@@ -66,11 +66,6 @@ object ProtocolHelper {
       .withLookupResponse(LookupResponse()
         .withNodes(nodes.map(node)))
 
-  def disconnect(src: PeerNode): Protocol =
-    Protocol()
-      .withHeader(header(src))
-      .withDisconnect(Disconnect())
-
   def upstreamMessage(src: PeerNode, upstream: AnyProto): Protocol =
     Protocol()
       .withHeader(header(src))

--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -39,26 +39,42 @@ object HandleMessages {
       .fold(Log[F].error("Upstream not available").as(notHandled(upstreamNotAvailable))) { usmsg =>
         usmsg.typeUrl match {
           // TODO interpolate this string to check if class exists
-
           case "type.googleapis.com/coop.rchain.comm.protocol.rchain.Heartbeat" =>
             handleHeartbeat[F](sender, toHeartbeat(proto).toOption)
-
           case "type.googleapis.com/coop.rchain.comm.protocol.rchain.Packet" =>
             handlePacket[F](sender, toPacket(proto).toOption)
-
           case "type.googleapis.com/coop.rchain.comm.protocol.rchain.ProtocolHandshake" =>
             handleProtocolHandshake[F](sender, toProtocolHandshake(proto).toOption, defaultTimeout)
-
+          case "type.googleapis.com/coop.rchain.comm.protocol.rchain.Disconnect" =>
+            handleDisconnect[F](sender, toDisconnect(proto).toOption)
           case _ =>
             Log[F].error(s"Unexpected message type ${usmsg.typeUrl}") *> notHandled(
               unexpectedMessage(usmsg.typeUrl)).pure[F]
         }
       }
 
+  def handleDisconnect[F[_]: Monad: Capture: Metrics: TransportLayer: Log: ConnectionsCell](
+      sender: PeerNode,
+      maybeDisconnect: Option[Disconnect]): F[CommunicationResponse] = {
+
+    val errorMsg = s"Expecting Disconnect, got something else."
+    def handleNone: F[CommunicationResponse] =
+      Log[F].error(errorMsg).as(notHandled(unknownCommError(errorMsg)))
+
+    maybeDisconnect.fold(handleNone)(disconnect =>
+      for {
+        _ <- Log[F].info(s"Forgetting about ${sender.toAddress}.")
+        _ <- TransportLayer[F].disconnect(sender)
+        _ <- ConnectionsCell[F].modify(_.removeConn[F](sender))
+        _ <- Metrics[F].incrementCounter("disconnect-recv-count")
+      } yield handledWithoutMessage)
+
+  }
+
   def handlePacket[F[_]: Monad: Time: TransportLayer: ErrorHandler: Log: PacketHandler: RPConfAsk](
       remote: PeerNode,
       maybePacket: Option[Packet]): F[CommunicationResponse] = {
-    val errorMsg = s"Expecting Packet from frame, got something else. Stopping the node."
+    val errorMsg = s"Expecting Packet, got something else. Stopping the node."
     def handleNone: F[CommunicationResponse] =
       for {
         _     <- Log[F].error(errorMsg)

--- a/comm/src/main/scala/coop/rchain/comm/transport/CommMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/CommMessages.scala
@@ -56,4 +56,14 @@ object CommMessages {
     case a                                           => Left(UnknownProtocolError(s"Was expecting Packet, got $a"))
   }
 
+  def disconnect(src: PeerNode): routing.Protocol = {
+    val d = Disconnect()
+    ProtocolHelper.upstreamMessage(src, AnyProto.pack(d))
+  }
+
+  def toDisconnect(proto: routing.Protocol): CommErr[Disconnect] = proto.message match {
+    case routing.Protocol.Message.Upstream(upstream) => Right(upstream.unpack(Disconnect))
+    case a                                           => Left(UnknownProtocolError(s"Was expecting Disconnect, got $a"))
+  }
+
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -49,7 +49,6 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
           if (log.isTraceEnabled) {
             val peerNode = ProtocolHelper.toPeerNode(sender)
             val msgType = msg match {
-              case m if m.isDisconnect     => "disconnect"
               case m if m.isLookup         => "lookup"
               case m if m.isLookupResponse => "lookup response"
               case m if m.isPing           => "ping"

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -36,7 +36,6 @@ class SslSessionServerInterceptor() extends ServerInterceptor {
           if (log.isTraceEnabled) {
             val peerNode = ProtocolHelper.toPeerNode(sender)
             val msgType = msg match {
-              case m if m.isDisconnect     => "disconnect"
               case m if m.isLookup         => "lookup"
               case m if m.isLookupResponse => "lookup response"
               case m if m.isPing           => "ping"

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -188,7 +188,7 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
                         local: PeerNode,
                         remote: PeerNode): F[CommErr[Protocol]] =
               for {
-                _ <- transportLayer.shutdown(ProtocolHelper.disconnect(local))
+                _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- roundTripWithPing(transportLayer, local, remote)
               } yield r
 
@@ -210,7 +210,7 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
                         local: PeerNode,
                         remote: PeerNode): F[Unit] =
               for {
-                _ <- transportLayer.shutdown(ProtocolHelper.disconnect(local))
+                _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- sendPing(transportLayer, local, remote)
                 _ = await()
               } yield r
@@ -229,7 +229,7 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
                         remote1: PeerNode,
                         remote2: PeerNode): F[Unit] =
               for {
-                _ <- transportLayer.shutdown(ProtocolHelper.disconnect(local))
+                _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- broadcastPing(transportLayer, local, remote1, remote2)
                 _ = await()
               } yield r

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -192,7 +192,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       _   <- log.info("Shutting down transport layer, broadcasting DISCONNECT")
       loc <- rpConfAsk.reader(_.local)
       ts  <- time.currentMillis
-      msg = ProtocolHelper.disconnect(loc)
+      msg = CommMessages.disconnect(loc)
       _   <- transport.shutdown(msg)
       _   <- log.info("Shutting down metrics server...")
       _   <- Task.delay(servers.metricsServer.stop())


### PR DESCRIPTION
## Overview
Disconnect is part of RChain protocol and should not be handled by kademlia as it is not correctly clearing connections list

Integration tests passing

```
===========================================================
=================TEST SUMMARY RESULTS======================
PASS: peer1.rchain.coop: Metrics API http/tcp/40403 is available.
PASS: peer0.rchain.coop: Metrics API http/tcp/40403 is available.
PASS: peer1.rchain.coop: Peers count correct in node logs.
PASS: peer0.rchain.coop: Peers count correct in node logs.
PASS: peer1.rchain.coop: Rholang evaluation of files performed correctly.
PASS: peer0.rchain.coop: Rholang evaluation of files performed correctly.
PASS: peer0.rchain.coop: REPL loader success!
PASS: peer1.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: peer0.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: bootstrap.rchain.coop: Proposal of blocks for deployed contracts worked.
PASS: peer1.rchain.coop: No errors defined by "ERROR" in logs.
PASS: peer0.rchain.coop: No errors defined by "ERROR" in logs.
PASS: peer1.rchain.coop: No text of "RuntimeException" in logs.
PASS: peer0.rchain.coop: No text of "RuntimeException" in logs.
PASS ALL: All tests successfully passed
===========================================================
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-948
