### PR TITLE
only push dockerhub latest on master branch tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,8 @@ deploy:deploy-rnode-to-dockerhub:
     - sudo docker tag coop.rchain/rnode:latest rchain/rnode:${CI_COMMIT_REF_NAME}
     - sudo docker push rchain/rnode:${CI_COMMIT_REF_NAME} 
     - |
-      if [[ $CI_COMMIT_TAG == v* ]]; then
-        echo "Is a release tag starting with v. Tag and push latest.";
+      if [[ $CI_COMMIT_TAG == v* && $CI_COMMIT_REF_NAME == "master" ]]; then
+        echo "Is a release tag starting with v and master branch. Tag and push to dockerhub latest.";
         sudo docker tag coop.rchain/rnode:latest rchain/rnode:latest
         sudo docker push rchain/rnode:latest 
       fi


### PR DESCRIPTION
## Overview
A little patch to last commit as this makes it so dockerhub latest only updates on master branch tag via gitlab CD.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-204

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
