### PR TITLE
Set blockNumber to be 1 greater than largest parent blockNumber

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -258,10 +258,15 @@ class MultiParentCasperImpl[
                        case _ => ().pure[F]
                      }
                      .map(_ => {
+                       val maxBlockNumber: Long =
+                         p.foldLeft(0L) {
+                           case (acc, block) => math.max(acc, blockNumber(block))
+                         }
+
                        val postState = RChainState()
                          .withTuplespace(computedStateHash)
                          .withBonds(bonds(p.head))
-                         .withBlockNumber(p.headOption.fold(0L)(blockNumber) + 1)
+                         .withBlockNumber(maxBlockNumber + 1)
 
                        val body = Body()
                          .withPostState(postState)

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -259,7 +259,7 @@ class MultiParentCasperImpl[
                      }
                      .map(_ => {
                        val maxBlockNumber: Long =
-                         p.foldLeft(0L) {
+                         p.foldLeft(-1L) {
                            case (acc, block) => math.max(acc, blockNumber(block))
                          }
 

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -115,7 +115,7 @@ object BlockAPI {
         maybeRuntimeManager <- casper.getRuntimeManager
         runtimeManager      = maybeRuntimeManager.get // This is safe. Please reluctantly accept until runtimeManager is no longer exposed.
         sortedListeningNames <- listeningNames.channels.toList
-                                     .traverse(channelSortable.sortMatch[F](_).map(_.term))
+                                 .traverse(channelSortable.sortMatch[F](_).map(_.term))
         maybeBlocksWithActiveName <- mainChain.toList.traverse { block =>
                                       getContinuationsWithBlockInfo[F](runtimeManager,
                                                                        sortedListeningNames,

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -202,7 +202,7 @@ class ValidateTest
     Validate.blockNumber[Id](block.withBlockNumber(17)) should be(Left(InvalidBlockNumber))
     Validate.blockNumber[Id](block) should be(Right(Valid))
     log.warns.size should be(1)
-    log.warns.head.contains("is not one more than parent number") should be(true)
+    log.warns.head.contains("is not one more than maximum parent number") should be(true)
   }
 
   it should "return true for sequential numbering" in withStore { implicit blockStore =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -24,9 +24,8 @@ object SystemProcesses {
       Task.now(Console.println(prettyPrinter.buildString(arg)))
   }
 
-  private implicit class ProduceOps(
-      res: Id[
-        Either[OutOfPhlogistonsError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]) {
+  private implicit class ProduceOps(res: Id[
+    Either[OutOfPhlogistonsError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]) {
     def foldResult(
         dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]): Task[Unit] =
       res.fold(err => Task.raiseError(OutOfPhlogistonsError), _.fold(Task.unit) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -66,7 +66,8 @@ object errors {
   final case class UnexpectedBundleContent(message: String)     extends InterpreterError(message)
   final case class UnrecognizedNormalizerError(message: String) extends InterpreterError(message)
 
-  final case object OutOfPhlogistonsError extends InterpreterError("Computation ran out of phlogistons.")
+  final case object OutOfPhlogistonsError
+      extends InterpreterError("Computation ran out of phlogistons.")
 
   final case class TopLevelWildcardsNotAllowedError(wildcards: String)
       extends InterpreterError(s"Top level wildcards are not allowed: $wildcards.")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -26,9 +26,14 @@ object implicits {
       }
     }
 
-  implicit val matchListQuote
-    : StorageMatch[BindPattern, OutOfPhlogistonsError.type, ListChannelWithRandom, ListChannelWithRandom] =
-    new StorageMatch[BindPattern, OutOfPhlogistonsError.type, ListChannelWithRandom, ListChannelWithRandom] {
+  implicit val matchListQuote: StorageMatch[BindPattern,
+                                            OutOfPhlogistonsError.type,
+                                            ListChannelWithRandom,
+                                            ListChannelWithRandom] =
+    new StorageMatch[BindPattern,
+                     OutOfPhlogistonsError.type,
+                     ListChannelWithRandom,
+                     ListChannelWithRandom] {
 
       def get(pattern: BindPattern, data: ListChannelWithRandom)
         : Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] = {


### PR DESCRIPTION
## Overview
Having a block height which is an increasing function of causal dependency means we can use it in a nice topological sort.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-612

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
