### PR TITLE
fix args network issue with peer prefix command for bootstrap connection

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -55,11 +55,6 @@ parser.add_argument("-n", "--network",
                     type=str,
                     default="rchain.coop",
                     help="set docker network name")
-parser.add_argument("--peer-command",
-                    dest='peer_command',
-                    type=str,
-                    default="run --bootstrap rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.rchain.coop:40400",
-                    help="peer container run command")
 parser.add_argument("-p", "--peers-amount",
                     dest='peer_amount',
                     type=int,
@@ -119,6 +114,7 @@ if len(sys.argv)==1:
     parser.print_help(sys.stderr)
     sys.exit(1)
 
+
 # Define globals
 args = parser.parse_args()
 client = docker.from_env()
@@ -126,6 +122,7 @@ RNODE_CMD = '/opt/docker/bin/rnode'
 # bonds_file = f'/tmp/bonds.{args.network}' alternate when dynamic bonds.txt creation/manpiulation file works
 bonds_file = os.path.dirname(os.path.realpath(__file__)) + '/demo-bonds.txt'
 container_bonds_file = f'{args.rnode_directory}/genesis/bonds.txt'
+peer_prefix_command=f'run --bootstrap rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.{args.network}:40400'
 
 
 def main():
@@ -591,7 +588,7 @@ def create_peer_nodes():
                 f"{bonds_file}:{container_bonds_file}", \
                 f"{peer_node[i]['volume'].name}:{args.rnode_directory}"
             ], \
-            command=f"{args.peer_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
+            command=f"{peer_prefix_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
             hostname=peer_node[i]['name'])
 
         print("Installing additonal packages on container.")


### PR DESCRIPTION
## Overview
network has a problem when using network other than default "rchain.coop" as it was connecting to invalid peer dns name. Moved peer prefix command out of args and it will now properly assign correct name for bootstrap.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-208

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
