### PR TITLE
Document dependency for Casper protos

### DIFF
--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -2,6 +2,12 @@ syntax = "proto3";
 package coop.rchain.casper.protocol;
 
 import "google/protobuf/empty.proto";
+
+// If you are building for other languages "scalapb.proto"
+// can be manually obtained here:
+// https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
+// make a scalapb directory in this file's location and place it inside
+
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
 

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+// See CapserMessage.proto if this is causing problems
 import "scalapb/scalapb.proto";
 
 option java_package = "coop.rchain.models";


### PR DESCRIPTION
## Overview
Added some information about the `scalapb.proto` dependency which is used by `CasperMessage.proto` and `RhoTypes.proto`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please 

This doesn't address any Rchain issues. This is to help 3rd parties integrate with the node API. There are no code changes, it is only documentation.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
