### PR TITLE
RHOL-11: Introduce ChargingReducer

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -11,9 +11,9 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.models._
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rholang.interpreter.{ErrorLog, Reduce, Runtime}
+import coop.rchain.rholang.interpreter.{ChargingReducer, ErrorLog, Runtime}
 import coop.rchain.rspace.internal.{Datum, WaitingContinuation}
 import coop.rchain.rspace.trace.Produce
 import coop.rchain.rspace.{Blake2b256Hash, ReplayException}
@@ -22,7 +22,8 @@ import monix.execution.Scheduler
 
 import scala.annotation.tailrec
 import scala.collection.immutable
-import scala.concurrent.SyncVar
+import scala.concurrent.duration._
+import scala.concurrent.{Await, SyncVar}
 import scala.util.{Failure, Success, Try}
 
 //runtime is a SyncVar for thread-safety, as all checkpoints share the same "hot store"
@@ -143,11 +144,11 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
       terms match {
         case deploy +: rem =>
           runtime.space.reset(hash)
-          val availablePhlos             = CostAccount(Integer.MAX_VALUE)
-          implicit val costAccountingAlg = CostAccountingAlg.unsafe[Task](availablePhlos) //FIXME this needs to come from the deploy params
-          val (phlosLeft, errors)        = injAttempt(deploy, runtime.reducer, runtime.errorLog)
-          val cost                       = phlosLeft.copy(cost = availablePhlos.cost.value - phlosLeft.cost)
-          val newCheckpoint              = runtime.space.createCheckpoint()
+          val availablePhlos = Cost(Integer.MAX_VALUE)
+          Await.ready(runtime.reducer.setAvailablePhlos(availablePhlos).runAsync, 1.second) // FIXME: This needs to come from the deploy params
+          val (phlosLeft, errors) = injAttempt(deploy, runtime.reducer, runtime.errorLog)
+          val cost                = phlosLeft.copy(cost = availablePhlos.value - phlosLeft.cost)
+          val newCheckpoint       = runtime.space.createCheckpoint()
           val deployResult = InternalProcessedDeploy(deploy,
                                                      cost,
                                                      newCheckpoint.log,
@@ -170,12 +171,12 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
                      hash: Blake2b256Hash): Either[(Option[Deploy], Failed), StateHash] =
       terms match {
         case InternalProcessedDeploy(deploy, _, log, status) +: rem =>
-          val availablePhlos             = CostAccount(Integer.MAX_VALUE)
-          implicit val costAccountingAlg = CostAccountingAlg.unsafe[Task](availablePhlos) // FIXME: This needs to come from the deploy params
+          val availablePhlos = Cost(Integer.MAX_VALUE)
+          Await.ready(runtime.replayReducer.setAvailablePhlos(availablePhlos).runAsync, 1.second) // FIXME: This needs to come from the deploy params
           runtime.replaySpace.rig(hash, log.toList)
           //TODO: compare replay deploy cost to given deploy cost
           val (phlosLeft, errors) = injAttempt(deploy, runtime.replayReducer, runtime.errorLog)
-          val cost                = phlosLeft.copy(cost = availablePhlos.cost.value - phlosLeft.cost)
+          val cost                = phlosLeft.copy(cost = availablePhlos.value - phlosLeft.cost)
           DeployStatus.fromErrors(errors) match {
             case int: InternalErrors => Left(Some(deploy) -> int)
             case replayStatus =>
@@ -198,21 +199,20 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     doReplayEval(terms, Blake2b256Hash.fromByteArray(initHash.toByteArray))
   }
 
-  private def injAttempt(deploy: Deploy, reducer: Reduce[Task], errorLog: ErrorLog)(
-      implicit scheduler: Scheduler,
-      costAlg: CostAccountingAlg[Task]): (PCost, Vector[Throwable]) = {
+  private def injAttempt(deploy: Deploy, reducer: ChargingReducer[Task], errorLog: ErrorLog)(
+      implicit scheduler: Scheduler): (PCost, Vector[Throwable]) = {
     implicit val rand: Blake2b512Random = Blake2b512Random(
       DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.raw.get)))
     Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
       case Success(_) =>
         val errors = errorLog.readAndClearErrorVector()
-        val cost   = CostAccount.toProto(costAlg.get().unsafeRunSync)
+        val cost   = CostAccount.toProto(reducer.getAvailablePhlos().unsafeRunSync)
         cost -> errors
 
       case Failure(ex) =>
         val otherErrors = errorLog.readAndClearErrorVector()
         val errors      = otherErrors :+ ex
-        val cost        = CostAccount.toProto(costAlg.get().unsafeRunSync)
+        val cost        = CostAccount.toProto(reducer.getAvailablePhlos().unsafeRunSync)
         cost -> errors
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts.{ProofOfStake, ProofOfStakeValidator}
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.protocol.{Deploy, DeployData}
+import coop.rchain.casper.protocol.Deploy
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.crypto.signatures.Ed25519

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -1,21 +1,21 @@
 package coop.rchain.casper.genesis.contracts
 
+import java.nio.file.Paths
+
 import coop.rchain.casper.util.rholang.InterpreterUtil.mkTerm
-import coop.rchain.catscontrib.Capture.taskCapture
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.collection.ListOps
-import coop.rchain.rholang.unittest.TestSet
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.collection.ListOps
+import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.unittest.TestSet
 import coop.rchain.shared.StoreType.InMem
-import java.nio.file.Paths
-
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import monix.eval.Task
 import monix.execution.Scheduler
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import scala.io.Source
 
 object TestSetUtil {
@@ -23,13 +23,11 @@ object TestSetUtil {
   def runtime(name: String): Runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
 
   def eval_term(term: Par, runtime: Runtime)(implicit scheduler: Scheduler,
-                                             rand: Blake2b512Random,
-                                             costAccountingAlg: CostAccountingAlg[Task]): Unit =
+                                             rand: Blake2b512Random): Unit =
     runtime.reducer.inj(term).unsafeRunSync
 
   def eval(code: String, runtime: Runtime)(implicit scheduler: Scheduler,
-                                           rand: Blake2b512Random,
-                                           costAccountingAlg: CostAccountingAlg[Task]): Unit =
+                                           rand: Blake2b512Random): Unit =
     mkTerm(code) match {
       case Right(term) => eval_term(term, runtime)
       case Left(ex)    => throw ex
@@ -39,20 +37,18 @@ object TestSetUtil {
                otherLibs: Seq[CompiledRholangSource],
                runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
-    val rand              = Blake2b512Random(128)
-    val costAccountingAlg = CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-    eval(ListOps.code, runtime)(implicitly, rand.splitShort(0), costAccountingAlg)
-    eval(TestSet.code, runtime)(implicitly, rand.splitShort(1), costAccountingAlg)
+    val rand = Blake2b512Random(128)
+    Await.ready(runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second) // FIXME: Cost available should come from the deploy data
+    eval(ListOps.code, runtime)(implicitly, rand.splitShort(0))
+    eval(TestSet.code, runtime)(implicitly, rand.splitShort(1))
 
     //load "libraries" required for this particular set of tests
     otherLibs.zipWithIndex.foreach {
       case (lib, idx) =>
-        eval(lib.code, runtime)(implicitly, rand.splitShort((idx + 2).toShort), costAccountingAlg)
+        eval(lib.code, runtime)(implicitly, rand.splitShort((idx + 2).toShort))
     }
 
-    eval(tests.code, runtime)(implicitly,
-                              rand.splitShort((otherLibs.length + 2).toShort),
-                              costAccountingAlg)
+    eval(tests.code, runtime)(implicitly, rand.splitShort((otherLibs.length + 2).toShort))
   }
 
   /**

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -53,36 +53,38 @@ trait Reduce[M[_]] {
 
 object Reduce {
 
-  private def substituteAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
+  private def substituteAndCharge[A: Chargeable,
+                                  F[_]: Substitute[?[_], A]: Sync: CostAccountingAlg](
       term: A,
       depth: Int,
-      env: Env[Par],
-      costAccountingAlg: CostAccountingAlg[M]): M[A] =
-    Substitute[M, A]
+      env: Env[Par]): F[A] =
+    Substitute[F, A]
       .substitute(term)(depth, env)
       .attempt
       .flatMap(_.fold(
         th => // On error charge for the initial term
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
+          CostAccountingAlg[F].charge(Cost(Chargeable[A].cost(term))) *> Sync[F]
             .raiseError[A](th),
         substTerm =>
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
+          CostAccountingAlg[F].charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[F].pure(
+            substTerm)
       ))
 
-  private def substituteNoSortAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
+  private def substituteNoSortAndCharge[A: Chargeable,
+                                        F[_]: Substitute[?[_], A]: Sync: CostAccountingAlg](
       term: A,
       depth: Int,
-      env: Env[Par],
-      costAccountingAlg: CostAccountingAlg[M]): M[A] =
-    Substitute[M, A]
+      env: Env[Par]): F[A] =
+    Substitute[F, A]
       .substituteNoSort(term)(depth, env)
       .attempt
       .flatMap(_.fold(
         th => // On error charge for the initial term
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
+          CostAccountingAlg[F].charge(Cost(Chargeable[A].cost(term))) *> Sync[F]
             .raiseError[A](th),
         substTerm =>
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
+          CostAccountingAlg[F].charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[F].pure(
+            substTerm)
       ))
 
   private def spatialMatchAndCharge[M[_]: Sync](target: Par, pattern: Par)(
@@ -267,7 +269,7 @@ object Reduce {
                                  costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       for {
         quote   <- eval(send.chan)
-        subChan <- substituteAndCharge[Quote, M](quote, 0, env, costAccountingAlg)
+        subChan <- substituteAndCharge[Quote, M](quote, 0, env)
         unbundled <- subChan.value.singleBundle() match {
                       case Some(value) =>
                         if (!value.writeFlag) {
@@ -280,8 +282,7 @@ object Reduce {
 
         data <- send.data.toList.traverse(x => evalExpr(x))
         substData <- data.traverse(p =>
-                      substituteAndCharge[Par, M](p, 0, env, costAccountingAlg).map(par =>
-                        Channel(Quote(par))))
+                      substituteAndCharge[Par, M](p, 0, env).map(par => Channel(Quote(par))))
         _ <- produce(unbundled, substData, send.persistent, rand)
         _ <- costAccountingAlg.charge(SEND_EVAL_COST)
       } yield ()
@@ -299,18 +300,13 @@ object Reduce {
                   .traverse(rb =>
                     for {
                       q <- unbundleReceive(rb)
-                      substPatterns <- rb.patterns.toList.traverse(
-                                        pattern =>
-                                          substituteAndCharge[Channel, M](pattern,
-                                                                          1,
-                                                                          env,
-                                                                          costAccountingAlg))
+                      substPatterns <- rb.patterns.toList.traverse(pattern =>
+                                        substituteAndCharge[Channel, M](pattern, 1, env))
                     } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q))
         // TODO: Allow for the environment to be stored with the body in the Tuplespace
         substBody <- substituteNoSortAndCharge[Par, M](receive.body,
                                                        0,
-                                                       env.shift(receive.bindCount),
-                                                       costAccountingAlg)
+                                                       env.shift(receive.bindCount))
         _ <- consume(binds, substBody, receive.persistent, rand)
         _ <- costAccountingAlg.charge(RECEIVE_EVAL_COST)
       } yield ()
@@ -404,10 +400,7 @@ object Reduce {
             case Nil => Applicative[M].pure(Right(()))
             case singleCase +: caseRem =>
               for {
-                pattern <- substituteAndCharge[Par, M](singleCase.pattern,
-                                                       1,
-                                                       env,
-                                                       costAccountingAlg)
+                pattern     <- substituteAndCharge[Par, M](singleCase.pattern, 1, env)
                 matchResult <- spatialMatchAndCharge[M](target, pattern)
                 res <- matchResult match {
                         case None =>
@@ -426,7 +419,7 @@ object Reduce {
       for {
         evaledTarget <- evalExpr(mat.target)
         // TODO(kyle): Make the matcher accept an environment, instead of substituting it.
-        substTarget <- substituteAndCharge[Par, M](evaledTarget, 0, env, costAccountingAlg)
+        substTarget <- substituteAndCharge[Par, M](evaledTarget, 0, env)
         _           <- firstMatch(substTarget, mat.cases)
         _           <- costAccountingAlg.charge(MATCH_EVAL_COST)
       } yield ()
@@ -477,7 +470,7 @@ object Reduce {
         costAccountingAlg: CostAccountingAlg[M]): M[Quote] =
       for {
         quote <- eval(rb.source)
-        subst <- substituteAndCharge[Quote, M](quote, 0, env, costAccountingAlg)
+        subst <- substituteAndCharge[Quote, M](quote, 0, env)
         // Check if we try to read from bundled channel
         unbndl <- subst.quote.get.singleBundle() match {
                    case Some(value) =>
@@ -639,16 +632,16 @@ object Reduce {
             v1 <- evalExpr(p1)
             v2 <- evalExpr(p2)
             // TODO: build an equality operator that takes in an environment.
-            sv1 <- substituteAndCharge[Par, M](v1, 0, env, costAccountingAlg)
-            sv2 <- substituteAndCharge[Par, M](v2, 0, env, costAccountingAlg)
+            sv1 <- substituteAndCharge[Par, M](v1, 0, env)
+            sv2 <- substituteAndCharge[Par, M](v2, 0, env)
             _   <- costAccountingAlg.charge(equalityCheckCost(sv1, sv2))
           } yield GBool(sv1 == sv2)
         case ENeqBody(ENeq(p1, p2)) =>
           for {
             v1  <- evalExpr(p1)
             v2  <- evalExpr(p2)
-            sv1 <- substituteAndCharge[Par, M](v1, 0, env, costAccountingAlg)
-            sv2 <- substituteAndCharge[Par, M](v2, 0, env, costAccountingAlg)
+            sv1 <- substituteAndCharge[Par, M](v1, 0, env)
+            sv2 <- substituteAndCharge[Par, M](v2, 0, env)
             _   <- costAccountingAlg.charge(equalityCheckCost(sv1, sv2))
           } yield GBool(sv1 != sv2)
         case EAndBody(EAnd(p1, p2)) =>
@@ -667,8 +660,8 @@ object Reduce {
         case EMatchesBody(EMatches(target, pattern)) =>
           for {
             evaledTarget <- evalExpr(target)
-            substTarget  <- substituteAndCharge[Par, M](evaledTarget, 0, env, costAccountingAlg)
-            substPattern <- substituteAndCharge[Par, M](pattern, 1, env, costAccountingAlg)
+            substTarget  <- substituteAndCharge[Par, M](evaledTarget, 0, env)
+            substPattern <- substituteAndCharge[Par, M](pattern, 1, env)
             matchResult  <- spatialMatchAndCharge[M](substTarget, substPattern)
           } yield GBool(matchResult.isDefined)
 
@@ -907,7 +900,7 @@ object Reduce {
         } else {
           for {
             exprEvaled <- evalExpr(p)
-            exprSubst  <- substituteAndCharge[Par, M](exprEvaled, 0, env, costAccountingAlg)
+            exprSubst  <- substituteAndCharge[Par, M](exprEvaled, 0, env)
             _          <- costAccountingAlg.charge(toByteArrayCost(exprSubst))
             ba         <- s.fromEither(serialize(exprSubst))
           } yield Expr(GByteArray(ByteString.copyFrom(ba)))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -53,7 +53,7 @@ trait Reduce[M[_]] {
 
 object Reduce {
 
-  def substituteAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
+  private def substituteAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
       term: A,
       depth: Int,
       env: Env[Par],
@@ -69,7 +69,7 @@ object Reduce {
           costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
       ))
 
-  def substituteNoSortAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
+  private def substituteNoSortAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
       term: A,
       depth: Int,
       env: Env[Par],

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -51,6 +51,30 @@ trait Reduce[M[_]] {
                                 costAccountingAlg: CostAccountingAlg[M]): M[Par]
 }
 
+// TODO:
+// In a perfect world we would an algebra of an interpreter encoded in the terms of
+// rholang's elimination and have the `ChargingReducer` forward the calls to the plain algebra
+// and charge accordingly. This would eliminate the "charge" calls from the algebra of a language.
+abstract class ChargingReducer[M[_]](implicit R: Reduce[M], C: CostAccountingAlg[M]) {
+  def getAvailablePhlos(): M[CostAccount] =
+    C.get()
+
+  def setAvailablePhlos(limit: Cost): M[Unit] =
+    C.set(CostAccount(0, limit))
+
+  def eval(par: Par)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
+    R.eval(par)
+
+  def inj(par: Par)(implicit rand: Blake2b512Random): M[Unit] =
+    R.inj(par)
+
+  def evalExpr(par: Par)(implicit env: Env[Par]): M[Par] =
+    R.evalExpr(par)
+
+  def evalExprToPar(expr: Expr)(implicit env: Env[Par]): M[Par] =
+    R.evalExprToPar(expr)
+}
+
 object Reduce {
 
   private def substituteAndCharge[A: Chargeable,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -4,23 +4,22 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.ByteString.ByteIterator
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.Channel.ChannelInstance
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
-import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ScalaBodyRef
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.interpreter.Registry.FixedRefs._
 import coop.rchain.rholang.interpreter.storage.implicits._
-import coop.rchain.rspace.pure.PureRSpace
 import monix.eval.Task
 import org.lightningj.util.ZBase32
+
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.collection.{Seq => RootSeq}
-import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 /**
   * Registry implements a radix tree for public lookup of one-sided bundles.
@@ -65,13 +64,11 @@ class Registry(private val space: Runtime.RhoPureSpace,
     (head, tail)
   }
 
-  private val lookupRef: Long = Runtime.BodyRefs.REG_LOOKUP
   private val lookupPatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
       freeCount = 2))
-  private val lookupChannels  = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](10))))))
-  private val insertRef: Long = Runtime.BodyRefs.REG_INSERT
+  private val lookupChannels = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](10))))))
   private val insertPatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
@@ -86,7 +83,6 @@ class Registry(private val space: Runtime.RhoPureSpace,
       freeCount = 2))
   private val deleteChannels = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](14))))))
 
-  private val publicLookupRef: Long = Runtime.BodyRefs.REG_PUBLIC_LOOKUP
   private val publicLookupChannels = List(
     Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](17))))))
   private val publicLookupPatterns = List(
@@ -94,9 +90,6 @@ class Registry(private val space: Runtime.RhoPureSpace,
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
       freeCount = 2))
 
-  private val publicRegisterRandomRef: Long = Runtime.BodyRefs.REG_PUBLIC_REGISTER_RANDOM
-  private val publicRegisterInsertCallbackRef: Long =
-    Runtime.BodyRefs.REG_PUBLIC_REGISTER_INSERT_CALLBACK
   private val publicRegisterRandomChannels = List(
     Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](18))))))
   // format: off
@@ -140,7 +133,6 @@ class Registry(private val space: Runtime.RhoPureSpace,
     Await.result(installTask.runAsync, 1.seconds)
   }
 
-  private val lookupCallbackRef: Long = Runtime.BodyRefs.REG_LOOKUP_CALLBACK
   private val prefixRetReplacePattern = BindPattern(
     Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
         ChanVar(FreeVar(1)),
@@ -164,12 +156,6 @@ class Registry(private val space: Runtime.RhoPureSpace,
   private val triePattern = BindPattern(
     Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true))),
     freeCount = 1)
-
-  private val insertCallbackRef: Long = Runtime.BodyRefs.REG_INSERT_CALLBACK
-
-  private val deleteRef: Long             = Runtime.BodyRefs.REG_DELETE
-  private val deleteRootCallbackRef: Long = Runtime.BodyRefs.REG_DELETE_ROOT_CALLBACK
-  private val deleteCallbackRef: Long     = Runtime.BodyRefs.REG_DELETE_CALLBACK
 
   private def parByteArray(bs: ByteString): Par = GByteArray(bs)
 
@@ -716,20 +702,6 @@ class Registry(private val space: Runtime.RhoPureSpace,
       case _ =>
         Task.unit
     }
-
-  val testingDispatchTable: Map[Long, Function1[RootSeq[ListChannelWithRandom], Task[Unit]]] =
-    Map(
-      lookupRef                       -> lookup,
-      lookupCallbackRef               -> lookupCallback,
-      insertRef                       -> insert,
-      insertCallbackRef               -> insertCallback,
-      deleteRef                       -> delete,
-      deleteRootCallbackRef           -> deleteRootCallback,
-      deleteCallbackRef               -> deleteCallback,
-      publicLookupRef                 -> publicLookup,
-      publicRegisterRandomRef         -> publicRegisterRandom,
-      publicRegisterInsertCallbackRef -> publicRegisterInsertCallback
-    )
 }
 
 object Registry {
@@ -746,6 +718,21 @@ object Registry {
     "rho:registry:lookup"         -> byteName(17),
     "rho:registry:insertRandom"   -> byteName(18)
   )
+
+  object FixedRefs {
+    val lookupRef: Long               = Runtime.BodyRefs.REG_LOOKUP
+    val lookupCallbackRef: Long       = Runtime.BodyRefs.REG_LOOKUP_CALLBACK
+    val insertRef: Long               = Runtime.BodyRefs.REG_INSERT
+    val deleteRef: Long               = Runtime.BodyRefs.REG_DELETE
+    val insertCallbackRef: Long       = Runtime.BodyRefs.REG_INSERT_CALLBACK
+    val deleteRootCallbackRef: Long   = Runtime.BodyRefs.REG_DELETE_ROOT_CALLBACK
+    val deleteCallbackRef: Long       = Runtime.BodyRefs.REG_DELETE_CALLBACK
+    val publicLookupRef: Long         = Runtime.BodyRefs.REG_PUBLIC_LOOKUP
+    val publicRegisterRandomRef: Long = Runtime.BodyRefs.REG_PUBLIC_REGISTER_RANDOM
+    val publicRegisterInsertCallbackRef: Long =
+      Runtime.BodyRefs.REG_PUBLIC_REGISTER_INSERT_CALLBACK
+
+  }
 
   object CRC14 {
     val INIT_REMAINDER: Short = 0

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -22,8 +22,8 @@ import monix.eval.Task
 
 import scala.collection.immutable
 
-class Runtime private (val reducer: Reduce[Task],
-                       val replayReducer: Reduce[Task],
+class Runtime private (val reducer: ChargingReducer[Task],
+                       val replayReducer: ChargingReducer[Task],
                        val space: RhoISpace,
                        val replaySpace: RhoReplayRSpace,
                        var errorLog: ErrorLog,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -176,10 +176,10 @@ object Runtime {
     lazy val replayDispatchTable: RhoDispatchMap =
       dispatchTableCreator(replaySpace, replayDispatcher)
 
-    lazy val dispatcher: RhoDispatch =
+    lazy val (dispatcher, reducer) =
       RholangAndScalaDispatcher.create(space, dispatchTable, urnMap)
 
-    lazy val replayDispatcher: RhoDispatch =
+    lazy val (replayDispatcher, replayReducer) =
       RholangAndScalaDispatcher.create(replaySpace, replayDispatchTable, urnMap)
 
     val procDefs: immutable.Seq[(Name, Arity, Remainder, Ref)] = {
@@ -202,6 +202,6 @@ object Runtime {
 
     assert(res.forall(_.isEmpty))
 
-    new Runtime(dispatcher.reducer, replayDispatcher.reducer, space, replaySpace, errorLog, context)
+    new Runtime(reducer, replayReducer, space, replaySpace, errorLog, context)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -139,7 +139,7 @@ object Runtime {
 
     def dispatchTableCreator(space: RhoISpace, dispatcher: RhoDispatch): RhoDispatchMap = {
       import BodyRefs._
-      val pureSpace: RhoPureSpace = new PureRSpace(space)
+      val pureSpace: RhoPureSpace = PureRSpace[Task].of(space)
       val registry                = new Registry(pureSpace, dispatcher)
       Map(
         STDOUT                     -> SystemProcesses.stdout,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -137,10 +137,10 @@ object Runtime {
     val errorLog                                  = new ErrorLog()
     implicit val ft: FunctorTell[Task, Throwable] = errorLog
 
-    def dispatchTableCreator(space: RhoISpace, dispatcher: RhoDispatch): RhoDispatchMap = {
+    def dispatchTableCreator(space: RhoISpace,
+                             dispatcher: RhoDispatch,
+                             registry: Registry): RhoDispatchMap = {
       import BodyRefs._
-      val pureSpace: RhoPureSpace = PureRSpace[Task].of(space)
-      val registry                = new Registry(pureSpace, dispatcher)
       Map(
         STDOUT                     -> SystemProcesses.stdout,
         STDOUT_ACK                 -> SystemProcesses.stdoutAck(space, dispatcher),
@@ -171,15 +171,15 @@ object Runtime {
                                        "rho:io:stderrAck" -> byteName(3))
 
     lazy val dispatchTable: RhoDispatchMap =
-      dispatchTableCreator(space, dispatcher)
+      dispatchTableCreator(space, dispatcher, registry)
 
     lazy val replayDispatchTable: RhoDispatchMap =
-      dispatchTableCreator(replaySpace, replayDispatcher)
+      dispatchTableCreator(replaySpace, replayDispatcher, replayRegistry)
 
-    lazy val (dispatcher, reducer) =
+    lazy val (dispatcher, reducer, registry) =
       RholangAndScalaDispatcher.create(space, dispatchTable, urnMap)
 
-    lazy val (replayDispatcher, replayReducer) =
+    lazy val (replayDispatcher, replayReducer, replayRegistry) =
       RholangAndScalaDispatcher.create(replaySpace, replayDispatchTable, urnMap)
 
     val procDefs: immutable.Seq[(Name, Arity, Remainder, Ref)] = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
@@ -10,6 +10,7 @@ trait CostAccountingAlg[F[_]] {
   def charge(cost: Cost): F[Unit]
   def charge(cost: CostAccount): F[Unit]
   def get(): F[CostAccount]
+  def set(cost: CostAccount): F[Unit]
 }
 
 object CostAccountingAlg {
@@ -37,6 +38,10 @@ object CostAccountingAlg {
       } yield ()
 
     override def get: F[CostAccount] = state.get
+
+    override def set(cost: CostAccount): F[Unit] =
+      state.set(cost)
+
     private val failOnOutOfPhlo: F[Unit] =
       FlatMap[F].ifM(state.get.map(_.cost.value < 0))(F.raiseError(OutOfPhlogistonsError), F.unit)
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -2,23 +2,18 @@ package coop.rchain.rholang.interpreter
 
 import cats.Parallel
 import cats.effect.Sync
+import cats.implicits._
 import cats.mtl.FunctorTell
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
 import coop.rchain.models._
-import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount, CostAccountingAlg}
-import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
-import coop.rchain.rspace.{FreudianSpace, ISpace}
-import cats.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rspace.pure.PureRSpace
 
 trait Dispatch[M[_], A, K] {
-
-  val reducer: Reduce[M]
-
   def dispatch(continuation: K, dataList: Seq[A]): M[Unit]
 }
 
@@ -35,10 +30,8 @@ object Dispatch {
         }): _*)
 }
 
-class RholangOnlyDispatcher[M[_]] private (_reducer: => Reduce[M])(implicit s: Sync[M])
+class RholangOnlyDispatcher[M[_]] private (reducer: => Reduce[M])(implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
-
-  val reducer: Reduce[M] = _reducer
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
@@ -69,24 +62,23 @@ object RholangOnlyDispatcher {
       implicit
       parallel: Parallel[M, F],
       s: Sync[M],
-      ft: FunctorTell[M, Throwable]): Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
+      ft: FunctorTell[M, Throwable])
+    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], Reduce[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangOnlyDispatcher(reducer)
     lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)
-    dispatcher
+    (dispatcher, reducer)
   }
 }
 
 class RholangAndScalaDispatcher[M[_]] private (
-    _reducer: => Reduce[M],
+    reducer: => Reduce[M],
     _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
     implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
-
-  val reducer: Reduce[M] = _reducer
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
@@ -120,17 +112,17 @@ object RholangAndScalaDispatcher {
   def create[M[_], F[_]](
       tuplespace: RhoISpace,
       dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]],
-      urnMap: Map[String, Par])(
-      implicit
-      parallel: Parallel[M, F],
-      s: Sync[M],
-      ft: FunctorTell[M, Throwable]): Dispatch[M, ListChannelWithRandom, TaggedContinuation] = {
+      urnMap: Map[String, Par])(implicit
+                                parallel: Parallel[M, F],
+                                s: Sync[M],
+                                ft: FunctorTell[M, Throwable])
+    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], Reduce[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
       new RholangAndScalaDispatcher(reducer, dispatchTable)
     lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)
-    dispatcher
+    (dispatcher, reducer)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -31,24 +31,17 @@ object Dispatch {
         }): _*)
 }
 
-class RholangOnlyDispatcher[M[_]] private (reducer: => Reduce[M])(implicit s: Sync[M])
+class RholangOnlyDispatcher[M[_]] private (reducer: => ChargingReducer[M])(implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
-      costAccountingAlg <- CostAccountingAlg.of(
-                            dataList
-                              .flatMap(_.cost)
-                              .map(CostAccount.fromProto(_))
-                              .toList
-                              .combineAll)
+
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
                 val env     = Dispatch.buildEnv(dataList)
                 val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
-                reducer.eval(parWithRand.body)(env,
-                                               Blake2b512Random.merge(randoms),
-                                               costAccountingAlg)
+                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
               case ScalaBodyRef(_) =>
                 s.unit
               case Empty =>
@@ -64,38 +57,33 @@ object RholangOnlyDispatcher {
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable])
-    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], Reduce[M]) = {
+    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
-      new RholangOnlyDispatcher(reducer)
-    lazy val reducer: Reduce[M] =
+      new RholangOnlyDispatcher(chargingReducer)
+    implicit lazy val costAccounting: CostAccountingAlg[M] =
+      CostAccountingAlg.unsafe[M](CostAccount(0))
+    implicit lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)
-    (dispatcher, reducer)
+    lazy val chargingReducer = new ChargingReducer[M]() {}
+    (dispatcher, chargingReducer)
   }
 }
 
 class RholangAndScalaDispatcher[M[_]] private (
-    reducer: => Reduce[M],
+    reducer: => ChargingReducer[M],
     _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
     implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
-      costAccountingAlg <- CostAccountingAlg.of(
-                            dataList
-                              .flatMap(_.cost)
-                              .map(CostAccount.fromProto(_))
-                              .toList
-                              .combineAll)
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
                 val env     = Dispatch.buildEnv(dataList)
                 val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
-                reducer.eval(parWithRand.body)(env,
-                                               Blake2b512Random.merge(randoms),
-                                               costAccountingAlg)
+                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
               case ScalaBodyRef(ref) =>
                 _dispatchTable.get(ref) match {
                   case Some(f) => f(dataList)
@@ -112,15 +100,22 @@ object RholangAndScalaDispatcher {
 
   def create(tuplespace: RhoISpace,
              dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], Task[Unit]]],
-             urnMap: Map[String, Par])(implicit ft: FunctorTell[Task, Throwable])
-    : (Dispatch[Task, ListChannelWithRandom, TaggedContinuation], Reduce[Task], Registry) = {
+             urnMap: Map[String, Par])(
+      implicit ft: FunctorTell[Task, Throwable]): (Dispatch[Task,
+                                                            ListChannelWithRandom,
+                                                            TaggedContinuation],
+                                                   ChargingReducer[Task],
+                                                   Registry) = {
     val pureSpace          = PureRSpace[Task].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation] =
-      new RholangAndScalaDispatcher(reducer, dispatchTable)
-    lazy val reducer: Reduce[Task] =
+      new RholangAndScalaDispatcher(chargingReducer, dispatchTable)
+    implicit lazy val costAccounting: CostAccountingAlg[Task] =
+      CostAccountingAlg.unsafe[Task](CostAccount(0))
+    implicit lazy val reducer: Reduce[Task] =
       new Reduce.DebruijnInterpreter[Task, Task.Par](tuplespaceAlg, urnMap)
+    lazy val chargingReducer    = new ChargingReducer[Task]() {}
     lazy val registry: Registry = new Registry(pureSpace, dispatcher)
-    (dispatcher, reducer, registry)
+    (dispatcher, chargingReducer, registry)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChannelDataWithCost.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChannelDataWithCost.scala
@@ -1,0 +1,6 @@
+package coop.rchain.rholang.interpreter.storage
+
+import coop.rchain.models.ListChannelWithRandom
+import coop.rchain.rholang.interpreter.accounting.CostAccount
+
+final case class ChannelDataWithCost(dataList: ListChannelWithRandom, cost: CostAccount)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -1,0 +1,88 @@
+package coop.rchain.rholang.interpreter.storage
+import cats.implicits._
+import coop.rchain.models.{BindPattern, Channel, ListChannelWithRandom, TaggedContinuation}
+import coop.rchain.rholang.interpreter.Runtime.RhoPureSpace
+import coop.rchain.rholang.interpreter.accounting.CostAccount._
+import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.errors
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rspace.pure.PureRSpace
+import coop.rchain.rspace.{Blake2b256Hash, Checkpoint, Match}
+import monix.eval.Task
+
+import scala.collection.immutable.Seq
+
+object ChargingRSpace {
+  def pureRSpace(implicit costAlg: CostAccountingAlg[Task], space: RhoPureSpace) =
+    new PureRSpace[Task,
+                   Channel,
+                   BindPattern,
+                   OutOfPhlogistonsError.type,
+                   ListChannelWithRandom,
+                   ListChannelWithRandom,
+                   TaggedContinuation] {
+
+      override def consume(channels: Seq[Channel],
+                           patterns: Seq[BindPattern],
+                           continuation: TaggedContinuation,
+                           persist: Boolean)(implicit m: Match[BindPattern,
+                                                               errors.OutOfPhlogistonsError.type,
+                                                               ListChannelWithRandom,
+                                                               ListChannelWithRandom])
+        : Task[Either[errors.OutOfPhlogistonsError.type,
+                      Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]] =
+        for {
+          //TODO(mateusz.gorski): move charging for the storage from Reduce here
+          //TODO(mateusz.gorski): refund the phlos if the match was found
+          consRes <- space.consume(channels, patterns, continuation, persist)
+          _       <- handleResult(consRes)
+        } yield consRes
+
+      override def install(channels: Seq[Channel],
+                           patterns: Seq[BindPattern],
+                           continuation: TaggedContinuation)(
+          implicit m: Match[BindPattern,
+                            errors.OutOfPhlogistonsError.type,
+                            ListChannelWithRandom,
+                            ListChannelWithRandom])
+        : Task[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
+        space.install(channels, patterns, continuation) // install is free
+
+      override def produce(channel: Channel, data: ListChannelWithRandom, persist: Boolean)(
+          implicit m: Match[BindPattern,
+                            errors.OutOfPhlogistonsError.type,
+                            ListChannelWithRandom,
+                            ListChannelWithRandom])
+        : Task[Either[errors.OutOfPhlogistonsError.type,
+                      Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]] =
+        for {
+          //TODO(mateusz.gorski): move charging for the storage from Reduce here
+          //TODO(mateusz.gorski): refund the phlos if the match was found
+          prodRes <- space.produce(channel, data, persist)
+          _       <- handleResult(prodRes)
+        } yield prodRes
+
+      private def handleResult(
+          result: Either[OutOfPhlogistonsError.type,
+                         Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]): Task[Unit] =
+        result match {
+          case Left(oope) =>
+            // if we run out of phlos during the match we have to zero phlos available
+            costAlg.get().flatMap(costAlg.charge(_)) >> Task.raiseError(oope)
+          case Right(Some((_, dataList))) =>
+            val rspaceMatchCost = dataList
+              .map(_.cost.map(CostAccount.fromProto(_)).getOrElse(CostAccount(0)))
+              .toList
+              .combineAll
+            //                  .map(ca => ca.copy(cost = Cost(Integer.MAX_VALUE) - ca.cost))
+            costAlg.charge(rspaceMatchCost)
+          case Right(None) =>
+            Task.unit
+        }
+
+      override def createCheckpoint(): Task[Checkpoint] =
+        space.createCheckpoint()
+      override def reset(hash: Blake2b256Hash): Task[Unit] = space.reset(hash)
+      override def close(): Task[Unit]                     = space.close()
+    }
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -13,7 +13,7 @@ import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoContext
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace._
@@ -58,10 +58,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "evalExpr" should "handle simple addition" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val addExpr      = EPlus(GInt(7), GInt(8))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(addExpr)
@@ -75,10 +75,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "evalExpr" should "handle long addition" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val addExpr      = EPlus(GInt(Int.MaxValue), GInt(Int.MaxValue))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(addExpr)
@@ -92,10 +92,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "evalExpr" should "leave ground values alone" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val groundExpr   = GInt(7)
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(groundExpr)
@@ -109,10 +109,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "evalExpr" should "handle equality between arbitary processes" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val eqExpr       = EEq(GPrivateBuilder("private_name"), GPrivateBuilder("private_name"))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(eqExpr)
@@ -125,10 +125,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "evalExpr" should "substitute before comparison." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
-      val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val emptyEnv = Env.makeEnv(Par(), Par())
       val eqExpr            = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
       val resultTask        = reducer.evalExpr(eqExpr)
@@ -141,16 +141,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Bundle" should "evaluate contents of bundle" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val bundleSend =
         Bundle(Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet()))
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(bundleSend)(env, splitRand, costAccounting)
+      val resultTask   = interpreter.eval(bundleSend)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -175,8 +175,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "throw an error if names are used against their polarity" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     /* for (n <- @bundle+ { y } ) { }  -> for (n <- y) { }
      */
     val y = GString("y")
@@ -187,7 +186,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val receiveResult = withTestSpace { space =>
       implicit val env = Env[Par]()
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
-      val task         = reducer.eval(receive).map(_ => space.store.toMap)
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
+      val task = reducer.eval(receive).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
     receiveResult should be(HashMap.empty)
@@ -203,7 +203,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val sendResult = withTestSpace { space =>
       implicit val env = Env[Par]()
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
-      val task         = reducer.eval(send).map(_ => space.store.toMap)
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
+      val task = reducer.eval(send).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
     sendResult should be(HashMap.empty)
@@ -213,16 +214,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send" should "place something in the tuplespace." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val send =
         Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(send)(env, splitRand, costAccounting)
+      val resultTask   = interpreter.eval(send)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -247,8 +248,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "verify that Bundle is writeable before sending on Bundle " in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     /* @bundle+ { x } !(7) -> x!(7)
      */
@@ -257,9 +257,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Send(Channel(Quote(Bundle(x, writeFlag = true, readFlag = false))), Seq(Expr(GInt(7))))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
-      val task         = reducer.eval(send)(env, splitRand, costAccounting).map(_ => space.store.toMap)
+      val task         = reducer.eval(send)(env, splitRand).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
 
@@ -275,8 +276,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of single channel Receive" should "place something in the tuplespace." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val receive =
@@ -287,10 +287,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 false,
                 3,
                 BitSet())
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val interpreter  = reducer
       implicit val env = Env[Par]()
-      val resultTask   = interpreter.eval(receive)(env, splitRand, costAccounting)
+      val resultTask   = interpreter.eval(receive)(env, splitRand)
       val inspectTask = for {
         _ <- resultTask
       } yield space.store.toMap
@@ -324,8 +325,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "verify that bundle is readable if receiving on Bundle" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(1)
     /* for (@Nil <- @bundle- { y } ) { }  -> for (n <- y) { }
      */
@@ -339,9 +339,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                           body = Par())
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
-      val task         = reducer.eval(receive)(env, splitRand, costAccounting).map(_ => space.store.toMap)
+      val task         = reducer.eval(receive)(env, splitRand).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
 
@@ -365,8 +366,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send | Receive" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
@@ -383,11 +383,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       BitSet()
     )
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -407,11 +408,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -432,8 +434,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   "eval of Send | Receive" should "when whole list is bound to list remainder, meet in the tuplespace and proceed. (RHOL-422)" in {
     // for(@[...a] <- @"channel") { … } | @"channel"!([7,8,9])
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
@@ -452,11 +453,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
     // format: on
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -476,11 +478,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -500,8 +503,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send on (7 + 8) | Receive on 15" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
@@ -519,11 +521,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
 
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
+        _ <- reducer.eval(send)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -543,11 +546,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -566,8 +570,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send of Receive | Receive" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val baseRand   = rand.splitByte(2)
     val splitRand0 = baseRand.splitByte(0)
     val splitRand1 = baseRand.splitByte(1)
@@ -590,12 +593,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
 
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val interpreter  = reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- interpreter.eval(send)(env, splitRand0, costAccounting)
-        _ <- interpreter.eval(receive)(env, splitRand1, costAccounting)
+        _ <- interpreter.eval(send)(env, splitRand0)
+        _ <- interpreter.eval(receive)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -621,11 +625,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -646,12 +651,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val bothResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env,
-                                                                           baseRand,
-                                                                           costAccounting)
+        _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env, baseRand)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -674,8 +678,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Simple match" should "capture and add to the environment." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
       val pattern = Send(ChanVar(FreeVar(0)), List(GInt(7), EVar(FreeVar(1))), false, BitSet())
@@ -697,7 +700,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       )
       implicit val env = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
-      val matchTask    = reducer.eval(matchTerm)(env, splitRand, costAccounting)
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
+      val matchTask = reducer.eval(matchTerm)(env, splitRand)
       val inspectTask = for {
         _ <- matchTask
       } yield space.store.toMap
@@ -725,8 +729,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send | Send | Receive join" should "meet in the tuplespace and proceed." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val splitRand2 = rand.splitByte(2)
@@ -750,12 +753,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       BitSet()
     )
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
-        _ <- reducer.eval(send1)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(send2)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(receive)(env, splitRand2, costAccounting)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(send2)(env, splitRand1)
+        _ <- reducer.eval(receive)(env, splitRand2)
       } yield space.store.toMap
       Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
     }
@@ -775,12 +779,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
-        _ <- reducer.eval(receive)(env, splitRand2, costAccounting)
-        _ <- reducer.eval(send1)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(send2)(env, splitRand1, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand2)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(send2)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -797,12 +802,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val interleavedResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val inspectTaskInterleaved = for {
-        _ <- reducer.eval(send1)(env, splitRand0, costAccounting)
-        _ <- reducer.eval(receive)(env, splitRand2, costAccounting)
-        _ <- reducer.eval(send2)(env, splitRand1, costAccounting)
+        _ <- reducer.eval(send1)(env, splitRand0)
+        _ <- reducer.eval(receive)(env, splitRand2)
+        _ <- reducer.eval(send2)(env, splitRand1)
       } yield space.store.toMap
       Await.result(inspectTaskInterleaved.runAsync, 3.seconds)
     }
@@ -821,8 +827,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of Send with remainder receive" should "capture the remainder." in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
@@ -833,11 +838,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               Send(Quote(GString("result")), Seq(EVar(BoundVar(0)))))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val task = for {
-        _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
-        _ <- reducer.eval(send)(env, splitRand0, costAccounting)
+        _ <- reducer.eval(receive)(env, splitRand1)
+        _ <- reducer.eval(send)(env, splitRand0)
       } yield space.store.toMap
       Await.result(task.runAsync, 3.seconds)
     }
@@ -861,8 +867,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of nth method" should "pick out the nth item from a list" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val nthCall: Expr =
       EMethod("nth", EList(List(GInt(7), GInt(8), GInt(9), GInt(10))), List[Par](GInt(2)))
@@ -870,6 +875,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val env = Env[Par]()
       val reducer =
         RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       Await.result(reducer.evalExprToPar(nthCall).runAsync, 3.seconds)
     }
     val expectedResult: Par = GInt(9)
@@ -884,9 +890,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                      GInt(10))),
               List[Par](GInt(1)))
     val indirectResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
-      val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand, costAccounting)
+      val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand)
       val inspectTask = for {
         _ <- nthTask
       } yield space.store.toMap
@@ -910,8 +917,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of New" should "use deterministic names and provide urn-based resources" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand   = rand.splitByte(42)
     val resultRand  = rand.splitByte(42)
     val chosenName  = resultRand.next
@@ -935,8 +941,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       val reducer = RholangOnlyDispatcher
         .create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42)))
         ._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
-      val nthTask      = reducer.eval(newProc)(env, splitRand, costAccounting)
+      val nthTask      = reducer.eval(newProc)(env, splitRand)
       val inspectTask = for {
         _ <- nthTask
       } yield space.store.toMap
@@ -970,8 +977,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   // format: on
   "eval of nth method in send position" should "change what is sent" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val nthCallEvalToSend: Expr =
       EMethod("nth",
@@ -984,9 +990,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val send: Par =
       Send(Quote(GString("result")), List[Par](nthCallEvalToSend), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
-      val nthTask      = reducer.eval(send)(env, splitRand, costAccounting)
+      val nthTask      = reducer.eval(send)(env, splitRand)
       val inspectTask = for {
         _ <- nthTask
       } yield space.store.toMap
@@ -1015,8 +1022,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of a method" should "substitute target before evaluating" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val hexToBytesCall: Expr =
       EMethod("hexToBytes", Expr(EVarBody(EVar(Var(BoundVar(0))))))
@@ -1024,6 +1030,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
       val reducer =
         RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       Await.result(reducer.evalExprToPar(hexToBytesCall).runAsync, 3.seconds)
     }
     val expectedResult: Par = Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))
@@ -1034,8 +1041,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "eval of `toByteArray` method on any process" should "return that process serialized" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     import coop.rchain.models.serialization.implicits._
     val proc = Receive(Seq(ReceiveBind(Seq(ChanVar(FreeVar(0))), Quote(GString("channel")))),
@@ -1048,9 +1054,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env[Par]()
-      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1073,8 +1080,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "substitute before serialization" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand = rand.splitByte(0)
     val unsubProc: Par =
       New(bindCount = 1, p = EVar(BoundVar(1)), locallyFree = BitSet(0))
@@ -1086,9 +1092,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     def wrapWithSend(p: Par): Par = Send(channel, List[Par](p), false, p.locallyFree)
 
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
-      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1108,8 +1115,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "return an error when `toByteArray` is called with arguments" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val toByteArrayWithArgumentsCall: EMethod =
       EMethod(
         "toByteArray",
@@ -1117,7 +1123,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List[Par](GInt(1)))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(toByteArrayWithArgumentsCall)
       val inspectTask = for {
@@ -1133,8 +1140,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
     import coop.rchain.models.serialization.implicits._
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val splitRand                 = rand.splitByte(0)
     val testString                = "testing testing"
     val base16Repr                = Base16.encode(testString.getBytes)
@@ -1142,9 +1148,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env[Par]()
-      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
+      val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1168,8 +1175,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "variable references" should "be substituted before being used." in {
     implicit val errorLog = new ErrorLog()
-    val splitRandResult   = rand.splitByte(3)
-    val splitRandSrc      = rand.splitByte(3)
+
+    val splitRandResult = rand.splitByte(3)
+    val splitRandSrc    = rand.splitByte(3)
     splitRandResult.next()
     val mergeRand =
       Blake2b512Random.merge(Seq(splitRandResult.splitByte(1), splitRandResult.splitByte(0)))
@@ -1194,11 +1202,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val result = withTestSpace { space =>
       implicit val errorLog = new ErrorLog()
-      implicit val costAccounting =
-        CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env[Par]()
-      val task        = reducer.eval(proc)(env, splitRandSrc, costAccounting)
+      val task        = reducer.eval(proc)(env, splitRandSrc)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1221,8 +1229,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "be substituted before being used in a match." in {
     implicit val errorLog = new ErrorLog()
-    val splitRandResult   = rand.splitByte(4)
-    val splitRandSrc      = rand.splitByte(4)
+
+    val splitRandResult = rand.splitByte(4)
+    val splitRandSrc    = rand.splitByte(4)
     splitRandResult.next()
     val proc = New(
       bindCount = 1,
@@ -1236,11 +1245,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val result = withTestSpace { space =>
       implicit val errorLog = new ErrorLog()
-      implicit val costAccounting =
-        CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env[Par]()
-      val task        = reducer.eval(proc)(env, splitRandSrc, costAccounting)
+      val task        = reducer.eval(proc)(env, splitRandSrc)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1263,10 +1272,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   it should "reference a variable that comes from a match in tuplespace" in {
     implicit val errorLog = new ErrorLog()
-    val baseRand          = rand.splitByte(7)
-    val splitRand0        = baseRand.splitByte(0)
-    val splitRand1        = baseRand.splitByte(1)
-    val mergeRand         = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
+
+    val baseRand   = rand.splitByte(7)
+    val splitRand0 = baseRand.splitByte(0)
+    val splitRand1 = baseRand.splitByte(1)
+    val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val proc = Par(
       sends = List(Send(chan = Quote(GInt(7)), data = List(GInt(10)))),
       receives = List(
@@ -1291,11 +1301,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val result = withTestSpace { space =>
       implicit val errorLog = new ErrorLog()
-      implicit val costAccounting =
-        CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
       val env         = Env[Par]()
-      val task        = reducer.eval(proc)(env, baseRand, costAccounting)
+      val task        = reducer.eval(proc)(env, baseRand)
       val inspectTask = for { _ <- task } yield space.store.toMap
       Await.result(inspectTask.runAsync, 3.seconds)
     }
@@ -1318,11 +1328,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "1 matches 1" should "return true" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), GInt(1)))
 
@@ -1335,11 +1345,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "1 matches 0" should "return false" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), GInt(0)))
 
@@ -1352,11 +1362,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "1 matches _" should "return true" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
       val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), EVar(Wildcard(Var.WildcardMsg()))))
 
@@ -1369,12 +1379,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "x matches 1" should "return true when x is bound to 1" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par](GInt(1))
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMatches(EVar(BoundVar(0)), GInt(1)))
 
@@ -1387,12 +1397,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "1 matches =x" should "return true when x is bound to 1" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par](GInt(1))
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), Connective(VarRefBody(VarRef(0, 1)))))
 
@@ -1405,12 +1415,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "'abc'.length()" should "return the length of the string" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(EMethodBody(EMethod("length", GString("abc"))))
 
@@ -1422,12 +1432,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "'abcabac'.slice(3, 6)" should "return 'aba'" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(3), GInt(6))))
@@ -1441,12 +1451,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "'Hello, ${name}!' % {'name': 'Alice'}" should "return 'Hello, Alice!" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(
         EPercentPercentBody(
@@ -1465,12 +1475,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "'abc' ++ 'def'" should "return 'abcdef" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(
         EPlusPlusBody(
@@ -1489,12 +1499,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "'${a} ${b}' % {'a': '1 ${b}', 'b': '2 ${a}'" should "return '1 ${b} 2 ${a}" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val inspectTask = reducer.evalExpr(
         EPercentPercentBody(
@@ -1519,12 +1529,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "[0, 1, 2, 3].length()" should "return the length of the list" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val list        = EList(List(GInt(0), GInt(1), GInt(2), GInt(3)))
       val inspectTask = reducer.evalExpr(EMethodBody(EMethod("length", list)))
@@ -1537,12 +1547,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "[3, 7, 2, 9, 4, 3, 7].slice(3, 5)" should "return [9, 4]" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val list = EList(List(GInt(3), GInt(7), GInt(2), GInt(9), GInt(4), GInt(3), GInt(7)))
       val inspectTask = reducer.evalExpr(
@@ -1557,12 +1567,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "[3, 2, 9] ++ [6, 1, 7]" should "return [3, 2, 9, 6, 1, 7]" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val lhsList = EList(List(GInt(3), GInt(2), GInt(9)))
       val rhsList = EList(List(GInt(6), GInt(1), GInt(7)))
@@ -1584,12 +1594,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'}.getOrElse(1, 'c')" should "return 'a'" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1604,12 +1614,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'}.getOrElse(3, 'c')" should "return 'c'" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1624,12 +1634,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'}.set(3, 'c')" should "return {1: 'a', 2: 'b', 3: 'c'}" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1646,12 +1656,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'}.set(2, 'c')" should "return {1: 'a', 2: 'c'}" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1668,12 +1678,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b', 3: 'c'}.keys()" should "return Set(1, 2, 3)" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(
         ParMap(
@@ -1696,12 +1706,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b', 3: 'c'}.size()" should "return 3" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(
         ParMap(
@@ -1720,12 +1730,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2, 3).size()" should "return 3" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.evalExpr(
@@ -1740,12 +1750,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2) + 3" should "return Set(1, 2, 3)" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
       val inspectTask = reducer.evalExpr(
@@ -1761,12 +1771,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b', 3: 'c'} - 3" should "return {1: 'a', 2: 'b'}" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map = EMapBody(
         ParMap(
@@ -1787,12 +1797,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2, 3) - 3" should "return Set(1, 2)" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.evalExpr(
@@ -1808,12 +1818,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2) ++ Set(3, 4)" should "return Set(1, 2, 3, 4)" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val lhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
       val rhsSet = ESetBody(ParSet(List[Par](GInt(3), GInt(4))))
@@ -1830,12 +1840,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'} ++ {3: 'c', 4: 'd'}" should "return union" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val lhsMap =
         EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
@@ -1861,12 +1871,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2, 3, 4) -- Set(1, 2)" should "return Set(3, 4)" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val lhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3), GInt(4))))
       val rhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
@@ -1883,12 +1893,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "Set(1, 2, 3).get(1)" should "not work" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val set         = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.eval(EMethodBody(EMethod("get", set, List(GInt(1)))))
@@ -1902,12 +1912,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   "{1: 'a', 2: 'b'}.add(1)" should "not work" in {
     implicit val errorLog = new ErrorLog()
-    implicit val costAccounting =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+
     withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
       val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+      Await.ready(reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
 
       val map         = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1)))))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -61,7 +61,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val addExpr      = EPlus(GInt(7), GInt(8))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(addExpr)
@@ -78,7 +78,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val addExpr      = EPlus(GInt(Int.MaxValue), GInt(Int.MaxValue))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(addExpr)
@@ -95,7 +95,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val groundExpr   = GInt(7)
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(groundExpr)
@@ -112,7 +112,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val eqExpr       = EEq(GPrivateBuilder("private_name"), GPrivateBuilder("private_name"))
       implicit val env = Env[Par]()
       val resultTask   = reducer.evalExpr(eqExpr)
@@ -128,7 +128,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     implicit val costAccounting =
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
-      val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer           = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val emptyEnv = Env.makeEnv(Par(), Par())
       val eqExpr            = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
       val resultTask        = reducer.evalExpr(eqExpr)
@@ -145,7 +145,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val bundleSend =
         Bundle(Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet()))
       val interpreter  = reducer
@@ -186,7 +186,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val receiveResult = withTestSpace { space =>
       implicit val env = Env[Par]()
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val task         = reducer.eval(receive).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
@@ -202,7 +202,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val sendResult = withTestSpace { space =>
       implicit val env = Env[Par]()
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val task         = reducer.eval(send).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
     }
@@ -217,7 +217,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val splitRand = rand.splitByte(0)
     val result = withTestSpace { space =>
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val send =
         Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
       val interpreter  = reducer
@@ -257,7 +257,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Send(Channel(Quote(Bundle(x, writeFlag = true, readFlag = false))), Seq(Expr(GInt(7))))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val task         = reducer.eval(send)(env, splitRand, costAccounting).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
@@ -287,7 +287,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 false,
                 3,
                 BitSet())
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val interpreter  = reducer
       implicit val env = Env[Par]()
       val resultTask   = interpreter.eval(receive)(env, splitRand, costAccounting)
@@ -339,7 +339,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                           body = Par())
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val task         = reducer.eval(receive)(env, splitRand, costAccounting).map(_ => space.store.toMap)
       Await.result(task.runAsync, 3.seconds)
@@ -383,7 +383,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       BitSet()
     )
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
         _ <- reducer.eval(send)(env, splitRand0, costAccounting)
@@ -407,7 +407,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
@@ -452,7 +452,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
     // format: on
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
         _ <- reducer.eval(send)(env, splitRand0, costAccounting)
@@ -476,7 +476,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
@@ -519,7 +519,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
 
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
         _ <- reducer.eval(send)(env, splitRand0, costAccounting)
@@ -543,7 +543,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
@@ -590,7 +590,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
 
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val interpreter  = reducer
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
@@ -621,7 +621,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
@@ -646,7 +646,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val bothResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env,
@@ -696,7 +696,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         BitSet()
       )
       implicit val env = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val matchTask    = reducer.eval(matchTerm)(env, splitRand, costAccounting)
       val inspectTask = for {
         _ <- matchTask
@@ -750,7 +750,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       BitSet()
     )
     val sendFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskSendFirst = for {
         _ <- reducer.eval(send1)(env, splitRand0, costAccounting)
@@ -775,7 +775,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val receiveFirstResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskReceiveFirst = for {
         _ <- reducer.eval(receive)(env, splitRand2, costAccounting)
@@ -797,7 +797,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
 
     val interleavedResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val inspectTaskInterleaved = for {
         _ <- reducer.eval(send1)(env, splitRand0, costAccounting)
@@ -833,7 +833,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               Send(Quote(GString("result")), Seq(EVar(BoundVar(0)))))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val task = for {
         _ <- reducer.eval(receive)(env, splitRand1, costAccounting)
@@ -869,7 +869,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val directResult: Par = withTestSpace { space =>
       implicit val env = Env[Par]()
       val reducer =
-        RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+        RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       Await.result(reducer.evalExprToPar(nthCall).runAsync, 3.seconds)
     }
     val expectedResult: Par = GInt(9)
@@ -884,7 +884,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                      GInt(10))),
               List[Par](GInt(1)))
     val indirectResult = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(nthCallEvalToSend)(env, splitRand, costAccounting)
       val inspectTask = for {
@@ -934,7 +934,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
       val reducer = RholangOnlyDispatcher
         .create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42)))
-        .reducer
+        ._2
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(newProc)(env, splitRand, costAccounting)
       val inspectTask = for {
@@ -984,7 +984,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val send: Par =
       Send(Quote(GString("result")), List[Par](nthCallEvalToSend), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(send)(env, splitRand, costAccounting)
       val inspectTask = for {
@@ -1023,7 +1023,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val directResult: Par = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
       val reducer =
-        RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+        RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       Await.result(reducer.evalExprToPar(hexToBytesCall).runAsync, 3.seconds)
     }
     val expectedResult: Par = Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))
@@ -1048,7 +1048,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env[Par]()
       val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1086,7 +1086,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     def wrapWithSend(p: Par): Par = Send(channel, List[Par](p), false, p.locallyFree)
 
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
       val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1117,7 +1117,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List[Par](GInt(1)))
 
     val result = withTestSpace { space =>
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       implicit val env = Env[Par]()
       val nthTask      = reducer.eval(toByteArrayWithArgumentsCall)
       val inspectTask = for {
@@ -1142,7 +1142,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
     def wrapWithSend(p: Par): Par = Send(Quote(GString("result")), List[Par](p), false, BitSet())
     val result = withTestSpace { space =>
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env[Par]()
       val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1196,7 +1196,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new ErrorLog()
       implicit val costAccounting =
         CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env[Par]()
       val task        = reducer.eval(proc)(env, splitRandSrc, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1238,7 +1238,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new ErrorLog()
       implicit val costAccounting =
         CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env[Par]()
       val task        = reducer.eval(proc)(env, splitRandSrc, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1293,7 +1293,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       implicit val errorLog = new ErrorLog()
       implicit val costAccounting =
         CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer     = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       val env         = Env[Par]()
       val task        = reducer.eval(proc)(env, baseRand, costAccounting)
       val inspectTask = for { _ <- task } yield space.store.toMap
@@ -1322,7 +1322,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), GInt(1)))
 
@@ -1339,7 +1339,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), GInt(0)))
 
@@ -1356,7 +1356,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
-      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer      = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), EVar(Wildcard(Var.WildcardMsg()))))
 
@@ -1374,7 +1374,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par](GInt(1))
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMatches(EVar(BoundVar(0)), GInt(1)))
 
@@ -1392,7 +1392,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par](GInt(1))
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMatches(GInt(1), Connective(VarRefBody(VarRef(0, 1)))))
 
@@ -1410,7 +1410,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(EMethodBody(EMethod("length", GString("abc"))))
 
@@ -1427,7 +1427,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(
         EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(3), GInt(6))))
@@ -1446,7 +1446,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(
         EPercentPercentBody(
@@ -1470,7 +1470,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(
         EPlusPlusBody(
@@ -1494,7 +1494,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val inspectTask = reducer.evalExpr(
         EPercentPercentBody(
@@ -1524,7 +1524,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val list        = EList(List(GInt(0), GInt(1), GInt(2), GInt(3)))
       val inspectTask = reducer.evalExpr(EMethodBody(EMethod("length", list)))
@@ -1542,7 +1542,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val list = EList(List(GInt(3), GInt(7), GInt(2), GInt(9), GInt(4), GInt(3), GInt(7)))
       val inspectTask = reducer.evalExpr(
@@ -1562,7 +1562,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val lhsList = EList(List(GInt(3), GInt(2), GInt(9)))
       val rhsList = EList(List(GInt(6), GInt(1), GInt(7)))
@@ -1589,7 +1589,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1609,7 +1609,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1629,7 +1629,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1651,7 +1651,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.evalExpr(
@@ -1673,7 +1673,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(
         ParMap(
@@ -1701,7 +1701,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(
         ParMap(
@@ -1725,7 +1725,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.evalExpr(
@@ -1745,7 +1745,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
       val inspectTask = reducer.evalExpr(
@@ -1766,7 +1766,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map = EMapBody(
         ParMap(
@@ -1792,7 +1792,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val set = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.evalExpr(
@@ -1813,7 +1813,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val lhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
       val rhsSet = ESetBody(ParSet(List[Par](GInt(3), GInt(4))))
@@ -1835,7 +1835,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val lhsMap =
         EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
@@ -1866,7 +1866,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val lhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3), GInt(4))))
       val rhsSet = ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
@@ -1888,7 +1888,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val set         = ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3))))
       val inspectTask = reducer.eval(EMethodBody(EMethod("get", set, List(GInt(1)))))
@@ -1907,7 +1907,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     withTestSpace { space =>
       implicit val env = Env.makeEnv[Par]()
 
-      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space).reducer
+      val reducer = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
 
       val map         = EMapBody(ParMap(List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")))))
       val inspectTask = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1)))))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -35,7 +35,7 @@ trait RegistryTester extends PersistentStoreTester {
                         TaggedContinuation]) => R
   ): R =
     withTestSpace { space =>
-      val pureSpace: Runtime.RhoPureSpace = new PureRSpace(space)
+      val pureSpace: Runtime.RhoPureSpace = PureRSpace[Task].of(space)
       lazy val registry: Registry         = new Registry(pureSpace, dispatcher)
       lazy val dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation] =
         RholangAndScalaDispatcher

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
@@ -27,7 +27,7 @@ class EvalBench {
   def createTest(state: EvalBenchStateBase): Task[Vector[Throwable]] = {
     val par = state.term.getOrElse(throw new Error("Failed to prepare executable rholang term"))
     state.runtime.reducer
-      .inj(par)(state.rand, state.costAccountAlg)
+      .inj(par)(state.rand)
       .map(_ => state.runtime.readAndClearErrorVector())
   }
 

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
@@ -2,19 +2,19 @@ package coop.rchain.rspace.bench
 import java.io.{FileNotFoundException, InputStreamReader}
 import java.nio.file.{Files, Path}
 
+import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import coop.rchain.rspace.bench.WideBench.WideBenchState
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-import coop.rchain.catscontrib.TaskContrib._
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, _}
 
 class WideBench {
 
@@ -43,8 +43,7 @@ object WideBench {
 
     lazy val runtime: Runtime  = Runtime.create(dbDir, mapSize)
     def rand: Blake2b512Random = Blake2b512Random(128)
-    val costAccountAlg: CostAccountingAlg[Task] =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+    Await.ready(runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runAsync, 1.second)
     var setupTerm: Option[Par] = None
     var term: Option[Par]      = None
 
@@ -89,7 +88,7 @@ object WideEvalBenchState {
   def createTest(t: Option[Par], state: WideBenchState): Task[Vector[Throwable]] = {
     val par = t.getOrElse(throw new Error("Failed to prepare executable rholang term"))
     state.runtime.reducer
-      .inj(par)(state.rand, state.costAccountAlg)
+      .inj(par)(state.rand)
       .map(_ => state.runtime.readAndClearErrorVector())
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -5,32 +5,47 @@ import coop.rchain.rspace._
 
 import scala.collection.immutable.Seq
 
-class PureRSpace[F[_]: Sync, C, P, E, A, R, K](space: FreudianSpace[C, P, E, A, R, K]) {
-
+trait PureRSpace[F[_], C, P, E, A, R, K] {
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
-    Sync[F].delay(space.consume(channels, patterns, continuation, persist))
+      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]] =
-    Sync[F].delay(space.install(channels, patterns, continuation))
+      implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]]
 
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
-    Sync[F].delay(space.produce(channel, data, persist))
+      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
 
-  def createCheckpoint(): F[Checkpoint] = Sync[F].delay(space.createCheckpoint())
+  def createCheckpoint(): F[Checkpoint]
 
-  def reset(hash: Blake2b256Hash): F[Unit] = Sync[F].delay(space.reset(hash))
+  def reset(hash: Blake2b256Hash): F[Unit]
 
-  def close(): F[Unit] = Sync[F].delay(space.close())
+  def close(): F[Unit]
 }
 
 object PureRSpace {
   def apply[F[_]](implicit F: Sync[F]): PureRSpaceApplyBuilders[F] = new PureRSpaceApplyBuilders(F)
 
   final class PureRSpaceApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
-    def of[C, P, E, A, R, K](space: FreudianSpace[C, P, E, A, R, K]) =
-      new PureRSpace[F, C, P, E, A, R, K](space)(F)
+    def of[C, P, E, A, R, K](
+        space: FreudianSpace[C, P, E, A, R, K]): PureRSpace[F, C, P, E, A, R, K] =
+      new PureRSpace[F, C, P, E, A, R, K] {
+        def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
+            implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
+          F.delay(space.consume(channels, patterns, continuation, persist))
+
+        def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
+            implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]] =
+          F.delay(space.install(channels, patterns, continuation))
+
+        def produce(channel: C, data: A, persist: Boolean)(
+            implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
+          F.delay(space.produce(channel, data, persist))
+
+        def createCheckpoint(): F[Checkpoint] = F.delay(space.createCheckpoint())
+
+        def reset(hash: Blake2b256Hash): F[Unit] = F.delay(space.reset(hash))
+
+        def close(): F[Unit] = F.delay(space.close())
+      }
   }
 }


### PR DESCRIPTION
## Overview
Relative to #1504 (review it first).
This PR introduced `ChargingReducer` that wraps `DebruijInterpreter` and `CostAccounting`.
This is necessary for proper sharing of the cost state between different parts of the interpreter (specifically dispatcher and reducer).

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
