### PR TITLE
RHOL-588: Add format validation of BlockMessage fields

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -105,6 +105,55 @@ object Validate {
       }
     }
 
+  def formatOfFields[F[_]: Monad: Log](b: BlockMessage): F[Boolean] =
+    if (b.blockHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block hash is empty."))
+      } yield false
+    } else if (b.header.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block header is missing."))
+      } yield false
+    } else if (b.body.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block body is missing."))
+      } yield false
+    } else if (b.sender.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block sender is empty."))
+      } yield false
+    } else if (b.sig.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block signature is empty."))
+      } yield false
+    } else if (b.sigAlgorithm.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block signature algorithm is empty."))
+      } yield false
+    } else if (b.shardId.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block shard identifier is empty."))
+      } yield false
+    } else if (b.header.get.postStateHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))
+      } yield false
+    } else if (b.header.get.newCodeHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block new code hash is empty."))
+      } yield false
+    } else if (b.header.get.commReductionsHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block comm reductions hash is empty."))
+      } yield false
+    } else if (b.body.get.postState.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block post state is missing."))
+      } yield false
+    } else {
+      true.pure[F]
+    }
+
   /*
    * TODO: Double check ordering of validity checks
    * TODO: Add check for missing fields
@@ -283,7 +332,8 @@ object Validate {
       Applicative[F].pure(Right(Valid))
     } else {
       for {
-        _ <- Log[F].warn(ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected."))
+        _ <- Log[F].warn(
+              ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected."))
       } yield Left(InvalidShardId)
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -118,10 +118,6 @@ object Validate {
       for {
         _ <- Log[F].warn(ignore(b, s"block body is missing."))
       } yield false
-    } else if (b.sender.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block sender is empty."))
-      } yield false
     } else if (b.sig.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block signature is empty."))
@@ -137,14 +133,6 @@ object Validate {
     } else if (b.header.get.postStateHash.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))
-      } yield false
-    } else if (b.header.get.newCodeHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block new code hash is empty."))
-      } yield false
-    } else if (b.header.get.commReductionsHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block comm reductions hash is empty."))
       } yield false
     } else if (b.body.get.postState.isEmpty) {
       for {

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -5,9 +5,10 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
+import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
 import coop.rchain.casper.util.DagOperations.bfTraverse
-import coop.rchain.casper.util.{ProtoUtil}
+import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.ProtoUtil.bonds
 import coop.rchain.casper.util.rholang.{InterpreterUtil, RuntimeManager}
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
@@ -145,6 +146,10 @@ object Validate {
     } else if (b.body.get.postState.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state is missing."))
+      } yield false
+    } else if (b.body.get.commReductions.exists(_.eventInstance == EventInstance.Empty)) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"one of block comm reduction events is empty."))
       } yield false
     } else {
       true.pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -134,6 +134,14 @@ object Validate {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))
       } yield false
+    } else if (b.header.get.newCodeHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block new code hash is empty."))
+      } yield false
+    } else if (b.header.get.commReductionsHash.isEmpty) {
+      for {
+        _ <- Log[F].warn(ignore(b, s"block comm reductions hash is empty."))
+      } yield false
     } else if (b.body.get.postState.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state is missing."))

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -563,6 +563,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     val header = Header()
       .withPostStateHash(ByteString.copyFrom(postStateHash))
       .withParentsHashList(Seq(signedInvalidBlock.blockHash))
+      .withNewCodeHash(ProtoUtil.protoSeqHash(deploys))
+      .withCommReductionsHash(ProtoUtil.protoSeqHash(Seq.empty))
     val blockHash = Blake2b256.hash(header.toByteArray)
     val body      = Body().withPostState(postState).withNewCode(deploys)
     val serializedJustifications =

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -416,7 +416,7 @@ class ValidateTest
     activeRuntime.close()
   }
 
-  "Field format validation" should "suceed on a valid block and fail on empty fields" in {
+  "Field format validation" should "succeed on a valid block and fail on empty fields" in {
     val genesis = Genesis.withoutContracts(Map.empty, 0L, 0L, "rchain")
     Validate.formatOfFields[Id](genesis) should be(true)
     Validate.formatOfFields[Id](genesis.withBlockHash(ByteString.EMPTY)) should be(false)

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -416,25 +416,23 @@ class ValidateTest
     activeRuntime.close()
   }
 
-  "Field format validation" should "succeed on a valid block and fail on empty fields" in {
-    val genesis = Genesis.withoutContracts(Map.empty, 0L, 0L, "rchain")
-    Validate.formatOfFields[Id](genesis) should be(true)
-    Validate.formatOfFields[Id](genesis.withBlockHash(ByteString.EMPTY)) should be(false)
-    Validate.formatOfFields[Id](genesis.clearHeader) should be(false)
-    Validate.formatOfFields[Id](genesis.clearBody) should be(false)
-    Validate.formatOfFields[Id](genesis.withSender(ByteString.EMPTY)) should be(false)
-    Validate.formatOfFields[Id](genesis.withSig(ByteString.EMPTY)) should be(false)
-    Validate.formatOfFields[Id](genesis.withSigAlgorithm("")) should be(false)
-    Validate.formatOfFields[Id](genesis.withShardId("")) should be(false)
-    Validate.formatOfFields[Id](genesis.withBody(genesis.body.get.clearPostState)) should be(false)
-    Validate.formatOfFields[Id](
-      genesis.withHeader(genesis.header.get.withPostStateHash(ByteString.EMPTY))
-    ) should be(false)
-    Validate.formatOfFields[Id](
-      genesis.withHeader(genesis.header.get.withNewCodeHash(ByteString.EMPTY))
-    ) should be(false)
-    Validate.formatOfFields[Id](
-      genesis.withHeader(genesis.header.get.withCommReductionsHash(ByteString.EMPTY))
-    ) should be(false)
+  "Field format validation" should "succeed on a valid block and fail on empty fields" in withStore {
+    implicit blockStore =>
+      implicit val blockStoreChain = storeForStateWithChain[StateWithChain](blockStore)
+      implicit val chain           = createChain[StateWithChain](1).runS(initState)
+      implicit val (sk, _)         = Ed25519.newKeyPair
+      val genesis                  = signedBlock(0)
+      Validate.formatOfFields[Id](genesis) should be(true)
+      Validate.formatOfFields[Id](genesis.withBlockHash(ByteString.EMPTY)) should be(false)
+      Validate.formatOfFields[Id](genesis.clearHeader) should be(false)
+      Validate.formatOfFields[Id](genesis.clearBody) should be(false)
+      Validate.formatOfFields[Id](genesis.withSig(ByteString.EMPTY)) should be(false)
+      Validate.formatOfFields[Id](genesis.withSigAlgorithm("")) should be(false)
+      Validate.formatOfFields[Id](genesis.withShardId("")) should be(false)
+      Validate.formatOfFields[Id](genesis.withBody(genesis.body.get.clearPostState)) should be(
+        false)
+      Validate.formatOfFields[Id](
+        genesis.withHeader(genesis.header.get.withPostStateHash(ByteString.EMPTY))
+      ) should be(false)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -415,4 +415,26 @@ class ValidateTest
 
     activeRuntime.close()
   }
+
+  "Field format validation" should "suceed on a valid block and fail on empty fields" in {
+    val genesis = Genesis.withoutContracts(Map.empty, 0L, 0L, "rchain")
+    Validate.formatOfFields[Id](genesis) should be(true)
+    Validate.formatOfFields[Id](genesis.withBlockHash(ByteString.EMPTY)) should be(false)
+    Validate.formatOfFields[Id](genesis.clearHeader) should be(false)
+    Validate.formatOfFields[Id](genesis.clearBody) should be(false)
+    Validate.formatOfFields[Id](genesis.withSender(ByteString.EMPTY)) should be(false)
+    Validate.formatOfFields[Id](genesis.withSig(ByteString.EMPTY)) should be(false)
+    Validate.formatOfFields[Id](genesis.withSigAlgorithm("")) should be(false)
+    Validate.formatOfFields[Id](genesis.withShardId("")) should be(false)
+    Validate.formatOfFields[Id](genesis.withBody(genesis.body.get.clearPostState)) should be(false)
+    Validate.formatOfFields[Id](
+      genesis.withHeader(genesis.header.get.withPostStateHash(ByteString.EMPTY))
+    ) should be(false)
+    Validate.formatOfFields[Id](
+      genesis.withHeader(genesis.header.get.withNewCodeHash(ByteString.EMPTY))
+    ) should be(false)
+    Validate.formatOfFields[Id](
+      genesis.withHeader(genesis.header.get.withCommReductionsHash(ByteString.EMPTY))
+    ) should be(false)
+  }
 }

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -15,6 +15,7 @@ import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts.{ProofOfStake, ProofOfStakeValidator, Rev}
 import coop.rchain.casper.helper.{BlockGenerator, BlockStoreFixture}
 import coop.rchain.casper.helper.BlockGenerator._
+import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.ProtoUtil.termDeploy
@@ -439,6 +440,9 @@ class ValidateTest
       ) should be(false)
       Validate.formatOfFields[Id](
         genesis.withHeader(genesis.header.get.withCommReductionsHash(ByteString.EMPTY))
+      ) should be(false)
+      Validate.formatOfFields[Id](
+        genesis.withBody(genesis.body.get.withCommReductions(List(Event(EventInstance.Empty))))
       ) should be(false)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -434,5 +434,11 @@ class ValidateTest
       Validate.formatOfFields[Id](
         genesis.withHeader(genesis.header.get.withPostStateHash(ByteString.EMPTY))
       ) should be(false)
+      Validate.formatOfFields[Id](
+        genesis.withHeader(genesis.header.get.withNewCodeHash(ByteString.EMPTY))
+      ) should be(false)
+      Validate.formatOfFields[Id](
+        genesis.withHeader(genesis.header.get.withCommReductionsHash(ByteString.EMPTY))
+      ) should be(false)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -70,6 +70,8 @@ trait BlockGenerator {
       header = Header()
         .withPostStateHash(ByteString.copyFrom(postStateHash))
         .withParentsHashList(parentsHashList)
+        .withNewCodeHash(ProtoUtil.protoSeqHash(deploys))
+        .withCommReductionsHash(ProtoUtil.protoSeqHash(tsLog))
         .withTimestamp(now)
       blockHash = Blake2b256.hash(header.toByteArray)
       body      = Body().withPostState(postState).withNewCode(deploys).withCommReductions(tsLog)


### PR DESCRIPTION
## Overview
Adds non-empty validators for BlockMessage fields

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-588

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
As per discussion with @KentShikama, validation of blockHash (that it matches to recomputation of the header's hash) and deployCount (that it matches to the length of newCode) will be done in a separate PR.