### PR TITLE
CORE-1102 Change interfaces to 0.0.0.0 for http servers

### DIFF
--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -178,7 +178,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       httpServer <- LiftIO[Task].liftIO {
                      val prometheusService = NewPrometheusReporter.service(prometheusReporter)
                      BlazeBuilder[IO]
-                       .bindHttp(conf.server.httpPort, "localhost")
+                       .bindHttp(conf.server.httpPort, "0.0.0.0")
                        .mountService(jsonrpc.service, "/")
                        .mountService(Lykke.service, "/lykke")
                        .mountService(prometheusService, "/metrics")
@@ -187,7 +187,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       metricsServer <- LiftIO[Task].liftIO {
                         val prometheusService = NewPrometheusReporter.service(prometheusReporter)
                         BlazeBuilder[IO]
-                          .bindHttp(conf.server.metricsPort, "localhost")
+                          .bindHttp(conf.server.metricsPort, "0.0.0.0")
                           .mountService(prometheusService, "/")
                           .mountService(prometheusService, "/metrics")
                           .start


### PR DESCRIPTION
## Overview
Currently http4s only opens on 127.0.0.1. We need to open it on all interfaces so it is available e.g via docker

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please CORE-1102
