### PR TITLE
store the container logs as separate files

### DIFF
--- a/integration-testing/src/tools/rnode.py
+++ b/integration-testing/src/tools/rnode.py
@@ -40,12 +40,13 @@ class Node:
         return address
 
     def cleanup(self):
-        with log_box(logging.info, f"Logs for node {self.container.name}:"):
-            logs = self.logs().splitlines()
-            for log_line in logs:
-                logging.info(f"{self.container.name}: {log_line}")
+        log_file = f"{self.container.name}.log"
+        
+        with open(log_file, "w") as f:
+            f.write(self.logs())
 
-        logging.info(f"Remove container {self.container.name}")
+        logging.info(f"Remove container {self.container.name}. Logs have been written to {log_file}")
+
         self.container.remove(force=True, v=True)
 
     def deploy(self, contract):


### PR DESCRIPTION
## Overview
At the end of the test execution, store the container logs as separate files such that they are easier to read

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
no jira

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
