### PR TITLE
RHOL-592: Catch lexer errors

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -63,7 +63,9 @@ object Interpreter {
         case e: Error if e.getMessage.startsWith("Unterminated string at EOF, beginning at") =>
           LexerError(e.getMessage)
         case e: Error if e.getMessage.startsWith("Illegal Character") => LexerError(e.getMessage)
-        case th                                                       => UnrecognizedInterpreterError(th)
+        case e: Error if e.getMessage.startsWith("Unterminated string on line") =>
+          LexerError(e.getMessage)
+        case th => UnrecognizedInterpreterError(th)
       }
 
   private def normalizeTerm[M[_]](term: Proc, inputs: ProcVisitInputs)(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -11,6 +11,7 @@ import coop.rchain.models.rholang.sort.Sortable
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
 import coop.rchain.rholang.interpreter.errors.{
   InterpreterError,
+  LexerError,
   SyntaxError,
   TopLevelFreeVariablesNotAllowedError,
   TopLevelWildcardsNotAllowedError,
@@ -59,7 +60,10 @@ object Interpreter {
       .leftMap {
         case ex: Exception if ex.getMessage.toLowerCase.contains("syntax") =>
           SyntaxError(ex.getMessage)
-        case th => UnrecognizedInterpreterError(th)
+        case e: Error if e.getMessage.startsWith("Unterminated string at EOF, beginning at") =>
+          LexerError(e.getMessage)
+        case e: Error if e.getMessage.startsWith("Illegal Character") => LexerError(e.getMessage)
+        case th                                                       => UnrecognizedInterpreterError(th)
       }
 
   private def normalizeTerm[M[_]](term: Proc, inputs: ProcVisitInputs)(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -21,6 +21,7 @@ object errors {
 
   final case class NormalizerError(message: String) extends InterpreterError(message)
   final case class SyntaxError(message: String)     extends InterpreterError(message)
+  final case class LexerError(message: String)      extends InterpreterError(message)
 
   final case class UnboundVariableRef(varName: String, line: Int, col: Int)
       extends InterpreterError(s"Variable reference: =$varName at $line:$col is unbound.")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -12,7 +12,12 @@ class LexerTest extends FlatSpec with Matchers {
     Interpreter.buildNormalizedTerm(new StringReader(input)).runAttempt()
 
   "Lexer" should "return LexerError for unterminated string at EOF" in {
-    val attempt = attemptMkTerm("""{{ @"ack!(0)""")
+    val attempt = attemptMkTerm("""{{ @"ack!(0) }}""")
+    attempt.left.value shouldBe a[LexerError]
+  }
+
+  it should "return LexerError for unterminated string on particular line" in {
+    val attempt = attemptMkTerm("{{ @\"ack\n!(0) }}")
     attempt.left.value shouldBe a[LexerError]
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -1,0 +1,24 @@
+package coop.rchain.rholang.interpreter
+import java.io.StringReader
+
+import coop.rchain.models.Par
+import coop.rchain.rholang.interpreter.errors.LexerError
+import org.scalatest.EitherValues._
+import org.scalatest.{FlatSpec, Matchers}
+
+class LexerTest extends FlatSpec with Matchers {
+
+  def attemptMkTerm(input: String): Either[Throwable, Par] =
+    Interpreter.buildNormalizedTerm(new StringReader(input)).runAttempt()
+
+  "Lexer" should "return LexerError for unterminated string at EOF" in {
+    val attempt = attemptMkTerm("""{{ @"ack!(0)""")
+    attempt.left.value shouldBe a[LexerError]
+  }
+
+  it should "return LexerError for illegal character" in {
+    val attempt =
+      attemptMkTerm("""("x is ${value}" % {"value" : x})""")
+    attempt.left.value shouldBe a[LexerError]
+  }
+}


### PR DESCRIPTION
## Overview
No more `UnrecognizedInterpreterError` for errors thrown by the lexer.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-592

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR