### PR TITLE
OPS-225 - change CI test for network convergence by looking in logs

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -113,7 +113,7 @@ parser.add_argument("-T", "--tests-to-run",
                     dest='tests_to_run',
                     type=str,
                     nargs='+',
-                    default=['network_sockets', 'count', 'eval', 'count', 'repl', 'propose', 'errors', 'RuntimeException'],
+                    default=['network_sockets', 'count', 'eval', 'repl', 'propose', 'errors', 'RuntimeException'],
                     help="run these tests in this order")
 parser.add_argument("--thread-pool-size",
                     dest='thread_pool_size',


### PR DESCRIPTION
## Overview
As Prometheus metrics is changing and going away in near future, modify network convergence test in CI to use logs to test peer count instead of Prometheus metrics API.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/OPS-225

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
