### PR TITLE
CORE-1051/52 -  Print the whole stacktrace &  Stop logging warn when disconnecting

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -85,8 +85,7 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
         _ <- log.debug(s"Disconnecting from peer ${peer.toAddress}")
         _ <- s.connections.get(peer) match {
               case Some(c) => Task.delay(c.shutdown()).attempt.void
-              case _ =>
-                log.warn(s"Can't disconnect from peer ${peer.toAddress}. Connection not found.")
+              case _ => Task.unit // ignore if connection does not exists already
             }
       } yield s.copy(connections = s.connections - peer)
     }

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -290,8 +290,9 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
             Log[Task]
               .error(
                 "Libsodium is NOT installed on your system. Please install libsodium (https://github.com/jedisct1/libsodium) and try again.")
-          case th =>
-            th.getStackTrace.toList.traverse(ste => Log[Task].error(ste.toString))
+          case th => log.error("Caught unhandable error. Existing. Stacktrace below.") *> Task.delay {
+            th.printStackTrace();
+          }
         } *> exit0.as(Right(())))
 
   private def generateCasperConstructor(runtimeManager: RuntimeManager)(


### PR DESCRIPTION
## Overview
1. Print the whole stacktrace when unhandled error happens
2. Stop logging warn when disconnecting a peer whose connection no longer exists

It is typicall that multiple threads will try to close same
connection. One will succeed, the otherone should just ignore if
connection was already closed (does not exist)

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1051 & CORE-1052
