### PR TITLE
NO-TICKET: Rholang: Prevent from going into inf loop when printing error.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -96,7 +96,7 @@ object RholangCLI {
           case Right(par)                 => evaluatePar(runtime)(par)
           case Left(ie: InterpreterError) =>
             // we don't want to print stack trace for user errors
-            Console.err.print(ie.toString)
+            ie.printStackTrace(System.err)
           case Left(th) =>
             th.printStackTrace(Console.err)
         }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -76,9 +76,10 @@ object errors {
       s"Top level free variables are not allowed: $freeVars."
   }
   final case class SubstituteError(override val toString: String) extends InterpreterError
-  final case class UnrecognizedInterpreterError(throwable: Throwable)
-      extends RuntimeException(throwable)
-      with InterpreterError
+  final case class UnrecognizedInterpreterError(throwable: Throwable) extends InterpreterError {
+    override def getMessage: String = throwable.getMessage
+    override def toString: String   = throwable.getLocalizedMessage
+  }
   final case class SortMatchError(override val toString: String) extends InterpreterError
   final case class ReduceError(override val toString: String)    extends InterpreterError
   final case class MethodNotDefined(method: String, otherType: String) extends InterpreterError {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -77,8 +77,7 @@ object errors {
   }
   final case class SubstituteError(override val toString: String) extends InterpreterError
   final case class UnrecognizedInterpreterError(throwable: Throwable) extends InterpreterError {
-    override def getMessage: String = throwable.getMessage
-    override def toString: String   = throwable.getLocalizedMessage
+    override def toString: String   = s"UnrecognizedInterpreterError(${throwable.getMessage})"
   }
   final case class SortMatchError(override val toString: String) extends InterpreterError
   final case class ReduceError(override val toString: String)    extends InterpreterError

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
@@ -1,0 +1,29 @@
+package coop.rchain.rholang.interpreter
+import java.io.StringReader
+
+import coop.rchain.rholang.interpreter.errors.UnrecognizedInterpreterError
+import org.scalatest.{FlatSpec, Matchers}
+
+class ErrorsSpec extends FlatSpec with Matchers {
+
+  "Printing stack trace from rholang interpreter" should "not go into infinite loop causing SOE" in {
+    val invalidRholang = "@\"network!(10)"
+    try {
+      Interpreter.buildNormalizedTerm(new StringReader(invalidRholang)).value
+    } catch {
+      case ex: UnrecognizedInterpreterError =>
+        try {
+          ex.printStackTrace(System.err)
+          assert(true)
+        } catch {
+          case _: StackOverflowError =>
+            // fail the test when SOE is thrown when printing the error stacktrace
+            assert(false)
+        }
+      case _ =>
+        // if error different than expected UnrecognizedInterpreterError was thrown also fail
+        assert(false)
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
Title says it all.

Example stacktrace:
```
Unterminated string on line 14 begining at column 8
	at coop.rchain.rholang.interpreter.Interpreter$.$anonfun$buildAST$2(Interpreter.scala:62)
	at cats.syntax.EitherOps$.leftMap$extension(either.scala:142)
	at coop.rchain.rholang.interpreter.Interpreter$.buildAST(Interpreter.scala:59)
	at coop.rchain.rholang.interpreter.Interpreter$.buildNormalizedTerm(Interpreter.scala:40)
	at coop.rchain.rholang.interpreter.RholangCLI$.processFile(RholangCLI.scala:120)
	at coop.rchain.rholang.interpreter.RholangCLI$.$anonfun$main$1(RholangCLI.scala:55)
	at coop.rchain.rholang.interpreter.RholangCLI$.$anonfun$main$1$adapted(RholangCLI.scala:55)
	at scala.collection.immutable.List.foreach(List.scala:389)
	at coop.rchain.rholang.interpreter.RholangCLI$.main(RholangCLI.scala:55)
	at coop.rchain.rholang.interpreter.RholangCLI.main(RholangCLI.scala)
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the (developer wiki)[https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain] for instructions.
- [ ] Your GitHub account is also an account with (Travis CI)[https://travis-ci.org]. Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
