### PR TITLE
Casper: Don't hash the source into the random state.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -387,4 +387,11 @@ object ProtoUtil {
     )
 
   def termDeployNow(term: Par): Deploy = termDeploy(term, System.currentTimeMillis())
+
+  /**
+    * Strip a deploy down to the fields we are using to seed the Deterministic name generator.
+    * The fields stripped are the term and anything that depends on the term (Currently only the sig)
+    */
+  def stripDeployData(d: DeployData): DeployData =
+    d.withTerm("").withSig(ByteString.EMPTY)
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -196,7 +196,8 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
   private def injAttempt(deploy: Deploy, reducer: Reduce[Task], errorLog: ErrorLog)(
       implicit scheduler: Scheduler,
       costAlg: CostAccountingAlg[Task]): (PCost, Vector[Throwable]) = {
-    implicit val rand: Blake2b512Random = Blake2b512Random(DeployData.toByteArray(deploy.raw.get))
+    implicit val rand: Blake2b512Random = Blake2b512Random(
+      DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.raw.get)))
     Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
       case Success(_) =>
         val errors = errorLog.readAndClearErrorVector()


### PR DESCRIPTION
This allows users to sign names that will be generated without solving a
signature quine.
