### PR TITLE
Fix basic wallet to specify destination and status separately

### DIFF
--- a/casper/src/main/rholang/BasicWallet.rho
+++ b/casper/src/main/rholang/BasicWallet.rho
@@ -46,11 +46,20 @@ contract @"BasicWallet"(@purse, @algorithm, @pk, return) = {
             contract @[*basicWallet, "deposit"](@amount, @src, success) = {
               @[purse, "deposit"]!(amount, src, *success)
             } |
-            contract @[*basicWallet, "withdraw"](@amount, @nonce, @sig, return) = {
+            contract @[*basicWallet, "transfer"](@amount, @nonce, @sig, destination, status) = {
               new verifyResult in {
-                verify!(nonce, amount, *return, sig, *verifyResult) | for(@verified <- verifyResult) {
-                  if (verified) { @[purse, "split"]!(amount, *return) }
-                  else { return!([]) }
+                verify!(nonce, amount, *destination, sig, *verifyResult) | for(@verified <- verifyResult) {
+                  if (verified) { 
+                    new splitResultCh in {
+                      @[purse, "split"]!(amount, *splitResultCh) |
+                      for(@splitResult  <- splitResultCh) {
+                        match splitResult {
+                          []        => { status!("Overdraft") }
+                          [payment] => { destination!(payment) | status!("Success") }
+                        }
+                      }
+                    }
+                  } else { status!("Invalid signature or nonce") }
                 }
               }
             } |

--- a/casper/src/test/rholang/BasicWalletTest.rho
+++ b/casper/src/test/rholang/BasicWalletTest.rho
@@ -3,8 +3,8 @@
 //requires BasicWallet, MakeMint, TestSet, LinkedList
 @"sk"!("1388803416a5869f3d4682fb3fae738278287b80d1a5a52ddf89be8eb9dac59d") |
 @"pk"!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
-@"sig0"!("1a79a137f6d69537fbbca6fd8ce4d6017a8dcb34d15f8dc504010f0585a073bb3137385e61ab8dd01cb194250370a36a64321edb1e83209db91c366ad4bd4503") |
-@"sig1"!("fcc6d1cee23981d915982bd86ed80942c34d521e6db77d9770e4aad95c06439680eda99c11e43d87abf8718682b578eadb11a658887d5ee4e562674b93e9570f") |
+@"sig0"!("facc9e70f74c118fab7680f8ab7619198571bb7ebdcc80cc527982a358194858157c5f3dd422bf68cc9dc6a3b7b2b99b69ec9e0ebf54f26d57bda1d4d5c5a70a") |
+@"sig1"!("10bbfbd09e6490bac5621a994b0bb2ff3d2437d05f315d397c14765c9a4c31a598ba267213646bcfd2615e51f36c6c0c8c315ffa7565b654015d09a92a46d507") |
 @"invalidSig"!("b8cea97ee7afdab7eb6ebabe8fde9ca8f9dbd3b877e8fe6b6cfd4bcef5cfdcfccec9fd8de9e39df4b6f5a2f7b6d9da8cffef48fab85faddbaab8ebca4af4ab07") |
 
 contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
@@ -16,17 +16,17 @@ contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
   }
 } |
 
-contract @"transfer"(@wallet, @amount, @nonce, @sig, destReturn, contractReturn) = {
-  new transfer, statusCh in {
+contract @"transfer"(@wallet, @amount, @nonce, @sig, destination, contractReturn) = {
+  new transfer, status in {
     contract transfer(return) = {
       //send to known channel so that I can make the right signature
-      @[wallet, "transfer"]!(amount, nonce, sig, "wPurse", *statusCh) |
-      for(@status <- statusCh) {
-        match status {
-          "Success" => {for(@result <- @"wPurse"){ destReturn!(result) }}
-          _ => { Nil }
+      @[wallet, "transfer"]!(amount, nonce, sig, "myWithdraw", *status) |
+      for(@result <- status){ 
+        match result {
+          "Success" => {for(@purse <- @"myWithdraw"){ destination!(purse) }}
+          _         => { Nil }
         } |
-        return!(status)
+        return!(result) 
       }
     } |
     contractReturn!(*transfer)
@@ -101,7 +101,7 @@ contract @"getNonce"(@wallet, return) = {
         @"deposit"!(wallet, 300, otherPurse, "overdrawDep") |
         @"deposit"!(wallet, 30, otherPurse, "depWallet") |
         @"transfer"!(wallet, 60, 0, invalidSig, Nil, "failTransfer") |
-        @"transfer"!(wallet, 60, 0, sig0, "transferredPurse", "transfer0Nonce") |
+        @"transfer"!(wallet, 60, 0, sig0, "wPurse", "transfer0Nonce") |
         @"transfer"!(wallet, 10, 1, sig1, Nil, "transfer1Nonce") |
       @"TestSet"!(
         "Wallet deposit should work as expected.",
@@ -125,7 +125,7 @@ contract @"getNonce"(@wallet, return) = {
         @["TestSet", "after"]!("Wallet transfer should not accept invalid signatures or nonces.", {
           for(doTransfer <- @"transfer0Nonce") {
             @"transfer0Nonce"!(*doTransfer) |
-            doTransfer!("status") | for(@wPurse <- @"transferredPurse"; @"Success" <- @"status") {
+            doTransfer!("status") | for(@wPurse <- @"wPurse"; @"Success" <- @"status") {
               @"getBalance"!(wPurse, "purseBalance") |
               @"getNonce"!(wallet, "walletNonce") |
               @"TestSet"!(

--- a/casper/src/test/rholang/BasicWalletTest.rho
+++ b/casper/src/test/rholang/BasicWalletTest.rho
@@ -3,8 +3,8 @@
 //requires BasicWallet, MakeMint, TestSet, LinkedList
 @"sk"!("1388803416a5869f3d4682fb3fae738278287b80d1a5a52ddf89be8eb9dac59d") |
 @"pk"!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
-@"sig0"!("facc9e70f74c118fab7680f8ab7619198571bb7ebdcc80cc527982a358194858157c5f3dd422bf68cc9dc6a3b7b2b99b69ec9e0ebf54f26d57bda1d4d5c5a70a") |
-@"sig1"!("10bbfbd09e6490bac5621a994b0bb2ff3d2437d05f315d397c14765c9a4c31a598ba267213646bcfd2615e51f36c6c0c8c315ffa7565b654015d09a92a46d507") |
+@"sig0"!("1a79a137f6d69537fbbca6fd8ce4d6017a8dcb34d15f8dc504010f0585a073bb3137385e61ab8dd01cb194250370a36a64321edb1e83209db91c366ad4bd4503") |
+@"sig1"!("fcc6d1cee23981d915982bd86ed80942c34d521e6db77d9770e4aad95c06439680eda99c11e43d87abf8718682b578eadb11a658887d5ee4e562674b93e9570f") |
 @"invalidSig"!("b8cea97ee7afdab7eb6ebabe8fde9ca8f9dbd3b877e8fe6b6cfd4bcef5cfdcfccec9fd8de9e39df4b6f5a2f7b6d9da8cffef48fab85faddbaab8ebca4af4ab07") |
 
 contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
@@ -16,14 +16,20 @@ contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
   }
 } |
 
-contract @"withdraw"(@wallet, @amount, @nonce, @sig, return) = {
-  new withdraw in {
-    contract withdraw(return) = {
+contract @"transfer"(@wallet, @amount, @nonce, @sig, destReturn, contractReturn) = {
+  new transfer, statusCh in {
+    contract transfer(return) = {
       //send to known channel so that I can make the right signature
-      @[wallet, "withdraw"]!(amount, nonce, sig, "myWithdraw") |
-      for(@result <- @"myWithdraw"){ return!(result) }
+      @[wallet, "transfer"]!(amount, nonce, sig, "wPurse", *statusCh) |
+      for(@status <- statusCh) {
+        match status {
+          "Success" => {for(@result <- @"wPurse"){ destReturn!(result) }}
+          _ => { Nil }
+        } |
+        return!(status)
+      }
     } |
-    return!(*withdraw)
+    contractReturn!(*transfer)
   }
 } |
 
@@ -94,9 +100,9 @@ contract @"getNonce"(@wallet, return) = {
         @"getBalance"!(wallet, "walletBalance") |
         @"deposit"!(wallet, 300, otherPurse, "overdrawDep") |
         @"deposit"!(wallet, 30, otherPurse, "depWallet") |
-        @"withdraw"!(wallet, 60, 0, invalidSig, "failWithdraw") |
-        @"withdraw"!(wallet, 60, 0, sig0, "withdraw0Nonce") |
-        @"withdraw"!(wallet, 10, 1, sig1, "withdraw1Nonce") |
+        @"transfer"!(wallet, 60, 0, invalidSig, Nil, "failTransfer") |
+        @"transfer"!(wallet, 60, 0, sig0, "transferredPurse", "transfer0Nonce") |
+        @"transfer"!(wallet, 10, 1, sig1, Nil, "transfer1Nonce") |
       @"TestSet"!(
         "Wallet deposit should work as expected.",
         [
@@ -109,21 +115,21 @@ contract @"getNonce"(@wallet, return) = {
       
       @["TestSet", "after"]!("Wallet deposit should work as expected.", {
         @"TestSet"!(
-          "Wallet withdraw should not accept invalid signatures or nonces.",
+          "Wallet transfer should not accept invalid signatures or nonces.",
           [
-            ["failWithdraw", []], //bad signature
-            ["withdraw1Nonce", []] //nonce out of order
+            ["failTransfer", "Invalid signature or nonce"], //bad signature
+            ["transfer1Nonce", "Invalid signature or nonce"] //nonce out of order
           ]
         ) |
         
-        @["TestSet", "after"]!("Wallet withdraw should not accept invalid signatures or nonces.", {
-          for(doWithdraw <- @"withdraw0Nonce") {
-            @"withdraw0Nonce"!(*doWithdraw) |
-            doWithdraw!("wPurse") | for(@[wPurse] <- @"wPurse") {
+        @["TestSet", "after"]!("Wallet transfer should not accept invalid signatures or nonces.", {
+          for(doTransfer <- @"transfer0Nonce") {
+            @"transfer0Nonce"!(*doTransfer) |
+            doTransfer!("status") | for(@wPurse <- @"transferredPurse"; @"Success" <- @"status") {
               @"getBalance"!(wPurse, "purseBalance") |
               @"getNonce"!(wallet, "walletNonce") |
               @"TestSet"!(
-                "Wallet withdraw should work as expected.",
+                "Wallet transfer should work as expected.",
                 [
                   ["purseBalance", 60],
                   ["walletBalance", 70],


### PR DESCRIPTION
## Overview
The withdraw function specified the return channel for an Option[Purse], but it should really have two return channels: one being the status (false for overdraft or bad signature, true otherwise) and the other being the return channel used for the purse (only on success); the latter needing to be signed over for security. The PR makes this change.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-644

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
