### PR TITLE
CORE-949 - remove TransportLayer from Kademlia

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -12,7 +12,7 @@ import coop.rchain.shared._
 import coop.rchain.comm.protocol.routing._
 
 object KademliaNodeDiscovery {
-  def create[F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: KademliaRPC](
+  def create[F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](
       src: PeerNode,
       defaultTimeout: FiniteDuration)(init: Option[PeerNode]): F[KademliaNodeDiscovery[F]] =
     for {
@@ -23,8 +23,7 @@ object KademliaNodeDiscovery {
 }
 
 private[discovery] class KademliaNodeDiscovery[
-    F[_]: Monad: Capture: Log: Time: Metrics: TransportLayer: KademliaRPC](src: PeerNode,
-                                                                           timeout: FiniteDuration)
+    F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](src: PeerNode, timeout: FiniteDuration)
     extends NodeDiscovery[F] {
 
   private val table = PeerTable(src)


### PR DESCRIPTION
## Overview
Now Kademlia is dependend only on instance of KademliaRPC. This way in
the future Kademlia can use different TranposrtLayer (one without SSL
for example) or completely different way to suuport RPCs


### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-949