### PR TITLE
RHOL-606: Add compression for packets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,13 +45,14 @@ lazy val shared = (project in file("shared"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
-    libraryDependencies ++= commonDependencies ++ Seq(
+    libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
       catsCore,
       catsEffect,
       catsMtl,
+      lz4,
       monix,
-      scodecCore,
-      scodecBits
+      scodecBits,
+      scodecCore
     )
   )
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -20,12 +20,13 @@ import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.rchain.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
-import coop.rchain.comm.transport.CommMessages.packet
+import coop.rchain.comm.transport.CommMessages.{packet, toPacket}
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.effects.PacketHandler
 import coop.rchain.shared.{Log, LogSource, Time}
+import coop.rchain.shared.ByteStringOps._
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -343,7 +344,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                                             br: ApprovedBlockRequest): F[Option[Packet]] =
       for {
         _ <- Log[F].info(s"Received ApprovedBlockRequest from $peer")
-      } yield Some(Packet(transport.ApprovedBlock.id, approvedBlock.toByteString))
+      } yield Some(toPacket(transport.ApprovedBlock, approvedBlock.toByteString))
 
     override def handleNoApprovedBlockAvailable(na: NoApprovedBlockAvailable): F[Option[Packet]] =
       for {
@@ -504,8 +505,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     }
 
   private def noApprovedBlockAvailable(peer: PeerNode): Packet =
-    Packet(transport.NoApprovedBlockAvailable.id,
-           NoApprovedBlockAvailable("NoApprovedBlockAvailable", peer.toString).toByteString)
+    toPacket(transport.NoApprovedBlockAvailable,
+             NoApprovedBlockAvailable("NoApprovedBlockAvailable", peer.toString).toByteString)
 
 }
 

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/p2p.proto
@@ -25,7 +25,8 @@ message ProtocolHandshakeResponse {
 
 message Packet {
   string typeId  = 1;
-  bytes  content = 2;
+  bool   compressed = 2;
+  bytes  content = 3;
 }
 
 message Disconnect {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,7 @@ object Dependencies {
   val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % kamonVersion
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
+  val lz4                 = "org.apache.commons"          % "commons-compress"          % "1.18"
   val monix               = "io.monix"                   %% "monix"                     % "3.0.0-RC1"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.7.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.4"

--- a/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
@@ -1,0 +1,82 @@
+package coop.rchain.shared
+
+import java.io._
+
+import com.google.protobuf.ByteString
+import coop.rchain.shared.Resources._
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream.Parameters
+import org.apache.commons.compress.compressors.lz4.{FramedLZ4CompressorInputStream, FramedLZ4CompressorOutputStream}
+
+import scala.util.control.NonFatal
+
+object ByteStringOps {
+
+  implicit class RichByteString(bs: ByteString) {
+    def compress: ByteString = compressLZ4(bs)
+
+    def decompress: Option[ByteString] =
+      try {
+        Some(decompressLZ4(bs))
+      } catch {
+        case e: IOException => None
+      }
+  }
+
+  private def compressLZ4(bs: ByteString): ByteString = {
+    withResource(bs.newInput()) { is =>
+      withResource(new PipedOutputStream()) { pos =>
+        withResource(new PipedInputStream(pos)) { pis =>
+          new Thread {
+            override def run(): Unit =
+              // Write compressed data to [[PipedOutputStream]]
+              withResource(new FramedLZ4CompressorOutputStream(pos, Parameters.DEFAULT)) { lz4os =>
+                val data  = new Array[Byte](8192)
+                var count = is.read(data)
+
+                while (count != -1) {
+                  lz4os.write(data, 0, count)
+                  count = is.read(data)
+                }
+              }
+          }.start()
+
+          // Read compressed data into [[ByteString]]
+          ByteString.readFrom(pis)
+        }
+      }
+    }
+  }
+
+  private def decompressLZ4(bs: ByteString): ByteString = {
+    val pos = new PipedOutputStream()
+
+    withResource(bs.newInput()) { is =>
+      withResource(new PipedInputStream(pos)) { pis =>
+        new Thread {
+          override def run(): Unit =
+            withResource(new FramedLZ4CompressorInputStream(is)) { lz4is =>
+              // `pos` has to be closed from within this thread
+              var exception: Throwable = null
+              try {
+                val data  = new Array[Byte](8192)
+                var count = lz4is.read(data)
+
+                while (count != -1) {
+                  pos.write(data, 0, count)
+                  count = lz4is.read(data)
+                }
+              } catch {
+                case NonFatal(e) =>
+                  exception = e
+                  throw e
+              } finally {
+                closeAndAddSuppressed(exception, pos)
+              }
+            }
+        }.start()
+
+        ByteString.readFrom(pis)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Adds compression with the LZ4 compression algorithm which gives us high compression and decompression speeds.

The compression and decompression works by writing to a `PipedOutputStream` from within a spawned thread. A compressed/decompressed `ByteString` can then be created by reading from the `PipedInputStream` that is connected to the `PipedOutputStream`.
This is much more memory efficient than writing to a `ByteArrayOutputStream` and creating the `ByteString` with `ByteString.copyFrom(os.toByteArray)`.

I observed that a block with 40521 bytes was compressed down to 15467 bytes.
Bigger blocks should yield better compression ratios.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-606

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the (developer wiki)[https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain] for instructions.
- [ ] Your GitHub account is also an account with (Travis CI)[https://travis-ci.org]. Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.
