### PR TITLE
Adds modules for alpha equivalence, name equivalence, and exact text matching

### DIFF
--- a/rholang/src/main/k/rholang/alpha-equivalence.k
+++ b/rholang/src/main/k/rholang/alpha-equivalence.k
@@ -1,0 +1,9 @@
+module ALPHA-EQUIVALENCE
+imports NAME-EQUIVALENCE
+
+// A function to determine if two processes/names are alpha equivalent
+
+
+
+
+endmodule

--- a/rholang/src/main/k/rholang/exact-matching-function.k
+++ b/rholang/src/main/k/rholang/exact-matching-function.k
@@ -1,0 +1,22 @@
+module EXACT-MATCHING-FUNCTION
+imports MATCHING-FUNCTION
+
+// *******************************************************************
+//                      EXACT-MATCHING-FUNCTION
+// *******************************************************************
+// ******* ******* ******* ******* ******* ******* ******* ******* ******* ******* ******* //
+// THE DEFINITION OF THE EXACT "match" FUNCTION (NOT the match process)
+// This is used to match patterns within patterns, which have to be exact text matches.
+// ******* ******* ******* ******* ******* ******* ******* ******* ******* ******* ******* //
+
+rule <thread> ... <k>
+        match["TEXTMATCH"]( P:HigherPat ; Q:HigherPat )
+     => #if toString( P:HigherPat ) ==String toString( Q:HigherPat ) #then
+        Nil
+        #else
+        #(MATCHFAIL)["TEXTMATCH"]
+        #fi
+        ... </k> ... </thread>
+
+
+endmodule

--- a/rholang/src/main/k/rholang/matching-function.k
+++ b/rholang/src/main/k/rholang/matching-function.k
@@ -232,54 +232,27 @@ rule <thread> ... <k> ...
           => match[S]( C ; D ) ... </k> ... </thread>
 
 // When the pattern is a "for"
-// This is not quite correct, but it's on its way. It still needs alpha equivalence, among other
-// things. If you responsibly code, it will still match most things correctly. In a future update
-// it will match exactly the correct terms, while failing to match anything else.
+// The channels in the "for" pattern must match exactly -- not even up to alpha equivalence
 rule <thread> ...
         <k> ... matchstdform[S:String](
                             "listen"[C:HigherNamePat][D:HigherNamePat][P:HigherProcPat] ;
                             "listen"[E:HigherNamePat][F:HigherNamePat][R:HigherProcPat] ;
                             true
                           )
-          => match["HIGHERNAMEMATCH"](C ; E)
+          => match["TEXTMATCH"](C ; E)
           ~> match[S](D ; F)
           ~> match[S](P ; R) ... </k> ... </thread>
 
-// THIS is how it should be.
-//rule <thread> ... <k> ... matchstdform(
-//                          "listen"[C:HigherName][D:HigherName][P:HigherProc] ;
-//                          "listen"[E:HigherName][F:HigherName][R:HigherProc] ;
-//                          true )
-//          => AreTheseHigherNamesEqual(C ; E) ~> match(D ; F) ~> match(P ; R) ... </k> ...</thread>
-
-
 // When the pattern is a persistent "for"
-// *** This is also incorrect; we need things like in the previous listen construct
+// The channels in the persistent "for" pattern must match exactly--not even up to alpha equivalence
 rule <thread> ... <k> ... matchstdform[S:String](
                               "persistentlisten"[C:HigherNamePat][D:HigherNamePat][P:HigherProcPat];
                               "persistentlisten"[E:HigherNamePat][F:HigherNamePat][R:HigherProcPat];
                               true
                             )
-          => match["HIGHERNAMEMATCH"](C ; E)
+          => match["TEXTMATCH"](C ; E)
           ~> match[S](D ; F)
           ~> match[S](P ; R) ... </k> ... </thread>
-
-// The (logic of the) code we would use for a more correct version
-
-// When the pattern is a persistent "for"
-//rule <thread> ... <k> ... match(
-//                              "persistentlisten"(C:HigherName)(D:HigherName)(P:HigherProc),
-//                              "persistentlisten"(E:HigherName)(F:HigherName)(R:HigherProc),
-//                              true )
-//          => match("persistentlisten"(D)(P),"persistentlisten"(F)(R),C == E)
-//             ... </k> ... </thread>
-//
-//rule <thread> ... <k> ... match(
-//                              "persistentlisten"(D:HigherName)(P:HigherProc),
-//                              "persistentlisten"(F:HigherName)(R:HigherProc),
-//                              true)
-//          => match(intostdmatchform(D),intostdmatchform(F))
-//          ~> match(intostdmatchform(P),intostdmatchform(R)) ... </k> ... </thread>
 
 
 // When the pattern is "send"

--- a/rholang/src/main/k/rholang/name-equivalence.k
+++ b/rholang/src/main/k/rholang/name-equivalence.k
@@ -1,0 +1,13 @@
+module NAME-EQUIVALENCE
+imports FREE
+
+// A function that determines if two names are equivalent
+// This will be used to determine equivalence on a send/receive
+// Names are equivalent, modulo:
+//        1. order of any processes in parallel (unless they form part of a pattern within a
+//           pattern)
+//        2. any `| Nil` , except the same caveat as (1)
+//        3. arithmetic expressions on the top level
+//        4. alpha equivalence 
+
+endmodule

--- a/rholang/src/main/k/rholang/name-equivalence.k
+++ b/rholang/src/main/k/rholang/name-equivalence.k
@@ -8,6 +8,7 @@ imports FREE
 //           pattern)
 //        2. any `| Nil` , except the same caveat as (1)
 //        3. arithmetic expressions on the top level
-//        4. alpha equivalence 
+//        4. alpha equivalence
+//        5. added evals/quots, e.g. the names @{@Nil!(0)} and @{*@{@Nil!(0)}} are equivalent.
 
 endmodule

--- a/rholang/src/main/k/rholang/program-restrictions.k
+++ b/rholang/src/main/k/rholang/program-restrictions.k
@@ -1,5 +1,5 @@
 module PROGRAM-RESTRICTIONS
-imports FREE
+imports ALPHA-EQUIVALENCE
 
 // *******************************************************************
 //                          PROGRAM-RESTRICTIONS

--- a/rholang/src/main/k/rholang/rho-syntax.k
+++ b/rholang/src/main/k/rholang/rho-syntax.k
@@ -261,6 +261,10 @@ syntax KResult ::= Int
               | Id
               | Bool
 
+// For exact text matching
+syntax String ::= "toString(" HigherPat ")"
+
+
 // In Rholang we distinguish between variables and wildcards
 syntax Var ::=
             // Standard variable
@@ -300,6 +304,10 @@ syntax Fun  ::=
               | "fv(" String "," HigherPat "," Id ")"
               // For determining if the entire program has free variables in it
               | "fvInitial(" HigherPat ")"
+              // A function to determine if two names are equivalent
+              | "areNameEquivalent(" HigherNamePat "," HigherNamePat ")"
+              // A function to determine alpha equivalence
+              | "areAlphaEquivalent(" HigherPat "," HigherPat ")"
 
 // Some syntax specifically for the "match" process
 syntax MatchCase  ::= ProcPat "=>" "{" Proc "}" [binder]

--- a/rholang/src/main/k/rholang/specific-matching-rules.k
+++ b/rholang/src/main/k/rholang/specific-matching-rules.k
@@ -1,5 +1,5 @@
 module SPECIFIC-MATCHING-RULES
-imports MATCHING-FUNCTION
+imports EXACT-MATCHING-FUNCTION
 
 // *******************************************************************
 //                   SPECIFIC-MATCHING-RULES


### PR DESCRIPTION
## Overview
1. Adds modules for alpha equivalence, name equivalence, and exact text matching. The module for exact text matching is complete, and some modifications to the matching algorithm are made in `matching-function.k` in order to incorporate it.
2. Also adds the functions `areNameEquivalent( )` and `areAlphaEquivalent( )` in the syntactic category `Fun` which will eventually check for name and alpha equivalence.
3. Changes some of the `imports` tags to fit in these modules appropriately.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.