### PR TITLE
change default jdk from Oracle to OpenJDK in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 dist: trusty
+jdk:
+  - openjdk8
 
 matrix:
   include:


### PR DESCRIPTION
## Overview
Default Travis jdk is Oracle. We should change it to openjdk to be consistent with our project

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-207

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
