### PR TITLE
RHOL-11: Change return type of RSpace match from Option to Either.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -11,7 +11,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime._
-import coop.rchain.rholang.interpreter.errors.OutOfPhloError
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
@@ -50,7 +50,7 @@ object Runtime {
   private type CPARK[F[_, _, _, _, _, _]] =
     F[Channel,
       BindPattern,
-      OutOfPhloError.type,
+      OutOfPhlogistonsError.type,
       ListChannelWithRandom,
       ListChannelWithRandom,
       TaggedContinuation]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -11,6 +11,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime._
+import coop.rchain.rholang.interpreter.errors.OutOfPhloError
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
@@ -46,8 +47,13 @@ object Runtime {
   private type CPAK[F[_, _, _, _]] =
     F[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation]
 
-  private type CPARK[F[_, _, _, _, _]] =
-    F[Channel, BindPattern, ListChannelWithRandom, ListChannelWithRandom, TaggedContinuation]
+  private type CPARK[F[_, _, _, _, _, _]] =
+    F[Channel,
+      BindPattern,
+      OutOfPhloError.type,
+      ListChannelWithRandom,
+      ListChannelWithRandom,
+      TaggedContinuation]
 
   type Name      = Par
   type Arity     = Int

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -1,16 +1,17 @@
 package coop.rchain.rholang.interpreter
 
+import cats.Id
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.encryption.Curve25519
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray}
 import coop.rchain.models._
-import coop.rchain.rholang.interpreter.storage.implicits._
-import coop.rchain.rspace.{FreudianSpace, ISpace, IStore}
-import monix.eval.Task
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.interpreter.Runtime.RhoISpace
+import coop.rchain.rholang.interpreter.errors.OutOfPhloError
+import coop.rchain.rholang.interpreter.storage.implicits._
+import monix.eval.Task
 
 import scala.util.Try
 
@@ -23,11 +24,17 @@ object SystemProcesses {
       Task(Console.println(prettyPrinter.buildString(arg)))
   }
 
-  def stdoutAck(space: FreudianSpace[Channel,
-                                     BindPattern,
-                                     ListChannelWithRandom,
-                                     ListChannelWithRandom,
-                                     TaggedContinuation],
+  private implicit class ProduceOps(
+      res: Id[
+        Either[OutOfPhloError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]) {
+    def foldResult(
+        dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]): Task[Unit] =
+      res.fold(err => Task.raiseError(OutOfPhloError), _.fold(Task.unit) {
+        case (cont, channels) => _dispatch(dispatcher)(cont, channels)
+      })
+  }
+
+  def stdoutAck(space: RhoISpace,
                 dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(ListChannelWithRandom(Seq(arg, ack), rand, cost)) =>
@@ -36,7 +43,7 @@ object SystemProcesses {
           .produce(ack,
                    ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand, cost),
                    false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
   }
 
@@ -45,11 +52,7 @@ object SystemProcesses {
       Task(Console.err.println(prettyPrinter.buildString(arg)))
   }
 
-  def stderrAck(space: FreudianSpace[Channel,
-                                     BindPattern,
-                                     ListChannelWithRandom,
-                                     ListChannelWithRandom,
-                                     TaggedContinuation],
+  def stderrAck(space: RhoISpace,
                 dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(ListChannelWithRandom(Seq(arg, ack), rand, cost)) =>
@@ -58,7 +61,7 @@ object SystemProcesses {
           .produce(ack,
                    ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand, cost),
                    false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
   }
 
@@ -76,11 +79,7 @@ object SystemProcesses {
 
   //  The following methods will be made available to contract authors.
 
-  def secp256k1Verify(space: FreudianSpace[Channel,
-                                           BindPattern,
-                                           ListChannelWithRandom,
-                                           ListChannelWithRandom,
-                                           TaggedContinuation],
+  def secp256k1Verify(space: RhoISpace,
                       dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(
@@ -92,15 +91,11 @@ object SystemProcesses {
           .produce(ack,
                    ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand, cost),
                    false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
   }
 
-  def ed25519Verify(space: FreudianSpace[Channel,
-                                         BindPattern,
-                                         ListChannelWithRandom,
-                                         ListChannelWithRandom,
-                                         TaggedContinuation],
+  def ed25519Verify(space: RhoISpace,
                     dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(
@@ -112,18 +107,14 @@ object SystemProcesses {
           .produce(ack,
                    ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand, cost),
                    false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
     case _ =>
       illegalArgumentException(
         "ed25519Verify expects data, signature and public key (all as byte arrays) and ack channel as arguments")
   }
 
-  def sha256Hash(space: FreudianSpace[Channel,
-                                      BindPattern,
-                                      ListChannelWithRandom,
-                                      ListChannelWithRandom,
-                                      TaggedContinuation],
+  def sha256Hash(space: RhoISpace,
                  dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
@@ -135,17 +126,13 @@ object SystemProcesses {
                                   rand,
                                   cost),
             false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
     case _ =>
       illegalArgumentException("sha256Hash expects byte array and return channel as arguments")
   }
 
-  def keccak256Hash(space: FreudianSpace[Channel,
-                                         BindPattern,
-                                         ListChannelWithRandom,
-                                         ListChannelWithRandom,
-                                         TaggedContinuation],
+  def keccak256Hash(space: RhoISpace,
                     dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
@@ -157,17 +144,13 @@ object SystemProcesses {
                                   rand,
                                   cost),
             false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
     case _ =>
       illegalArgumentException("keccak256Hash expects byte array and return channel as arguments")
   }
 
-  def blake2b256Hash(space: FreudianSpace[Channel,
-                                          BindPattern,
-                                          ListChannelWithRandom,
-                                          ListChannelWithRandom,
-                                          TaggedContinuation],
+  def blake2b256Hash(space: RhoISpace,
                      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation])
     : Seq[ListChannelWithRandom] => Task[Unit] = {
     case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
@@ -179,7 +162,7 @@ object SystemProcesses {
                                   rand,
                                   cost),
             false)
-          .fold(Task.unit) { case (cont, channels) => _dispatch(dispatcher)(cont, channels) }
+          .foldResult(dispatcher)
       }
     case _ =>
       illegalArgumentException("blake2b256Hash expects byte array and return channel as arguments")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray}
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.errors.OutOfPhloError
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.implicits._
 import monix.eval.Task
 
@@ -26,10 +26,10 @@ object SystemProcesses {
 
   private implicit class ProduceOps(
       res: Id[
-        Either[OutOfPhloError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]) {
+        Either[OutOfPhlogistonsError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]) {
     def foldResult(
         dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]): Task[Unit] =
-      res.fold(err => Task.raiseError(OutOfPhloError), _.fold(Task.unit) {
+      res.fold(err => Task.raiseError(OutOfPhlogistonsError), _.fold(Task.unit) {
         case (cont, channels) => _dispatch(dispatcher)(cont, channels)
       })
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -12,7 +12,7 @@ import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rspace.{FreudianSpace, ISpace}
 import cats.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.errors.OutOfPhloError
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rspace.pure.PureRSpace
 
 trait Dispatch[M[_], A, K] {
@@ -73,7 +73,7 @@ object RholangOnlyDispatcher {
     val pureSpace: PureRSpace[M,
                               Channel,
                               BindPattern,
-                              OutOfPhloError.type,
+                              OutOfPhlogistonsError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation] =
@@ -135,7 +135,7 @@ object RholangAndScalaDispatcher {
     val pureSpace: PureRSpace[M,
                               Channel,
                               BindPattern,
-                              OutOfPhloError.type,
+                              OutOfPhlogistonsError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -11,6 +11,8 @@ import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount, CostAccoun
 import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rspace.{FreudianSpace, ISpace}
 import cats.implicits._
+import coop.rchain.rholang.interpreter.Runtime.RhoISpace
+import coop.rchain.rholang.interpreter.errors.OutOfPhloError
 import coop.rchain.rspace.pure.PureRSpace
 
 trait Dispatch[M[_], A, K] {
@@ -63,12 +65,7 @@ class RholangOnlyDispatcher[M[_]] private (_reducer: => Reduce[M])(implicit s: S
 
 object RholangOnlyDispatcher {
 
-  def create[M[_], F[_]](tuplespace: FreudianSpace[Channel,
-                                                   BindPattern,
-                                                   ListChannelWithRandom,
-                                                   ListChannelWithRandom,
-                                                   TaggedContinuation],
-                         urnMap: Map[String, Par] = Map.empty)(
+  def create[M[_], F[_]](tuplespace: RhoISpace, urnMap: Map[String, Par] = Map.empty)(
       implicit
       parallel: Parallel[M, F],
       s: Sync[M],
@@ -76,6 +73,7 @@ object RholangOnlyDispatcher {
     val pureSpace: PureRSpace[M,
                               Channel,
                               BindPattern,
+                              OutOfPhloError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation] =
@@ -127,11 +125,7 @@ class RholangAndScalaDispatcher[M[_]] private (
 object RholangAndScalaDispatcher {
 
   def create[M[_], F[_]](
-      tuplespace: FreudianSpace[Channel,
-                                BindPattern,
-                                ListChannelWithRandom,
-                                ListChannelWithRandom,
-                                TaggedContinuation],
+      tuplespace: RhoISpace,
       dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]],
       urnMap: Map[String, Par])(
       implicit
@@ -141,6 +135,7 @@ object RholangAndScalaDispatcher {
     val pureSpace: PureRSpace[M,
                               Channel,
                               BindPattern,
+                              OutOfPhloError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -66,7 +66,7 @@ object errors {
   final case class UnexpectedBundleContent(message: String)     extends InterpreterError(message)
   final case class UnrecognizedNormalizerError(message: String) extends InterpreterError(message)
 
-  final case object OutOfPhloError extends InterpreterError("Computation run out of phlogistons.")
+  final case object OutOfPhlogistonsError extends InterpreterError("Computation ran out of phlogistons.")
 
   final case class TopLevelWildcardsNotAllowedError(wildcards: String)
       extends InterpreterError(s"Top level wildcards are not allowed: $wildcards.")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -66,6 +66,8 @@ object errors {
   final case class UnexpectedBundleContent(message: String)     extends InterpreterError(message)
   final case class UnrecognizedNormalizerError(message: String) extends InterpreterError(message)
 
+  final case object OutOfPhloError extends InterpreterError("Computation run out of phlogistons.")
+
   final case class TopLevelWildcardsNotAllowedError(wildcards: String)
       extends InterpreterError(s"Top level wildcards are not allowed: $wildcards.")
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
@@ -6,7 +6,7 @@ import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.rholang.interpreter.Dispatch
-import coop.rchain.rholang.interpreter.errors.{OutOfPhloError, ReduceError}
+import coop.rchain.rholang.interpreter.errors.{OutOfPhlogistonsError, ReduceError}
 import coop.rchain.rspace.pure.PureRSpace
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
@@ -25,7 +25,7 @@ object TuplespaceAlg {
       pureRSpace: PureRSpace[F,
                              Channel,
                              BindPattern,
-                             OutOfPhloError.type,
+                             OutOfPhlogistonsError.type,
                              ListChannelWithRandom,
                              ListChannelWithRandom,
                              TaggedContinuation],
@@ -37,7 +37,7 @@ object TuplespaceAlg {
                          persistent: Boolean): F[CostAccount] = {
       // TODO: Handle the environment in the store
       def go(
-          res: Either[OutOfPhloError.type,
+          res: Either[OutOfPhlogistonsError.type,
                       Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]): F[CostAccount] =
         res match {
           case Right(Some((continuation, dataList))) =>
@@ -71,7 +71,7 @@ object TuplespaceAlg {
         case _ =>
           val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
           def go(
-              res: Either[OutOfPhloError.type,
+              res: Either[OutOfPhlogistonsError.type,
                           Option[(TaggedContinuation, Seq[ListChannelWithRandom])]])
             : F[CostAccount] =
             res match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
@@ -6,7 +6,7 @@ import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.rholang.interpreter.Dispatch
-import coop.rchain.rholang.interpreter.errors.ReduceError
+import coop.rchain.rholang.interpreter.errors.{OutOfPhloError, ReduceError}
 import coop.rchain.rspace.pure.PureRSpace
 import cats.implicits._
 import coop.rchain.models.rholang.implicits._
@@ -25,6 +25,7 @@ object TuplespaceAlg {
       pureRSpace: PureRSpace[F,
                              Channel,
                              BindPattern,
+                             OutOfPhloError.type,
                              ListChannelWithRandom,
                              ListChannelWithRandom,
                              TaggedContinuation],
@@ -35,24 +36,26 @@ object TuplespaceAlg {
                          data: ListChannelWithRandom,
                          persistent: Boolean): F[CostAccount] = {
       // TODO: Handle the environment in the store
-      def go(res: Option[(TaggedContinuation, Seq[ListChannelWithRandom])]): F[CostAccount] =
-        res
-          .map {
-            case (continuation, dataList) =>
-              val rspaceMatchCost =
-                dataList
-                  .map(_.cost.map(CostAccount.fromProto(_)).getOrElse(CostAccount.zero))
-                  .toList
-                  .combineAll
-              if (persistent) {
-                List(dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount.zero),
-                     produce(channel, data, persistent)).parSequence
-                  .map(_.combineAll + rspaceMatchCost)
-              } else {
-                dispatcher.dispatch(continuation, dataList) *> rspaceMatchCost.pure[F]
-              }
-          }
-          .getOrElse(F.pure(CostAccount.zero))
+      def go(
+          res: Either[OutOfPhloError.type,
+                      Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]): F[CostAccount] =
+        res match {
+          case Right(Some((continuation, dataList))) =>
+            val rspaceMatchCost =
+              dataList
+                .map(_.cost.map(CostAccount.fromProto(_)).getOrElse(CostAccount.zero))
+                .toList
+                .combineAll
+            if (persistent) {
+              List(dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount.zero),
+                   produce(channel, data, persistent)).parSequence
+                .map(_.combineAll + rspaceMatchCost)
+            } else {
+              dispatcher.dispatch(continuation, dataList) *> rspaceMatchCost.pure[F]
+            }
+
+          case Right(None) => F.pure(CostAccount.zero)
+        }
 
       for {
         res  <- pureRSpace.produce(channel, data, persist = persistent)
@@ -67,9 +70,12 @@ object TuplespaceAlg {
         case Nil => F.raiseError(ReduceError("Error: empty binds"))
         case _ =>
           val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
-          def go(res: Option[(TaggedContinuation, Seq[ListChannelWithRandom])]): F[CostAccount] =
+          def go(
+              res: Either[OutOfPhloError.type,
+                          Option[(TaggedContinuation, Seq[ListChannelWithRandom])]])
+            : F[CostAccount] =
             res match {
-              case Some((continuation, dataList)) =>
+              case Right(Some((continuation, dataList))) =>
                 val rspaceMatchCost =
                   dataList
                     .map(_.cost.map(CostAccount.fromProto(_)).getOrElse(CostAccount.zero))
@@ -84,7 +90,7 @@ object TuplespaceAlg {
                 } else {
                   dispatcher.dispatch(continuation, dataList) *> rspaceMatchCost.pure[F]
                 }
-              case None => F.pure(CostAccount.zero)
+              case Right(None) => F.pure(CostAccount.zero)
             }
 
           for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -10,7 +10,7 @@ import coop.rchain.rholang.interpreter.matcher._
 import OptionalFreeMapWithCost._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.accounting.CostAccount
-import coop.rchain.rholang.interpreter.errors.OutOfPhloError
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
 
 //noinspection ConvertExpressionToSAM
@@ -27,11 +27,11 @@ object implicits {
     }
 
   implicit val matchListQuote
-    : StorageMatch[BindPattern, OutOfPhloError.type, ListChannelWithRandom, ListChannelWithRandom] =
-    new StorageMatch[BindPattern, OutOfPhloError.type, ListChannelWithRandom, ListChannelWithRandom] {
+    : StorageMatch[BindPattern, OutOfPhlogistonsError.type, ListChannelWithRandom, ListChannelWithRandom] =
+    new StorageMatch[BindPattern, OutOfPhlogistonsError.type, ListChannelWithRandom, ListChannelWithRandom] {
 
       def get(pattern: BindPattern, data: ListChannelWithRandom)
-        : Either[OutOfPhloError.type, Option[ListChannelWithRandom]] = {
+        : Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] = {
         val (cost, resultMatch) = SpatialMatcher
           .foldMatch(data.channels, pattern.patterns, pattern.remainder)
           .runWithCost

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -10,6 +10,7 @@ import coop.rchain.rholang.interpreter.matcher._
 import OptionalFreeMapWithCost._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.accounting.CostAccount
+import coop.rchain.rholang.interpreter.errors.OutOfPhloError
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
 
 //noinspection ConvertExpressionToSAM
@@ -26,15 +27,16 @@ object implicits {
     }
 
   implicit val matchListQuote
-    : StorageMatch[BindPattern, ListChannelWithRandom, ListChannelWithRandom] =
-    new StorageMatch[BindPattern, ListChannelWithRandom, ListChannelWithRandom] {
+    : StorageMatch[BindPattern, OutOfPhloError.type, ListChannelWithRandom, ListChannelWithRandom] =
+    new StorageMatch[BindPattern, OutOfPhloError.type, ListChannelWithRandom, ListChannelWithRandom] {
 
-      def get(pattern: BindPattern, data: ListChannelWithRandom): Option[ListChannelWithRandom] = {
+      def get(pattern: BindPattern, data: ListChannelWithRandom)
+        : Either[OutOfPhloError.type, Option[ListChannelWithRandom]] = {
         val (cost, resultMatch) = SpatialMatcher
           .foldMatch(data.channels, pattern.patterns, pattern.remainder)
           .runWithCost
 
-        resultMatch
+        val result = resultMatch
           .map {
             case (freeMap: FreeMap, caughtRem: Seq[Channel]) =>
               val remainderMap = pattern.remainder match {
@@ -53,6 +55,7 @@ object implicits {
                                     data.randomState,
                                     Some(CostAccount.toProto(cost)))
           }
+        Right(result)
       }
     }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -32,7 +32,7 @@ trait PersistentStoreTester {
   def withTestSpace[R](
       f: FreudianSpace[Channel,
                 BindPattern,
-                OutOfPhloError.type,
+                OutOfPhlogistonsError.type,
                 ListChannelWithRandom,
                 ListChannelWithRandom,
                 TaggedContinuation] => R): R = {
@@ -40,7 +40,7 @@ trait PersistentStoreTester {
     val context: RhoContext = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
     val space = RSpace.create[Channel,
                               BindPattern,
-                              OutOfPhloError.type,
+                              OutOfPhlogistonsError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation](context, Branch("test"))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -32,6 +32,7 @@ trait PersistentStoreTester {
   def withTestSpace[R](
       f: FreudianSpace[Channel,
                 BindPattern,
+                OutOfPhloError.type,
                 ListChannelWithRandom,
                 ListChannelWithRandom,
                 TaggedContinuation] => R): R = {
@@ -39,6 +40,7 @@ trait PersistentStoreTester {
     val context: RhoContext = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
     val space = RSpace.create[Channel,
                               BindPattern,
+                              OutOfPhloError.type,
                               ListChannelWithRandom,
                               ListChannelWithRandom,
                               TaggedContinuation](context, Branch("test"))

--- a/roscala/src/test/scala/coop/rchain/roscala/actor/ActorSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/actor/ActorSpec.scala
@@ -232,46 +232,46 @@ class ActorSpec extends VmSpecUtils {
     "(block (increase foo 1) (increase foo 2))" should "increase value by 3" inMultimode {
 
       /** Testing `QueueMbox`
-        *
-        * Warning: This might not test `QueueMbox` when run in
-        * multi-threaded mode since the ordering of scheduled tasks is
-        * of importance here.
-        *
-        * The first message will lock up the mailbox of `foo`.
-        * The second message arrives at the mailbox of `foo` before
-        * the first message got processed (and the mailbox got
-        * unlocked again). This turns the locked mailbox into a
-        * `QueueMbox` where the second message, `2`, gets enqueued.
-        *
-        * Then the first message gets processed.
-        * The processing results in a call to `Actor.update` which sets
-        * `i` to `1`.
-        * `Actor.update` also calls `QueueMbox.nextMsg`.
-        *
-        * In `QueueMbox.nextMsg` two things happen:
-        * 1) The mailbox of `foo` becomes the (singleton) `LockedMbox`
-        * 2) The second message, `2`, gets dequeued and scheduled which
-        * invokes the `increase` method on the argument `2`
-        *
-        * At some point after `QueueMbox.nextMsg` the `increase` method
-        * will run and increase `i` by `2`.
-        *
-        * litvec:
-        *   0:   {BlockExpr}
-        * codevec:
-        *   0:   fork 8
-        *   1:   alloc 2
-        *   2:   xfer global[foo],arg[0]
-        *   4:   lit 1,arg[1]
-        *   5:   xfer global[increase],trgt
-        *   7:   xmit/nxt 2
-        *   8:   alloc 2
-        *   9:   xfer global[foo],arg[0]
-        *   11:  lit 2,arg[1]
-        *   12:  xfer global[increase],trgt
-        *   14:  xmit/nxt 2
-        *
-        */
+     *
+     * Warning: This might not test `QueueMbox` when run in
+     * multi-threaded mode since the ordering of scheduled tasks is
+     * of importance here.
+     *
+     * The first message will lock up the mailbox of `foo`.
+     * The second message arrives at the mailbox of `foo` before
+     * the first message got processed (and the mailbox got
+     * unlocked again). This turns the locked mailbox into a
+     * `QueueMbox` where the second message, `2`, gets enqueued.
+     *
+     * Then the first message gets processed.
+     * The processing results in a call to `Actor.update` which sets
+     * `i` to `1`.
+     * `Actor.update` also calls `QueueMbox.nextMsg`.
+     *
+     * In `QueueMbox.nextMsg` two things happen:
+     * 1) The mailbox of `foo` becomes the (singleton) `LockedMbox`
+     * 2) The second message, `2`, gets dequeued and scheduled which
+     * invokes the `increase` method on the argument `2`
+     *
+     * At some point after `QueueMbox.nextMsg` the `increase` method
+     * will run and increase `i` by `2`.
+     *
+     * litvec:
+     *   0:   {BlockExpr}
+     * codevec:
+     *   0:   fork 8
+     *   1:   alloc 2
+     *   2:   xfer global[foo],arg[0]
+     *   4:   lit 1,arg[1]
+     *   5:   xfer global[increase],trgt
+     *   7:   xmit/nxt 2
+     *   8:   alloc 2
+     *   9:   xfer global[foo],arg[0]
+     *   11:  lit 2,arg[1]
+     *   12:  xfer global[increase],trgt
+     *   14:  xmit/nxt 2
+     *
+     */
       val fixture                   = defineActor
       implicit val m: SymbolOffsets = fixture.symbolOffsets
 
@@ -297,7 +297,7 @@ class ActorSpec extends VmSpecUtils {
 
       fixture.foo.extension.slot.unsafeGet(0) shouldBe Fixnum(3)
     }
-    */
+     */
 
     "Failing to unlock" should "turn an EmptyMbox into a LockedMbox" inMultimode {
 

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -18,14 +18,15 @@ class BasicBench {
 
     val space = state.testSpace
 
-    space.consume(List("ch1", "ch2"),
-                  List(StringMatch("bad"), StringMatch("finger")),
-                  new StringsCaptor,
-                  false)
+    space
+      .consume(List("ch1", "ch2"),
+               List(StringMatch("bad"), StringMatch("finger")),
+               new StringsCaptor,
+               false)
 
     val r1 = space.produce("ch1", "bad", false)
 
-    assert(r1.isEmpty)
+    assert(r1.right.get.isEmpty)
 
     val r2 = space.produce("ch2", "finger", false)
 
@@ -49,8 +50,9 @@ object BasicBench {
     val testStore: LMDBStore[String, Pattern, String, StringsCaptor] =
       LMDBStore.create[String, Pattern, String, StringsCaptor](context)
 
-    val testSpace: RSpace[String, Pattern, String, String, StringsCaptor] =
-      RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, Branch("bench"))
+    val testSpace: RSpace[String, Pattern, Nothing, String, String, StringsCaptor] =
+      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore,
+                                                                             Branch("bench"))
 
     @TearDown
     def tearDown() = {

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{Await, Future}
 @org.openjdk.jmh.annotations.State(Scope.Thread)
 trait RSpaceBench {
 
-  var space: FreudianSpace[Channel, Pattern, Entry, Entry, EntriesCaptor] = null
+  var space: FreudianSpace[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] = null
 
   val channel  = Channel("friends#" + 1.toString)
   val channels = List(channel)
@@ -96,7 +96,8 @@ class LMDBBench extends RSpaceBench {
     val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
+                                                                                  Branch.MASTER)
   }
 
   @TearDown
@@ -119,7 +120,8 @@ class InMemBench extends RSpaceBench {
     assert(context.trieStore.toMap.isEmpty)
     val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
+                                                                                  Branch.MASTER)
   }
 
   @TearDown
@@ -147,7 +149,8 @@ class MixedBench extends RSpaceBench {
     assert(context.trieStore.toMap.isEmpty)
     val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
+                                                                                  Branch.MASTER)
   }
 
   @TearDown

--- a/rspace/src/main/scala/coop/rchain/rspace/FreudianSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/FreudianSpace.scala
@@ -17,14 +17,15 @@ import scala.concurrent.SyncVar
   *
   * @tparam C a type representing a channel
   * @tparam P a type representing a pattern
+  * @tparam E a type representing an illegal state in matching algorithm
   * @tparam A a type representing an arbitrary piece of data
   * @tparam R a type representing a match result
   * @tparam K a type representing a continuation
   */
-trait FreudianSpace[C, P, A, R, K] extends ISpace[Id, C, P, A, R, K] {
+trait FreudianSpace[C, P, E, A, R, K] extends ISpace[Id, C, P, E, A, R, K] {
 
   /**
-    * A store which statisfies the [[IStore]] interface.
+    * A store which satisfies the [[IStore]] interface.
     */
   val store: IStore[C, P, A, K]
 
@@ -38,7 +39,8 @@ trait FreudianSpace[C, P, A, R, K] extends ISpace[Id, C, P, A, R, K] {
   /** Searches through data, looking for a match with a given pattern.
     *
     * If there is a match, we return the matching [[DataCandidate]],
-    * along with the remaining unmatched data.
+    * along with the remaining unmatched data. If an illegal state is reached
+    * during searching for a match we short circuit and return the state.
     */
   @tailrec
   private[rspace] final def findMatchingDataCandidate(
@@ -46,19 +48,22 @@ trait FreudianSpace[C, P, A, R, K] extends ISpace[Id, C, P, A, R, K] {
       data: Seq[(Datum[A], Int)],
       pattern: P,
       prefix: Seq[(Datum[A], Int)]
-  )(implicit m: Match[P, A, R]): Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])] =
+  )(implicit m: Match[P, E, A, R]): Either[E, Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])]] =
     data match {
-      case Nil => None
+      case Nil => Right(None)
       case (indexedDatum @ (Datum(matchCandidate, persist, produceRef), dataIndex)) :: remaining =>
         m.get(pattern, matchCandidate) match {
-          case None =>
+          case Left(ex) =>
+            Left(ex)
+          case Right(None) =>
             findMatchingDataCandidate(channel, remaining, pattern, indexedDatum +: prefix)
-          case Some(mat) if persist =>
-            Some((DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex), data))
-          case Some(mat) =>
-            Some(
-              (DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex),
-               prefix ++ remaining))
+          case Right(Some(mat)) if persist =>
+            Right(Some((DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex), data)))
+          case Right(Some(mat)) =>
+            Right(
+              Some(
+                (DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex),
+                 prefix ++ remaining)))
         }
     }
 
@@ -77,31 +82,36 @@ trait FreudianSpace[C, P, A, R, K] extends ISpace[Id, C, P, A, R, K] {
     * Potential match candidates are supplied by the `channelToIndexedData` cache.
     *
     * After a match is found, we remove the matching datum from the candidate cache for
-    * remaining matches.
+    * remaining matches. If an illegal state is reached when searching a matching candidate
+    * we treat it as if no match was found and append the illegal state to result list.
     */
   @tailrec
   private[rspace] final def extractDataCandidates(
       channelPatternPairs: Seq[(C, P)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
-      acc: Seq[Option[DataCandidate[C, R]]])(
-      implicit m: Match[P, A, R]): Seq[Option[DataCandidate[C, R]]] =
+      acc: Seq[Either[E, Option[DataCandidate[C, R]]]])(
+      implicit m: Match[P, E, A, R]): Seq[Either[E, Option[DataCandidate[C, R]]]] =
     channelPatternPairs match {
       case Nil =>
         acc.reverse
       case (channel, pattern) :: tail =>
-        val maybeTuple: Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])] =
-          for {
-            indexedData <- channelToIndexedData.get(channel)
-            result      <- findMatchingDataCandidate(channel, indexedData, pattern, Nil)
-          } yield result
+        val maybeTuple: Either[E, Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])]] =
+          channelToIndexedData.get(channel) match {
+            case Some(indexedData) =>
+              findMatchingDataCandidate(channel, indexedData, pattern, Nil)
+            case None =>
+              Right(None)
+          }
 
         maybeTuple match {
-          case Some((cand, rem)) =>
+          case Left(e) =>
+            extractDataCandidates(tail, channelToIndexedData, Left(e) +: acc)
+          case Right(Some((cand, rem))) =>
             extractDataCandidates(tail,
                                   channelToIndexedData.updated(channel, rem),
-                                  Some(cand) +: acc)
-          case None =>
-            extractDataCandidates(tail, channelToIndexedData, None +: acc)
+                                  Right(Some(cand)) +: acc)
+          case Right(None) =>
+            extractDataCandidates(tail, channelToIndexedData, Right(None) +: acc)
         }
     }
 
@@ -112,18 +122,20 @@ trait FreudianSpace[C, P, A, R, K] extends ISpace[Id, C, P, A, R, K] {
       channels: Seq[C],
       matchCandidates: Seq[(WaitingContinuation[P, K], Int)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]])(
-      implicit m: Match[P, A, R]): Option[ProduceCandidate[C, P, R, K]] =
+      implicit m: Match[P, E, A, R]): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
     matchCandidates match {
       case Nil =>
-        None
+        Right(None)
       case (p @ WaitingContinuation(patterns, _, _, _), index) :: remaining =>
-        val maybeDataCandidates: Option[Seq[DataCandidate[C, R]]] =
+        val maybeDataCandidates: Either[E, Option[Seq[DataCandidate[C, R]]]] =
           extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+            .map(_.sequence)
         maybeDataCandidates match {
-          case None =>
+          case Left(e) => Left(e)
+          case Right(None) =>
             extractFirstMatch(channels, remaining, channelToIndexedData)
-          case Some(dataCandidates) =>
-            Some(ProduceCandidate(channels, p, index, dataCandidates))
+          case Right(Some(dataCandidates)) =>
+            Right(Some(ProduceCandidate(channels, p, index, dataCandidates)))
         }
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/FreudianSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/FreudianSpace.scala
@@ -105,7 +105,7 @@ trait FreudianSpace[C, P, E, A, R, K] extends ISpace[Id, C, P, E, A, R, K] {
 
         maybeTuple match {
           case Left(e) =>
-            extractDataCandidates(tail, channelToIndexedData, Left(e) +: acc)
+            (Left(e) +: acc).reverse
           case Right(Some((cand, rem))) =>
             extractDataCandidates(tail,
                                   channelToIndexedData.updated(channel, rem),

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -8,11 +8,12 @@ import scala.collection.immutable.Seq
   *
   * @tparam C a type representing a channel
   * @tparam P a type representing a pattern
+  * @tparam E a type representing an illegal state in matching algorithm
   * @tparam A a type representing an arbitrary piece of data
   * @tparam R a type representing a match result
   * @tparam K a type representing a continuation
   */
-trait ISpace[F[_], C, P, A, R, K] {
+trait ISpace[F[_], C, P, E, A, R, K] {
 
   /** Searches the store for data matching all the given patterns at the given channels.
     *
@@ -38,10 +39,10 @@ trait ISpace[F[_], C, P, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, A, R]): F[Option[(K, Seq[R])]]
+      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, A, R]): F[Option[(K, Seq[R])]]
+      implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
     * given channel.
@@ -67,7 +68,7 @@ trait ISpace[F[_], C, P, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, A, R]): F[Option[(K, Seq[R])]]
+      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
 
   /** Creates a checkpoint.
     *

--- a/rspace/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Match.scala
@@ -4,10 +4,11 @@ package coop.rchain.rspace
   * Type class for matching patterns with data.
   *
   * @tparam P A type representing patterns
+  * @tparam E A type representing illegal state
   * @tparam A A type representing data
   * @tparam R A type representing a match result
   */
-trait Match[P, A, R] {
+trait Match[P, E, A, R] {
 
-  def get(p: P, a: A): Option[R]
+  def get(p: P, a: A): Either[E, Option[R]]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -14,14 +14,13 @@ import scala.collection.immutable.Seq
 import scala.util.Random
 import kamon._
 
-class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
+class RSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
     serializeA: Serialize[A],
     serializeK: Serialize[K]
-) extends RSpaceOps[C, P, A, R, K](store, branch)
-    with FreudianSpace[C, P, A, R, K] {
+) extends RSpaceOps[C, P, E, A, R, K](store, branch) {
 
   override protected[this] val logger: Logger = Logger[this.type]
 
@@ -32,8 +31,8 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
   private[this] val produceSpan   = Kamon.buildSpan("rspace.produce")
   protected[this] val installSpan = Kamon.buildSpan("rspace.install")
 
-  def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, A, R]): Option[(K, Seq[R])] =
+  override def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
+      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
       if (channels.isEmpty) {
         val msg = "channels can't be empty"
@@ -66,11 +65,14 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
           c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
         }.toMap
 
-        val options: Option[Seq[DataCandidate[C, R]]] =
+        val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
           extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+            .map(_.sequence)
 
         options match {
-          case None =>
+          case Left(e) =>
+            Left(e)
+          case Right(None) =>
             store.putWaitingContinuation(
               txn,
               channels,
@@ -79,8 +81,8 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
             logger.debug(s"""|consume: no data found,
                              |storing <(patterns, continuation): ($patterns, $continuation)>
                              |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-            None
-          case Some(dataCandidates) =>
+            Right(None)
+          case Right(Some(dataCandidates)) =>
             consumeCommCounter.increment()
 
             eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
@@ -95,13 +97,13 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
                   ()
               }
             logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
-            Some((continuation, dataCandidates.map(_.datum.a)))
+            Right(Some((continuation, dataCandidates.map(_.datum.a))))
         }
       }
     }
 
-  def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, A, R]): Option[(K, Seq[R])] =
+  override def produce(channel: C, data: A, persist: Boolean)(
+      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(produceSpan.start(), finishSpan = true) {
       store.withTxn(store.createTxnWrite()) { txn =>
         val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
@@ -117,11 +119,12 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
          * Could also be implemented with a lazy `foldRight`.
          */
         @tailrec
-        def extractProduceCandidate(groupedChannels: Seq[Seq[C]],
-                                    batChannel: C,
-                                    data: Datum[A]): Option[ProduceCandidate[C, P, R, K]] =
+        def extractProduceCandidate(
+            groupedChannels: Seq[Seq[C]],
+            batChannel: C,
+            data: Datum[A]): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
           groupedChannels match {
-            case Nil => None
+            case Nil => Right(None)
             case channels :: remaining =>
               val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
                 Random.shuffle(store.getWaitingContinuation(txn, channels).zipWithIndex)
@@ -142,17 +145,20 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
                 }
               }.toMap
               extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
-                case None             => extractProduceCandidate(remaining, batChannel, data)
-                case produceCandidate => produceCandidate
+                case Left(e)                 => Left(e)
+                case Right(None)             => extractProduceCandidate(remaining, batChannel, data)
+                case Right(produceCandidate) => Right(produceCandidate)
               }
           }
 
         extractProduceCandidate(groupedChannels, channel, Datum(data, persist, produceRef)) match {
-          case Some(
-              ProduceCandidate(channels,
-                               WaitingContinuation(_, continuation, persistK, consumeRef),
-                               continuationIndex,
-                               dataCandidates)) =>
+          case Left(e) => Left(e)
+          case Right(
+              Some(
+                ProduceCandidate(channels,
+                                 WaitingContinuation(_, continuation, persistK, consumeRef),
+                                 continuationIndex,
+                                 dataCandidates))) =>
             produceCommCounter.increment()
 
             eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
@@ -170,12 +176,12 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
                   store.removeJoin(txn, candidateChannel, channels)
               }
             logger.debug(s"produce: matching continuation found at <channels: $channels>")
-            Some(continuation, dataCandidates.map(_.datum.a))
-          case None =>
+            Right(Some(continuation, dataCandidates.map(_.datum.a)))
+          case Right(None) =>
             logger.debug(s"produce: no matching continuation found")
             store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
             logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
-            None
+            Right(None)
         }
       }
     }
@@ -190,15 +196,15 @@ class RSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
 object RSpace {
 
-  def create[C, P, A, R, K](context: Context[C, P, A, K], branch: Branch)(
+  def create[C, P, E, A, R, K](context: Context[C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): RSpace[C, P, A, R, K] =
+      sk: Serialize[K]): RSpace[C, P, E, A, R, K] =
     create(context.createStore(branch), branch)
 
-  def createInMemory[C, P, A, R, K](
+  def createInMemory[C, P, E, A, R, K](
       trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]],
                             Blake2b256Hash,
                             GNAT[C, P, A, K]],
@@ -206,7 +212,7 @@ object RSpace {
                       sc: Serialize[C],
                       sp: Serialize[P],
                       sa: Serialize[A],
-                      sk: Serialize[K]): RSpace[C, P, A, R, K] = {
+                      sk: Serialize[K]): RSpace[C, P, E, A, R, K] = {
 
     val mainStore = InMemoryStore
       .create[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
@@ -215,19 +221,19 @@ object RSpace {
     create(mainStore, branch)
   }
 
-  def create[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
+  def create[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): RSpace[C, P, A, R, K] = {
+      sk: Serialize[K]): RSpace[C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
     implicit val codecA: Codec[A] = sa.toCodec
     implicit val codecK: Codec[K] = sk.toCodec
 
-    val space = new RSpace[C, P, A, R, K](store, branch)
+    val space = new RSpace[C, P, E, A, R, K](store, branch)
 
     /*
      * history.initialize returns true if the history trie contains no root (i.e. is empty).

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -16,18 +16,18 @@ import scala.util.Random
 import kamon._
 import kamon.trace.Tracer.SpanBuilder
 
-abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branch: Branch)(
+abstract class RSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A, K], val branch: Branch)(
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
     serializeK: Serialize[K]
-) extends FreudianSpace[C, P, A, R, K] {
+) extends FreudianSpace[C, P, E, A, R, K] {
 
   protected[this] val logger: Logger
   protected[this] val installSpan: SpanBuilder
 
-  private[this] val installs: SyncVar[Installs[C, P, A, R, K]] = {
-    val installs = new SyncVar[Installs[C, P, A, R, K]]()
+  private[this] val installs: SyncVar[Installs[C, P, E, A, R, K]] = {
+    val installs = new SyncVar[Installs[C, P, E, A, R, K]]()
     installs.put(Map.empty)
     installs
   }
@@ -41,7 +41,7 @@ abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branc
   private[this] def install(txn: store.Transaction,
                             channels: Seq[C],
                             patterns: Seq[P],
-                            continuation: K)(implicit m: Match[P, A, R]): Option[(K, Seq[R])] = {
+                            continuation: K)(implicit m: Match[P, E, A, R]): Option[(K, Seq[R])] = {
     if (channels.length =!= patterns.length) {
       val msg = "channels.length must equal patterns.length"
       logger.error(msg)
@@ -65,11 +65,14 @@ abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branc
       c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
     }.toMap
 
-    val options: Option[Seq[DataCandidate[C, R]]] =
+    val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
       extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+        .map(_.sequence)
 
     options match {
-      case None =>
+      case Left(e) =>
+        throw new RuntimeException(s"Installing should always be valid: $e")
+      case Right(None) =>
         installs.update(_.updated(channels, Install(patterns, continuation, m)))
         store.installWaitingContinuation(
           txn,
@@ -79,14 +82,14 @@ abstract class RSpaceOps[C, P, A, R, K](val store: IStore[C, P, A, K], val branc
         logger.debug(s"""|storing <(patterns, continuation): ($patterns, $continuation)>
                          |at <channels: $channels>""".stripMargin.replace('\n', ' '))
         None
-      case Some(_) =>
+      case Right(Some(_)) =>
         throw new RuntimeException("Installing can be done only on startup")
     }
 
   }
 
   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, A, R]): Option[(K, Seq[R])] =
+      implicit m: Match[P, E, A, R]): Option[(K, Seq[R])] =
     Kamon.withSpan(installSpan.start(), finishSpan = true) {
       store.withTxn(store.createTxnWrite()) { txn =>
         install(txn, channels, patterns, continuation)

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -71,7 +71,7 @@ abstract class RSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A, K], val br
 
     options match {
       case Left(e) =>
-        throw new RuntimeException(s"Installing should always be valid: $e")
+        throw new RuntimeException(s"Install never result in an invalid match: $e")
       case Right(None) =>
         installs.update(_.updated(channels, Install(patterns, continuation, m)))
         store.installWaitingContinuation(

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -24,8 +24,7 @@ class ReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
     serializeP: Serialize[P],
     serializeA: Serialize[A],
     serializeK: Serialize[K]
-) extends RSpaceOps[C, P, E, A, R, K](store, branch)
-    with FreudianSpace[C, P, E, A, R, K] {
+) extends RSpaceOps[C, P, E, A, R, K](store, branch) {
 
   override protected[this] val logger: Logger = Logger[this.type]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -18,14 +18,14 @@ import scala.concurrent.SyncVar
 import scala.util.Random
 import kamon._
 
-class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
+class ReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
     serializeA: Serialize[A],
     serializeK: Serialize[K]
-) extends RSpaceOps[C, P, A, R, K](store, branch)
-    with FreudianSpace[C, P, A, R, K] {
+) extends RSpaceOps[C, P, E, A, R, K](store, branch)
+    with FreudianSpace[C, P, E, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]
 
@@ -43,7 +43,7 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
   protected[this] val installSpan = Kamon.buildSpan("replayrspace.install")
 
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, A, R]): Option[(K, Seq[R])] =
+      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
       if (channels.length =!= patterns.length) {
         val msg = "channels.length must equal patterns.length"
@@ -59,7 +59,9 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
               }
             }
           }.toMap
-          extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+          extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil)
+            .flatMap(_.toOption)
+            .sequence
         }
 
         def storeWaitingContinuation(replays: ReplayData,
@@ -124,23 +126,23 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
         replays.get(consumeRef) match {
           case None =>
-            storeWaitingContinuation(replays, consumeRef, None)
+            Right(storeWaitingContinuation(replays, consumeRef, None))
           case Some(comms) =>
             val commOrDataCandidates: Either[COMM, Seq[DataCandidate[C, R]]] =
               getCommOrDataCandidates(comms.iterator().asScala.toList)
 
             commOrDataCandidates match {
               case Left(commRef) =>
-                storeWaitingContinuation(replays, consumeRef, Some(commRef))
+                Right(storeWaitingContinuation(replays, consumeRef, Some(commRef)))
               case Right(dataCandidates) =>
-                handleMatches(dataCandidates, replays, consumeRef, comms)
+                Right(handleMatches(dataCandidates, replays, consumeRef, comms))
             }
         }
       }
     }
 
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, A, R]): Option[(K, Seq[R])] =
+      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(produceSpan.start(), finishSpan = true) {
       store.withTxn(store.createTxnWrite()) { txn =>
         @tailrec
@@ -162,8 +164,8 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
                 c -> { if (c == channel) Seq((Datum(data, persist, produceRef), -1)) else as }
               }.toMap
               extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
-                case None             => runMatcher(comm, produceRef, remaining)
-                case produceCandidate => produceCandidate
+                case Right(None)             => runMatcher(comm, produceRef, remaining)
+                case Right(produceCandidate) => produceCandidate
               }
           }
 
@@ -236,15 +238,15 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
         replays.get(produceRef) match {
           case None =>
-            storeDatum(replays, produceRef, None)
+            Right(storeDatum(replays, produceRef, None))
           case Some(comms) =>
             val commOrProduceCandidate: Either[COMM, ProduceCandidate[C, P, R, K]] =
               getCommOrProduceCandidate(comms.iterator().asScala.toList)
             commOrProduceCandidate match {
               case Left(comm) =>
-                storeDatum(replays, produceRef, Some(comm))
+                Right(storeDatum(replays, produceRef, Some(comm)))
               case Right(produceCandidate) =>
-                handleMatch(produceCandidate, replays, produceRef, comms)
+                Right(handleMatch(produceCandidate, replays, produceRef, comms))
             }
         }
       }
@@ -303,12 +305,12 @@ class ReplayRSpace[C, P, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
 
 object ReplayRSpace {
 
-  def create[C, P, A, R, K](context: Context[C, P, A, K], branch: Branch)(
+  def create[C, P, E, A, R, K](context: Context[C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): ReplayRSpace[C, P, A, R, K] = {
+      sk: Serialize[K]): ReplayRSpace[C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -326,7 +328,7 @@ object ReplayRSpace {
         InMemoryStore.create(mixedContext.trieStore, branch)
     }
 
-    val replaySpace = new ReplayRSpace[C, P, A, R, K](mainStore, branch)
+    val replaySpace = new ReplayRSpace[C, P, E, A, R, K](mainStore, branch)
 
     /*
      * history.initialize returns true if the history trie contains no root (i.e. is empty).
@@ -341,7 +343,7 @@ object ReplayRSpace {
     replaySpace
   }
 
-  def createInMemory[C, P, A, R, K](
+  def createInMemory[C, P, E, A, R, K](
       trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]],
                             Blake2b256Hash,
                             GNAT[C, P, A, K]],
@@ -349,7 +351,7 @@ object ReplayRSpace {
                       sc: Serialize[C],
                       sp: Serialize[P],
                       sa: Serialize[A],
-                      sk: Serialize[K]): ReplayRSpace[C, P, A, R, K] = {
+                      sk: Serialize[K]): ReplayRSpace[C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -360,7 +362,7 @@ object ReplayRSpace {
       .create[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
         trieStore,
         branch)
-    val replaySpace = new ReplayRSpace[C, P, A, R, K](mainStore, branch)
+    val replaySpace = new ReplayRSpace[C, P, E, A, R, K](mainStore, branch)
 
     /*
      * history.initialize returns true if the history trie contains no root (i.e. is empty).

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -49,8 +49,9 @@ object StringExamples {
 
   object implicits {
 
-    implicit object stringMatch extends Match[Pattern, String, String] {
-      def get(p: Pattern, a: String): Option[String] = Some(a).filter(p.isMatch)
+    implicit object stringMatch extends Match[Pattern, Nothing, String, String] {
+      def get(p: Pattern, a: String): Either[Nothing, Option[String]] =
+        Right(Some(a).filter(p.isMatch))
     }
 
     implicit object stringSerialize extends Serialize[String] {

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -120,9 +120,9 @@ object internal {
       }
   }
 
-  case class Install[P, A, R, K](patterns: Seq[P], continuation: K, _match: Match[P, A, R])
+  case class Install[P, E, A, R, K](patterns: Seq[P], continuation: K, _match: Match[P, E, A, R])
 
-  type Installs[C, P, A, R, K] = Map[Seq[C], Install[P, A, R, K]]
+  type Installs[C, P, E, A, R, K] = Map[Seq[C], Install[P, E, A, R, K]]
 
   import scodec.{Attempt, Err}
 

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -5,20 +5,21 @@ import coop.rchain.rspace._
 
 import scala.collection.immutable.Seq
 
-class PureRSpace[F[_], C, P, A, R, K](space: FreudianSpace[C, P, A, R, K]) {
+class PureRSpace[F[_], C, P, E, A, R, K](space: FreudianSpace[C, P, E, A, R, K]) {
 
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, A, R],
-      s: Sync[F]): F[Option[(K, Seq[R])]] =
+      implicit m: Match[P, E, A, R],
+      s: Sync[F]): F[Either[E, Option[(K, Seq[R])]]] =
     s.delay(space.consume(channels, patterns, continuation, persist))
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, A, R],
+      implicit m: Match[P, E, A, R],
       s: Sync[F]): F[Option[(K, Seq[R])]] =
     s.delay(space.install(channels, patterns, continuation))
 
-  def produce(channel: C, data: A, persist: Boolean)(implicit m: Match[P, A, R],
-                                                     s: Sync[F]): F[Option[(K, Seq[R])]] =
+  def produce(channel: C, data: A, persist: Boolean)(
+      implicit m: Match[P, E, A, R],
+      s: Sync[F]): F[Either[E, Option[(K, Seq[R])]]] =
     s.delay(space.produce(channel, data, persist))
 
   def createCheckpoint()(s: Sync[F]): F[Checkpoint] = s.delay(space.createCheckpoint())

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace
 
+import cats.Id
 import coop.rchain.rspace.internal.GNAT
 import scodec.bits.ByteVector
 
@@ -13,10 +14,16 @@ package object util {
   def getK[A, K](t: Option[(K, A)]): K =
     t.map(_._1).get
 
+  def getK[A, K](e: Either[_, Option[(K, A)]]): K =
+    getK(e.right.get)
+
   /** Runs a continuation with the accompanying data
     */
-  def runK[T](t: Option[((T) => Unit, T)]): Unit =
-    t.foreach { case (k, data) => k(data) }
+//  def runK[T](t: Option[((T) => Unit, T)]): Unit =
+//    t.foreach { case (k, data) => k(data) }
+
+  def runK[T](e: Id[Either[Nothing, Option[((T) => Unit, T)]]]): Unit =
+    e.right.get.foreach { case (k, data) => k(data) }
 
   /** Runs a list of continuations with the accompanying data
     */

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -15,13 +15,10 @@ package object util {
     t.map(_._1).get
 
   def getK[A, K](e: Either[_, Option[(K, A)]]): K =
-    getK(e.right.get)
+    e.map(_.map(_._1).get).right.get
 
   /** Runs a continuation with the accompanying data
     */
-//  def runK[T](t: Option[((T) => Unit, T)]): Unit =
-//    t.foreach { case (k, data) => k(data) }
-
   def runK[T](e: Id[Either[Nothing, Option[((T) => Unit, T)]]]): Unit =
     e.right.get.foreach { case (k, data) => k(data) }
 

--- a/rspace/src/main/tut/Tutorial.md
+++ b/rspace/src/main/tut/Tutorial.md
@@ -190,24 +190,25 @@ Here is the definition of the `Match` type class.
   * Type class for matching patterns with data.
   *
   * @tparam P A type representing patterns
+  * @tparam E A type representing illegal state
   * @tparam A A type representing data
   * @tparam R A type representing a match result
   */
-trait Match[P, A, R] {
+trait Match[P, E, A, R] {
 
-  def get(p: P, a: A): Option[R]
+  def get(p: P, a: A): Either[E, Option[R]]
 }
 ```
 
 Let's try defining an instance of `Match` for `Pattern` and `Entry`.
 ```tut
-implicit object matchPatternEntry extends Match[Pattern, Entry, Entry] {
-  def get(p: Pattern, a: Entry): Option[Entry] =
+implicit object matchPatternEntry extends Match[Pattern, Nothing, Entry, Entry] {
+  def get(p: Pattern, a: Entry): Either[Nothing, Option[Entry]] =
     p match {
-      case NameMatch(last) if a.name.last == last        => Some(a)
-      case CityMatch(city) if a.address.city == city     => Some(a)
-      case StateMatch(state) if a.address.state == state => Some(a)
-      case _                                             => None
+      case NameMatch(last) if a.name.last == last        => Right(Some(a))
+      case CityMatch(city) if a.address.city == city     => Right(Some(a))
+      case StateMatch(state) if a.address.state == state => Right(Some(a))
+      case _                                             => Right(None)
     }
 }
 
@@ -233,7 +234,7 @@ val context: Context[Channel, Pattern, Entry, Printer] = Context.create[Channel,
 ```
 Now we can create an RSpace using the created context
 ```tut
-val space = RSpace.create[Channel, Pattern, Entry, Entry, Printer](context, coop.rchain.rspace.history.Branch.MASTER)
+val space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, Printer](context, coop.rchain.rspace.history.Branch.MASTER)
 ```
 
 ### Producing and Consuming
@@ -427,13 +428,13 @@ Let's see how this works in practice. We'll start by creating a new, untouched R
 ```tut
 val rollbackExampleStorePath: Path = Files.createTempDirectory("rspace-address-book-example-")
 val rollbackExampleContext: Context[Channel, Pattern, Entry, Printer] = Context.create[Channel, Pattern, Entry, Printer](rollbackExampleStorePath,  1024L * 1024L * 100L)
-val rollbackExampleSpace = RSpace.create[Channel, Pattern, Entry, Entry, Printer](rollbackExampleContext, coop.rchain.rspace.history.Branch.MASTER)
+val rollbackExampleSpace = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, Printer](rollbackExampleContext, coop.rchain.rspace.history.Branch.MASTER)
 val cres =
   rollbackExampleSpace.consume(List(Channel("friends")),
                 List(CityMatch(city = "Crystal Lake")),
                 new Printer,
                 persist = false)
-cres.isEmpty
+cres.right.get.isEmpty
 ```
 
 We can now create a checkpoint and store it's root.
@@ -443,28 +444,28 @@ val checkpointHash = rollbackExampleSpace.createCheckpoint.root
 
 The first `produceAlice` operation should be able to find data stored by the consume.
 ```tut
-def produceAlice(): Option[(Printer, Seq[Entry])] = rollbackExampleSpace.produce(Channel("friends"), alice, persist = false)
-produceAlice.isDefined
+def produceAlice(): Either[Nothing, Option[(Printer, Seq[Entry])]] = rollbackExampleSpace.produce(Channel("friends"), alice, persist = false)
+produceAlice.toOption.flatten.isDefined
 ```
 
 Running the same operation again shouldn't return anything, as data hasn't been persisted.
 ```tut
-produceAlice.isEmpty
+produceAlice.right.get.isEmpty
 ```
 Every following repetition of the operation above should yield an empty result.
 ```tut
-produceAlice.isEmpty
+produceAlice.right.get.isEmpty
 ```
 
 After re-setting the RSpace to the state from the saved checkpoint the first produce operation should again return an non-empty result.
 ```tut
 rollbackExampleSpace.reset(checkpointHash)
-produceAlice.isDefined
+produceAlice.toOption.flatten.isDefined
 ```
 And again, every following operation should yield an empty result
 Every following repetition of the operation above should yield an empty result.
 ```tut
-produceAlice.isEmpty
+produceAlice.right.get.isEmpty
 ```
 
 ### Finishing Up

--- a/rspace/src/test/scala/coop/rchain/rspace/CastTestHelpers.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/CastTestHelpers.scala
@@ -1,0 +1,13 @@
+package coop.rchain.rspace
+import cats.Id
+import org.scalatest.enablers.Definition
+
+trait CastTestHelpers {
+  // Some helpers for usage only in the tests -- save us A LOT of explicit casting from Either to Option
+  // it is safe because left type of `Either` is `Nothing` -- we don't expect any invalid states from the matcher
+  implicit def eitherDefinitionScalatest[E, A]: Definition[Id[Either[E, Option[A]]]] =
+    new Definition[Id[Either[E, Option[A]]]] {
+      override def isDefined(thing: Id[Either[E, Option[A]]]): Boolean =
+        thing.right.get.isDefined
+    }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.Duration
 
 trait ConcurrencyTests
     extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor]
-    with CastTestHelpers {
+    with TestImplicitHelpers {
 
   def version: String
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -10,7 +10,9 @@ import scala.concurrent.Await
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 
-trait ConcurrencyTests extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor] {
+trait ConcurrencyTests
+    extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CastTestHelpers {
 
   def version: String
 
@@ -32,11 +34,11 @@ trait ConcurrencyTests extends StorageTestsBase[Channel, Pattern, Entry, Entries
             persist = false
           )
 
-          r1 shouldBe None
+          r1 shouldBe Right(None)
 
           val r2 = space.produce(channel, bob, persist = false)
 
-          r2 shouldBe None
+          r2 shouldBe Right(None)
 
           val r3 = space.produce(channel, bob, persist = false)
 
@@ -104,18 +106,19 @@ trait ConcurrencyTests extends StorageTestsBase[Channel, Pattern, Entry, Entries
         for (_ <- 1 to iterations) {
           val r1 = space.produce(channel, bob, persist = false)
 
-          r1 shouldBe None
+          r1 shouldBe Right(None)
 
           val r2 = space.produce(channel, bob, persist = false)
 
-          r2 shouldBe None
+          r2 shouldBe Right(None)
 
-          val r3 = space.consume(
-            List(channel, channel),
-            List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
-            new EntriesCaptor,
-            persist = false
-          )
+          val r3 = space
+            .consume(
+              List(channel, channel),
+              List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+              new EntriesCaptor,
+              persist = false
+            )
 
           r3 shouldBe defined
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -19,7 +19,8 @@ import scala.collection.immutable.Seq
 
 //noinspection ZeroIndexToHead
 trait HistoryActionsTests
-    extends StorageTestsBase[String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
+    with CastTestHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
 
@@ -53,8 +54,9 @@ trait HistoryActionsTests
       joins: Map[Blake2b256Hash, Seq[Seq[String]]]
   )
 
-  def validateIndexedStates(space: FreudianSpace[String, Pattern, String, String, StringsCaptor],
-                            indexedStates: Seq[(State, Int)]): Boolean = {
+  def validateIndexedStates(
+      space: FreudianSpace[String, Pattern, Nothing, String, String, StringsCaptor],
+      indexedStates: Seq[(State, Int)]): Boolean = {
     val tests: Seq[Any] = indexedStates
       .map {
         case (State(checkpoint, expectedContents, expectedJoins), chunkNo) =>
@@ -258,11 +260,11 @@ trait HistoryActionsTests
 
       val r1 = space.consume(channels, List(Wildcard), new StringsCaptor, persist = false)
 
-      r1 shouldBe None
+      r1 shouldBe Right(None)
 
       val r2 = space.produce(channels.head, "datum", persist = false)
 
-      r2 shouldBe defined
+      r2.right.get shouldBe defined
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.Seq
 //noinspection ZeroIndexToHead
 trait HistoryActionsTests
     extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
-    with CastTestHelpers
+    with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
 
@@ -264,7 +264,7 @@ trait HistoryActionsTests
 
       val r2 = space.produce(channels.head, "datum", persist = false)
 
-      r2.right.get shouldBe defined
+      r2 shouldBe defined
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -10,7 +10,7 @@ import org.scalatest.AppendedClues
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 trait IStoreTests
-    extends StorageTestsBase[String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
     with GeneratorDrivenPropertyChecks
     with AppendedClues {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
@@ -4,7 +4,8 @@ import coop.rchain.rspace.examples.StringExamples.{Pattern, StringsCaptor, Wildc
 import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.internal._
 
-trait JoinOperationsTests extends StorageTestsBase[String, Pattern, String, StringsCaptor] {
+trait JoinOperationsTests
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor] {
 
   "joins" should "remove joins if no PsK" in withTestSpace { space =>
     val store = space.store

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -19,7 +19,7 @@ import scala.util.Random
 //noinspection ZeroIndexToHead,NameBooleanParameters
 trait ReplayRSpaceTests
     extends ReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
-    with CastTestHelpers {
+    with TestImplicitHelpers {
 
   def consumeMany[C, P, A, R, K](
       space: FreudianSpace[C, P, Nothing, A, R, K],
@@ -73,7 +73,7 @@ trait ReplayRSpaceTests
       val rigPont       = space.createCheckpoint()
 
       resultConsume shouldBe Right(None)
-      resultProduce.right.get shouldBe defined
+      resultProduce shouldBe defined
 
       replaySpace.rig(emptyPoint.root, rigPont.log)
 
@@ -685,12 +685,12 @@ trait ReplayRSpaceTests
       space.install(key, patterns, continuation)
       replaySpace.install(key, patterns, continuation)
 
-      space.produce(channel, datum, persist = false).right.get shouldBe defined
+      space.produce(channel, datum, persist = false) shouldBe defined
       val afterProduce = space.createCheckpoint()
 
       replaySpace.rig(afterProduce.root, afterProduce.log)
 
-      replaySpace.produce(channel, datum, persist = false).right.get shouldBe defined
+      replaySpace.produce(channel, datum, persist = false) shouldBe defined
   }
 
   "reset" should

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -17,29 +17,31 @@ import scala.collection.{immutable, mutable}
 import scala.util.Random
 
 //noinspection ZeroIndexToHead,NameBooleanParameters
-trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, String] {
+trait ReplayRSpaceTests
+    extends ReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
+    with CastTestHelpers {
 
   def consumeMany[C, P, A, R, K](
-      space: FreudianSpace[C, P, A, R, K],
+      space: FreudianSpace[C, P, Nothing, A, R, K],
       range: Range,
       shuffle: Boolean,
       channelsCreator: Int => List[C],
       patterns: List[P],
       continuationCreator: Int => K,
-      persist: Boolean)(implicit matcher: Match[P, A, R]): List[Option[(K, Seq[R])]] =
+      persist: Boolean)(implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
-      space.consume(channelsCreator(i), patterns, continuationCreator(i), persist)
+      space.consume(channelsCreator(i), patterns, continuationCreator(i), persist).right.get
     }
 
-  def produceMany[C, P, A, R, K](
-      space: FreudianSpace[C, P, A, R, K],
-      range: Range,
-      shuffle: Boolean,
-      channelCreator: Int => C,
-      datumCreator: Int => A,
-      persist: Boolean)(implicit matcher: Match[P, A, R]): List[Option[(K, immutable.Seq[R])]] =
+  def produceMany[C, P, A, R, K](space: FreudianSpace[C, P, Nothing, A, R, K],
+                                 range: Range,
+                                 shuffle: Boolean,
+                                 channelCreator: Int => C,
+                                 datumCreator: Int => A,
+                                 persist: Boolean)(
+      implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, immutable.Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
-      space.produce(channelCreator(i), datumCreator(i), persist)
+      space.produce(channelCreator(i), datumCreator(i), persist).right.get
     }
 
   "reset to a checkpoint from a different branch" should "work" in withTestSpaces {
@@ -70,8 +72,8 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       val resultProduce = space.produce(channels(0), datum, false)
       val rigPont       = space.createCheckpoint()
 
-      resultConsume shouldBe None
-      resultProduce shouldBe defined
+      resultConsume shouldBe Right(None)
+      resultProduce.right.get shouldBe defined
 
       replaySpace.rig(emptyPoint.root, rigPont.log)
 
@@ -79,7 +81,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       val replayResultProduce = replaySpace.produce(channels(0), datum, false)
       val finalPoint          = space.createCheckpoint()
 
-      replayResultConsume shouldBe None
+      replayResultConsume shouldBe Right(None)
       replayResultProduce shouldBe resultProduce
       finalPoint.root shouldBe rigPont.root
       replaySpace.getReplayData shouldBe empty
@@ -683,12 +685,12 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       space.install(key, patterns, continuation)
       replaySpace.install(key, patterns, continuation)
 
-      space.produce(channel, datum, persist = false) shouldBe defined
+      space.produce(channel, datum, persist = false).right.get shouldBe defined
       val afterProduce = space.createCheckpoint()
 
       replaySpace.rig(afterProduce.root, afterProduce.log)
 
-      replaySpace.produce(channel, datum, persist = false) shouldBe defined
+      replaySpace.produce(channel, datum, persist = false).right.get shouldBe defined
   }
 
   "reset" should
@@ -702,13 +704,13 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
       val emptyPoint = space.createCheckpoint()
 
-      space.consume(channels, patterns, continuation, false) shouldBe None
+      space.consume(channels, patterns, continuation, false) shouldBe Right(None)
 
       val rigPoint = space.createCheckpoint()
 
       replaySpace.rig(emptyPoint.root, rigPoint.log)
 
-      replaySpace.consume(channels, patterns, continuation, false) shouldBe None
+      replaySpace.consume(channels, patterns, continuation, false) shouldBe Right(None)
 
       val replayStore = replaySpace.store
 
@@ -738,13 +740,13 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
       val emptyPoint = space.createCheckpoint()
 
-      space.consume(channels, patterns, continuation, false) shouldBe None
+      space.consume(channels, patterns, continuation, false) shouldBe Right(None)
 
       val rigPoint = space.createCheckpoint()
 
       replaySpace.rig(emptyPoint.root, rigPoint.log)
 
-      replaySpace.consume(channels, patterns, continuation, false) shouldBe None
+      replaySpace.consume(channels, patterns, continuation, false) shouldBe Right(None)
 
       val replayStore = replaySpace.store
 
@@ -787,7 +789,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
     }
 }
 
-trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionValues {
+trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
   val logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   override def withFixture(test: NoArgTest): Outcome = {
@@ -795,7 +797,7 @@ trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with Opti
     super.withFixture(test)
   }
 
-  def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
+  def withTestSpaces[S](f: (RSpace[C, P, E, A, A, K], ReplayRSpace[C, P, E, A, A, K]) => S)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
@@ -803,18 +805,18 @@ trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with Opti
       sk: Serialize[K]): S
 }
 
-trait LMDBReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
-  override def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
-      implicit
-      sc: Serialize[C],
-      sp: Serialize[P],
-      sa: Serialize[A],
-      sk: Serialize[K]): S = {
+trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+  override def withTestSpaces[S](
+      f: (RSpace[C, P, E, A, A, K], ReplayRSpace[C, P, E, A, A, K]) => S)(implicit
+                                                                          sc: Serialize[C],
+                                                                          sp: Serialize[P],
+                                                                          sa: Serialize[A],
+                                                                          sk: Serialize[K]): S = {
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.create[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
-    val space       = RSpace.create[C, P, A, A, K](context, Branch.MASTER)
-    val replaySpace = ReplayRSpace.create[C, P, A, A, K](context, Branch.REPLAY)
+    val space       = RSpace.create[C, P, E, A, A, K](context, Branch.MASTER)
+    val replaySpace = ReplayRSpace.create[C, P, E, A, A, K](context, Branch.REPLAY)
 
     try {
       f(space, replaySpace)
@@ -827,18 +829,18 @@ trait LMDBReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, 
   }
 }
 
-trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
-  override def withTestSpaces[S](f: (RSpace[C, P, A, A, K], ReplayRSpace[C, P, A, A, K]) => S)(
-      implicit
-      sc: Serialize[C],
-      sp: Serialize[P],
-      sa: Serialize[A],
-      sk: Serialize[K]): S = {
+trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+  override def withTestSpaces[S](
+      f: (RSpace[C, P, E, A, A, K], ReplayRSpace[C, P, E, A, A, K]) => S)(implicit
+                                                                          sc: Serialize[C],
+                                                                          sp: Serialize[P],
+                                                                          sa: Serialize[A],
+                                                                          sk: Serialize[K]): S = {
 
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
-    val space     = RSpace.createInMemory[C, P, A, A, K](trieStore, Branch.REPLAY)
+    val space     = RSpace.createInMemory[C, P, E, A, A, K](trieStore, Branch.REPLAY)
     val replaySpace =
-      ReplayRSpace.createInMemory[C, P, A, A, K](trieStore, Branch.REPLAY)
+      ReplayRSpace.createInMemory[C, P, E, A, A, K](trieStore, Branch.REPLAY)
 
     try {
       f(space, replaySpace)
@@ -850,9 +852,9 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
 }
 
 class LMDBReplayRSpaceTests
-    extends LMDBReplayRSpaceTestsBase[String, Pattern, String, String]
+    extends LMDBReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
     with ReplayRSpaceTests {}
 
 class InMemoryRSpaceTests
-    extends InMemoryReplayRSpaceTestsBase[String, Pattern, String, String]
+    extends InMemoryReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
     with ReplayRSpaceTests {}

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -22,7 +22,7 @@ import org.scalatest.enablers.Definition
 
 trait StorageActionsTests
     extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
-    with CastTestHelpers
+    with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -11,24 +11,27 @@ import coop.rchain.shared.PathOps._
 import org.scalatest.BeforeAndAfterAll
 import scodec.Codec
 
-trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor] {
+trait StorageExamplesTests
+    extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CastTestHelpers {
 
   "CORE-365: A joined consume on duplicate channels followed by two produces on that channel" should
     "return a continuation and the produced data" in withTestSpace { space =>
     val store = space.store
 
-    val r1 = space.consume(
-      List(Channel("friends"), Channel("friends")),
-      List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r1 = space
+      .consume(
+        List(Channel("friends"), Channel("friends")),
+        List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+        new EntriesCaptor,
+        persist = false
+      )
 
-    r1 shouldBe None
+    r1 shouldBe Right(None)
 
     val r2 = space.produce(Channel("friends"), bob, persist = false)
 
-    r2 shouldBe None
+    r2 shouldBe Right(None)
 
     val r3 = space.produce(Channel("friends"), bob, persist = false)
 
@@ -46,18 +49,19 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
 
     val r1 = space.produce(Channel("friends"), bob, persist = false)
 
-    r1 shouldBe None
+    r1 shouldBe Right(None)
 
     val r2 = space.produce(Channel("friends"), bob, persist = false)
 
-    r2 shouldBe None
+    r2 shouldBe Right(None)
 
-    val r3 = space.consume(
-      List(Channel("friends"), Channel("friends")),
-      List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r3 = space
+      .consume(
+        List(Channel("friends"), Channel("friends")),
+        List(CityMatch(city = "Crystal Lake"), CityMatch(city = "Crystal Lake")),
+        new EntriesCaptor,
+        persist = false
+      )
 
     r3 shouldBe defined
 
@@ -71,24 +75,25 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     "return a continuation and the produced data" in withTestSpace { space =>
     val store = space.store
 
-    val r1 = space.consume(
-      List(Channel("colleagues"), Channel("friends"), Channel("friends")),
-      List(CityMatch(city = "Crystal Lake"),
-           CityMatch(city = "Crystal Lake"),
-           CityMatch(city = "Crystal Lake")),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r1 = space
+      .consume(
+        List(Channel("colleagues"), Channel("friends"), Channel("friends")),
+        List(CityMatch(city = "Crystal Lake"),
+             CityMatch(city = "Crystal Lake"),
+             CityMatch(city = "Crystal Lake")),
+        new EntriesCaptor,
+        persist = false
+      )
 
-    r1 shouldBe None
+    r1 shouldBe Right(None)
 
     val r2 = space.produce(Channel("friends"), bob, persist = false)
 
-    r2 shouldBe None
+    r2 shouldBe Right(None)
 
     val r3 = space.produce(Channel("friends"), bob, persist = false)
 
-    r3 shouldBe None
+    r3 shouldBe Right(None)
 
     val r4 = space.produce(Channel("colleagues"), alice, persist = false)
 
@@ -104,34 +109,35 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     "return a continuation and the produced data" in withTestSpace { space =>
     val store = space.store
 
-    val r1 = space.consume(
-      List(
-        Channel("family"),
-        Channel("family"),
-        Channel("family"),
-        Channel("family"),
-        Channel("colleagues"),
-        Channel("colleagues"),
-        Channel("colleagues"),
-        Channel("friends"),
-        Channel("friends")
-      ),
-      List(
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake")
-      ),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r1 = space
+      .consume(
+        List(
+          Channel("family"),
+          Channel("family"),
+          Channel("family"),
+          Channel("family"),
+          Channel("colleagues"),
+          Channel("colleagues"),
+          Channel("colleagues"),
+          Channel("friends"),
+          Channel("friends")
+        ),
+        List(
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake")
+        ),
+        new EntriesCaptor,
+        persist = false
+      )
 
-    r1 shouldBe None
+    r1 shouldBe Right(None)
 
     val r2  = space.produce(Channel("friends"), bob, persist = false)
     val r3  = space.produce(Channel("family"), carol, persist = false)
@@ -143,14 +149,14 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     val r9  = space.produce(Channel("family"), carol, persist = false)
     val r10 = space.produce(Channel("family"), carol, persist = false)
 
-    r2 shouldBe None
-    r3 shouldBe None
-    r4 shouldBe None
-    r5 shouldBe None
-    r6 shouldBe None
-    r7 shouldBe None
-    r8 shouldBe None
-    r9 shouldBe None
+    r2 shouldBe Right(None)
+    r3 shouldBe Right(None)
+    r4 shouldBe Right(None)
+    r5 shouldBe Right(None)
+    r6 shouldBe Right(None)
+    r7 shouldBe Right(None)
+    r8 shouldBe Right(None)
+    r9 shouldBe Right(None)
     r10 shouldBe defined
 
     runK(r10)
@@ -173,42 +179,43 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     val r8 = space.produce(Channel("family"), carol, persist = false)
     val r9 = space.produce(Channel("family"), carol, persist = false)
 
-    r1 shouldBe None
-    r2 shouldBe None
-    r3 shouldBe None
-    r4 shouldBe None
-    r5 shouldBe None
-    r6 shouldBe None
-    r7 shouldBe None
-    r8 shouldBe None
-    r9 shouldBe None
+    r1 shouldBe Right(None)
+    r2 shouldBe Right(None)
+    r3 shouldBe Right(None)
+    r4 shouldBe Right(None)
+    r5 shouldBe Right(None)
+    r6 shouldBe Right(None)
+    r7 shouldBe Right(None)
+    r8 shouldBe Right(None)
+    r9 shouldBe Right(None)
 
-    val r10 = space.consume(
-      List(
-        Channel("family"),
-        Channel("family"),
-        Channel("family"),
-        Channel("family"),
-        Channel("colleagues"),
-        Channel("colleagues"),
-        Channel("colleagues"),
-        Channel("friends"),
-        Channel("friends")
-      ),
-      List(
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake")
-      ),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r10 = space
+      .consume(
+        List(
+          Channel("family"),
+          Channel("family"),
+          Channel("family"),
+          Channel("family"),
+          Channel("colleagues"),
+          Channel("colleagues"),
+          Channel("colleagues"),
+          Channel("friends"),
+          Channel("friends")
+        ),
+        List(
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake")
+        ),
+        new EntriesCaptor,
+        persist = false
+      )
 
     r10 shouldBe defined
     runK(r10)
@@ -221,34 +228,35 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     "return a continuation and the produced data" in withTestSpace { space =>
     val store = space.store
 
-    val r1 = space.consume(
-      List(
-        Channel("family"),
-        Channel("colleagues"),
-        Channel("family"),
-        Channel("friends"),
-        Channel("friends"),
-        Channel("family"),
-        Channel("colleagues"),
-        Channel("colleagues"),
-        Channel("family")
-      ),
-      List(
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Herbert"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Crystal Lake"),
-        CityMatch(city = "Herbert")
-      ),
-      new EntriesCaptor,
-      persist = false
-    )
+    val r1 = space
+      .consume(
+        List(
+          Channel("family"),
+          Channel("colleagues"),
+          Channel("family"),
+          Channel("friends"),
+          Channel("friends"),
+          Channel("family"),
+          Channel("colleagues"),
+          Channel("colleagues"),
+          Channel("family")
+        ),
+        List(
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Herbert"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Herbert")
+        ),
+        new EntriesCaptor,
+        persist = false
+      )
 
-    r1 shouldBe None
+    r1 shouldBe Right(None)
 
     val r2  = space.produce(Channel("friends"), bob, persist = false)
     val r3  = space.produce(Channel("family"), carol, persist = false)
@@ -260,14 +268,14 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
     val r9  = space.produce(Channel("family"), carol, persist = false)
     val r10 = space.produce(Channel("family"), carol, persist = false)
 
-    r2 shouldBe None
-    r3 shouldBe None
-    r4 shouldBe None
-    r5 shouldBe None
-    r6 shouldBe None
-    r7 shouldBe None
-    r8 shouldBe None
-    r9 shouldBe None
+    r2 shouldBe Right(None)
+    r3 shouldBe Right(None)
+    r4 shouldBe Right(None)
+    r5 shouldBe Right(None)
+    r6 shouldBe Right(None)
+    r7 shouldBe Right(None)
+    r8 shouldBe Right(None)
+    r9 shouldBe Right(None)
     r10 shouldBe defined
 
     runK(r10)
@@ -278,7 +286,7 @@ trait StorageExamplesTests extends StorageTestsBase[Channel, Pattern, Entry, Ent
 }
 
 class InMemoryStoreStorageExamplesTestsBase
-    extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor] {
+    extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor] {
 
   override def withTestSpace[R](f: T => R): R = {
     implicit val cg: Codec[GNAT[Channel, Pattern, Entry, EntriesCaptor]] = codecGNAT(
@@ -299,7 +307,8 @@ class InMemoryStoreStorageExamplesTestsBase
       Entry,
       EntriesCaptor](trieStore, branch)
 
-    val testSpace = RSpace.create[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, branch)
+    val testSpace =
+      RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore, branch)
     testStore.withTxn(testStore.createTxnWrite())(testStore.clear)
     trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear)
     initialize(trieStore, branch)
@@ -317,7 +326,7 @@ class InMemoryStoreStorageExamplesTests
     with StorageExamplesTests
 
 class LMDBStoreStorageExamplesTestBase
-    extends StorageTestsBase[Channel, Pattern, Entry, EntriesCaptor]
+    extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path    = Files.createTempDirectory("rchain-storage-test-")
@@ -328,7 +337,8 @@ class LMDBStoreStorageExamplesTestBase
     val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
     val testSpace =
-      RSpace.create[Channel, Pattern, Entry, Entry, EntriesCaptor](testStore, Branch.MASTER)
+      RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
+                                                                            Branch.MASTER)
     try {
       testStore.withTxn(testStore.createTxnWrite())(txn => testStore.clear(txn))
       f(testSpace)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -13,7 +13,7 @@ import scodec.Codec
 
 trait StorageExamplesTests
     extends StorageTestsBase[Channel, Pattern, Nothing, Entry, EntriesCaptor]
-    with CastTestHelpers {
+    with TestImplicitHelpers {
 
   "CORE-365: A joined consume on duplicate channels followed by two produces on that channel" should
     "return a continuation and the produced data" in withTestSpace { space =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -11,9 +11,9 @@ import coop.rchain.shared.PathOps._
 import org.scalatest._
 import scodec.Codec
 
-trait StorageTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionValues {
+trait StorageTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
 
-  type T = FreudianSpace[C, P, A, A, K]
+  type T = FreudianSpace[C, P, E, A, A, K]
 
   val logger: Logger = Logger(this.getClass.getName.stripSuffix("$"))
 
@@ -28,7 +28,7 @@ trait StorageTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionVal
 }
 
 class InMemoryStoreTestsBase
-    extends StorageTestsBase[String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   override def withTestSpace[S](f: T => S): S = {
@@ -47,7 +47,8 @@ class InMemoryStoreTestsBase
       String,
       StringsCaptor](trieStore, branch)
 
-    val testSpace = RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, branch)
+    val testSpace =
+      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, branch)
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)
@@ -69,7 +70,7 @@ class InMemoryStoreTestsBase
 }
 
 class LMDBStoreTestsBase
-    extends StorageTestsBase[String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
@@ -84,7 +85,7 @@ class LMDBStoreTestsBase
     val env        = Context.create[String, Pattern, String, StringsCaptor](dbDir, mapSize)
     val testStore  = LMDBStore.create[String, Pattern, String, StringsCaptor](env, testBranch)
     val testSpace =
-      RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, testBranch)
+      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, testBranch)
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)
@@ -107,7 +108,7 @@ class LMDBStoreTestsBase
 }
 
 class MixedStoreTestsBase
-    extends StorageTestsBase[String, Pattern, String, StringsCaptor]
+    extends StorageTestsBase[String, Pattern, Nothing, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-mixed-storage-test-")
@@ -126,7 +127,7 @@ class MixedStoreTestsBase
         testBranch)
 
     val testSpace =
-      RSpace.create[String, Pattern, String, String, StringsCaptor](testStore, testBranch)
+      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, testBranch)
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)

--- a/rspace/src/test/scala/coop/rchain/rspace/TestImplicitHelpers.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/TestImplicitHelpers.scala
@@ -2,7 +2,8 @@ package coop.rchain.rspace
 import cats.Id
 import org.scalatest.enablers.Definition
 
-trait CastTestHelpers {
+//noinspection ConvertExpressionToSAM
+trait TestImplicitHelpers {
   // Some helpers for usage only in the tests -- save us A LOT of explicit casting from Either to Option
   // it is safe because left type of `Either` is `Nothing` -- we don't expect any invalid states from the matcher
   implicit def eitherDefinitionScalatest[E, A]: Definition[Id[Either[E, Option[A]]]] =


### PR DESCRIPTION
## Overview
Refactors `rspace`'s `Match` typeclass from:
```scala
trait Match[P, A, R] {
  def get(p: P, a: A): Option[R]
}
```
to
```scala
trait Match[P, E, A, R] {
  def get(p: P, a: A): Either[E, Option[R]]
}
```
This change turned out to be necessary when wiring cost accounting with the RSpace lookups.  `RSpace` uses `Rholang`'s _spatial matcher_ ,as an implementation of `Match` typeclass, to find a match between receive patterns and targets. Every comparison done by the _spatial matcher_ is being charged for. We want to short circuit as soon as deploy runs out of phlogistons. Initial return type of `Match` - `Option[R]` - indicates only whether the match was found or not, there is no way to propagate the information about running out of phlogistons. New return type `Either[E, Option[R]]` still carries the information as previous implementation (in the form of `Right(Option[R])`) while `Left(E)` can represent any type of invalid state. At the moment it is just `OutOfPhlogistonError` and `Nothing` when we don't expect invalid states to occur.

Note:
I have also considered using different return type for `A` in `Option[A]` , one that could also represent invalid state, but this wouldn't be a good solution for various of reasons:
1. Internal logic of `RSpace` treats `None` as no match found and saves the data (or continuation) in the tuplespace.
2. `Option` with its two states is too constrained to represent three states:
-- match found
-- no match found
-- deploy runs out of phlo

All the logic of RSpace is retained.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the (developer wiki)[https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain] for instructions.
- [ ] Your GitHub account is also an account with (Travis CI)[https://travis-ci.org]. Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
