### PR TITLE
Add a WalletCheck that holds a wallet until someone presents a 'ticket'...

### DIFF
--- a/casper/src/main/rholang/WalletCheck.rho
+++ b/casper/src/main/rholang/WalletCheck.rho
@@ -1,0 +1,72 @@
+// WalletCheck: holds funds until a public key with the given hash is presented,
+//     then creates a wallet with that public key and those funds.
+
+// create: makes a wallet check
+//
+// bytearray hash: the hash of the public key
+// Purse purse: the funds to put in the wallet
+contract @["WalletCheck", "create"](@hash, @purse) = {
+  new doneStore in {
+    doneStore!(false) |
+    
+    // claims the wallet by presenting the preimage of the hash
+    //
+    // bytearray pubkey
+    // name statusOut
+    // bytearray sig: signature of [pubKey, statusOut]
+    contract @hash(@[pubKey, statusOut], @sig) = {
+      for (@done <- doneStore) {
+        if (done) {
+          doneStore!(done) |
+          *statusOut!([false, "Already claimed wallet"])
+        } else {
+          // verify signature 
+          new verifiedOut in {
+            @"secp256k1Verify"!([pubKey, statusOut].toByteArray(), sig, pubKey, *verifiedOut) |
+            for (@verified <- verifiedOut) {
+              if (verified) {
+                new hashOut in {
+                  @"keccak256Hash"!(pubKey.toByteArray(), *hashOut) |
+                  for (@pkHash <- hashOut) {
+                    if (pkHash == hash) {
+                      new walletOut in {
+                        @"BasicWallet"!(purse, "secp256k1", pubKey, *walletOut) |
+                        for (@wallet <- walletOut) {
+                          doneStore!(true) |
+                          new pkbaOut in {
+                            pkbaOut!(pubKey.toByteArray()) |
+                            for (@pkba <- pkbaOut) {
+                              statusOut!([true, pkba]) |
+                              contract @{[pkba, "getNonce"]}(return) = {
+                                @[wallet, "getNonce"]!(return)
+                              } |
+                              contract @{[pkba, "getBalance"]}(return) = {
+                                @[wallet, "getBalance"]!(return)
+                              } |
+                              contract @{[pkba, "deposit"]}(@amount, @src, success) = {
+                                @[wallet, "deposit"]!(amount, src, *success)
+                              } |
+                              contract @{[pkba, "transfer"]}(@amount, @nonce, @sig, destination, status) = {
+                                @[wallet, "transfer"]!(amount, nonce, sig, *destination, *status)
+                              }
+                            }
+                          }
+                        }
+                      }
+                    } else {
+                      doneStore!(done) |
+                      statusOut!([false, "Public key is not the preimage of hash"])
+                    }
+                  }
+                }
+              } else {
+                doneStore!(done) |
+                statusOut!([false, "Signature verification failed"])
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/casper/src/main/rholang/WalletCheck.rho
+++ b/casper/src/main/rholang/WalletCheck.rho
@@ -15,41 +15,47 @@ contract @["WalletCheck", "create"](@hash, @purse) = {
     // name statusOut
     // bytearray sig: signature of [pubKey, statusOut]
     contract @hash(@[pubKey, statusOut], @sig) = {
+      
+      // Make sure the purse hasn't already been claimed
       for (@done <- doneStore) {
         if (done) {
           doneStore!(done) |
           *statusOut!([false, "Already claimed wallet"])
         } else {
-          // verify signature 
+
+          // Verify signature 
           new verifiedOut in {
             @"secp256k1Verify"!([pubKey, statusOut].toByteArray(), sig, pubKey, *verifiedOut) |
             for (@verified <- verifiedOut) {
               if (verified) {
                 new hashOut in {
+
+                  // Check that given pubKey is the preimage of hash
                   @"keccak256Hash"!(pubKey.toByteArray(), *hashOut) |
                   for (@pkHash <- hashOut) {
                     if (pkHash == hash) {
                       new walletOut in {
+
+                        // Create the wallet
                         @"BasicWallet"!(purse, "secp256k1", pubKey, *walletOut) |
                         for (@wallet <- walletOut) {
                           doneStore!(true) |
-                          new pkbaOut in {
-                            pkbaOut!(pubKey.toByteArray()) |
-                            for (@pkba <- pkbaOut) {
-                              statusOut!([true, pkba]) |
-                              contract @{[pkba, "getNonce"]}(return) = {
-                                @[wallet, "getNonce"]!(return)
-                              } |
-                              contract @{[pkba, "getBalance"]}(return) = {
-                                @[wallet, "getBalance"]!(return)
-                              } |
-                              contract @{[pkba, "deposit"]}(@amount, @src, success) = {
-                                @[wallet, "deposit"]!(amount, src, *success)
-                              } |
-                              contract @{[pkba, "transfer"]}(@amount, @nonce, @sig, destination, status) = {
-                                @[wallet, "transfer"]!(amount, nonce, sig, *destination, *status)
-                              }
-                            }
+                          
+                          // Install a forwarder to the wallet at a forgeable name.
+                          // TODO: This is completely insecure.  Once the
+                          //   registry is done, use that.
+                          statusOut!([true, pubKey]) |
+                          contract @{[pubKey, "getNonce"]}(return) = {
+                            @[wallet, "getNonce"]!(return)
+                          } |
+                          contract @{[pubKey, "getBalance"]}(return) = {
+                            @[wallet, "getBalance"]!(return)
+                          } |
+                          contract @{[pubKey, "deposit"]}(@amount, @src, success) = {
+                            @[wallet, "deposit"]!(amount, src, *success)
+                          } |
+                          contract @{[pubKey, "transfer"]}(@amount, @nonce, @sig, destination, status) = {
+                            @[wallet, "transfer"]!(amount, nonce, sig, *destination, *status)
                           }
                         }
                       }

--- a/casper/src/main/rholang/WalletCheck.rho
+++ b/casper/src/main/rholang/WalletCheck.rho
@@ -20,7 +20,7 @@ contract @["WalletCheck", "create"](@hash, @purse) = {
       for (@done <- doneStore) {
         if (done) {
           doneStore!(done) |
-          *statusOut!([false, "Already claimed wallet"])
+          @statusOut!([false, "Already claimed wallet"])
         } else {
 
           // Verify signature 
@@ -38,36 +38,29 @@ contract @["WalletCheck", "create"](@hash, @purse) = {
 
                         // Create the wallet
                         @"BasicWallet"!(purse, "secp256k1", pubKey, *walletOut) |
-                        for (@wallet <- walletOut) {
-                          doneStore!(true) |
-                          
-                          // Install a forwarder to the wallet at a forgeable name.
-                          // TODO: This is completely insecure.  Once the
-                          //   registry is done, use that.
-                          statusOut!([true, pubKey]) |
-                          contract @{[pubKey, "getNonce"]}(return) = {
-                            @[wallet, "getNonce"]!(return)
-                          } |
-                          contract @{[pubKey, "getBalance"]}(return) = {
-                            @[wallet, "getBalance"]!(return)
-                          } |
-                          contract @{[pubKey, "deposit"]}(@amount, @src, success) = {
-                            @[wallet, "deposit"]!(amount, src, *success)
-                          } |
-                          contract @{[pubKey, "transfer"]}(@amount, @nonce, @sig, destination, status) = {
-                            @[wallet, "transfer"]!(amount, nonce, sig, *destination, *status)
-                          }
-                        }
+
+                        // Advertise the private name on a forgeable one
+                        // TODO: This is completely insecure.  Once the
+                        //   registry is done, use that.
+                        for (@[wallet] <- walletOut) {
+                          @pubKey!!(wallet) |
+                        
+                          // Return success
+                          @statusOut!([true, wallet])
+                        } |
+                        
+                        // All done
+                        doneStore!(true)
                       }
                     } else {
                       doneStore!(done) |
-                      statusOut!([false, "Public key is not the preimage of hash"])
+                      @statusOut!([false, "Public key is not the preimage of hash"])
                     }
                   }
                 }
               } else {
                 doneStore!(done) |
-                statusOut!([false, "Signature verification failed"])
+                @statusOut!([false, "Signature verification failed"])
               }
             }
           }


### PR DESCRIPTION
… a signed message including the public key that is the preimage of the hash.

## Overview
Ethereum accounts are the hashes of the public keys of the account holders.  We want to create wallets for account holders, but they need to be able to sign claims for funds.  This is something like the coat check pattern, but it holds a wallet.  Given a hash and a purse, it creates a claim contract at the hash that waits for a 'ticket', a signed message containing the public key and a status return channel.  Once it checks that everything's in order, it creates a BasicWallet containing the purse that uses the given public key, then creates a forwarder at the pubKey.

The use of forgeable names is completely insecure and should be replaced by use of the registry when it's ready.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-661
