### PR TITLE
Scala 2.12.6 with parallel compiler backend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import com.typesafe.sbt.packager.docker._
 
 lazy val projectSettings = Seq(
   organization := "coop.rchain",
-  scalaVersion := "2.12.4",
+  scalaVersion := "2.12.6",
   version := "0.1.0-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -1,3 +1,5 @@
+import java.lang.Runtime.getRuntime
+
 import sbt._
 import sbt.Keys._
 
@@ -23,7 +25,8 @@ object CompilerSettings {
       "-encoding", "UTF-8",
       "-feature",
       "-language:_",
-      "-unchecked"
+      "-unchecked",
+      "-Ybackend-parallelism", getRuntime.availableProcessors().toString
     )
     // format: on
 


### PR DESCRIPTION
## Overview
 - Bump Scala version to 2.12.6 
 - use the `-Ybackend-parallelism` flag for faster compilation

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.