### PR TITLE
Make sure InterpreterError's methods don't cause exceptions themselves

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -84,7 +84,7 @@ object RholangCLI {
       Console.println("Errors received during evaluation:")
       for {
         error <- errors
-      } Console.println(error.toString())
+      } Console.println(error.getMessage)
     }
 
   @tailrec
@@ -96,7 +96,7 @@ object RholangCLI {
           case Right(par)                 => evaluatePar(runtime)(par)
           case Left(ie: InterpreterError) =>
             // we don't want to print stack trace for user errors
-            Console.err.print(ie.toString)
+            Console.err.print(ie.getMessage)
           case Left(th) =>
             th.printStackTrace(Console.err)
         }
@@ -119,7 +119,7 @@ object RholangCLI {
     Interpreter
       .buildNormalizedTerm(source)
       .runAttempt
-      .fold(_.printStackTrace(System.err), processTerm)
+      .fold(_.printStackTrace(Console.err), processTerm)
   }
 
   @tailrec

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -11,25 +11,27 @@ object errors {
   type InterpreterErrorsM[M[_]] = MonadError[M, InterpreterError]
   def interpreterErrorM[M[_]: Monad: InterpreterErrorsM] = MonadError[M, InterpreterError]
 
-  trait InterpreterError extends Throwable {
-    override def getMessage = toString
+  sealed abstract class InterpreterError(message: String) extends Throwable(message) {
+
+    def this(message: String, cause: Throwable) {
+      this(message)
+      initCause(cause)
+    }
   }
-  final case class NormalizerError(override val toString: String) extends InterpreterError
-  final case class SyntaxError(override val toString: String)     extends InterpreterError
+
+  final case class NormalizerError(message: String) extends InterpreterError(message)
+  final case class SyntaxError(message: String)     extends InterpreterError(message)
+
   final case class UnboundVariableRef(varName: String, line: Int, col: Int)
-      extends InterpreterError {
-    override def toString: String =
-      s"Variable reference: =$varName at $line:$col is unbound."
-  }
+      extends InterpreterError(s"Variable reference: =$varName at $line:$col is unbound.")
+
   final case class UnexpectedNameContext(varName: String,
                                          procVarLine: Int,
                                          procVarCol: Int,
                                          nameContextLine: Int,
                                          nameContextCol: Int)
-      extends InterpreterError {
-    override def toString: String =
-      s"Proc variable: $varName at $procVarLine:$procVarCol used in Name context at $nameContextLine:$nameContextCol"
-  }
+      extends InterpreterError(
+        s"Proc variable: $varName at $procVarLine:$procVarCol used in Name context at $nameContextLine:$nameContextCol")
 
   final case class UnexpectedReuseOfNameContextFree(
       varName: String,
@@ -37,10 +39,9 @@ object errors {
       firstUseCol: Int,
       secondUseLine: Int,
       secondUseCol: Int
-  ) extends InterpreterError {
-    override def toString: String =
-      s"Free variable $varName is used twice as a binder (at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in name context."
-  }
+  ) extends InterpreterError(
+        s"Free variable $varName is used twice as a binder " +
+          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in name context.")
 
   final case class UnexpectedProcContext(
       varName: String,
@@ -48,10 +49,9 @@ object errors {
       nameVarCol: Int,
       processContextLine: Int,
       processContextCol: Int
-  ) extends InterpreterError {
-    override def toString: String =
-      s"Name variable: $varName at $nameVarLine:$nameVarCol used in process context at $processContextLine:$processContextCol"
-  }
+  ) extends InterpreterError(
+        s"Name variable: $varName at $nameVarLine:$nameVarCol " +
+          s"used in process context at $processContextLine:$processContextCol")
 
   final case class UnexpectedReuseOfProcContextFree(
       varName: String,
@@ -59,52 +59,39 @@ object errors {
       firstUseCol: Int,
       secondUseLine: Int,
       secondUseCol: Int
-  ) extends InterpreterError {
-    override def toString: String =
-      s"Free variable $varName is used twice as a binder (at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in process context."
-  }
+  ) extends InterpreterError(
+        s"Free variable $varName is used twice as a binder " +
+          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in process context.")
 
-  final case class UnexpectedBundleContent(override val toString: String) extends InterpreterError
-  final case class UnrecognizedNormalizerError(override val toString: String)
-      extends InterpreterError
-  final case class TopLevelWildcardsNotAllowedError(wildcards: String) extends InterpreterError {
-    override def toString: String =
-      s"Top level wildcards are not allowed: $wildcards."
-  }
-  final case class TopLevelFreeVariablesNotAllowedError(freeVars: String) extends InterpreterError {
-    override def toString: String =
-      s"Top level free variables are not allowed: $freeVars."
-  }
-  final case class SubstituteError(override val toString: String) extends InterpreterError
+  final case class UnexpectedBundleContent(message: String)     extends InterpreterError(message)
+  final case class UnrecognizedNormalizerError(message: String) extends InterpreterError(message)
+
+  final case class TopLevelWildcardsNotAllowedError(wildcards: String)
+      extends InterpreterError(s"Top level wildcards are not allowed: $wildcards.")
+
+  final case class TopLevelFreeVariablesNotAllowedError(freeVars: String)
+      extends InterpreterError(s"Top level free variables are not allowed: $freeVars.")
+
+  final case class SubstituteError(message: String) extends InterpreterError(message)
+
   final case class UnrecognizedInterpreterError(throwable: Throwable)
-      extends RuntimeException(throwable)
-      with InterpreterError
-  final case class SortMatchError(override val toString: String) extends InterpreterError
-  final case class ReduceError(override val toString: String)    extends InterpreterError
-  final case class MethodNotDefined(method: String, otherType: String) extends InterpreterError {
-    override def toString: String =
-      s"Error: Method `$method` is not defined on $otherType."
-  }
-  final case class MethodArgumentNumberMismatch(
-      method: String,
-      expected: Int,
-      actual: Int
-  ) extends InterpreterError {
-    override def toString: String =
-      s"Error: Method `$method` expects $expected Par argument(s), but got $actual argument(s)."
-  }
-  final case class OperatorNotDefined(op: String, otherType: String) extends InterpreterError {
-    override def toString: String =
-      s"Error: Operator `$op` is not defined on $otherType."
-  }
-  final case class OperatorExpectedError(
-      op: String,
-      expected: String,
-      otherType: String
-  ) extends InterpreterError {
-    override def toString: String =
-      s"Error: Operator `$op` expected $expected but got $otherType."
-  }
+      extends InterpreterError("Unrecognized interpreter error", throwable)
+
+  final case class SortMatchError(message: String) extends InterpreterError(message)
+  final case class ReduceError(message: String)    extends InterpreterError(message)
+
+  final case class MethodNotDefined(method: String, otherType: String)
+      extends InterpreterError(s"Error: Method `$method` is not defined on $otherType.")
+
+  final case class MethodArgumentNumberMismatch(method: String, expected: Int, actual: Int)
+      extends InterpreterError(
+        s"Error: Method `$method` expects $expected Par argument(s), but got $actual argument(s).")
+
+  final case class OperatorNotDefined(op: String, otherType: String)
+      extends InterpreterError(s"Error: Operator `$op` is not defined on $otherType.")
+
+  final case class OperatorExpectedError(op: String, expected: String, otherType: String)
+      extends InterpreterError(s"Error: Operator `$op` is not defined on $otherType.")
 
   implicit val monadErrorTask: MonadError[Task, InterpreterError] =
     new MonadError[Task, InterpreterError] {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
@@ -1,0 +1,26 @@
+package coop.rchain.rholang.interpreter
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+import coop.rchain.rholang.interpreter.errors.{InterpreterError, UnrecognizedInterpreterError}
+import org.scalacheck.ScalacheckShapeless._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Assertion, FlatSpec, Matchers}
+
+class ErrorsSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  "Using Throwable methods on InterpreterError" should "not cause exceptions itself" in {
+    forAll { e: InterpreterError =>
+      checkThrowableMethodsAreSafe(e)
+      checkThrowableMethodsAreSafe(UnrecognizedInterpreterError(e))
+    }
+  }
+
+  private def checkThrowableMethodsAreSafe[T <: Throwable](e: T): Assertion =
+    noException should be thrownBy {
+      e.toString
+      e.getMessage
+      e.getCause
+      val devNull = new PrintStream(new ByteArrayOutputStream())
+      e.printStackTrace(devNull /* avoid garbage output in tests */ )
+    }
+}


### PR DESCRIPTION
## Overview
This fixes a `StackOverflowError` when calling `toString` on an `UnrecognizedInterpreterError`, and adds tests to prevent similar errors in the future.

### JIRA issue:
RHOL-713

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.