### PR TITLE
[RHOL-631] finish justification follows validation

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -25,6 +25,7 @@ case object MissingBlocks           extends InvalidBlock
 case object InvalidBlockNumber      extends InvalidBlock with Slashable
 case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
 case object InvalidParents          extends InvalidBlock with Slashable
+case object InvalidFollows          extends InvalidBlock with Slashable
 case object InvalidSequenceNumber   extends InvalidBlock with Slashable
 case object InvalidShardId          extends InvalidBlock with Slashable
 case object JustificationRegression extends InvalidBlock with Slashable

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -172,7 +172,9 @@ object Validate {
                                Validate.repeatDeploy[F](block, dag))
       blockNumberStatus <- repeatedDeployStatus.joinRight.traverse(_ =>
                             Validate.blockNumber[F](block))
-      parentsStatus <- blockNumberStatus.joinRight.traverse(_ =>
+      followsStatus <- blockNumberStatus.joinRight.traverse(_ =>
+                        Validate.justificationFollows[F](block, genesis, dag))
+      parentsStatus <- followsStatus.joinRight.traverse(_ =>
                         Validate.parents[F](block, genesis, dag))
       sequenceNumberStatus <- parentsStatus.joinRight.traverse(_ =>
                                Validate.sequenceNumber[F](block, dag))
@@ -396,6 +398,36 @@ object Validate {
                  } yield Left(InvalidParents)
     } yield status
   }
+
+  /*
+   * This check must come before Validate.parents
+   */
+  def justificationFollows[F[_]: Monad: Log: BlockStore](
+      b: BlockMessage,
+      genesis: BlockMessage,
+      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] =
+    for {
+      latestMessages <- ProtoUtil.toLatestMessage[F](b.justifications, dag)
+      validators     = latestMessages.keySet
+      creatorLatestBlock <- ProtoUtil.creatorJustification(b).foldM(genesis) {
+                             case (_, Justification(_, latestBlockHash)) =>
+                               for {
+                                 latestBlock <- ProtoUtil.unsafeGetBlock[F](latestBlockHash)
+                               } yield latestBlock
+                           }
+      creatorBonds = ProtoUtil.bonds(creatorLatestBlock).map(_.validator).toSet
+      result       = creatorBonds == validators
+      status <- if (result) {
+                 Applicative[F].pure(Right(Valid))
+               } else {
+                 for {
+                   _ <- Log[F].warn(
+                         ignore(
+                           b,
+                           "the justifications of block are not follow from bonds of creator justification block"))
+                 } yield Left(InvalidFollows)
+               }
+    } yield status
 
   /*
    * When we switch between equivocation forks for a slashed validator, we will potentially get a

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -411,8 +411,7 @@ class ValidateTest
         true)
 
       log.warns.size should be(1)
-      log.warns.forall(_.contains(
-        "the justifications of block are not follow from bonds of creator justification block")) should be(
+      log.warns.forall(_.contains("not follow from bonds of creator justification block")) should be(
         true)
   }
 


### PR DESCRIPTION
## Overview
it should be that for a block, we have `toLatestMessages(block.justifications).keys == bonds(creatorJustification(block)).keys` where .keys return all the validators.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-631

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [X] You assigned one person to review this PR

