### PR TITLE
make sure the base16 representation has an even number of digits when decoding

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
@@ -4,10 +4,10 @@ object Base16 {
   def encode(input: Array[Byte]): String = bytes2hex(input, None)
 
   def decode(input: String): Array[Byte] = {
-    val paddedInput = {
+    val paddedInput = 
       if (input.length % 2 == 0) input
       else "0" + input
-    }
+
     hex2bytes(paddedInput)
   }
 

--- a/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
@@ -3,13 +3,13 @@ package coop.rchain.crypto.codec
 object Base16 {
   def encode(input: Array[Byte]): String = bytes2hex(input, None)
 
-  def decode(input: String): Array[Byte] =
-    if (input.length % 2 == 0) {
-      hex2bytes(input)
-    } else {
-      // TODO: Learn how to handle errors more functionally
-      throw new Error("Input must always be even in length")
+  def decode(input: String): Array[Byte] = {
+    val paddedInput = {
+      if (input.length % 2 == 0) input
+      else "0" + input
     }
+    hex2bytes(paddedInput)
+  }
 
   private def bytes2hex(bytes: Array[Byte], sep: Option[String]): String =
     bytes.map("%02x".format(_)).mkString(sep.getOrElse(""))

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -37,7 +37,13 @@ object Secp256k1 {
     kpg.initialize(new ECGenParameterSpec(curveName), SecureRandomUtil.secureRandomNonBlocking)
     val kp = kpg.generateKeyPair
 
-    val sec = Base16.decode(kp.getPrivate.asInstanceOf[ECPrivateKey].getS().toString(16))
+    val base16Sec = {
+      val s = kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16)
+      if (s.length % 2 == 0) s
+      else "0" + s
+    }
+
+    val sec = Base16.decode(base16Sec)
     val pub = Secp256k1.toPublic(sec)
 
     (PrivateKey(sec), PublicKey(pub))

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -37,13 +37,7 @@ object Secp256k1 {
     kpg.initialize(new ECGenParameterSpec(curveName), SecureRandomUtil.secureRandomNonBlocking)
     val kp = kpg.generateKeyPair
 
-    val base16Sec = {
-      val s = kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16)
-      if (s.length % 2 == 0) s
-      else "0" + s
-    }
-
-    val sec = Base16.decode(base16Sec)
+    val sec = Base16.decode(kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16))
     val pub = Secp256k1.toPublic(sec)
 
     (PrivateKey(sec), PublicKey(pub))

--- a/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
@@ -1,0 +1,14 @@
+package coop.rchain.crypto.codec
+
+import org.scalatest._
+import prop._
+
+class Base16Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+  property("decode works on any encoded string") {
+    forAll { (input: Array[Byte]) =>
+      val encoded = Base16.encode(input)
+      val decoded = Base16.decode(encoded)
+      decoded should equal(input)
+    }
+  }
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import prop._
 
 class Base16Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
-  property("decode works on any encoded string") {
+  property("decode after encode returns the original input") {
     forAll { (input: Array[Byte]) =>
       val encoded = Base16.encode(input)
       val decoded = Base16.decode(encoded)


### PR DESCRIPTION
## Overview
The previous implementation of Base16.decode asserts that the number of digits is even. Now we pad it with an 0 in such a situation.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-981

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
