### PR TITLE
CORE-1090 CI - add --thread-pool-size option with 100 default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ test:integration-test-for-p2p-network:
     - ./scripts/install_bnfc.sh
     - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile node/docker:publishLocal
     - sudo python3.6 -m pip install argparse docker pexpect requests
-    - sudo ./scripts/p2p-test-tool.py -b -t -p 2 -m 1024m
+    - sudo ./scripts/p2p-test-tool.py -b -t -p 2 -m 2048m
 
 test:integration-test-for-artifact-creation:
   stage: test 

--- a/scripts/boot-p2p.py
+++ b/scripts/boot-p2p.py
@@ -62,6 +62,12 @@ parser.add_argument("--rnode-directory",
 parser.add_argument("-r", "--remove",
                     action='store_true',
                     help="forcibly remove containers that start with bootstrap and peer associated to network name")
+parser.add_argument("-t", "--thread-pool-size",
+                    dest='thread_pool_size',
+                    type=int,
+                    default="100",
+                    help="set maximum number of threads used by rnode")
+
 # Print -h/help if no args
 if len(sys.argv)==1:
     parser.print_help(sys.stderr)
@@ -232,7 +238,7 @@ def create_bootstrap_node():
         #         bonds_file: {'bind': container_bonds_file, 'mode': 'rw'}, \
         #         bootstrap_node['volume'].name: {'bind': args.rnode_directory, 'mode': 'rw'} \
         # }, \
-        command=f"{args.bootstrap_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {bootstrap_node['name']}", \
+        command=f"{args.bootstrap_command} --thread-pool-size {args.thread_pool_size} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {bootstrap_node['name']}", \
         hostname=bootstrap_node['name'])
     return 0
 
@@ -259,7 +265,7 @@ def create_peer_nodes():
                 f"{bonds_file}:{container_bonds_file}", \
                 f"{peer_node[i]['volume'].name}:{args.rnode_directory}"
             ], \
-            command=f"{peer_prefix_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
+            command=f"{peer_prefix_command} --thread-pool-size {args.thread_pool_size} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
             hostname=peer_node[i]['name'])
     return 0
       

--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -49,7 +49,7 @@ parser.add_argument("-l", "--logs",
 parser.add_argument("-m", "--memory",
                     dest='memory',
                     type=str,
-                    default="1024m",
+                    default="2048m",
                     help="set docker memory limit for all nodes")
 parser.add_argument("-n", "--network",
                     dest='network',
@@ -115,6 +115,11 @@ parser.add_argument("-T", "--tests-to-run",
                     nargs='+',
                     default=['network_sockets', 'count', 'eval', 'repl', 'propose', 'errors', 'RuntimeException'],
                     help="run these tests in this order")
+parser.add_argument("--thread-pool-size",
+                    dest='thread_pool_size',
+                    type=int,
+                    default="100",
+                    help="set maximum number of threads used by rnode")
 # Print -h/help if no args
 if len(sys.argv)==1:
     parser.print_help(sys.stderr)
@@ -659,7 +664,7 @@ def create_bootstrap_node():
         #         bonds_file: {'bind': container_bonds_file, 'mode': 'rw'}, \
         #         bootstrap_node['volume'].name: {'bind': args.rnode_directory, 'mode': 'rw'} \
         # }, \
-        command=f"{args.bootstrap_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {bootstrap_node['name']}", \
+        command=f"{args.bootstrap_command} --thread-pool-size {args.thread_pool_size} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {bootstrap_node['name']}", \
         hostname=bootstrap_node['name'])
     print("Installing additonal packages on container.")
     r = container.exec_run(cmd='apt-get update', user='root').output.decode("utf-8")
@@ -690,7 +695,7 @@ def create_peer_nodes():
                 f"{bonds_file}:{container_bonds_file}", \
                 f"{peer_node[i]['volume'].name}:{args.rnode_directory}"
             ], \
-            command=f"{args.peer_command} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
+            command=f"{args.peer_command} --thread-pool-size {args.thread_pool_size} --validator-private-key {validator_private_key} --validator-public-key {validator_public_key} --host {peer_node[i]['name']}", \
             hostname=peer_node[i]['name'])
 
         print("Installing additonal packages on container.")


### PR DESCRIPTION
## Overview
New threads option needs a smaller default for smaller testing instances. Adding that for gitlab p2p-test-tool for CI/CD as well as boot-p2p tool.  Increased default container memory limit to 2GB from 1GB while I was making changes.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/CORE-1090

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
