### PR TITLE
Rholang: Fix bug where pattern connectives were leaking.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -700,15 +700,12 @@ object ProcNormalizeMatcher {
                                                                  line,
                                                                  col))
                         })
-          bindCount = mergedFrees.countNoWildcards
-          binds     = receipts.map(receipt => receipt._1)
-          bindingsConnectiveUsed = binds
-            .flatMap(_.patterns)
-            .exists(c => ChannelLocallyFree.connectiveUsed(c))
+          bindCount  = mergedFrees.countNoWildcards
+          binds      = receipts.map(receipt => receipt._1)
           updatedEnv = input.env.absorbFree(mergedFrees)._1
           bodyResult <- normalizeMatch[M](p.proc_,
                                           ProcVisitInputs(VectorPar(), updatedEnv, thisLevelFree))
-          connective = sourcesConnectives || bodyResult.par.connectiveUsed || bindingsConnectiveUsed
+          connective = sourcesConnectives || bodyResult.par.connectiveUsed
         } yield
           ProcVisitOutputs(
             input.par.prepend(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -479,7 +479,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         persistent = false,
         bindCount,
         BitSet(),
-        connectiveUsed = true
+        connectiveUsed = false
       )))
     result.knownFree should be(inputs.knownFree)
   }
@@ -531,7 +531,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         persistent = false,
         bindCount,
         BitSet(),
-        connectiveUsed = true
+        connectiveUsed = false
       )))
     result.knownFree should be(inputs.knownFree)
   }
@@ -564,7 +564,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         persistent = false,
         bindCount,
         BitSet(),
-        connectiveUsed = true
+        connectiveUsed = false
       ))
 
     result.par should be(expected)
@@ -713,7 +713,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
           persistent = false,
           bindCount,
           BitSet(),
-          connectiveUsed = true
+          connectiveUsed = false
         ))
 
     result.par should be(expectedResult)
@@ -871,7 +871,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
           Par(),
           persistent = false,
           bindCount,
-          connectiveUsed = true
+          connectiveUsed = false
         ))
 
     result.par should be(expectedResult)


### PR DESCRIPTION
## Overview
ConnectiveUsed should not be set in a receive based on usage in patterns.
