### PR TITLE
fix missing char in repl eval statement

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -82,7 +82,7 @@ parser.add_argument("--repl-commands",
                     nargs='+',
                     default=['5',
                         'new s(`rho:io:stdout`) in { s!("foo") }',
-                        '@"listCh"!([1, 2, 3]) | for(@list <- @"listCh"){ match list { [a, b, c] => { new s(`rho:io:stdout` in { s!(a) } } } }'],
+                        '@"listCh"!([1, 2, 3]) | for(@list <- @"listCh"){ match list { [a, b, c] => { new s(`rho:io:stdout`) in { s!(a) } } } }'],
                     help="set repl commands to run as a list")
 parser.add_argument("--repl-load-repetitions",
                     dest='repl_load_repetitions',


### PR DESCRIPTION
## Overview
MIssing char in rholang statement was causing issues on repl test 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-222

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
