### PR TITLE
Fix swallow exceptions in finally

### DIFF
--- a/shared/src/main/scala/coop/rchain/shared/Resources.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Resources.scala
@@ -12,8 +12,8 @@ object Resources {
     * @param a A given resource implementing [[AutoCloseable]]
     * @param f A function that takes this resource as its argument
     */
-  def withResource[A <: AutoCloseable, B](r: => A)(f: A => B): B = {
-    val resource: A = r
+  def withResource[A <: AutoCloseable, B](a: => A)(f: A => B): B = {
+    val resource: A = a
     require(resource != null, "resource is null")
     var exception: Throwable = null
     try {

--- a/shared/src/main/scala/coop/rchain/shared/Resources.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Resources.scala
@@ -1,4 +1,5 @@
 package coop.rchain.shared
+import scala.util.control.NonFatal
 
 object Resources {
 
@@ -11,10 +12,30 @@ object Resources {
     * @param a A given resource implementing [[AutoCloseable]]
     * @param f A function that takes this resource as its argument
     */
-  def withResource[A <: AutoCloseable, B](a: A)(f: A => B): B =
+  def withResource[A <: AutoCloseable, B](r: => A)(f: A => B): B = {
+    val resource: A = r
+    require(resource != null, "resource is null")
+    var exception: Throwable = null
     try {
-      f(a)
+      f(resource)
+    } catch {
+      case NonFatal(e) =>
+        exception = e
+        throw e
     } finally {
-      a.close()
+      closeAndAddSuppressed(exception, resource)
+    }
+  }
+
+  private def closeAndAddSuppressed(e: Throwable, resource: AutoCloseable): Unit =
+    if (e != null) {
+      try {
+        resource.close()
+      } catch {
+        case NonFatal(suppressed) =>
+          e.addSuppressed(suppressed)
+      }
+    } else {
+      resource.close()
     }
 }

--- a/shared/src/test/scala/coop/rchain/shared/ResourcesSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/ResourcesSpec.scala
@@ -1,0 +1,39 @@
+package coop.rchain.shared
+import coop.rchain.shared.Resources.withResource
+import org.scalatest.{FlatSpec, Matchers}
+
+class ResourcesSpec extends FlatSpec with Matchers {
+
+  val resource = new AutoCloseable {
+    override def close(): Unit = throw new Exception("close")
+  }
+
+  "Try-finally" should "swallow exception in try-block when exception in finally is thrown" in {
+    val caught = intercept[Exception](
+      try {
+        throw new Exception("try-block")
+      } finally {
+        throw new Exception("finally")
+      }
+    )
+
+    caught.getMessage shouldBe "finally"
+    caught.getSuppressed shouldBe empty
+  }
+
+  "withResource" should "not swallow exception in try-block when exception in finally is thrown" in {
+    val caught = intercept[Exception](
+      withResource(resource)(_ => throw new Exception("try-block"))
+    )
+
+    caught.getMessage shouldBe "try-block"
+  }
+
+  it should "add the exception thrown in finally as suppressed" in {
+    val caught = intercept[Exception](
+      withResource(resource)(_ => throw new Exception("try-block"))
+    )
+
+    caught.getSuppressed.apply(0).getMessage shouldBe "close"
+  }
+}


### PR DESCRIPTION
Currently when using `withResource` there is a chance that exceptions in the `try` block get swallowed by an exception thrown in `finally`.
See: https://medium.com/@dkomanov/scala-try-with-resources-735baad0fd7d