### PR TITLE
CORE-1075 Upgrade http4s to 0.19.0-M1 to adhere to cats-effect dependency hell

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
   </appender>
 
   <logger name="coop.rchain.rspace" level="warn" />
+  <logger name="org.http4s.blaze.pipeline.stages" level="error" />
   <logger name="io.netty" level="warn" />
 
   <root level="debug">

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val osClassifier: String = Detector.detect(Seq("fedora")).osClassifier
 
   val circeVersion  = "0.9.1"
-  val http4sVersion = "0.18.0"
+  val http4sVersion = "0.19.0-M1"
   val kamonVersion  = "1.1.0"
 
   // format: off


### PR DESCRIPTION
## Overview
We live in cats dependency hell. Monix 3.0.0.RC1 runs on cats effect 0.10 that
maybe just maybe is compatible with cats effect 1.0.0-RC2. Http4s
0.18.x runs on 0.10 but bunch of other stuff in node runs on
1.0.0-RC2.
Cats ecosystem is very unstable at the moment and will likely not
change very fast soon. This is our reality at the moment.


### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1075
