### PR TITLE
Maximum bipartite matching in listMatch (v2)

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatch.scala
@@ -1,0 +1,104 @@
+package coop.rchain.rholang.interpreter.matcher
+
+import cats._
+import cats.data.StateT
+import cats.implicits._
+
+object MaximumBipartiteMatch {
+  def apply[P, T, F[_]: Monad](matchFun: (P, T) => F[Boolean]): MaximumBipartiteMatch[P, T, F] = {
+    val fM = implicitly[Monad[F]]
+    new MaximumBipartiteMatch[P, T, F] {
+      private[matcher] override implicit val fMonad: Monad[F] = fM
+      private[matcher] override val matchFunction             = matchFun
+    }
+  }
+}
+
+/**
+  * Implements the MaximumBipartiteMatch algorithm, according to:
+  * http://olympiad.cs.uct.ac.za/presentations/camp2_2017/bipartitematching-robin.pdf
+  * (mainly the "Alternative approach" section)
+  * <p/>
+  * All the effects produced by calling the provided `matchFunction`
+  * are going to be retained in the final effect via which the algo returns.
+  * See type signatures for `machFunction` and `findMatches`.
+  *
+  * @tparam P type of pattern / the U set
+  * @tparam T type of term / the V set
+  * @tparam F the target Monadic effect this algorithm is to be embedded into
+  */
+trait MaximumBipartiteMatch[P, T, F[_]] {
+
+  private[matcher] implicit val fMonad: Monad[F]
+  private[matcher] val matchFunction: (P, T) => F[Boolean]
+
+  private case class S(matches: Map[T, Pattern], seenTargets: Set[T])
+  type Pattern    = (P, Candidates)
+  type Candidates = Seq[T]
+
+  def findMatches(patterns: List[Pattern]): F[Option[Map[T, P]]] = {
+    val findMatches             = patterns.forallM(MBM.resetSeen() >> findMatch(_))
+    val result: F[(S, Boolean)] = findMatches.run(S(Map.empty, Set.empty))
+    result.map {
+      case (state, true) => Some(state.matches.mapValues(_._1))
+      case _             => None
+    }
+  }
+
+  private type MBM[A] = StateT[F, S, A]
+  import MBM._
+
+  private def findMatch(pattern: Pattern): MBM[Boolean] =
+    pattern match {
+      //there are no more candidates for this pattern, there's not a match
+      case (_, Stream.Empty) => pure(false)
+      case (p, candidate +: candidates) =>
+        FlatMap[MBM].ifM(notSeen(candidate))(
+          //that is a new candidate, let's try to match it
+          FlatMap[MBM].ifM(liftF(matchFunction(p, candidate)))(
+            //this candidate matches the pattern, let's try to assign it a match
+            addSeen(candidate) >> tryClaimMatch(candidate, pattern),
+            //this candidate doesn't match, proceed to the others
+            findMatch((p, candidates))
+          ),
+          //we've seen this candidate already, proceed to the others
+          findMatch((p, candidates)),
+        )
+    }
+
+  private def tryClaimMatch(candidate: T, pattern: Pattern): MBM[Boolean] =
+    for {
+      previousMatch <- getMatch(candidate)
+      result <- previousMatch match {
+                 case None =>
+                   //we're first, we claim a match
+                   claimMatch(candidate, pattern) *> pure(true)
+                 case Some(previousPattern) =>
+                   //try to find a different match for the previous pattern
+                   FlatMap[MBM].ifM(findMatch(previousPattern))(
+                     //if found, we can match current pattern with this candidate despite it being taken
+                     claimMatch(candidate, pattern) *> pure(true),
+                     //else, current pattern can't be matched with this candidate given the current matches, try others
+                     findMatch(pattern)
+                   )
+               }
+    } yield result
+
+  private object MBM {
+
+    def pure[A](a: A): MBM[A] = a.pure[MBM]
+
+    def liftF[A](fa: F[A]): MBM[A] = StateT.liftF(fa)
+
+    def resetSeen(): MBM[Unit] = StateT.modify[F, S](s => s.copy(seenTargets = Set.empty))
+
+    def notSeen(t: T): MBM[Boolean] = StateT.inspect[F, S, Boolean](!_.seenTargets.contains(t))
+
+    def addSeen(t: T): MBM[Unit] = StateT.modify[F, S](s => s.copy(seenTargets = s.seenTargets + t))
+
+    def getMatch(t: T): MBM[Option[Pattern]] = StateT.inspect(_.matches.get(t))
+
+    def claimMatch(candidate: T, pattern: Pattern): MBM[Unit] =
+      StateT.modify[F, S](s => s.copy(matches = s.matches + (candidate -> pattern)))
+  }
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -67,6 +67,13 @@ package object matcher {
           })
         )
       })
+
+    def liftF[A](option: Option[A]): OptionalFreeMapWithCost[A] =
+      StateT((m: FreeMap) => {
+        OptionT(State((c: CostAccount) => {
+          (c, option.map(m -> _))
+        }))
+      })
   }
 
   type NonDetFreeMapWithCost[A] = StateT[StreamT[State[CostAccount, ?], ?], FreeMap, A]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -145,6 +145,16 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     assertSpatialMatch(target: Par, pattern: Par, expectedResult)
   }
 
+  "Matching patterns to equal targets" should "work" in {
+    //     Matching:  free0 | free1
+    //           to:  1 | 1
+    // should yield:  Some(Map(0 -> 1 | 1))
+    val target: Par    = GInt(1).prepend(GInt(1), depth = 0)
+    val pattern: Par   = EVar(FreeVar(1)).prepend(EVar(FreeVar(0)), depth = 0).withConnectiveUsed(true)
+    val expectedResult = Some(Map[Int, Par](0 -> target))
+    assertSpatialMatch(target, pattern, expectedResult)
+  }
+
   "Matching that requires revision of prior matches" should "work" in {
     //     Matching:  [1, [free0]] | [free1, [2]]
     //           to:  [1, [2]] | [1, [3]]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -155,6 +155,18 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     assertSpatialMatch(target, pattern, expectedResult)
   }
 
+  "Matching multiple reminders" should "assign captures to remainders greedily" in {
+    //     Matching:  free0 | free1 | _
+    //           to:  1 | 2 | 3
+    // should yield:  Some(Map(0 -> 1 | 2 | 3))
+    val target: Par = GInt(3).prepend(GInt(2), depth = 0).prepend(GInt(1), depth = 0)
+    val pattern: Par = EVar(Wildcard(WildcardMsg()))
+      .prepend(EVar(FreeVar(1)), depth = 0)
+      .prepend(EVar(FreeVar(0)), depth = 0)
+    val expectedResult = Some(Map[Int, Par](0 -> target))
+    assertSpatialMatch(target, pattern, expectedResult)
+  }
+
   "Matching that requires revision of prior matches" should "work" in {
     //     Matching:  [1, [free0]] | [free1, [2]]
     //           to:  [1, [2]] | [1, [3]]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -72,10 +72,15 @@ class VarMatcherSpec extends FlatSpec with Matchers {
     val pattern: Par = EVar(FreeVar(0))
     assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(7))))
   }
-  "Matching var with var" should "fail" in {
+  "Matching bound var with free var" should "fail" in {
     val target: Par  = EVar(BoundVar(0))
     val pattern: Par = EVar(FreeVar(0))
     assertSpatialMatch(target, pattern, None)
+  }
+  "Matching bound var with a wildcard" should "succeed" in {
+    val target: Par  = EVar(BoundVar(0))
+    val pattern: Par = EVar(Wildcard(WildcardMsg()))
+    assertSpatialMatch(target, pattern, Some(Map()))
   }
   "Matching lists of grounds with lists of vars" should "work" in {
     val target: Par = EList(List[Par](GString("add"), GInt(7), GInt(8)), BitSet())


### PR DESCRIPTION
## Overview

This is #1272 with review comments applied.

I've first added tests securing the corner cases we've discovered so far (3 for why MBM is required instead of Stable Marriage, 1 for why remainders have to be handled using placeholder patterns)

I've then made remainder Par-s' fields to be updated atomically (see `Make merger overwrite the whole Par field instead of adding to it`), so that the stale state from previous matches doesn't linger once switching to MBM. Notice this is tested with the old matching algo as well, before introducing MBM. The tests for that are also the tests showing why MBM is needed.

Then MBM is introduced in the next 2 commits.

Lastly, memoization for MBM's calls to `matchFunction` follows.

I've skipped adding the `MonadState` constraint for F and controlling state updates from inside MBM, because:
1. atomic updates of par's fields fix the issue that we wanted to address with that,
2. I'd have to also constrain the state in that `MonadState[F, S]` to be a `Monoid`, or otherwise assert its merge-ability,
3. That would require a substantial rework of the algo's code.

Hope this approach is acceptable. Looking forward to your comments :)

---

Reimplements matching of List[Pattern] with List[Term], making it deterministic and polynomial-time, according to the [Maximum Bipartite Matching algorithm](http://olympiad.cs.uct.ac.za/presentations/camp2_2017/bipartitematching-robin.pdf) (see: "alternate version" in the slides)

Supersedes #1201 due to a counterexample we've missed initially.

### JIRA issue:
https://rchain.atlassian.net/browse/RHOL-533

### Checklist
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.