### PR TITLE
Rspace/core 1042/clear function not deterministic

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -230,7 +230,7 @@ object RSpace {
      * to the empty store state with the clear method.
      */
     val _ = if (history.initialize(store.trieStore, branch)) {
-      space.createCheckpoint()
+      val checkpoint = space.createCheckpoint()
     }
 
     space

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -230,7 +230,7 @@ object RSpace {
      * to the empty store state with the clear method.
      */
     val _ = if (history.initialize(store.trieStore, branch)) {
-      val checkpoint = space.createCheckpoint()
+      space.createCheckpoint()
     }
 
     space

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -114,7 +114,7 @@ abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branc
     val emptyRootHash: Blake2b256Hash =
       store.withTxn(store.createTxnRead()) { txn =>
         store.withTrieTxn(txn) { trieTxn =>
-          store.trieStore.getAllPastRoots(trieTxn).last
+          store.trieStore.getEmptyRoot(trieTxn)
         }
       }
     reset(emptyRootHash)

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -26,6 +26,10 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def validateAndPutRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
+  private[rspace] def getEmptyRoot(txn: T): Blake2b256Hash
+
+  private[rspace] def putEmptyRoot(txn: T, hash: Blake2b256Hash): Unit
+
   private[rspace] def put(txn: T, key: Blake2b256Hash, value: Trie[K, V]): Unit
 
   private[rspace] def get(txn: T, key: Blake2b256Hash): Option[Trie[K, V]]

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -1,16 +1,17 @@
 package coop.rchain.rspace.history
 
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
-import coop.rchain.rspace.{Blake2b256Hash, LMDBOps}
+import coop.rchain.rspace.{Blake2b256Hash, LMDBOps, Serialize}
 import coop.rchain.rspace.internal._
-import coop.rchain.shared.ByteVectorOps._
 import coop.rchain.shared.Resources.withResource
+import coop.rchain.shared.ByteVectorOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
 import scodec.Codec
-import scodec.bits.BitVector
+import scodec.bits.{BitVector, ByteVector}
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
@@ -19,9 +20,11 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
                                    protected[this] val databasePath: Path,
                                    _dbTrie: Dbi[ByteBuffer],
                                    _dbRoot: Dbi[ByteBuffer],
-                                   _dbPastRoots: Dbi[ByteBuffer])(implicit
-                                                                  codecK: Codec[K],
-                                                                  codecV: Codec[V])
+                                   _dbPastRoots: Dbi[ByteBuffer],
+                                   _dbEmptyRoots: Dbi[ByteBuffer],
+)(implicit
+  codecK: Codec[K],
+  codecV: Codec[V])
     extends ITrieStore[Txn[ByteBuffer], K, V]
     with LMDBOps {
 
@@ -47,12 +50,14 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
     _dbTrie.close()
     _dbRoot.close()
     _dbPastRoots.close()
+    _dbEmptyRoots.close()
   }
 
   private[rspace] def clear(txn: Txn[ByteBuffer]): Unit = {
     _dbTrie.drop(txn)
     _dbRoot.drop(txn)
     _dbPastRoots.drop(txn)
+    _dbEmptyRoots.drop(txn)
   }
 
   private[rspace] def getRoot(txn: Txn[ByteBuffer], branch: Branch): Option[Blake2b256Hash] =
@@ -75,7 +80,7 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
     _dbRoot.put(txn, branch, hash)(Codec[Branch], Codec[Blake2b256Hash])
 
   private[rspace] def getAllPastRoots(txn: Txn[ByteBuffer]): Seq[Blake2b256Hash] =
-    withResource(_dbPastRoots.iterate(txn)) { (it: CursorIterator[ByteBuffer]) =>
+    withResource(_dbPastRoots.iterate(txn)) { it: CursorIterator[ByteBuffer] =>
       it.asScala.foldLeft(Seq.empty[Blake2b256Hash]) { (acc, keyVal) =>
         acc ++ Codec[Seq[Blake2b256Hash]].decode(BitVector(keyVal.`val`())).map(_.value).get
       }
@@ -107,6 +112,27 @@ class LMDBTrieStore[K, V] private (val env: Env[ByteBuffer],
           }
       }
       .getOrElse(throw new Exception(s"Unknown root."))
+
+  val stringSerialize: Serialize[String] = new Serialize[String] {
+
+    def encode(a: String): ByteVector =
+      ByteVector.view(a.getBytes(StandardCharsets.UTF_8))
+
+    def decode(bytes: ByteVector): Either[Throwable, String] =
+      Right(new String(bytes.toArray, StandardCharsets.UTF_8))
+  }
+
+  implicit val stringCodec: Codec[String] = stringSerialize.toCodec
+
+  val emptyRootKey = "emptyRoot"
+
+  override private[rspace] def getEmptyRoot(txn: Txn[ByteBuffer]) =
+    _dbEmptyRoots
+      .get(txn, emptyRootKey)(Codec[String], Codec[Blake2b256Hash])
+      .getOrElse(throw new Exception(s"Missing empty root."))
+
+  override private[rspace] def putEmptyRoot(txn: Txn[ByteBuffer], hash: Blake2b256Hash): Unit =
+    _dbEmptyRoots.put(txn, emptyRootKey, hash)(Codec[String], Codec[Blake2b256Hash])
 }
 
 object LMDBTrieStore {
@@ -116,7 +142,8 @@ object LMDBTrieStore {
                                                      codecV: Codec[V]): LMDBTrieStore[K, V] = {
     val dbTrie: Dbi[ByteBuffer]      = env.openDbi("Trie", MDB_CREATE)
     val dbRoots: Dbi[ByteBuffer]     = env.openDbi("Roots", MDB_CREATE)
+    val dbEmptyRoot: Dbi[ByteBuffer] = env.openDbi("EmptyRoot", MDB_CREATE)
     val dbPastRoots: Dbi[ByteBuffer] = env.openDbi("PastRoots", MDB_CREATE)
-    new LMDBTrieStore[K, V](env, path, dbTrie, dbRoots, dbPastRoots)
+    new LMDBTrieStore[K, V](env, path, dbTrie, dbRoots, dbPastRoots, dbEmptyRoot)
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -44,7 +44,8 @@ package object history {
           val rootHash = Trie.hash(root)
           store.put(txn, rootHash, root)
           store.putRoot(txn, branch, rootHash)
-          logger.debug(s"workingRootHash: $rootHash")
+          store.putEmptyRoot(txn, rootHash)
+          logger.debug(s"workingRootHash: $rootHash, setup the empty root in trie")
           true
         case Some(_) =>
           false

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -27,3 +27,5 @@ class PureRSpace[F[_], C, P, A, R, K](space: ISpace[C, P, A, R, K]) {
 
   def close()(s: Sync[F]): F[Unit] = s.delay(space.close())
 }
+
+

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1019,6 +1019,27 @@ trait StorageActionsTests
       checkpoint1.log shouldBe empty
   }
 
+  "clear" should "reset to the same hash on multiple runs" in withTestSpace { space =>
+    val store    = space.store
+    val key      = List("ch1")
+    val patterns = List(Wildcard)
+    val keyHash  = store.hashChannels(key)
+
+    val ch2 = space.createCheckpoint()
+
+    val r = space.consume(key, patterns, new StringsCaptor, persist = false)
+
+    val checkpoint0 = space.createCheckpoint()
+    checkpoint0.log should not be empty
+    space.createCheckpoint()
+    space.clear()
+    store.createCheckpoint()
+    space.clear()
+    val checkpoint2 = space.createCheckpoint()
+    checkpoint2.log shouldBe empty
+    checkpoint2.root shouldBe ch2.root
+  }
+
   def validateIndexedStates(space: ISpace[String, Pattern, String, String, StringsCaptor],
                             indexedStates: Seq[(State, Int)]): Boolean = {
     val tests: Seq[Any] = indexedStates

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1023,21 +1023,24 @@ trait StorageActionsTests
     val store    = space.store
     val key      = List("ch1")
     val patterns = List(Wildcard)
-    val keyHash  = store.hashChannels(key)
+    val emptyCheckpoint = space.createCheckpoint()
 
-    val ch2 = space.createCheckpoint()
-
-    val r = space.consume(key, patterns, new StringsCaptor, persist = false)
-
+    //put some data so the checkpoint is != empty
+    space.consume(key, patterns, new StringsCaptor, persist = false)
     val checkpoint0 = space.createCheckpoint()
     checkpoint0.log should not be empty
+
     space.createCheckpoint()
     space.clear()
+
+    //force clearing of trie store state
     store.createCheckpoint()
     space.clear()
+
+    //the checkpointing mechanism should not interfere with the empty root
     val checkpoint2 = space.createCheckpoint()
     checkpoint2.log shouldBe empty
-    checkpoint2.root shouldBe ch2.root
+    checkpoint2.root shouldBe emptyCheckpoint.root
   }
 
   def validateIndexedStates(space: ISpace[String, Pattern, String, String, StringsCaptor],


### PR DESCRIPTION
## Overview
Clear function was depending on `getAllRoots` mechanism which did not return stable results.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/projects/CORE/issues/CORE-1042

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
none
