### PR TITLE
Remove untraced comm event

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -32,8 +32,8 @@ case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
 case object NeglectedEquivocation   extends InvalidBlock with Slashable
 case object InvalidTransaction      extends InvalidBlock with Slashable
 case object InvalidBondsCache       extends InvalidBlock with Slashable
-case object InvalidBlockHash   extends InvalidBlock with Slashable
-case object InvalidDeployCount extends InvalidBlock with Slashable
+case object InvalidBlockHash        extends InvalidBlock with Slashable
+case object InvalidDeployCount      extends InvalidBlock with Slashable
 
 object BlockStatus {
   def valid: BlockStatus                    = Valid

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
@@ -16,7 +16,7 @@ sealed trait DeployStatus { self =>
 }
 final case object Succeeded                                                     extends DeployStatus
 sealed trait Failed                                                             extends DeployStatus
-final case object UnusedCommEvent                                               extends Failed
+final case class UnusedCommEvent(ex: ReplayException)                           extends Failed
 final case class ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) extends Failed
 final case object UnknownFailure                                                extends Failed
 final case class UserErrors(errors: Vector[Throwable])                          extends Failed
@@ -36,6 +36,6 @@ object DeployStatus {
         if (internalErrors.nonEmpty) InternalErrors(internalErrors)
         else if (userErrors.nonEmpty) UserErrors(userErrors)
         else Succeeded
-      )(_ => UnusedCommEvent)
+      )(ex => UnusedCommEvent(ex))
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
@@ -16,7 +16,7 @@ sealed trait DeployStatus { self =>
 }
 final case object Succeeded                                                     extends DeployStatus
 sealed trait Failed                                                             extends DeployStatus
-final case class UntracedCommEvent(ex: ReplayException)                         extends Failed
+final case object UnusedCommEvent                                               extends Failed
 final case class ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) extends Failed
 final case object UnknownFailure                                                extends Failed
 final case class UserErrors(errors: Vector[Throwable])                          extends Failed
@@ -32,10 +32,10 @@ object DeployStatus {
 
     internalErrors
       .collectFirst { case ex: ReplayException => ex }
-      .fold(
+      .fold[DeployStatus](
         if (internalErrors.nonEmpty) InternalErrors(internalErrors)
         else if (userErrors.nonEmpty) UserErrors(userErrors)
         else Succeeded
-      )(UntracedCommEvent(_))
+      )(_ => UnusedCommEvent)
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -90,8 +90,8 @@ object InterpreterUtil {
             }
           case Left((None, status)) =>
             status match {
-              case UnusedCommEvent =>
-                Log[F].warn(s"Found unused comm event") *> (Right(none[StateHash])
+              case UnusedCommEvent(ex: ReplayException) =>
+                Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> (Right(none[StateHash])
                   .leftCast[BlockException] -> knownStateHashes).pure[F]
             }
           case Right(computedStateHash) =>

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -184,9 +184,8 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
                 Try(runtime.replaySpace.createCheckpoint()) match {
                   case Success(newCheckpoint) =>
                     doReplayEval(rem, newCheckpoint.root)
-                  case Failure(_) =>
-                    // TODO: Match _ for type of exception
-                    Left(none[Deploy] -> UnusedCommEvent)
+                  case Failure(ex: ReplayException) =>
+                    Left(none[Deploy] -> UnusedCommEvent(ex))
                 }
               }
           }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.util.rholang
 
+import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.PrettyPrinter.buildString
@@ -54,7 +55,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
   }
 
   def replayComputeState(hash: StateHash, terms: Seq[InternalProcessedDeploy])(
-      implicit scheduler: Scheduler): Either[(Deploy, Failed), StateHash] = {
+      implicit scheduler: Scheduler): Either[(Option[Deploy], Failed), StateHash] = {
     val runtime = runtimeContainer.take()
     val result  = replayEval(terms, runtime, hash)
     runtimeContainer.put(runtime)
@@ -151,7 +152,6 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
                                                      cost,
                                                      newCheckpoint.log,
                                                      DeployStatus.fromErrors(errors))
-
           if (errors.isEmpty) doEval(rem, newCheckpoint.root, acc :+ deployResult)
           else doEval(rem, hash, acc :+ deployResult)
 
@@ -161,13 +161,13 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     doEval(terms, Blake2b256Hash.fromByteArray(initHash.toByteArray), Vector.empty)
   }
 
-  private def replayEval(
-      terms: Seq[InternalProcessedDeploy],
-      runtime: Runtime,
-      initHash: StateHash)(implicit scheduler: Scheduler): Either[(Deploy, Failed), StateHash] = {
+  private def replayEval(terms: Seq[InternalProcessedDeploy],
+                         runtime: Runtime,
+                         initHash: StateHash)(
+      implicit scheduler: Scheduler): Either[(Option[Deploy], Failed), StateHash] = {
 
     def doReplayEval(terms: Seq[InternalProcessedDeploy],
-                     hash: Blake2b256Hash): Either[(Deploy, Failed), StateHash] =
+                     hash: Blake2b256Hash): Either[(Option[Deploy], Failed), StateHash] =
       terms match {
         case InternalProcessedDeploy(deploy, _, log, status) +: rem =>
           implicit val costAccountingAlg = CostAccountingAlg.unsafe[Task](CostAccount.zero)
@@ -175,11 +175,10 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
           //TODO: compare replay deploy cost to given deploy cost
           val (_, errors) = injAttempt(deploy, runtime.replayReducer, runtime.errorLog)
           DeployStatus.fromErrors(errors) match {
-            case ute: UntracedCommEvent => Left(deploy -> ute)
-            case int: InternalErrors    => Left(deploy -> int)
+            case int: InternalErrors => Left(Some(deploy) -> int)
             case replayStatus =>
               if (status.isFailed != replayStatus.isFailed)
-                Left(deploy -> ReplayStatusMismatch(replayStatus, status))
+                Left(Some(deploy) -> ReplayStatusMismatch(replayStatus, status))
               else if (errors.nonEmpty) doReplayEval(rem, hash)
               else {
                 val newCheckpoint = runtime.replaySpace.createCheckpoint()
@@ -187,7 +186,14 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
               }
           }
 
-        case _ => Right(ByteString.copyFrom(hash.bytes.toArray))
+        case _ => {
+          val replayData = runtime.replaySpace.getReplayData
+          if (replayData.isEmpty) {
+            Right(ByteString.copyFrom(hash.bytes.toArray))
+          } else {
+            Left(none[Deploy] -> UnusedCommEvent)
+          }
+        }
       }
 
     doReplayEval(terms, Blake2b256Hash.fromByteArray(initHash.toByteArray))

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -454,7 +454,7 @@ class ValidateTest
   "Block hash format validation" should "fail on invalid hash" in {
     val (sk, pk) = Ed25519.newKeyPair
     val block    = HashSetCasperTest.createGenesis(Map(pk -> 1))
-    val genesis = ProtoUtil.signBlock(block, BlockDag(), pk, sk, "ed25519", "rchain")
+    val genesis  = ProtoUtil.signBlock(block, BlockDag(), pk, sk, "ed25519", "rchain")
     Validate.blockHash[Id](genesis) should be(Right(Valid))
     Validate.blockHash[Id](
       genesis.withBlockHash(ByteString.copyFromUtf8("123"))
@@ -464,7 +464,7 @@ class ValidateTest
   "Block deploy count validation" should "fail on invalid number of deploys" in {
     val (sk, pk) = Ed25519.newKeyPair
     val block    = HashSetCasperTest.createGenesis(Map(pk -> 1))
-    val genesis = ProtoUtil.signBlock(block, BlockDag(), pk, sk, "ed25519", "rchain")
+    val genesis  = ProtoUtil.signBlock(block, BlockDag(), pk, sk, "ed25519", "rchain")
     Validate.deployCount[Id](genesis) should be(Right(Valid))
     Validate.deployCount[Id](
       genesis.withHeader(genesis.header.get.withDeployCount(100))

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -357,7 +357,7 @@ class InterpreterUtilTest
     tsHash should be(Some(computedTsHash))
   }
 
-  "validateBlockCheckpoint" should "pass linked list test" in {
+  it should "pass linked list test" in {
     val deploys = Vector(
       """
         |contract @"recursionTest"(@list) = {
@@ -405,7 +405,7 @@ class InterpreterUtilTest
     tsHash should be(Some(computedTsHash))
   }
 
-  "validateBlockCheckpoint" should "pass persistent produce test with causality" in {
+  it should "pass persistent produce test with causality" in {
     val deploys =
       Vector("""new x, y, delay in {
               contract delay(@n) = {
@@ -457,7 +457,7 @@ class InterpreterUtilTest
     tsHash should be(Some(computedTsHash))
   }
 
-  "validateBlockCheckpoint" should "pass tests involving primitives" in {
+  it should "pass tests involving primitives" in {
     val deploys =
       Vector(
         """
@@ -506,7 +506,7 @@ class InterpreterUtilTest
     tsHash should be(Some(computedTsHash))
   }
 
-  "validateBlockCheckpoint" should "pass tests involving pick" in {
+  it should "pass tests involving races" in {
     (0 to 10).foreach { _ =>
       val deploys =
         Vector(
@@ -547,5 +547,37 @@ class InterpreterUtilTest
 
       tsHash should be(Some(computedTsHash))
     }
+  }
+
+  it should "return None for logs containing extra comm events" in {
+    val deploys = (0 until 1).map(i => {
+      val code = s"for(_ <- @$i){ Nil } | @$i!($i)"
+      val term = InterpreterUtil.mkTerm(code).right.get
+      ProtoUtil.termDeployNow(term)
+    })
+
+    val (Right((computedTsHash, processedDeploys)), _) =
+      computeDeploysCheckpoint[Id](Seq.empty,
+                                   deploys,
+                                   BlockMessage(),
+                                   initState,
+                                   knownStateHashes,
+                                   runtimeManager)
+    val intProcessedDeploys = processedDeploys.map(ProcessedDeployUtil.fromInternal)
+    //create single deploy with log that includes excess comm events
+    val badProcessedDeploy = intProcessedDeploys.head.copy(
+      log = intProcessedDeploys.head.log ++ intProcessedDeploys.last.log)
+    val chain: BlockDag =
+      createBlock[StateWithChain](Seq.empty,
+                                  deploys = Seq(badProcessedDeploy, intProcessedDeploys.last),
+                                  tsHash = computedTsHash)
+        .runS(initState)
+    val block = chain.idToBlocks(0)
+
+    val (Right(tsHash), _) =
+      validateBlockCheckpoint[Id](block, block, chain, knownStateHashes, runtimeManager)
+
+    tsHash should be(None)
+
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -511,19 +511,18 @@ class InterpreterUtilTest
       val deploys =
         Vector(
           """
-            |      contract @"loop"(@xs) = {
-            |        match xs {
-            |          [] => {
-            |            for (@winner <- @"ch") {
-            |              @"return"!(winner)
-            |            }
-            |          }
-            |          [first, ...rest] => {
-            |            @"ch"!(first) | @"loop"!(rest)
-            |          }
-            |        }
-            |      } |
-            |      @"loop"!(["a","b","c","d"])
+            | contract @"loop"(@xs) = {
+            |   match xs {
+            |     [] => {
+            |       for (@winner <- @"ch") {
+            |         @"return"!(winner)
+            |       }
+            |     }
+            |     [first, ...rest] => {
+            |       @"ch"!(first) | @"loop"!(rest)
+            |     }
+            |   }
+            | } | @"loop"!(["a","b","c","d"])
             |""".stripMargin
         ).map(s =>
           ProtoUtil.termDeploy(InterpreterUtil.mkTerm(s).right.get, System.currentTimeMillis()))

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -262,7 +262,8 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
       val root = store.createCheckpoint()
       Checkpoint(root, Seq.empty)
     } else {
-      val msg = "unused comm event"
+      // TODO: Make error message more informative
+      val msg = s"unused comm event: replayData multimap has ${replayData.get.size} elements left"
       logger.error(msg)
       throw new ReplayException(msg)
     }

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -163,7 +163,7 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
                 val as = store.getData(txn, Seq(c)).zipWithIndex.filter {
                   case (Datum(_, _, source), _) => comm.produces.contains(source)
                 }
-                c -> { if (c == channel) (Datum(data, persist, produceRef), -1) +: as else as }
+                c -> { if (c == channel) Seq((Datum(data, persist, produceRef), -1)) else as }
               }.toMap
               extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
                 case None             => runMatcher(comm, produceRef, remaining)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -133,15 +133,7 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
         replays.get(consumeRef) match {
           case None =>
-            runMatcher(None) match {
-              case None =>
-                storeWaitingContinuation(replays, consumeRef, None)
-              case Some(_) =>
-                val msg = "untraced event resulted in a comm event"
-                logger.error(msg)
-                replayData.put(replays)
-                throw new ReplayException(msg)
-            }
+            storeWaitingContinuation(replays, consumeRef, None)
           case Some(comms) =>
             val commOrDataCandidates: Either[COMM, Seq[DataCandidate[C, R]]] =
               getCommOrDataCandidates(comms.iterator().asScala.toList)
@@ -269,16 +261,7 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
         replays.get(produceRef) match {
           case None =>
-            runMatcher(None, produceRef, groupedChannels) match {
-              case None =>
-                storeDatum(replays, produceRef, None)
-              case Some(ProduceCandidate(channels, _, _, _)) =>
-                logger.debug(s"produce: matching continuation found at <channels: $channels>")
-                val msg = "untraced event resulted in a comm event"
-                logger.error(msg)
-                replayData.put(replays)
-                throw new ReplayException(msg)
-            }
+            storeDatum(replays, produceRef, None)
           case Some(comms) =>
             val commOrProduceCandidate: Either[COMM, ProduceCandidate[C, P, R, K]] =
               getCommOrProduceCandidate(comms.iterator().asScala.toList)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -257,10 +257,15 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
         updatedReplays.removeBinding(produceRef, commRef)
     }
 
-  def createCheckpoint(): Checkpoint = {
-    val root = store.createCheckpoint()
-    Checkpoint(root, Seq.empty)
-  }
+  def createCheckpoint(): Checkpoint =
+    if (replayData.get.isEmpty) {
+      val root = store.createCheckpoint()
+      Checkpoint(root, Seq.empty)
+    } else {
+      val msg = "unused comm event"
+      logger.error(msg)
+      throw new ReplayException(msg)
+    }
 
   def getReplayData: ReplayData = replayData.get
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -649,10 +649,12 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       mm.get(cr).map(_.size).value shouldBe 2
 
       replaySpace.consume(channels, patterns, k, persist = false)
+      replaySpace.consume(channels, patterns, k, persist = false)
+      replaySpace.produce(channels(0), datum, persist = false)
 
       mm.get(cr).map(_.size).value shouldBe 1
 
-      replaySpace.consume(channels, patterns, k, persist = false)
+      replaySpace.produce(channels(0), datum, persist = false)
 
       mm.get(cr) shouldBe None
   }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -612,7 +612,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       replaySpace.getReplayData shouldBe empty
     }
 
-  "consuming" should "correctly remove things from replay data" in withTestSpaces {
+  "Replay rspace" should "correctly remove things from replay data" in withTestSpaces {
     (space, replaySpace) =>
       val emptyPoint = space.createCheckpoint()
 
@@ -657,51 +657,6 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       replaySpace.produce(channels(0), datum, persist = false)
 
       mm.get(cr) shouldBe None
-  }
-
-  "producing" should "correctly remove things from replay data" in withTestSpaces {
-    (space, replaySpace) =>
-      val emptyPoint = space.createCheckpoint()
-
-      val channels = List("ch1")
-      val patterns = List[Pattern](Wildcard)
-      val k        = "continuation"
-      val datum    = "datum"
-
-      val pr = Produce.create(channels(0), datum, persist = false)
-
-      consumeMany(
-        space,
-        range = 0 to 1,
-        shuffle = false,
-        channelsCreator = const(channels),
-        patterns = patterns,
-        continuationCreator = const(k),
-        persist = false
-      )
-      produceMany(
-        space,
-        range = 0 to 1,
-        shuffle = false,
-        channelCreator = const(channels(0)),
-        datumCreator = const(datum),
-        persist = false
-      )
-      val rigPoint = space.createCheckpoint()
-
-      replaySpace.rig(emptyPoint.root, rigPoint.log)
-
-      val mm: mutable.Map[IOEvent, Multiset[COMM]] = replaySpace.getReplayData
-
-      mm.get(pr).map(_.size).value shouldBe 2
-
-      replaySpace.produce(channels(0), datum, persist = false)
-
-      mm.get(pr).map(_.size).value shouldBe 1
-
-      replaySpace.produce(channels(0), datum, persist = false)
-
-      mm.get(pr) shouldBe None
   }
 
   "producing" should "return same, stable checkpoint root hashes" in {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -57,20 +57,6 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       space.store.isEmpty shouldBe true
   }
 
-  "Creating a COMM Event that is not contained in the trace log" should "throw a ReplayException" in
-    withTestSpaces { (space, replaySpace) =>
-      val ch1 = "ch1"
-
-      val initialCheckpoint = space.createCheckpoint()
-      replaySpace.rig(initialCheckpoint.root, initialCheckpoint.log)
-
-      replaySpace.consume(List(ch1), List(Wildcard), "continuation", false)
-
-      assertThrows[ReplayException] {
-        replaySpace.produce(ch1, data = "datum1", persist = false)
-      }
-    }
-
   "Creating a COMM Event" should "replay correctly" in
     withTestSpaces { (space, replaySpace) =>
       val channels     = List("ch1")


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.

Paired with @goral09 and @odeac 

We do not need the untraced comm event because if there is a comm event that can happen but is not in the replay logs, then the resulting replay rspace's tuplespace/state hash will not match the hash in the block that contains the replay logs. We need to remove the untraced comm event because of the following case:

            for (@winner <- @"ch") {
              @"return"!(winner)
            } | @"ch"!(1) | @"ch"!(2)

The replay logs say that `for (@winner <- @"ch")` matches with `@"ch"!(1)`. Assume the replay rspace then gets called in the order of 1) `for (@winner <- @"ch")`, 2) `@"ch"!(2)`, and 3) `@"ch"!(1)` . Previously it would complain that `@"ch"!(2)` can match with `for (@winner <- @"ch")` and thus it would generate an untraced comm event. However, `for (@winner <- @"ch")` was just waiting for the `@"ch"!(1)` that was about to come.

Integration tests pass as below

```

collected 4 items                                                                                                                     

test/network/test_basics.py::test_metrics_api_socket PASSED                                                                     [ 25%]
test/network/test_basics.py::test_node_logs_for_errors PASSED                                                                   [ 50%]
test/network/test_basics.py::test_node_logs_for_RuntimeException PASSED                                                         [ 75%]
test/network/test_casper_propose_and_deploy.py::test_casper_propose_and_deploy PASSED                                           [100%]

===================================================== 4 passed in 196.43 seconds ======================================================
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

https://rchain.atlassian.net/browse/RHOL-694

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You have someone in mind to assign for review. Make this assignment after submitting the PR.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
