### PR TITLE
OPS-221 - Disable Travis cache to see if it helps transient issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
 script:
   - ./scripts/build-subprojects.sh
 
-before_cache:
-  - find $HOME/.sbt -name "*.lock" -type f -delete
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+# before_cache:
+#  - find $HOME/.sbt -name "*.lock" -type f -delete
+#  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
 
 cache:
   false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
 
 cache:
-  timeout: 360 # default is 180 
-  directories:
-    - "$HOME/.ivy2/cache"
-    - "$HOME/.sbt"
-    - "$HOME/.coursier"
+  false
+  # timeout: 360 # default is 180 
+  # directories:
+  #   - "$HOME/.ivy2/cache"
+  #   - "$HOME/.sbt"
+  #   - "$HOME/.coursier"
 
 after_success:
   - "./scripts/create-artifacts.sh"


### PR DESCRIPTION
## Overview
Travis CI Cache may help sometimes in reducing build times (5 mins or so) but it also may introduce other bizarre issues depending on network congestion as it is stored on network accessible storage. I'm going to disable it for a while and see if problems go away. If not we'll enable it again. As mentioned above, rather than take 40 minutes is just will sometimes take 30-35 minutes to complete Travis unit tests. This will also allow us to compare and see how much time we are really saving by using cache.
For more reading, https://docs.travis-ci.com/user/caching/. This may or may not help the issue we are having.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please 
https://rchain.atlassian.net/browse/OPS-221
Transient issue we are having 
https://rchain.atlassian.net/browse/OPS-218

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
