### PR TITLE
Adds example contract that generates (10^{depth+1}-1)/9 messages.

### DIFF
--- a/rholang/examples/dupe.rho
+++ b/rholang/examples/dupe.rho
@@ -1,0 +1,9 @@
+new dupe in {
+  contract dupe(@depth) = {
+    if (depth <= 0) {
+      Nil
+    } else {
+      dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1) | dupe!(depth - 1)
+    }
+  } | dupe!(2)
+}


### PR DESCRIPTION
## Overview
Code signing didn't work last time; trying again.

Adds example contract that generates (10^{depth+1}-1)/9 messages.  Used for measuring comm events per second.  The depth in this version is kept low so that the automated testing doesn't take forever.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-645
