### PR TITLE
p2p-test-tool: Wait until nodes see each other

### DIFF
--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -152,7 +152,7 @@ def main():
         remove_resources_by_network(args.network)
         boot_p2p_network()
         if not args.skip_convergence_test == True:
-            for container in client.containers.list(all=True, filters={"name":f'bootstrap.{args.network}'}):
+            for container in client.containers.list(all=True, filters={"name":f'(bootstrap|peer\\d+).{args.network}'}):
                 if check_network_convergence(container) != 0:
                     show_logs()
                     show_containers()


### PR DESCRIPTION
The script waits until bootstrap node sees each peer and immediately after that checks whether peer nodes see each other plus bootstrap node, but that doesn't need to be the case yet.

This change makes the script wait until all nodes see each other. Test for peer count effectively becomes noop. Desire to remove it is low as this is script is obsolete.