### PR TITLE
CORE-1113 Change behaviour of --thread-pool-size

### DIFF
--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -30,8 +30,10 @@ object Main {
 
     val exec: Task[Unit] =
       for {
-        conf     <- Configuration(args)
-        poolSize = conf.server.threadPoolSize
+        conf <- Configuration(args)
+        poolSize <- conf.server.threadPoolSize.fold(Task.delay {
+                     Runtime.getRuntime().availableProcessors() * 2
+                   })(_.pure[Task])
         //TODO create separate scheduler for casper
         scheduler = Scheduler.fixedPool("node-io", poolSize)
         _         <- Task.unit.asyncBoundary(scheduler)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -57,7 +57,6 @@ object Configuration {
   private val DefaultApprovalProtocolDuration   = 5.minutes
   private val DefaultApprovalProtocolInterval   = 5.seconds
   private val DefaultMaxMessageSize: Int        = 100 * 1024 * 1024
-  private val DefaultThreadPoolSize: Int        = 4000
 
   private val DefaultBootstrapServer: PeerNode = PeerNode
     .parse("rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109:40400")
@@ -134,7 +133,7 @@ object Configuration {
             DefaultStoreType,
             DefaultMaxNumOfConnections,
             DefaultMaxMessageSize,
-            DefaultThreadPoolSize
+            None
           ),
           GrpcServer(
             options.grpcHost.getOrElse(DefaultGrpcHost),
@@ -277,7 +276,7 @@ object Configuration {
       get(_.run.maxMessageSize, _.server.flatMap(_.maxMessageSize), DefaultMaxMessageSize)
 
     val threadPoolSize =
-      get(_.run.threadPoolSize, _.server.flatMap(_.threadPoolSize), DefaultThreadPoolSize)
+      getOpt(_.run.threadPoolSize, _.server.flatMap(_.threadPoolSize))
 
     val shardId = get(_.run.shardId, _.validators.flatMap(_.shardId), DefaultShardId)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -21,7 +21,7 @@ case class Server(
     storeType: StoreType,
     maxNumOfConnections: Int,
     maxMessageSize: Int,
-    threadPoolSize: Int
+    threadPoolSize: Option[Int]
 )
 
 case class GrpcServer(


### PR DESCRIPTION
## Overview
The flag becomes an optional field (both in arguments and in
configuration file). If not provided the default pool size becomes
twice size the core numbers

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1113