### PR TITLE
Replace SNAPSHOT dependencies with jitpack.io-published for faster build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,9 @@ lazy val projectSettings = Seq(
   version := "0.1.0-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
-    Resolver.sonatypeRepo("snapshots")),
+    Resolver.sonatypeRepo("snapshots"),
+    "jitpack" at "https://jitpack.io"
+  ),
   scalafmtOnCompile := true
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,8 +26,10 @@ object Dependencies {
   val http4sCirce         = "org.http4s"                 %% "http4s-circe"              % http4sVersion
   val http4sDSL           = "org.http4s"                 %% "http4s-dsl"                % http4sVersion
   val jaxb                = "javax.xml.bind"              % "jaxb-api"                  % "2.1"
-  val jline               = ("org.scala-lang"             % "jline"                      % "2.10.7").exclude("org.fusesource.jansi", "jansi")
-  val kalium              = "coop.rchain"                 % "kalium"                    % "0.8.1-SNAPSHOT"
+  val jline               = ("org.scala-lang"             % "jline"                     % "2.10.7")
+    .exclude("org.fusesource.jansi", "jansi")
+  // see https://jitpack.io/#rchain/kalium
+  val kalium              = "com.github.rchain"           % "kalium"                    % "0.8.1"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
   val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % kamonVersion
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.1"
@@ -54,7 +56,8 @@ object Dependencies {
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.5"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.2"
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.+"
-  val secp256k1Java       = "coop.rchain"                 % "secp256k1-java"            % "0.1-SNAPSHOT"
+  // see https://jitpack.io/#rchain/secp256k1-java
+  val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
   val tomlScala           = "tech.sparse"                %% "toml-scala"                % "0.1.1"
 
   // format: on


### PR DESCRIPTION
## Overview

Having even a single SNAPSHOT dependency causes each build to re-check
for newer version of that dependency, incurring significant slowdown.

On my laptop, this commit saves 45s for a full rebuild.

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.