### PR TITLE
CORE-1029  Remove timestamp and seq from header - not being used

### DIFF
--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/routing.proto
@@ -18,8 +18,6 @@ message Node {
 
 message Header {
     Node   sender         = 1;
-    uint64 timestamp      = 2;
-    uint64 seq            = 3;
 }
 
 message Ping {

--- a/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
@@ -32,7 +32,6 @@ object ProtocolHelper {
   def header(src: PeerNode): Header =
     Header()
       .withSender(node(src))
-      .withTimestamp(System.currentTimeMillis)
 
   def node(n: PeerNode): Node =
     Node()

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -45,7 +45,7 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.Protocol(Protocol(Some(Header(Some(sender), _, _)), msg))) =>
+        case TLResponse(Payload.Protocol(Protocol(Some(Header(Some(sender))), msg))) =>
           if (log.isTraceEnabled) {
             val peerNode = ProtocolHelper.toPeerNode(sender)
             val msgType = msg match {

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -32,7 +32,7 @@ class SslSessionServerInterceptor() extends ServerInterceptor {
 
     override def onMessage(message: ReqT): Unit =
       message match {
-        case TLRequest(Some(Protocol(Some(Header(Some(sender), _, _)), msg))) =>
+        case TLRequest(Some(Protocol(Some(Header(Some(sender))), msg))) =>
           if (log.isTraceEnabled) {
             val peerNode = ProtocolHelper.toPeerNode(sender)
             val msgType = msg match {

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -29,7 +29,6 @@ package object effects {
       log: Log[Task],
       time: Time[Task],
       metrics: Metrics[Task],
-      transport: TransportLayer[Task],
       kademliaRPC: KademliaRPC[Task]
   ): Task[NodeDiscovery[Task]] =
     KademliaNodeDiscovery.create[Task](src, defaultTimeout)(init)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -349,7 +349,6 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
                       .nodeDiscovery(local, defaultTimeout)(initPeer)(log,
                                                                       time,
                                                                       metrics,
-                                                                      transport,
                                                                       kademliaRPC)
                       .toEffect
     blockStore = LMDBBlockStore.create[Effect](conf.blockstorage)(


### PR DESCRIPTION
## Overview
Needed by @goral09 to write integration tests. Timestamp and sequence used to be needed by UdpTransportLayer, but they are not needed now.

Also: remove transportlayer when node discovery is being created, not used by node discovery

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1029  