### PR TITLE
Add two retries (10 sec each) when closing grpc clients

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -71,5 +71,12 @@ Blockchain length: ${response.length}
     (response.success, response.message)
   }
 
-  override def close(): Unit = channel.shutdown().awaitTermination(3, TimeUnit.SECONDS)
+  override def close(): Unit = {
+    val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
+    if (!terminated) {
+      println(
+        "warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+      channel.awaitTermination(10, TimeUnit.SECONDS)
+    }
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -75,7 +75,7 @@ Blockchain length: ${response.length}
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {
       println(
-        "warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
@@ -63,10 +63,11 @@ class GrpcDiagnosticsService(host: String, port: Int)
   def threads: Task[Threads] =
     Task.delay(blockingStub.getThreads(Empty()))
 
-    override def close(): Unit = {
+  override def close(): Unit = {
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
-    if(!terminated) {
-      println("warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+    if (!terminated) {
+      println(
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
@@ -63,5 +63,12 @@ class GrpcDiagnosticsService(host: String, port: Int)
   def threads: Task[Threads] =
     Task.delay(blockingStub.getThreads(Empty()))
 
-  override def close(): Unit = channel.shutdown().awaitTermination(3, TimeUnit.SECONDS)
+    override def close(): Unit = {
+    val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
+    if(!terminated) {
+      println("warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+      channel.awaitTermination(10, TimeUnit.SECONDS)
+    }
+  }
+
 }

--- a/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
@@ -57,5 +57,12 @@ class GrpcReplClient(host: String, port: Int) extends ReplClient[Task] with Clos
   private def processError(t: Throwable): Throwable =
     Option(t.getCause).getOrElse(t)
 
-  override def close(): Unit = channel.shutdown().awaitTermination(3, TimeUnit.SECONDS)
+  override def close(): Unit = {
+    val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
+    if (!terminated) {
+      println(
+        "warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+      channel.awaitTermination(10, TimeUnit.SECONDS)
+    }
+  }
 }

--- a/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
@@ -61,7 +61,7 @@ class GrpcReplClient(host: String, port: Int) extends ReplClient[Task] with Clos
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {
       println(
-        "warn: did not shutdown after 10 seconds, retrbying with additional 10 seconds timeout")
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }


### PR DESCRIPTION
## Overview
When grpc clients will not have time to properly close connection, they freak out with

```
SEVERE: ~ Channel io.grpc.internal.ManagedChannelImpl-5 for target grpc:30015 was not shutdown properly!!! ~
```

 I've added extended the time to await termination, also added two retries. Should be more then enough. Maybe reconsider the close functionality to try more then twice? Worth considering.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-943
