### PR TITLE
CORE-887 resource exhausted

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -283,7 +283,8 @@ object Validate {
       Applicative[F].pure(Right(Valid))
     } else {
       for {
-        _ <- Log[F].warn(ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected."))
+        _ <- Log[F].warn(
+              ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected."))
       } yield Left(InvalidShardId)
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -46,7 +46,7 @@ class GrpcDeployService(host: String, port: Int) extends DeployService[Task] wit
   }
 
   def showBlocks(): Task[String] = Task.delay {
-    val response = blockingStub.showBlocks2(Empty()).toList
+    val response = blockingStub.showBlocks(Empty()).toList
 
     val showResponses = response
       .map {

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -16,7 +16,6 @@ trait DeployService[F[_]] {
   def createBlock(): F[(Boolean, String)] //create block and add to Casper internal state
   def showBlock(q: BlockQuery): F[String]
   def showBlocks(): F[String]
-  def showBlocks2(): F[String]
   def addBlock(b: BlockMessage): F[(Boolean, String)]
 }
 
@@ -47,15 +46,24 @@ class GrpcDeployService(host: String, port: Int) extends DeployService[Task] wit
   }
 
   def showBlocks(): Task[String] = Task.delay {
-    val response = blockingStub.showBlocks(Empty())
-    response.toProtoString
-  }
+    val response = blockingStub.showBlocks2(Empty()).toList
 
-  def showBlocks2(): Task[String] = Task.delay {
-    val response = blockingStub.showBlocks2(Empty())
-    response.toList.foldLeft("") {
-      case (acc, bi) => acc + bi.toProtoString + "\n"
-    }
+    val showResponses = response
+      .map {
+        case bi =>
+          s"""
+------------- block ${bi.blockNumber} ---------------
+${bi.toProtoString}
+-----------------------------------------------------
+"""
+      }
+      .mkString("\n")
+
+    val showLength =
+      s"""
+Blockchain length: ${response.length}
+"""
+    showResponses + "\n" + showLength
   }
 
   def addBlock(b: BlockMessage): Task[(Boolean, String)] = Task.delay {

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -16,6 +16,7 @@ trait DeployService[F[_]] {
   def createBlock(): F[(Boolean, String)] //create block and add to Casper internal state
   def showBlock(q: BlockQuery): F[String]
   def showBlocks(): F[String]
+  def showBlocks2(): F[String]
   def addBlock(b: BlockMessage): F[(Boolean, String)]
 }
 
@@ -48,6 +49,13 @@ class GrpcDeployService(host: String, port: Int) extends DeployService[Task] wit
   def showBlocks(): Task[String] = Task.delay {
     val response = blockingStub.showBlocks(Empty())
     response.toProtoString
+  }
+
+  def showBlocks2(): Task[String] = Task.delay {
+    val response = blockingStub.showBlocks2(Empty())
+    response.toList.foldLeft("") {
+      case (acc, bi) => acc + bi.toProtoString + "\n"
+    }
   }
 
   def addBlock(b: BlockMessage): Task[(Boolean, String)] = Task.delay {

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -18,7 +18,7 @@ import coop.rchain.comm.protocol.routing.TransportLayerGrpc.TransportLayerStub
 import monix.eval._, monix.execution._
 import scala.concurrent.TimeoutException
 
-class TcpTransportLayer(host: String, port: Int, cert: String, key: String)(
+class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxMessageSize: Int)(
     implicit scheduler: Scheduler,
     cell: TcpTransportLayer.TransportCell[Task],
     log: Log[Task])
@@ -60,6 +60,7 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String)(
       c <- Task.delay {
             NettyChannelBuilder
               .forAddress(peer.endpoint.host, peer.endpoint.tcpPort)
+              .maxInboundMessageSize(maxMessageSize)
               .negotiationType(NegotiationType.TLS)
               .sslContext(clientSslContext)
               .intercept(new SslSessionClientInterceptor())
@@ -160,6 +161,7 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String)(
     Task.delay {
       NettyServerBuilder
         .forPort(port)
+        .maxMessageSize(maxMessageSize)
         .sslContext(serverSslContext)
         .addService(TransportLayerGrpc.bindService(transportLayer, scheduler))
         .intercept(new SslSessionServerInterceptor())

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -34,7 +34,9 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
 
   def createTransportLayer(env: TcpTlsEnvironment): Task[TransportLayer[Task]] =
     Cell.mvarCell(TransportState.empty).map { cell =>
-      new TcpTransportLayer(env.host, env.port, env.cert, env.key, 4 * 1024 * 1024)(scheduler, cell, log)
+      new TcpTransportLayer(env.host, env.port, env.cert, env.key, 4 * 1024 * 1024)(scheduler,
+                                                                                    cell,
+                                                                                    log)
     }
 
   def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -34,7 +34,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
 
   def createTransportLayer(env: TcpTlsEnvironment): Task[TransportLayer[Task]] =
     Cell.mvarCell(TransportState.empty).map { cell =>
-      new TcpTransportLayer(env.host, env.port, env.cert, env.key)(scheduler, cell, log)
+      new TcpTransportLayer(env.host, env.port, env.cert, env.key, 4 * 1024 * 1024)(scheduler, cell, log)
     }
 
   def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -17,6 +17,7 @@ service DeployService {
   rpc createBlock(google.protobuf.Empty) returns (DeployServiceResponse) {}
   rpc showBlock(BlockQuery) returns (BlockQueryResponse) {}
   rpc showBlocks(google.protobuf.Empty) returns (BlocksResponse) {}
+  rpc showBlocks2(google.protobuf.Empty) returns (stream BlockInfo) {}
   rpc listenForDataAtName(Channel) returns (ListeningNameDataResponse) {}
   rpc listenForContinuationAtName(Channels) returns (ListeningNameContinuationResponse) {}
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -16,8 +16,7 @@ service DeployService {
   rpc addBlock(BlockMessage) returns (DeployServiceResponse) {}
   rpc createBlock(google.protobuf.Empty) returns (DeployServiceResponse) {}
   rpc showBlock(BlockQuery) returns (BlockQueryResponse) {}
-  rpc showBlocks(google.protobuf.Empty) returns (BlocksResponse) {}
-  rpc showBlocks2(google.protobuf.Empty) returns (stream BlockInfo) {}
+  rpc showBlocks(google.protobuf.Empty) returns (stream BlockInfo) {}
   rpc listenForDataAtName(Channel) returns (ListeningNameDataResponse) {}
   rpc listenForContinuationAtName(Channels) returns (ListeningNameContinuationResponse) {}
 }

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -31,10 +31,7 @@ private[api] class DeployGrpcService[
   override def showBlock(q: BlockQuery): Future[BlockQueryResponse] =
     BlockAPI.getBlockQueryResponse[F](q).toFuture
 
-  override def showBlocks(e: Empty): Future[BlocksResponse] =
-    BlockAPI.getBlocksResponse[F].toFuture
-
-  override def showBlocks2(request: Empty, observer: StreamObserver[BlockInfo]): Unit =
+  override def showBlocks(request: Empty, observer: StreamObserver[BlockInfo]): Unit =
     BlockAPI.getBlocksResponse[F].toFuture.onComplete {
       case Success(blockResponse) =>
         blockResponse.blocks.foreach(bi => observer.onNext(bi))

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -3,6 +3,7 @@ package coop.rchain.node.api
 import coop.rchain.node.diagnostics
 import coop.rchain.p2p.effects._
 import io.grpc.{Server, ServerBuilder}
+import io.grpc.netty.NettyServerBuilder
 
 import scala.concurrent.Future
 import cats._
@@ -43,7 +44,7 @@ object GrpcServer {
       port: Int,
       runtime: Runtime)(implicit scheduler: Scheduler): F[Server] =
     Capture[F].capture {
-      ServerBuilder
+      NettyServerBuilder
         .forPort(port)
         .addService(ReplGrpc.bindService(new ReplGrpcService(runtime), scheduler))
         .addService(DiagnosticsGrpc.bindService(diagnostics.grpc[F], scheduler))
@@ -54,7 +55,7 @@ object GrpcServer {
       F[_]: Capture: Monad: MultiParentCasperConstructor: Log: SafetyOracle: BlockStore: Futurable](
       port: Int)(implicit scheduler: Scheduler): F[Server] =
     Capture[F].capture {
-      ServerBuilder
+      NettyServerBuilder
         .forPort(port)
         .addService(DeployServiceGrpc.bindService(new DeployGrpcService[F], scheduler))
         .build

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -75,13 +75,16 @@ package object effects {
         } yield r
     }
 
-  def tcpTransportLayer(host: String, port: Int, certPath: Path, keyPath: Path)(
-      implicit scheduler: Scheduler,
-      connections: TcpTransportLayer.TransportCell[Task],
-      log: Log[Task]): TcpTransportLayer = {
+  def tcpTransportLayer(host: String,
+                        port: Int,
+                        certPath: Path,
+                        keyPath: Path,
+                        maxMessageSize: Int)(implicit scheduler: Scheduler,
+                                             connections: TcpTransportLayer.TransportCell[Task],
+                                             log: Log[Task]): TcpTransportLayer = {
     val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
     val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
-    new TcpTransportLayer(host, port, cert, key)
+    new TcpTransportLayer(host, port, cert, key, maxMessageSize)
   }
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -37,6 +37,8 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
+  private val maxMessageSize: Int = 100 * 1024 * 1024 // TODO should be part of configuration
+
   implicit def eiterTrpConfAsk(implicit ev: RPConfAsk[Task]): RPConfAsk[Effect] =
     new EitherTApplicativeAsk[Task, RPConf, CommError]
 
@@ -335,10 +337,11 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       new Exception(s"CommError: $commError")
     }, e => { UnknownCommError(e.getMessage) })
     metrics = diagnostics.metrics[Task]
-    transport = effects.tcpTransportLayer(host, port, conf.tls.certificate, conf.tls.key)(
-      scheduler,
-      tcpConnections,
-      log)
+    transport = effects.tcpTransportLayer(host,
+                                          port,
+                                          conf.tls.certificate,
+                                          conf.tls.key,
+                                          maxMessageSize)(scheduler, tcpConnections, log)
     kademliaRPC = effects.kademliaRPC(local, defaultTimeout)(metrics, transport)
     initPeer    = if (conf.server.standalone) None else Some(conf.server.bootstrap)
     nodeDiscovery <- effects


### PR DESCRIPTION
## Overview
The problem orbits around the problem that grpc-java has a limit on maximum size of the message that is being sent and received. In our project grpc-java is used in two places:
1. as an underlaying transport layer that allows sending messages between nodes
2. as an API server

Originally the issue (CORE-887) was about `show-blocks`, thus manifesting itself in the latter (API server). When calling `show-blocks` on a node, the node would send the description of the *whole* blockchain (all blocks). At some point that description would exceed the maximum message size and the server would throw an exception.

Solution to this problem was to send that information in chunks, stream fashion.

While working on this problem, I've realized that there is a bigger issue here at hand - in the transport layer. Blocks themselves can exceed the maximum message size and so making them to big to be sent via transport layer. It is possible to deploy a contract that once proposed will generate enormous amount of comm events. Example of such contract below:

```
new dupe, stdout(`rho:io:stdout`), stdoutAck(`rho:io:stdoutAck`) in {
contract dupe(@depth) = {
  if (depth <= 0) { Nil } else {  dupe!(depth-1) | dupe!(depth-1) | dupe!(depth-1) | dupe!(depth-1) |  dupe!(depth-1) | dupe!(depth-1) | dupe!(depth-1) | dupe!(depth-1) | dupe!(depth-1) }
} |
dupe!(5)
}
```

This generates block of size 8 MB, that is bigger then the default value of maximum message sized allowed by grpc-java (4MB). 
For the testnet (in this PR) we address the issue by extending the maximum message size to be 100MB (and a value that can be configured).
For main-net (not in this PR) we must consider chunking up blocks when sending them between nodes, if the block is bigger then the maximum message size.

In this PR I did the following:
1. created `maxMessageSize` that configures both grpc-java (the transport layer and server api), its default value is 100 MB. Value is hardcoded, we might consider adding a flag in configuration for it.
2. switched grpc-java in server api to explicitly use the Netty server (because only on netty server you can explicitly set that value
3. I've created new version of `show-blocks` that sends them in a streaming fashion to the caller

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-887
