### PR TITLE
Don't measure coverage for files that flicker it without reason

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+# Coverage of the following flickers notoriously despite no changes being made.
+# We'll ignore them until we find a way to have reliable coverage measurements for them.
+ignore:
+- "roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala"
+- "roscala/src/main/scala/coop/rchain/roscala/ob/mbox/QueueMbox.scala"


### PR DESCRIPTION
## Overview
Based on coverage change history for the files:
```
- "casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala"
- "roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala"
- "roscala/src/main/scala/coop/rchain/roscala/ob/mbox/QueueMbox.scala"
```
I think it's justified to ignore coverage reports for them, especially that coverage drops block merges since recently.

Codecov reports for those files:
https://codecov.io/gh/rchain/rchain/branch/dev/history/roscala/src/main/scala/coop/rchain/roscala/ob/Tuple.scala?before=b75c0118f0ac71b6364eb69cd49f0e788dac55c2
https://codecov.io/gh/rchain/rchain/branch/dev/history/roscala/src/main/scala/coop/rchain/roscala/ob/mbox/QueueMbox.scala?before=b75c0118f0ac71b6364eb69cd49f0e788dac55c2
https://codecov.io/gh/rchain/rchain/branch/dev/history/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala?before=8c0ff225ed88569b2f45f8df7b4f682ad786b452

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.