### PR TITLE
Bump scalafmt, fix 'scalafmt exploded' errors, change parens formatting

### DIFF
--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -32,7 +32,8 @@ trait BlockStoreTest
 
   private[this] implicit def liftToBlockHash(s: String): BlockHash = ByteString.copyFromUtf8(s)
   private[this] implicit def liftToBlockStoreElement(
-      s: (String, BlockMessage)): (BlockHash, BlockMessage) =
+      s: (String, BlockMessage)
+  ): (BlockHash, BlockMessage) =
     (ByteString.copyFromUtf8(s._1), s._2)
 
   private[this] val blockHashGen: Gen[BlockHash] = for {
@@ -47,9 +48,11 @@ trait BlockStoreTest
       version   <- arbitrary[Long]
       timestamp <- arbitrary[Long]
     } yield
-      (hash.toStringUtf8,
-       BlockMessage(blockHash = hash)
-         .withHeader(Header().withVersion(version).withTimestamp(timestamp)))
+      (
+        hash.toStringUtf8,
+        BlockMessage(blockHash = hash)
+          .withHeader(Header().withVersion(version).withTimestamp(timestamp))
+      )
 
   private[this] val blockStoreElementsGen: Gen[List[(String, BlockMessage)]] =
     distinctListOfGen(blockStoreElementGen)(_._1 == _._1)
@@ -70,7 +73,8 @@ trait BlockStoreTest
    with a maximum number of elements to discard
     */
   def distinctListOfGen[T](gen: Gen[T], maxDiscarded: Int = 1000)(
-      comp: (T, T) => Boolean): Gen[List[T]] = {
+      comp: (T, T) => Boolean
+  ): Gen[List[T]] = {
     val seen      = new scala.collection.mutable.ListBuffer[T]
     var discarded = 0
 

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -10,11 +10,12 @@ import coop.rchain.metrics.Metrics
 
 import scala.language.higherKinds
 
-class InMemBlockStore[F[_]] private ()(implicit
-                                       monadF: Monad[F],
-                                       refF: Ref[F, Map[BlockHash, BlockMessage]],
-                                       metricsF: Metrics[F])
-    extends BlockStore[F] {
+class InMemBlockStore[F[_]] private ()(
+    implicit
+    monadF: Monad[F],
+    refF: Ref[F, Map[BlockHash, BlockMessage]],
+    metricsF: Metrics[F]
+) extends BlockStore[F] {
 
   def get(blockHash: BlockHash): F[Option[BlockMessage]] =
     for {
@@ -22,8 +23,10 @@ class InMemBlockStore[F[_]] private ()(implicit
       state <- refF.get
     } yield state.get(blockHash)
 
-  @deprecated(message = "to be removed when casper code no longer needs the whole DB in memmory",
-              since = "0.5")
+  @deprecated(
+    message = "to be removed when casper code no longer needs the whole DB in memmory",
+    since = "0.5"
+  )
   def asMap(): F[Map[BlockHash, BlockMessage]] =
     for {
       _     <- metricsF.incrementCounter("block-store-as-map")
@@ -54,10 +57,12 @@ class InMemBlockStore[F[_]] private ()(implicit
 }
 
 object InMemBlockStore {
-  def create[F[_]](implicit
-                   monadF: Monad[F],
-                   refF: Ref[F, Map[BlockHash, BlockMessage]],
-                   metricsF: Metrics[F]): BlockStore[F] =
+  def create[F[_]](
+      implicit
+      monadF: Monad[F],
+      refF: Ref[F, Map[BlockHash, BlockMessage]],
+      metricsF: Metrics[F]
+  ): BlockStore[F] =
     new InMemBlockStore()
 
   def createWithId: BlockStore[Id] = {

--- a/casper/src/main/scala/coop/rchain/casper/BlockDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockDag.scala
@@ -19,13 +19,15 @@ import scala.collection.immutable.{HashMap, HashSet}
  *              to remember the sorting before that block. The offset gives the block
  *              number for the first block in the currently maintained sorting.
  */
-final case class BlockDag(childMap: Map[BlockHash, Set[BlockHash]],
-                          latestMessages: Map[Validator, BlockMessage],
-                          latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
-                          currentSeqNum: Map[Validator, Int],
-                          dataLookup: BlockMetadata.Lookup,
-                          topoSort: Vector[Vector[BlockHash]],
-                          sortOffset: Long)
+final case class BlockDag(
+    childMap: Map[BlockHash, Set[BlockHash]],
+    latestMessages: Map[Validator, BlockMessage],
+    latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
+    currentSeqNum: Map[Validator, Int],
+    dataLookup: BlockMetadata.Lookup,
+    topoSort: Vector[Vector[BlockHash]],
+    sortOffset: Long
+)
 
 object BlockDag {
   type LatestMessages = Map[Validator, BlockHash]

--- a/casper/src/main/scala/coop/rchain/casper/BlockMetadata.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockMetadata.scala
@@ -5,10 +5,12 @@ import com.google.protobuf.ByteString
 import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.protocol.{BlockMessage, Justification}
 
-final case class BlockMetadata(blockHash: BlockHash,
-                               parents: List[BlockHash],
-                               sender: ByteString,
-                               justifications: List[Justification])
+final case class BlockMetadata(
+    blockHash: BlockHash,
+    parents: List[BlockHash],
+    sender: ByteString,
+    justifications: List[Justification]
+)
 
 object BlockMetadata {
   type Lookup = Map[BlockHash, BlockMetadata]

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -61,39 +61,45 @@ sealed abstract class MultiParentCasperInstances {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  def hashSetCasper[
-      F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk](
+  def hashSetCasper[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk](
       runtimeManager: RuntimeManager,
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
-      shardId: String)(implicit scheduler: Scheduler): F[MultiParentCasper[F]] = {
+      shardId: String
+  )(implicit scheduler: Scheduler): F[MultiParentCasper[F]] = {
     val genesisBonds          = ProtoUtil.bonds(genesis)
     val initialLatestMessages = genesisBonds.map(_.validator -> genesis).toMap
     val dag = BlockDag.empty
-      .copy(latestMessages = initialLatestMessages,
-            dataLookup = Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
-            topoSort = Vector(Vector(genesis.blockHash)))
+      .copy(
+        latestMessages = initialLatestMessages,
+        dataLookup = Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
+        topoSort = Vector(Vector(genesis.blockHash))
+      )
     for {
       validateBlockCheckpointResult <- InterpreterUtil
                                         .validateBlockCheckpoint[F](
                                           genesis,
                                           dag,
                                           Set[StateHash](runtimeManager.emptyStateHash),
-                                          runtimeManager)
+                                          runtimeManager
+                                        )
       (maybePostGenesisStateHash, _) = validateBlockCheckpointResult
       postGenesisStateHash <- maybePostGenesisStateHash match {
                                case Left(BlockException(ex)) => Sync[F].raiseError[StateHash](ex)
                                case Right(None) =>
                                  Sync[F].raiseError[StateHash](
-                                   new Exception("Genesis tuplespace validation failed!"))
+                                   new Exception("Genesis tuplespace validation failed!")
+                                 )
                                case Right(Some(hash)) => hash.pure[F]
                              }
     } yield
-      new MultiParentCasperImpl[F](runtimeManager,
-                                   validatorId,
-                                   genesis,
-                                   dag,
-                                   postGenesisStateHash,
-                                   shardId)
+      new MultiParentCasperImpl[F](
+        runtimeManager,
+        validatorId,
+        genesis,
+        dag,
+        postGenesisStateHash,
+        shardId
+      )
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -39,7 +39,8 @@ object CasperConf {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def parseValidatorsFile[F[_]: Monad: Capture: Log](
-      knownValidatorsFile: Option[String]): F[Set[ByteString]] =
+      knownValidatorsFile: Option[String]
+  ): F[Set[ByteString]] =
     knownValidatorsFile match {
       //TODO: Add default set? Throw error?
       case None => Set.empty[ByteString].pure[F]
@@ -52,7 +53,8 @@ object CasperConf {
                 .fromFile(file)
                 .getLines()
                 .map(line => ByteString.copyFrom(Base16.decode(line)))
-                .toSet)
+                .toSet
+            )
           }
           .flatMap {
             case Success(validators) => validators.pure[F]
@@ -64,9 +66,11 @@ object CasperConf {
           }
     }
 
-  def publicKey(givenPublicKey: Option[Array[Byte]],
-                sigAlgorithm: String,
-                privateKey: Array[Byte]): Array[Byte] = {
+  def publicKey(
+      givenPublicKey: Option[Array[Byte]],
+      sigAlgorithm: String,
+      privateKey: Array[Byte]
+  ): Array[Byte] = {
 
     val maybeInferred = sigAlgorithm match {
       case "ed25519" =>

--- a/casper/src/main/scala/coop/rchain/casper/LastApprovedBlock.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastApprovedBlock.scala
@@ -19,7 +19,8 @@ object LastApprovedBlock extends LastApprovedBlockInstances {
     MaybeCell.unsafe[F, ApprovedBlock](init)
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: LastApprovedBlock[F]): LastApprovedBlock[T[F, ?]] =
+      implicit C: LastApprovedBlock[F]
+  ): LastApprovedBlock[T[F, ?]] =
     new MaybeCell[T[F, ?], ApprovedBlock] {
       override def get: T[F, Option[ApprovedBlock]] =
         C.get.liftM[T]

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -26,14 +26,14 @@ import coop.rchain.catscontrib.TaskContrib._
 import scala.collection.immutable.HashSet
 import scala.collection.mutable
 
-class MultiParentCasperImpl[
-    F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk](
+class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk](
     runtimeManager: RuntimeManager,
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,
     initialDag: BlockDag,
     postGenesisStateHash: StateHash,
-    shardId: String)(implicit scheduler: Scheduler)
+    shardId: String
+)(implicit scheduler: Scheduler)
     extends MultiParentCasper[F] {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
@@ -91,15 +91,19 @@ class MultiParentCasperImpl[
                  case Right((_, false)) =>
                    Log[F]
                      .info(
-                       s"Block ${PrettyPrinter.buildString(b.blockHash)} is already being processed by another thread.")
+                       s"Block ${PrettyPrinter.buildString(b.blockHash)} is already being processed by another thread."
+                     )
                      .map(_ => BlockStatus.processing)
                  case Right((_, true)) =>
-                   internalAddBlock(b).flatMap(status =>
-                     Capture[F].capture { processingBlocks.update(_ - b.blockHash); status })
+                   internalAddBlock(b).flatMap(
+                     status =>
+                       Capture[F].capture { processingBlocks.update(_ - b.blockHash); status }
+                   )
                  case Left(ex) =>
                    Log[F]
                      .warn(
-                       s"Block ${PrettyPrinter.buildString(b.blockHash)} encountered an exception during processing: ${ex.getMessage}")
+                       s"Block ${PrettyPrinter.buildString(b.blockHash)} encountered an exception during processing: ${ex.getMessage}"
+                     )
                      .map(_ => BlockStatus.exception(ex))
                }
     } yield result
@@ -119,7 +123,8 @@ class MultiParentCasperImpl[
             case _ =>
               Capture[F].capture { blockBuffer -= b } *> blockBufferDependencyDagState.modify(
                 blockBufferDependencyDag =>
-                  DoublyLinkedDagOperations.remove(blockBufferDependencyDag, b.blockHash))
+                  DoublyLinkedDagOperations.remove(blockBufferDependencyDag, b.blockHash)
+              )
           }
       _ <- attempt match {
             case MissingBlocks           => ().pure[F]
@@ -136,16 +141,20 @@ class MultiParentCasperImpl[
       _                         <- lastFinalizedBlockContainer.set(updatedLastFinalizedBlock)
     } yield attempt
 
-  private def updateLastFinalizedBlock(dag: BlockDag,
-                                       lastFinalizedBlock: BlockMessage): F[BlockMessage] =
+  private def updateLastFinalizedBlock(
+      dag: BlockDag,
+      lastFinalizedBlock: BlockMessage
+  ): F[BlockMessage] =
     for {
       childrenHashes <- dag.childMap
                          .getOrElse(lastFinalizedBlock.blockHash, Set.empty[BlockHash])
                          .pure[F]
       children <- childrenHashes.toList.traverse(ProtoUtil.unsafeGetBlock[F])
-      maybeFinalizedChild <- ListContrib.findM(children,
-                                               (block: BlockMessage) =>
-                                                 isGreaterThanFaultToleranceThreshold(dag, block))
+      maybeFinalizedChild <- ListContrib.findM(
+                              children,
+                              (block: BlockMessage) =>
+                                isGreaterThanFaultToleranceThreshold(dag, block)
+                            )
       newFinalizedBlock <- maybeFinalizedChild match {
                             case Some(finalizedChild) =>
                               updateLastFinalizedBlock(dag, finalizedChild)
@@ -225,15 +234,19 @@ class MultiParentCasperImpl[
       result <- Capture[F].capture { deployHist.clone() }
       _ <- DagOperations
             .bfTraverseF[F, BlockMessage](p.toList)(ProtoUtil.unsafeGetParents[F])
-            .foreach(b =>
-              Capture[F].capture {
-                b.body.foreach(_.deploys.flatMap(_.deploy).foreach(result -= _))
-            })
+            .foreach(
+              b =>
+                Capture[F].capture {
+                  b.body.foreach(_.deploys.flatMap(_.deploy).foreach(result -= _))
+                }
+            )
     } yield result.toSeq
 
-  private def createProposal(p: Seq[BlockMessage],
-                             r: Seq[Deploy],
-                             justifications: Seq[Justification]): F[CreateBlockStatus] =
+  private def createProposal(
+      p: Seq[BlockMessage],
+      r: Seq[Deploy],
+      justifications: Seq[Justification]
+  ): F[CreateBlockStatus] =
     for {
       now                      <- Time[F].currentMillis
       possibleProcessedDeploys <- updateKnownStateHashes(knownStateHashesContainer, p, r)
@@ -241,7 +254,8 @@ class MultiParentCasperImpl[
                  case Left(ex) =>
                    Log[F]
                      .error(
-                       s"Critical error encountered while processing deploys: ${ex.getMessage}")
+                       s"Critical error encountered while processing deploys: ${ex.getMessage}"
+                     )
                      .map(_ => CreateBlockStatus.internalDeployError(ex))
 
                  case Right((computedStateHash, processedDeploys)) =>
@@ -253,7 +267,8 @@ class MultiParentCasperImpl[
                          val errorsMessage = errors.map(_.getMessage).mkString("\n")
                          Log[F].error(
                            s"Internal error encountered while processing deploy ${PrettyPrinter
-                             .buildString(deploy)}: $errorsMessage")
+                             .buildString(deploy)}: $errorsMessage"
+                         )
                        case _ => ().pure[F]
                      }
                      .map(_ => {
@@ -280,15 +295,18 @@ class MultiParentCasperImpl[
   private def updateKnownStateHashes(
       knownStateHashesContainer: AtomicSyncVarF[F, Set[StateHash]],
       p: Seq[BlockMessage],
-      r: Seq[Deploy]): F[Either[Throwable, (StateHash, Seq[InternalProcessedDeploy])]] =
+      r: Seq[Deploy]
+  ): F[Either[Throwable, (StateHash, Seq[InternalProcessedDeploy])]] =
     knownStateHashesContainer
       .modify[(Either[Throwable, (StateHash, Seq[InternalProcessedDeploy])])] { knownStateHashes =>
         for {
-          possibleProcessedDeploys <- InterpreterUtil.computeDeploysCheckpoint[F](p,
-                                                                                  r,
-                                                                                  _blockDag.get,
-                                                                                  knownStateHashes,
-                                                                                  runtimeManager)
+          possibleProcessedDeploys <- InterpreterUtil.computeDeploysCheckpoint[F](
+                                       p,
+                                       r,
+                                       _blockDag.get,
+                                       knownStateHashes,
+                                       runtimeManager
+                                     )
         } yield (possibleProcessedDeploys._2, possibleProcessedDeploys._1)
       }
 
@@ -327,16 +345,25 @@ class MultiParentCasperImpl[
       postValidationStatus <- Validate.blockSummary[F](b, genesis, dag, shardId)
       postTransactionsCheckStatus <- postValidationStatus.traverse(
                                       _ =>
-                                        Validate.transactions[F](b,
-                                                                 dag,
-                                                                 emptyStateHash,
-                                                                 runtimeManager,
-                                                                 knownStateHashesContainer))
-      postBondsCacheStatus <- postTransactionsCheckStatus.joinRight.traverse(_ =>
-                               Validate.bondsCache[F](b, runtimeManager))
-      postNeglectedInvalidBlockStatus <- postBondsCacheStatus.joinRight.traverse(_ =>
-                                          Validate
-                                            .neglectedInvalidBlock[F](b, invalidBlockTracker.toSet))
+                                        Validate.transactions[F](
+                                          b,
+                                          dag,
+                                          emptyStateHash,
+                                          runtimeManager,
+                                          knownStateHashesContainer
+                                        )
+                                    )
+      postBondsCacheStatus <- postTransactionsCheckStatus.joinRight.traverse(
+                               _ => Validate.bondsCache[F](b, runtimeManager)
+                             )
+      postNeglectedInvalidBlockStatus <- postBondsCacheStatus.joinRight.traverse(
+                                          _ =>
+                                            Validate
+                                              .neglectedInvalidBlock[F](
+                                                b,
+                                                invalidBlockTracker.toSet
+                                              )
+                                        )
       postNeglectedEquivocationCheckStatus <- postNeglectedInvalidBlockStatus.joinRight
                                                .traverse(
                                                  _ =>
@@ -345,12 +372,15 @@ class MultiParentCasperImpl[
                                                        equivocationsTracker,
                                                        b,
                                                        dag,
-                                                       genesis))
+                                                       genesis
+                                                     )
+                                               )
       blockBufferDependencyDag <- blockBufferDependencyDagState.get
       postEquivocationCheckStatus <- postNeglectedEquivocationCheckStatus.joinRight.traverse(
                                       _ =>
                                         EquivocationDetector
-                                          .checkEquivocations[F](blockBufferDependencyDag, b, dag))
+                                          .checkEquivocations[F](blockBufferDependencyDag, b, dag)
+                                    )
       status = postEquivocationCheckStatus.joinRight.merge
       _      <- addEffects(status, b)
     } yield status
@@ -361,7 +391,8 @@ class MultiParentCasperImpl[
       //Add successful! Send block to peers, log success, try to add other blocks
       case Valid =>
         addToState(block) *> CommUtil.sendBlock[F](block) *> Log[F].info(
-          s"Added ${PrettyPrinter.buildString(block.blockHash)}")
+          s"Added ${PrettyPrinter.buildString(block.blockHash)}"
+        )
       case MissingBlocks =>
         for {
           _              <- Capture[F].capture { blockBuffer += block }
@@ -374,7 +405,8 @@ class MultiParentCasperImpl[
                                   blockHash =>
                                     BlockStore[F]
                                       .contains(blockHash)
-                                      .map(contains => !contains))
+                                      .map(contains => !contains)
+                                )
           _ <- missingDependencies.traverse(hash => handleMissingDependency(hash, block))
         } yield ()
       case AdmissibleEquivocation =>
@@ -392,7 +424,8 @@ class MultiParentCasperImpl[
           }
         } *>
           addToState(block) *> CommUtil.sendBlock[F](block) *> Log[F].info(
-          s"Added admissible equivocation child block ${PrettyPrinter.buildString(block.blockHash)}")
+          s"Added admissible equivocation child block ${PrettyPrinter.buildString(block.blockHash)}"
+        )
       case IgnorableEquivocation =>
         /*
          * We don't have to include these blocks to the equivocation tracker because if any validator
@@ -400,7 +433,8 @@ class MultiParentCasperImpl[
          * through the admissible equivocations.
          */
         Log[F].info(
-          s"Did not add block ${PrettyPrinter.buildString(block.blockHash)} as that would add an equivocation to the BlockDAG")
+          s"Did not add block ${PrettyPrinter.buildString(block.blockHash)} as that would add an equivocation to the BlockDAG"
+        )
       case InvalidUnslashableBlock =>
         handleInvalidBlockEffect(status, block)
       case InvalidBlockNumber =>
@@ -439,14 +473,16 @@ class MultiParentCasperImpl[
       _ <- blockBufferDependencyDagState.modify(
             blockBufferDependencyDag =>
               DoublyLinkedDagOperations
-                .add[BlockHash](blockBufferDependencyDag, hash, parentBlock.blockHash))
+                .add[BlockHash](blockBufferDependencyDag, hash, parentBlock.blockHash)
+          )
       _ <- CommUtil.sendBlockRequest[F](BlockRequest(Base16.encode(hash.toByteArray), hash))
     } yield ()
 
   private def handleInvalidBlockEffect(status: BlockStatus, block: BlockMessage): F[Unit] =
     for {
       _ <- Log[F].warn(
-            s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}.")
+            s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}."
+          )
       // TODO: Slash block for status except InvalidUnslashableBlock
       _ <- Capture[F].capture(invalidBlockTracker += block.blockHash) *> addToState(block)
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
@@ -25,8 +25,10 @@ object MultiParentCasperRef {
   def unsafe[F[_]: Sync](casperRef: Option[MultiParentCasper[F]] = None): MultiParentCasperRef[F] =
     MaybeCell.unsafe[F, MultiParentCasper[F]](casperRef)
 
-  def withCasper[F[_]: Monad: Log: MultiParentCasperRef, A](f: MultiParentCasper[F] => F[A],
-                                                            default: A): F[A] =
+  def withCasper[F[_]: Monad: Log: MultiParentCasperRef, A](
+      f: MultiParentCasper[F] => F[A],
+      default: A
+  ): F[A] =
     MultiParentCasperRef[F].get flatMap {
       case Some(casper) => f(casper)
       case None =>

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -71,12 +71,16 @@ sealed abstract class SafetyOracleInstances {
                                } else {
                                  val vertexCount = candidateWeights.keys.size
                                  for {
-                                   edgeCount <- agreementGraphEdgeCount(blockDag,
-                                                                        estimate,
-                                                                        candidateWeights)
+                                   edgeCount <- agreementGraphEdgeCount(
+                                                 blockDag,
+                                                 estimate,
+                                                 candidateWeights
+                                               )
                                  } yield
-                                   minTotalValidatorWeight(estimate,
-                                                           maxCliqueMinSize(vertexCount, edgeCount))
+                                   minTotalValidatorWeight(
+                                     estimate,
+                                     maxCliqueMinSize(vertexCount, edgeCount)
+                                   )
                                }
         } yield minMaxCliqueWeight
 
@@ -85,8 +89,10 @@ sealed abstract class SafetyOracleInstances {
           mainParentWeightMap <- computeMainParentWeightMap(estimate)
         } yield weightMapTotal(mainParentWeightMap)
 
-      private def computeCandidateWeights(blockDag: BlockDag,
-                                          estimate: BlockMessage): F[Map[Validator, Int]] =
+      private def computeCandidateWeights(
+          blockDag: BlockDag,
+          estimate: BlockMessage
+      ): F[Map[Validator, Int]] =
         for {
           weights <- computeMainParentWeightMap(estimate)
           candidateWeights <- weights.toList.traverse {
@@ -117,8 +123,10 @@ sealed abstract class SafetyOracleInstances {
           }
         } yield mainParentWeightMap
 
-      private def findMaximumClique(edges: List[(Validator, Validator)],
-                                    candidates: Map[Validator, Int]): (List[Validator], Int) =
+      private def findMaximumClique(
+          edges: List[(Validator, Validator)],
+          candidates: Map[Validator, Int]
+      ): (List[Validator], Int) =
         Clique
           .findCliquesRecursive(edges)
           .foldLeft((List[Validator](), 0)) {
@@ -134,11 +142,15 @@ sealed abstract class SafetyOracleInstances {
             }
           }
 
-      private def agreementGraphEdgeCount(blockDag: BlockDag,
-                                          estimate: BlockMessage,
-                                          candidates: Map[Validator, Int]): F[Int] = {
-        def findAgreeingJustificationHash(justificationHashes: List[BlockHash],
-                                          validator: Validator): F[Option[BlockHash]] =
+      private def agreementGraphEdgeCount(
+          blockDag: BlockDag,
+          estimate: BlockMessage,
+          candidates: Map[Validator, Int]
+      ): F[Int] = {
+        def findAgreeingJustificationHash(
+            justificationHashes: List[BlockHash],
+            validator: Validator
+        ): F[Option[BlockHash]] =
           ListContrib.findM(
             justificationHashes,
             justificationHash =>
@@ -159,7 +171,8 @@ sealed abstract class SafetyOracleInstances {
                                         .pure[F]
                 agreeingJustificationHash <- findAgreeingJustificationHash(
                                               justificationHashes.toList,
-                                              second)
+                                              second
+                                            )
               } yield agreeingJustificationHash.isDefined
             case None => false.pure[F]
           }
@@ -193,14 +206,16 @@ sealed abstract class SafetyOracleInstances {
                                                  justificationHash =>
                                                    for {
                                                      justificationBlock <- unsafeGetBlock[F](
-                                                                            justificationHash)
+                                                                            justificationHash
+                                                                          )
                                                      isSenderSecond = justificationBlock.sender == second
                                                      result = if (isSenderSecond) {
                                                        Some(justificationBlock)
                                                      } else {
                                                        none[BlockMessage]
                                                      }
-                                                   } yield result)
+                                                   } yield result
+                                               )
                 _                        = assert(justificationBlockSecondList.flatten.length == 1)
                 justificationBlockSecond = justificationBlockSecondList.flatten.head
                 potentialDisagreements   <- filterChildren(justificationBlockSecond, second)
@@ -223,9 +238,12 @@ sealed abstract class SafetyOracleInstances {
               Monad[F].ifM(seesAgreement(first, second))(
                 Monad[F].ifM(seesAgreement(second, first))(
                   Monad[F].ifM(neverEventuallySeeDisagreement(first, second))(
-                    Monad[F].ifM(neverEventuallySeeDisagreement(second, first))(true.pure[F],
-                                                                                false.pure[F]),
-                    false.pure[F]),
+                    Monad[F].ifM(neverEventuallySeeDisagreement(second, first))(
+                      true.pure[F],
+                      false.pure[F]
+                    ),
+                    false.pure[F]
+                  ),
                   false.pure[F]
                 ),
                 false.pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -40,8 +40,10 @@ object Validate {
   def ignore(b: BlockMessage, reason: String): String =
     s"Ignoring block ${PrettyPrinter.buildString(b.blockHash)} because $reason"
 
-  def approvedBlock[F[_]: Applicative: Log](a: ApprovedBlock,
-                                            requiredValidators: Set[ByteString]): F[Boolean] = {
+  def approvedBlock[F[_]: Applicative: Log](
+      a: ApprovedBlock,
+      requiredValidators: Set[ByteString]
+  ): F[Boolean] = {
     val maybeSigData = for {
       c     <- a.candidate
       bytes = c.toByteArray
@@ -87,9 +89,11 @@ object Validate {
       } yield false
     }
 
-  def blockSender[F[_]: Monad: Log: BlockStore](b: BlockMessage,
-                                                genesis: BlockMessage,
-                                                dag: BlockDag): F[Boolean] =
+  def blockSender[F[_]: Monad: Log: BlockStore](
+      b: BlockMessage,
+      genesis: BlockMessage,
+      dag: BlockDag
+  ): F[Boolean] =
     if (b == genesis) {
       true.pure[F] //genesis block has a valid sender
     } else {
@@ -101,7 +105,9 @@ object Validate {
                      _ <- Log[F].warn(
                            ignore(
                              b,
-                             s"block creator ${PrettyPrinter.buildString(b.sender)} has 0 weight."))
+                             s"block creator ${PrettyPrinter.buildString(b.sender)} has 0 weight."
+                           )
+                         )
                    } yield false
       } yield result
     }
@@ -160,28 +166,39 @@ object Validate {
       block: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDag,
-      shardId: String): F[Either[BlockStatus, ValidBlock]] =
+      shardId: String
+  ): F[Either[BlockStatus, ValidBlock]] =
     for {
       blockHashStatus   <- Validate.blockHash[F](block)
       deployCountStatus <- blockHashStatus.traverse(_ => Validate.deployCount[F](block))
-      missingBlockStatus <- deployCountStatus.joinRight.traverse(_ =>
-                             Validate.missingBlocks[F](block, dag))
-      timestampStatus <- missingBlockStatus.joinRight.traverse(_ =>
-                          Validate.timestamp[F](block, dag))
-      repeatedDeployStatus <- timestampStatus.joinRight.traverse(_ =>
-                               Validate.repeatDeploy[F](block, dag))
-      blockNumberStatus <- repeatedDeployStatus.joinRight.traverse(_ =>
-                            Validate.blockNumber[F](block))
-      followsStatus <- blockNumberStatus.joinRight.traverse(_ =>
-                        Validate.justificationFollows[F](block, genesis, dag))
-      parentsStatus <- followsStatus.joinRight.traverse(_ =>
-                        Validate.parents[F](block, genesis, dag))
-      sequenceNumberStatus <- parentsStatus.joinRight.traverse(_ =>
-                               Validate.sequenceNumber[F](block, dag))
-      justificationRegressionsStatus <- sequenceNumberStatus.joinRight.traverse(_ =>
-                                         Validate.justificationRegressions[F](block, genesis, dag))
-      shardIdentifierStatus <- justificationRegressionsStatus.joinRight.traverse(_ =>
-                                Validate.shardIdentifier[F](block, shardId))
+      missingBlockStatus <- deployCountStatus.joinRight.traverse(
+                             _ => Validate.missingBlocks[F](block, dag)
+                           )
+      timestampStatus <- missingBlockStatus.joinRight.traverse(
+                          _ => Validate.timestamp[F](block, dag)
+                        )
+      repeatedDeployStatus <- timestampStatus.joinRight.traverse(
+                               _ => Validate.repeatDeploy[F](block, dag)
+                             )
+      blockNumberStatus <- repeatedDeployStatus.joinRight.traverse(
+                            _ => Validate.blockNumber[F](block)
+                          )
+      followsStatus <- blockNumberStatus.joinRight.traverse(
+                        _ => Validate.justificationFollows[F](block, genesis, dag)
+                      )
+      parentsStatus <- followsStatus.joinRight.traverse(
+                        _ => Validate.parents[F](block, genesis, dag)
+                      )
+      sequenceNumberStatus <- parentsStatus.joinRight.traverse(
+                               _ => Validate.sequenceNumber[F](block, dag)
+                             )
+      justificationRegressionsStatus <- sequenceNumberStatus.joinRight.traverse(
+                                         _ =>
+                                           Validate.justificationRegressions[F](block, genesis, dag)
+                                       )
+      shardIdentifierStatus <- justificationRegressionsStatus.joinRight.traverse(
+                                _ => Validate.shardIdentifier[F](block, shardId)
+                              )
     } yield shardIdentifierStatus.joinRight
 
   /**
@@ -189,17 +206,19 @@ object Validate {
     */
   def missingBlocks[F[_]: Monad: Log: BlockStore](
       block: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] =
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       parentsPresent <- ProtoUtil.parentHashes(block).toList.forallM(p => BlockStore[F].contains(p))
-      justificationsPresent <- block.justifications.toList.forallM(j =>
-                                BlockStore[F].contains(j.latestBlockHash))
+      justificationsPresent <- block.justifications.toList
+                                .forallM(j => BlockStore[F].contains(j.latestBlockHash))
       result <- if (parentsPresent && justificationsPresent) {
                  Applicative[F].pure(Right(Valid))
                } else {
                  for {
                    _ <- Log[F].debug(
-                         s"Fetching missing dependencies for ${PrettyPrinter.buildString(block.blockHash)}.")
+                         s"Fetching missing dependencies for ${PrettyPrinter.buildString(block.blockHash)}."
+                       )
                  } yield Left(MissingBlocks)
                }
     } yield result
@@ -212,7 +231,8 @@ object Validate {
     */
   def repeatDeploy[F[_]: Monad: Log: BlockStore](
       block: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] = {
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] = {
     val deployKeySet = (for {
       bd <- block.body.toList
       d  <- bd.deploys.flatMap(_.deploy)
@@ -227,14 +247,20 @@ object Validate {
                             _.body.exists(
                               _.deploys
                                 .flatMap(_.deploy)
-                                .exists(_.raw.exists(p =>
-                                  deployKeySet.contains((p.user, p.timestamp))))))
+                                .exists(
+                                  _.raw.exists(p => deployKeySet.contains((p.user, p.timestamp)))
+                                )
+                            )
+                          )
       result <- duplicatedBlock match {
                  case Some(b) =>
                    for {
-                     _ <- Log[F].warn(ignore(
-                           block,
-                           s"found deploy by the same (user, millisecond timestamp) produced in the block(${b.blockHash})"))
+                     _ <- Log[F].warn(
+                           ignore(
+                             block,
+                             s"found deploy by the same (user, millisecond timestamp) produced in the block(${b.blockHash})"
+                           )
+                         )
                    } yield Left(InvalidRepeatDeploy)
                  case None => Applicative[F].pure(Right(Valid))
                }
@@ -244,7 +270,8 @@ object Validate {
   // This is not a slashable offence
   def timestamp[F[_]: Monad: Log: Time: BlockStore](
       b: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] =
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       currentTime  <- Time[F].currentMillis
       timestamp    = b.header.get.timestamp
@@ -267,7 +294,8 @@ object Validate {
                    _ <- Log[F].warn(
                          ignore(
                            b,
-                           s"block timestamp $timestamp is not between latest parent block time and current time.")
+                           s"block timestamp $timestamp is not between latest parent block time and current time."
+                         )
                        )
                  } yield Left(InvalidUnslashableBlock)
                }
@@ -275,7 +303,8 @@ object Validate {
 
   // Agnostic of non-parent justifications
   def blockNumber[F[_]: Monad: Log: BlockStore](
-      b: BlockMessage): F[Either[InvalidBlock, ValidBlock]] =
+      b: BlockMessage
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       parents <- ProtoUtil.unsafeGetParents[F](b)
       maxBlockNumber = parents.foldLeft(-1L) {
@@ -305,13 +334,14 @@ object Validate {
     */
   def sequenceNumber[F[_]: Monad: Log: BlockStore](
       b: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] =
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       creatorJustificationSeqNumber <- ProtoUtil.creatorJustification(b).foldM(-1) {
                                         case (_, Justification(_, latestBlockHash)) =>
                                           for {
-                                            latestBlock <- ProtoUtil.unsafeGetBlock[F](
-                                                            latestBlockHash)
+                                            latestBlock <- ProtoUtil
+                                                            .unsafeGetBlock[F](latestBlockHash)
                                           } yield latestBlock.seqNum
                                       }
       number = b.seqNum
@@ -320,9 +350,12 @@ object Validate {
                  Applicative[F].pure(Right(Valid))
                } else {
                  for {
-                   _ <- Log[F].warn(ignore(
-                         b,
-                         s"seq number $number is not one more than creator justification number $creatorJustificationSeqNumber."))
+                   _ <- Log[F].warn(
+                         ignore(
+                           b,
+                           s"seq number $number is not one more than creator justification number $creatorJustificationSeqNumber."
+                         )
+                       )
                  } yield Left(InvalidSequenceNumber)
                }
     } yield status
@@ -330,13 +363,15 @@ object Validate {
   // Agnostic of justifications
   def shardIdentifier[F[_]: Monad: Log: BlockStore](
       b: BlockMessage,
-      shardId: String): F[Either[InvalidBlock, ValidBlock]] =
+      shardId: String
+  ): F[Either[InvalidBlock, ValidBlock]] =
     if (b.shardId == shardId) {
       Applicative[F].pure(Right(Valid))
     } else {
       for {
         _ <- Log[F].warn(
-              ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected."))
+              ignore(b, s"got shard identifier ${b.shardId} while $shardId was expected.")
+            )
       } yield Left(InvalidShardId)
     }
 
@@ -374,9 +409,11 @@ object Validate {
   /**
     * Works only with fully explicit justifications.
     */
-  def parents[F[_]: Monad: Log: BlockStore](b: BlockMessage,
-                                            genesis: BlockMessage,
-                                            dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] = {
+  def parents[F[_]: Monad: Log: BlockStore](
+      b: BlockMessage,
+      genesis: BlockMessage,
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] = {
     val maybeParentHashes = ProtoUtil.parentHashes(b)
     val parentHashes = maybeParentHashes match {
       case hashes if hashes.isEmpty => Seq(genesis.blockHash)
@@ -394,7 +431,8 @@ object Validate {
                else
                  for {
                    _ <- Log[F].warn(
-                         ignore(b, "block parents did not match estimate based on justification."))
+                         ignore(b, "block parents did not match estimate based on justification.")
+                       )
                  } yield Left(InvalidParents)
     } yield status
   }
@@ -405,7 +443,8 @@ object Validate {
   def justificationFollows[F[_]: Monad: Log: BlockStore](
       b: BlockMessage,
       genesis: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] =
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       latestMessages     <- ProtoUtil.toLatestMessage[F](b.justifications, dag)
       validators         = latestMessages.keySet
@@ -421,7 +460,9 @@ object Validate {
                    _ <- Log[F].warn(
                          ignore(
                            b,
-                           s"the justifications of block are ${justifications}, do not follow from bonds of creator justification block"))
+                           s"the justifications of block are ${justifications}, do not follow from bonds of creator justification block"
+                         )
+                       )
                  } yield Left(InvalidFollows)
                }
     } yield status
@@ -436,15 +477,18 @@ object Validate {
   def justificationRegressions[F[_]: Monad: Log: BlockStore](
       b: BlockMessage,
       genesis: BlockMessage,
-      dag: BlockDag): F[Either[InvalidBlock, ValidBlock]] = {
+      dag: BlockDag
+  ): F[Either[InvalidBlock, ValidBlock]] = {
     val latestMessagesOfBlock             = ProtoUtil.toLatestMessageHashes(b.justifications)
     val maybeLatestMessagesFromSenderView = dag.latestMessagesOfLatestMessages.get(b.sender)
     maybeLatestMessagesFromSenderView match {
       case Some(latestMessagesFromSenderView) =>
-        justificationRegressionsAux[F](b,
-                                       latestMessagesOfBlock,
-                                       latestMessagesFromSenderView,
-                                       genesis)
+        justificationRegressionsAux[F](
+          b,
+          latestMessagesOfBlock,
+          latestMessagesFromSenderView,
+          genesis
+        )
       case None =>
         // We cannot have a justification regression if we don't have a previous latest message from sender
         Applicative[F].pure(Right(Valid))
@@ -455,7 +499,8 @@ object Validate {
       b: BlockMessage,
       latestMessagesOfBlock: Map[Validator, BlockHash],
       latestMessagesFromSenderView: Map[Validator, BlockHash],
-      genesis: BlockMessage): F[Either[InvalidBlock, ValidBlock]] =
+      genesis: BlockMessage
+  ): F[Either[InvalidBlock, ValidBlock]] =
     for {
       containsJustificationRegression <- latestMessagesOfBlock.toList.existsM {
                                           case (validator, currentBlockJustificationHash) =>
@@ -466,10 +511,12 @@ object Validate {
                                               val previousBlockJustificationHash =
                                                 latestMessagesFromSenderView.getOrElse(
                                                   validator,
-                                                  genesis.blockHash)
+                                                  genesis.blockHash
+                                                )
                                               isJustificationRegression[F](
                                                 currentBlockJustificationHash,
-                                                previousBlockJustificationHash)
+                                                previousBlockJustificationHash
+                                              )
                                             }
                                         }
       status <- if (containsJustificationRegression) {
@@ -483,7 +530,8 @@ object Validate {
 
   private def isJustificationRegression[F[_]: Monad: Log: BlockStore](
       currentBlockJustificationHash: BlockHash,
-      previousBlockJustificationHash: BlockHash): F[Boolean] =
+      previousBlockJustificationHash: BlockHash
+  ): F[Boolean] =
     for {
       currentBlockJustification <- ProtoUtil
                                     .unsafeGetBlock[F](currentBlockJustificationHash)
@@ -501,8 +549,8 @@ object Validate {
       dag: BlockDag,
       emptyStateHash: StateHash,
       runtimeManager: RuntimeManager,
-      knownStateHashesContainer: AtomicSyncVarF[F, Set[StateHash]])(
-      implicit scheduler: Scheduler): F[Either[BlockStatus, ValidBlock]] =
+      knownStateHashesContainer: AtomicSyncVarF[F, Set[StateHash]]
+  )(implicit scheduler: Scheduler): F[Either[BlockStatus, ValidBlock]] =
     for {
       maybeStateHash <- knownStateHashesContainer
                          .modify[Either[BlockException, Option[StateHash]]] { knownStateHashes =>
@@ -513,7 +561,8 @@ object Validate {
                                                                  block,
                                                                  dag,
                                                                  knownStateHashes,
-                                                                 runtimeManager)
+                                                                 runtimeManager
+                                                               )
                              (maybeStateHash, updatedknownStateHashes) = validateBlockCheckpointResult
                            } yield (updatedknownStateHashes, maybeStateHash)
                          }
@@ -530,9 +579,11 @@ object Validate {
     */
   def neglectedInvalidBlock[F[_]: Applicative](
       block: BlockMessage,
-      invalidBlockTracker: Set[BlockHash]): F[Either[InvalidBlock, ValidBlock]] = {
-    val invalidJustifications = block.justifications.filter(justification =>
-      invalidBlockTracker.contains(justification.latestBlockHash))
+      invalidBlockTracker: Set[BlockHash]
+  ): F[Either[InvalidBlock, ValidBlock]] = {
+    val invalidJustifications = block.justifications.filter(
+      justification => invalidBlockTracker.contains(justification.latestBlockHash)
+    )
     val neglectedInvalidJustification = invalidJustifications.exists { justification =>
       val slashedValidatorBond = bonds(block).find(_.validator == justification.validator)
       slashedValidatorBond match {
@@ -549,7 +600,8 @@ object Validate {
 
   def bondsCache[F[_]: Applicative: Log](
       b: BlockMessage,
-      runtimeManager: RuntimeManager): F[Either[InvalidBlock, ValidBlock]] = {
+      runtimeManager: RuntimeManager
+  ): F[Either[InvalidBlock, ValidBlock]] = {
     val bonds = ProtoUtil.bonds(b)
     ProtoUtil.tuplespace(b) match {
       case Some(tuplespaceHash) =>
@@ -560,7 +612,8 @@ object Validate {
             } else {
               for {
                 _ <- Log[F].warn(
-                      "Bonds in proof of stake contract do not match block's bond cache.")
+                      "Bonds in proof of stake contract do not match block's bond cache."
+                    )
               } yield Left(InvalidBondsCache)
             }
           case Failure(ex: Throwable) =>

--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -7,9 +7,11 @@ import coop.rchain.casper.protocol.Signature
 import coop.rchain.casper.util.SignatureAlgorithms
 import coop.rchain.shared.{Log, LogSource}
 
-case class ValidatorIdentity(publicKey: Array[Byte],
-                             privateKey: Array[Byte],
-                             sigAlgorithm: String) {
+case class ValidatorIdentity(
+    publicKey: Array[Byte],
+    privateKey: Array[Byte],
+    sigAlgorithm: String
+) {
   def signature(data: Array[Byte]): Signature = {
     val sig = SignatureAlgorithms.lookup(sigAlgorithm)(data, privateKey)
     Signature(ByteString.copyFrom(publicKey), sigAlgorithm, ByteString.copyFrom(sig))

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -48,7 +48,8 @@ object BlockAPI {
     MultiParentCasperRef
       .withCasper[F, DeployServiceResponse](
         casperDeploy(_),
-        DeployServiceResponse(success = false, s"Error: Casper instance not available"))
+        DeployServiceResponse(success = false, s"Error: Casper instance not available")
+      )
   }
 
   def addBlock[F[_]: Monad: MultiParentCasperRef: Log](b: BlockMessage): F[DeployServiceResponse] =
@@ -77,12 +78,13 @@ object BlockAPI {
           } yield result,
           DeployServiceResponse(success = false, "Error: There is another propose in progress.")
             .pure[F]
-      ),
+        ),
       DeployServiceResponse(success = false, "Error: Casper instance not available")
     )
 
   def getListeningNameDataResponse[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
-      listeningName: Channel): F[ListeningNameDataResponse] = {
+      listeningName: Channel
+  ): F[ListeningNameDataResponse] = {
     def casperResponse(implicit casper: MultiParentCasper[F], channelCodec: Codec[Channel]) =
       for {
         mainChain           <- getMainChainFromTip[F]
@@ -90,25 +92,30 @@ object BlockAPI {
         runtimeManager      = maybeRuntimeManager.get // This is safe. Please reluctantly accept until runtimeManager is no longer exposed.
         sortedListeningName <- channelSortable.sortMatch[F](listeningName).map(_.term)
         maybeBlocksWithActiveName <- mainChain.toList.traverse { block =>
-                                      getDataWithBlockInfo[F](runtimeManager,
-                                                              sortedListeningName,
-                                                              block)
+                                      getDataWithBlockInfo[F](
+                                        runtimeManager,
+                                        sortedListeningName,
+                                        block
+                                      )
                                     }
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield
-        ListeningNameDataResponse(status = "Success",
-                                  blockResults = blocksWithActiveName,
-                                  length = blocksWithActiveName.length)
+        ListeningNameDataResponse(
+          status = "Success",
+          blockResults = blocksWithActiveName,
+          length = blocksWithActiveName.length
+        )
 
     implicit val channelCodec: Codec[Channel] = serializeChannel.toCodec
     MultiParentCasperRef.withCasper[F, ListeningNameDataResponse](
       casperResponse(_, channelCodec),
-      ListeningNameDataResponse(status = "Error: Casper instance not available"))
+      ListeningNameDataResponse(status = "Error: Casper instance not available")
+    )
   }
 
-  def getListeningNameContinuationResponse[
-      F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
-      listeningNames: Channels): F[ListeningNameContinuationResponse] = {
+  def getListeningNameContinuationResponse[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+      listeningNames: Channels
+  ): F[ListeningNameContinuationResponse] = {
     def casperResponse(implicit casper: MultiParentCasper[F], channelCodec: Codec[Channel]) =
       for {
         mainChain           <- getMainChainFromTip[F]
@@ -117,20 +124,25 @@ object BlockAPI {
         sortedListeningNames <- listeningNames.channels.toList
                                  .traverse(channelSortable.sortMatch[F](_).map(_.term))
         maybeBlocksWithActiveName <- mainChain.toList.traverse { block =>
-                                      getContinuationsWithBlockInfo[F](runtimeManager,
-                                                                       sortedListeningNames,
-                                                                       block)
+                                      getContinuationsWithBlockInfo[F](
+                                        runtimeManager,
+                                        sortedListeningNames,
+                                        block
+                                      )
                                     }
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield
-        ListeningNameContinuationResponse(status = "Success",
-                                          blockResults = blocksWithActiveName,
-                                          length = blocksWithActiveName.length)
+        ListeningNameContinuationResponse(
+          status = "Success",
+          blockResults = blocksWithActiveName,
+          length = blocksWithActiveName.length
+        )
 
     implicit val channelCodec: Codec[Channel] = serializeChannel.toCodec
     MultiParentCasperRef.withCasper[F, ListeningNameContinuationResponse](
       casperResponse(_, channelCodec),
-      ListeningNameContinuationResponse(status = "Error: Casper instance not available"))
+      ListeningNameContinuationResponse(status = "Error: Casper instance not available")
+    )
   }
 
   private def getMainChainFromTip[F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore]
@@ -145,7 +157,8 @@ object BlockAPI {
   private def getDataWithBlockInfo[F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore](
       runtimeManager: RuntimeManager,
       sortedListeningName: Channel,
-      block: BlockMessage)(implicit channelCodec: Codec[Channel]): F[Option[DataWithBlockInfo]] =
+      block: BlockMessage
+  )(implicit channelCodec: Codec[Channel]): F[Option[DataWithBlockInfo]] =
     if (isListeningNameReduced(block, immutable.Seq(sortedListeningName))) {
       val stateHash =
         ProtoUtil.tuplespace(block).get
@@ -158,31 +171,33 @@ object BlockAPI {
       none[DataWithBlockInfo].pure[F]
     }
 
-  private def getContinuationsWithBlockInfo[
-      F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore](
+  private def getContinuationsWithBlockInfo[F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore](
       runtimeManager: RuntimeManager,
       sortedListeningNames: immutable.Seq[Channel],
-      block: BlockMessage)(
-      implicit channelCodec: Codec[Channel]): F[Option[ContinuationsWithBlockInfo]] =
+      block: BlockMessage
+  )(implicit channelCodec: Codec[Channel]): F[Option[ContinuationsWithBlockInfo]] =
     if (isListeningNameReduced(block, sortedListeningNames)) {
       val stateHash =
         ProtoUtil.tuplespace(block).get
       val continuations: Seq[(Seq[BindPattern], Par)] =
         runtimeManager.getContinuation(stateHash, sortedListeningNames)
-      val continuationInfos = continuations.map(continuation =>
-        WaitingContinuationInfo(continuation._1, Some(continuation._2)))
+      val continuationInfos = continuations.map(
+        continuation => WaitingContinuationInfo(continuation._1, Some(continuation._2))
+      )
       for {
         blockInfo <- getBlockInfoWithoutTuplespace[F](block)
       } yield
         Option[ContinuationsWithBlockInfo](
-          ContinuationsWithBlockInfo(continuationInfos, Some(blockInfo)))
+          ContinuationsWithBlockInfo(continuationInfos, Some(blockInfo))
+        )
     } else {
       none[ContinuationsWithBlockInfo].pure[F]
     }
 
   private def isListeningNameReduced(
       block: BlockMessage,
-      sortedListeningName: immutable.Seq[Channel])(implicit channelCodec: Codec[Channel]) = {
+      sortedListeningName: immutable.Seq[Channel]
+  )(implicit channelCodec: Codec[Channel]) = {
     val serializedLog = for {
       bd    <- block.body.toSeq
       pd    <- bd.deploys
@@ -197,8 +212,9 @@ object BlockAPI {
         channelHash == StableHashProvider.hash(sortedListeningName)
       case COMM(consume, produces) =>
         consume.channelsHash == StableHashProvider.hash(sortedListeningName) ||
-          produces.exists(produce =>
-            produce.channelsHash == StableHashProvider.hash(sortedListeningName))
+          produces.exists(
+            produce => produce.channelsHash == StableHashProvider.hash(sortedListeningName)
+          )
     }
   }
 
@@ -216,11 +232,13 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, BlocksResponse](
       casperResponse(_),
-      BlocksResponse(status = "Error: Casper instance not available"))
+      BlocksResponse(status = "Error: Casper instance not available")
+    )
   }
 
   def getBlockQueryResponse[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
-      q: BlockQuery): F[BlockQueryResponse] = {
+      q: BlockQuery
+  ): F[BlockQueryResponse] = {
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         dag        <- MultiParentCasper[F].blockDag
@@ -230,32 +248,38 @@ object BlockAPI {
                                  for {
                                    blockInfo <- getFullBlockInfo[F](block)
                                  } yield
-                                   BlockQueryResponse(status = "Success",
-                                                      blockInfo = Some(blockInfo))
+                                   BlockQueryResponse(
+                                     status = "Success",
+                                     blockInfo = Some(blockInfo)
+                                   )
                                case None =>
                                  BlockQueryResponse(
-                                   status = s"Error: Failure to find block with hash ${q.hash}")
-                                   .pure[F]
+                                   status = s"Error: Failure to find block with hash ${q.hash}"
+                                 ).pure[F]
                              }
       } yield blockQueryResponse
 
     MultiParentCasperRef.withCasper[F, BlockQueryResponse](
       casperResponse(_),
-      BlockQueryResponse(status = "Error: Casper instance not available"))
+      BlockQueryResponse(status = "Error: Casper instance not available")
+    )
   }
 
   private def getBlockInfo[A, F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage,
-      constructor: (BlockMessage,
-                    Long,
-                    Int,
-                    BlockHash,
-                    String,
-                    Long,
-                    BlockHash,
-                    Seq[BlockHash],
-                    Float,
-                    Float) => A): F[A] =
+      constructor: (
+          BlockMessage,
+          Long,
+          Int,
+          BlockHash,
+          String,
+          Long,
+          BlockHash,
+          Seq[BlockHash],
+          Float,
+          Float
+      ) => A
+  ): F[A] =
     for {
       dag         <- MultiParentCasper[F].blockDag
       header      = block.header.getOrElse(Header.defaultInstance)
@@ -272,22 +296,25 @@ object BlockAPI {
       normalizedFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, block)
       initialFault             <- MultiParentCasper[F].normalizedInitialFault(ProtoUtil.weightMap(block))
     } yield
-      constructor(block,
-                  version,
-                  deployCount,
-                  tsHash,
-                  tsDesc,
-                  timestamp,
-                  mainParent,
-                  parentsHashList,
-                  normalizedFaultTolerance,
-                  initialFault)
+      constructor(
+        block,
+        version,
+        deployCount,
+        tsHash,
+        tsDesc,
+        timestamp,
+        mainParent,
+        parentsHashList,
+        normalizedFaultTolerance,
+        initialFault
+      )
 
   private def getFullBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
-      block: BlockMessage): F[BlockInfo] = getBlockInfo[BlockInfo, F](block, constructBlockInfo[F])
-  private def getBlockInfoWithoutTuplespace[
-      F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
-      block: BlockMessage): F[BlockInfoWithoutTuplespace] =
+      block: BlockMessage
+  ): F[BlockInfo] = getBlockInfo[BlockInfo, F](block, constructBlockInfo[F])
+  private def getBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
+      block: BlockMessage
+  ): F[BlockInfoWithoutTuplespace] =
     getBlockInfo[BlockInfoWithoutTuplespace, F](block, constructBlockInfoWithoutTuplespace[F])
 
   private def constructBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
@@ -300,7 +327,8 @@ object BlockAPI {
       mainParent: BlockHash,
       parentsHashList: Seq[BlockHash],
       normalizedFaultTolerance: Float,
-      initialFault: Float): BlockInfo =
+      initialFault: Float
+  ): BlockInfo =
     BlockInfo(
       blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
       blockSize = block.serializedSize.toString,
@@ -316,8 +344,7 @@ object BlockAPI {
       sender = PrettyPrinter.buildStringNoLimit(block.sender),
       shardId = block.shardId
     )
-  private def constructBlockInfoWithoutTuplespace[
-      F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
+  private def constructBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage,
       version: Long,
       deployCount: Int,
@@ -327,7 +354,8 @@ object BlockAPI {
       mainParent: BlockHash,
       parentsHashList: Seq[BlockHash],
       normalizedFaultTolerance: Float,
-      initialFault: Float): BlockInfoWithoutTuplespace =
+      initialFault: Float
+  ): BlockInfoWithoutTuplespace =
     BlockInfoWithoutTuplespace(
       blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
       blockSize = block.serializedSize.toString,
@@ -344,7 +372,8 @@ object BlockAPI {
 
   private def getBlock[F[_]: Monad: MultiParentCasper: BlockStore](
       q: BlockQuery,
-      dag: BlockDag): F[Option[BlockMessage]] =
+      dag: BlockDag
+  ): F[Option[BlockMessage]] =
     for {
       findResult <- BlockStore[F].find(h => {
                      Base16.encode(h.toByteArray).startsWith(q.hash)
@@ -367,7 +396,9 @@ object BlockAPI {
       case BlockException(ex) =>
         DeployServiceResponse(success = false, s"Error during block processing: $ex")
       case Processing =>
-        DeployServiceResponse(success = false,
-                              "No action taken since other thread is already processing the block.")
+        DeployServiceResponse(
+          success = false,
+          "No action taken since other thread is already processing the block."
+        )
     }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
@@ -9,10 +9,11 @@ trait DoublyLinkedDag[A] {
   val childToParentAdjacencyList: Map[A, Set[A]]
   val dependencyFree: Set[A]
 }
-case class BlockDependencyDag(parentToChildAdjacencyList: Map[BlockHash, Set[BlockHash]],
-                              childToParentAdjacencyList: Map[BlockHash, Set[BlockHash]],
-                              dependencyFree: Set[BlockHash])
-    extends DoublyLinkedDag[BlockHash]
+case class BlockDependencyDag(
+    parentToChildAdjacencyList: Map[BlockHash, Set[BlockHash]],
+    childToParentAdjacencyList: Map[BlockHash, Set[BlockHash]],
+    dependencyFree: Set[BlockHash]
+) extends DoublyLinkedDag[BlockHash]
 
 object BlockDependencyDag {
   def empty: BlockDependencyDag =

--- a/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
@@ -29,10 +29,11 @@ object EventConverter {
         Comm(
           CommEvent(
             Some(ConsumeEvent(rspaceConsume.channelsHash, rspaceConsume.hash)),
-            rspaceProduces.map(rspaceProduce =>
-              ProduceEvent(rspaceProduce.channelsHash, rspaceProduce.hash))
+            rspaceProduces
+              .map(rspaceProduce => ProduceEvent(rspaceProduce.channelsHash, rspaceProduce.hash))
           )
-        ))
+        )
+      )
   }
 
   def toRspaceEvent(event: Event): RspaceEvent = event match {

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -22,8 +22,10 @@ object ProtoUtil {
    * c is in the blockchain of b iff c == b or c is in the blockchain of the main parent of b
    */
   // TODO: Move into BlockDAG and remove corresponding param once that is moved over from simulator
-  def isInMainChain[F[_]: Monad: BlockStore](candidate: BlockMessage,
-                                             target: BlockMessage): F[Boolean] =
+  def isInMainChain[F[_]: Monad: BlockStore](
+      candidate: BlockMessage,
+      target: BlockMessage
+  ): F[Boolean] =
     if (candidate == target) {
       true.pure[F]
     } else {
@@ -43,7 +45,8 @@ object ProtoUtil {
 
   def getMainChain[F[_]: Monad: BlockStore](
       estimate: BlockMessage,
-      acc: IndexedSeq[BlockMessage]): F[IndexedSeq[BlockMessage]] = {
+      acc: IndexedSeq[BlockMessage]
+  ): F[IndexedSeq[BlockMessage]] = {
     val parentsHashes       = ProtoUtil.parentHashes(estimate)
     val maybeMainParentHash = parentsHashes.headOption
     for {
@@ -77,7 +80,8 @@ object ProtoUtil {
 
   def findCreatorJustificationAncestorWithSeqNum[F[_]: Monad: BlockStore](
       b: BlockMessage,
-      seqNum: SequenceNumber): F[Option[BlockMessage]] =
+      seqNum: SequenceNumber
+  ): F[Option[BlockMessage]] =
     if (b.seqNum == seqNum) {
       Option[BlockMessage](b).pure[F]
     } else {
@@ -91,7 +95,8 @@ object ProtoUtil {
   def getCreatorJustificationAsList[F[_]: Monad: BlockStore](
       block: BlockMessage,
       validator: Validator,
-      goalFunc: BlockMessage => Boolean = _ => false): F[List[BlockMessage]] = {
+      goalFunc: BlockMessage => Boolean = _ => false
+  ): F[List[BlockMessage]] = {
     val maybeCreatorJustificationHash =
       block.justifications.find(_.validator == validator)
     maybeCreatorJustificationHash match {
@@ -193,10 +198,12 @@ object ProtoUtil {
    * TODO: Update the logic of this function to make use of the trace logs and
    * say that two blocks don't conflict if they act on disjoint sets of channels
    */
-  def conflicts[F[_]: Monad: BlockStore](b1: BlockMessage,
-                                         b2: BlockMessage,
-                                         genesis: BlockMessage,
-                                         dag: BlockDag): F[Boolean] =
+  def conflicts[F[_]: Monad: BlockStore](
+      b1: BlockMessage,
+      b2: BlockMessage,
+      genesis: BlockMessage,
+      dag: BlockDag
+  ): F[Boolean] =
     for {
       gca <- DagOperations.greatestCommonAncestorF[F](b1, b2, genesis, dag)
       result <- if (gca == b1 || gca == b2) {
@@ -207,7 +214,8 @@ object ProtoUtil {
                    for {
                      bAncestors <- DagOperations
                                     .bfTraverseF[F, BlockMessage](List(b))(
-                                      ProtoUtil.unsafeGetParents[F])
+                                      ProtoUtil.unsafeGetParents[F]
+                                    )
                                     .takeWhile(_ != gca)
                                     .toList
                      deploys = bAncestors
@@ -223,9 +231,11 @@ object ProtoUtil {
                }
     } yield result
 
-  def chooseNonConflicting[F[_]: Monad: BlockStore](blocks: Seq[BlockMessage],
-                                                    genesis: BlockMessage,
-                                                    dag: BlockDag): F[Seq[BlockMessage]] = {
+  def chooseNonConflicting[F[_]: Monad: BlockStore](
+      blocks: Seq[BlockMessage],
+      genesis: BlockMessage,
+      dag: BlockDag
+  ): F[Seq[BlockMessage]] = {
     def nonConflicting(b: BlockMessage): BlockMessage => F[Boolean] =
       conflicts[F](_, b, genesis, dag).map(b => !b)
 
@@ -249,7 +259,8 @@ object ProtoUtil {
     }
 
   def toLatestMessageHashes(
-      justifications: Seq[Justification]): immutable.Map[Validator, BlockHash] =
+      justifications: Seq[Justification]
+  ): immutable.Map[Validator, BlockHash] =
     justifications.foldLeft(Map.empty[Validator, BlockHash]) {
       case (acc, Justification(validator, block)) =>
         acc.updated(validator, block)
@@ -257,7 +268,8 @@ object ProtoUtil {
 
   def toLatestMessage[F[_]: Monad: BlockStore](
       justifications: Seq[Justification],
-      dag: BlockDag): F[immutable.Map[Validator, BlockMessage]] =
+      dag: BlockDag
+  ): F[immutable.Map[Validator, BlockMessage]] =
     justifications.toList.foldM(Map.empty[Validator, BlockMessage]) {
       case (acc, Justification(validator, hash)) =>
         for {
@@ -274,10 +286,12 @@ object ProtoUtil {
   def hashByteArrays(items: Array[Byte]*): ByteString =
     ByteString.copyFrom(Blake2b256.hash(Array.concat(items: _*)))
 
-  def blockHeader(body: Body,
-                  parentHashes: Seq[ByteString],
-                  version: Long,
-                  timestamp: Long): Header =
+  def blockHeader(
+      body: Body,
+      parentHashes: Seq[ByteString],
+      version: Long,
+      timestamp: Long
+  ): Header =
     Header()
       .withParentsHashList(parentHashes)
       .withPostStateHash(protoHash(body.postState.get))
@@ -286,10 +300,12 @@ object ProtoUtil {
       .withVersion(version)
       .withTimestamp(timestamp)
 
-  def unsignedBlockProto(body: Body,
-                         header: Header,
-                         justifications: Seq[Justification],
-                         shardId: String): BlockMessage = {
+  def unsignedBlockProto(
+      body: Body,
+      header: Header,
+      justifications: Seq[Justification],
+      shardId: String
+  ): BlockMessage = {
     val hash = hashUnsignedBlock(header, justifications)
 
     BlockMessage()
@@ -305,12 +321,14 @@ object ProtoUtil {
     hashByteArrays(items: _*)
   }
 
-  def hashSignedBlock(header: Header,
-                      sender: ByteString,
-                      sigAlgorithm: String,
-                      seqNum: Int,
-                      shardId: String,
-                      extraBytes: ByteString): BlockHash =
+  def hashSignedBlock(
+      header: Header,
+      sender: ByteString,
+      sigAlgorithm: String,
+      seqNum: Int,
+      shardId: String,
+      extraBytes: ByteString
+  ): BlockHash =
     hashByteArrays(
       header.toByteArray,
       sender.toByteArray,
@@ -320,12 +338,14 @@ object ProtoUtil {
       extraBytes.toByteArray
     )
 
-  def signBlock(block: BlockMessage,
-                dag: BlockDag,
-                pk: Array[Byte],
-                sk: Array[Byte],
-                sigAlgorithm: String,
-                shardId: String): BlockMessage = {
+  def signBlock(
+      block: BlockMessage,
+      dag: BlockDag,
+      pk: Array[Byte],
+      sk: Array[Byte],
+      sigAlgorithm: String,
+      shardId: String
+  ): BlockMessage = {
 
     val header = {
       //TODO refactor casper code to avoid the usage of Option fields in the block datastructures

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/ApproveBlockProtocol.scala
@@ -37,7 +37,8 @@ abstract class ApproveBlockProtocolInstances {
 
 object ApproveBlockProtocol {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: ApproveBlockProtocol[F]): ApproveBlockProtocol[T[F, ?]] =
+      implicit C: ApproveBlockProtocol[F]
+  ): ApproveBlockProtocol[T[F, ?]] =
     new ApproveBlockProtocol[T[F, ?]] {
       override def addApproval(a: BlockApproval): T[F, Unit] = C.addApproval(a).liftM[T]
       override def run(): T[F, Unit]                         = C.run().liftM[T]
@@ -46,51 +47,55 @@ object ApproveBlockProtocol {
   def apply[F[_]](implicit instance: ApproveBlockProtocol[F]): ApproveBlockProtocol[F] = instance
 
   //For usage in tests only
-  def unsafe[
-      F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: Timer: Metrics: RPConfAsk: LastApprovedBlock](
+  def unsafe[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: Timer: Metrics: RPConfAsk: LastApprovedBlock](
       block: BlockMessage,
       trustedValidators: Set[ByteString],
       requiredSigs: Int,
       duration: FiniteDuration,
       interval: FiniteDuration,
       sigsF: Ref[F, Set[Signature]],
-      start: Long): ApproveBlockProtocol[F] =
-    new ApproveBlockProtocolImpl[F](block,
-                                    requiredSigs,
-                                    trustedValidators,
-                                    start,
-                                    duration,
-                                    interval,
-                                    sigsF)
+      start: Long
+  ): ApproveBlockProtocol[F] =
+    new ApproveBlockProtocolImpl[F](
+      block,
+      requiredSigs,
+      trustedValidators,
+      start,
+      duration,
+      interval,
+      sigsF
+    )
 
   def of[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: Timer: Metrics: RPConfAsk: LastApprovedBlock](
       block: BlockMessage,
       trustedValidators: Set[ByteString],
       requiredSigs: Int,
       duration: FiniteDuration,
-      interval: FiniteDuration): F[ApproveBlockProtocol[F]] =
+      interval: FiniteDuration
+  ): F[ApproveBlockProtocol[F]] =
     for {
       now   <- implicitly[Timer[F]].clock.realTime(MILLISECONDS)
       sigsF <- Ref.of[F, Set[Signature]](Set.empty)
     } yield
-      new ApproveBlockProtocolImpl[F](block,
-                                      requiredSigs,
-                                      trustedValidators,
-                                      now,
-                                      duration,
-                                      interval,
-                                      sigsF)
+      new ApproveBlockProtocolImpl[F](
+        block,
+        requiredSigs,
+        trustedValidators,
+        now,
+        duration,
+        interval,
+        sigsF
+      )
 
-  private class ApproveBlockProtocolImpl[
-      F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: Timer: Metrics: RPConfAsk: LastApprovedBlock](
+  private class ApproveBlockProtocolImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: Timer: Metrics: RPConfAsk: LastApprovedBlock](
       val block: BlockMessage,
       val requiredSigs: Int,
       val trustedValidators: Set[ByteString],
       val start: Long,
       val duration: FiniteDuration,
       val interval: FiniteDuration,
-      private val sigsF: Ref[F, Set[Signature]])
-      extends ApproveBlockProtocol[F] {
+      private val sigsF: Ref[F, Set[Signature]]
+  ) extends ApproveBlockProtocol[F] {
     private implicit val logSource: LogSource = LogSource(this.getClass)
 
     private val candidate                 = ApprovedBlockCandidate(Some(block), requiredSigs)
@@ -174,7 +179,8 @@ object ApproveBlockProtocol {
                 val serializedApprovedBlock = block.toByteString
                 for {
                   _ <- Log[F].info(
-                        s"APPROVAL: Beginning send of ApprovedBlock $candidateHash to peers...")
+                        s"APPROVAL: Beginning send of ApprovedBlock $candidateHash to peers..."
+                      )
                   _ <- CommUtil.sendToPeers[F](transport.ApprovedBlock, serializedApprovedBlock)
                   _ <- Log[F].info(s"APPROVAL: Sent ApprovedBlock $candidateHash to peers.")
                 } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -28,31 +28,35 @@ import scala.util.Try
   * Validator side of the protocol defined in
   * https://rchain.atlassian.net/wiki/spaces/CORE/pages/485556483/Initializing+the+Blockchain+--+Protocol+for+generating+the+Genesis+block
   */
-class BlockApproverProtocol(validatorId: ValidatorIdentity,
-                            deployTimestamp: Long,
-                            runtimeManager: RuntimeManager,
-                            bonds: Map[Array[Byte], Int],
-                            wallets: Seq[PreWallet],
-                            requiredSigs: Int)(implicit scheduler: Scheduler) {
+class BlockApproverProtocol(
+    validatorId: ValidatorIdentity,
+    deployTimestamp: Long,
+    runtimeManager: RuntimeManager,
+    bonds: Map[Array[Byte], Int],
+    wallets: Seq[PreWallet],
+    requiredSigs: Int
+)(implicit scheduler: Scheduler) {
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private val _bonds                        = bonds.map(e => ByteString.copyFrom(e._1) -> e._2)
 
-  def unapprovedBlockPacketHandler[
-      F[_]: Capture: Monad: TransportLayer: Log: Time: ErrorHandler: RPConfAsk](
+  def unapprovedBlockPacketHandler[F[_]: Capture: Monad: TransportLayer: Log: Time: ErrorHandler: RPConfAsk](
       peer: PeerNode,
-      u: UnapprovedBlock): F[Option[Packet]] =
+      u: UnapprovedBlock
+  ): F[Option[Packet]] =
     if (u.candidate.isEmpty) {
       Log[F]
         .warn("Candidate is not defined.")
         .map(_ => none[Packet])
     } else {
       val candidate = u.candidate.get
-      val validCandidate = BlockApproverProtocol.validateCandidate(runtimeManager,
-                                                                   candidate,
-                                                                   requiredSigs,
-                                                                   deployTimestamp,
-                                                                   wallets,
-                                                                   _bonds)
+      val validCandidate = BlockApproverProtocol.validateCandidate(
+        runtimeManager,
+        candidate,
+        requiredSigs,
+        deployTimestamp,
+        wallets,
+        _bonds
+      )
       validCandidate match {
         case Right(_) =>
           for {
@@ -73,15 +77,19 @@ class BlockApproverProtocol(validatorId: ValidatorIdentity,
 }
 
 object BlockApproverProtocol {
-  def getBlockApproval(expectedCandidate: ApprovedBlockCandidate,
-                       validatorId: ValidatorIdentity): BlockApproval = {
+  def getBlockApproval(
+      expectedCandidate: ApprovedBlockCandidate,
+      validatorId: ValidatorIdentity
+  ): BlockApproval = {
     val sigData = Blake2b256.hash(expectedCandidate.toByteArray)
     val sig     = validatorId.signature(sigData)
     BlockApproval(Some(expectedCandidate), Some(sig))
   }
 
-  def getApproval(candidate: ApprovedBlockCandidate,
-                  validatorId: ValidatorIdentity): BlockApproval =
+  def getApproval(
+      candidate: ApprovedBlockCandidate,
+      validatorId: ValidatorIdentity
+  ): BlockApproval =
     getBlockApproval(candidate, validatorId)
 
   def validateCandidate(
@@ -90,7 +98,8 @@ object BlockApproverProtocol {
       requiredSigs: Int,
       timestamp: Long,
       wallets: Seq[PreWallet],
-      bonds: Map[ByteString, Int])(implicit scheduler: Scheduler): Either[String, Unit] =
+      bonds: Map[ByteString, Int]
+  )(implicit scheduler: Scheduler): Either[String, Unit] =
     for {
       _ <- (candidate.requiredSigs == requiredSigs)
             .either(())
@@ -111,7 +120,8 @@ object BlockApproverProtocol {
             .forall(
               d =>
                 genesisBlessedTerms.contains(d.deploy.term.get) && genesisBlessedDeploys
-                  .exists(dd => deployDataEq.eqv(dd, d.deploy.raw.get)))
+                  .exists(dd => deployDataEq.eqv(dd, d.deploy.raw.get))
+            )
             .either(())
             .or("Candidate deploys do not match expected deploys.")
       _ <- (blockDeploys.size == genesisBlessedContracts.size)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -37,12 +37,12 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
 
   def apply[F[_]](implicit ev: CasperPacketHandler[F]): CasperPacketHandler[F] = ev
 
-  def of[
-      F[_]: LastApprovedBlock: Metrics: Timer: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Time: Log: MultiParentCasperRef](
+  def of[F[_]: LastApprovedBlock: Metrics: Timer: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Time: Log: MultiParentCasperRef](
       conf: CasperConf,
       delay: FiniteDuration,
       runtimeManager: RuntimeManager,
-      toTask: F[_] => Task[_])(implicit scheduler: Scheduler): F[CasperPacketHandler[F]] =
+      toTask: F[_] => Task[_]
+  )(implicit scheduler: Scheduler): F[CasperPacketHandler[F]] =
     if (conf.approveGenesis) {
       for {
         walletsFile <- Genesis.toFile[F](conf.walletsFile, conf.genesisPath.resolve("wallets.txt"))
@@ -52,34 +52,41 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         bonds <- Genesis
                   .getBonds[F](bondsFile, conf.numValidators, conf.genesisPath)
         validatorId <- ValidatorIdentity.fromConfig[F](conf)
-        bap = new BlockApproverProtocol(validatorId.get,
-                                        timestamp,
-                                        runtimeManager,
-                                        bonds,
-                                        wallets,
-                                        conf.requiredSigs)
+        bap = new BlockApproverProtocol(
+          validatorId.get,
+          timestamp,
+          runtimeManager,
+          bonds,
+          wallets,
+          conf.requiredSigs
+        )
         gv <- Ref.of[F, CasperPacketHandlerInternal[F]](
-               new GenesisValidatorHandler(runtimeManager, validatorId.get, conf.shardId, bap))
+               new GenesisValidatorHandler(runtimeManager, validatorId.get, conf.shardId, bap)
+             )
       } yield new CasperPacketHandlerImpl[F](gv)
     } else if (conf.createGenesis) {
       for {
-        genesis <- Genesis.fromInputFiles[F](conf.bondsFile,
-                                             conf.numValidators,
-                                             conf.genesisPath,
-                                             conf.walletsFile,
-                                             runtimeManager,
-                                             conf.shardId,
-                                             conf.deployTimestamp)
+        genesis <- Genesis.fromInputFiles[F](
+                    conf.bondsFile,
+                    conf.numValidators,
+                    conf.genesisPath,
+                    conf.walletsFile,
+                    runtimeManager,
+                    conf.shardId,
+                    conf.deployTimestamp
+                  )
         validatorId <- ValidatorIdentity.fromConfig[F](conf)
         bondedValidators = genesis.body
           .flatMap(_.postState.map(_.bonds.map(_.validator).toSet))
           .getOrElse(Set.empty)
         abp <- ApproveBlockProtocol
-                .of[F](genesis,
-                       bondedValidators,
-                       conf.requiredSigs,
-                       conf.approveGenesisDuration,
-                       conf.approveGenesisInterval)
+                .of[F](
+                  genesis,
+                  bondedValidators,
+                  conf.requiredSigs,
+                  conf.approveGenesisDuration,
+                  conf.approveGenesisInterval
+                )
                 .map(protocol => {
                   toTask(protocol.run()).forkAndForget.runAsync
                   protocol
@@ -88,11 +95,14 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         _ <- Sync[F].delay {
               val _ = toTask(
                 StandaloneCasperHandler
-                  .approveBlockInterval(conf.approveGenesisInterval,
-                                        conf.shardId,
-                                        runtimeManager,
-                                        validatorId,
-                                        standalone)).forkAndForget.runAsync
+                  .approveBlockInterval(
+                    conf.approveGenesisInterval,
+                    conf.shardId,
+                    runtimeManager,
+                    validatorId,
+                    standalone
+                  )
+              ).forkAndForget.runAsync
               ().pure[F]
             }
       } yield new CasperPacketHandlerImpl[F](standalone)
@@ -101,10 +111,13 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         validators  <- CasperConf.parseValidatorsFile[F](conf.knownValidatorsFile)
         validatorId <- ValidatorIdentity.fromConfig[F](conf)
         bootstrap <- Ref.of[F, CasperPacketHandlerInternal[F]](
-                      new BootstrapCasperHandler(runtimeManager,
-                                                 conf.shardId,
-                                                 validatorId,
-                                                 validators))
+                      new BootstrapCasperHandler(
+                        runtimeManager,
+                        conf.shardId,
+                        validatorId,
+                        validators
+                      )
+                    )
         casperPacketHandler = new CasperPacketHandlerImpl[F](bootstrap)
         _ <- Sync[F].delay {
               implicit val ph: PacketHandler[F] = PacketHandler.pf[F](casperPacketHandler.handle)
@@ -137,12 +150,12 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * When in this state node can't handle any other message type so it will return `F[None]`
     **/
-  private[comm] class GenesisValidatorHandler[
-      F[_]: Capture: Sync: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock](
+  private[comm] class GenesisValidatorHandler[F[_]: Capture: Sync: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock](
       runtimeManager: RuntimeManager,
       validatorId: ValidatorIdentity,
       shardId: String,
-      blockApprover: BlockApproverProtocol)(implicit scheduler: Scheduler)
+      blockApprover: BlockApproverProtocol
+  )(implicit scheduler: Scheduler)
       extends CasperPacketHandlerInternal[F] {
     private val nonePacket: F[Option[Packet]] = Monad[F].pure(None: Option[Packet])
 
@@ -150,20 +163,26 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Option[Packet]] =
       nonePacket
     override def handleApprovedBlock(
-        ab: ApprovedBlock): F[(Option[MultiParentCasper[F]], Option[Packet])] =
+        ab: ApprovedBlock
+    ): F[(Option[MultiParentCasper[F]], Option[Packet])] =
       for {
         _ <- Log[F].info("Received ApprovedBlock message while in GenesisValidatorHandler state.")
-        casperO <- onApprovedBlockTransition(ab,
-                                             Set(ByteString.copyFrom(validatorId.publicKey)),
-                                             runtimeManager,
-                                             Some(validatorId),
-                                             shardId)
-        _ <- casperO.fold(Log[F].warn("MultiParentCasper instance not created."))(_ =>
-              Log[F].info("MultiParentCasper instance created."))
+        casperO <- onApprovedBlockTransition(
+                    ab,
+                    Set(ByteString.copyFrom(validatorId.publicKey)),
+                    runtimeManager,
+                    Some(validatorId),
+                    shardId
+                  )
+        _ <- casperO.fold(Log[F].warn("MultiParentCasper instance not created."))(
+              _ => Log[F].info("MultiParentCasper instance created.")
+            )
       } yield (casperO, none[Packet])
 
-    override def handleApprovedBlockRequest(peer: PeerNode,
-                                            br: ApprovedBlockRequest): F[Option[Packet]] =
+    override def handleApprovedBlockRequest(
+        peer: PeerNode,
+        br: ApprovedBlockRequest
+    ): F[Option[Packet]] =
       RPConfAsk[F].reader(_.local).map(noApprovedBlockAvailable(_).some)
 
     override def handleBlockApproval(ba: BlockApproval): F[Option[Packet]] =
@@ -184,9 +203,9 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * For all other messages it will return `F[None]`.
     **/
-  private[comm] class StandaloneCasperHandler[
-      F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock](
-      approveProtocol: ApproveBlockProtocol[F])(implicit scheduler: Scheduler)
+  private[comm] class StandaloneCasperHandler[F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock](
+      approveProtocol: ApproveBlockProtocol[F]
+  )(implicit scheduler: Scheduler)
       extends CasperPacketHandlerInternal[F] {
 
     private val nonePacket: F[Option[Packet]] = Applicative[F].pure(None: Option[Packet])
@@ -196,10 +215,13 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Option[Packet]] =
       nonePacket
     override def handleApprovedBlock(
-        ab: ApprovedBlock): F[(Option[MultiParentCasper[F]], Option[Packet])] =
+        ab: ApprovedBlock
+    ): F[(Option[MultiParentCasper[F]], Option[Packet])] =
       nonePacket.map(none[MultiParentCasper[F]] -> _)
-    override def handleApprovedBlockRequest(peer: PeerNode,
-                                            br: ApprovedBlockRequest): F[Option[Packet]] =
+    override def handleApprovedBlockRequest(
+        peer: PeerNode,
+        br: ApprovedBlockRequest
+    ): F[Option[Packet]] =
       RPConfAsk[F].reader(_.local).map(noApprovedBlockAvailable(_).some)
 
     override def handleUnapprovedBlock(peer: PeerNode, ub: UnapprovedBlock): F[Option[Packet]] =
@@ -215,32 +237,35 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   }
 
   object StandaloneCasperHandler {
-    def approveBlockInterval[
-        F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: Timer: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef](
+    def approveBlockInterval[F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: Timer: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef](
         interval: FiniteDuration,
         shardId: String,
         runtimeManager: RuntimeManager,
         validatorId: Option[ValidatorIdentity],
-        capserHandlerInternal: Ref[F, CasperPacketHandlerInternal[F]])(
-        implicit scheduler: Scheduler): F[Unit] =
+        capserHandlerInternal: Ref[F, CasperPacketHandlerInternal[F]]
+    )(implicit scheduler: Scheduler): F[Unit] =
       for {
         _                  <- implicitly[Timer[F]].sleep(interval)
         lastApprovedBlockO <- LastApprovedBlock[F].get
         cont <- lastApprovedBlockO match {
                  case None =>
-                   approveBlockInterval[F](interval,
-                                           shardId,
-                                           runtimeManager,
-                                           validatorId,
-                                           capserHandlerInternal)
+                   approveBlockInterval[F](
+                     interval,
+                     shardId,
+                     runtimeManager,
+                     validatorId,
+                     capserHandlerInternal
+                   )
                  case Some(approvedBlock) =>
                    val blockMessage = approvedBlock.candidate.flatMap(_.block).get
                    for {
                      _ <- BlockStore[F].put(blockMessage.blockHash, blockMessage)
-                     casper <- MultiParentCasper.hashSetCasper[F](runtimeManager,
-                                                                  validatorId,
-                                                                  blockMessage,
-                                                                  shardId)
+                     casper <- MultiParentCasper.hashSetCasper[F](
+                                runtimeManager,
+                                validatorId,
+                                blockMessage,
+                                shardId
+                              )
                      _   <- MultiParentCasperRef[F].set(casper)
                      _   <- Log[F].info("Making a transition to ApprovedBlockRecievedHandler state.")
                      abh = new ApprovedBlockReceivedHandler[F](casper, approvedBlock)
@@ -254,20 +279,22 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
     * `F[None]` to all other message types.
     **/
-  private[comm] class BootstrapCasperHandler[
-      F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock](
+  private[comm] class BootstrapCasperHandler[F[_]: Sync: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock](
       runtimeManager: RuntimeManager,
       shardId: String,
       validatorId: Option[ValidatorIdentity],
-      validators: Set[ByteString])(implicit scheduler: Scheduler)
+      validators: Set[ByteString]
+  )(implicit scheduler: Scheduler)
       extends CasperPacketHandlerInternal[F] {
     private val nonePacket: F[Option[Packet]] = Applicative[F].pure(None: Option[Packet])
 
     override def handleBlockMessage(bm: BlockMessage): F[Option[Packet]] = nonePacket
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Option[Packet]] =
       nonePacket
-    override def handleApprovedBlockRequest(peer: PeerNode,
-                                            br: ApprovedBlockRequest): F[Option[Packet]] =
+    override def handleApprovedBlockRequest(
+        peer: PeerNode,
+        br: ApprovedBlockRequest
+    ): F[Option[Packet]] =
       Option(noApprovedBlockAvailable(peer)).pure[F]
 
     override def handleUnapprovedBlock(peer: PeerNode, ub: UnapprovedBlock): F[Option[Packet]] =
@@ -275,9 +302,11 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     override def handleBlockApproval(ba: BlockApproval): F[Option[Packet]] = nonePacket
 
     override def handleApprovedBlock(
-        ab: ApprovedBlock): F[(Option[MultiParentCasper[F]], Option[Packet])] =
+        ab: ApprovedBlock
+    ): F[(Option[MultiParentCasper[F]], Option[Packet])] =
       onApprovedBlockTransition(ab, validators, runtimeManager, validatorId, shardId).map(
-        _ -> none[Packet])
+        _ -> none[Packet]
+      )
 
     override def handleNoApprovedBlockAvailable(na: NoApprovedBlockAvailable): F[Option[Packet]] =
       for {
@@ -291,11 +320,10 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * In the future it will be possible to create checkpoint with new [[ApprovedBlock]].
     **/
-  class ApprovedBlockReceivedHandler[
-      F[_]: RPConfAsk: BlockStore: Monad: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler](
+  class ApprovedBlockReceivedHandler[F[_]: RPConfAsk: BlockStore: Monad: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler](
       private val casper: MultiParentCasper[F],
-      approvedBlock: ApprovedBlock)
-      extends CasperPacketHandlerInternal[F] {
+      approvedBlock: ApprovedBlock
+  ) extends CasperPacketHandlerInternal[F] {
 
     implicit val _casper = casper
 
@@ -304,7 +332,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     // Possible optimization in the future
     // TODO: accept update to approved block (this will be needed for checkpointing)
     override def handleApprovedBlock(
-        ab: ApprovedBlock): F[(Option[MultiParentCasper[F]], Option[Packet])] =
+        ab: ApprovedBlock
+    ): F[(Option[MultiParentCasper[F]], Option[Packet])] =
       nonePacket.map(none[MultiParentCasper[F]] -> _)
 
     override def handleUnapprovedBlock(peer: PeerNode, ub: UnapprovedBlock): F[Option[Packet]] =
@@ -328,8 +357,9 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         local      <- RPConfAsk[F].reader(_.local)
         block      <- BlockStore[F].get(br.hash)
         serialized = block.map(_.toByteString)
-        maybeMsg = serialized.map(serializedMessage =>
-          packet(local, transport.BlockMessage, serializedMessage))
+        maybeMsg = serialized.map(
+          serializedMessage => packet(local, transport.BlockMessage, serializedMessage)
+        )
         send     <- maybeMsg.traverse(msg => TransportLayer[F].send(peer, msg))
         hash     = PrettyPrinter.buildString(br.hash)
         logIntro = s"Received request for block $hash from $peer."
@@ -339,8 +369,10 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
             }
       } yield none[Packet]
 
-    override def handleApprovedBlockRequest(peer: PeerNode,
-                                            br: ApprovedBlockRequest): F[Option[Packet]] =
+    override def handleApprovedBlockRequest(
+        peer: PeerNode,
+        br: ApprovedBlockRequest
+    ): F[Option[Packet]] =
       for {
         _ <- Log[F].info(s"Received ApprovedBlockRequest from $peer")
       } yield Some(Packet(transport.ApprovedBlock.id, approvedBlock.toByteString))
@@ -351,10 +383,9 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       } yield none[Packet]
   }
 
-  class CasperPacketHandlerImpl[
-      F[_]: Monad: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: LastApprovedBlock: MultiParentCasperRef](
-      private val cphI: Ref[F, CasperPacketHandlerInternal[F]])
-      extends CasperPacketHandler[F] {
+  class CasperPacketHandlerImpl[F[_]: Monad: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: LastApprovedBlock: MultiParentCasperRef](
+      private val cphI: Ref[F, CasperPacketHandlerInternal[F]]
+  ) extends CasperPacketHandler[F] {
 
     override def handle(peer: PeerNode): PartialFunction[Packet, F[Option[Packet]]] =
       Function
@@ -386,7 +417,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                       for {
                         _ <- MultiParentCasperRef[F].set(casperInstance)
                         _ <- Log[F].info(
-                              "Making a transition to ApprovedBlockRecievedHandler state.")
+                              "Making a transition to ApprovedBlockRecievedHandler state."
+                            )
                         abr = new ApprovedBlockReceivedHandler(casperInstance, ab)
                         _   <- cphI.set(abr)
                       } yield ()
@@ -427,9 +459,9 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         }
   }
 
-  private def handleNewBlock[
-      F[_]: Monad: MultiParentCasper: TransportLayer: Log: Time: ErrorHandler](
-      b: BlockMessage): F[Unit] =
+  private def handleNewBlock[F[_]: Monad: MultiParentCasper: TransportLayer: Log: Time: ErrorHandler](
+      b: BlockMessage
+  ): F[Unit] =
     for {
       _ <- Log[F].info(s"Received ${PrettyPrinter.buildString(b)}.")
       _ <- MultiParentCasper[F].addBlock(b)
@@ -470,13 +502,13 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       Try(NoApprovedBlockAvailable.parseFrom(msg.content.toByteArray)).toOption
     else None
 
-  private def onApprovedBlockTransition[
-      F[_]: Sync: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock](
+  private def onApprovedBlockTransition[F[_]: Sync: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock](
       b: ApprovedBlock,
       validators: Set[ByteString],
       runtimeManager: RuntimeManager,
       validatorId: Option[ValidatorIdentity],
-      shardId: String)(implicit scheduler: Scheduler): F[Option[MultiParentCasper[F]]] =
+      shardId: String
+  )(implicit scheduler: Scheduler): F[Option[MultiParentCasper[F]]] =
     for {
       isValid <- Validate.approvedBlock[F](b, validators)
       casper <- if (isValid) {
@@ -495,7 +527,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     } yield casper
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: CasperPacketHandler[F]): CasperPacketHandler[T[F, ?]] =
+      implicit C: CasperPacketHandler[F]
+  ): CasperPacketHandler[T[F, ?]] =
     new CasperPacketHandler[T[F, ?]] {
       override def handle(peer: PeerNode): PartialFunction[Packet, T[F, Option[Packet]]] =
         PartialFunction { (p: Packet) =>
@@ -504,8 +537,10 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     }
 
   private def noApprovedBlockAvailable(peer: PeerNode): Packet =
-    Packet(transport.NoApprovedBlockAvailable.id,
-           NoApprovedBlockAvailable("NoApprovedBlockAvailable", peer.toString).toByteString)
+    Packet(
+      transport.NoApprovedBlockAvailable.id,
+      NoApprovedBlockAvailable("NoApprovedBlockAvailable", peer.toString).toByteString
+    )
 
 }
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -42,7 +42,8 @@ object DeployRuntime {
     }
 
   def listenForContinuationAtName[F[_]: Sync: Timer: DeployService: Capture](
-      names: List[Name]): F[Unit] =
+      names: List[Name]
+  ): F[Unit] =
     gracefulExit {
       listenAtNameUntilChanges(names) { pars: List[Par] =>
         val channels = pars.map(par => Channel(ChannelInstance.Quote(par)))
@@ -52,11 +53,13 @@ object DeployRuntime {
     }
 
   //Accepts a Rholang source file and deploys it to Casper
-  def deployFileProgram[F[_]: Monad: ErrorHandler: Capture: DeployService](purseAddress: String,
-                                                                           phloLimit: Int,
-                                                                           phloPrice: Int,
-                                                                           nonce: Int,
-                                                                           file: String): F[Unit] =
+  def deployFileProgram[F[_]: Monad: ErrorHandler: Capture: DeployService](
+      purseAddress: String,
+      phloLimit: Int,
+      phloPrice: Int,
+      nonce: Int,
+      file: String
+  ): F[Unit] =
     Try(Source.fromFile(file).mkString) match {
       case Success(code) =>
         gracefulExit(

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -90,7 +90,8 @@ Blockchain length: ${response.length}
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {
       println(
-        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout"
+      )
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtName.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtName.scala
@@ -66,8 +66,9 @@ object ListenAtName {
     loop
   }
 
-  def listenAtNameUntilChanges[A, G[_], F[_]: Sync: Timer](name: G[Name])(
-      request: G[Par] => F[Seq[A]])(implicit par: BuildPar[λ[A => F[G[A]]]]) = {
+  def listenAtNameUntilChanges[A, G[_], F[_]: Sync: Timer](
+      name: G[Name]
+  )(request: G[Par] => F[Seq[A]])(implicit par: BuildPar[λ[A => F[G[A]]]]) = {
     val nameF = name.pure[F]
 
     val retrieve =

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/ProcessedDeployUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/ProcessedDeployUtil.scala
@@ -5,10 +5,12 @@ import coop.rchain.casper.protocol._
 import coop.rchain.models.PCost
 import coop.rchain.rspace.trace
 
-case class InternalProcessedDeploy(deploy: Deploy,
-                                   cost: PCost,
-                                   log: Seq[trace.Event],
-                                   status: DeployStatus)
+case class InternalProcessedDeploy(
+    deploy: Deploy,
+    cost: PCost,
+    log: Seq[trace.Event],
+    status: DeployStatus
+)
 
 object ProcessedDeployUtil {
 

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -29,7 +29,8 @@ import scala.util.{Failure, Success, Try}
 class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: SyncVar[Runtime]) {
 
   def captureResults(start: StateHash, term: Par, name: String = "__SCALA__")(
-      implicit scheduler: Scheduler): Seq[Par] = {
+      implicit scheduler: Scheduler
+  ): Seq[Par] = {
     val runtime                   = runtimeContainer.take()
     val deploy                    = ProtoUtil.termDeploy(term, System.currentTimeMillis())
     val (_, Seq(processedDeploy)) = newEval(deploy :: Nil, runtime, start)
@@ -52,7 +53,8 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
   }
 
   def replayComputeState(hash: StateHash, terms: Seq[InternalProcessedDeploy])(
-      implicit scheduler: Scheduler): Either[(Option[Deploy], Failed), StateHash] = {
+      implicit scheduler: Scheduler
+  ): Either[(Option[Deploy], Failed), StateHash] = {
     val runtime = runtimeContainer.take()
     val result  = replayEval(terms, runtime, hash)
     runtimeContainer.put(runtime)
@@ -60,7 +62,8 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
   }
 
   def computeState(hash: StateHash, terms: Seq[Deploy])(
-      implicit scheduler: Scheduler): (StateHash, Seq[InternalProcessedDeploy]) = {
+      implicit scheduler: Scheduler
+  ): (StateHash, Seq[InternalProcessedDeploy]) = {
     val runtime = runtimeContainer.take()
     val result  = newEval(terms, runtime, hash)
     runtimeContainer.put(runtime)
@@ -122,8 +125,10 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     } yield par
   }
 
-  def getContinuation(hash: ByteString,
-                      channels: immutable.Seq[Channel]): Seq[(Seq[BindPattern], Par)] = {
+  def getContinuation(
+      hash: ByteString,
+      channels: immutable.Seq[Channel]
+  ): Seq[(Seq[BindPattern], Par)] = {
     val resetRuntime = getResetRuntime(hash)
     val results: Seq[WaitingContinuation[BindPattern, TaggedContinuation]] =
       resetRuntime.space.getWaitingContinuations(channels)
@@ -134,12 +139,15 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
   }
 
   private def newEval(terms: Seq[Deploy], runtime: Runtime, initHash: StateHash)(
-      implicit scheduler: Scheduler): (StateHash, Seq[InternalProcessedDeploy]) = {
+      implicit scheduler: Scheduler
+  ): (StateHash, Seq[InternalProcessedDeploy]) = {
 
     @tailrec
-    def doEval(terms: Seq[Deploy],
-               hash: Blake2b256Hash,
-               acc: Vector[InternalProcessedDeploy]): (StateHash, Vector[InternalProcessedDeploy]) =
+    def doEval(
+        terms: Seq[Deploy],
+        hash: Blake2b256Hash,
+        acc: Vector[InternalProcessedDeploy]
+    ): (StateHash, Vector[InternalProcessedDeploy]) =
       terms match {
         case deploy +: rem =>
           runtime.space.reset(hash)
@@ -148,10 +156,12 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
           val (phlosLeft, errors)        = injAttempt(deploy, runtime.reducer, runtime.errorLog)
           val cost                       = phlosLeft.copy(cost = availablePhlos.cost.value - phlosLeft.cost)
           val newCheckpoint              = runtime.space.createCheckpoint()
-          val deployResult = InternalProcessedDeploy(deploy,
-                                                     cost,
-                                                     newCheckpoint.log,
-                                                     DeployStatus.fromErrors(errors))
+          val deployResult = InternalProcessedDeploy(
+            deploy,
+            cost,
+            newCheckpoint.log,
+            DeployStatus.fromErrors(errors)
+          )
           if (errors.isEmpty) doEval(rem, newCheckpoint.root, acc :+ deployResult)
           else doEval(rem, hash, acc :+ deployResult)
 
@@ -161,13 +171,16 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     doEval(terms, Blake2b256Hash.fromByteArray(initHash.toByteArray), Vector.empty)
   }
 
-  private def replayEval(terms: Seq[InternalProcessedDeploy],
-                         runtime: Runtime,
-                         initHash: StateHash)(
-      implicit scheduler: Scheduler): Either[(Option[Deploy], Failed), StateHash] = {
+  private def replayEval(
+      terms: Seq[InternalProcessedDeploy],
+      runtime: Runtime,
+      initHash: StateHash
+  )(implicit scheduler: Scheduler): Either[(Option[Deploy], Failed), StateHash] = {
 
-    def doReplayEval(terms: Seq[InternalProcessedDeploy],
-                     hash: Blake2b256Hash): Either[(Option[Deploy], Failed), StateHash] =
+    def doReplayEval(
+        terms: Seq[InternalProcessedDeploy],
+        hash: Blake2b256Hash
+    ): Either[(Option[Deploy], Failed), StateHash] =
       terms match {
         case InternalProcessedDeploy(deploy, _, log, status) +: rem =>
           val availablePhlos             = CostAccount(Integer.MAX_VALUE)
@@ -200,9 +213,11 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
 
   private def injAttempt(deploy: Deploy, reducer: Reduce[Task], errorLog: ErrorLog)(
       implicit scheduler: Scheduler,
-      costAlg: CostAccountingAlg[Task]): (PCost, Vector[Throwable]) = {
+      costAlg: CostAccountingAlg[Task]
+  ): (PCost, Vector[Throwable]) = {
     implicit val rand: Blake2b512Random = Blake2b512Random(
-      DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.raw.get)))
+      DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.raw.get))
+    )
     Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
       case Success(_) =>
         val errors = errorLog.readAndClearErrorVector()

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -37,34 +37,48 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator with B
     def createChain[F[_]: Monad: BlockDagState: Time: BlockStore]: F[BlockMessage] =
       for {
         genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
-        b2 <- createBlock[F](Seq(genesis.blockHash),
-                             v2,
-                             bonds,
-                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b3 <- createBlock[F](Seq(genesis.blockHash),
-                             v1,
-                             bonds,
-                             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-        b4 <- createBlock[F](Seq(b2.blockHash),
-                             v2,
-                             bonds,
-                             HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
-        b5 <- createBlock[F](Seq(b2.blockHash),
-                             v1,
-                             bonds,
-                             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
-        _ <- createBlock[F](Seq(b4.blockHash),
-                            v2,
-                            bonds,
-                            HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b7 <- createBlock[F](Seq(b4.blockHash),
-                             v1,
-                             bonds,
-                             HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-        b8 <- createBlock[F](Seq(b7.blockHash),
-                             v1,
-                             bonds,
-                             HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
+        b2 <- createBlock[F](
+               Seq(genesis.blockHash),
+               v2,
+               bonds,
+               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+             )
+        b3 <- createBlock[F](
+               Seq(genesis.blockHash),
+               v1,
+               bonds,
+               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+             )
+        b4 <- createBlock[F](
+               Seq(b2.blockHash),
+               v2,
+               bonds,
+               HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash)
+             )
+        b5 <- createBlock[F](
+               Seq(b2.blockHash),
+               v1,
+               bonds,
+               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash)
+             )
+        _ <- createBlock[F](
+              Seq(b4.blockHash),
+              v2,
+              bonds,
+              HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+            )
+        b7 <- createBlock[F](
+               Seq(b4.blockHash),
+               v1,
+               bonds,
+               HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+             )
+        b8 <- createBlock[F](
+               Seq(b7.blockHash),
+               v1,
+               bonds,
+               HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash)
+             )
       } yield b8
 
     val chain: IndexedBlockDag = createChain[StateWithChain].runS(initState)
@@ -108,34 +122,44 @@ class CliqueOracleTest extends FlatSpec with Matchers with BlockGenerator with B
                  Seq(genesis.blockHash),
                  v2,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+               )
           b3 <- createBlock[F](
                  Seq(genesis.blockHash),
                  v1,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+               )
           b4 <- createBlock[F](
                  Seq(b2.blockHash),
                  v3,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
+               )
           b5 <- createBlock[F](
                  Seq(b3.blockHash),
                  v2,
                  bonds,
-                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash))
-          b6 <- createBlock[F](Seq(b4.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
-          b7 <- createBlock[F](Seq(b5.blockHash),
-                               v3,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
-          b8 <- createBlock[F](Seq(b6.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
+               )
+          b6 <- createBlock[F](
+                 Seq(b4.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
+               )
+          b7 <- createBlock[F](
+                 Seq(b5.blockHash),
+                 v3,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+               )
+          b8 <- createBlock[F](
+                 Seq(b6.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+               )
         } yield b8
 
       val chain: IndexedBlockDag = createChain[StateWithChain].runS(initState)

--- a/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
@@ -37,34 +37,48 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator with Blo
       def createChain[F[_]: Monad: BlockDagState: Time: BlockStore]: F[BlockMessage] =
         for {
           genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
-          b2 <- createBlock[F](Seq(genesis.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-          b3 <- createBlock[F](Seq(genesis.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-          b4 <- createBlock[F](Seq(b2.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
-          b5 <- createBlock[F](Seq(b2.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
-          _ <- createBlock[F](Seq(b4.blockHash),
-                              v2,
-                              bonds,
-                              HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-          b7 <- createBlock[F](Seq(b4.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-          b8 <- createBlock[F](Seq(b7.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
+          b2 <- createBlock[F](
+                 Seq(genesis.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+               )
+          b3 <- createBlock[F](
+                 Seq(genesis.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+               )
+          b4 <- createBlock[F](
+                 Seq(b2.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash)
+               )
+          b5 <- createBlock[F](
+                 Seq(b2.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash)
+               )
+          _ <- createBlock[F](
+                Seq(b4.blockHash),
+                v2,
+                bonds,
+                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+              )
+          b7 <- createBlock[F](
+                 Seq(b4.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+               )
+          b8 <- createBlock[F](
+                 Seq(b7.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash)
+               )
         } yield b8
 
       implicit val blockStoreChain = storeForStateWithChain[StateWithChain](blockStore)
@@ -76,7 +90,8 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator with Blo
         for {
           forkchoice <- Estimator.tips[F](
                          chain.withLatestMessages(HashMap.empty[Validator, BlockMessage]),
-                         genesis)
+                         genesis
+                       )
           _ = forkchoice.head should be(genesis)
         } yield ()
       checkForkchoice[Id]
@@ -93,34 +108,48 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator with Blo
       def createChain[F[_]: Monad: BlockDagState: Time: BlockStore]: F[BlockMessage] =
         for {
           genesis <- createBlock[F](Seq(), ByteString.EMPTY, bonds)
-          b2 <- createBlock[F](Seq(genesis.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-          b3 <- createBlock[F](Seq(genesis.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash))
-          b4 <- createBlock[F](Seq(b2.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash))
-          b5 <- createBlock[F](Seq(b2.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash))
-          _ <- createBlock[F](Seq(b4.blockHash),
-                              v2,
-                              bonds,
-                              HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-          b7 <- createBlock[F](Seq(b4.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash))
-          b8 <- createBlock[F](Seq(b7.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash))
+          b2 <- createBlock[F](
+                 Seq(genesis.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+               )
+          b3 <- createBlock[F](
+                 Seq(genesis.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
+               )
+          b4 <- createBlock[F](
+                 Seq(b2.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash)
+               )
+          b5 <- createBlock[F](
+                 Seq(b2.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash)
+               )
+          _ <- createBlock[F](
+                Seq(b4.blockHash),
+                v2,
+                bonds,
+                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+              )
+          b7 <- createBlock[F](
+                 Seq(b4.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
+               )
+          b8 <- createBlock[F](
+                 Seq(b7.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash)
+               )
         } yield b8
 
       implicit val blockStoreChain = storeForStateWithChain[StateWithChain](blockStore)
@@ -159,34 +188,44 @@ class ForkchoiceTest extends FlatSpec with Matchers with BlockGenerator with Blo
                  Seq(genesis.blockHash),
                  v2,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+               )
           b3 <- createBlock[F](
                  Seq(genesis.blockHash),
                  v1,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+               )
           b4 <- createBlock[F](
                  Seq(b2.blockHash),
                  v3,
                  bonds,
-                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash))
+                 HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
+               )
           b5 <- createBlock[F](
                  Seq(b3.blockHash),
                  v2,
                  bonds,
-                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash))
-          b6 <- createBlock[F](Seq(b4.blockHash),
-                               v1,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
-          b7 <- createBlock[F](Seq(b5.blockHash),
-                               v3,
-                               bonds,
-                               HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
-          b8 <- createBlock[F](Seq(b6.blockHash),
-                               v2,
-                               bonds,
-                               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
+               )
+          b6 <- createBlock[F](
+                 Seq(b4.blockHash),
+                 v1,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
+               )
+          b7 <- createBlock[F](
+                 Seq(b5.blockHash),
+                 v3,
+                 bonds,
+                 HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+               )
+          b8 <- createBlock[F](
+                 Seq(b6.blockHash),
+                 v2,
+                 bonds,
+                 HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+               )
         } yield b8
 
       implicit val blockStoreChain = storeForStateWithChain[StateWithChain](blockStore)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -77,7 +77,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
                    case Right((running, statusB)) =>
                      running.join.map((_, statusB).tupled)
-                 })
+                 }
+               )
     } yield result
     val threadStatuses: (BlockStatus, BlockStatus) =
       testProgram.value.unsafeRunSync(scheduler).right.get
@@ -143,11 +144,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     ).zipWithIndex.map(s => ProtoUtil.sourceDeploy(s._1, start + s._2))
 
     val Created(signedBlock1) = MultiParentCasper[Id].deploy(deployDatas.head) *> MultiParentCasper[
-      Id].createBlock
+      Id
+    ].createBlock
     MultiParentCasper[Id].addBlock(signedBlock1)
 
     val Created(signedBlock2) = MultiParentCasper[Id].deploy(deployDatas(1)) *> MultiParentCasper[
-      Id].createBlock
+      Id
+    ].createBlock
     MultiParentCasper[Id].addBlock(signedBlock2)
     val storage = blockTuplespaceContents(signedBlock2)
 
@@ -165,8 +168,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     val startTime = System.currentTimeMillis()
     val source    = " for(@x <- @0){ @0!(x) } | @0!(0) "
-    val deploys = (source #:: source #:: Stream.empty[String]).zipWithIndex.map(s =>
-      ProtoUtil.sourceDeploy(s._1, startTime + s._2))
+    val deploys = (source #:: source #:: Stream.empty[String]).zipWithIndex
+      .map(s => ProtoUtil.sourceDeploy(s._1, startTime + s._2))
     deploys.foreach(MultiParentCasper[Id].deploy(_))
     val Created(block) = MultiParentCasper[Id].createBlock
     val _              = MultiParentCasper[Id].addBlock(block)
@@ -180,7 +183,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     import node._
 
     val Created(block) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeployData(0)) *> MultiParentCasper[
-      Id].createBlock
+      Id
+    ].createBlock
     val invalidBlock = block.withSig(ByteString.EMPTY)
 
     MultiParentCasper[Id].addBlock(invalidBlock)
@@ -197,7 +201,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     import node._
 
     val Created(signedBlock) = MultiParentCasper[Id].deploy(ProtoUtil.basicDeployData(0)) *> MultiParentCasper[
-      Id].createBlock
+      Id
+    ].createBlock
 
     MultiParentCasper[Id].addBlock(signedBlock)
 
@@ -324,7 +329,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     nodes(1).logEff.warns
       .count(_ contains "found deploy by the same (user, millisecond timestamp) produced") should be(
-      1)
+      1
+    )
     nodes.foreach(_.tearDownNode())
 
     nodes.foreach { node =>
@@ -364,8 +370,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     nodes(2).logEff.infos
       .count(_ startsWith "Requested missing block") should be(1)
-    nodes(1).logEff.infos.count(s =>
-      (s startsWith "Received request for block") && (s endsWith "Response sent.")) should be(1)
+    nodes(1).logEff.infos.count(
+      s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
+    ) should be(1)
 
     nodes.foreach(_.tearDownNode())
     nodes.foreach { node =>
@@ -450,7 +457,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(1)
 
     nodes(1).casperEff.normalizedInitialFault(ProtoUtil.weightMap(genesis)) should be(
-      1f / (1f + 3f + 5f + 7f))
+      1f / (1f + 3f + 5f + 7f)
+    )
     nodes.foreach(_.tearDownNode())
 
     validateBlockStore(nodes(0)) { blockStore =>
@@ -514,8 +522,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     nodes(1).logEff.infos
       .count(_ startsWith "Requested missing block") should be(10)
-    nodes(0).logEff.infos.count(s =>
-      (s startsWith "Received request for block") && (s endsWith "Response sent.")) should be(10)
+    nodes(0).logEff.infos.count(
+      s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
+    ) should be(10)
 
     nodes.foreach(_.tearDown())
   }
@@ -586,9 +595,11 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     nodes.foreach(_.tearDown())
   }
 
-  private def buildBlockWithInvalidJustification(nodes: IndexedSeq[HashSetCasperTestNode[Id]],
-                                                 deploys: immutable.IndexedSeq[ProcessedDeploy],
-                                                 signedInvalidBlock: BlockMessage) = {
+  private def buildBlockWithInvalidJustification(
+      nodes: IndexedSeq[HashSetCasperTestNode[Id]],
+      deploys: immutable.IndexedSeq[ProcessedDeploy],
+      signedInvalidBlock: BlockMessage
+  ) = {
     val postState     = RChainState().withBonds(ProtoUtil.bonds(genesis)).withBlockNumber(2)
     val postStateHash = Blake2b256.hash(postState.toByteArray)
     val header = Header()
@@ -602,12 +613,14 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     val serializedBlockHash = ByteString.copyFrom(blockHash)
     val blockThatPointsToInvalidBlock =
       BlockMessage(serializedBlockHash, Some(header), Some(body), serializedJustifications)
-    ProtoUtil.signBlock(blockThatPointsToInvalidBlock,
-                        nodes(1).casperEff.blockDag,
-                        validators(1),
-                        validatorKeys(1),
-                        "ed25519",
-                        "rchain")
+    ProtoUtil.signBlock(
+      blockThatPointsToInvalidBlock,
+      nodes(1).casperEff.blockDag,
+      validators(1),
+      validatorKeys(1),
+      "ed25519",
+      "rchain"
+    )
   }
 }
 
@@ -619,8 +632,9 @@ object HashSetCasperTest {
     node.dir.recursivelyDelete()
   }
 
-  def blockTuplespaceContents(block: BlockMessage)(
-      implicit casper: MultiParentCasper[Id]): String = {
+  def blockTuplespaceContents(
+      block: BlockMessage
+  )(implicit casper: MultiParentCasper[Id]): String = {
     val tsHash = block.body.get.postState.get.tuplespace
     MultiParentCasper[Id].storageContents(tsHash)
   }
@@ -631,9 +645,11 @@ object HashSetCasperTest {
   def createGenesis(bonds: Map[Array[Byte], Int]): BlockMessage =
     buildGenesis(Seq.empty, bonds, 0L)
 
-  def buildGenesis(wallets: Seq[PreWallet],
-                   bonds: Map[Array[Byte], Int],
-                   deployTimestamp: Long): BlockMessage = {
+  def buildGenesis(
+      wallets: Seq[PreWallet],
+      bonds: Map[Array[Byte], Int],
+      deployTimestamp: Long
+  ): BlockMessage = {
     val initial           = Genesis.withoutContracts(bonds, 0L, deployTimestamp, "rchain")
     val storageDirectory  = Files.createTempDirectory(s"hash-set-casper-test-genesis")
     val storageSize: Long = 1024L * 1024
@@ -646,7 +662,8 @@ object HashSetCasperTest {
       wallets,
       emptyStateHash,
       runtimeManager,
-      deployTimestamp)
+      deployTimestamp
+    )
     activeRuntime.close()
     genesis
   }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -69,7 +69,9 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
       implicit val casperEffect = NoOpsCasperEffect(
         HashMap[BlockHash, BlockMessage](
           (ProtoUtil.stringToByteString(genesisHashString), genesisBlock),
-          (ProtoUtil.stringToByteString(secondHashString), secondBlock)))(syncId, blockStore)
+          (ProtoUtil.stringToByteString(secondHashString), secondBlock)
+        )
+      )(syncId, blockStore)
       implicit val logEff = new LogStub[Id]()(syncId)
       implicit val casperRef = {
         val tmp = MultiParentCasperRef.of[Id]
@@ -79,11 +81,13 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
       implicit val turanOracleEffect: SafetyOracle[Id] =
         SafetyOracle.turanOracle[Id](syncId, blockStore)
       val q = BlockQuery(hash = secondBlockQuery)
-      val blockQueryResponse = BlockAPI.getBlockQueryResponse[Id](q)(syncId,
-                                                                     casperRef,
-                                                                     logEff,
-                                                                     turanOracleEffect,
-                                                                     blockStore)
+      val blockQueryResponse = BlockAPI.getBlockQueryResponse[Id](q)(
+        syncId,
+        casperRef,
+        logEff,
+        turanOracleEffect,
+        blockStore
+      )
       val blockInfo = blockQueryResponse.blockInfo.get
       blockQueryResponse.status should be("Success")
       blockInfo.blockHash should be(secondHashString)
@@ -103,7 +107,9 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
       implicit val casperEffect = NoOpsCasperEffect(
         HashMap[BlockHash, BlockMessage](
           (ProtoUtil.stringToByteString(genesisHashString), genesisBlock),
-          (ProtoUtil.stringToByteString(secondHashString), secondBlock)))(syncId, blockStore)
+          (ProtoUtil.stringToByteString(secondHashString), secondBlock)
+        )
+      )(syncId, blockStore)
       implicit val logEff = new LogStub[Id]()(syncId)
       implicit val casperRef = {
         val tmp = MultiParentCasperRef.of[Id]
@@ -113,12 +119,15 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
       implicit val turanOracleEffect: SafetyOracle[Id] =
         SafetyOracle.turanOracle[Id](syncId, blockStore)
       val q = BlockQuery(hash = badTestHashQuery)
-      val blockQueryResponse = BlockAPI.getBlockQueryResponse[Id](q)(syncId,
-                                                                     casperRef,
-                                                                     logEff,
-                                                                     turanOracleEffect,
-                                                                     blockStore)
+      val blockQueryResponse = BlockAPI.getBlockQueryResponse[Id](q)(
+        syncId,
+        casperRef,
+        logEff,
+        turanOracleEffect,
+        blockStore
+      )
       blockQueryResponse.status should be(
-        s"Error: Failure to find block with hash ${badTestHashQuery}")
+        s"Error: Failure to find block with hash ${badTestHashQuery}"
+      )
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -46,37 +46,44 @@ class BlocksResponseAPITest
              Seq(genesis.blockHash),
              v2,
              bonds,
-             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+           )
       b3 <- createBlock[StateWithChain](
              Seq(genesis.blockHash),
              v1,
              bonds,
-             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash))
+             HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
+           )
       b4 <- createBlock[StateWithChain](
              Seq(b2.blockHash),
              v3,
              bonds,
-             HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash))
+             HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
+           )
       b5 <- createBlock[StateWithChain](
              Seq(b3.blockHash),
              v2,
              bonds,
-             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash))
+             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
+           )
       b6 <- createBlock[StateWithChain](
              Seq(b4.blockHash),
              v1,
              bonds,
-             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash))
+             HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
+           )
       b7 <- createBlock[StateWithChain](
              Seq(b5.blockHash),
              v3,
              bonds,
-             HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+             HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+           )
       b8 <- createBlock[StateWithChain](
              Seq(b6.blockHash),
              v2,
              bonds,
-             HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash))
+             HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
+           )
     } yield b8
 
   val chain: IndexedBlockDag = createChain.runS(initState)
@@ -84,9 +91,11 @@ class BlocksResponseAPITest
 
   implicit val blockStoreEffect = BlockStore[Id]
   implicit val casperEffect: MultiParentCasper[Id] =
-    NoOpsCasperEffect[Id](HashMap.empty[BlockHash, BlockMessage],
-                          Estimator.tips[Id](chain, genesis),
-                          chain)(syncId, blockStoreEffect)
+    NoOpsCasperEffect[Id](
+      HashMap.empty[BlockHash, BlockMessage],
+      Estimator.tips[Id](chain, genesis),
+      chain
+    )(syncId, blockStoreEffect)
   implicit val logEff = new LogStub[Id]
   implicit val casperRef = {
     val tmp = MultiParentCasperRef.of[Id]

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -43,8 +43,9 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
     ).map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis()))
 
     implicit val logEff = new LogStub[Effect]
-    def testProgram(implicit casperRef: MultiParentCasperRef[Effect])
-      : Effect[(DeployServiceResponse, DeployServiceResponse)] = EitherT.liftF(
+    def testProgram(
+        implicit casperRef: MultiParentCasperRef[Effect]
+    ): Effect[(DeployServiceResponse, DeployServiceResponse)] = EitherT.liftF(
       for {
         t1 <- (BlockAPI.deploy[Effect](deploys.head) *> BlockAPI.createBlock[Effect]).value.fork
         _  <- implicitly[Timer[Task]].sleep(2.second)

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -103,10 +103,13 @@ class ListeningNameAPITest extends FlatSpec with Matchers with BlockStoreFixture
     val data2   = listeningNameResponse2.blockResults.map(_.postBlockData)
     val blocks2 = listeningNameResponse2.blockResults.map(_.block)
     data2 should be(
-      List(List(resultData, resultData, resultData, resultData),
-           List(resultData, resultData, resultData),
-           List(resultData, resultData),
-           List(resultData)))
+      List(
+        List(resultData, resultData, resultData, resultData),
+        List(resultData, resultData, resultData),
+        List(resultData, resultData),
+        List(resultData)
+      )
+    )
     blocks2.length should be(4)
     listeningNameResponse2.length should be(4)
 
@@ -141,7 +144,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with BlockStoreFixture
         List(resultData, resultData, resultData),
         List(resultData, resultData),
         List(resultData)
-      ))
+      )
+    )
     blocks3.length should be(7)
     listeningNameResponse3.length should be(7)
 
@@ -168,7 +172,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with BlockStoreFixture
         Seq(
           Channel(Quote(Par().copy(exprs = Seq(Expr(GInt(1)), Expr(GInt(2)))))),
           Channel(Quote(Par().copy(exprs = Seq(Expr(GInt(2)), Expr(GInt(1)), Expr(GInt(3))))))
-        ))
+        )
+      )
     val result = WaitingContinuationInfo(
       List(
         BindPattern(Vector(Channel(Quote(Par().copy(exprs = Vector(Expr(GInt(1))))))), None, 0),
@@ -189,7 +194,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with BlockStoreFixture
         Seq(
           Channel(Quote(Par().copy(exprs = Seq(Expr(GInt(2)), Expr(GInt(1)), Expr(GInt(3)))))),
           Channel(Quote(Par().copy(exprs = Seq(Expr(GInt(1)), Expr(GInt(2))))))
-        ))
+        )
+      )
     val listeningNameResponse2 =
       BlockAPI.getListeningNameContinuationResponse[Id](listeningNamesShuffled2)
     val continuations2 = listeningNameResponse2.blockResults.map(_.postBlockContinuations)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -68,13 +68,15 @@ class GenesisTest extends FlatSpec with Matchers with BeforeAndAfterEach with Bl
   "Genesis.fromInputFiles" should "generate random validators when no bonds file is given" in {
     val runtime        = Runtime.create(storageLocation, storageSize)
     val runtimeManager = RuntimeManager.fromRuntime(runtime)
-    val _ = Genesis.fromInputFiles[Id](None,
-                                       numValidators,
-                                       genesisPath,
-                                       None,
-                                       runtimeManager,
-                                       rchainShardId,
-                                       Some(System.currentTimeMillis()))
+    val _ = Genesis.fromInputFiles[Id](
+      None,
+      numValidators,
+      genesisPath,
+      None,
+      runtimeManager,
+      rchainShardId,
+      Some(System.currentTimeMillis())
+    )
     runtime.close()
 
     log.warns.find(_.contains("bonds")) should be(None)
@@ -96,7 +98,8 @@ class GenesisTest extends FlatSpec with Matchers with BeforeAndAfterEach with Bl
     runtime.close()
 
     log.warns.count(_.contains("does not exist. Falling back on generating random validators.")) should be(
-      1)
+      1
+    )
     log.infos.count(_.contains("Created validator")) should be(numValidators)
   }
 
@@ -111,17 +114,20 @@ class GenesisTest extends FlatSpec with Matchers with BeforeAndAfterEach with Bl
     val runtime        = Runtime.create(storageLocation, storageSize)
     val runtimeManager = RuntimeManager.fromRuntime(runtime)
     val _ =
-      Genesis.fromInputFiles[Id](Some(badBondsFile),
-                                 numValidators,
-                                 path,
-                                 None,
-                                 runtimeManager,
-                                 rchainShardId,
-                                 Some(System.currentTimeMillis()))
+      Genesis.fromInputFiles[Id](
+        Some(badBondsFile),
+        numValidators,
+        path,
+        None,
+        runtimeManager,
+        rchainShardId,
+        Some(System.currentTimeMillis())
+      )
     runtime.close()
 
     log.warns.count(_.contains("cannot be parsed. Falling back on generating random validators.")) should be(
-      1)
+      1
+    )
     log.infos.count(_.contains("Created validator")) should be(numValidators)
   }
 
@@ -133,13 +139,15 @@ class GenesisTest extends FlatSpec with Matchers with BeforeAndAfterEach with Bl
     val runtime        = Runtime.create(storageLocation, storageSize)
     val runtimeManager = RuntimeManager.fromRuntime(runtime)
     val genesis =
-      Genesis.fromInputFiles[Id](Some(bondsFile),
-                                 numValidators,
-                                 path,
-                                 None,
-                                 runtimeManager,
-                                 rchainShardId,
-                                 Some(System.currentTimeMillis()))
+      Genesis.fromInputFiles[Id](
+        Some(bondsFile),
+        numValidators,
+        path,
+        None,
+        runtimeManager,
+        rchainShardId,
+        Some(System.currentTimeMillis())
+      )
     runtime.close()
     val bonds = ProtoUtil.bonds(genesis)
 
@@ -158,13 +166,15 @@ class GenesisTest extends FlatSpec with Matchers with BeforeAndAfterEach with Bl
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime)
     val emptyStateHash = runtimeManager.emptyStateHash
 
-    val genesis = Genesis.fromInputFiles[Id](None,
-                                             numValidators,
-                                             genesisPath,
-                                             None,
-                                             runtimeManager,
-                                             rchainShardId,
-                                             Some(System.currentTimeMillis()))
+    val genesis = Genesis.fromInputFiles[Id](
+      None,
+      numValidators,
+      genesisPath,
+      None,
+      runtimeManager,
+      rchainShardId,
+      Some(System.currentTimeMillis())
+    )
     BlockStore[Id].put(genesis.blockHash, genesis)
     val blockDag = BlockDag.empty
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -22,22 +22,28 @@ object TestSetUtil {
 
   def runtime(name: String): Runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
 
-  def eval_term(term: Par, runtime: Runtime)(implicit scheduler: Scheduler,
-                                             rand: Blake2b512Random,
-                                             costAccountingAlg: CostAccountingAlg[Task]): Unit =
+  def eval_term(term: Par, runtime: Runtime)(
+      implicit scheduler: Scheduler,
+      rand: Blake2b512Random,
+      costAccountingAlg: CostAccountingAlg[Task]
+  ): Unit =
     runtime.reducer.inj(term).unsafeRunSync
 
-  def eval(code: String, runtime: Runtime)(implicit scheduler: Scheduler,
-                                           rand: Blake2b512Random,
-                                           costAccountingAlg: CostAccountingAlg[Task]): Unit =
+  def eval(code: String, runtime: Runtime)(
+      implicit scheduler: Scheduler,
+      rand: Blake2b512Random,
+      costAccountingAlg: CostAccountingAlg[Task]
+  ): Unit =
     mkTerm(code) match {
       case Right(term) => eval_term(term, runtime)
       case Left(ex)    => throw ex
     }
 
-  def runTests(tests: CompiledRholangSource,
-               otherLibs: Seq[CompiledRholangSource],
-               runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
+  def runTests(
+      tests: CompiledRholangSource,
+      otherLibs: Seq[CompiledRholangSource],
+      runtime: Runtime
+  )(implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
     val rand              = Blake2b512Random(128)
     val costAccountingAlg = CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
@@ -50,9 +56,11 @@ object TestSetUtil {
         eval(lib.code, runtime)(implicitly, rand.splitShort((idx + 2).toShort), costAccountingAlg)
     }
 
-    eval(tests.code, runtime)(implicitly,
-                              rand.splitShort((otherLibs.length + 2).toShort),
-                              costAccountingAlg)
+    eval(tests.code, runtime)(
+      implicitly,
+      rand.splitShort((otherLibs.length + 2).toShort),
+      costAccountingAlg
+    )
   }
 
   /**

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -56,7 +56,8 @@ trait BlockGenerator {
       justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
       deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
       tsHash: ByteString = ByteString.EMPTY,
-      shardId: String = "rchain"): F[BlockMessage] =
+      shardId: String = "rchain"
+  ): F[BlockMessage] =
     for {
       chain             <- blockDagState[F].get
       now               <- Time[F].currentMillis
@@ -79,13 +80,15 @@ trait BlockGenerator {
           Justification(creator, latestBlockHash)
       }
       serializedBlockHash = ByteString.copyFrom(blockHash)
-      block = BlockMessage(serializedBlockHash,
-                           Some(header),
-                           Some(body),
-                           serializedJustifications,
-                           creator,
-                           nextCreatorSeqNum,
-                           shardId = shardId)
+      block = BlockMessage(
+        serializedBlockHash,
+        Some(header),
+        Some(body),
+        serializedJustifications,
+        creator,
+        nextCreatorSeqNum,
+        shardId = shardId
+      )
       idToBlocks     = chain.idToBlocks + (nextId -> block)
       _              <- BlockStore[F].put(serializedBlockHash, block)
       latestMessages = chain.latestMessages + (block.sender -> block)
@@ -102,15 +105,17 @@ trait BlockGenerator {
       updatedSeqNumbers = chain.currentSeqNum.updated(creator, nextCreatorSeqNum)
       updatedSort       = TopologicalSortUtil.update(chain.topoSort, chain.sortOffset, block)
       updatedLookup     = chain.dataLookup.updated(block.blockHash, BlockMetadata.fromBlock(block))
-      newChain = IndexedBlockDag(idToBlocks,
-                                 childMap,
-                                 latestMessages,
-                                 latestMessagesOfLatestMessages,
-                                 nextId,
-                                 updatedSeqNumbers,
-                                 updatedLookup,
-                                 updatedSort,
-                                 chain.sortOffset)
+      newChain = IndexedBlockDag(
+        idToBlocks,
+        childMap,
+        latestMessages,
+        latestMessagesOfLatestMessages,
+        nextId,
+        updatedSeqNumbers,
+        updatedLookup,
+        updatedSort,
+        chain.sortOffset
+      )
       _ <- blockDagState[F].set(newChain)
     } yield block
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockStoreFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockStoreFixture.scala
@@ -24,9 +24,11 @@ trait BlockStoreFixture extends BeforeAndAfter { self: Suite =>
 }
 
 object BlockStoreTestFixture {
-  def env(path: Path,
-          mapSize: Long,
-          flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)): Env[ByteBuffer] =
+  def env(
+      path: Path,
+      mapSize: Long,
+      flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+  ): Env[ByteBuffer] =
     Env
       .create()
       .setMapSize(mapSize)

--- a/casper/src/test/scala/coop/rchain/casper/helper/IndexedBlockDag.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/IndexedBlockDag.scala
@@ -25,15 +25,17 @@ case class IndexedBlockDag(dag: BlockDag, idToBlocks: Map[Int, BlockMessage], cu
 object IndexedBlockDag {
   def empty: IndexedBlockDag = IndexedBlockDag(BlockDag.empty, Map.empty[Int, BlockMessage], 0)
 
-  def apply(idToBlocks: Map[Int, BlockMessage],
-            childMap: Map[BlockHash, Set[BlockHash]],
-            latestMessages: Map[Validator, BlockMessage],
-            latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
-            currentId: Int,
-            currentSeqNum: Map[Validator, Int],
-            dataLookup: BlockMetadata.Lookup,
-            topoSort: Vector[Vector[BlockHash]],
-            sortOffset: Long): IndexedBlockDag = IndexedBlockDag(
+  def apply(
+      idToBlocks: Map[Int, BlockMessage],
+      childMap: Map[BlockHash, Set[BlockHash]],
+      latestMessages: Map[Validator, BlockMessage],
+      latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
+      currentId: Int,
+      currentSeqNum: Map[Validator, Int],
+      dataLookup: BlockMetadata.Lookup,
+      topoSort: Vector[Vector[BlockHash]],
+      sortOffset: Long
+  ): IndexedBlockDag = IndexedBlockDag(
     BlockDag(
       childMap,
       latestMessages,

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -14,8 +14,8 @@ import scala.collection.mutable.{Map => MutableMap}
 class NoOpsCasperEffect[F[_]: Sync: BlockStore] private (
     private val blockStore: MutableMap[BlockHash, BlockMessage],
     estimatorFunc: IndexedSeq[BlockMessage],
-    blockDagFunc: BlockDag)
-    extends MultiParentCasper[F] {
+    blockDagFunc: BlockDag
+) extends MultiParentCasper[F] {
 
   def store: Map[BlockHash, BlockMessage] = blockStore.toMap
 
@@ -40,13 +40,15 @@ object NoOpsCasperEffect {
   def apply[F[_]: Sync: BlockStore](
       blockStore: Map[BlockHash, BlockMessage] = Map.empty,
       estimatorFunc: IndexedSeq[BlockMessage] = Vector(BlockMessage()),
-      blockDagFunc: BlockDag = BlockDag.empty): F[NoOpsCasperEffect[F]] =
+      blockDagFunc: BlockDag = BlockDag.empty
+  ): F[NoOpsCasperEffect[F]] =
     for {
       _ <- Sync[F].delay { blockStore.map((BlockStore[F].put _).tupled) }
     } yield new NoOpsCasperEffect[F](MutableMap(blockStore.toSeq: _*), estimatorFunc, blockDagFunc)
   def apply[F[_]: Sync: BlockStore](): F[NoOpsCasperEffect[F]] =
     apply(Map.empty, Vector(BlockMessage()), BlockDag.empty)
   def apply[F[_]: Sync: BlockStore](
-      blockStore: Map[BlockHash, BlockMessage]): F[NoOpsCasperEffect[F]] =
+      blockStore: Map[BlockHash, BlockMessage]
+  ): F[NoOpsCasperEffect[F]] =
     apply(blockStore, Vector(BlockMessage()), BlockDag.empty)
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/CliqueTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CliqueTest.scala
@@ -6,19 +6,21 @@ import org.scalatest.{Assertion, FlatSpec, Matchers}
 import scala.annotation.tailrec
 
 class CliqueTest extends FlatSpec with Matchers with BlockGenerator with BlockStoreFixture {
-  val e = List((1, 6),
-               (1, 2),
-               (1, 3),
-               (2, 6),
-               (2, 4),
-               (2, 3),
-               (3, 6),
-               (4, 6),
-               (4, 7),
-               (4, 5),
-               (5, 7),
-               (8, 9),
-               (10, 11))
+  val e = List(
+    (1, 6),
+    (1, 2),
+    (1, 3),
+    (2, 6),
+    (2, 4),
+    (2, 3),
+    (3, 6),
+    (4, 6),
+    (4, 7),
+    (4, 5),
+    (5, 7),
+    (8, 9),
+    (10, 11)
+  )
 
   private def compare(l: List[Int], r: List[Int]): Boolean = {
     @tailrec

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
@@ -104,10 +104,12 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
 
     val sigs = (1 to n).map(_ => Ed25519.newKeyPair)
     val TestFixture(lab, abp, candidate, startTime, sigsF) =
-      ApproveBlockProtocolTest.createProtocol(n,
-                                              duration = d,
-                                              interval = 1.millisecond,
-                                              sigs.map(_._2).toSet)
+      ApproveBlockProtocolTest.createProtocol(
+        n,
+        duration = d,
+        interval = 1.millisecond,
+        sigs.map(_._2).toSet
+      )
     ctx.tick(startTime.milliseconds) //align clocks
     val cancelToken = abp.run().fork.runAsync
 
@@ -136,10 +138,12 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     implicit val metricsTest = new MetricsTestImpl[Task]()
 
     val TestFixture(lab, abp, candidate, startTime, _) =
-      ApproveBlockProtocolTest.createProtocol(n,
-                                              duration = d,
-                                              interval = 1.millisecond,
-                                              sigs.map(_._2).toSet)
+      ApproveBlockProtocolTest.createProtocol(
+        n,
+        duration = d,
+        interval = 1.millisecond,
+        sigs.map(_._2).toSet
+      )
     ctx.tick(startTime.milliseconds) // align clocks
 
     val cancelToken = abp.run().fork.runAsync
@@ -182,10 +186,12 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     implicit val metricsTest       = new MetricsTestImpl[Task]()
 
     val TestFixture(lab, abp, _, startTime, _) =
-      ApproveBlockProtocolTest.createProtocol(0,
-                                              duration = d,
-                                              interval = 1.millisecond,
-                                              Set(validatorPk))
+      ApproveBlockProtocolTest.createProtocol(
+        0,
+        duration = d,
+        interval = 1.millisecond,
+        Set(validatorPk)
+      )
 
     ctx.tick(startTime.milliseconds) // align clocks
 
@@ -221,7 +227,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
   }
 
   private def infosContain[F[_]](start: String, size: Int)(
-      implicit logStub: LogStub[F]): Assertion =
+      implicit logStub: LogStub[F]
+  ): Assertion =
     logStub.infos.filter(_.startsWith(start)).size should be(size)
 
   it should "send UnapprovedBlock message to peers at every interval" in {
@@ -288,36 +295,43 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
 }
 
 object ApproveBlockProtocolTest {
-  def approval(c: ApprovedBlockCandidate,
-               validatorSk: Array[Byte],
-               validatorPk: Array[Byte]): BlockApproval = {
+  def approval(
+      c: ApprovedBlockCandidate,
+      validatorSk: Array[Byte],
+      validatorPk: Array[Byte]
+  ): BlockApproval = {
     val sigData = Blake2b256.hash(c.toByteArray)
     val sig     = Ed25519.sign(sigData, validatorSk)
     BlockApproval(
       Some(c),
-      Some(Signature(ByteString.copyFrom(validatorPk), "ed25519", ByteString.copyFrom(sig))))
+      Some(Signature(ByteString.copyFrom(validatorPk), "ed25519", ByteString.copyFrom(sig)))
+    )
   }
 
   def invalidApproval(c: ApprovedBlockCandidate): BlockApproval = {
     val (sk, pk) = Ed25519.newKeyPair
     val sigData  = Blake2b256.hash(c.toByteArray ++ "wrong data".toArray.map(_.toByte))
     val sig      = Ed25519.sign(sigData, sk)
-    BlockApproval(Some(c),
-                  Some(Signature(ByteString.copyFrom(pk), "ed25519", ByteString.copyFrom(sig))))
+    BlockApproval(
+      Some(c),
+      Some(Signature(ByteString.copyFrom(pk), "ed25519", ByteString.copyFrom(sig)))
+    )
   }
 
-  final case class TestFixture(lab: LastApprovedBlock[Task],
-                               protocol: ApproveBlockProtocol[Task],
-                               candidate: ApprovedBlockCandidate,
-                               startTime: Long,
-                               sigsF: Ref[Task, Set[Signature]])
+  final case class TestFixture(
+      lab: LastApprovedBlock[Task],
+      protocol: ApproveBlockProtocol[Task],
+      candidate: ApprovedBlockCandidate,
+      startTime: Long,
+      sigsF: Ref[Task, Set[Signature]]
+  )
 
-  def createProtocol(requiredSigs: Int,
-                     duration: FiniteDuration,
-                     interval: FiniteDuration,
-                     validatorsPk: Set[Array[Byte]])(
-      implicit logStub: LogStub[Task],
-      metrics: MetricsTestImpl[Task]): TestFixture = {
+  def createProtocol(
+      requiredSigs: Int,
+      duration: FiniteDuration,
+      interval: FiniteDuration,
+      validatorsPk: Set[Array[Byte]]
+  )(implicit logStub: LogStub[Task], metrics: MetricsTestImpl[Task]): TestFixture = {
     implicit val time            = new LogicalTime[Task]()
     implicit val transportLayer  = new TransportLayerStub[Task]
     val src: PeerNode            = peerNode("src", 40400)

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
@@ -62,7 +62,8 @@ object BlockApproverProtocolTest {
       requiredSigs: Int,
       wallets: Seq[PreWallet],
       sk: Array[Byte],
-      bonds: Map[Array[Byte], Int]): (BlockApproverProtocol, HashSetCasperTestNode[Id]) = {
+      bonds: Map[Array[Byte], Int]
+  ): (BlockApproverProtocol, HashSetCasperTestNode[Id]) = {
     import monix.execution.Scheduler.Implicits.global
 
     val runtimeDir     = BlockStoreTestFixture.dbDir
@@ -75,12 +76,14 @@ object BlockApproverProtocolTest {
     val genesis = HashSetCasperTest.buildGenesis(wallets, bonds, deployTimestamp)
     val node    = HashSetCasperTestNode.network(Vector(sk), genesis).head
 
-    new BlockApproverProtocol(node.validatorId,
-                              deployTimestamp,
-                              runtimeManager,
-                              bonds,
-                              wallets,
-                              requiredSigs) -> node
+    new BlockApproverProtocol(
+      node.validatorId,
+      deployTimestamp,
+      runtimeManager,
+      bonds,
+      wallets,
+      requiredSigs
+    ) -> node
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -15,8 +15,8 @@ import coop.rchain.comm.transport._
 
 class TransportLayerTestImpl[F[_]: Monad](
     identity: PeerNode,
-    val msgQueues: Map[PeerNode, Ref[F, mutable.Queue[Protocol]]])
-    extends TransportLayer[F] {
+    val msgQueues: Map[PeerNode, Ref[F, mutable.Queue[Protocol]]]
+) extends TransportLayer[F] {
 
   def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]] = ???
 
@@ -50,8 +50,10 @@ class TransportLayerTestImpl[F[_]: Monad](
 }
 
 object TransportLayerTestImpl {
-  def handleQueue[F[_]: Monad](dispatch: Protocol => F[CommunicationResponse],
-                               qRef: Ref[F, mutable.Queue[Protocol]]): F[Unit] =
+  def handleQueue[F[_]: Monad](
+      dispatch: Protocol => F[CommunicationResponse],
+      qRef: Ref[F, mutable.Queue[Protocol]]
+  ): F[Unit] =
     for {
       maybeProto <- qRef.modify { q =>
                      if (q.nonEmpty) {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -37,7 +37,8 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
         .mkTerm(s""" for(@nn <- @"nn"){ @(nn, "value")!("$captureChannel") } """)
         .right
         .get,
-      captureChannel)
+      captureChannel
+    )
 
     result.size should be(1)
     result.head should be(InterpreterUtil.mkTerm(purseValue).right.get)
@@ -56,7 +57,8 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
     manyResults.size should be(n)
     (1 to n).forall(i => manyResults.contains(InterpreterUtil.mkTerm(i.toString).right.get)) should be(
-      true)
+      true
+    )
   }
 
   "emptyStateHash" should "not remember previous hot store state" in {
@@ -84,8 +86,9 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     )
 
     def deployCost(p: Seq[InternalProcessedDeploy]): Long = p.map(_.cost.cost).sum
-    val deploy = terms.map(t =>
-      ProtoUtil.termDeploy(InterpreterUtil.mkTerm(t).right.get, System.currentTimeMillis()))
+    val deploy = terms.map(
+      t => ProtoUtil.termDeploy(InterpreterUtil.mkTerm(t).right.get, System.currentTimeMillis())
+    )
     val (_, firstDeploy) =
       runtimeManager.computeState(runtimeManager.emptyStateHash, deploy.head :: Nil)
     val (_, secondDeploy) =
@@ -102,10 +105,14 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     assert(secondDeployCost < compoundDeployCost)
     assert(
       firstDeployCost == deployCost(
-        compoundDeploy.find(_.deploy == firstDeploy.head.deploy).toVector))
+        compoundDeploy.find(_.deploy == firstDeploy.head.deploy).toVector
+      )
+    )
     assert(
       secondDeployCost == deployCost(
-        compoundDeploy.find(_.deploy == secondDeploy.head.deploy).toVector))
+        compoundDeploy.find(_.deploy == secondDeploy.head.deploy).toVector
+      )
+    )
     assert((firstDeployCost + secondDeployCost) == compoundDeployCost)
   }
 }

--- a/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/ProtocolHelper.scala
@@ -14,8 +14,10 @@ object ProtocolHelper {
       h <- proto.header
       s <- h.sender
     } yield
-      PeerNode(NodeIdentifier(s.id.toByteArray),
-               Endpoint(s.host.toStringUtf8, s.tcpPort, s.udpPort))
+      PeerNode(
+        NodeIdentifier(s.id.toByteArray),
+        Endpoint(s.host.toStringUtf8, s.tcpPort, s.udpPort)
+      )
 
   implicit def toProtocolBytes(x: String): ByteString =
     com.google.protobuf.ByteString.copyFromUtf8(x)
@@ -51,14 +53,18 @@ object ProtocolHelper {
   def lookup(src: PeerNode, id: Seq[Byte]): Protocol =
     Protocol()
       .withHeader(header(src))
-      .withLookup(Lookup()
-        .withId(id.toArray))
+      .withLookup(
+        Lookup()
+          .withId(id.toArray)
+      )
 
   def lookupResponse(src: PeerNode, nodes: Seq[PeerNode]): Protocol =
     Protocol()
       .withHeader(header(src))
-      .withLookupResponse(LookupResponse()
-        .withNodes(nodes.map(node)))
+      .withLookupResponse(
+        LookupResponse()
+          .withNodes(nodes.map(node))
+      )
 
   def upstreamMessage(src: PeerNode, upstream: AnyProto): Protocol =
     Protocol()

--- a/comm/src/main/scala/coop/rchain/comm/UPnP.scala
+++ b/comm/src/main/scala/coop/rchain/comm/UPnP.scala
@@ -61,7 +61,8 @@ object UPnP {
         case Some(true) =>
           println(
             s"WARNING - Gateway's external IP address ${gateway.getExternalIPAddress} is from a private address block. " +
-              "This machine is behind more than one NAT.")
+              "This machine is behind more than one NAT."
+          )
         case Some(_) =>
           println("INFO - Gateway's external IP address is from a public address block.")
         case _ => println("WARNING - Can't parse gateway's external IP address. It's maybe IPv6.")
@@ -70,7 +71,8 @@ object UPnP {
       val mappings = getPortMappings(gateway).filter(m => ports.contains(m.getExternalPort))
       mappings.foreach { m =>
         print(
-          s"INFO - Removing an existing port mapping for port ${m.getProtocol}/${m.getExternalPort}")
+          s"INFO - Removing an existing port mapping for port ${m.getProtocol}/${m.getExternalPort}"
+        )
         removePort(gateway, m) match {
           case Right(_) => println(" [success]")
           case _        => println(" [failed]")
@@ -91,7 +93,8 @@ object UPnP {
 
       if (result.exists(r => !r)) {
         println(
-          "ERROR - Could not open the ports via UPnP. Please open it manually on your router!")
+          "ERROR - Could not open the ports via UPnP. Please open it manually on your router!"
+        )
       } else {
         println("INFO - UPnP port forwarding was most likely successful!")
       }
@@ -163,14 +166,17 @@ object UPnP {
   }
 
   // TODO: Allow different external and internal ports
-  def addPort(device: GatewayDevice,
-              port: Int,
-              protocol: String,
-              description: String): Either[CommError, Boolean] =
+  def addPort(
+      device: GatewayDevice,
+      port: Int,
+      protocol: String,
+      description: String
+  ): Either[CommError, Boolean] =
     try {
       Right(
         device
-          .addPortMapping(port, port, device.getLocalAddress.getHostAddress, protocol, description))
+          .addPortMapping(port, port, device.getLocalAddress.getHostAddress, protocol, description)
+      )
     } catch {
       case NonFatal(ex: Exception) => Left(UnknownCommError(ex.toString))
     }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -18,7 +18,8 @@ import scala.concurrent.duration._
 object KademliaNodeDiscovery {
   def create[F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](
       src: PeerNode,
-      defaultTimeout: FiniteDuration)(init: Option[PeerNode]): F[KademliaNodeDiscovery[F]] =
+      defaultTimeout: FiniteDuration
+  )(init: Option[PeerNode]): F[KademliaNodeDiscovery[F]] =
     for {
       knd <- (new KademliaNodeDiscovery[F](src, defaultTimeout)).pure[F]
       _   <- init.fold(().pure[F])(p => knd.addNode(p))
@@ -26,9 +27,10 @@ object KademliaNodeDiscovery {
 
 }
 
-private[discovery] class KademliaNodeDiscovery[
-    F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](src: PeerNode, timeout: FiniteDuration)
-    extends NodeDiscovery[F] {
+private[discovery] class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](
+    src: PeerNode,
+    timeout: FiniteDuration
+) extends NodeDiscovery[F] {
 
   private val table = PeerTable(src)
 
@@ -79,7 +81,8 @@ private[discovery] class KademliaNodeDiscovery[
               r =>
                 !potentials.contains(r)
                   && r.id.key != id.key
-                  && table.find(r.id.key).isEmpty)
+                  && table.find(r.id.key).isEmpty
+            )
           } >>= (find(peerSet.tail, _, i + 1))
       } else {
         potentials.toSeq.pure[F]
@@ -98,7 +101,7 @@ private[discovery] class KademliaNodeDiscovery[
           case Protocol(_, Protocol.Message.Lookup(lookup)) => handleLookup(sender, lookup)
           case _                                            => notHandled(unexpectedMessage(protocol.toString)).pure[F]
         })
-    }
+      }
 
   private def handlePing: F[CommunicationResponse] =
     for {

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
@@ -17,7 +17,8 @@ object KademliaRPC extends KademliaRPCInstances {
   def apply[F[_]](implicit P: KademliaRPC[F]): KademliaRPC[F] = P
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit P: KademliaRPC[F]): KademliaRPC[T[F, ?]] =
+      implicit P: KademliaRPC[F]
+  ): KademliaRPC[T[F, ?]] =
     new KademliaRPC[T[F, ?]] {
       def ping(node: PeerNode): T[F, Boolean]                         = P.ping(node).liftM[T]
       def lookup(key: Seq[Byte], peer: PeerNode): T[F, Seq[PeerNode]] = P.lookup(key, peer).liftM[T]

--- a/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
@@ -19,7 +19,8 @@ object NodeDiscovery extends NodeDiscoveryInstances {
   def apply[F[_]](implicit L: NodeDiscovery[F]): NodeDiscovery[F] = L
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: NodeDiscovery[F]): NodeDiscovery[T[F, ?]] =
+      implicit C: NodeDiscovery[F]
+  ): NodeDiscovery[T[F, ?]] =
     new NodeDiscovery[T[F, ?]] {
       def discover: T[F, Unit]       = C.discover.liftM[T]
       def peers: T[F, Seq[PeerNode]] = C.peers.liftM[T]

--- a/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
@@ -37,9 +37,11 @@ final case class PeerTableEntry[A](entry: A, gkey: A => Seq[Byte]) extends Keyed
 
 object PeerTable {
 
-  def apply[A <: PeerNode](home: A,
-                           k: Int = PeerTable.Redundancy,
-                           alpha: Int = PeerTable.Alpha): PeerTable[A] =
+  def apply[A <: PeerNode](
+      home: A,
+      k: Int = PeerTable.Redundancy,
+      alpha: Int = PeerTable.Alpha
+  ): PeerTable[A] =
     new PeerTable[A](home, k, alpha)
 
   // Number of bits considered in the distance function. Taken from the

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -68,8 +68,7 @@ object Connect {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  def clearConnections[
-      F[_]: Capture: Monad: Time: ConnectionsCell: RPConfAsk: TransportLayer: Log: Metrics]
+  def clearConnections[F[_]: Capture: Monad: Time: ConnectionsCell: RPConfAsk: TransportLayer: Log: Metrics]
     : F[Int] = {
 
     def sendHeartbeat(peer: PeerNode): F[(PeerNode, CommErr[RoutingProtocol])] =
@@ -99,8 +98,7 @@ object Connect {
     } yield cleared
   }
 
-  def findAndConnect[
-      F[_]: Capture: Monad: Log: Time: Metrics: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
+  def findAndConnect[F[_]: Capture: Monad: Log: Time: Metrics: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
       conn: (PeerNode, FiniteDuration) => F[Unit]
   ): F[List[PeerNode]] =
     for {
@@ -117,10 +115,10 @@ object Connect {
           }
     } yield peersAndResonses.filter(_._2.isRight).map(_._1)
 
-  def connect[
-      F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
+  def connect[F[_]: Capture: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
       peer: PeerNode,
-      timeout: FiniteDuration): F[Unit] =
+      timeout: FiniteDuration
+  ): F[Unit] =
     for {
       tss      <- Time[F].currentMillis
       peerAddr = peer.toAddress
@@ -131,7 +129,8 @@ object Connect {
       ph       = protocolHandshake(local)
       phsresp  <- TransportLayer[F].roundTrip(peer, ph, timeout * 2) >>= ErrorHandler[F].fromEither
       _ <- Log[F].debug(
-            s"Received protocol handshake response from ${ProtocolHelper.sender(phsresp)}.")
+            s"Received protocol handshake response from ${ProtocolHelper.sender(phsresp)}."
+          )
       _   <- ConnectionsCell[F].modify(_.addConn[F](peer))
       tsf <- Time[F].currentMillis
       _   <- Metrics[F].record("connect-time-ms", tsf - tss)

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -3,7 +3,9 @@ package coop.rchain.comm.rp
 import coop.rchain.comm.PeerNode
 import scala.concurrent.duration._
 
-case class RPConf(local: PeerNode,
-                  defaultTimeout: FiniteDuration,
-                  clearConnections: ClearConnetionsConf)
+case class RPConf(
+    local: PeerNode,
+    defaultTimeout: FiniteDuration,
+    clearConnections: ClearConnetionsConf
+)
 case class ClearConnetionsConf(maxNumOfConnections: Int, numOfConnectionsPinged: Int)

--- a/comm/src/main/scala/coop/rchain/comm/transport/CertificateHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/CertificateHelper.scala
@@ -91,7 +91,7 @@ object CertificateHelper {
 
     val info     = new X509CertInfo
     val from     = new java.util.Date()
-    val to       = new java.util.Date(from.getTime + 365 * 86400000l)
+    val to       = new java.util.Date(from.getTime + 365 * 86400000L)
     val interval = new CertificateValidity(from, to)
     val serial   = new BigInteger(64, new SecureRandom())
     val owner    = new X500Name(s"CN=$address")
@@ -127,10 +127,12 @@ case class ParameterSpec(
 
 case object ParameterSpec {
   def apply(ecParamSpec: ECParameterSpec): ParameterSpec =
-    ParameterSpec(ecParamSpec.getCurve,
-                  ecParamSpec.getGenerator,
-                  ecParamSpec.getOrder,
-                  ecParamSpec.getCofactor)
+    ParameterSpec(
+      ecParamSpec.getCurve,
+      ecParamSpec.getGenerator,
+      ecParamSpec.getOrder,
+      ecParamSpec.getCofactor
+    )
 }
 
 object CertificatePrinter {

--- a/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
@@ -25,14 +25,18 @@ object HostnameTrustManagerFactory {
 
 private class HostnameTrustManager extends X509ExtendedTrustManager {
 
-  def checkClientTrusted(x509Certificates: Array[X509Certificate],
-                         authType: String,
-                         socket: Socket): Unit =
+  def checkClientTrusted(
+      x509Certificates: Array[X509Certificate],
+      authType: String,
+      socket: Socket
+  ): Unit =
     throw new CertificateException("Not allowed validation method")
 
-  def checkClientTrusted(x509Certificates: Array[X509Certificate],
-                         authType: String,
-                         sslEngine: SSLEngine): Unit = {
+  def checkClientTrusted(
+      x509Certificates: Array[X509Certificate],
+      authType: String,
+      sslEngine: SSLEngine
+  ): Unit = {
     Option(sslEngine.getHandshakeSession)
       .getOrElse(throw new CertificateException("No handshake session"))
 
@@ -41,21 +45,26 @@ private class HostnameTrustManager extends X509ExtendedTrustManager {
       .publicAddress(cert.getPublicKey)
       .map(Base16.encode)
       .getOrElse(
-        throw new CertificateException(s"Certificate's public key has the wrong algorithm"))
+        throw new CertificateException(s"Certificate's public key has the wrong algorithm")
+      )
     checkIdentity(Some(peerHost), cert, "https")
   }
 
   def checkClientTrusted(x509Certificates: Array[X509Certificate], authType: String): Unit =
     throw new CertificateException("Not allowed validation method")
 
-  def checkServerTrusted(x509Certificates: Array[X509Certificate],
-                         authType: String,
-                         socket: Socket): Unit =
+  def checkServerTrusted(
+      x509Certificates: Array[X509Certificate],
+      authType: String,
+      socket: Socket
+  ): Unit =
     throw new CertificateException("Not allowed validation method")
 
-  def checkServerTrusted(x509Certificates: Array[X509Certificate],
-                         authType: String,
-                         sslEngine: SSLEngine): Unit = {
+  def checkServerTrusted(
+      x509Certificates: Array[X509Certificate],
+      authType: String,
+      sslEngine: SSLEngine
+  ): Unit = {
     val sslSession = Option(sslEngine.getHandshakeSession)
       .getOrElse(throw new CertificateException("No handshake session"))
 
@@ -69,8 +78,11 @@ private class HostnameTrustManager extends X509ExtendedTrustManager {
           .publicAddress(cert.getPublicKey)
           .map(Base16.encode)
           .filter(_ == peerHost.getOrElse(""))
-          .getOrElse(throw new CertificateException(
-            s"Certificate's public address doesn't match the hostname"))
+          .getOrElse(
+            throw new CertificateException(
+              s"Certificate's public address doesn't match the hostname"
+            )
+          )
 
       case _ =>
         throw new CertificateException("No endpoint identification algorithm")
@@ -82,9 +94,11 @@ private class HostnameTrustManager extends X509ExtendedTrustManager {
 
   def getAcceptedIssuers: Array[X509Certificate] = EmptyArrays.EMPTY_X509_CERTIFICATES
 
-  private def checkIdentity(hostname: Option[String],
-                            cert: X509Certificate,
-                            algorithm: String): Unit = {
+  private def checkIdentity(
+      hostname: Option[String],
+      cert: X509Certificate,
+      algorithm: String
+  ): Unit = {
     import sun.security.util.HostnameChecker
     algorithm.toLowerCase match {
       case "https" =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -12,9 +12,11 @@ import io.grpc._
 import javax.net.ssl.SSLSession
 
 class SslSessionClientInterceptor() extends ClientInterceptor {
-  def interceptCall[ReqT, RespT](method: MethodDescriptor[ReqT, RespT],
-                                 callOptions: CallOptions,
-                                 next: Channel): ClientCall[ReqT, RespT] =
+  def interceptCall[ReqT, RespT](
+      method: MethodDescriptor[ReqT, RespT],
+      callOptions: CallOptions,
+      next: Channel
+  ): ClientCall[ReqT, RespT] =
     new SslSessionClientCallInterceptor(next.newCall(method, callOptions))
 }
 
@@ -60,7 +62,8 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
             log.trace(s"Response [$msgType] from peer ${peerNode.toAddress}")
           }
           val sslSession: Option[SSLSession] = Option(
-            self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION))
+            self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)
+          )
           if (sslSession.isEmpty) {
             log.warn("No TLS Session. Closing connection")
             close()

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -21,9 +21,10 @@ class SslSessionServerInterceptor() extends ServerInterceptor {
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private val log                           = Log.log[Id]
 
-  private class InterceptionListener[ReqT, RespT](next: ServerCall.Listener[ReqT],
-                                                  call: ServerCall[ReqT, RespT])
-      extends ServerCall.Listener[ReqT] {
+  private class InterceptionListener[ReqT, RespT](
+      next: ServerCall.Listener[ReqT],
+      call: ServerCall[ReqT, RespT]
+  ) extends ServerCall.Listener[ReqT] {
 
     override def onHalfClose(): Unit = next.onHalfClose()
     override def onCancel(): Unit    = next.onCancel()
@@ -47,7 +48,8 @@ class SslSessionServerInterceptor() extends ServerInterceptor {
             log.trace(s"Request [$msgType] from peer ${peerNode.toAddress}")
           }
           val sslSession: Option[SSLSession] = Option(
-            call.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION))
+            call.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)
+          )
           if (sslSession.isEmpty) {
             log.warn("No TLS Session. Closing connection")
             close()

--- a/comm/src/main/scala/coop/rchain/p2p/effects/PacketHandler.scala
+++ b/comm/src/main/scala/coop/rchain/p2p/effects/PacketHandler.scala
@@ -16,7 +16,8 @@ object PacketHandler extends PacketHandlerInstances {
   def apply[F[_]: PacketHandler]: PacketHandler[F] = implicitly[PacketHandler[F]]
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: PacketHandler[F]): PacketHandler[T[F, ?]] =
+      implicit C: PacketHandler[F]
+  ): PacketHandler[T[F, ?]] =
     new PacketHandler[T[F, ?]] {
       def handlePacket(peer: PeerNode, packet: Packet): T[F, Option[Packet]] =
         C.handlePacket(peer, packet).liftM[T]
@@ -25,7 +26,8 @@ object PacketHandler extends PacketHandlerInstances {
   def pf[F[_]](pfForPeer: (PeerNode) => PartialFunction[Packet, F[Option[Packet]]])(
       implicit ev1: Applicative[F],
       ev2: Log[F],
-      errorHandler: ApplicativeError_[F, CommError]): PacketHandler[F] =
+      errorHandler: ApplicativeError_[F, CommError]
+  ): PacketHandler[F] =
     new PacketHandler[F] {
       def handlePacket(peer: PeerNode, packet: Packet): F[Option[Packet]] = {
         val errorMsg = s"Unable to handle packet $packet"

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -38,7 +38,8 @@ class ClearConnectionsSpec
 
   describe("Node when called to clear connectios") {
     describe(
-      "if number of connectons is smaller or equal to 2/3 of number of maximum connectons allowed") {
+      "if number of connectons is smaller or equal to 2/3 of number of maximum connectons allowed"
+    ) {
       it("should not clear any of existing connections") {
         // given
         implicit val connections = mkConnections(peer("A"), peer("B"))
@@ -132,9 +133,11 @@ class ClearConnectionsSpec
 
   private def conf(maxNumOfConnections: Int, numOfConnectionsPinged: Int = 5): RPConfAsk[Id] =
     new ConstApplicativeAsk(
-      RPConf(clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
-             defaultTimeout = FiniteDuration(1, MILLISECONDS),
-             local = peer("src"))
+      RPConf(
+        clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
+        defaultTimeout = FiniteDuration(1, MILLISECONDS),
+        local = peer("src")
+      )
     )
 
   def alwaysSuccess: Protocol => CommErr[Protocol] =

--- a/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
@@ -71,7 +71,8 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
 
     describe("and there already are some connections") {
       it(
-        "should ask NodeDiscovery for the list of peers and try to the one he is not connected yet") {
+        "should ask NodeDiscovery for the list of peers and try to the one he is not connected yet"
+      ) {
         // given
         implicit val connections = mkConnections(peer("B"))
         // when
@@ -113,9 +114,11 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
       defaultTimeout: FiniteDuration
   ): RPConfAsk[Id] =
     new ConstApplicativeAsk(
-      RPConf(clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
-             defaultTimeout = defaultTimeout,
-             local = peer("src"))
+      RPConf(
+        clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
+        defaultTimeout = defaultTimeout,
+        local = peer("src")
+      )
     )
 
   implicit def eiterTrpConfAsk: RPConfAsk[Effect] =

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -29,9 +29,11 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
 
   def createTransportLayer(env: TcpTlsEnvironment): Task[TransportLayer[Task]] =
     Cell.mvarCell(TransportState.empty).map { cell =>
-      new TcpTransportLayer(env.host, env.port, env.cert, env.key, 4 * 1024 * 1024)(scheduler,
-                                                                                    cell,
-                                                                                    log)
+      new TcpTransportLayer(env.host, env.port, env.cert, env.key, 4 * 1024 * 1024)(
+        scheduler,
+        cell,
+        log
+      )
     }
 
   def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -108,10 +108,12 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   }
 
   abstract class ThreeNodesRuntime[A](val dispatcher: Dispatcher[F]) extends Runtime[A] {
-    def execute(transportLayer: TransportLayer[F],
-                local: PeerNode,
-                remote1: PeerNode,
-                remote2: PeerNode): F[A]
+    def execute(
+        transportLayer: TransportLayer[F],
+        local: PeerNode,
+        remote1: PeerNode,
+        remote2: PeerNode
+    ): F[A]
 
     def run(): ThreeNodesResult =
       extract(
@@ -145,18 +147,22 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
     }
   }
 
-  def roundTripWithPing(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode,
-                        timeout: FiniteDuration = 3.second): F[CommErr[Protocol]] =
+  def roundTripWithPing(
+      transportLayer: TransportLayer[F],
+      local: PeerNode,
+      remote: PeerNode,
+      timeout: FiniteDuration = 3.second
+  ): F[CommErr[Protocol]] =
     transportLayer.roundTrip(remote, ProtocolHelper.ping(local), timeout)
 
   def sendPing(transportLayer: TransportLayer[F], local: PeerNode, remote: PeerNode): F[Unit] =
     transportLayer.send(remote, ProtocolHelper.ping(local))
 
-  def broadcastPing(transportLayer: TransportLayer[F],
-                    local: PeerNode,
-                    remotes: PeerNode*): F[Unit] =
+  def broadcastPing(
+      transportLayer: TransportLayer[F],
+      local: PeerNode,
+      remotes: PeerNode*
+  ): F[Unit] =
     transportLayer.broadcast(remotes, ProtocolHelper.ping(local))
 
 }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -24,9 +24,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "everything is fine" should {
         "send and receive the message" in
           new TwoNodesRuntime[CommErr[Protocol]](Dispatcher.pongDispatcher[F]) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               roundTripWithPing(transportLayer, local, remote)
 
             val result: TwoNodesResult = run()
@@ -51,9 +53,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "response takes to long" should {
         "fail with a timeout" in
           new TwoNodesRuntime[CommErr[Protocol]](Dispatcher.pongDispatcherWithDelay(500)) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               roundTripWithPing(transportLayer, local, remote, 200.millis)
 
             val result: TwoNodesResult = run()
@@ -65,24 +69,29 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "there is no response body" should {
         "fail with a communication error" in
           new TwoNodesRuntime[CommErr[Protocol]](Dispatcher.withoutMessageDispatcher) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               roundTripWithPing(transportLayer, local, remote)
 
             val result: TwoNodesResult = run()
 
             result() shouldEqual Left(
-              InternalCommunicationError("Was expecting message, nothing arrived"))
+              InternalCommunicationError("Was expecting message, nothing arrived")
+            )
           }
       }
 
       "peer is not listening" should {
         "fail with peer unavailable error" in
           new TwoNodesRemoteDeadRuntime[CommErr[Protocol]](Dispatcher.pongDispatcher[F]) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               roundTripWithPing(transportLayer, local, remote)
 
             val result: TwoNodesResult = run()
@@ -94,15 +103,18 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "there was a peer-side error" should {
         "fail with an internal communication error" in
           new TwoNodesRuntime[CommErr[Protocol]](Dispatcher.internalCommunicationErrorDispatcher[F]) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               roundTripWithPing(transportLayer, local, remote)
 
             val result: TwoNodesResult = run()
 
             result() shouldEqual Left(
-              InternalCommunicationError("Got response: Internal communication error. Test"))
+              InternalCommunicationError("Got response: Internal communication error. Test")
+            )
           }
       }
     }
@@ -110,9 +122,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
     "sending a message" should {
       "deliver the message" in
         new TwoNodesRuntime[Unit](Dispatcher.dispatcherWithLatch[F]()) {
-          def execute(transportLayer: TransportLayer[F],
-                      local: PeerNode,
-                      remote: PeerNode): F[Unit] =
+          def execute(
+              transportLayer: TransportLayer[F],
+              local: PeerNode,
+              remote: PeerNode
+          ): F[Unit] =
             for {
               r <- sendPing(transportLayer, local, remote)
               _ = await()
@@ -130,9 +144,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
 
       "not wait for a response" in
         new TwoNodesRuntime[Long](Dispatcher.dispatcherWithLatch[F]()) {
-          def execute(transportLayer: TransportLayer[F],
-                      local: PeerNode,
-                      remote: PeerNode): F[Long] =
+          def execute(
+              transportLayer: TransportLayer[F],
+              local: PeerNode,
+              remote: PeerNode
+          ): F[Long] =
             for {
               _ <- sendPing(transportLayer, local, remote)
               t = System.currentTimeMillis()
@@ -154,10 +170,12 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
     "broadcasting a message" should {
       "send the message to all peers" in
         new ThreeNodesRuntime[Unit](Dispatcher.dispatcherWithLatch[F](2)) {
-          def execute(transportLayer: TransportLayer[F],
-                      local: PeerNode,
-                      remote1: PeerNode,
-                      remote2: PeerNode): F[Unit] =
+          def execute(
+              transportLayer: TransportLayer[F],
+              local: PeerNode,
+              remote1: PeerNode,
+              remote2: PeerNode
+          ): F[Unit] =
             for {
               r <- broadcastPing(transportLayer, local, remote1, remote2)
               _ = await()
@@ -184,9 +202,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "doing a round trip" should {
         "not send the message" in
           new TwoNodesRuntime[CommErr[Protocol]](Dispatcher.pongDispatcher[F]) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[CommErr[Protocol]] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[CommErr[Protocol]] =
               for {
                 _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- roundTripWithPing(transportLayer, local, remote)
@@ -206,9 +226,11 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "sending a message" should {
         "not send the message" in
           new TwoNodesRuntime[Unit](Dispatcher.dispatcherWithLatch[F]()) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote: PeerNode): F[Unit] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Unit] =
               for {
                 _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- sendPing(transportLayer, local, remote)
@@ -224,10 +246,12 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
       "broadcasting a message" should {
         "not send any messages" in
           new ThreeNodesRuntime[Unit](Dispatcher.dispatcherWithLatch[F](2)) {
-            def execute(transportLayer: TransportLayer[F],
-                        local: PeerNode,
-                        remote1: PeerNode,
-                        remote2: PeerNode): F[Unit] =
+            def execute(
+                transportLayer: TransportLayer[F],
+                local: PeerNode,
+                remote1: PeerNode,
+                remote2: PeerNode
+            ): F[Unit] =
               for {
                 _ <- transportLayer.shutdown(CommMessages.disconnect(local))
                 r <- broadcastPing(transportLayer, local, remote1, remote2)

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -50,7 +50,8 @@ object EffectsTestInstances {
   def createRPConfAsk[F[_]: Applicative](
       local: PeerNode,
       defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS),
-      clearConnections: ClearConnetionsConf = ClearConnetionsConf(1, 1)) =
+      clearConnections: ClearConnetionsConf = ClearConnetionsConf(1, 1)
+  ) =
     new ConstApplicativeAsk[F, RPConf](RPConf(local, defaultTimeout, clearConnections))
 
   class TransportLayerStub[F[_]: Capture: Applicative] extends TransportLayer[F] {

--- a/comm/src/test/scala/coop/rchain/p2p/URIParseSpec.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/URIParseSpec.scala
@@ -10,8 +10,13 @@ class URIParseSpec extends FlatSpec with Matchers {
   "A well formed rnode URI" should "parse into a PeerNode" in {
     val uri = "rnode://abcdef@localhost:12345"
     PeerNode.parse(uri) should be(
-      Right(PeerNode(NodeIdentifier(Seq(0xAB.toByte, 0xCD.toByte, 0xEF.toByte)),
-                     Endpoint("localhost", 12345, 12345))))
+      Right(
+        PeerNode(
+          NodeIdentifier(Seq(0xAB.toByte, 0xCD.toByte, 0xEF.toByte)),
+          Endpoint("localhost", 12345, 12345)
+        )
+      )
+    )
   }
 
   "A non-rnode URI" should "parse as an error" in {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
@@ -44,19 +44,23 @@ class Blake2b512Block {
 
   // gives the output as if block were the last block processed, but does not
   // invalidate or modify internal state
-  def peekFinalRoot(block: Array[Byte],
-                    inOffset: Int,
-                    output: Array[Byte],
-                    outOffset: Int): Unit = {
+  def peekFinalRoot(
+      block: Array[Byte],
+      inOffset: Int,
+      output: Array[Byte],
+      outOffset: Int
+  ): Unit = {
     val tempChainValue: Array[Long] = new Array[Long](8)
     compress(block, inOffset, tempChainValue, true, true, true)
     Pack.longToLittleEndian(tempChainValue, output, outOffset)
   }
 
-  def finalizeInternal(block: Array[Byte],
-                       inOffset: Int,
-                       output: Array[Byte],
-                       outOffset: Int): Unit = {
+  def finalizeInternal(
+      block: Array[Byte],
+      inOffset: Int,
+      output: Array[Byte],
+      outOffset: Int
+  ): Unit = {
     val tempChainValue: Array[Long] = new Array[Long](8)
     compress(block, inOffset, tempChainValue, true, true, false)
     for (i <- 0 until 4) {
@@ -84,12 +88,14 @@ class Blake2b512Block {
     (collapsedCV * 31 + (t0 ^ (t0 >>> 32)).toInt) * 31 + (t1 ^ (t1 >>> 32)).toInt
   }
 
-  private[this] def compress(msg: Array[Byte],
-                             offset: Int,
-                             newChainValue: Array[Long],
-                             peek: Boolean,
-                             finalize: Boolean,
-                             rootFinalize: Boolean): Unit = {
+  private[this] def compress(
+      msg: Array[Byte],
+      offset: Int,
+      newChainValue: Array[Long],
+      peek: Boolean,
+      finalize: Boolean,
+      rootFinalize: Boolean
+  ): Unit = {
     val internalState: Array[Long] = new Array[Long](BLOCK_LENGTH_LONGS)
     def g(m1: Long, m2: Long, posA: Int, posB: Int, posC: Int, posD: Int): Unit = {
       def rotr64(x: Long, rot: Int): Long =
@@ -110,8 +116,8 @@ class Blake2b512Block {
     def init(): Unit = {
       Array.copy(chainValue, 0, internalState, 0, CHAIN_VALUE_LENGTH)
       Array.copy(IV, 0, internalState, CHAIN_VALUE_LENGTH, 4)
-      val f0 = if (finalize) 0xffffffffffffffffL else 0x0L
-      val f1 = if (rootFinalize) 0xffffffffffffffffL else 0x0L
+      val f0 = if (finalize) 0XFFFFFFFFFFFFFFFFL else 0X0L
+      val f1 = if (rootFinalize) 0XFFFFFFFFFFFFFFFFL else 0X0L
       internalState(12) = newT0 ^ IV(4)
       internalState(13) = newT1 ^ IV(5)
       internalState(14) = f0 ^ IV(6)
@@ -201,9 +207,9 @@ object Blake2b512Block {
 
   // Produced from the square root of primes 2, 3, 5, 7, 11, 13, 17, 19.
   // The same as SHA-512 IV.
-  val IV: Array[Long] = Array(0x6a09e667f3bcc908L, 0xbb67ae8584caa73bL, 0x3c6ef372fe94f82bL,
-    0xa54ff53a5f1d36f1L, 0x510e527fade682d1L, 0x9b05688c2b3e6c1fL, 0x1f83d9abfb41bd6bL,
-    0x5be0cd19137e2179L)
+  val IV: Array[Long] = Array(0X6A09E667F3BCC908L, 0XBB67AE8584CAA73BL, 0X3C6EF372FE94F82BL,
+    0XA54FF53A5F1D36F1L, 0X510E527FADE682D1L, 0X9B05688C2B3E6C1FL, 0X1F83D9ABFB41BD6BL,
+    0X5BE0CD19137E2179L)
 
   // Message word permutations:
   val SIGMA: Array[Array[Byte]] =
@@ -228,9 +234,9 @@ object Blake2b512Block {
   val BLOCK_LENGTH_LONGS: Int  = 16
   val DIGEST_LENGTH_BYTES: Int = 64
   // Depth = 255, Fanout = ??, Keylength = 0, Digest length = 64 bytes
-  val PARAM_VALUE_0: Long = 0xff000040L
+  val PARAM_VALUE_0: Long = 0XFF000040L
   // Inner length = 32 bytes
-  val PARAM_VALUE_2: Long = 0x2000L
+  val PARAM_VALUE_2: Long = 0X2000L
 
   // This will give invalid results and is for testing only.
   def tweakT0(src: Blake2b512Block): Unit =

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
@@ -18,8 +18,10 @@ import scala.annotation.tailrec
   * Blake2b512.merge uses online tree hashing to merge two random generator
   * states.
   */
-class Blake2b512Random private (private val digest: Blake2b512Block,
-                                private val lastBlock: ByteBuffer) {
+class Blake2b512Random private (
+    private val digest: Blake2b512Block,
+    private val lastBlock: ByteBuffer
+) {
   private val pathView: ByteBuffer = lastBlock.duplicate()
   pathView.limit(112)
   private val countView: LongBuffer = {

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
@@ -100,9 +100,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "52884e9cfaf738709d271e9c0268f05964395678d9ccd61b187d67224a464230")
+      "52884e9cfaf738709d271e9c0268f05964395678d9ccd61b187d67224a464230"
+    )
     Base16.encode(res2) should be(
-      "cfa2ebb91185e9764a5aef6c7f5a6756cfe0f48a33c5bfabffdacac55d32f24a")
+      "cfa2ebb91185e9764a5aef6c7f5a6756cfe0f48a33c5bfabffdacac55d32f24a"
+    )
   }
   it should "handle splitShort as well." in {
     val b2Random = Blake2b512Random(emptyMsg)
@@ -110,9 +112,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = split.next()
     val res2     = split.next()
     Base16.encode(res1) should be(
-      "745ce0f59aa7ebadc31c097126ac85870c3364b561d1d81935eb01ef5968d4b3")
+      "745ce0f59aa7ebadc31c097126ac85870c3364b561d1d81935eb01ef5968d4b3"
+    )
     Base16.encode(res2) should be(
-      "2d7bd219e4ce1e18e38c06eecdf17098ed49d66890086d19543a84fe88d80d67")
+      "2d7bd219e4ce1e18e38c06eecdf17098ed49d66890086d19543a84fe88d80d67"
+    )
   }
   it should "correctly implement wraparound." in {
     val b2Random = Blake2b512Random(emptyMsg)
@@ -122,13 +126,17 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res3 = b2Random.next()
     val res4 = b2Random.next()
     Base16.encode(res1) should be(
-      "b63ea0e23d853977e02707364c753bd414c4828e294c1b0c39d046bacf18f5cf")
+      "b63ea0e23d853977e02707364c753bd414c4828e294c1b0c39d046bacf18f5cf"
+    )
     Base16.encode(res2) should be(
-      "4b850fc7d0a930cd89a8907ccee22f41941bd896127e71301eba137a347b131f")
+      "4b850fc7d0a930cd89a8907ccee22f41941bd896127e71301eba137a347b131f"
+    )
     Base16.encode(res3) should be(
-      "a913716961120edbbb9f08cc513a40321de334aa99a6991f97eff93b799f9cab")
+      "a913716961120edbbb9f08cc513a40321de334aa99a6991f97eff93b799f9cab"
+    )
     Base16.encode(res4) should be(
-      "be14efe796e8a10a8bbc55e4691f8eeb71df5dc37b0b0b79133150b8cc90533a")
+      "be14efe796e8a10a8bbc55e4691f8eeb71df5dc37b0b0b79133150b8cc90533a"
+    )
   }
 
   it should "roll over when enough byte-splits have occurred" in {
@@ -139,9 +147,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1 = rollover.next()
     val res2 = rollover.next()
     Base16.encode(res1) should be(
-      "0f6ccee70daf946d23361a92e672515898a287456c38517bd92bb0925ee18103")
+      "0f6ccee70daf946d23361a92e672515898a287456c38517bd92bb0925ee18103"
+    )
     Base16.encode(res2) should be(
-      "7d9a1831ce7f42b818c61223f709d55dd9cf310b01e19e2526d2d13e1b9ed61c")
+      "7d9a1831ce7f42b818c61223f709d55dd9cf310b01e19e2526d2d13e1b9ed61c"
+    )
   }
   it should "correctly handle nexts that are then rolled over" in {
     val b2Random = Blake2b512Random(emptyMsg)
@@ -153,9 +163,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res2 = rollover.next()
 
     Base16.encode(res1) should be(
-      "1fa2af2fdc0521dacc1b06d0dc9ee729075283c7e2ba8df7b637bd05134e2d30")
+      "1fa2af2fdc0521dacc1b06d0dc9ee729075283c7e2ba8df7b637bd05134e2d30"
+    )
     Base16.encode(res2) should be(
-      "9c7a9b1f04907c73263a81178540a5d7e3102fe260a9f15b80ff91f87de2039b")
+      "9c7a9b1f04907c73263a81178540a5d7e3102fe260a9f15b80ff91f87de2039b"
+    )
   }
   val partialMsg: Array[Byte] = "Hello, World!".getBytes(StandardCharsets.UTF_8)
   "Partial" should "give a predictable result" in {
@@ -163,9 +175,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "34c06b6f6907595709c44a1c2f4940210d99b04302937a88e14a5c5e2d439221")
+      "34c06b6f6907595709c44a1c2f4940210d99b04302937a88e14a5c5e2d439221"
+    )
     Base16.encode(res2) should be(
-      "7c3c57f0220fa003ad9c10fd785001c11f2b626f0d5da8367499200e10166276")
+      "7c3c57f0220fa003ad9c10fd785001c11f2b626f0d5da8367499200e10166276"
+    )
   }
   val singleBlockMsg: Array[Byte] =
     "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa "
@@ -175,9 +189,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "459691c149f10c8cf45a4f84421d89e97228b91e046f7afbcf3a4131216c538b")
+      "459691c149f10c8cf45a4f84421d89e97228b91e046f7afbcf3a4131216c538b"
+    )
     Base16.encode(res2) should be(
-      "1e676c4ad57a46408312a5209e8498d43023e43ab0bfabfc57a535663dfa3918")
+      "1e676c4ad57a46408312a5209e8498d43023e43ab0bfabfc57a535663dfa3918"
+    )
   }
   val blockAndPartMsg: Array[Byte] =
     "quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores "
@@ -187,9 +203,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "c27d88a63898e9f593ae34439112572feedd241c4223e6c62e997e45267b285d")
+      "c27d88a63898e9f593ae34439112572feedd241c4223e6c62e997e45267b285d"
+    )
     Base16.encode(res2) should be(
-      "8c8d36972e4bfa65fdde555c1247ee221ff7c0031e92ec790aa01549321e7c86")
+      "8c8d36972e4bfa65fdde555c1247ee221ff7c0031e92ec790aa01549321e7c86"
+    )
   }
   val multiBlockMsg: Array[Byte] =
     "eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem "
@@ -199,9 +217,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "07ac715093bb984b8f9364b6ccdf89ca63dbdcc164000d115ee333d6566b3e87")
+      "07ac715093bb984b8f9364b6ccdf89ca63dbdcc164000d115ee333d6566b3e87"
+    )
     Base16.encode(res2) should be(
-      "1235bb1ec4ba9bf58f6f0aa10aaf53e373191a1c6a849fbc7b8a1d31a0affc61")
+      "1235bb1ec4ba9bf58f6f0aa10aaf53e373191a1c6a849fbc7b8a1d31a0affc61"
+    )
   }
   val multiBlockAndPartialMsg: Array[Byte] =
     "Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?\nAt vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga."
@@ -211,9 +231,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1     = b2Random.next()
     val res2     = b2Random.next()
     Base16.encode(res1) should be(
-      "828f766bc845c41944f1a9933b0835afabf636abd93f8bd986db7a73c7de056c")
+      "828f766bc845c41944f1a9933b0835afabf636abd93f8bd986db7a73c7de056c"
+    )
     Base16.encode(res2) should be(
-      "890399ff51fd6f02c09ad76d69c51445805252c60d7511a767e2e01dce0c45cd")
+      "890399ff51fd6f02c09ad76d69c51445805252c60d7511a767e2e01dce0c45cd"
+    )
   }
 
   "A merge with a single child" should "give a predictable result" in {
@@ -223,9 +245,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1              = singleMergeRandom.next()
     val res2              = singleMergeRandom.next()
     Base16.encode(res1) should be(
-      "a3904853d9db8de44202bf6ab64c2ee5b6c78fe8abc7799dc0e3426d6572e4eb")
+      "a3904853d9db8de44202bf6ab64c2ee5b6c78fe8abc7799dc0e3426d6572e4eb"
+    )
     Base16.encode(res2) should be(
-      "1d6da76e99ce1fa6fe756f7d7117c3eae6c0fd4fa53854e04de3083d557d0a01")
+      "1d6da76e99ce1fa6fe756f7d7117c3eae6c0fd4fa53854e04de3083d557d0a01"
+    )
   }
 
   "A merge with two children" should "give a predictable result" in {
@@ -236,9 +260,11 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1              = singleMergeRandom.next()
     val res2              = singleMergeRandom.next()
     Base16.encode(res1) should be(
-      "ce190f4283d4b11653cb78ee8fbc68a5b8cb62511a1f2ed3e836400e62144fa9")
+      "ce190f4283d4b11653cb78ee8fbc68a5b8cb62511a1f2ed3e836400e62144fa9"
+    )
     Base16.encode(res2) should be(
-      "460e913fb6f2250fb1ae2cd6ceeb5501b0d83b29abd538d3508ec6845904342d")
+      "460e913fb6f2250fb1ae2cd6ceeb5501b0d83b29abd538d3508ec6845904342d"
+    )
   }
 
   "A merge with many children" should "group by 255's until a single internal node is reached." in {
@@ -258,8 +284,10 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1   = merged.next()
     val res2   = merged.next()
     Base16.encode(res1) should be(
-      "1af9db74651a8aa5e667311151d6b556939d0eb478980cce2ebd0b2cbc7183a8")
+      "1af9db74651a8aa5e667311151d6b556939d0eb478980cce2ebd0b2cbc7183a8"
+    )
     Base16.encode(res2) should be(
-      "e6015287968435ef7b9656daf52083619aeb237db24bf09b2f878575d616572a")
+      "e6015287968435ef7b9656daf52083619aeb237db24bf09b2f878575d616572a"
+    )
   }
 }

--- a/models/src/main/scala/coop/rchain/models/AlwaysEqual.scala
+++ b/models/src/main/scala/coop/rchain/models/AlwaysEqual.scala
@@ -20,7 +20,9 @@ object AlwaysEqual {
   implicit def wrap[A](unwrapped: A): AlwaysEqual[A] = apply(unwrapped)
 
   implicit def alwaysEqualTypeMapper[B, A](
-      implicit tm: TypeMapper[B, A]): TypeMapper[B, AlwaysEqual[A]] =
-    TypeMapper[B, AlwaysEqual[A]](b => AlwaysEqual(tm.toCustom(b)))(wrappedA =>
-      tm.toBase(wrappedA.get))
+      implicit tm: TypeMapper[B, A]
+  ): TypeMapper[B, AlwaysEqual[A]] =
+    TypeMapper[B, AlwaysEqual[A]](b => AlwaysEqual(tm.toCustom(b)))(
+      wrappedA => tm.toBase(wrappedA.get)
+    )
 }

--- a/models/src/main/scala/coop/rchain/models/BundleOps.scala
+++ b/models/src/main/scala/coop/rchain/models/BundleOps.scala
@@ -5,8 +5,10 @@ import cats.Show
 object BundleOps {
   implicit class BundleEnhance(b: Bundle) {
     def merge(other: Bundle): Bundle =
-      other.copy(readFlag = b.readFlag && other.readFlag,
-                 writeFlag = b.writeFlag && other.writeFlag)
+      other.copy(
+        readFlag = b.readFlag && other.readFlag,
+        writeFlag = b.writeFlag && other.writeFlag
+      )
   }
 
   implicit val showInstance: Show[Bundle] = Show.show[Bundle] { bundle =>

--- a/models/src/main/scala/coop/rchain/models/HasLocallyFree.scala
+++ b/models/src/main/scala/coop/rchain/models/HasLocallyFree.scala
@@ -38,7 +38,7 @@ object HasLocallyFree {
         HasLocallyFree[A].connectiveUsed(source._1) || HasLocallyFree[B].connectiveUsed(source._2)
 
       override def locallyFree(source: (A, B), depth: Int): BitSet =
-        HasLocallyFree[A].locallyFree(source._1, depth) | HasLocallyFree[B].locallyFree(source._2,
-                                                                                        depth)
+        HasLocallyFree[A].locallyFree(source._1, depth) | HasLocallyFree[B]
+          .locallyFree(source._2, depth)
     }
 }

--- a/models/src/main/scala/coop/rchain/models/ParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMap.scala
@@ -7,10 +7,12 @@ import monix.eval.Coeval
 import scala.collection.immutable.BitSet
 import coop.rchain.models.rholang.implicits._
 
-case class ParMap(ps: SortedParMap,
-                  connectiveUsed: Boolean,
-                  locallyFree: Coeval[BitSet],
-                  remainder: Option[Var]) {
+case class ParMap(
+    ps: SortedParMap,
+    connectiveUsed: Boolean,
+    locallyFree: Coeval[BitSet],
+    remainder: Option[Var]
+) {
 
   override def equals(o: scala.Any): Boolean = o match {
     case parMap: ParMap => this.ps == parMap.ps && this.remainder == parMap.remainder
@@ -21,16 +23,20 @@ case class ParMap(ps: SortedParMap,
 }
 
 object ParMap {
-  def apply(seq: Seq[(Par, Par)],
-            connectiveUsed: Boolean,
-            locallyFree: Coeval[BitSet],
-            remainder: Option[Var]) =
+  def apply(
+      seq: Seq[(Par, Par)],
+      connectiveUsed: Boolean,
+      locallyFree: Coeval[BitSet],
+      remainder: Option[Var]
+  ) =
     new ParMap(SortedParMap(seq), connectiveUsed, locallyFree.memoize, remainder)
 
-  def apply(seq: Seq[(Par, Par)],
-            connectiveUsed: Boolean,
-            locallyFree: BitSet,
-            remainder: Option[Var]): ParMap =
+  def apply(
+      seq: Seq[(Par, Par)],
+      connectiveUsed: Boolean,
+      locallyFree: BitSet,
+      remainder: Option[Var]
+  ): ParMap =
     apply(seq, connectiveUsed, Coeval.pure(locallyFree), remainder)
 
   def apply(seq: Seq[(Par, Par)]): ParMap =

--- a/models/src/main/scala/coop/rchain/models/ParMapTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMapTypeMapper.scala
@@ -10,10 +10,12 @@ object ParMapTypeMapper {
     ParMap(emap.kvs.map(unzip), emap.connectiveUsed, emap.locallyFree, emap.remainder)
 
   private[models] def parMapToEMap(parMap: ParMap): EMap =
-    EMap(parMap.ps.sortedMap.map(t => zip(t._1, t._2)),
-         parMap.locallyFree.value,
-         parMap.connectiveUsed,
-         parMap.remainder)
+    EMap(
+      parMap.ps.sortedMap.map(t => zip(t._1, t._2)),
+      parMap.locallyFree.value,
+      parMap.connectiveUsed,
+      parMap.remainder
+    )
 
   private[models] def unzip(kvp: KeyValuePair): (Par, Par) = (kvp.key, kvp.value)
 

--- a/models/src/main/scala/coop/rchain/models/ParSet.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSet.scala
@@ -7,10 +7,12 @@ import monix.eval.Coeval
 import scala.collection.immutable.BitSet
 
 //locallyFree is of type Coeval to make use of memoization
-case class ParSet(ps: SortedParHashSet,
-                  connectiveUsed: Boolean,
-                  locallyFree: Coeval[BitSet],
-                  remainder: Option[Var]) {
+case class ParSet(
+    ps: SortedParHashSet,
+    connectiveUsed: Boolean,
+    locallyFree: Coeval[BitSet],
+    remainder: Option[Var]
+) {
 
   override def equals(o: scala.Any): Boolean = o match {
     case parSet: ParSet =>
@@ -23,15 +25,19 @@ case class ParSet(ps: SortedParHashSet,
 }
 
 object ParSet {
-  def apply(ps: Seq[Par],
-            connectiveUsed: Boolean,
-            locallyFree: Coeval[BitSet],
-            remainder: Option[Var]): ParSet =
+  def apply(
+      ps: Seq[Par],
+      connectiveUsed: Boolean,
+      locallyFree: Coeval[BitSet],
+      remainder: Option[Var]
+  ): ParSet =
     ParSet(SortedParHashSet(ps), connectiveUsed, locallyFree.memoize, remainder)
 
-  def apply(ps: Seq[Par],
-            connectiveUsed: Boolean = false,
-            remainder: Option[Var] = None): ParSet = {
+  def apply(
+      ps: Seq[Par],
+      connectiveUsed: Boolean = false,
+      remainder: Option[Var] = None
+  ): ParSet = {
     val shs = SortedParHashSet(ps)
     ParSet(shs, connectiveUsed, Coeval.delay(updateLocallyFree(shs)).memoize, remainder)
   }

--- a/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSetTypeMapper.scala
@@ -8,10 +8,12 @@ object ParSetTypeMapper {
     TypeMapper(esetToParSet)(parSetToESet)
 
   private[models] def esetToParSet(eset: ESet): ParSet =
-    ParSet(ps = eset.ps,
-           locallyFree = Coeval.delay(eset.locallyFree.get),
-           connectiveUsed = eset.connectiveUsed,
-           remainder = eset.remainder)
+    ParSet(
+      ps = eset.ps,
+      locallyFree = Coeval.delay(eset.locallyFree.get),
+      connectiveUsed = eset.connectiveUsed,
+      remainder = eset.remainder
+    )
 
   private[models] def parSetToESet(parSet: ParSet): ESet =
     ESet(parSet.ps.sortedPars, parSet.locallyFree.value, parSet.connectiveUsed, parSet.remainder)

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -138,13 +138,17 @@ object implicits {
   def apply(r: Receive): Par =
     new Par(receives = Vector(r), locallyFree = r.locallyFree, connectiveUsed = r.connectiveUsed)
   def apply(n: New): Par =
-    new Par(news = Vector(n),
-            locallyFree = NewLocallyFree.locallyFree(n, 0),
-            connectiveUsed = NewLocallyFree.connectiveUsed(n))
+    new Par(
+      news = Vector(n),
+      locallyFree = NewLocallyFree.locallyFree(n, 0),
+      connectiveUsed = NewLocallyFree.connectiveUsed(n)
+    )
   def apply(e: Expr): Par =
-    new Par(exprs = Vector(e),
-            locallyFree = ExprLocallyFree.locallyFree(e, 0),
-            connectiveUsed = ExprLocallyFree.connectiveUsed(e))
+    new Par(
+      exprs = Vector(e),
+      locallyFree = ExprLocallyFree.locallyFree(e, 0),
+      connectiveUsed = ExprLocallyFree.connectiveUsed(e)
+    )
   def apply(m: Match): Par =
     new Par(matches = Vector(m), locallyFree = m.locallyFree, connectiveUsed = m.connectiveUsed)
   def apply(g: GPrivate): Par =
@@ -178,7 +182,7 @@ object implicits {
       matches = Vector.empty[Match],
       ids = Vector.empty[GPrivate],
       bundles = Vector.empty[Bundle],
-      connectives = Vector.empty[Connective],
+      connectives = Vector.empty[Connective]
     )
   }
 
@@ -208,9 +212,11 @@ object implicits {
   implicit class ParExtension[T](p: T)(implicit toPar: T => Par) {
     // Convenience prepend methods
     def prepend(s: Send): Par =
-      p.copy(sends = s +: p.sends,
-             locallyFree = p.locallyFree | s.locallyFree,
-             connectiveUsed = p.connectiveUsed || s.connectiveUsed)
+      p.copy(
+        sends = s +: p.sends,
+        locallyFree = p.locallyFree | s.locallyFree,
+        connectiveUsed = p.connectiveUsed || s.connectiveUsed
+      )
     def prepend(r: Receive): Par =
       p.copy(
         receives = r +: p.receives,
@@ -233,9 +239,11 @@ object implicits {
           .connectiveUsed(e)
       )
     def prepend(m: Match): Par =
-      p.copy(matches = m +: p.matches,
-             locallyFree = p.locallyFree | m.locallyFree,
-             connectiveUsed = p.connectiveUsed || m.connectiveUsed)
+      p.copy(
+        matches = m +: p.matches,
+        locallyFree = p.locallyFree | m.locallyFree,
+        connectiveUsed = p.connectiveUsed || m.connectiveUsed
+      )
     def prepend(b: Bundle): Par =
       p.copy(
         bundles = b +: p.bundles,

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ConnectiveSortMatcher.scala
@@ -13,20 +13,26 @@ private[sort] object ConnectiveSortMatcher extends Sortable[Connective] {
         for {
           pars <- cb.ps.toList.traverse(Sortable[Par].sortMatch[F])
         } yield
-          ScoredTerm(Connective(ConnAndBody(cb.withPs(pars.map(_.term.get)))),
-                     Node(Score.CONNECTIVE_AND, pars.map(_.score): _*))
+          ScoredTerm(
+            Connective(ConnAndBody(cb.withPs(pars.map(_.term.get)))),
+            Node(Score.CONNECTIVE_AND, pars.map(_.score): _*)
+          )
       case ConnOrBody(cb) =>
         for {
           pars <- cb.ps.toList.traverse(Sortable[Par].sortMatch[F])
         } yield
-          ScoredTerm(Connective(ConnOrBody(cb.withPs(pars.map(_.term.get)))),
-                     Node(Score.CONNECTIVE_OR, pars.map(_.score): _*))
+          ScoredTerm(
+            Connective(ConnOrBody(cb.withPs(pars.map(_.term.get)))),
+            Node(Score.CONNECTIVE_OR, pars.map(_.score): _*)
+          )
       case ConnNotBody(p) =>
         for {
           scoredPar <- Sortable.sortMatch(p)
         } yield
-          ScoredTerm(Connective(ConnNotBody(scoredPar.term.get)),
-                     Node(Score.CONNECTIVE_NOT, scoredPar.score))
+          ScoredTerm(
+            Connective(ConnNotBody(scoredPar.term.get)),
+            Node(Score.CONNECTIVE_NOT, scoredPar.score)
+          )
       case v @ VarRefBody(VarRef(index, depth)) =>
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_VARREF, index, depth)).pure[F]
       case v @ ConnBool(_) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ExprSortMatcher.scala
@@ -35,114 +35,146 @@ private[sort] object ExprSortMatcher extends Sortable[Expr] {
           sortedPar1 <- Sortable.sortMatch(em.p1)
           sortedPar2 <- Sortable.sortMatch(em.p2)
         } yield
-          constructExpr(EMultBody(EMult(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EMULT, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EMultBody(EMult(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EMULT, sortedPar1.score, sortedPar2.score)
+          )
       case EDivBody(ed) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ed.p1)
           sortedPar2 <- Sortable.sortMatch(ed.p2)
         } yield
-          constructExpr(EDivBody(EDiv(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EDIV, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EDivBody(EDiv(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EDIV, sortedPar1.score, sortedPar2.score)
+          )
       case EPlusBody(ep) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ep.p1)
           sortedPar2 <- Sortable.sortMatch(ep.p2)
         } yield
-          constructExpr(EPlusBody(EPlus(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EPLUS, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EPlusBody(EPlus(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EPLUS, sortedPar1.score, sortedPar2.score)
+          )
       case EMinusBody(em) =>
         for {
           sortedPar1 <- Sortable.sortMatch(em.p1)
           sortedPar2 <- Sortable.sortMatch(em.p2)
         } yield
-          constructExpr(EMinusBody(EMinus(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EMINUS, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EMinusBody(EMinus(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EMINUS, sortedPar1.score, sortedPar2.score)
+          )
       case ELtBody(el) =>
         for {
           sortedPar1 <- Sortable.sortMatch(el.p1)
           sortedPar2 <- Sortable.sortMatch(el.p2)
         } yield
-          constructExpr(ELtBody(ELt(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.ELT, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            ELtBody(ELt(sortedPar1.term, sortedPar2.term)),
+            Node(Score.ELT, sortedPar1.score, sortedPar2.score)
+          )
       case ELteBody(el) =>
         for {
           sortedPar1 <- Sortable.sortMatch(el.p1)
           sortedPar2 <- Sortable.sortMatch(el.p2)
         } yield
-          constructExpr(ELteBody(ELte(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.ELTE, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            ELteBody(ELte(sortedPar1.term, sortedPar2.term)),
+            Node(Score.ELTE, sortedPar1.score, sortedPar2.score)
+          )
       case EGtBody(eg) =>
         for {
           sortedPar1 <- Sortable.sortMatch(eg.p1)
           sortedPar2 <- Sortable.sortMatch(eg.p2)
         } yield
-          constructExpr(EGtBody(EGt(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EGT, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EGtBody(EGt(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EGT, sortedPar1.score, sortedPar2.score)
+          )
       case EGteBody(eg) =>
         for {
           sortedPar1 <- Sortable.sortMatch(eg.p1)
           sortedPar2 <- Sortable.sortMatch(eg.p2)
         } yield
-          constructExpr(EGteBody(EGte(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EGTE, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EGteBody(EGte(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EGTE, sortedPar1.score, sortedPar2.score)
+          )
       case EEqBody(ee) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ee.p1)
           sortedPar2 <- Sortable.sortMatch(ee.p2)
         } yield
-          constructExpr(EEqBody(EEq(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EEQ, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EEqBody(EEq(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EEQ, sortedPar1.score, sortedPar2.score)
+          )
       case ENeqBody(en) =>
         for {
           sortedPar1 <- Sortable.sortMatch(en.p1)
           sortedPar2 <- Sortable.sortMatch(en.p2)
         } yield
-          constructExpr(ENeqBody(ENeq(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.ENEQ, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            ENeqBody(ENeq(sortedPar1.term, sortedPar2.term)),
+            Node(Score.ENEQ, sortedPar1.score, sortedPar2.score)
+          )
       case EAndBody(ea) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ea.p1)
           sortedPar2 <- Sortable.sortMatch(ea.p2)
         } yield
-          constructExpr(EAndBody(EAnd(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EAND, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EAndBody(EAnd(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EAND, sortedPar1.score, sortedPar2.score)
+          )
       case EOrBody(eo) =>
         for {
           sortedPar1 <- Sortable.sortMatch(eo.p1)
           sortedPar2 <- Sortable.sortMatch(eo.p2)
         } yield
-          constructExpr(EOrBody(EOr(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EOR, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EOrBody(EOr(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EOR, sortedPar1.score, sortedPar2.score)
+          )
 
       case EMatchesBody(em) =>
         for {
           sortedTarget  <- Sortable.sortMatch(em.target)
           sortedPattern <- Sortable.sortMatch(em.pattern)
         } yield
-          constructExpr(EMatchesBody(EMatches(sortedTarget.term, sortedPattern.term)),
-                        Node(Score.EMATCHES, sortedTarget.score, sortedPattern.score))
+          constructExpr(
+            EMatchesBody(EMatches(sortedTarget.term, sortedPattern.term)),
+            Node(Score.EMATCHES, sortedTarget.score, sortedPattern.score)
+          )
       case EPercentPercentBody(ep) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ep.p1)
           sortedPar2 <- Sortable.sortMatch(ep.p2)
         } yield
-          constructExpr(EPercentPercentBody(EPercentPercent(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EPERCENT, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EPercentPercentBody(EPercentPercent(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EPERCENT, sortedPar1.score, sortedPar2.score)
+          )
       case EPlusPlusBody(ep) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ep.p1)
           sortedPar2 <- Sortable.sortMatch(ep.p2)
         } yield
-          constructExpr(EPlusPlusBody(EPlusPlus(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EPLUSPLUS, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EPlusPlusBody(EPlusPlus(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EPLUSPLUS, sortedPar1.score, sortedPar2.score)
+          )
       case EMinusMinusBody(ep) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ep.p1)
           sortedPar2 <- Sortable.sortMatch(ep.p2)
         } yield
-          constructExpr(EMinusMinusBody(EMinusMinus(sortedPar1.term, sortedPar2.term)),
-                        Node(Score.EMINUSMINUS, sortedPar1.score, sortedPar2.score))
+          constructExpr(
+            EMinusMinusBody(EMinusMinus(sortedPar1.term, sortedPar2.term)),
+            Node(Score.EMINUSMINUS, sortedPar1.score, sortedPar2.score)
+          )
       case EMethodBody(em) =>
         for {
           args         <- em.arguments.toList.traverse(Sortable[Par].sortMatch[F])
@@ -151,8 +183,8 @@ private[sort] object ExprSortMatcher extends Sortable[Expr] {
           constructExpr(
             EMethodBody(em.withArguments(args.map(_.term.get)).withTarget(sortedTarget.term.get)),
             Node(
-              Seq(Leaf(Score.EMETHOD), Leaf(em.methodName), sortedTarget.score) ++ args.map(
-                _.score))
+              Seq(Leaf(Score.EMETHOD), Leaf(em.methodName), sortedTarget.score) ++ args.map(_.score)
+            )
           )
       case eg =>
         for {

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -21,14 +21,18 @@ private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
         for {
           sortedPars <- gl.ps.toList.traverse(Sortable[Par].sortMatch[F])
         } yield
-          ScoredTerm(EListBody(gl.withPs(sortedPars.map(_.term.get))),
-                     Node(Score.ELIST, sortedPars.map(_.score): _*))
+          ScoredTerm(
+            EListBody(gl.withPs(sortedPars.map(_.term.get))),
+            Node(Score.ELIST, sortedPars.map(_.score): _*)
+          )
       case ETupleBody(gt) =>
         for {
           sortedPars <- gt.ps.toList.traverse(Sortable[Par].sortMatch[F])
         } yield
-          ScoredTerm(ETupleBody(gt.withPs(sortedPars.map(_.term.get))),
-                     Node(Score.ETUPLE, sortedPars.map(_.score): _*))
+          ScoredTerm(
+            ETupleBody(gt.withPs(sortedPars.map(_.term.get))),
+            Node(Score.ETUPLE, sortedPars.map(_.score): _*)
+          )
       // Note ESet and EMap rely on the stableness of Scala's sort
       // See https://github.com/scala/scala/blob/2.11.x/src/library/scala/collection/SeqLike.scala#L627
       case ESetBody(gs) =>
@@ -39,10 +43,13 @@ private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
         } yield
           ScoredTerm(
             ESetBody(
-              ParSet(SortedParHashSet(sortedPars.map(_.term.get)),
-                     gs.connectiveUsed,
-                     gs.locallyFree,
-                     gs.remainder)),
+              ParSet(
+                SortedParHashSet(sortedPars.map(_.term.get)),
+                gs.connectiveUsed,
+                gs.locallyFree,
+                gs.remainder
+              )
+            ),
             Node(Leaf(Score.ESET) :: sortedPars.map(_.score) ::: remainderScoreOpt.toList)
           )
       case EMapBody(gm) =>
@@ -59,13 +66,15 @@ private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
         } yield
           ScoredTerm(
             EMapBody(
-              ParMap(sortedPars.map(_.term), gm.connectiveUsed, gm.locallyFree, gm.remainder)),
+              ParMap(sortedPars.map(_.term), gm.connectiveUsed, gm.locallyFree, gm.remainder)
+            ),
             Node(Leaf(Score.EMAP) :: sortedPars.map(_.score) ::: remainderScoreOpt.toList)
           )
       case GByteArray(ba) =>
         ScoredTerm(g, Node(Score.EBYTEARR, Leaf(ba.toStringUtf8))).pure[F]
       case _ => //TODO(mateusz.gorski): rethink it
         Sync[F].raiseError(
-          new IllegalArgumentException("GroundSortMatcher passed unknown Expr instance"))
+          new IllegalArgumentException("GroundSortMatcher passed unknown Expr instance")
+        )
     }
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/MatchSortMatcher.scala
@@ -12,13 +12,17 @@ private[sort] object MatchSortMatcher extends Sortable[Match] {
         sortedPattern <- Sortable.sortMatch(matchCase.pattern)
         sortedBody    <- Sortable.sortMatch(matchCase.source)
       } yield
-        ScoredTerm(MatchCase(sortedPattern.term, sortedBody.term, matchCase.freeCount),
-                   Node(Seq(sortedPattern.score) ++ Seq(sortedBody.score)))
+        ScoredTerm(
+          MatchCase(sortedPattern.term, sortedBody.term, matchCase.freeCount),
+          Node(Seq(sortedPattern.score) ++ Seq(sortedBody.score))
+        )
     for {
       sortedValue <- Sortable.sortMatch(m.target)
       scoredCases <- m.cases.toList.traverse(sortCase)
     } yield
-      ScoredTerm(Match(sortedValue.term, scoredCases.map(_.term), m.locallyFree, m.connectiveUsed),
-                 Node(Score.MATCH, Seq(sortedValue.score) ++ scoredCases.map(_.score): _*))
+      ScoredTerm(
+        Match(sortedValue.term, scoredCases.map(_.term), m.locallyFree, m.connectiveUsed),
+        Node(Score.MATCH, Seq(sortedValue.score) ++ scoredCases.map(_.score): _*)
+      )
   }
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/ReceiveSortMatcher.scala
@@ -35,13 +35,17 @@ object ReceiveSortMatcher extends Sortable[Receive] {
       sortedBody      <- Sortable.sortMatch(r.body)
     } yield
       ScoredTerm(
-        Receive(sortedBinds.map(_.term),
-                sortedBody.term,
-                r.persistent,
-                r.bindCount,
-                r.locallyFree,
-                r.connectiveUsed),
-        Node(Score.RECEIVE,
-             Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*)
+        Receive(
+          sortedBinds.map(_.term),
+          sortedBody.term,
+          r.persistent,
+          r.bindCount,
+          r.locallyFree,
+          r.connectiveUsed
+        ),
+        Node(
+          Score.RECEIVE,
+          Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*
+        )
       )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/SendSortMatcher.scala
@@ -20,6 +20,7 @@ private[sort] object SendSortMatcher extends Sortable[Send] {
       persistentScore = if (s.persistent) 1 else 0
       sendScore = Node(
         Score.SEND,
-        Seq(Leaf(persistentScore)) ++ Seq(sortedChan.score) ++ sortedData.map(_.score): _*)
+        Seq(Leaf(persistentScore)) ++ Seq(sortedChan.score) ++ sortedData.map(_.score): _*
+      )
     } yield ScoredTerm(sortedSend, sendScore)
 }

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -9,7 +9,8 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
 object implicits {
   def mkProtobufInstance[T <: GeneratedMessage with Message[T]](
-      comp: GeneratedMessageCompanion[T]) = new Serialize[T] {
+      comp: GeneratedMessageCompanion[T]
+  ) = new Serialize[T] {
 
     override def encode(a: T): ByteVector =
       ByteVector.view(comp.toByteArray(a))

--- a/models/src/test/scala/coop/rchain/models/BundleOpsSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/BundleOpsSpec.scala
@@ -21,8 +21,10 @@ class BundleOpsSpec extends FunSuite {
       val result = b1.merge(b2)
       assert(!result.readFlag, "Name should not be readable")
       assert(result.writeFlag, "Name should be writeable")
-      assert(result.body.get === par,
-             "Flattened bundles should contain process found in the innermost bundle.")
+      assert(
+        result.body.get === par,
+        "Flattened bundles should contain process found in the innermost bundle."
+      )
     }
 
     withClue("""
@@ -36,8 +38,10 @@ class BundleOpsSpec extends FunSuite {
       val result = b1.merge(b2)
       assert(!result.readFlag, "Name should not be readable")
       assert(!result.writeFlag, "Name should not be writeable")
-      assert(result.body.get === par,
-             "Flattened bundles should contain process found in the innermost bundle.")
+      assert(
+        result.body.get === par,
+        "Flattened bundles should contain process found in the innermost bundle."
+      )
     }
 
   }

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -35,7 +35,8 @@ class SortedParHashSetSpec extends FlatSpec with Matchers {
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2)), locallyFree = BitSet(2))
-        ))
+        )
+      )
     Seq(parGround, parExpr, parMethods)
   }
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -34,10 +34,14 @@ class ScoredTermSpec extends FlatSpec with Matchers {
     unsortedTerms.sorted should be(sortedTerms)
   }
   "ScoredTerm" should "Sort so that smaller nodes are put first" in {
-    val unsortedTerms = Seq(ScoredTerm("foo", Node(Seq(Leaves(1, 2), Leaves(2, 2)))),
-                            ScoredTerm("bar", Node(Seq(Leaves(1, 1), Leaves(2, 2)))))
-    val sortedTerms = Seq(ScoredTerm("bar", Node(Seq(Leaves(1, 1), Leaves(2, 2)))),
-                          ScoredTerm("foo", Node(Seq(Leaves(1, 2), Leaves(2, 2)))))
+    val unsortedTerms = Seq(
+      ScoredTerm("foo", Node(Seq(Leaves(1, 2), Leaves(2, 2)))),
+      ScoredTerm("bar", Node(Seq(Leaves(1, 1), Leaves(2, 2))))
+    )
+    val sortedTerms = Seq(
+      ScoredTerm("bar", Node(Seq(Leaves(1, 1), Leaves(2, 2)))),
+      ScoredTerm("foo", Node(Seq(Leaves(1, 2), Leaves(2, 2))))
+    )
     unsortedTerms.sorted should be(sortedTerms)
   }
 }
@@ -45,24 +49,28 @@ class ScoredTermSpec extends FlatSpec with Matchers {
 class VarSortMatcherSpec extends FlatSpec with Matchers {
   "Different kinds of variables" should "bin separately" in {
     val parVars = Par(
-      exprs = List(EVar(BoundVar(2)),
-                   EVar(Wildcard(Var.WildcardMsg())),
-                   EVar(BoundVar(1)),
-                   EVar(FreeVar(0)),
-                   EVar(FreeVar(2)),
-                   EVar(BoundVar(0)),
-                   EVar(FreeVar(1))),
+      exprs = List(
+        EVar(BoundVar(2)),
+        EVar(Wildcard(Var.WildcardMsg())),
+        EVar(BoundVar(1)),
+        EVar(FreeVar(0)),
+        EVar(FreeVar(2)),
+        EVar(BoundVar(0)),
+        EVar(FreeVar(1))
+      ),
       locallyFree = BitSet(0, 1, 2),
       connectiveUsed = true
     )
     val sortedParVars: Option[Par] = Par(
-      exprs = List(EVar(BoundVar(0)),
-                   EVar(BoundVar(1)),
-                   EVar(BoundVar(2)),
-                   EVar(FreeVar(0)),
-                   EVar(FreeVar(1)),
-                   EVar(FreeVar(2)),
-                   EVar(Wildcard(Var.WildcardMsg()))),
+      exprs = List(
+        EVar(BoundVar(0)),
+        EVar(BoundVar(1)),
+        EVar(BoundVar(2)),
+        EVar(FreeVar(0)),
+        EVar(FreeVar(1)),
+        EVar(FreeVar(2)),
+        EVar(Wildcard(Var.WildcardMsg()))
+      ),
       locallyFree = BitSet(0, 1, 2),
       connectiveUsed = true
     )
@@ -120,7 +128,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           (GInt(2), ParSet(Seq[Par](GInt(2), GInt(1)))),
           (GInt(2), GInt(1)),
           (GInt(1), GInt(1))
-        ))
+        )
+      )
     val sortedParGround: Par =
       ParMap(Seq[(Par, Par)]((GInt(1), GInt(1)), (GInt(2), GInt(1))))
 
@@ -138,10 +147,13 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
   "Par" should "Sort according to PEMDAS" in {
     val parExpr =
       Par(
-        exprs = List(EMinus(GInt(4), GInt(3)),
-                     EDiv(GInt(1), GInt(5)),
-                     EPlus(GInt(1), GInt(3)),
-                     EMult(GInt(6), GInt(3))))
+        exprs = List(
+          EMinus(GInt(4), GInt(3)),
+          EDiv(GInt(1), GInt(5)),
+          EPlus(GInt(1), GInt(3)),
+          EMult(GInt(6), GInt(3))
+        )
+      )
     val sortedParExpr: Par =
       Par(
         exprs = List(
@@ -149,7 +161,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EDiv(GInt(1), GInt(5)),
           EPlus(GInt(1), GInt(3)),
           EMinus(GInt(4), GInt(3))
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -164,7 +177,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EGt(GBool(false), GBool(true)),
           ELte(GInt(1), GInt(5)),
           EGte(GBool(false), GBool(true))
-        ))
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         exprs = List(
@@ -174,7 +188,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EGte(GBool(false), GBool(true)),
           EEq(GInt(4), GInt(3)),
           ENeq(GInt(1), GInt(5))
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -186,14 +201,16 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EOr(EVar(BoundVar(0)), EVar(BoundVar(1))),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2)),
           EOr(EVar(BoundVar(3)), EVar(BoundVar(4)))
-        ))
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         exprs = List(
           EOr(EVar(BoundVar(0)), EVar(BoundVar(1))),
           EOr(EVar(BoundVar(3)), EVar(BoundVar(4))),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2))
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -206,15 +223,17 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EMethod("mth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2)), locallyFree = BitSet(2))
-        ))
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         exprs = List(
           EMethod("mth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2)),
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2)), locallyFree = BitSet(2)),
-          EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2)),
-        ))
+          EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -227,7 +246,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Send(Quote(GInt(5)), List(GInt(3)), true, BitSet()),
           Send(Quote(GInt(4)), List(GInt(2)), false, BitSet()),
           Send(Quote(GInt(5)), List(GInt(2)), false, BitSet())
-        ))
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         sends = List(
@@ -235,7 +255,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Send(Quote(GInt(5)), List(GInt(2)), false, BitSet()),
           Send(Quote(GInt(5)), List(GInt(3)), false, BitSet()),
           Send(Quote(GInt(5)), List(GInt(3)), true, BitSet())
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -244,11 +265,13 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     val parExpr =
       Par(
         receives = List(
-          Receive(List(ReceiveBind(List(Quote(GInt(1))), Quote(GInt(3)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet()),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(1))), Quote(GInt(3)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          ),
           Receive(
             List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
             EVar(BoundVar(0)),
@@ -256,35 +279,46 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             0,
             BitSet()
           ),
-          Receive(List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet()),
-          Receive(List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
-                  Par(),
-                  true,
-                  0,
-                  BitSet()),
-          Receive(List(ReceiveBind(List(Quote(GInt(100))), Quote(GInt(2)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet())
-        ))
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          ),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
+            Par(),
+            true,
+            0,
+            BitSet()
+          ),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(100))), Quote(GInt(2)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          )
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         receives = List(
-          Receive(List(ReceiveBind(List(Quote(GInt(100))), Quote(GInt(2)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet()),
-          Receive(List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet()),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(100))), Quote(GInt(2)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          ),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          ),
           Receive(
             List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))),
             EVar(BoundVar(0)),
@@ -292,13 +326,16 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             0,
             BitSet()
           ),
-          Receive(List(ReceiveBind(List(Quote(GInt(1))), Quote(GInt(3)))),
-                  Par(),
-                  false,
-                  0,
-                  BitSet()),
+          Receive(
+            List(ReceiveBind(List(Quote(GInt(1))), Quote(GInt(3)))),
+            Par(),
+            false,
+            0,
+            BitSet()
+          ),
           Receive(List(ReceiveBind(List(Quote(GInt(0))), Quote(GInt(3)))), Par(), true, 0, BitSet())
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -308,24 +345,34 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(
         matches = List(
           Match(GInt(5), List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))), BitSet()),
-          Match(GBool(true),
-                List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))),
-                BitSet()),
-          Match(GBool(true),
-                List(MatchCase(GInt(4), GInt(4)), MatchCase(GInt(3), GInt(3))),
-                BitSet())
-        ))
+          Match(
+            GBool(true),
+            List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))),
+            BitSet()
+          ),
+          Match(
+            GBool(true),
+            List(MatchCase(GInt(4), GInt(4)), MatchCase(GInt(3), GInt(3))),
+            BitSet()
+          )
+        )
+      )
     val sortedParMatch: Option[Par] =
       Par(
         matches = List(
-          Match(GBool(true),
-                List(MatchCase(GInt(4), GInt(4)), MatchCase(GInt(3), GInt(3))),
-                BitSet()),
-          Match(GBool(true),
-                List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))),
-                BitSet()),
+          Match(
+            GBool(true),
+            List(MatchCase(GInt(4), GInt(4)), MatchCase(GInt(3), GInt(3))),
+            BitSet()
+          ),
+          Match(
+            GBool(true),
+            List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))),
+            BitSet()
+          ),
           Match(GInt(5), List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))), BitSet())
-        ))
+        )
+      )
     val result = SortTest.sort(parMatch)
     result.term should be(sortedParMatch.get)
   }
@@ -339,7 +386,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           New(bindCount = 2, p = Par()),
           New(bindCount = 2, uri = Vector("rho:io:stdout"), p = Par()),
           New(bindCount = 2, uri = Vector("rho:io:stderr"), p = Par())
-        ))
+        )
+      )
     val sortedParNew =
       Par(
         news = List(
@@ -348,7 +396,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           New(bindCount = 2, uri = Vector("rho:io:stdout"), p = Par()),
           New(bindCount = 2, uri = Vector("rho:io:stdout"), p = GInt(7)),
           New(bindCount = 2, p = Par())
-        ))
+        )
+      )
     val result = SortTest.sort(parNew)
     result.term should be(sortedParNew.get)
   }
@@ -371,7 +420,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EVar(BoundVar(1)),
           EOr(GBool(false), GBool(true)),
           GInt(1)
-        ))
+        )
+      )
     val sortedParExpr: Option[Par] =
       Par(
         exprs = List(
@@ -380,7 +430,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EDiv(GInt(1), GInt(5)),
           EEq(GInt(4), GInt(3)),
           EOr(GBool(false), GBool(true))
-        ))
+        )
+      )
     val result = SortTest.sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
@@ -394,7 +445,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EVar(BoundVar(1)),
           EOr(GBool(false), GBool(true)),
           GInt(1)
-        ))
+        )
+      )
     val sortedParExpr: Par =
       Par(
         exprs = List(
@@ -403,7 +455,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EDiv(GInt(1), GInt(5)),
           EEq(GInt(4), GInt(3)),
           EOr(GBool(false), GBool(true))
-        ))
+        )
+      )
 
     val bundle = Bundle(parExpr)
     val result = SortTest.sort(bundle)
@@ -419,7 +472,8 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EVar(BoundVar(1)),
           EOr(GBool(false), GBool(true)),
           GInt(1)
-        ))
+        )
+      )
     val sortedParExpr: Par =
       Par(
         exprs = List(
@@ -428,18 +482,26 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EDiv(GInt(1), GInt(5)),
           EEq(GInt(4), GInt(3)),
           EOr(GBool(false), GBool(true))
-        ))
+        )
+      )
 
     val nestedBundle = Bundle(
-      Bundle(Bundle(parExpr, writeFlag = true, readFlag = false),
-             writeFlag = false,
-             readFlag = true))
+      Bundle(
+        Bundle(parExpr, writeFlag = true, readFlag = false),
+        writeFlag = false,
+        readFlag = true
+      )
+    )
     val result = SortTest.sort(nestedBundle)
     result.term should be(
       Bundle(
-        Bundle(Bundle(sortedParExpr, writeFlag = true, readFlag = false),
-               writeFlag = false,
-               readFlag = true)))
+        Bundle(
+          Bundle(sortedParExpr, writeFlag = true, readFlag = false),
+          writeFlag = false,
+          readFlag = true
+        )
+      )
+    )
   }
 
   it should "sort logical connectives in \"not\", \"and\", \"or\" order" in {
@@ -447,11 +509,22 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(
         connectives = List(
           Connective(
-            ConnAndBody(ConnectiveBody(
-              List(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), List(EVar(FreeVar(2))), false))))),
+            ConnAndBody(
+              ConnectiveBody(
+                List(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), List(EVar(FreeVar(2))), false))
+              )
+            )
+          ),
           Connective(
-            ConnOrBody(ConnectiveBody(List(New(1, EVar(Wildcard(Var.WildcardMsg()))),
-                                           New(2, EVar(Wildcard(Var.WildcardMsg()))))))),
+            ConnOrBody(
+              ConnectiveBody(
+                List(
+                  New(1, EVar(Wildcard(Var.WildcardMsg()))),
+                  New(2, EVar(Wildcard(Var.WildcardMsg())))
+                )
+              )
+            )
+          ),
           Connective(VarRefBody(VarRef(0, 2))),
           Connective(ConnInt(true)),
           Connective(ConnBool(true)),
@@ -472,11 +545,22 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Connective(ConnByteArray(true)),
           Connective(ConnNotBody(Par())),
           Connective(
-            ConnAndBody(ConnectiveBody(
-              List(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), List(EVar(FreeVar(2))), false))))),
+            ConnAndBody(
+              ConnectiveBody(
+                List(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), List(EVar(FreeVar(2))), false))
+              )
+            )
+          ),
           Connective(
-            ConnOrBody(ConnectiveBody(List(New(1, EVar(Wildcard(Var.WildcardMsg()))),
-                                           New(2, EVar(Wildcard(Var.WildcardMsg()))))))),
+            ConnOrBody(
+              ConnectiveBody(
+                List(
+                  New(1, EVar(Wildcard(Var.WildcardMsg()))),
+                  New(2, EVar(Wildcard(Var.WildcardMsg())))
+                )
+              )
+            )
+          ),
           Connective(VarRefBody(VarRef(0, 2)))
         ),
         connectiveUsed = true

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -33,7 +33,8 @@ object testImplicits {
     Arbitrary(
       Arbitrary
         .arbitrary[Seq[Par]]
-        .map(pars => SortedParHashSet(pars)))
+        .map(pars => SortedParHashSet(pars))
+    )
 
   implicit def arbParTupleSeq: Arbitrary[Seq[(Par, Par)]] =
     Arbitrary(Gen.listOf(Gen.zip(arbPar.arbitrary, arbPar.arbitrary)))

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -43,17 +43,23 @@ object Main {
 
   private def mainProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] = {
     implicit val replService: GrpcReplClient =
-      new GrpcReplClient(conf.grpcServer.host,
-                         conf.grpcServer.portInternal,
-                         conf.server.maxMessageSize)
+      new GrpcReplClient(
+        conf.grpcServer.host,
+        conf.grpcServer.portInternal,
+        conf.server.maxMessageSize
+      )
     implicit val diagnosticsService: GrpcDiagnosticsService =
-      new diagnostics.client.GrpcDiagnosticsService(conf.grpcServer.host,
-                                                    conf.grpcServer.portInternal,
-                                                    conf.server.maxMessageSize)
+      new diagnostics.client.GrpcDiagnosticsService(
+        conf.grpcServer.host,
+        conf.grpcServer.portInternal,
+        conf.server.maxMessageSize
+      )
     implicit val deployService: GrpcDeployService =
-      new GrpcDeployService(conf.grpcServer.host,
-                            conf.grpcServer.portExternal,
-                            conf.server.maxMessageSize)
+      new GrpcDeployService(
+        conf.grpcServer.host,
+        conf.grpcServer.portExternal,
+        conf.server.maxMessageSize
+      )
 
     val program = conf.command match {
       case Eval(files) => new ReplRuntime().evalProgram[Task](files)
@@ -71,12 +77,14 @@ object Main {
       case _                 => conf.printHelp()
     }
 
-    program.doOnFinish(_ =>
-      Task.delay {
-        replService.close()
-        diagnosticsService.close()
-        deployService.close()
-    })
+    program.doOnFinish(
+      _ =>
+        Task.delay {
+          replService.close()
+          diagnosticsService.close()
+          deployService.close()
+        }
+    )
   }
 
   private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] =

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -42,7 +42,8 @@ private[api] object DeployGrpcService {
         BlockAPI.getListeningNameDataResponse[F](listeningName).toTask
 
       override def listenForContinuationAtName(
-          listeningNames: Channels): Task[ListeningNameContinuationResponse] =
+          listeningNames: Channels
+      ): Task[ListeningNameContinuationResponse] =
         BlockAPI.getListeningNameContinuationResponse[F](listeningNames).toTask
     }
 }

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -31,7 +31,8 @@ object GrpcServer {
       nodeDiscovery: NodeDiscovery[Task],
       jvmMetrics: JvmMetrics[Task],
       nodeMetrics: NodeMetrics[Task],
-      connectionsCell: ConnectionsCell[Task]): Task[Server] =
+      connectionsCell: ConnectionsCell[Task]
+  ): Task[Server] =
     Task.delay {
       NettyServerBuilder
         .forPort(port)
@@ -41,10 +42,10 @@ object GrpcServer {
         .build
     }
 
-  def acquireExternalServer[
-      F[_]: Sync: Capture: MultiParentCasperRef: Log: SafetyOracle: BlockStore: Taskable](
+  def acquireExternalServer[F[_]: Sync: Capture: MultiParentCasperRef: Log: SafetyOracle: BlockStore: Taskable](
       port: Int,
-      maxMessageSize: Int)(implicit scheduler: Scheduler): F[Server] =
+      maxMessageSize: Int
+  )(implicit scheduler: Scheduler): F[Server] =
     Capture[F].capture {
       NettyServerBuilder
         .forPort(port)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -27,9 +27,10 @@ object Configuration {
     Profile("docker", dataDir = (() => Paths.get("/var/lib/rnode"), "Defaults to /var/lib/rnode"))
 
   private val defaultProfile =
-    Profile("default",
-            dataDir =
-              (() => Paths.get(sys.props("user.home"), ".rnode"), "Defaults to $HOME/.rnode"))
+    Profile(
+      "default",
+      dataDir = (() => Paths.get(sys.props("user.home"), ".rnode"), "Defaults to $HOME/.rnode")
+    )
 
   private val profiles: Map[String, Profile] =
     Map(defaultProfile.name -> defaultProfile, dockerProfile.name -> dockerProfile)
@@ -64,8 +65,9 @@ object Configuration {
     .get
   private val DefaultShardId = "rchain"
 
-  private def loadConfigurationFile(configFile: File)(
-      implicit log: Log[Task]): Task[Option[TomlConfiguration]] =
+  private def loadConfigurationFile(
+      configFile: File
+  )(implicit log: Log[Task]): Task[Option[TomlConfiguration]] =
     for {
       _       <- log.info(s"Using configuration file: $configFile")
       configE <- Task.delay(toml.TomlConfiguration.from(configFile))
@@ -98,7 +100,8 @@ object Configuration {
     } yield result
 
   private def apply(options: commandline.Options, command: Command, profile: Profile)(
-      implicit log: Log[Task]): Task[Configuration] =
+      implicit log: Log[Task]
+  ): Task[Configuration] =
     if (command == Run) {
       for {
         dataDir    <- Task.pure(options.run.data_dir.getOrElse(profile.dataDir._1()))
@@ -107,7 +110,8 @@ object Configuration {
         config     <- loadConfigurationFile(configFile)
         effectiveDataDir <- Task.pure(
                              if (options.run.data_dir.isDefined) dataDir
-                             else config.flatMap(_.server.flatMap(_.dataDir)).getOrElse(dataDir))
+                             else config.flatMap(_.server.flatMap(_.dataDir)).getOrElse(dataDir)
+                           )
         _      = System.setProperty("rnode.data.dir", effectiveDataDir.toString)
         result <- Task.pure(apply(effectiveDataDir, options, config))
         _      <- log.info(s"Starting with profile ${profile.name}")
@@ -169,9 +173,11 @@ object Configuration {
       )
     }
 
-  private def apply(dataDir: Path,
-                    options: commandline.Options,
-                    config: Option[TomlConfiguration]): Configuration = {
+  private def apply(
+      dataDir: Path,
+      options: commandline.Options,
+      config: Option[TomlConfiguration]
+  ): Configuration = {
     val command: Command = options.subcommand match {
       case Some(options.eval)        => Eval(options.eval.fileNames())
       case Some(options.repl)        => Repl
@@ -179,11 +185,13 @@ object Configuration {
       case Some(options.deploy)      =>
         //TODO: change the defaults before main net
         import options.deploy._
-        Deploy(from.getOrElse("0x"),
-               phloLimit.getOrElse(0),
-               phloPrice.getOrElse(0),
-               nonce.getOrElse(0),
-               location())
+        Deploy(
+          from.getOrElse("0x"),
+          phloLimit.getOrElse(0),
+          phloPrice.getOrElse(0),
+          nonce.getOrElse(0),
+          location()
+        )
       case Some(options.deployDemo) => DeployDemo
       case Some(options.propose)    => Propose
       case Some(options.showBlock)  => ShowBlock(options.showBlock.hash())
@@ -194,13 +202,17 @@ object Configuration {
 
     import commandline.Options._
 
-    def getOpt[A](fo: commandline.Options => Option[A],
-                  fc: TomlConfiguration => Option[A]): Option[A] =
+    def getOpt[A](
+        fo: commandline.Options => Option[A],
+        fc: TomlConfiguration => Option[A]
+    ): Option[A] =
       fo(options).orElse(config.flatMap(fc))
 
-    def get[A](fo: commandline.Options => Option[A],
-               fc: TomlConfiguration => Option[A],
-               default: => A): A =
+    def get[A](
+        fo: commandline.Options => Option[A],
+        fc: TomlConfiguration => Option[A],
+        default: => A
+    ): A =
       getOpt(fo, fc).getOrElse(default)
 
     // gRPC
@@ -225,13 +237,17 @@ object Configuration {
     val requiredSigs =
       get(_.run.requiredSigs, _.validators.flatMap(_.requiredSigs), DefaultRequiredSigns)
     val genesisApproveInterval =
-      get(_.run.interval,
-          _.validators.flatMap(_.approveGenesisInterval),
-          DefaultApprovalProtocolInterval)
+      get(
+        _.run.interval,
+        _.validators.flatMap(_.approveGenesisInterval),
+        DefaultApprovalProtocolInterval
+      )
     val genesisAppriveDuration =
-      get(_.run.duration,
-          _.validators.flatMap(_.approveGenesisDuration),
-          DefaultApprovalProtocolDuration)
+      get(
+        _.run.duration,
+        _.validators.flatMap(_.approveGenesisDuration),
+        DefaultApprovalProtocolDuration
+      )
 
     val deployTimestamp = getOpt(_.run.deployTimestamp, _.validators.flatMap(_.deployTimestamp))
 
@@ -239,9 +255,11 @@ object Configuration {
     val mapSize: Long        = get(_.run.map_size, _.server.flatMap(_.mapSize), DefaultMapSize)
     val storeType: StoreType =
       get(_.run.storeType, _.server.flatMap(_.storeType.flatMap(StoreType.from)), DefaultStoreType)
-    val casperBlockStoreSize: Long = get(_.run.casperBlockStoreSize,
-                                         _.server.flatMap(_.casperBlockStoreSize),
-                                         DefaultCasperBlockStoreSize)
+    val casperBlockStoreSize: Long = get(
+      _.run.casperBlockStoreSize,
+      _.server.flatMap(_.casperBlockStoreSize),
+      DefaultCasperBlockStoreSize
+    )
 
     // TLS
     val certificate: Option[Path] = getOpt(_.run.certificate, _.tls.flatMap(_.certificate))
@@ -261,13 +279,17 @@ object Configuration {
     val knownValidators     = getOpt(_.run.knownValidators, _.validators.flatMap(_.known))
     val validatorPublicKey  = getOpt(_.run.validatorPublicKey, _.validators.flatMap(_.publicKey))
     val validatorPrivateKey = getOpt(_.run.validatorPrivateKey, _.validators.flatMap(_.privateKey))
-    val validatorSigAlgorithm = get(_.run.validatorSigAlgorithm,
-                                    _.validators.flatMap(_.sigAlgorithm),
-                                    DefaultValidatorSigAlgorithm)
+    val validatorSigAlgorithm = get(
+      _.run.validatorSigAlgorithm,
+      _.validators.flatMap(_.sigAlgorithm),
+      DefaultValidatorSigAlgorithm
+    )
     val walletsFile: Option[String] = getOpt(_.run.walletsFile, _.validators.flatMap(_.walletsFile))
-    val maxNumOfConnections = get(_.run.maxNumOfConnections,
-                                  _.server.flatMap(_.maxNumOfConnections),
-                                  DefaultMaxNumOfConnections)
+    val maxNumOfConnections = get(
+      _.run.maxNumOfConnections,
+      _.server.flatMap(_.maxNumOfConnections),
+      DefaultMaxNumOfConnections
+    )
 
     val maxMessageSize: Int =
       get(_.run.maxMessageSize, _.server.flatMap(_.maxMessageSize), DefaultMaxMessageSize)
@@ -348,11 +370,13 @@ object Configuration {
       case Some(options.deploy)      =>
         //TODO: change the defaults before main net
         import options.deploy._
-        Deploy(from.getOrElse("0x"),
-               phloLimit.getOrElse(0),
-               phloPrice.getOrElse(0),
-               nonce.getOrElse(0),
-               location())
+        Deploy(
+          from.getOrElse("0x"),
+          phloLimit.getOrElse(0),
+          phloPrice.getOrElse(0),
+          nonce.getOrElse(0),
+          location()
+        )
       case Some(options.deployDemo) => DeployDemo
       case Some(options.propose)    => Propose
       case Some(options.showBlock)  => ShowBlock(options.showBlock.hash())
@@ -399,8 +423,10 @@ final class Configuration(
   private def check(source: String, from: String): Task[(String, Option[String])] =
     IpChecker.checkFrom[Task](from).map((source, _))
 
-  private def checkNext(prev: (String, Option[String]),
-                        next: Task[(String, Option[String])]): Task[(String, Option[String])] =
+  private def checkNext(
+      prev: (String, Option[String]),
+      next: Task[(String, Option[String])]
+  ): Task[(String, Option[String])] =
     prev._2.fold(next)(_ => Task.pure(prev))
 
   private def upnpIpCheck(externalAddress: Option[String]): Task[(String, Option[String])] =
@@ -418,7 +444,8 @@ final class Configuration(
     }
 
   private def whoAmI(port: Int, externalAddress: Option[String])(
-      implicit log: Log[Task]): Task[String] =
+      implicit log: Log[Task]
+  ): Task[String] =
     for {
       _      <- log.info("flag --host was not provided, guessing your external IP address")
       r      <- checkAll(externalAddress)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -35,9 +35,11 @@ object Converter {
     val argType: ArgType.V = ArgType.FLAG
   }
 
-  private def nameConverter[A](onPub: List[String] => A,
-                               onPriv: List[String] => A,
-                               argType0: ArgType.V) = new ValueConverter[List[String] => A] {
+  private def nameConverter[A](
+      onPub: List[String] => A,
+      onPriv: List[String] => A,
+      argType0: ArgType.V
+  ) = new ValueConverter[List[String] => A] {
     import cats.instances.either._
     import cats.instances.option._
     import cats.syntax.traverse._
@@ -70,7 +72,8 @@ object Converter {
           case (_, duration :: Nil) :: Nil =>
             val finiteDuration = Some(Duration(duration)).collect { case f: FiniteDuration => f }
             finiteDuration.fold[Either[String, Option[FiniteDuration]]](
-              Left("Expected finite duration."))(fd => Right(Some(fd)))
+              Left("Expected finite duration.")
+            )(fd => Right(Some(fd)))
           case Nil => Right(None)
           case _   => Left("Provide a duration.")
         }
@@ -115,8 +118,10 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   version(s"RChain Node ${BuildInfo.version}")
   printedName = "rchain"
 
-  val profile = opt[String](name = "profile",
-                            descr = "Which predefined set of defaults to use: default or docker.")
+  val profile = opt[String](
+    name = "profile",
+    descr = "Which predefined set of defaults to use: default or docker."
+  )
 
   val configFile = opt[Path](descr = "Path to the configuration file.")
 
@@ -142,14 +147,16 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       opt[Int](descr = "Default timeout for roundtrip connections. Default 1 second.")
 
     val certificate =
-      opt[Path](short = 'c',
-                descr =
-                  "Path to node's X.509 certificate file, that is being used for identification")
+      opt[Path](
+        short = 'c',
+        descr = "Path to node's X.509 certificate file, that is being used for identification"
+      )
 
     val key =
-      opt[Path](short = 'k',
-                descr =
-                  "Path to node's private key PEM file, that is being used for TLS communication")
+      opt[Path](
+        short = 'k',
+        descr = "Path to node's private key PEM file, that is being used for TLS communication"
+      )
 
     val secureRandomNonBlocking =
       opt[Flag](descr = "Use a non blocking secure random instance")
@@ -192,7 +199,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val requiredSigs =
       opt[Int](
         descr =
-          "Number of signatures from trusted validators required to creating an approved genesis block.")
+          "Number of signatures from trusted validators required to creating an approved genesis block."
+      )
 
     val deployTimestamp =
       opt[Long](
@@ -209,7 +217,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val interval =
       opt[FiniteDuration](
         short = 'i',
-        descr = "Interval at which condition for creating ApprovedBlock will be checked.")
+        descr = "Interval at which condition for creating ApprovedBlock will be checked."
+      )
 
     val genesisValidator =
       opt[Flag](descr = "Start a node as a genesis validator.")
@@ -241,11 +250,13 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     )
 
     val validatorPrivateKey = opt[String](
-      descr = "Base16 encoding of the private key to use for signing a proposed blocks.")
+      descr = "Base16 encoding of the private key to use for signing a proposed blocks."
+    )
 
     val validatorSigAlgorithm = opt[String](
       descr = "Name of the algorithm to use for signing proposed blocks. " +
-        "Currently supported values: ed25519")
+        "Currently supported values: ed25519"
+    )
 
     val shardId = opt[String](
       descr = "Identifier of the shard this node is connected to."
@@ -260,7 +271,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val eval = new Subcommand("eval") {
     descr(
-      "Starts a thin client that will evaluate rholang in file on a existing running node. See grpcHost and grpcPort.")
+      "Starts a thin client that will evaluate rholang in file on a existing running node. See grpcHost and grpcPort."
+    )
 
     val fileNames = trailArg[List[String]](required = true)(stringListConverter)
   }
@@ -268,7 +280,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val deployDemo = new Subcommand("deploy-demo") {
     descr(
-      "Demo sending some placeholder Deploy operations to Casper on an existing running node at regular intervals")
+      "Demo sending some placeholder Deploy operations to Casper on an existing running node at regular intervals"
+    )
   }
   addSubcommand(deployDemo)
 
@@ -276,7 +289,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     descr(
       "Deploy a Rholang source file to Casper on an existing running node. " +
         "The deploy will be packaged and sent as a block to the network depending " +
-        "on the configuration of the Casper instance.")
+        "on the configuration of the Casper instance."
+    )
 
     val addressCheck: String => Boolean = addr =>
       addr.startsWith("0x") && addr.drop(2).matches("[0-9a-fA-F]+")
@@ -293,7 +307,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     )
 
     val nonce = opt[Int](
-      descr = "This allows you to overwrite your own pending transactions that use the same nonce.")
+      descr = "This allows you to overwrite your own pending transactions that use the same nonce."
+    )
 
     val location = trailArg[String](required = true)
   }
@@ -302,7 +317,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val showBlock = new Subcommand("show-block") {
     descr(
       "View properties of a block known by Casper on an existing running node." +
-        "Output includes: parent hashes, storage contents of the tuplespace.")
+        "Output includes: parent hashes, storage contents of the tuplespace."
+    )
     val hash =
       trailArg[String](name = "hash", required = true, descr = "the hash value of the block")
   }
@@ -310,19 +326,23 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val showBlocks = new Subcommand("show-blocks") {
     descr(
-      "View list of blocks on the main chain in the current Casper view on an existing running node.")
+      "View list of blocks on the main chain in the current Casper view on an existing running node."
+    )
   }
   addSubcommand(showBlocks)
 
   def listenAtName[R](name: String, desc: String)(
-      implicit conv: ValueConverter[List[String] => R]) = new Subcommand(name) {
+      implicit conv: ValueConverter[List[String] => R]
+  ) = new Subcommand(name) {
     descr(desc)
 
     val typeOfName =
-      opt[List[String] => R](required = true,
-                             descr = "Type of the specified name",
-                             name = "type",
-                             short = 't')
+      opt[List[String] => R](
+        required = true,
+        descr = "Type of the specified name",
+        name = "type",
+        short = 't'
+      )
 
     val content =
       opt[List[String]](required = true, descr = "Rholang name", name = "content", short = 'c')
@@ -345,7 +365,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val propose = new Subcommand("propose") {
     descr(
-      "Force Casper (on an existing running node) to propose a block based on its accumulated deploys.")
+      "Force Casper (on an existing running node) to propose a block based on its accumulated deploys."
+    )
   }
   addSubcommand(propose)
 

--- a/node/src/main/scala/coop/rchain/node/diagnostics/JmxReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/JmxReporter.scala
@@ -79,7 +79,8 @@ private[diagnostics] class NodeMetricsSnapshotBean(snapshot: PeriodSnapshot) ext
 private[diagnostics] object NodeMetricsSnapshotBean {
   def apply(): NodeMetricsSnapshotBean =
     new NodeMetricsSnapshotBean(
-      PeriodSnapshot(Instant.EPOCH, Instant.EPOCH, MetricsSnapshot(Nil, Nil, Nil, Nil)))
+      PeriodSnapshot(Instant.EPOCH, Instant.EPOCH, MetricsSnapshot(Nil, Nil, Nil, Nil))
+    )
   def apply(metrics: PeriodSnapshot): NodeMetricsSnapshotBean =
     new NodeMetricsSnapshotBean(metrics)
 }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/JvmMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/JvmMetrics.scala
@@ -19,7 +19,8 @@ object JvmMetrics extends JmxMetricsInstances {
   def apply[F[_]](implicit M: JvmMetrics[F]): JvmMetrics[F] = M
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: JvmMetrics[F]): JvmMetrics[T[F, ?]] =
+      implicit C: JvmMetrics[F]
+  ): JvmMetrics[T[F, ?]] =
     new JvmMetrics[T[F, ?]] {
       def processCpu: T[F, ProcessCpu]                   = C.processCpu.liftM[T]
       def memoryUsage: T[F, MemoryUsage]                 = C.memoryUsage.liftM[T]

--- a/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
@@ -48,14 +48,16 @@ class NewPrometheusReporter extends MetricReporter {
   */
 object NewPrometheusReporter {
 
-  case class Configuration(startEmbeddedServer: Boolean,
-                           embeddedServerHostname: String,
-                           embeddedServerPort: Int,
-                           defaultBuckets: Seq[java.lang.Double],
-                           timeBuckets: Seq[java.lang.Double],
-                           informationBuckets: Seq[java.lang.Double],
-                           customBuckets: Map[String, Seq[java.lang.Double]],
-                           includeEnvironmentTags: Boolean)
+  case class Configuration(
+      startEmbeddedServer: Boolean,
+      embeddedServerHostname: String,
+      embeddedServerPort: Int,
+      defaultBuckets: Seq[java.lang.Double],
+      timeBuckets: Seq[java.lang.Double],
+      informationBuckets: Seq[java.lang.Double],
+      customBuckets: Map[String, Seq[java.lang.Double]],
+      includeEnvironmentTags: Boolean
+  )
 
   object Configuration {
 

--- a/node/src/main/scala/coop/rchain/node/diagnostics/NodeMetrics.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/NodeMetrics.scala
@@ -15,7 +15,8 @@ object NodeMetrics extends NodeMetricsInstances {
   def apply[F[_]](implicit M: NodeMetrics[F]): NodeMetrics[F] = M
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](
-      implicit C: NodeMetrics[F]): NodeMetrics[T[F, ?]] =
+      implicit C: NodeMetrics[F]
+  ): NodeMetrics[T[F, ?]] =
     new NodeMetrics[T[F, ?]] {
       def metrics: T[F, NodeCoreMetrics] = C.metrics.liftM[T]
     }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
@@ -10,8 +10,10 @@ import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{information, none, time}
 import kamon.metric.MeasurementUnit.Dimension._
 
-class ScrapeDataBuilder(prometheusConfig: NewPrometheusReporter.Configuration,
-                        environmentTags: Map[String, String] = Map.empty) {
+class ScrapeDataBuilder(
+    prometheusConfig: NewPrometheusReporter.Configuration,
+    environmentTags: Map[String, String] = Map.empty
+) {
   private val builder              = new StringBuilder()
   private val decimalFormatSymbols = DecimalFormatSymbols.getInstance(Locale.ROOT)
   private val numberFormat         = new DecimalFormat("#0.0########", decimalFormatSymbols)
@@ -37,7 +39,8 @@ class ScrapeDataBuilder(prometheusConfig: NewPrometheusReporter.Configuration,
   }
 
   private def appendValueMetric(metricType: String, alwaysIncreasing: Boolean)(
-      group: (String, Seq[MetricValue])): Unit = {
+      group: (String, Seq[MetricValue])
+  ): Unit = {
     val (metricName, snapshots) = group
     val unit                    = snapshots.headOption.map(_.unit).getOrElse(none)
     val normalizedMetricName = normalizeMetricName(metricName, unit) + {
@@ -64,10 +67,12 @@ class ScrapeDataBuilder(prometheusConfig: NewPrometheusReporter.Configuration,
 
     snapshots.foreach(metric => {
       if (metric.distribution.count > 0) {
-        appendHistogramBuckets(normalizedMetricName,
-                               metric.tags,
-                               metric,
-                               resolveBucketConfiguration(metric))
+        appendHistogramBuckets(
+          normalizedMetricName,
+          metric.tags,
+          metric,
+          resolveBucketConfiguration(metric)
+        )
 
         val count = format(metric.distribution.count)
         val sum   = format(scale(metric.distribution.sum, metric.unit))
@@ -77,10 +82,12 @@ class ScrapeDataBuilder(prometheusConfig: NewPrometheusReporter.Configuration,
     })
   }
 
-  private def appendTimeSerieValue(name: String,
-                                   tags: Map[String, String],
-                                   value: String,
-                                   suffix: String = ""): Unit = {
+  private def appendTimeSerieValue(
+      name: String,
+      tags: Map[String, String],
+      value: String,
+      suffix: String = ""
+  ): Unit = {
     append(name)
     append(suffix)
     appendTags(tags)
@@ -99,10 +106,12 @@ class ScrapeDataBuilder(prometheusConfig: NewPrometheusReporter.Configuration,
       }
     )
 
-  private def appendHistogramBuckets(name: String,
-                                     tags: Map[String, String],
-                                     metric: MetricDistribution,
-                                     buckets: Seq[java.lang.Double]): Unit = {
+  private def appendHistogramBuckets(
+      name: String,
+      tags: Map[String, String],
+      metric: MetricDistribution,
+      buckets: Seq[java.lang.Double]
+  ): Unit = {
     val distributionBuckets            = metric.distribution.bucketsIterator
     var currentDistributionBucket      = distributionBuckets.next()
     var currentDistributionBucketValue = scale(currentDistributionBucket.value, metric.unit)

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
@@ -47,7 +47,9 @@ class GrpcDiagnosticsService(host: String, port: Int, maxMessageSize: Int)
             PeerNode(
               NodeIdentifier(p.key.toByteArray.toSeq),
               Endpoint(p.host, p.port, p.port)
-          )))
+            )
+        )
+      )
 
   def listDiscoveredPeers: Task[Seq[PeerNode]] =
     stub
@@ -59,7 +61,9 @@ class GrpcDiagnosticsService(host: String, port: Int, maxMessageSize: Int)
               PeerNode(
                 NodeIdentifier(p.key.toByteArray.toSeq),
                 Endpoint(p.host, p.port, p.port)
-            )))
+              )
+          )
+      )
 
   def nodeCoreMetrics: Task[NodeCoreMetrics] =
     stub.getNodeCoreMetrics(Empty())
@@ -83,7 +87,8 @@ class GrpcDiagnosticsService(host: String, port: Int, maxMessageSize: Int)
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {
       println(
-        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout"
+      )
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }

--- a/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/package.scala
@@ -227,14 +227,20 @@ package object diagnostics {
     new DiagnosticsGrpcMonix.Diagnostics {
       def listPeers(request: Empty): Task[Peers] =
         connectionsCell.read.map { ps =>
-          Peers(ps.map(p =>
-            Peer(p.endpoint.host, p.endpoint.udpPort, ByteString.copyFrom(p.id.key.toArray))))
+          Peers(
+            ps.map(
+              p => Peer(p.endpoint.host, p.endpoint.udpPort, ByteString.copyFrom(p.id.key.toArray))
+            )
+          )
         }
 
       def listDiscoveredPeers(request: Empty): Task[Peers] =
         nodeDiscovery.peers.map { ps =>
-          Peers(ps.map(p =>
-            Peer(p.endpoint.host, p.endpoint.udpPort, ByteString.copyFrom(p.id.key.toArray))))
+          Peers(
+            ps.map(
+              p => Peer(p.endpoint.host, p.endpoint.udpPort, ByteString.copyFrom(p.id.key.toArray))
+            )
+          )
         }
 
       def getProcessCpu(request: Empty): Task[ProcessCpu] =

--- a/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
@@ -68,7 +68,8 @@ class GrpcReplClient(host: String, port: Int, maxMessageSize: Int)
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {
       println(
-        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout")
+        "warn: did not shutdown after 10 seconds, retrying with additional 10 seconds timeout"
+      )
       channel.awaitTermination(10, TimeUnit.SECONDS)
     }
   }

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -49,7 +49,8 @@ package object effects {
   def kademliaRPC(src: PeerNode, timeout: FiniteDuration)(
       implicit
       metrics: Metrics[Task],
-      transport: TransportLayer[Task]): KademliaRPC[Task] =
+      transport: TransportLayer[Task]
+  ): KademliaRPC[Task] =
     new KademliaRPC[Task] {
       def ping(node: PeerNode): Task[Boolean] =
         for {
@@ -64,23 +65,29 @@ package object effects {
           req = ProtocolHelper.lookup(src, key)
           r <- TransportLayer[Task]
                 .roundTrip(remoteNode, req, timeout)
-                .map(_.toOption
-                  .map {
-                    case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
-                      lr.nodes.map(ProtocolHelper.toPeerNode)
-                    case _ => Seq()
-                  }
-                  .getOrElse(Seq()))
+                .map(
+                  _.toOption
+                    .map {
+                      case Protocol(_, Protocol.Message.LookupResponse(lr)) =>
+                        lr.nodes.map(ProtocolHelper.toPeerNode)
+                      case _ => Seq()
+                    }
+                    .getOrElse(Seq())
+                )
         } yield r
     }
 
-  def tcpTransportLayer(host: String,
-                        port: Int,
-                        certPath: Path,
-                        keyPath: Path,
-                        maxMessageSize: Int)(implicit scheduler: Scheduler,
-                                             connections: TcpTransportLayer.TransportCell[Task],
-                                             log: Log[Task]): TcpTransportLayer = {
+  def tcpTransportLayer(
+      host: String,
+      port: Int,
+      certPath: Path,
+      keyPath: Path,
+      maxMessageSize: Int
+  )(
+      implicit scheduler: Scheduler,
+      connections: TcpTransportLayer.TransportCell[Task],
+      log: Log[Task]
+  ): TcpTransportLayer = {
     val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
     val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
     new TcpTransportLayer(host, port, cert, key, maxMessageSize)

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -52,7 +52,8 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
   if (!dataDirFile.exists()) {
     if (!dataDirFile.mkdir()) {
       println(
-        s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}")
+        s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
+      )
       System.exit(-1)
     }
   }
@@ -60,7 +61,8 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
   // Check if data_dir has read/write access
   if (!dataDirFile.isDirectory || !dataDirFile.canRead || !dataDirFile.canWrite) {
     println(
-      s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}")
+      s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
+    )
     System.exit(-1)
   }
 
@@ -169,12 +171,16 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
   ): Effect[Servers] =
     for {
       grpcServerExternal <- GrpcServer
-                             .acquireExternalServer[Effect](conf.grpcServer.portExternal,
-                                                            conf.server.maxMessageSize)
+                             .acquireExternalServer[Effect](
+                               conf.grpcServer.portExternal,
+                               conf.server.maxMessageSize
+                             )
       grpcServerInternal <- GrpcServer
-                             .acquireInternalServer(conf.grpcServer.portInternal,
-                                                    conf.server.maxMessageSize,
-                                                    runtime)
+                             .acquireInternalServer(
+                               conf.grpcServer.portInternal,
+                               conf.server.maxMessageSize,
+                               runtime
+                             )
                              .toEffect
       prometheusReporter = new NewPrometheusReporter()
 
@@ -194,7 +200,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
 
   def startServers(servers: Servers)(
       implicit
-      log: Log[Task],
+      log: Log[Task]
   ): Effect[Unit] =
     GrpcServer.start(servers.grpcServerExternal, servers.grpcServerInternal).toEffect
 
@@ -225,8 +231,10 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       _   <- log.info("Goodbye.")
     } yield ()).unsafeRunSync
 
-  def startReportJvmMetrics(implicit metrics: Metrics[Task],
-                            jvmMetrics: JvmMetrics[Task]): Task[Unit] =
+  def startReportJvmMetrics(
+      implicit metrics: Metrics[Task],
+      jvmMetrics: JvmMetrics[Task]
+  ): Task[Unit] =
     Task.delay {
       import scala.concurrent.duration._
       scheduler.scheduleAtFixedRate(3.seconds, 3.second)(JvmMetrics.report[Task].unsafeRunSync)
@@ -263,11 +271,12 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       NodeDiscovery[Effect].handleCommunications(pm) >>= {
         case NotHandled(_) => HandleMessages.handle[Effect](pm, defaultTimeout)
         case handled       => handled.pure[Effect]
-    }
+      }
 
     val info: Effect[Unit] = for {
       _ <- Log[Effect].info(
-            s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})")
+            s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+          )
       _ <- if (conf.server.standalone) Log[Effect].info(s"Starting stand-alone node.")
           else Log[Effect].info(s"Starting node that will bootstrap from ${conf.server.bootstrap}")
     } yield ()
@@ -302,12 +311,14 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
           case th if th.containsMessageWith("Error loading shared library libsodium.so") =>
             Log[Task]
               .error(
-                "Libsodium is NOT installed on your system. Please install libsodium (https://github.com/jedisct1/libsodium) and try again.")
+                "Libsodium is NOT installed on your system. Please install libsodium (https://github.com/jedisct1/libsodium) and try again."
+              )
           case th =>
             log.error("Caught unhandable error. Exiting. Stacktrace below.") *> Task.delay {
               th.printStackTrace();
             }
-        } *> exit0.as(Right(())))
+        } *> exit0.as(Right(()))
+    )
 
   private def timerEff(implicit timerTask: Timer[Task]): Timer[Effect] =
     Timer.deriveEitherT(Functor[Task], timerTask)
@@ -326,8 +337,10 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
     // 1. set up configurations
     local          <- EitherT.fromEither[Task](PeerNode.parse(address))
     defaultTimeout = FiniteDuration(conf.server.defaultTimeout.toLong, MILLISECONDS)
-    rpClearConnConf = ClearConnetionsConf(conf.server.maxNumOfConnections,
-                                          numOfConnectionsPinged = 10) // TODO read from conf
+    rpClearConnConf = ClearConnetionsConf(
+      conf.server.maxNumOfConnections,
+      numOfConnectionsPinged = 10
+    ) // TODO read from conf
     // 2. create instances of typeclasses
     rpConfAsk            = effects.rpConfAsk(RPConf(local, defaultTimeout, rpClearConnConf))
     tcpConnections       <- effects.tcpConnections.toEffect
@@ -344,18 +357,22 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       port,
       conf.tls.certificate,
       conf.tls.key,
-      conf.server.maxMessageSize)(scheduler, tcpConnections, log)
+      conf.server.maxMessageSize
+    )(scheduler, tcpConnections, log)
     kademliaRPC = effects.kademliaRPC(local, defaultTimeout)(metrics, transport)
     initPeer    = if (conf.server.standalone) None else Some(conf.server.bootstrap)
     nodeDiscovery <- effects
-                      .nodeDiscovery(local, defaultTimeout)(initPeer)(log,
-                                                                      time,
-                                                                      metrics,
-                                                                      kademliaRPC)
+                      .nodeDiscovery(local, defaultTimeout)(initPeer)(
+                        log,
+                        time,
+                        metrics,
+                        kademliaRPC
+                      )
                       .toEffect
     blockStore = LMDBBlockStore.create[Effect](conf.blockstorage)(
       syncEffect,
-      Metrics.eitherT(Monad[Task], metrics))
+      Metrics.eitherT(Monad[Task], metrics)
+    )
 
     _              <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
     oracle         = SafetyOracle.turanOracle[Effect](Monad[Effect], blockStore)
@@ -384,7 +401,8 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
     packetHandler = PacketHandler.pf[Effect](casperPacketHandler.handle)(
       Applicative[Effect],
       Log.eitherTLog(Monad[Task], log),
-      ErrorHandler[Effect])
+      ErrorHandler[Effect]
+    )
     nodeCoreMetrics = diagnostics.nodeCoreMetrics[Task]
     jvmMetrics      = diagnostics.jvmMetrics[Task]
     // 3. run the node program.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.18")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 
-addSbtPlugin("com.geirsson"        % "sbt-scalafmt"        % "1.4.0")
+addSbtPlugin("com.geirsson"        % "sbt-scalafmt"        % "1.6.0-RC4")
 addSbtPlugin("com.eed3si9n"        % "sbt-assembly"        % "0.14.5")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"       % "1.5.1")
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest"         % "0.7.1")

--- a/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
+++ b/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
@@ -37,15 +37,17 @@ object PathRegexOptions {
   val nonEnd        = PathRegexOptions(end = false)
 }
 
-private[regex] case class PathToken(name: Option[String],
-                                    key: Int,
-                                    prefix: Option[Char],
-                                    delimiter: Option[Char],
-                                    optional: Boolean,
-                                    repeat: Boolean,
-                                    partial: Boolean,
-                                    pattern: Option[String],
-                                    rawPathPart: Option[String]) {
+private[regex] case class PathToken(
+    name: Option[String],
+    key: Int,
+    prefix: Option[Char],
+    delimiter: Option[Char],
+    optional: Boolean,
+    repeat: Boolean,
+    partial: Boolean,
+    pattern: Option[String],
+    rawPathPart: Option[String]
+) {
   def isRawPathPart: Boolean = rawPathPart.isDefined
 
   def isToken: Boolean = rawPathPart.isEmpty
@@ -62,8 +64,10 @@ private[regex] case class PathToken(name: Option[String],
     *
     * @throws IllegalArgumentException if token couldn't be formatted
     */
-  private[regex] def formatSegment(args: Map[String, Iterable[String]],
-                                   encode: String => String): String =
+  private[regex] def formatSegment(
+      args: Map[String, Iterable[String]],
+      encode: String => String
+  ): String =
     rawPathPart.getOrElse {
       val argName = name.getOrElse(key.toString)
       val sumSegments = args.get(argName) match {
@@ -79,7 +83,8 @@ private[regex] case class PathToken(name: Option[String],
             prefix.getOrElse("") + encValue
           } else {
             throw new IllegalArgumentException(
-              s"Expected $argName to match pattern ${matchRegex.get.pattern}, but got value $encValue")
+              s"Expected $argName to match pattern ${matchRegex.get.pattern}, but got value $encValue"
+            )
           }
         case Some(lstValue: Iterable[String]) =>
           val allValues =
@@ -93,7 +98,8 @@ private[regex] case class PathToken(name: Option[String],
                   }
                 } else {
                   throw new IllegalArgumentException(
-                    s"Expected $argName[$idx] to match pattern ${matchRegex.get.pattern}, but got value $encValue")
+                    s"Expected $argName[$idx] to match pattern ${matchRegex.get.pattern}, but got value $encValue"
+                  )
                 }
           allValues.mkString
       }
@@ -102,14 +108,16 @@ private[regex] case class PathToken(name: Option[String],
 }
 
 private[regex] object PathToken {
-  def apply(name: Option[String],
-            key: Int,
-            prefix: Option[Char],
-            delimiter: Option[Char],
-            optional: Boolean,
-            repeat: Boolean,
-            partial: Boolean,
-            pattern: String) =
+  def apply(
+      name: Option[String],
+      key: Int,
+      prefix: Option[Char],
+      delimiter: Option[Char],
+      optional: Boolean,
+      repeat: Boolean,
+      partial: Boolean,
+      pattern: String
+  ) =
     new PathToken(name, key, prefix, delimiter, optional, repeat, partial, Some(pattern), None)
   def apply(substring: String) =
     new PathToken(None, -1, None, None, false, false, false, None, Some(substring))
@@ -122,8 +130,10 @@ case class PathRegex(tokens: List[PathToken], options: RegexOptions) {
     * Takes some arguments (argument can be a value or a sequence of values),
     * and builds an Uri-path
     */
-  def toPath(args: Map[String, Iterable[String]],
-             encode: String => String = PathRegex.encodeUriComponent): Either[Throwable, String] =
+  def toPath(
+      args: Map[String, Iterable[String]],
+      encode: String => String = PathRegex.encodeUriComponent
+  ): Either[Throwable, String] =
     Try(tokens.map(_.formatSegment(args, encode)).mkString).toEither
 
   val keys: List[PathToken] = tokens.filter(_.isToken)
@@ -217,15 +227,17 @@ object PathRegex {
     } else {
       //we need to transform our string to UTF-8 (internally, Java/Scala uses UTF-16)
       str
-        .map(c =>
-          if (uriAllowedChars.contains(c)) {
-            c.toString
-          } else {
-            c.toString
-              .getBytes(StandardCharsets.UTF_8)
-              .map(b => "%%%02X".format(b))
-              .mkString("")
-        })
+        .map(
+          c =>
+            if (uriAllowedChars.contains(c)) {
+              c.toString
+            } else {
+              c.toString
+                .getBytes(StandardCharsets.UTF_8)
+                .map(b => "%%%02X".format(b))
+                .mkString("")
+            }
+        )
         .mkString("")
     }
 
@@ -240,10 +252,12 @@ object PathRegex {
   private[this] val rxPath =
     """(\\.)|(?:\:(\w+)(?:\(((?:\\.|[^\\()])+)\))?|\(((?:\\.|[^\\()])+)\))([+*?])?""".r
 
-  private[this] case class ParseState(subStr: String,
-                                      rawPathPart: String,
-                                      tokens: List[PathToken],
-                                      pathEscaped: Boolean)
+  private[this] case class ParseState(
+      subStr: String,
+      rawPathPart: String,
+      tokens: List[PathToken],
+      pathEscaped: Boolean
+  )
 
   /**
     * Parse a string for the raw tokens.
@@ -263,10 +277,13 @@ object PathRegex {
             case Some(escapeStr) =>
               //we found escape sequence, add it to our collectedPath
               toTokens(
-                ParseState(parseState.subStr.substring(mc.end),
-                           rawPathPart + escapeStr.charAt(1),
-                           parseState.tokens,
-                           true))
+                ParseState(
+                  parseState.subStr.substring(mc.end),
+                  rawPathPart + escapeStr.charAt(1),
+                  parseState.tokens,
+                  true
+                )
+              )
             case None =>
               val (prev, actualPath) =
                 if (!parseState.pathEscaped && rawPathPart.nonEmpty) {
@@ -313,7 +330,8 @@ object PathRegex {
               )
 
               toTokens(
-                ParseState(parseState.subStr.substring(mc.end), "", userToken :: tokens, false))
+                ParseState(parseState.subStr.substring(mc.end), "", userToken :: tokens, false)
+              )
           }
         case None =>
           val finalCollectedPath = parseState.rawPathPart + parseState.subStr

--- a/regex/src/test/scala/coop/rchain/regex/FsmUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/FsmUnitTests.scala
@@ -90,16 +90,19 @@ class FsmUnitTests extends FlatSpec with Matchers {
     assert(Fsm(Set(), Set(0, 1), 1, Set(0), Map(0 -> Map())).isEmpty)
 
     assert(
-      Fsm(Set('a', 'b'),
-          Set(0, 1, _ob, 2),
-          0,
-          Set(2),
-          Map(
-            0   -> Map('a' -> 1, 'b'   -> 1),
-            1   -> Map('a' -> _ob, 'b' -> _ob),
-            _ob -> Map('a' -> _ob, 'b' -> _ob),
-            2   -> Map('a' -> _ob, 'b' -> _ob),
-          )).isEmpty)
+      Fsm(
+        Set('a', 'b'),
+        Set(0, 1, _ob, 2),
+        0,
+        Set(2),
+        Map(
+          0   -> Map('a' -> 1, 'b'   -> 1),
+          1   -> Map('a' -> _ob, 'b' -> _ob),
+          _ob -> Map('a' -> _ob, 'b' -> _ob),
+          2   -> Map('a' -> _ob, 'b' -> _ob)
+        )
+      ).isEmpty
+    )
   }
 
   "Null FSM" should "behave as expected" in {
@@ -125,14 +128,18 @@ class FsmUnitTests extends FlatSpec with Matchers {
     val fsmE2 = Fsm(Set(), Set(0), 0, Set(0), Map(0 -> Map()))
     assert(!fsmE2.isEmpty)
 
-    val fsmE3 = Fsm(Set('a', 'b'),
-                    Set(0, 1, _ob, 2),
-                    0,
-                    Set(2),
-                    Map(0   -> Map('a' -> 1, 'b'   -> 1),
-                        1   -> Map('a' -> _ob, 'b' -> _ob),
-                        _ob -> Map('a' -> _ob, 'b' -> _ob),
-                        2   -> Map('a' -> _ob, 'b' -> _ob)))
+    val fsmE3 = Fsm(
+      Set('a', 'b'),
+      Set(0, 1, _ob, 2),
+      0,
+      Set(2),
+      Map(
+        0   -> Map('a' -> 1, 'b'   -> 1),
+        1   -> Map('a' -> _ob, 'b' -> _ob),
+        _ob -> Map('a' -> _ob, 'b' -> _ob),
+        2   -> Map('a' -> _ob, 'b' -> _ob)
+      )
+    )
 
     assert(fsmE3.isEmpty)
   }
@@ -226,11 +233,13 @@ class FsmUnitTests extends FlatSpec with Matchers {
       Set(1, 2, 3, 4, _ob),
       1,
       Set(4),
-      Map(1   -> Map('0' -> 2, '1'   -> 4),
-          2   -> Map('0' -> 3, '1'   -> 4),
-          3   -> Map('0' -> 3, '1'   -> 4),
-          4   -> Map('0' -> _ob, '1' -> _ob),
-          _ob -> Map('0' -> _ob, '1' -> _ob))
+      Map(
+        1   -> Map('0' -> 2, '1'   -> 4),
+        2   -> Map('0' -> 3, '1'   -> 4),
+        3   -> Map('0' -> 3, '1'   -> 4),
+        4   -> Map('0' -> _ob, '1' -> _ob),
+        _ob -> Map('0' -> _ob, '1' -> _ob)
+      )
     )
 
     assert(merged.reversed.states.size == 2)
@@ -255,11 +264,13 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Reduce" should "remove unreachable states" in {
-    val fsm = Fsm(Set('a'),
-                  Set(0, 1, 2),
-                  0,
-                  Set(1),
-                  Map(0 -> Map('a' -> 2), 1 -> Map('a' -> 2), 2 -> Map('a' -> 2)))
+    val fsm = Fsm(
+      Set('a'),
+      Set(0, 1, 2),
+      0,
+      Set(1),
+      Map(0 -> Map('a' -> 2), 1 -> Map('a' -> 2), 2 -> Map('a' -> 2))
+    )
 
     assert(fsm.isEmpty)
     assert(!fsm.accepts("a"))
@@ -332,8 +343,10 @@ class FsmUnitTests extends FlatSpec with Matchers {
       Set(0, 1),
       1,
       Set(1),
-      Map(0 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 0, 'c' -> 0),
-          1 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 1, 'c' -> 1))
+      Map(
+        0 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 0, 'c' -> 0),
+        1 -> Map(Fsm.anythingElse -> 0, 'a' -> 0, 'b' -> 1, 'c' -> 1)
+      )
     )
 
     assert(fsm1.accepts(""))
@@ -343,9 +356,11 @@ class FsmUnitTests extends FlatSpec with Matchers {
       Set(0, 1, 2),
       1,
       Set(0),
-      Map(0 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2),
-          1 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 0),
-          2 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2))
+      Map(
+        0 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2),
+        1 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 0),
+        2 -> Map(Fsm.anythingElse -> 2, 'a' -> 2, 'b' -> 2, 'c' -> 2)
+      )
     )
 
     assert(fsm2.accepts("c"))
@@ -388,14 +403,18 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * gives the incorrect result here.
     */
   "Star" should "pass advanced check" in {
-    val fsmS = Fsm(Set('a', 'b'),
-                   Set(0, 1, 2, _ob),
-                   0,
-                   Set(2),
-                   Map(0   -> Map('a' -> 0, 'b'   -> 1),
-                       1   -> Map('a' -> 2, 'b'   -> _ob),
-                       2   -> Map('a' -> _ob, 'b' -> _ob),
-                       _ob -> Map('a' -> _ob, 'b' -> _ob))).star
+    val fsmS = Fsm(
+      Set('a', 'b'),
+      Set(0, 1, 2, _ob),
+      0,
+      Set(2),
+      Map(
+        0   -> Map('a' -> 0, 'b'   -> 1),
+        1   -> Map('a' -> 2, 'b'   -> _ob),
+        2   -> Map('a' -> _ob, 'b' -> _ob),
+        _ob -> Map('a' -> _ob, 'b' -> _ob)
+      )
+    ).star
 
     assert(fsmS.alphabet == Set('a', 'b'))
     assert(fsmS.accepts(""))
@@ -537,13 +556,17 @@ class FsmUnitTests extends FlatSpec with Matchers {
   }
 
   "Difference" should "work" in {
-    val fsmAorB = Fsm(Set('a', 'b'),
-                      Set(0, 1, _ob),
-                      0,
-                      Set(1),
-                      Map(0   -> Map('a' -> 1, 'b'   -> 1),
-                          1   -> Map('a' -> _ob, 'b' -> _ob),
-                          _ob -> Map('a' -> _ob, 'b' -> _ob)))
+    val fsmAorB = Fsm(
+      Set('a', 'b'),
+      Set(0, 1, _ob),
+      0,
+      Set(1),
+      Map(
+        0   -> Map('a' -> 1, 'b'   -> 1),
+        1   -> Map('a' -> _ob, 'b' -> _ob),
+        _ob -> Map('a' -> _ob, 'b' -> _ob)
+      )
+    )
 
     val fsmA = createFsmA
     val fsmB = createFsmB
@@ -566,15 +589,17 @@ class FsmUnitTests extends FlatSpec with Matchers {
     * FSM accepts no strings but has 3 states, needs only 1
     */
   "Reduce" should "eliminate unused states" in {
-    val fsm3 = Fsm(Set('a'),
-                   Set(0, 1, 2),
-                   0,
-                   Set(1),
-                   Map(
-                     0 -> Map('a' -> 2),
-                     1 -> Map('a' -> 2),
-                     2 -> Map('a' -> 2)
-                   ))
+    val fsm3 = Fsm(
+      Set('a'),
+      Set(0, 1, 2),
+      0,
+      Set(1),
+      Map(
+        0 -> Map('a' -> 2),
+        1 -> Map('a' -> 2),
+        2 -> Map('a' -> 2)
+      )
+    )
 
     val fsm1 = fsm3.reduced
     assert(fsm1.states.size == 1)
@@ -593,11 +618,13 @@ class FsmUnitTests extends FlatSpec with Matchers {
       Set(1, 2, 3, 4, _ob),
       1,
       Set(4),
-      Map(1   -> Map('a' -> 2, 'b'   -> 4),
-          2   -> Map('a' -> 3, 'b'   -> 4),
-          3   -> Map('a' -> 3, 'b'   -> 4),
-          4   -> Map('a' -> _ob, 'b' -> _ob),
-          _ob -> Map('a' -> _ob, 'b' -> _ob))
+      Map(
+        1   -> Map('a' -> 2, 'b'   -> 4),
+        2   -> Map('a' -> 3, 'b'   -> 4),
+        3   -> Map('a' -> 3, 'b'   -> 4),
+        4   -> Map('a' -> _ob, 'b' -> _ob),
+        _ob -> Map('a' -> _ob, 'b' -> _ob)
+      )
     )
 
     val reducedFsm = mergedFsm.reduced
@@ -707,10 +734,12 @@ class FsmUnitTests extends FlatSpec with Matchers {
       Set(0, 1, 2, 3, 4, 5),
       0,
       Set(4),
-      Map(0 -> Map('/' -> 1),
-          1 -> Map('*' -> 2),
-          2 -> Map('/' -> 2, Fsm.anythingElse -> 2, '*' -> 3),
-          3 -> Map('/' -> 4, Fsm.anythingElse -> 2, '*' -> 3))
+      Map(
+        0 -> Map('/' -> 1),
+        1 -> Map('*' -> 2),
+        2 -> Map('/' -> 2, Fsm.anythingElse -> 2, '*' -> 3),
+        3 -> Map('/' -> 4, Fsm.anythingElse -> 2, '*' -> 3)
+      )
     )
 
     assert(fsm.strings.take(1).toList == "/**/" :: Nil)

--- a/regex/src/test/scala/coop/rchain/regex/MultiplierUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/MultiplierUnitTests.scala
@@ -24,40 +24,51 @@ class MultiplierUnitTests extends FlatSpec with Matchers {
     //a{3,4}, a{2,5} -> a{2,3} (with a{1,1}, a{0,2} left over)
     assert(
       Multiplier.parse("{3,4}").get.common(Multiplier.parse("{2,5}").get)
-        == Multiplier.parse("{2,3}").get)
+        == Multiplier.parse("{2,3}").get
+    )
     assert(
       (Multiplier.parse("{3,4}").get - Multiplier.parse("{2,3}").get)
-        == Multiplier.presetOne)
+        == Multiplier.presetOne
+    )
     assert(
       (Multiplier.parse("{2,5}").get - Multiplier.parse("{2,3}").get)
-        == Multiplier.parse("{0,2}").get)
+        == Multiplier.parse("{0,2}").get
+    )
     //a{2,}, a{1,5} -> a{1,5} (with a{1,}, a{0,0} left over)
     assert(
       Multiplier.parse("{2,}").get.common(Multiplier.parse("{1,5}").get)
-        == Multiplier.parse("{1,5}").get)
+        == Multiplier.parse("{1,5}").get
+    )
     assert(
       (Multiplier.parse("{2,}").get - Multiplier.parse("{1,5}").get)
-        == Multiplier.presetPlus)
+        == Multiplier.presetPlus
+    )
     assert(
       (Multiplier.parse("{1,5}").get - Multiplier.parse("{1,5}").get)
-        == Multiplier.presetZero)
+        == Multiplier.presetZero
+    )
     //a{3,}, a{2,} -> a{2,} (with a, epsilon left over)
     assert(
       Multiplier.parse("{3,}").get.common(Multiplier.parse("{2,}").get)
-        == Multiplier.parse("{2,}").get)
+        == Multiplier.parse("{2,}").get
+    )
     assert(
       (Multiplier.parse("{3,}").get - Multiplier.parse("{2,}").get)
-        == Multiplier.presetOne)
+        == Multiplier.presetOne
+    )
     assert(
       (Multiplier.parse("{2,}").get - Multiplier.parse("{2,}").get)
-        == Multiplier.presetZero)
+        == Multiplier.presetZero
+    )
     //a{3,}, a{3,} -> a{3,} (with zero, zero left over)
     assert(
       Multiplier.parse("{3,}").get.common(Multiplier.parse("{3,}").get)
-        == Multiplier.parse("{3,}").get)
+        == Multiplier.parse("{3,}").get
+    )
     assert(
       (Multiplier.parse("{3,}").get - Multiplier.parse("{3,}").get)
-        == Multiplier.presetZero)
+        == Multiplier.presetZero
+    )
   }
 
   "Multiplier common operation" should "work as expected" in {
@@ -68,7 +79,8 @@ class MultiplierUnitTests extends FlatSpec with Matchers {
     assert(
       Multiplier.parse("{3,}").get.common(Multiplier.parse("{2,5}").get) == Multiplier
         .parse("{2,5}")
-        .get)
+        .get
+    )
   }
 
   "Multiplier union" should "work" in {

--- a/regex/src/test/scala/coop/rchain/regex/PathRegexUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/PathRegexUnitTests.scala
@@ -16,8 +16,10 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
               val foundMatch   = matches.head
               val plainMatched = foundMatch.matched :: foundMatch.subgroups
 
-              assert(plainMatched == sampleGroups,
-                     s"::: $sample => $sampleGroups != ${foundMatch.subgroups}")
+              assert(
+                plainMatched == sampleGroups,
+                s"::: $sample => $sampleGroups != ${foundMatch.subgroups}"
+              )
             } else {
               assert(Nil == sampleGroups, s"::: $sample => $sampleGroups != Nil")
             }
@@ -65,10 +67,12 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
   "Simple paths" should "parse" in {
     parse("/test")
       .struct(List(PathToken("/test")))
-      .accept(("/test", List("/test")),
-              ("/route", Nil),
-              ("/test/route", Nil),
-              ("/test/", List("/test/")))
+      .accept(
+        ("/test", List("/test")),
+        ("/route", Nil),
+        ("/test/route", Nil),
+        ("/test/", List("/test/"))
+      )
       .build((Map(), Right("/test")), (Map("id" -> List("123")), Right("/test")))
 
     parse("/test/")
@@ -111,35 +115,47 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
   "Non-ending mode" should "work" in {
     parse("/test", PathRegexOptions.nonEnd)
       .struct(List(PathToken("/test")))
-      .accept(("/test/route", List("/test")),
-              ("/test", List("/test")),
-              ("/test/", List("/test/")),
-              ("/route", Nil))
+      .accept(
+        ("/test/route", List("/test")),
+        ("/test", List("/test")),
+        ("/test/", List("/test/")),
+        ("/route", Nil)
+      )
       .build((Map(), Right("/test")))
 
     parse("/test/", PathRegexOptions.nonEnd)
       .struct(List(PathToken("/test/")))
-      .accept(("/test/route", List("/test/")),
-              ("/test//route", List("/test/")),
-              ("/test", Nil),
-              ("/test//", List("/test//")))
+      .accept(
+        ("/test/route", List("/test/")),
+        ("/test//route", List("/test/")),
+        ("/test", Nil),
+        ("/test//", List("/test//"))
+      )
       .build((Map(), Right("/test/")))
 
     parse("/:test", PathRegexOptions.nonEnd)
       .struct(
-        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?""")))
+        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""))
+      )
       .accept(("/route", List("/route", "route")))
-      .build((Map(), Left(new IllegalArgumentException)),
-             (Map("test" -> List("a+b")), Right("/a%2Bb")),
-             (Map("test" -> List("abc")), Right("/abc")))
+      .build(
+        (Map(), Left(new IllegalArgumentException)),
+        (Map("test" -> List("a+b")), Right("/a%2Bb")),
+        (Map("test" -> List("abc")), Right("/abc"))
+      )
 
     parse("/:test/", PathRegexOptions.nonEnd)
       .struct(
-        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""),
-             PathToken("/")))
+        List(
+          PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""),
+          PathToken("/")
+        )
+      )
       .accept(("/route", Nil), ("/route/", List("/route/", "route")))
-      .build((Map(), Left(new IllegalArgumentException)),
-             (Map("test" -> List("abc")), Right("/abc/")))
+      .build(
+        (Map(), Left(new IllegalArgumentException)),
+        (Map("test" -> List("abc")), Right("/abc/"))
+      )
   }
 
   val noEndStrictOptions = PathRegexOptions(end = false, strict = true)
@@ -152,51 +168,67 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
     parse("/test/", noEndStrictOptions)
       .struct(List(PathToken("/test/")))
-      .accept(("/test", Nil),
-              ("/test/", List("/test/")),
-              ("/test//", List("/test/")),
-              ("/test/route", List("/test/")))
+      .accept(
+        ("/test", Nil),
+        ("/test/", List("/test/")),
+        ("/test//", List("/test/")),
+        ("/test/route", List("/test/"))
+      )
       .build((Map(), Right("/test/")))
   }
 
   "Combine modes" should "accept file path" in {
     parse("/test.json", noEndStrictOptions)
       .struct(List(PathToken("/test.json")))
-      .accept(("/test.json", List("/test.json")),
-              ("/test.json.hbs", Nil),
-              ("/test.json/route", List("/test.json")))
+      .accept(
+        ("/test.json", List("/test.json")),
+        ("/test.json.hbs", Nil),
+        ("/test.json/route", List("/test.json"))
+      )
       .build((Map(), Right("/test.json")))
   }
 
   "Combine modes" should "work with named argument" in {
     parse("/:test", noEndStrictOptions)
       .struct(
-        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?""")))
+        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""))
+      )
       .accept(("/route", List("/route", "route")), ("/route/", List("/route", "route")))
-      .build((Map(), Left(new IllegalArgumentException)),
-             (Map("test" -> List("abc")), Right("/abc")))
+      .build(
+        (Map(), Left(new IllegalArgumentException)),
+        (Map("test" -> List("abc")), Right("/abc"))
+      )
 
     parse("/:test/", noEndStrictOptions)
       .struct(
-        List(PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""),
-             PathToken("/")))
+        List(
+          PathToken(Some("test"), 0, Some('/'), Some('/'), false, false, false, """[^\/]+?"""),
+          PathToken("/")
+        )
+      )
       .accept(("/route", Nil), ("/route/", List("/route/", "route")))
-      .build((Map(), Left(new IllegalArgumentException)),
-             (Map("test" -> List("foobar")), Right("/foobar/")))
+      .build(
+        (Map(), Left(new IllegalArgumentException)),
+        (Map("test" -> List("foobar")), Right("/foobar/"))
+      )
   }
 
   "Single named parameter" should "pass test set" in {
     parse("/:test")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
       .accept(
         ("/route", List("/route", "route")),
         ("/another", List("/another", "another")),
@@ -217,28 +249,37 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:test", PathRegexOptions.strict)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
       .accept(("/route", List("/route", "route")), ("/route/", Nil))
       .build((Map("test" -> List("route")), Right("/route")))
 
     parse("/:test/", PathRegexOptions.strict)
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = false,
-                       repeat = false,
-                       partial = false,
-                       """[^\/]+?"""),
-             PathToken("/")))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          ),
+          PathToken("/")
+        )
+      )
       .accept(("/route/", List("/route/", "route")), ("/route//", Nil))
       .build((Map("test" -> List("route")), Right("/route/")))
   }
@@ -247,16 +288,22 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:test", PathRegexOptions.nonEnd)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/route.json", List("/route.json", "route.json")),
-              ("/route//", List("/route", "route")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route.json", List("/route.json", "route.json")),
+        ("/route//", List("/route", "route"))
+      )
       .build((Map("test" -> List("route")), Right("/route")))
   }
 
@@ -264,133 +311,181 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:test?")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = true,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/route", List("/route", "route")),
-              ("/route/nested", Nil),
-              ("/", List("/", null)),
-              ("//", Nil))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route", List("/route", "route")),
+        ("/route/nested", Nil),
+        ("/", List("/", null)),
+        ("//", Nil)
+      )
   }
 
   "Optional named parameter" should "work with strict mode" in {
     parse("/:test?", PathRegexOptions.strict)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = true,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
       .accept(("/route", List("/route", "route")), ("/", Nil), ("//", Nil))
       .build((Map(), Right("")), (Map("test" -> List("foobar")), Right("/foobar")))
 
     parse("/:test?/", PathRegexOptions.strict)
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = true,
-                       repeat = false,
-                       partial = false,
-                       """[^\/]+?"""),
-             PathToken("/")))
-      .accept(("/route", Nil),
-              ("/route/", List("/route/", "route")),
-              ("/", List("/", null)),
-              ("//", Nil))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          ),
+          PathToken("/")
+        )
+      )
+      .accept(
+        ("/route", Nil),
+        ("/route/", List("/route/", "route")),
+        ("/", List("/", null)),
+        ("//", Nil)
+      )
       .build((Map(), Right("/")), (Map("test" -> List("foobar")), Right("/foobar/")))
   }
 
   "Optional named parameter" should "work well in the middle of path" in {
     parse("/:test?/bar")
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = true,
-                       repeat = false,
-                       partial = false,
-                       """[^\/]+?"""),
-             PathToken("/bar")))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          ),
+          PathToken("/bar")
+        )
+      )
       .accept(("/foo/bar", List("/foo/bar", "foo")))
       .build((Map("test" -> List("foo")), Right("/foo/bar")))
 
     parse("/:test?-bar")
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = true,
-                       repeat = false,
-                       partial = true,
-                       """[^\/]+?"""),
-             PathToken("-bar")))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken("-bar")
+        )
+      )
       .accept(("/-bar", List("/-bar", null)), ("/foo-bar", List("/foo-bar", "foo")))
       .build((Map("test" -> List("aaa")), Right("/aaa-bar")))
 
     parse("/:test*-bar")
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = true,
-                       repeat = true,
-                       partial = true,
-                       """[^\/]+?"""),
-             PathToken("-bar")))
-      .accept(("/-bar", List("/-bar", null)),
-              ("/foo-bar", List("/foo-bar", "foo")),
-              ("/foo/baz-bar", List("/foo/baz-bar", "foo/baz")))
-      .build((Map("test" -> List("aaa")), Right("/aaa-bar")),
-             (Map("test" -> List("aaa", "bbb")), Right("/aaa/bbb-bar")))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = true,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken("-bar")
+        )
+      )
+      .accept(
+        ("/-bar", List("/-bar", null)),
+        ("/foo-bar", List("/foo-bar", "foo")),
+        ("/foo/baz-bar", List("/foo/baz-bar", "foo/baz"))
+      )
+      .build(
+        (Map("test" -> List("aaa")), Right("/aaa-bar")),
+        (Map("test" -> List("aaa", "bbb")), Right("/aaa/bbb-bar"))
+      )
   }
 
   "Repeated one or more times parameters." should "work" in {
     parse("/:test+")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = true,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/", Nil),
-              ("//", Nil),
-              ("/route", List("/route", "route")),
-              ("/some/basic/route", List("/some/basic/route", "some/basic/route")))
-      .build((Map(), Left(new IllegalArgumentException)),
-             (Map("test" -> List("foobar")), Right("/foobar")),
-             (Map("test" -> List("a", "b", "c")), Right("/a/b/c")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = true,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/", Nil),
+        ("//", Nil),
+        ("/route", List("/route", "route")),
+        ("/some/basic/route", List("/some/basic/route", "some/basic/route"))
+      )
+      .build(
+        (Map(), Left(new IllegalArgumentException)),
+        (Map("test" -> List("foobar")), Right("/foobar")),
+        (Map("test" -> List("a", "b", "c")), Right("/a/b/c"))
+      )
   }
 
   "Repeated parameter" should "support inline regex" in {
     parse("/:test(\\d+)+")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = true,
-                    partial = false,
-                    """\d+""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = true,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
       .accept(("/abc/456/789", Nil), ("/123/456/789", List("/123/456/789", "123/456/789")))
       .build(
         (Map("test" -> List("abc")), Left(new IllegalArgumentException)),
@@ -400,19 +495,26 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
     parse("/route.:ext(json|xml)+")
       .struct(
-        List(PathToken("/route"),
-             PathToken(Some("ext"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = false,
-                       repeat = true,
-                       partial = false,
-                       """json|xml""")))
-      .accept(("/route", Nil),
-              ("/route.json", List("/route.json", "json")),
-              ("/route.xml.json", List("/route.xml.json", "xml.json")),
-              ("/route.html", Nil))
+        List(
+          PathToken("/route"),
+          PathToken(
+            Some("ext"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = true,
+            partial = false,
+            """json|xml"""
+          )
+        )
+      )
+      .accept(
+        ("/route", Nil),
+        ("/route.json", List("/route.json", "json")),
+        ("/route.xml.json", List("/route.xml.json", "xml.json")),
+        ("/route.html", Nil)
+      )
       .build(
         (Map("ext" -> List("foobar")), Left(new IllegalArgumentException)),
         (Map("ext" -> List("xml")), Right("/route.xml")),
@@ -424,37 +526,52 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:test*")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = true,
-                    repeat = true,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/", List("/", null)),
-              ("//", Nil),
-              ("/route", List("/route", "route")),
-              ("/some/basic/route", List("/some/basic/route", "some/basic/route")))
-      .build((Map(), Right("")),
-             (Map("test" -> List("foobar")), Right("/foobar")),
-             (Map("test" -> List("foo", "bar")), Right("/foo/bar")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = true,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/", List("/", null)),
+        ("//", Nil),
+        ("/route", List("/route", "route")),
+        ("/some/basic/route", List("/some/basic/route", "some/basic/route"))
+      )
+      .build(
+        (Map(), Right("")),
+        (Map("test" -> List("foobar")), Right("/foobar")),
+        (Map("test" -> List("foo", "bar")), Right("/foo/bar"))
+      )
 
     parse("/route.:ext([a-z]+)*")
       .struct(
-        List(PathToken("/route"),
-             PathToken(Some("ext"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = true,
-                       repeat = true,
-                       partial = false,
-                       """[a-z]+""")))
-      .accept(("/route", List("/route", null)),
-              ("/route.json", List("/route.json", "json")),
-              ("/route.json.xml", List("/route.json.xml", "json.xml")),
-              ("/route.123", Nil))
+        List(
+          PathToken("/route"),
+          PathToken(
+            Some("ext"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = true,
+            repeat = true,
+            partial = false,
+            """[a-z]+"""
+          )
+        )
+      )
+      .accept(
+        ("/route", List("/route", null)),
+        ("/route.json", List("/route.json", "json")),
+        ("/route.json.xml", List("/route.json.xml", "json.xml")),
+        ("/route.123", Nil)
+      )
       .build(
         (Map(), Right("/route")),
         (Map("ext" -> Nil), Right("/route")),
@@ -469,48 +586,66 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:test(\\d+)")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """\d+""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
       .accept(("/abc", Nil), ("/123", List("/123", "123")))
-      .build((Map("test" -> List("abc")), Left(new IllegalArgumentException)),
-             (Map("test" -> List("123")), Right("/123")))
+      .build(
+        (Map("test" -> List("abc")), Left(new IllegalArgumentException)),
+        (Map("test" -> List("123")), Right("/123"))
+      )
 
     parse("/:test(\\d+)", PathRegexOptions.nonEnd)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """\d+""")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
       .accept(("/abc", Nil), ("/123", List("/123", "123")), ("/123/abc", List("/123", "123")))
-      .build((Map("test" -> List("abc")), Left(new IllegalArgumentException)),
-             (Map("test" -> List("123")), Right("/123")))
+      .build(
+        (Map("test" -> List("abc")), Left(new IllegalArgumentException)),
+        (Map("test" -> List("123")), Right("/123"))
+      )
   }
 
   "Custom named parameter" should "support wildcard" in {
     parse("/:test(.*)")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """.*""")))
-      .accept(("/anything/goes/here", List("/anything/goes/here", "anything/goes/here")),
-              ("/;,:@&=/+$-_.!/~*()", List("/;,:@&=/+$-_.!/~*()", ";,:@&=/+$-_.!/~*()")))
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """.*"""
+          )
+        )
+      )
+      .accept(
+        ("/anything/goes/here", List("/anything/goes/here", "anything/goes/here")),
+        ("/;,:@&=/+$-_.!/~*()", List("/;,:@&=/+$-_.!/~*()", ";,:@&=/+$-_.!/~*()"))
+      )
       .build(
         (Map("test" -> List("")), Right("/")),
         (Map("test" -> List("abc")), Right("/abc")),
@@ -523,14 +658,18 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:route([a-z]+)")
       .struct(
         List(
-          PathToken(Some("route"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[a-z]+""")))
+          PathToken(
+            Some("route"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[a-z]+"""
+          )
+        )
+      )
       .accept(("/abcde", List("/abcde", "abcde")), ("/12345", Nil))
       .build(
         (Map("route" -> List("")), Left(new IllegalArgumentException)),
@@ -543,30 +682,40 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/:route(this|that)")
       .struct(
         List(
-          PathToken(Some("route"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """this|that""")))
+          PathToken(
+            Some("route"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """this|that"""
+          )
+        )
+      )
       .accept(("/this", List("/this", "this")), ("/that", List("/that", "that")), ("/foo", Nil))
-      .build((Map("route" -> List("this")), Right("/this")),
-             (Map("route" -> List("that")), Right("/that")),
-             (Map("route" -> List("abc")), Left(new IllegalArgumentException)))
+      .build(
+        (Map("route" -> List("this")), Right("/this")),
+        (Map("route" -> List("that")), Right("/that")),
+        (Map("route" -> List("abc")), Left(new IllegalArgumentException))
+      )
 
     parse("/:path(abc|xyz)*")
       .struct(
         List(
-          PathToken(Some("path"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = true,
-                    repeat = true,
-                    partial = false,
-                    """abc|xyz""")))
+          PathToken(
+            Some("path"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = true,
+            partial = false,
+            """abc|xyz"""
+          )
+        )
+      )
       .accept(
         ("/abc", List("/abc", "abc")),
         ("/abc/abc", List("/abc/abc", "abc/abc")),
@@ -592,18 +741,24 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse(":test")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    None,
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/route", Nil),
-              ("route", List("route", "route")),
-              ("/route", Nil),
-              ("route/", List("route/", "route")))
+          PathToken(
+            Some("test"),
+            0,
+            None,
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route", Nil),
+        ("route", List("route", "route")),
+        ("/route", Nil),
+        ("route/", List("route/", "route"))
+      )
       .build(
         (Map("test" -> List("")), Left(new IllegalArgumentException)),
         (Map(), Left(new IllegalArgumentException)),
@@ -614,52 +769,70 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse(":test", PathRegexOptions.strict)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    None,
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
+          PathToken(
+            Some("test"),
+            0,
+            None,
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
       .accept(("/route", Nil), ("route", List("route", "route")), ("route/", Nil))
       .build((Map("test" -> List("route")), Right("route")))
 
     parse(":test", PathRegexOptions.nonEnd)
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    None,
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/route", Nil),
-              ("route", List("route", "route")),
-              ("route/", List("route/", "route")),
-              ("route/foobar", List("route", "route")))
+          PathToken(
+            Some("test"),
+            0,
+            None,
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route", Nil),
+        ("route", List("route", "route")),
+        ("route/", List("route/", "route")),
+        ("route/foobar", List("route", "route"))
+      )
       .build((Map("test" -> List("route")), Right("route")))
 
     parse(":test?")
       .struct(
         List(
-          PathToken(Some("test"),
-                    0,
-                    None,
-                    Some('/'),
-                    optional = true,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
-      .accept(("/route", Nil),
-              ("route", List("route", "route")),
-              ("", List("", null)),
-              ("route/foobar", Nil))
-      .build((Map(), Right("")),
-             (Map("test" -> List("")), Left(new IllegalArgumentException())),
-             (Map("test" -> List("route")), Right("route")))
+          PathToken(
+            Some("test"),
+            0,
+            None,
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route", Nil),
+        ("route", List("route", "route")),
+        ("", List("", null)),
+        ("route/foobar", Nil)
+      )
+      .build(
+        (Map(), Right("")),
+        (Map("test" -> List("")), Left(new IllegalArgumentException())),
+        (Map("test" -> List("route")), Right("route"))
+      )
   }
 
   "Formats" should "work" in {
@@ -670,38 +843,50 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
     parse("/:test.json")
       .struct(
-        List(PathToken(Some("test"),
-                       0,
-                       Some('/'),
-                       Some('/'),
-                       optional = false,
-                       repeat = false,
-                       partial = true,
-                       """[^\/]+?"""),
-             PathToken(".json")))
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken(".json")
+        )
+      )
       .accept(
         ("/.json", Nil),
         ("/test.json", List("/test.json", "test")),
         ("/route.json", List("/route.json", "route")),
         ("/route.json.json", List("/route.json.json", "route.json"))
       )
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("test" -> List("")), Left(new IllegalArgumentException())),
-             (Map("test" -> List("foo")), Right("/foo.json")))
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("test" -> List("")), Left(new IllegalArgumentException())),
+        (Map("test" -> List("foo")), Right("/foo.json"))
+      )
   }
 
   "Format params" should "work" in {
     parse("/test.:format")
       .struct(
-        List(PathToken("/test"),
-             PathToken(Some("format"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = false,
-                       repeat = false,
-                       partial = false,
-                       """[^\.]+?""")))
+        List(
+          PathToken("/test"),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
       .accept(("/test.html", List("/test.html", "html")), ("/test.txt.html", Nil))
       .build(
         (Map(), Left(new IllegalArgumentException())),
@@ -710,25 +895,31 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
       )
 
     parse("/test.:format.:format")
-      .struct(List(
-        PathToken("/test"),
-        PathToken(Some("format"),
-                  0,
-                  Some('.'),
-                  Some('.'),
-                  optional = false,
-                  repeat = false,
-                  partial = false,
-                  """[^\.]+?"""),
-        PathToken(Some("format"),
-                  1,
-                  Some('.'),
-                  Some('.'),
-                  optional = false,
-                  repeat = false,
-                  partial = false,
-                  """[^\.]+?""")
-      ))
+      .struct(
+        List(
+          PathToken("/test"),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          ),
+          PathToken(
+            Some("format"),
+            1,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
       .accept(("/test.html", Nil), ("/test.txt.html", List("/test.txt.html", "txt", "html")))
       .build(
         (Map(), Left(new IllegalArgumentException())),
@@ -740,34 +931,48 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
   "Format params" should "support multipliers" in {
     parse("/test.:format+")
       .struct(
-        List(PathToken("/test"),
-             PathToken(Some("format"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = false,
-                       repeat = true,
-                       partial = false,
-                       """[^\.]+?""")))
-      .accept(("/test.html", List("/test.html", "html")),
-              ("/test.txt.html", List("/test.txt.html", "txt.html")))
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("format" -> List("foo")), Right("/test.foo")),
-             (Map("format" -> List("foo", "bar")), Right("/test.foo.bar")))
+        List(
+          PathToken("/test"),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = true,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/test.html", List("/test.html", "html")),
+        ("/test.txt.html", List("/test.txt.html", "txt.html"))
+      )
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("format" -> List("foo")), Right("/test.foo")),
+        (Map("format" -> List("foo", "bar")), Right("/test.foo.bar"))
+      )
   }
 
   "Format params" should "support nonEnd mode" in {
     parse("/test.:format", PathRegexOptions.nonEnd)
       .struct(
-        List(PathToken("/test"),
-             PathToken(Some("format"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = false,
-                       repeat = false,
-                       partial = false,
-                       """[^\.]+?""")))
+        List(
+          PathToken("/test"),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
       .accept(("/test.html", List("/test.html", "html")), ("/test.txt.html", Nil))
       .build(
         (Map(), Left(new IllegalArgumentException())),
@@ -779,16 +984,21 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
   "Format params" should "support partial paths" in {
     parse("/test.:format.")
       .struct(
-        List(PathToken("/test"),
-             PathToken(Some("format"),
-                       0,
-                       Some('.'),
-                       Some('.'),
-                       optional = false,
-                       repeat = false,
-                       partial = false,
-                       """[^\.]+?"""),
-             PathToken(".")))
+        List(
+          PathToken("/test"),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          ),
+          PathToken(".")
+        )
+      )
       .accept(("/test.html.", List("/test.html.", "html")), ("/test.txt.html", Nil))
       .build(
         (Map(), Left(new IllegalArgumentException())),
@@ -799,51 +1009,67 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
   "Format and path params" should "work" in {
     parse("/:test.:format")
-      .struct(List(
-        PathToken(Some("test"),
-                  0,
-                  Some('/'),
-                  Some('/'),
-                  optional = false,
-                  repeat = false,
-                  partial = true,
-                  """[^\/]+?"""),
-        PathToken(Some("format"),
-                  1,
-                  Some('.'),
-                  Some('.'),
-                  optional = false,
-                  repeat = false,
-                  partial = false,
-                  """[^\.]+?""")
-      ))
-      .accept(("/route.html", List("/route.html", "route", "html")),
-              ("/route", Nil),
-              ("/route.html.json", List("/route.html.json", "route.html", "json")))
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("format" -> List("foo"), "test" -> List("route")), Right("/route.foo")))
+      .struct(
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken(
+            Some("format"),
+            1,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
+      .accept(
+        ("/route.html", List("/route.html", "route", "html")),
+        ("/route", Nil),
+        ("/route.html.json", List("/route.html.json", "route.html", "json"))
+      )
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("format" -> List("foo"), "test" -> List("route")), Right("/route.foo"))
+      )
   }
 
   "Format and path params" should "support optional" in {
     parse("/:test.:format?")
-      .struct(List(
-        PathToken(Some("test"),
-                  0,
-                  Some('/'),
-                  Some('/'),
-                  optional = false,
-                  repeat = false,
-                  partial = true,
-                  """[^\/]+?"""),
-        PathToken(Some("format"),
-                  1,
-                  Some('.'),
-                  Some('.'),
-                  optional = true,
-                  repeat = false,
-                  partial = false,
-                  """[^\.]+?""")
-      ))
+      .struct(
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken(
+            Some("format"),
+            1,
+            Some('.'),
+            Some('.'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
       .accept(
         ("/route", List("/route", "route", null)),
         ("/route.html", List("/route.html", "route", "html")),
@@ -858,24 +1084,30 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
     //and non-end mode
     parse("/:test.:format?", PathRegexOptions.nonEnd)
-      .struct(List(
-        PathToken(Some("test"),
-                  0,
-                  Some('/'),
-                  Some('/'),
-                  optional = false,
-                  repeat = false,
-                  partial = true,
-                  """[^\/]+?"""),
-        PathToken(Some("format"),
-                  1,
-                  Some('.'),
-                  Some('.'),
-                  optional = true,
-                  repeat = false,
-                  partial = false,
-                  """[^\.]+?""")
-      ))
+      .struct(
+        List(
+          PathToken(
+            Some("test"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = true,
+            """[^\/]+?"""
+          ),
+          PathToken(
+            Some("format"),
+            1,
+            Some('.'),
+            Some('.'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\.]+?"""
+          )
+        )
+      )
       .accept(
         ("/route", List("/route", "route", null)),
         ("/route.html", List("/route.html", "route", "html")),
@@ -895,73 +1127,96 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
       .struct(
         List(
           PathToken("/test"),
-          PathToken(Some("format"),
-                    0,
-                    Some('.'),
-                    Some('.'),
-                    optional = false,
-                    repeat = false,
-                    partial = true,
-                    """.*"""),
+          PathToken(
+            Some("format"),
+            0,
+            Some('.'),
+            Some('.'),
+            optional = false,
+            repeat = false,
+            partial = true,
+            """.*"""
+          ),
           PathToken("z")
-        ))
+        )
+      )
       .accept(
         ("/test.abc", Nil),
         ("/test.z", List("/test.z", "")),
         ("/test.abcz", List("/test.abcz", "abc"))
       )
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("format" -> List("")), Right("/test.z")),
-             (Map("format" -> List("foo")), Right("/test.fooz")))
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("format" -> List("")), Right("/test.z")),
+        (Map("format" -> List("foo")), Right("/test.fooz"))
+      )
   }
 
   "Unnamed params" should "work" in {
     parse("/(\\d+)")
       .struct(
         List(
-          PathToken(None,
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """\d+""")))
+          PathToken(
+            None,
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
       .accept(("/123", List("/123", "123")), ("/abc", Nil), ("/123/abc", Nil))
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("0" -> List("123")), Right("/123")))
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("0" -> List("123")), Right("/123"))
+      )
 
     parse("/(\\d+)", PathRegexOptions.nonEnd)
       .struct(
         List(
-          PathToken(None,
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """\d+""")))
-      .accept(("/123", List("/123", "123")),
-              ("/abc", Nil),
-              ("/123/abc", List("/123", "123")),
-              ("/123/", List("/123/", "123")))
-      .build((Map(), Left(new IllegalArgumentException())),
-             (Map("0" -> List("123")), Right("/123")))
+          PathToken(
+            None,
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
+      .accept(
+        ("/123", List("/123", "123")),
+        ("/abc", Nil),
+        ("/123/abc", List("/123", "123")),
+        ("/123/", List("/123/", "123"))
+      )
+      .build(
+        (Map(), Left(new IllegalArgumentException())),
+        (Map("0" -> List("123")), Right("/123"))
+      )
   }
 
   "Optional unnamed parameter" should "work" in {
     parse("/(\\d+)?")
       .struct(
         List(
-          PathToken(None,
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = true,
-                    repeat = false,
-                    partial = false,
-                    """\d+""")))
+          PathToken(
+            None,
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          )
+        )
+      )
       .accept(("/", List("/", null)), ("/123", List("/123", "123")))
       .build((Map(), Right("")), (Map("0" -> List("123")), Right("/123")))
   }
@@ -970,33 +1225,44 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
     parse("/(.*)")
       .struct(
         List(
-          PathToken(None,
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """.*""")))
-      .accept(("/", List("/", "")),
-              ("/123", List("/123", "123")),
-              ("/route/nested", List("/route/nested", "route/nested")))
+          PathToken(
+            None,
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """.*"""
+          )
+        )
+      )
+      .accept(
+        ("/", List("/", "")),
+        ("/123", List("/123", "123")),
+        ("/route/nested", List("/route/nested", "route/nested"))
+      )
       .build((Map("0" -> List("")), Right("/")), (Map("0" -> List("123")), Right("/123")))
   }
 
   "Escape sequences" should "work" in {
     parse("""/route\(\\(\d+\\)\)""")
       .struct(
-        List(PathToken("/route(\\"),
-             PathToken(None,
-                       0,
-                       None,
-                       Some('/'),
-                       optional = false,
-                       repeat = false,
-                       partial = false,
-                       """\d+\\"""),
-             PathToken(")")))
+        List(
+          PathToken("/route(\\"),
+          PathToken(
+            None,
+            0,
+            None,
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+\\"""
+          ),
+          PathToken(")")
+        )
+      )
       .accept(("/route(\\123\\)", List("/route(\\123\\)", "123\\")))
   }
 
@@ -1014,29 +1280,37 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
   "Two optional parameters" should "be supported" in {
     parse("/test\\/:uid(u\\d+)?:cid(c\\d+)?")
-      .struct(List(
-        PathToken("/test/"),
-        PathToken(Some("uid"),
-                  0,
-                  None,
-                  Some('/'),
-                  optional = true,
-                  repeat = false,
-                  partial = false,
-                  """u\d+"""),
-        PathToken(Some("cid"),
-                  1,
-                  None,
-                  Some('/'),
-                  optional = true,
-                  repeat = false,
-                  partial = false,
-                  """c\d+""")
-      ))
-      .accept(("/test", Nil),
-              ("/test/", List("/test/", null, null)),
-              ("/test/u123", List("/test/u123", "u123", null)),
-              ("/test/c123", List("/test/c123", null, "c123")))
+      .struct(
+        List(
+          PathToken("/test/"),
+          PathToken(
+            Some("uid"),
+            0,
+            None,
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """u\d+"""
+          ),
+          PathToken(
+            Some("cid"),
+            1,
+            None,
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """c\d+"""
+          )
+        )
+      )
+      .accept(
+        ("/test", Nil),
+        ("/test/", List("/test/", null, null)),
+        ("/test/u123", List("/test/u123", "u123", null)),
+        ("/test/c123", List("/test/c123", null, "c123"))
+      )
       .build(
         (Map("uid" -> List("u123")), Right("/test/u123")),
         (Map("cid" -> List("c123")), Right("/test/c123")),
@@ -1046,42 +1320,54 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
   "Unnamed group prefix" should "work" in {
     parse("/(apple-)?icon-:res(\\d+).png")
-      .struct(List(
-        PathToken(None,
-                  0,
-                  Some('/'),
-                  Some('/'),
-                  optional = true,
-                  repeat = false,
-                  partial = true,
-                  """apple-"""),
-        PathToken("icon-"),
-        PathToken(Some("res"),
-                  1,
-                  None,
-                  Some('/'),
-                  optional = false,
-                  repeat = false,
-                  partial = false,
-                  """\d+"""),
-        PathToken(".png")
-      ))
-      .accept(("/icon-240.png", List("/icon-240.png", null, "240")),
-              ("/apple-icon-240.png", List("/apple-icon-240.png", "apple-", "240")))
+      .struct(
+        List(
+          PathToken(
+            None,
+            0,
+            Some('/'),
+            Some('/'),
+            optional = true,
+            repeat = false,
+            partial = true,
+            """apple-"""
+          ),
+          PathToken("icon-"),
+          PathToken(
+            Some("res"),
+            1,
+            None,
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """\d+"""
+          ),
+          PathToken(".png")
+        )
+      )
+      .accept(
+        ("/icon-240.png", List("/icon-240.png", null, "240")),
+        ("/apple-icon-240.png", List("/apple-icon-240.png", "apple-", "240"))
+      )
   }
 
   "Unicode characters" should "work" in {
     parse("/:foo")
       .struct(
         List(
-          PathToken(Some("foo"),
-                    0,
-                    Some('/'),
-                    Some('/'),
-                    optional = false,
-                    repeat = false,
-                    partial = false,
-                    """[^\/]+?""")))
+          PathToken(
+            Some("foo"),
+            0,
+            Some('/'),
+            Some('/'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\/]+?"""
+          )
+        )
+      )
       .accept(("/café", List("/café", "café")))
       .build((Map("foo" -> List("café")), Right("/caf%C3%A9")))
 
@@ -1094,10 +1380,12 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
   "Ends with" should "work" in {
     parse("/test", PathRegexOptions(endsWith = List("?")))
       .struct(List(PathToken("/test")))
-      .accept(("/test", List("/test")),
-              ("/test?query=string", List("/test")),
-              ("/test/?query=string", List("/test/")),
-              ("/testx", Nil))
+      .accept(
+        ("/test", List("/test")),
+        ("/test?query=string", List("/test")),
+        ("/test/?query=string", List("/test/")),
+        ("/testx", Nil)
+      )
       .build((Map(), Right("/test")))
 
     parse("/test", PathRegexOptions(endsWith = List("?"), strict = true))
@@ -1108,26 +1396,34 @@ class PathRegexUnitTests extends FlatSpec with Matchers {
 
   "Custom delimiters" should "work" in {
     parse("$:foo$:bar?", PathRegexOptions(delimiters = Set('$')))
-      .struct(List(
-        PathToken(Some("foo"),
-                  0,
-                  Some('$'),
-                  Some('$'),
-                  optional = false,
-                  repeat = false,
-                  partial = false,
-                  """[^\$]+?"""),
-        PathToken(Some("bar"),
-                  1,
-                  Some('$'),
-                  Some('$'),
-                  optional = true,
-                  repeat = false,
-                  partial = false,
-                  """[^\$]+?""")
-      ))
+      .struct(
+        List(
+          PathToken(
+            Some("foo"),
+            0,
+            Some('$'),
+            Some('$'),
+            optional = false,
+            repeat = false,
+            partial = false,
+            """[^\$]+?"""
+          ),
+          PathToken(
+            Some("bar"),
+            1,
+            Some('$'),
+            Some('$'),
+            optional = true,
+            repeat = false,
+            partial = false,
+            """[^\$]+?"""
+          )
+        )
+      )
       .accept(("$x", List("$x", "x", null)), ("$x$y", List("$x$y", "x", "y")))
-      .build((Map("foo" -> List("foo")), Right("$foo")),
-             (Map("foo" -> List("foo"), "bar" -> List("bar")), Right("$foo$bar")))
+      .build(
+        (Map("foo" -> List("foo")), Right("$foo")),
+        (Map("foo" -> List("foo"), "bar" -> List("bar")), Right("$foo$bar"))
+      )
   }
 }

--- a/regex/src/test/scala/coop/rchain/regex/RegexPatternUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/RegexPatternUnitTests.scala
@@ -76,30 +76,39 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     assert(CharClassPattern.parse("\\Z").contains(CharClassPattern("Z")))
     assert(CharClassPattern.parse("[\\Z]").contains(CharClassPattern("Z")))
     assert(
-      CharClassPattern.parse("[^\\t\\[]").contains(CharClassPattern("\t[", negateCharSet = true)))
+      CharClassPattern.parse("[^\\t\\[]").contains(CharClassPattern("\t[", negateCharSet = true))
+    )
 
     assert(CharClassPattern.parse("a").contains(CharClassPattern("a")))
     assert(CharClassPattern.parse("\\s").contains(CharClassPattern(CharClassPattern.spacesCharSet)))
     assert(
       CharClassPattern
         .parse("\\S")
-        .contains(CharClassPattern(CharClassPattern.spacesCharSet, negateCharSet = true)))
+        .contains(CharClassPattern(CharClassPattern.spacesCharSet, negateCharSet = true))
+    )
     assert(CharClassPattern.parse("\\d").contains(CharClassPattern("0123456789")))
     assert(
       CharClassPattern
         .parse("\\D")
-        .contains(CharClassPattern("0123456789", negateCharSet = true)))
+        .contains(CharClassPattern("0123456789", negateCharSet = true))
+    )
     assert(
       CharClassPattern
         .parse("\\w")
         .contains(
-          CharClassPattern("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")))
+          CharClassPattern("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
+        )
+    )
     assert(
       CharClassPattern
         .parse("\\W")
         .contains(
-          CharClassPattern("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
-                           negateCharSet = true)))
+          CharClassPattern(
+            "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
+            negateCharSet = true
+          )
+        )
+    )
     assert(CharClassPattern.parse(".").contains(~CharClassPattern("")))
     assert(CharClassPattern.parse("[abc]").contains(CharClassPattern("abc")))
     assert(CharClassPattern.parse("[^abc]").contains(CharClassPattern("abc", negateCharSet = true)))
@@ -111,17 +120,20 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     assert(
       CharClassPattern
         .parse("[^\\x41-\\x44]")
-        .contains(CharClassPattern("ABCD", negateCharSet = true)))
+        .contains(CharClassPattern("ABCD", negateCharSet = true))
+    )
 
     assert(CharClassPattern.parse("[\\u0041]").contains(CharClassPattern("A")))
     assert(CharClassPattern.parse("[\\u0041-\\u0044]").contains(CharClassPattern("ABCD")))
 
     assert(
-      CharClassPattern.parse("[^\\u0041]").contains(CharClassPattern("A", negateCharSet = true)))
+      CharClassPattern.parse("[^\\u0041]").contains(CharClassPattern("A", negateCharSet = true))
+    )
     assert(
       CharClassPattern
         .parse("[^\\u0041-\\u0044]")
-        .contains(CharClassPattern("ABCD", negateCharSet = true)))
+        .contains(CharClassPattern("ABCD", negateCharSet = true))
+    )
   }
 
   "CharClassPattern parse" should "return None on invalid patterns" in {
@@ -143,23 +155,29 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
 
   "MultPattern parse" should "accept simple mult sequences" in {
     assert(
-      MultPattern.parse("a").contains(MultPattern(CharClassPattern("a"), Multiplier.presetOne)))
+      MultPattern.parse("a").contains(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
+    )
     assert(
-      MultPattern.parse("a*").contains(MultPattern(CharClassPattern("a"), Multiplier.presetStar)))
+      MultPattern.parse("a*").contains(MultPattern(CharClassPattern("a"), Multiplier.presetStar))
+    )
     assert(
       MultPattern
         .parse("a?")
-        .contains(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion)))
+        .contains(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion))
+    )
     assert(
-      MultPattern.parse("a+").contains(MultPattern(CharClassPattern("a"), Multiplier.presetPlus)))
+      MultPattern.parse("a+").contains(MultPattern(CharClassPattern("a"), Multiplier.presetPlus))
+    )
     assert(
       MultPattern
         .parse("a{3,5}")
-        .contains(MultPattern(CharClassPattern("a"), Multiplier(Some(3), Some(5)))))
+        .contains(MultPattern(CharClassPattern("a"), Multiplier(Some(3), Some(5))))
+    )
     assert(
       MultPattern
         .parse("a{3,}")
-        .contains(MultPattern(CharClassPattern("a"), Multiplier(Some(3), Multiplier.Inf))))
+        .contains(MultPattern(CharClassPattern("a"), Multiplier(Some(3), Multiplier.Inf)))
+    )
   }
 
   "MultPattern parse" should "return None on invalid patterns" in {
@@ -174,11 +192,13 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     val a = MultPattern(CharClassPattern("a"), Multiplier.presetOne)
     assert(a == a.multiply(Multiplier.presetOne))
     assert(
-      MultPattern(CharClassPattern("a"), Multiplier(Some(2), Some(2))) == a.multiply(
-        Multiplier(Some(2), Some(2))))
+      MultPattern(CharClassPattern("a"), Multiplier(Some(2), Some(2))) == a
+        .multiply(Multiplier(Some(2), Some(2)))
+    )
     assert(
       MultPattern(CharClassPattern("a"), Multiplier.presetPlus)
-        .multiply(Multiplier(Some(3), Some(4))) == a.multiply(Multiplier(Some(3), Multiplier.Inf)))
+        .multiply(Multiplier(Some(3), Some(4))) == a.multiply(Multiplier(Some(3), Multiplier.Inf))
+    )
   }
 
   "RegexPattern parse" should "parse groups" in {
@@ -186,7 +206,9 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       MultPattern
         .tryParse("(a)")
         .contains(
-          (MultPattern(AltPattern(ConcPattern(CharClassPattern("a"))), Multiplier.presetOne), 3)))
+          (MultPattern(AltPattern(ConcPattern(CharClassPattern("a"))), Multiplier.presetOne), 3)
+        )
+    )
 
     val ain = MultPattern.parse("((a))").get.toFsm()
     assert(ain.accepts("a"))
@@ -196,7 +218,10 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       ab == AltPattern(
         ConcPattern(
           MultPattern(AltPattern(ConcPattern(CharClassPattern("a"))), Multiplier.presetOne) ::
-            MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil)))
+            MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil
+        )
+      )
+    )
 
     assert(ab.toFsm().accepts("ab"))
 
@@ -218,21 +243,31 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     assert(
       ConcPattern
         .parse("a")
-        .contains(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))))
+        .contains(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)))
+    )
 
     assert(
       ConcPattern
         .parse("ab")
-        .contains(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-          :: MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil)))
+        .contains(
+          ConcPattern(
+            MultPattern(CharClassPattern("a"), Multiplier.presetOne)
+              :: MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil
+          )
+        )
+    )
 
     assert(
       ConcPattern
         .parse("abc")
         .contains(
-          ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-            :: MultPattern(CharClassPattern("b"), Multiplier.presetOne)
-            :: MultPattern(CharClassPattern("c"), Multiplier.presetOne) :: Nil)))
+          ConcPattern(
+            MultPattern(CharClassPattern("a"), Multiplier.presetOne)
+              :: MultPattern(CharClassPattern("b"), Multiplier.presetOne)
+              :: MultPattern(CharClassPattern("c"), Multiplier.presetOne) :: Nil
+          )
+        )
+    )
   }
 
   "ConcPattern parse" should "return None on invalid sequences" in {
@@ -246,7 +281,9 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) != MultPattern(
         CharClassPattern("a"),
-        Multiplier.presetOne))
+        Multiplier.presetOne
+      )
+    )
   }
 
   "AltPattern tryParse" should "parse alt sequences" in {
@@ -254,29 +291,49 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       RegexPattern
         .parse("a|b")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
-            ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil)))
+          AltPattern(
+            ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
+              ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil
+          )
+        )
+    )
 
     assert(
       RegexPattern
         .parse("a|b")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
-            ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil)))
+          AltPattern(
+            ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
+              ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil
+          )
+        )
+    )
 
     assert(
       RegexPattern
         .parse("a?b")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
-            MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil))))
+          AltPattern(
+            ConcPattern(
+              MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
+                MultPattern(CharClassPattern("b"), Multiplier.presetOne) :: Nil
+            )
+          )
+        )
+    )
 
     assert(
       RegexPattern
         .parse("a?b{3,}")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
-            MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) :: Nil))))
+          AltPattern(
+            ConcPattern(
+              MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
+                MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) :: Nil
+            )
+          )
+        )
+    )
 
     assert(RegexPattern.parse("ac*").nonEmpty)
 
@@ -288,17 +345,29 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       RegexPattern
         .parse("a?b{3,}c*")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
-            MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) ::
-            MultPattern(CharClassPattern("c"), Multiplier(Some(0), Multiplier.Inf)) :: Nil))))
+          AltPattern(
+            ConcPattern(
+              MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
+                MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) ::
+                MultPattern(CharClassPattern("c"), Multiplier(Some(0), Multiplier.Inf)) :: Nil
+            )
+          )
+        )
+    )
 
     assert(
       RegexPattern
         .parse("a?b{3,}c*")
         .contains(
-          AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
-            MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) ::
-            MultPattern(CharClassPattern("c"), Multiplier(Some(0), Multiplier.Inf)) :: Nil))))
+          AltPattern(
+            ConcPattern(
+              MultPattern(CharClassPattern("a"), Multiplier.presetQuestion) ::
+                MultPattern(CharClassPattern("b"), Multiplier(Some(3), Multiplier.Inf)) ::
+                MultPattern(CharClassPattern("c"), Multiplier(Some(0), Multiplier.Inf)) :: Nil
+            )
+          )
+        )
+    )
   }
 
   "AltPattern" should "handle union operations" in {
@@ -306,8 +375,10 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
       (ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion)) |
         ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetQuestion))) == AltPattern(
         ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion)) :: ConcPattern(
-          MultPattern(CharClassPattern("b"), Multiplier.presetQuestion)) :: Nil
-      ))
+          MultPattern(CharClassPattern("b"), Multiplier.presetQuestion)
+        ) :: Nil
+      )
+    )
   }
 
   "Empty" should "work for all char classes" in {
@@ -411,56 +482,78 @@ class RegexPatternUnitTests extends FlatSpec with Matchers {
   "MultPattern" should "pass equality check" in {
     assert(
       MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-        == MultPattern(CharClassPattern("a"), Multiplier.presetOne))
+        == MultPattern(CharClassPattern("a"), Multiplier.presetOne)
+    )
     assert(
       MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-        != MultPattern(CharClassPattern("b"), Multiplier.presetOne))
+        != MultPattern(CharClassPattern("b"), Multiplier.presetOne)
+    )
     assert(
       MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-        != MultPattern(CharClassPattern("a"), Multiplier.presetQuestion))
+        != MultPattern(CharClassPattern("a"), Multiplier.presetQuestion)
+    )
     assert(
       MultPattern(CharClassPattern("a"), Multiplier.presetOne)
-        != MultPattern(CharClassPattern("a"), Multiplier(Some(1), Some(2))))
+        != MultPattern(CharClassPattern("a"), Multiplier(Some(1), Some(2)))
+    )
     assert(MultPattern(CharClassPattern("a"), Multiplier.presetOne) != CharClassPattern("a"))
   }
 
   "ConcPattern" should "pass equality check" in {
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
-        == ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)))
+        == ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
+    )
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
-        != ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)))
+        != ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne))
+    )
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
-        != ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion)))
+        != ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetQuestion))
+    )
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
-        != ConcPattern(MultPattern(CharClassPattern("a"), Multiplier(Some(1), Some(2)))))
+        != ConcPattern(MultPattern(CharClassPattern("a"), Multiplier(Some(1), Some(2))))
+    )
     assert(
       ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))
-        != ConcPattern.presetEmptyString)
+        != ConcPattern.presetEmptyString
+    )
   }
 
   "Nested Patterns" should "pass equality checks" in {
     assert(
-      AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
-        ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) :: Nil)
-        == AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne))))
+      AltPattern(
+        ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
+          ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) :: Nil
+      )
+        == AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)))
+    )
 
     assert(
-      AltPattern(ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
-        ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil)
-        == AltPattern(ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) ::
-          ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) :: Nil))
+      AltPattern(
+        ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) ::
+          ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) :: Nil
+      )
+        == AltPattern(
+          ConcPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne)) ::
+            ConcPattern(MultPattern(CharClassPattern("a"), Multiplier.presetOne)) :: Nil
+        )
+    )
   }
 
   "ConcPattern" should "be a result of + operation" in {
     assert(
       RegexPattern
         .parse("ba")
-        .contains(AltPattern(MultPattern(CharClassPattern("b"), Multiplier.presetOne) +
-          MultPattern(CharClassPattern("a"), Multiplier.presetOne))))
+        .contains(
+          AltPattern(
+            MultPattern(CharClassPattern("b"), Multiplier.presetOne) +
+              MultPattern(CharClassPattern("a"), Multiplier.presetOne)
+          )
+        )
+    )
   }
 
   "CharClassPattern toString" should "work on all patterns" in {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnIndexMap.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnIndexMap.scala
@@ -21,11 +21,15 @@ class DebruijnIndexMap[T](val next: Int, val env: Map[String, (Int, T, Int, Int)
     val finalNext  = next + binders.next
     val adjustNext = next
     binders.env.foldLeft((this, List[(String, Int, Int)]())) {
-      case ((db: DebruijnIndexMap[T], shadowed: List[(String, Int, Int)]),
-            (k: String, (level: Int, varType: T @unchecked, line: Int, col: Int))) => {
+      case (
+          (db: DebruijnIndexMap[T], shadowed: List[(String, Int, Int)]),
+          (k: String, (level: Int, varType: T @unchecked, line: Int, col: Int))
+          ) => {
         val shadowedNew = if (db.env.contains(k)) (k, line, col) :: shadowed else shadowed
-        (DebruijnIndexMap(finalNext, db.env + (k -> ((level + adjustNext, varType, line, col)))),
-         shadowedNew)
+        (
+          DebruijnIndexMap(finalNext, db.env + (k -> ((level + adjustNext, varType, line, col)))),
+          shadowedNew
+        )
       }
     }
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -69,7 +69,8 @@ object Interpreter {
       }
 
   private def normalizeTerm[M[_]](term: Proc, inputs: ProcVisitInputs)(
-      implicit sync: Sync[M]): M[ProcVisitOutputs] =
+      implicit sync: Sync[M]
+  ): M[ProcVisitOutputs] =
     ProcNormalizeMatcher.normalizeMatch[M](term, inputs).flatMap { normalizedTerm =>
       if (normalizedTerm.knownFree.count > 0) {
         if (normalizedTerm.knownFree.wildcards.isEmpty) {
@@ -77,13 +78,15 @@ object Interpreter {
             case (name, (_, _, line, col)) => s"$name at $line:$col"
           }
           sync.raiseError(
-            TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString("", ", ", "")))
+            TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString("", ", ", ""))
+          )
         } else {
           val topLevelWildcardList = normalizedTerm.knownFree.wildcards.map {
             case (line, col) => s"_ (wildcard) at $line:$col"
           }
           sync.raiseError(
-            TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", "")))
+            TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", ""))
+          )
         }
       } else normalizedTerm.pure[M]
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -20,12 +20,14 @@ object PrettyPrinter {
     PrettyPrinter(freeShift, boundShift, "free", "a", 23, 128)
 }
 
-case class PrettyPrinter(freeShift: Int,
-                         boundShift: Int,
-                         freeId: String,
-                         baseId: String,
-                         rotation: Int,
-                         maxVarCount: Int) {
+case class PrettyPrinter(
+    freeShift: Int,
+    boundShift: Int,
+    freeId: String,
+    baseId: String,
+    rotation: Int,
+    maxVarCount: Int
+) {
 
   val indentStr = "  "
 
@@ -168,7 +170,8 @@ case class PrettyPrinter(freeShift: Int,
       case b: Bundle =>
         BundleOps.showInstance.show(b) + "{ " + (indentStr * (indent + 1)) + buildString(
           b.body,
-          indent + 1) + " }"
+          indent + 1
+        ) + " }"
 
       case n: New =>
         "new " + buildVariables(n.bindCount) + " in {\n" +
@@ -210,14 +213,16 @@ case class PrettyPrinter(freeShift: Int,
         if (isEmpty(par)) "Nil"
         else {
           val list =
-            List(par.bundles,
-                 par.sends,
-                 par.receives,
-                 par.news,
-                 par.exprs,
-                 par.matches,
-                 par.ids,
-                 par.connectives)
+            List(
+              par.bundles,
+              par.sends,
+              par.receives,
+              par.news,
+              par.exprs,
+              par.matches,
+              par.ids,
+              par.connectives
+            )
           ((false, "") /: list) {
             case ((prevNonEmpty, string), items) =>
               if (items.nonEmpty) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ReceiveBindsSortMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ReceiveBindsSortMatcher.scala
@@ -10,20 +10,25 @@ import coop.rchain.models.rholang.implicits._
 object ReceiveBindsSortMatcher {
   // Used during normalize to presort the binds.
   def preSortBinds[F[_]: Sync, T](
-      binds: Seq[(Seq[Channel], Channel, Option[Var], DebruijnLevelMap[T])])
-    : F[Seq[(ReceiveBind, DebruijnLevelMap[T])]] = {
+      binds: Seq[(Seq[Channel], Channel, Option[Var], DebruijnLevelMap[T])]
+  ): F[Seq[(ReceiveBind, DebruijnLevelMap[T])]] = {
     val bindSortings = binds.toList
       .map {
-        case (patterns: Seq[Channel],
-              channel: Channel,
-              remainder: Option[Var],
-              knownFree: DebruijnLevelMap[T]) =>
+        case (
+            patterns: Seq[Channel],
+            channel: Channel,
+            remainder: Option[Var],
+            knownFree: DebruijnLevelMap[T]
+            ) =>
           for {
             sortedBind <- sortBind(
-                           ReceiveBind(patterns,
-                                       channel,
-                                       remainder,
-                                       freeCount = knownFree.countNoWildcards))
+                           ReceiveBind(
+                             patterns,
+                             channel,
+                             remainder,
+                             freeCount = knownFree.countNoWildcards
+                           )
+                         )
           } yield ScoredTerm((sortedBind.term, knownFree), sortedBind.score)
       }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -35,20 +35,24 @@ import scala.util.Try
   */
 trait Reduce[M[_]] {
 
-  def eval(par: Par)(implicit env: Env[Par],
-                     rand: Blake2b512Random,
-                     costAccountingAlg: CostAccountingAlg[M]): M[Unit]
+  def eval(par: Par)(
+      implicit env: Env[Par],
+      rand: Blake2b512Random,
+      costAccountingAlg: CostAccountingAlg[M]
+  ): M[Unit]
 
-  def inj(par: Par)(implicit rand: Blake2b512Random,
-                    costAccountingAlg: CostAccountingAlg[M]): M[Unit]
+  def inj(
+      par: Par
+  )(implicit rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit]
 
   /**
     * Evaluate any top level expressions in @param Par .
     */
   def evalExpr(par: Par)(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par]
 
-  def evalExprToPar(expr: Expr)(implicit env: Env[Par],
-                                costAccountingAlg: CostAccountingAlg[M]): M[Par]
+  def evalExprToPar(
+      expr: Expr
+  )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par]
 }
 
 object Reduce {
@@ -57,36 +61,43 @@ object Reduce {
       term: A,
       depth: Int,
       env: Env[Par],
-      costAccountingAlg: CostAccountingAlg[M]): M[A] =
+      costAccountingAlg: CostAccountingAlg[M]
+  ): M[A] =
     Substitute[M, A]
       .substitute(term)(depth, env)
       .attempt
-      .flatMap(_.fold(
-        th => // On error charge for the initial term
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
-            .raiseError[A](th),
-        substTerm =>
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
-      ))
+      .flatMap(
+        _.fold(
+          th => // On error charge for the initial term
+            costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
+              .raiseError[A](th),
+          substTerm =>
+            costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
+        )
+      )
 
   private def substituteNoSortAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](
       term: A,
       depth: Int,
       env: Env[Par],
-      costAccountingAlg: CostAccountingAlg[M]): M[A] =
+      costAccountingAlg: CostAccountingAlg[M]
+  ): M[A] =
     Substitute[M, A]
       .substituteNoSort(term)(depth, env)
       .attempt
-      .flatMap(_.fold(
-        th => // On error charge for the initial term
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
-            .raiseError[A](th),
-        substTerm =>
-          costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
-      ))
+      .flatMap(
+        _.fold(
+          th => // On error charge for the initial term
+            costAccountingAlg.charge(Cost(Chargeable[A].cost(term))) *> Sync[M]
+              .raiseError[A](th),
+          substTerm =>
+            costAccountingAlg.charge(Cost(Chargeable[A].cost(substTerm))) *> Sync[M].pure(substTerm)
+        )
+      )
 
   private def spatialMatchAndCharge[M[_]: Sync](target: Par, pattern: Par)(
-      implicit costAlg: CostAccountingAlg[M]): M[Option[(FreeMap, Unit)]] =
+      implicit costAlg: CostAccountingAlg[M]
+  ): M[Option[(FreeMap, Unit)]] =
     for {
       // phlos available before going to the matcher
       phlosAvailable <- costAlg.get()
@@ -94,7 +105,8 @@ object Reduce {
                  .fromEither(
                    SpatialMatcher
                      .spatialMatch(target, pattern)
-                     .runWithCost(phlosAvailable))
+                     .runWithCost(phlosAvailable)
+                 )
                  .flatMap {
                    case (phlosLeft, result) =>
                      val phloUsed = phlosLeft.copy(cost = phlosAvailable.cost - phlosLeft.cost)
@@ -107,13 +119,15 @@ object Reduce {
                  }
     } yield result
 
-  class DebruijnInterpreter[M[_], F[_]](tuplespaceAlg: TuplespaceAlg[M],
-                                        private val urnMap: Map[String, Par])(
+  class DebruijnInterpreter[M[_], F[_]](
+      tuplespaceAlg: TuplespaceAlg[M],
+      private val urnMap: Map[String, Par]
+  )(
       implicit
       parallel: cats.Parallel[M, F],
       s: Sync[M],
-      fTell: FunctorTell[M, Throwable])
-      extends Reduce[M] {
+      fTell: FunctorTell[M, Throwable]
+  ) extends Reduce[M] {
 
     /**
       * Materialize a send in the store, optionally returning the matched continuation.
@@ -128,7 +142,8 @@ object Reduce {
         chan: Quote,
         data: Seq[Channel],
         persistent: Boolean,
-        rand: Blake2b512Random)(implicit costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+        rand: Blake2b512Random
+    )(implicit costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       for {
         _ <- costAccountingAlg.charge(Channel(chan).storageCost + data.storageCost)
         c <- tuplespaceAlg.produce(Channel(chan), ListChannelWithRandom(data, rand), persistent)
@@ -150,7 +165,8 @@ object Reduce {
         binds: Seq[(BindPattern, Quote)],
         body: Par,
         persistent: Boolean,
-        rand: Blake2b512Random)(implicit costAccountingAlg: CostAccountingAlg[M]): M[Unit] = {
+        rand: Blake2b512Random
+    )(implicit costAccountingAlg: CostAccountingAlg[M]): M[Unit] = {
       val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
       val srcs                                              = sources.map(q => Channel(q)).toList
       val rspaceCost                                        = body.storageCost + patterns.storageCost + srcs.storageCost
@@ -172,9 +188,11 @@ object Reduce {
       * @param par
       * @return
       */
-    override def eval(par: Par)(implicit env: Env[Par],
-                                rand: Blake2b512Random,
-                                costAccountingAlg: CostAccountingAlg[M]): M[Unit] = {
+    override def eval(par: Par)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] = {
       val filteredExprs = par.exprs.filter { expr =>
         expr.exprInstance match {
           case _: EVarBody    => true
@@ -183,15 +201,18 @@ object Reduce {
           case _              => false
         }
       }
-      val starts = Vector(par.sends.size,
-                          par.receives.size,
-                          par.news.size,
-                          par.matches.size,
-                          par.bundles.size,
-                          filteredExprs.size)
-        .scanLeft(0)(_ + _)
-      def handle[A](eval: (A => (Env[Par], Blake2b512Random, CostAccountingAlg[M]) => M[Unit]),
-                    start: Int)(ta: (A, Int)): M[Unit] = {
+      val starts = Vector(
+        par.sends.size,
+        par.receives.size,
+        par.news.size,
+        par.matches.size,
+        par.bundles.size,
+        filteredExprs.size
+      ).scanLeft(0)(_ + _)
+      def handle[A](
+          eval: (A => (Env[Par], Blake2b512Random, CostAccountingAlg[M]) => M[Unit]),
+          start: Int
+      )(ta: (A, Int)): M[Unit] = {
         val newRand =
           if (starts(6) == 1)
             rand
@@ -238,15 +259,16 @@ object Reduce {
       ).parSequence.as(Unit)
     }
 
-    override def inj(par: Par)(implicit rand: Blake2b512Random,
-                               costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    override def inj(
+        par: Par
+    )(implicit rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       for {
         _ <- eval(par)(Env[Par](), rand, costAccountingAlg)
       } yield ()
 
-    private def evalExplicit(send: Send)(env: Env[Par],
-                                         rand: Blake2b512Random,
-                                         costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def evalExplicit(
+        send: Send
+    )(env: Env[Par], rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       eval(send)(env, rand, costAccountingAlg)
 
     /** Algorithm as follows:
@@ -262,9 +284,11 @@ object Reduce {
       * @param env An execution context
       * @return
       */
-    private def eval(send: Send)(implicit env: Env[Par],
-                                 rand: Blake2b512Random,
-                                 costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def eval(send: Send)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] =
       for {
         quote   <- eval(send.chan)
         subChan <- substituteAndCharge[Quote, M](quote, 0, env, costAccountingAlg)
@@ -279,38 +303,49 @@ object Reduce {
                     }
 
         data <- send.data.toList.traverse(x => evalExpr(x))
-        substData <- data.traverse(p =>
-                      substituteAndCharge[Par, M](p, 0, env, costAccountingAlg).map(par =>
-                        Channel(Quote(par))))
+        substData <- data.traverse(
+                      p =>
+                        substituteAndCharge[Par, M](p, 0, env, costAccountingAlg)
+                          .map(par => Channel(Quote(par)))
+                    )
         _ <- produce(unbundled, substData, send.persistent, rand)
         _ <- costAccountingAlg.charge(SEND_EVAL_COST)
       } yield ()
 
-    private def evalExplicit(receive: Receive)(env: Env[Par],
-                                               rand: Blake2b512Random,
-                                               costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def evalExplicit(
+        receive: Receive
+    )(env: Env[Par], rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       eval(receive)(env, rand, costAccountingAlg)
 
-    private def eval(receive: Receive)(implicit env: Env[Par],
-                                       rand: Blake2b512Random,
-                                       costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def eval(receive: Receive)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] =
       for {
         binds <- receive.binds.toList
-                  .traverse(rb =>
-                    for {
-                      q <- unbundleReceive(rb)
-                      substPatterns <- rb.patterns.toList.traverse(
-                                        pattern =>
-                                          substituteAndCharge[Channel, M](pattern,
-                                                                          1,
-                                                                          env,
-                                                                          costAccountingAlg))
-                    } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q))
+                  .traverse(
+                    rb =>
+                      for {
+                        q <- unbundleReceive(rb)
+                        substPatterns <- rb.patterns.toList.traverse(
+                                          pattern =>
+                                            substituteAndCharge[Channel, M](
+                                              pattern,
+                                              1,
+                                              env,
+                                              costAccountingAlg
+                                            )
+                                        )
+                      } yield (BindPattern(substPatterns, rb.remainder, rb.freeCount), q)
+                  )
         // TODO: Allow for the environment to be stored with the body in the Tuplespace
-        substBody <- substituteNoSortAndCharge[Par, M](receive.body,
-                                                       0,
-                                                       env.shift(receive.bindCount),
-                                                       costAccountingAlg)
+        substBody <- substituteNoSortAndCharge[Par, M](
+                      receive.body,
+                      0,
+                      env.shift(receive.bindCount),
+                      costAccountingAlg
+                    )
         _ <- consume(binds, substBody, receive.persistent, rand)
         _ <- costAccountingAlg.charge(RECEIVE_EVAL_COST)
       } yield ()
@@ -326,8 +361,9 @@ object Reduce {
       *                  an exception.
       *
       */
-    private def eval(valproc: Var)(implicit env: Env[Par],
-                                   costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+    private def eval(
+        valproc: Var
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
       costAccountingAlg.charge(VAR_EVAL_COST) *> {
         valproc.varInstance match {
           case BoundVar(level) =>
@@ -360,8 +396,9 @@ object Reduce {
       *            a binding for channel
       * @return A quoted process or "channel value"
       */
-    private def eval(channel: Channel)(implicit env: Env[Par],
-                                       costAccountingAlg: CostAccountingAlg[M]): M[Quote] =
+    private def eval(
+        channel: Channel
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Quote] =
       costAccountingAlg.charge(CHANNEL_EVAL_COST) *> {
         channel.channelInstance match {
           case Quote(p) =>
@@ -378,13 +415,15 @@ object Reduce {
         }
       }
 
-    private def evalExplicit(mat: Match)(env: Env[Par],
-                                         rand: Blake2b512Random,
-                                         costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def evalExplicit(
+        mat: Match
+    )(env: Env[Par], rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       eval(mat)(env, rand, costAccountingAlg)
-    private def eval(mat: Match)(implicit env: Env[Par],
-                                 rand: Blake2b512Random,
-                                 costAccountingAlg: CostAccountingAlg[M]): M[Unit] = {
+    private def eval(mat: Match)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] = {
       def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
         Range(0, freeCount).foldLeft(env)(
           (acc, e) =>
@@ -393,21 +432,24 @@ object Reduce {
                 case Some(p) => p
                 case None    => Par()
               }
-          )
+            )
         )
 
       def firstMatch(target: Par, cases: Seq[MatchCase])(implicit env: Env[Par]): M[Unit] = {
         def firstMatchM(
-            state: Tuple2[Par, Seq[MatchCase]]): M[Either[Tuple2[Par, Seq[MatchCase]], Unit]] = {
+            state: Tuple2[Par, Seq[MatchCase]]
+        ): M[Either[Tuple2[Par, Seq[MatchCase]], Unit]] = {
           val (target, cases) = state
           cases match {
             case Nil => Applicative[M].pure(Right(()))
             case singleCase +: caseRem =>
               for {
-                pattern <- substituteAndCharge[Par, M](singleCase.pattern,
-                                                       1,
-                                                       env,
-                                                       costAccountingAlg)
+                pattern <- substituteAndCharge[Par, M](
+                            singleCase.pattern,
+                            1,
+                            env,
+                            costAccountingAlg
+                          )
                 matchResult <- spatialMatchAndCharge[M](target, pattern)
                 res <- matchResult match {
                         case None =>
@@ -439,13 +481,15 @@ object Reduce {
       * @param neu
       * @return
       */
-    private def evalExplicit(neu: New)(env: Env[Par],
-                                       rand: Blake2b512Random,
-                                       costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def evalExplicit(
+        neu: New
+    )(env: Env[Par], rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       eval(neu)(env, rand, costAccountingAlg)
-    private def eval(neu: New)(implicit env: Env[Par],
-                               rand: Blake2b512Random,
-                               costAccountingAlg: CostAccountingAlg[M]): M[Unit] = {
+    private def eval(neu: New)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] = {
       def alloc(count: Int, urns: Seq[String]): M[Env[Par]] = {
         val simpleNews = (0 until (count - urns.size)).toList.foldLeft(env) { (_env, _) =>
           val addr: Par = GPrivate(ByteString.copyFrom(rand.next()))
@@ -456,9 +500,11 @@ object Reduce {
             case Some(p) => Right(newEnv.put(p))
             case None    => Left(ReduceError(s"Unknown urn for new: ${urn}"))
           }
-        def foldLeftEarly[A, B, E](init: B,
-                                   as: Seq[A],
-                                   cata: (B, A) => Either[E, B]): Either[E, B] =
+        def foldLeftEarly[A, B, E](
+            init: B,
+            as: Seq[A],
+            cata: (B, A) => Either[E, B]
+        ): Either[E, B] =
           Foldable[List].foldM(as.toList, init)(cata)
         foldLeftEarly(simpleNews, urns, addUrn) match {
           case Right(env) => Applicative[M].pure(env)
@@ -472,9 +518,9 @@ object Reduce {
         }
     }
 
-    private[this] def unbundleReceive(rb: ReceiveBind)(
-        implicit env: Env[Par],
-        costAccountingAlg: CostAccountingAlg[M]): M[Quote] =
+    private[this] def unbundleReceive(
+        rb: ReceiveBind
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Quote] =
       for {
         quote <- eval(rb.source)
         subst <- substituteAndCharge[Quote, M](quote, 0, env, costAccountingAlg)
@@ -491,17 +537,20 @@ object Reduce {
                  }
       } yield unbndl
 
-    private def evalExplicit(bundle: Bundle)(env: Env[Par],
-                                             rand: Blake2b512Random,
-                                             costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def evalExplicit(
+        bundle: Bundle
+    )(env: Env[Par], rand: Blake2b512Random, costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
       eval(bundle)(env, rand, costAccountingAlg)
-    private def eval(bundle: Bundle)(implicit env: Env[Par],
-                                     rand: Blake2b512Random,
-                                     costAccountingAlg: CostAccountingAlg[M]): M[Unit] =
+    private def eval(bundle: Bundle)(
+        implicit env: Env[Par],
+        rand: Blake2b512Random,
+        costAccountingAlg: CostAccountingAlg[M]
+    ): M[Unit] =
       eval(bundle.body)
 
-    def evalExprToPar(expr: Expr)(implicit env: Env[Par],
-                                  costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+    def evalExprToPar(
+        expr: Expr
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
       expr.exprInstance match {
         case EVarBody(EVar(v)) =>
           for {
@@ -525,13 +574,16 @@ object Reduce {
         case _               => evalExprToExpr(expr).map(e => fromExpr(e)(identity))
       }
 
-    private def evalExprToExpr(expr: Expr)(implicit env: Env[Par],
-                                           costAccountingAlg: CostAccountingAlg[M]): M[Expr] = {
-      def relop(p1: Par,
-                p2: Par,
-                relopb: (Boolean, Boolean) => Boolean,
-                relopi: (Long, Long) => Boolean,
-                relops: (String, String) => Boolean): M[Expr] =
+    private def evalExprToExpr(
+        expr: Expr
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Expr] = {
+      def relop(
+          p1: Par,
+          p2: Par,
+          relopb: (Boolean, Boolean) => Boolean,
+          relopi: (Long, Long) => Boolean,
+          relops: (String, String) => Boolean
+      ): M[Expr] =
         for {
           v1 <- evalSingleExpr(p1)
           v2 <- evalSingleExpr(p2)
@@ -725,8 +777,9 @@ object Reduce {
                                       }
                                       .toList
                                       .sequence[M, (String, String)]
-                                      .map(keyValuePairs =>
-                                        GString(interpolate(lhs, keyValuePairs)))
+                                      .map(
+                                        keyValuePairs => GString(interpolate(lhs, keyValuePairs))
+                                      )
                            _ <- costAccountingAlg.charge(LOOKUP_COST * lhs.length)
                          } yield result
                        case (_: GString, other) =>
@@ -857,8 +910,10 @@ object Reduce {
     }
 
     private abstract class Method() {
-      def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                        costAccountingAlg: CostAccountingAlg[M]): M[Par]
+      def apply(p: Par, args: Seq[Par])(
+          implicit env: Env[Par],
+          costAccountingAlg: CostAccountingAlg[M]
+      ): M[Par]
     }
 
     private[this] val nth: Method = new Method() {
@@ -869,8 +924,10 @@ object Reduce {
           Left(ReduceError("Error: index out of bound: " + nth))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.length != 1) {
           s.raiseError(ReduceError("Error: nth expects 1 argument"))
         } else {
@@ -887,7 +944,9 @@ object Reduce {
                        case _ =>
                          s.raiseError(
                            ReduceError(
-                             "Error: nth applied to something that wasn't a list or tuple."))
+                             "Error: nth applied to something that wasn't a list or tuple."
+                           )
+                         )
                      }
           } yield result
         }
@@ -897,11 +956,14 @@ object Reduce {
       def serialize(p: Par): Either[ReduceError, Array[Byte]] =
         Either
           .fromTry(Try(Serialize[Par].encode(p).toArray))
-          .leftMap(th =>
-            ReduceError(s"Error: exception thrown when serializing $p." + th.getMessage))
+          .leftMap(
+            th => ReduceError(s"Error: exception thrown when serializing $p." + th.getMessage)
+          )
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.nonEmpty) {
           s.raiseError(ReduceError("Error: toByteArray does not take arguments"))
         } else {
@@ -916,8 +978,10 @@ object Reduce {
 
     private[this] val hexToBytes: Method = new Method() {
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.nonEmpty) {
           s.raiseError(ReduceError("Error: hexToBytes does not take arguments"))
         } else {
@@ -925,12 +989,15 @@ object Reduce {
             case Some(Expr(GString(encoded))) =>
               def decodingError(th: Throwable) =
                 ReduceError(
-                  s"Error: exception was thrown when decoding input string to hexadecimal: ${th.getMessage}")
+                  s"Error: exception was thrown when decoding input string to hexadecimal: ${th.getMessage}"
+                )
               for {
                 _           <- costAccountingAlg.charge(hexToByteCost(encoded))
                 encodingRes = Try(ByteString.copyFrom(Base16.decode(encoded)))
-                res <- encodingRes.fold(th => s.raiseError(decodingError(th)),
-                                        ba => Applicative[M].pure[Par](Expr(GByteArray(ba))))
+                res <- encodingRes.fold(
+                        th => s.raiseError(decodingError(th)),
+                        ba => Applicative[M].pure[Par](Expr(GByteArray(ba)))
+                      )
               } yield res
             case _ =>
               s.raiseError(ReduceError("Error: hexToBytes can be called only on single strings."))
@@ -939,7 +1006,8 @@ object Reduce {
     }
 
     private[this] def method(methodName: String, expectedArgsLength: Int, args: Seq[Par])(
-        thunk: => M[Par]): M[Par] =
+        thunk: => M[Par]
+    ): M[Par] =
       if (args.length != expectedArgsLength) {
         s.raiseError(MethodArgumentNumberMismatch(methodName, expectedArgsLength, args.length))
       } else {
@@ -952,8 +1020,10 @@ object Reduce {
 
       def union(baseExpr: Expr, otherExpr: Expr)(implicit costAccountingAlg: CostAccountingAlg[M]) =
         (baseExpr.exprInstance, otherExpr.exprInstance) match {
-          case (ESetBody(base @ ParSet(basePs, _, _, _)),
-                ESetBody(other @ ParSet(otherPs, _, _, _))) =>
+          case (
+              ESetBody(base @ ParSet(basePs, _, _, _)),
+              ESetBody(other @ ParSet(otherPs, _, _, _))
+              ) =>
             costAccountingAlg.charge(ADD_COST * basePs.size) *> Applicative[M].pure[Expr](
               ESetBody(
                 ParSet(
@@ -961,24 +1031,32 @@ object Reduce {
                   base.connectiveUsed || other.connectiveUsed,
                   locallyFreeUnion(base.locallyFree, other.locallyFree),
                   None
-                )))
-          case (EMapBody(base @ ParMap(baseMap, _, _, _)),
-                EMapBody(other @ ParMap(otherMap, _, _, _))) =>
+                )
+              )
+            )
+          case (
+              EMapBody(base @ ParMap(baseMap, _, _, _)),
+              EMapBody(other @ ParMap(otherMap, _, _, _))
+              ) =>
             costAccountingAlg.charge(ADD_COST * baseMap.size) *>
               Applicative[M].pure[Expr](
                 EMapBody(
-                  ParMap((baseMap ++ otherMap.sortedMap).toSeq,
-                         base.connectiveUsed || other.connectiveUsed,
-                         locallyFreeUnion(base.locallyFree, other.locallyFree),
-                         None)
+                  ParMap(
+                    (baseMap ++ otherMap.sortedMap).toSeq,
+                    base.connectiveUsed || other.connectiveUsed,
+                    locallyFreeUnion(base.locallyFree, other.locallyFree),
+                    None
+                  )
                 )
               )
           case (other, _) =>
             s.raiseError(MethodNotDefined("union", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("union", 1, args.length))
@@ -995,17 +1073,23 @@ object Reduce {
 
       def diff(baseExpr: Expr, otherExpr: Expr)(implicit costAccountingAlg: CostAccountingAlg[M]) =
         (baseExpr.exprInstance, otherExpr.exprInstance) match {
-          case (ESetBody(base @ ParSet(basePs, _, _, _)),
-                ESetBody(other @ ParSet(otherPs, _, _, _))) =>
+          case (
+              ESetBody(base @ ParSet(basePs, _, _, _)),
+              ESetBody(other @ ParSet(otherPs, _, _, _))
+              ) =>
             // diff is implemented in terms of foldLeft that at each step
             // removes one element from the collection.
             costAccountingAlg.charge(REMOVE_COST * basePs.size) *>
               Applicative[M].pure[Expr](
                 ESetBody(
-                  ParSet(basePs.diff(otherPs.sortedPars.toSet),
-                         base.connectiveUsed || other.connectiveUsed,
-                         locallyFreeUnion(base.locallyFree, other.locallyFree),
-                         None)))
+                  ParSet(
+                    basePs.diff(otherPs.sortedPars.toSet),
+                    base.connectiveUsed || other.connectiveUsed,
+                    locallyFreeUnion(base.locallyFree, other.locallyFree),
+                    None
+                  )
+                )
+              )
           case (EMapBody(ParMap(basePs, _, _, _)), EMapBody(ParMap(otherPs, _, _, _))) =>
             val newMap = basePs -- otherPs.keys
             costAccountingAlg.charge(REMOVE_COST * basePs.size) *>
@@ -1016,8 +1100,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("diff", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("diff", 1, args.length))
@@ -1034,18 +1120,24 @@ object Reduce {
           case ESetBody(base @ ParSet(basePs, _, _, _)) =>
             Applicative[M].pure[Expr](
               ESetBody(
-                ParSet(basePs + par,
-                       base.connectiveUsed || par.connectiveUsed,
-                       base.locallyFree.map(b => b | par.locallyFree),
-                       None)))
+                ParSet(
+                  basePs + par,
+                  base.connectiveUsed || par.connectiveUsed,
+                  base.locallyFree.map(b => b | par.locallyFree),
+                  None
+                )
+              )
+            )
           //TODO(mateusz.gorski): think whether cost accounting for addition should be dependend on the operands
 
           case other =>
             s.raiseError(MethodNotDefined("add", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("add", 1, args.length))
@@ -1063,23 +1155,33 @@ object Reduce {
           case ESetBody(base @ ParSet(basePs, _, _, _)) =>
             Applicative[M].pure[Expr](
               ESetBody(
-                ParSet(basePs - par,
-                       base.connectiveUsed || par.connectiveUsed,
-                       base.locallyFree.map(b => b | par.locallyFree),
-                       None)))
+                ParSet(
+                  basePs - par,
+                  base.connectiveUsed || par.connectiveUsed,
+                  base.locallyFree.map(b => b | par.locallyFree),
+                  None
+                )
+              )
+            )
           case EMapBody(base @ ParMap(basePs, _, _, _)) =>
             Applicative[M].pure[Expr](
               EMapBody(
-                ParMap(basePs - par,
-                       base.connectiveUsed || par.connectiveUsed,
-                       base.locallyFree.map(b => b | par.locallyFree),
-                       None)))
+                ParMap(
+                  basePs - par,
+                  base.connectiveUsed || par.connectiveUsed,
+                  base.locallyFree.map(b => b | par.locallyFree),
+                  None
+                )
+              )
+            )
           case other =>
             s.raiseError(MethodNotDefined("delete", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("delete", 1, args.length))
@@ -1102,8 +1204,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("contains", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("contains", 1, args.length))
@@ -1124,8 +1228,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("get", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("get", 1, args.length))
@@ -1146,8 +1252,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("getOrElse", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("getOrElse", 2, args.length))
@@ -1169,8 +1277,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("set", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("set", 2, args.length))
@@ -1192,8 +1302,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("keys", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("slice", 2, args.length))
@@ -1214,8 +1326,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("size", other.typ))
         }
 
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("size", 0, args.length))
@@ -1236,8 +1350,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("length", other.typ))
         }
       //TODO(mateusz.gorski): add cost accounting
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("length", 0, args.length))
@@ -1267,8 +1383,10 @@ object Reduce {
             s.raiseError(MethodNotDefined("slice", other.typ))
         }
       //TODO(mateusz.gorski): add cost accounting
-      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par],
-                                                 costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+      override def apply(
+          p: Par,
+          args: Seq[Par]
+      )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("slice", 2, args.length))
@@ -1301,11 +1419,13 @@ object Reduce {
         "slice"       -> slice
       )
 
-    def evalSingleExpr(p: Par)(implicit env: Env[Par],
-                               costAccountingAlg: CostAccountingAlg[M]): M[Expr] =
+    def evalSingleExpr(
+        p: Par
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Expr] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
-          ReduceError("Error: parallel or non expression found where expression expected."))
+          ReduceError("Error: parallel or non expression found where expression expected.")
+        )
       else
         p.exprs match {
           case (e: Expr) +: Nil => evalExprToExpr(e)
@@ -1313,11 +1433,13 @@ object Reduce {
             s.raiseError(ReduceError("Error: Multiple expressions given."))
         }
 
-    def evalToLong(p: Par)(implicit env: Env[Par],
-                           costAccountingAlg: CostAccountingAlg[M]): M[Long] =
+    def evalToLong(
+        p: Par
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Long] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
-          ReduceError("Error: parallel or non expression found where expression expected."))
+          ReduceError("Error: parallel or non expression found where expression expected.")
+        )
       else
         p.exprs match {
           case Expr(GInt(v)) +: Nil =>
@@ -1334,18 +1456,21 @@ object Reduce {
                          case GInt(v) => Applicative[M].pure(v)
                          case _ =>
                            s.raiseError(
-                             ReduceError("Error: expression didn't evaluate to integer."))
+                             ReduceError("Error: expression didn't evaluate to integer.")
+                           )
                        }
             } yield result
           case _ =>
             s.raiseError(ReduceError("Error: Integer expected, or unimplemented expression."))
         }
 
-    def evalToBool(p: Par)(implicit env: Env[Par],
-                           costAccountingAlg: CostAccountingAlg[M]): M[Boolean] =
+    def evalToBool(
+        p: Par
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Boolean] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
-          ReduceError("Error: parallel or non expression found where expression expected."))
+          ReduceError("Error: parallel or non expression found where expression expected.")
+        )
       else
         p.exprs match {
           case Expr(GBool(b)) +: Nil =>
@@ -1362,7 +1487,8 @@ object Reduce {
                          case GBool(b) => Applicative[M].pure(b)
                          case _ =>
                            s.raiseError(
-                             ReduceError("Error: expression didn't evaluate to boolean."))
+                             ReduceError("Error: expression didn't evaluate to boolean.")
+                           )
                        }
             } yield result
           case _ =>
@@ -1398,8 +1524,9 @@ object Reduce {
     /**
       * Evaluate any top level expressions in @param Par .
       */
-    def evalExpr(par: Par)(implicit env: Env[Par],
-                           costAccountingAlg: CostAccountingAlg[M]): M[Par] =
+    def evalExpr(
+        par: Par
+    )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
       for {
         evaledExprs <- par.exprs.toList.traverse(expr => evalExprToPar(expr))
         // Note: the locallyFree cache in par could now be invalid, but given

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -97,31 +97,42 @@ class RegistryImpl[F[_]](
   private val lookupPatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
-      freeCount = 2))
+      freeCount = 2
+    )
+  )
   private val lookupChannels = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](10))))))
   private val insertPatterns = List(
     BindPattern(
-      Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
-          Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
-          ChanVar(FreeVar(2))),
+      Seq(
+        Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
+        Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
+        ChanVar(FreeVar(2))
+      ),
       freeCount = 3
-    ))
+    )
+  )
   private val insertChannels = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](12))))))
   private val deletePatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
-      freeCount = 2))
+      freeCount = 2
+    )
+  )
   private val deleteChannels = List(Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](14))))))
 
   private val publicLookupChannels = List(
-    Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](17))))))
+    Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](17)))))
+  )
   private val publicLookupPatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
-      freeCount = 2))
+      freeCount = 2
+    )
+  )
 
   private val publicRegisterRandomChannels = List(
-    Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](18))))))
+    Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](18)))))
+  )
   // format: off
   private val publicRegisterRandomPatterns = List(
     BindPattern(
@@ -131,39 +142,56 @@ class RegistryImpl[F[_]](
 
   private val publicRegisterInsertCallbackPatterns = List(
     BindPattern(
-      Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
-          Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
-          ChanVar(FreeVar(2))),
+      Seq(
+        Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
+        Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
+        ChanVar(FreeVar(2))
+      ),
       freeCount = 3
     ),
-    BindPattern(Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true))),
-                freeCount = 1)
+    BindPattern(
+      Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true))),
+      freeCount = 1
+    )
   )
 
   def testInstall(): F[Unit] =
     for {
-      _ <- space.install(lookupChannels,
-                         lookupPatterns,
-                         TaggedContinuation(ScalaBodyRef(lookupRef)))
-      _ <- space.install(insertChannels,
-                         insertPatterns,
-                         TaggedContinuation(ScalaBodyRef(insertRef)))
-      _ <- space.install(deleteChannels,
-                         deletePatterns,
-                         TaggedContinuation(ScalaBodyRef(deleteRef)))
-      _ <- space.install(publicLookupChannels,
-                         publicLookupPatterns,
-                         TaggedContinuation(ScalaBodyRef(publicLookupRef)))
-      _ <- space.install(publicRegisterRandomChannels,
-                         publicRegisterRandomPatterns,
-                         TaggedContinuation(ScalaBodyRef(publicRegisterRandomRef)))
+      _ <- space.install(
+            lookupChannels,
+            lookupPatterns,
+            TaggedContinuation(ScalaBodyRef(lookupRef))
+          )
+      _ <- space.install(
+            insertChannels,
+            insertPatterns,
+            TaggedContinuation(ScalaBodyRef(insertRef))
+          )
+      _ <- space.install(
+            deleteChannels,
+            deletePatterns,
+            TaggedContinuation(ScalaBodyRef(deleteRef))
+          )
+      _ <- space.install(
+            publicLookupChannels,
+            publicLookupPatterns,
+            TaggedContinuation(ScalaBodyRef(publicLookupRef))
+          )
+      _ <- space.install(
+            publicRegisterRandomChannels,
+            publicRegisterRandomPatterns,
+            TaggedContinuation(ScalaBodyRef(publicRegisterRandomRef))
+          )
     } yield Unit
 
   private val prefixRetReplacePattern = BindPattern(
-    Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
-        ChanVar(FreeVar(1)),
-        ChanVar(FreeVar(2))),
-    freeCount = 3)
+    Seq(
+      Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
+      ChanVar(FreeVar(1)),
+      ChanVar(FreeVar(2))
+    ),
+    freeCount = 3
+  )
   private val prefixValueRetReplacePattern = BindPattern(
     Seq(
       Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
@@ -174,19 +202,23 @@ class RegistryImpl[F[_]](
     freeCount = 4
   )
   private val parentKeyDataReplacePattern = BindPattern(
-    Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
-        Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
-        ChanVar(FreeVar(2))),
+    Seq(
+      Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)),
+      Quote(Par(exprs = Seq(EVar(FreeVar(1))), connectiveUsed = true)),
+      ChanVar(FreeVar(2))
+    ),
     freeCount = 3
   )
   private val triePattern = BindPattern(
     Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true))),
-    freeCount = 1)
+    freeCount = 1
+  )
 
   private def parByteArray(bs: ByteString): Par = GByteArray(bs)
 
   private def handleResult[E <: Throwable](
-      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]): F[Unit] =
+      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]
+  ): F[Unit] =
     resultF.flatMap({
       case Right(Some((continuation, dataList))) => dispatcher.dispatch(continuation, dataList)
       case Right(None)                           => F.unit
@@ -214,105 +246,132 @@ class RegistryImpl[F[_]](
       case _                     => F.unit
     }
 
-  private def failAndReplace(data: Channel,
-                             replaceChan: Channel,
-                             retChan: Channel,
-                             dataRand: Blake2b512Random,
-                             failRand: Blake2b512Random): F[Unit] =
+  private def failAndReplace(
+      data: Channel,
+      replaceChan: Channel,
+      retChan: Channel,
+      dataRand: Blake2b512Random,
+      failRand: Blake2b512Random
+  ): F[Unit] =
     for {
       _ <- replace(data, replaceChan, dataRand)
       _ <- fail(retChan, failRand)
     } yield ()
 
-  private def fetchDataLookup(dataSource: Quote,
-                              key: Channel,
-                              ret: Channel,
-                              rand: Blake2b512Random): F[Unit] = {
+  private def fetchDataLookup(
+      dataSource: Quote,
+      key: Channel,
+      ret: Channel,
+      rand: Blake2b512Random
+  ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
       _ <- handleResult(
-            space.produce(Quote(channel),
-                          ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
-                          false))
+            space.produce(
+              Quote(channel),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              false
+            )
+          )
       _ <- handleResult(
             space.consume(
               Seq[Channel](Quote(channel), dataSource),
               Seq(prefixRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(lookupCallbackRef)),
               false
-            ))
+            )
+          )
     } yield ()
   }
 
-  private def fetchDataInsert(dataSource: Quote,
-                              key: Channel,
-                              value: Channel,
-                              ret: Channel,
-                              rand: Blake2b512Random): F[Unit] = {
+  private def fetchDataInsert(
+      dataSource: Quote,
+      key: Channel,
+      value: Channel,
+      ret: Channel,
+      rand: Blake2b512Random
+  ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
       _ <- handleResult(
             space.produce(
               Quote(channel),
               ListChannelWithRandom(Seq(key, value, ret, Channel(dataSource)), rand, None),
-              false))
+              false
+            )
+          )
       _ <- handleResult(
             space.consume(
               Seq[Channel](Quote(channel), dataSource),
               Seq(prefixValueRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(insertCallbackRef)),
               false
-            ))
+            )
+          )
     } yield ()
   }
 
-  private def fetchDataRootDelete(dataSource: Quote,
-                                  key: Channel,
-                                  ret: Channel,
-                                  rand: Blake2b512Random): F[Unit] = {
+  private def fetchDataRootDelete(
+      dataSource: Quote,
+      key: Channel,
+      ret: Channel,
+      rand: Blake2b512Random
+  ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
       _ <- handleResult(
-            space.produce(Quote(channel),
-                          ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
-                          false))
+            space.produce(
+              Quote(channel),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              false
+            )
+          )
       _ <- handleResult(
             space.consume(
               Seq[Channel](Quote(channel), dataSource),
               Seq(prefixRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(deleteRootCallbackRef)),
               false
-            ))
+            )
+          )
     } yield ()
   }
 
-  private def fetchDataDelete(dataSource: Quote,
-                              key: Channel,
-                              ret: Channel,
-                              rand: Blake2b512Random,
-                              parentKey: Channel,
-                              parentData: Channel,
-                              parentReplace: Channel,
-                              parentRand: Blake2b512Random): F[Unit] = {
+  private def fetchDataDelete(
+      dataSource: Quote,
+      key: Channel,
+      ret: Channel,
+      rand: Blake2b512Random,
+      parentKey: Channel,
+      parentData: Channel,
+      parentReplace: Channel,
+      parentRand: Blake2b512Random
+  ): F[Unit] = {
     val keyChannel: Par    = GPrivate(ByteString.copyFrom(rand.next()))
     val parentChannel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
       _ <- handleResult(
-            space.produce(Quote(keyChannel),
-                          ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
-                          false))
+            space.produce(
+              Quote(keyChannel),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              false
+            )
+          )
       _ <- handleResult(
             space.produce(
               Quote(parentChannel),
               ListChannelWithRandom(Seq(parentKey, parentData, parentReplace), parentRand, None),
-              false))
+              false
+            )
+          )
       _ <- handleResult(
             space.consume(
               Seq[Channel](Quote(keyChannel), Quote(parentChannel), dataSource),
               Seq(prefixRetReplacePattern, parentKeyDataReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(deleteCallbackRef)),
               false
-            ))
+            )
+          )
     } yield ()
   }
 
@@ -336,8 +395,10 @@ class RegistryImpl[F[_]](
 
   def lookupCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
-               ListChannelWithRandom(Seq(data), dataRand, dataCost)) =>
+      case Seq(
+          ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
           val Channel(Quote(keyPar))                   = key
@@ -364,10 +425,13 @@ class RegistryImpl[F[_]](
 
                   replace(data, replaceChan, dataRand).flatMap(
                     _ =>
-                      fetchDataLookup(Quote(ps(2)),
-                                      Channel(Quote(parByteArray(newKey))),
-                                      ret,
-                                      callRand))
+                      fetchDataLookup(
+                        Quote(ps(2)),
+                        Channel(Quote(parByteArray(newKey))),
+                        ret,
+                        callRand
+                      )
+                  )
                 } else
                   localFail()
             }
@@ -393,8 +457,10 @@ class RegistryImpl[F[_]](
 
   def insertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, value, ret, replaceChan), callRand, callCost),
-               ListChannelWithRandom(Seq(data), dataRand, dataCost)) =>
+      case Seq(
+          ListChannelWithRandom(Seq(key, value, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
           val Channel(Quote(keyPar))       = key
@@ -406,8 +472,8 @@ class RegistryImpl[F[_]](
           def insert() = {
             val tuple: Par  = ETuple(Seq(GInt(0), parByteArray(tail), valuePar))
             val newMap: Par = ParMap(SortedParMap(parMap.ps + (parByteArray(head) -> tuple)))
-            replace(Channel(Quote(newMap)), replaceChan, dataRand).flatMap(_ =>
-              succeed(valuePar, ret, callRand))
+            replace(Channel(Quote(newMap)), replaceChan, dataRand)
+              .flatMap(_ => succeed(valuePar, ret, callRand))
           }
           parMap.ps.get(parByteArray(head)) match {
             case None => insert()
@@ -429,14 +495,19 @@ class RegistryImpl[F[_]](
                     SortedParMap(
                       Seq[(Par, Par)](
                         parByteArray(oldEdgeHead) -> ETuple(
-                          Seq(ps(0), parByteArray(oldEdgeTail), ps(2))),
+                          Seq(ps(0), parByteArray(oldEdgeTail), ps(2))
+                        ),
                         parByteArray(newEdgeHead) -> ETuple(
-                          Seq(GInt(0), parByteArray(newEdgeTail), valuePar))
-                      )))
+                          Seq(GInt(0), parByteArray(newEdgeTail), valuePar)
+                        )
+                      )
+                    )
+                  )
                   val newName: Par      = GPrivate(ByteString.copyFrom(callRand.next()))
                   val updatedTuple: Par = ETuple(Seq(GInt(1), outgoingEdge, newName))
                   val updatedMap: Par = ParMap(
-                    SortedParMap(parMap.ps + (parByteArray(head) -> updatedTuple)))
+                    SortedParMap(parMap.ps + (parByteArray(head) -> updatedTuple))
+                  )
                   for {
                     _ <- replace(Quote(updatedMap), replaceChan, dataRand)
                     _ <- replace(Quote(newMap), Quote(newName), callRand.splitByte(0))
@@ -458,11 +529,14 @@ class RegistryImpl[F[_]](
 
                       replace(data, replaceChan, dataRand).flatMap(
                         _ =>
-                          fetchDataInsert(Quote(ps(2)),
-                                          Channel(Quote(parByteArray(newKey))),
-                                          value,
-                                          ret,
-                                          callRand))
+                          fetchDataInsert(
+                            Quote(ps(2)),
+                            Channel(Quote(parByteArray(newKey))),
+                            value,
+                            ret,
+                            callRand
+                          )
+                      )
                     } else {
                       split()
                     }
@@ -490,8 +564,10 @@ class RegistryImpl[F[_]](
 
   def deleteRootCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
-               ListChannelWithRandom(Seq(data), dataRand, dataCost)) =>
+      case Seq(
+          ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
           val Channel(Quote(keyPar))                   = key
@@ -518,14 +594,16 @@ class RegistryImpl[F[_]](
               case Some(Expr(GInt(1))) =>
                 if (tail.startsWith(edgeAdditional)) {
                   val newKey = tail.substring(edgeAdditional.size)
-                  fetchDataDelete(Quote(ps(2)),
-                                  Channel(Quote(parByteArray(newKey))),
-                                  ret,
-                                  callRand,
-                                  Quote(parByteArray(head)),
-                                  data,
-                                  replaceChan,
-                                  dataRand)
+                  fetchDataDelete(
+                    Quote(ps(2)),
+                    Channel(Quote(parByteArray(newKey))),
+                    ret,
+                    callRand,
+                    Quote(parByteArray(head)),
+                    data,
+                    replaceChan,
+                    dataRand
+                  )
                 } else {
                   localFail()
                 }
@@ -542,10 +620,12 @@ class RegistryImpl[F[_]](
       case Seq(
           ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
           ListChannelWithRandom(Seq(parentKey, parentData, parentReplace), parentRand, parentCost),
-          ListChannelWithRandom(Seq(data), dataRand, dataCost)) =>
+          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ) =>
         def localFail() =
-          replace(parentData, parentReplace, parentRand).flatMap(_ =>
-            failAndReplace(data, replaceChan, ret, dataRand, callRand))
+          replace(parentData, parentReplace, parentRand).flatMap(
+            _ => failAndReplace(data, replaceChan, ret, dataRand, callRand)
+          )
         try {
           val Channel(Quote(keyPar))     = key
           val Some(Expr(GByteArray(bs))) = keyPar.singleExpr
@@ -574,7 +654,8 @@ class RegistryImpl[F[_]](
                 val mergedEdge        = parByteArray(mergeStream.toByteString())
                 val updatedTuple: Par = ETuple(Seq(ps(0), mergedEdge, ps(2)))
                 val updatedMap: Par = ParMap(
-                  SortedParMap(parMap.ps + (parentKeyPar -> updatedTuple)))
+                  SortedParMap(parMap.ps + (parentKeyPar -> updatedTuple))
+                )
                 replace(Quote(updatedMap), parentReplace, parentRand)
               }
             }
@@ -614,14 +695,16 @@ class RegistryImpl[F[_]](
               case Some(Expr(GInt(1))) =>
                 if (tail.startsWith(edgeAdditional)) {
                   val newKey = tail.substring(edgeAdditional.size)
-                  fetchDataDelete(Quote(ps(2)),
-                                  Channel(Quote(parByteArray(newKey))),
-                                  ret,
-                                  callRand,
-                                  Quote(parByteArray(head)),
-                                  data,
-                                  replaceChan,
-                                  dataRand)
+                  fetchDataDelete(
+                    Quote(ps(2)),
+                    Channel(Quote(parByteArray(newKey))),
+                    ret,
+                    callRand,
+                    Quote(parByteArray(head)),
+                    data,
+                    replaceChan,
+                    dataRand
+                  )
                 } else {
                   localFail()
                 }
@@ -654,7 +737,9 @@ class RegistryImpl[F[_]](
                 val args = RootSeq(
                   ListChannelWithRandom(
                     Seq(Quote(parByteArray(ByteString.copyFrom(bytes, 0, 32))), ret),
-                    rand))
+                    rand
+                  )
+                )
                 lookup(args)
               } else {
                 localFail()
@@ -685,7 +770,8 @@ class RegistryImpl[F[_]](
             val resultChan: Par = GPrivate(ByteString.copyFrom(rand.next()))
             val uriPar: Par     = GUri(buildURI(bytes))
             val args = RootSeq(
-              ListChannelWithRandom(Seq(Quote(partialKey), Quote(valPar), Quote(resultChan)), rand))
+              ListChannelWithRandom(Seq(Quote(partialKey), Quote(valPar), Quote(resultChan)), rand)
+            )
             for {
               _ <- handleResult(
                     space.produce(
@@ -693,14 +779,16 @@ class RegistryImpl[F[_]](
                       // This re-use of rand is fine because we throw it away in the callback below.
                       ListChannelWithRandom(Seq(Quote(uriPar), value, ret), rand, None),
                       false
-                    ))
+                    )
+                  )
               _ <- handleResult(
                     space.consume(
                       Seq[Channel](Quote(curryChan), Quote(resultChan)),
                       publicRegisterInsertCallbackPatterns,
                       TaggedContinuation(ScalaBodyRef(publicRegisterInsertCallbackRef)),
                       false
-                    ))
+                    )
+                  )
               _ <- insert(args)
             } yield ()
           }
@@ -713,8 +801,10 @@ class RegistryImpl[F[_]](
 
   def publicRegisterInsertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(urn, expectedValue, ret), _, callCost),
-               ListChannelWithRandom(Seq(value), valRand, valCost)) =>
+      case Seq(
+          ListChannelWithRandom(Seq(urn, expectedValue, ret), _, callCost),
+          ListChannelWithRandom(Seq(value), valRand, valCost)
+          ) =>
         ret match {
           case Channel(retQ @ Quote(_)) =>
             if (expectedValue == value)
@@ -731,8 +821,9 @@ class RegistryImpl[F[_]](
 
 object Registry {
   val registryRoot = GPrivate(
-    ByteString.copyFrom(
-      Base16.decode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697")))
+    ByteString
+      .copyFrom(Base16.decode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697"))
+  )
 
   def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -133,12 +133,12 @@ class RegistryImpl[F[_]](
   private val publicRegisterRandomChannels = List(
     Channel(Quote(GPrivate(ByteString.copyFrom(Array[Byte](18)))))
   )
-  // format: off
   private val publicRegisterRandomPatterns = List(
     BindPattern(
       Seq(Quote(Par(exprs = Seq(EVar(FreeVar(0))), connectiveUsed = true)), ChanVar(FreeVar(1))),
-      freeCount = 2))
-  // format: on
+      freeCount = 2
+    )
+  )
 
   private val publicRegisterInsertCallbackPatterns = List(
     BindPattern(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -28,13 +28,17 @@ object RholangCLI {
     val binary = opt[Boolean](descr = "outputs binary protobuf serialization")
     val text   = opt[Boolean](descr = "outputs textual protobuf serialization")
 
-    val data_dir = opt[Path](required = false,
-                             descr = "Path to data directory",
-                             default = Some(Files.createTempDirectory("rspace-store-")))
+    val data_dir = opt[Path](
+      required = false,
+      descr = "Path to data directory",
+      default = Some(Files.createTempDirectory("rspace-store-"))
+    )
 
-    val map_size = opt[Long](required = false,
-                             descr = "Map size (in bytes)",
-                             default = Some(1024L * 1024L * 1024L))
+    val map_size = opt[Long](
+      required = false,
+      descr = "Map size (in bytes)",
+      default = Some(1024L * 1024L * 1024L)
+    )
 
     val files =
       trailArg[List[String]](required = false, descr = "Rholang source file")(stringListConverter)
@@ -108,7 +112,8 @@ object RholangCLI {
   }
 
   def processFile(conf: Conf, runtime: Runtime, fileName: String)(
-      implicit scheduler: Scheduler): Unit = {
+      implicit scheduler: Scheduler
+  ): Unit = {
     val processTerm: Par => Unit =
       if (conf.binary()) writeBinary(fileName)
       else if (conf.text()) writeHumanReadable(fileName)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -14,8 +14,9 @@ trait Costs {
   final val SUM_COST: Cost         = Cost(3)
   final val SUBTRACTION_COST: Cost = Cost(3)
 
-  def equalityCheckCost[T <: GeneratedMessage with Message[T],
-                        P <: GeneratedMessage with Message[P]](x: T, y: P): Cost =
+  def equalityCheckCost[T <: GeneratedMessage with Message[T], P <: GeneratedMessage with Message[
+    P
+  ]](x: T, y: P): Cost =
     Cost(scala.math.min(x.serializedSize, y.serializedSize))
 
   final val BOOLEAN_AND_COST = Cost(2)
@@ -41,8 +42,9 @@ trait Costs {
   // serializing any Par into a Array[Byte]:
   // + allocates byte array of the same size as `serializedSize`
   // + then it copies all elements of the Par
-  def toByteArrayCost[T <: GeneratedMessage with Message[T]](a: T)(
-      implicit comp: GeneratedMessageCompanion[T]): Cost =
+  def toByteArrayCost[T <: GeneratedMessage with Message[T]](
+      a: T
+  )(implicit comp: GeneratedMessageCompanion[T]): Cost =
     Cost(a.serializedSize)
 
   //TODO(mateusz.gorski): adjust the cost of the nth method call.
@@ -64,13 +66,16 @@ trait Costs {
   final val MATCH_EVAL_COST = Cost(12)
 
   implicit def toStorageCostOps[A <: GeneratedMessage with Message[A]](a: Seq[A])(
-      implicit gm: GeneratedMessageCompanion[A]) = new StorageCostOps(a: _*)(gm)
+      implicit gm: GeneratedMessageCompanion[A]
+  ) = new StorageCostOps(a: _*)(gm)
 
   implicit def toStorageCostOps[A <: GeneratedMessage with Message[A]](a: A)(
-      implicit gm: GeneratedMessageCompanion[A]) = new StorageCostOps(a)(gm)
+      implicit gm: GeneratedMessageCompanion[A]
+  ) = new StorageCostOps(a)(gm)
 
   class StorageCostOps[A <: GeneratedMessage with Message[A]](a: A*)(
-      gm: GeneratedMessageCompanion[A]) {
+      gm: GeneratedMessageCompanion[A]
+  ) {
     def storageCost: Cost = Cost(a.map(a => gm.toByteArray(a).size).sum)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -26,13 +26,15 @@ object errors {
   final case class UnboundVariableRef(varName: String, line: Int, col: Int)
       extends InterpreterError(s"Variable reference: =$varName at $line:$col is unbound.")
 
-  final case class UnexpectedNameContext(varName: String,
-                                         procVarLine: Int,
-                                         procVarCol: Int,
-                                         nameContextLine: Int,
-                                         nameContextCol: Int)
-      extends InterpreterError(
-        s"Proc variable: $varName at $procVarLine:$procVarCol used in Name context at $nameContextLine:$nameContextCol")
+  final case class UnexpectedNameContext(
+      varName: String,
+      procVarLine: Int,
+      procVarCol: Int,
+      nameContextLine: Int,
+      nameContextCol: Int
+  ) extends InterpreterError(
+        s"Proc variable: $varName at $procVarLine:$procVarCol used in Name context at $nameContextLine:$nameContextCol"
+      )
 
   final case class UnexpectedReuseOfNameContextFree(
       varName: String,
@@ -42,7 +44,8 @@ object errors {
       secondUseCol: Int
   ) extends InterpreterError(
         s"Free variable $varName is used twice as a binder " +
-          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in name context.")
+          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in name context."
+      )
 
   final case class UnexpectedProcContext(
       varName: String,
@@ -52,7 +55,8 @@ object errors {
       processContextCol: Int
   ) extends InterpreterError(
         s"Name variable: $varName at $nameVarLine:$nameVarCol " +
-          s"used in process context at $processContextLine:$processContextCol")
+          s"used in process context at $processContextLine:$processContextCol"
+      )
 
   final case class UnexpectedReuseOfProcContextFree(
       varName: String,
@@ -62,7 +66,8 @@ object errors {
       secondUseCol: Int
   ) extends InterpreterError(
         s"Free variable $varName is used twice as a binder " +
-          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in process context.")
+          s"(at $firstUseLine:$firstUseCol and $secondUseLine:$secondUseCol) in process context."
+      )
 
   final case class UnexpectedBundleContent(message: String)     extends InterpreterError(message)
   final case class UnrecognizedNormalizerError(message: String) extends InterpreterError(message)
@@ -89,7 +94,8 @@ object errors {
 
   final case class MethodArgumentNumberMismatch(method: String, expected: Int, actual: Int)
       extends InterpreterError(
-        s"Error: Method `$method` expects $expected Par argument(s), but got $actual argument(s).")
+        s"Error: Method `$method` expects $expected Par argument(s), but got $actual argument(s)."
+      )
 
   final case class OperatorNotDefined(op: String, otherType: String)
       extends InterpreterError(s"Error: Operator `$op` is not defined on $otherType.")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatch.scala
@@ -9,7 +9,8 @@ import scala.collection.immutable.Stream
 
 object MaximumBipartiteMatch {
   def apply[P, T, R, F[_]: Monad](
-      matchFun: (P, T) => F[Option[R]]): MaximumBipartiteMatch[P, T, R, F] = {
+      matchFun: (P, T) => F[Option[R]]
+  ): MaximumBipartiteMatch[P, T, R, F] = {
     val fM = implicitly[Monad[F]]
     new MaximumBipartiteMatch[P, T, R, F] {
       private[matcher] override implicit val fMonad: Monad[F] = fM

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -34,11 +34,13 @@ trait SpatialMatcher[T, P] {
 
 object SpatialMatcher extends SpatialMatcherInstances {
   def spatialMatch[T, P](target: T, pattern: P)(
-      implicit sm: SpatialMatcher[T, P]): OptionalFreeMapWithCost[Unit] =
+      implicit sm: SpatialMatcher[T, P]
+  ): OptionalFreeMapWithCost[Unit] =
     SpatialMatcher[T, P].spatialMatch(target, pattern)
 
   def nonDetMatch[T, P](target: T, pattern: P)(
-      implicit sm: SpatialMatcher[T, P]): NonDetFreeMapWithCost[Unit] =
+      implicit sm: SpatialMatcher[T, P]
+  ): NonDetFreeMapWithCost[Unit] =
     SpatialMatcher[T, P].nonDetMatch(target, pattern)
 
   def apply[T, P](implicit sm: SpatialMatcher[T, P]) = sm
@@ -86,11 +88,13 @@ object SpatialMatcher extends SpatialMatcherInstances {
       }
     })
 
-  def subPars(par: Par,
-              min: ParCount,
-              max: ParCount,
-              minPrune: ParCount,
-              maxPrune: ParCount): Stream[(Par, Par)] = {
+  def subPars(
+      par: Par,
+      min: ParCount,
+      max: ParCount,
+      minPrune: ParCount,
+      maxPrune: ParCount
+  ): Stream[(Par, Par)] = {
 
     val sendMax    = math.min(max.sends, par.sends.size - minPrune.sends)
     val receiveMax = math.min(max.receives, par.receives.size - minPrune.receives)
@@ -117,20 +121,26 @@ object SpatialMatcher extends SpatialMatcherInstances {
       subIds      <- minMaxSubsets(par.ids, idMin, idMax)
       subBundles  <- minMaxSubsets(par.bundles, bundleMin, bundleMax)
     } yield
-      (Par(subSends._1,
-           subReceives._1,
-           subNews._1,
-           subExprs._1,
-           subMatches._1,
-           subIds._1,
-           subBundles._1),
-       Par(subSends._2,
-           subReceives._2,
-           subNews._2,
-           subExprs._2,
-           subMatches._2,
-           subIds._2,
-           subBundles._2))
+      (
+        Par(
+          subSends._1,
+          subReceives._1,
+          subNews._1,
+          subExprs._1,
+          subMatches._1,
+          subIds._1,
+          subBundles._1
+        ),
+        Par(
+          subSends._2,
+          subReceives._2,
+          subNews._2,
+          subExprs._2,
+          subMatches._2,
+          subIds._2,
+          subBundles._2
+        )
+      )
   }
 
   def minMaxSubsets[A](as: Seq[A], minSize: Int, maxSize: Int): Stream[(Seq[A], Seq[A])] = {
@@ -140,17 +150,17 @@ object SpatialMatcher extends SpatialMatcherInstances {
         case head +: rem =>
           (as.slice(0, 0), as, 0) #::
             (for {
-            countedTail               <- countedMaxSubsets(rem, maxSize)
-            (tail, complement, count) = countedTail
-            result <- {
-              if (count == maxSize)
-                Stream((tail, head +: complement, count))
-              else if (tail.isEmpty)
-                Stream((head +: tail, complement, 1))
-              else
-                Stream((tail, head +: complement, count), (head +: tail, complement, count + 1))
-            }
-          } yield result)
+              countedTail               <- countedMaxSubsets(rem, maxSize)
+              (tail, complement, count) = countedTail
+              result <- {
+                if (count == maxSize)
+                  Stream((tail, head +: complement, count))
+                else if (tail.isEmpty)
+                  Stream((head +: tail, complement, 1))
+                else
+                  Stream((tail, head +: complement, count), (head +: tail, complement, count + 1))
+              }
+            } yield result)
       }
     def worker(as: Seq[A], minSize: Int, maxSize: Int): Stream[(Seq[A], Seq[A], Int)] =
       if (maxSize < 0)
@@ -186,7 +196,8 @@ object SpatialMatcher extends SpatialMatcherInstances {
   // This helper function is useful in several productions
   def foldMatch[T, P](tlist: Seq[T], plist: Seq[P], remainder: Option[Var] = None)(
       implicit lft: HasLocallyFree[T],
-      sm: SpatialMatcher[T, P]): OptionalFreeMapWithCost[Seq[T]] =
+      sm: SpatialMatcher[T, P]
+  ): OptionalFreeMapWithCost[Seq[T]] =
     (tlist, plist) match {
       case (Nil, Nil) => OptionalFreeMapWithCost.pure(Nil)
       case (Nil, _) =>
@@ -214,9 +225,10 @@ object SpatialMatcher extends SpatialMatcherInstances {
         spatialMatch(t, p).flatMap(_ => foldMatch(trem, prem, remainder))
     }
 
-  def listMatchSingle[T](tlist: Seq[T], plist: Seq[T])(
-      implicit lf: HasLocallyFree[T],
-      sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] =
+  def listMatchSingle[T](
+      tlist: Seq[T],
+      plist: Seq[T]
+  )(implicit lf: HasLocallyFree[T], sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] =
     listMatchSingle_(tlist, plist, (p: Par, _: Seq[T]) => p, None, false)
 
   /** This function finds a single matching from a list of patterns and a list of targets.
@@ -235,13 +247,13 @@ object SpatialMatcher extends SpatialMatcherInstances {
     * @tparam T
     * @return
     */
-  def listMatchSingle_[T](tlist: Seq[T],
-                          plist: Seq[T],
-                          merger: (Par, Seq[T]) => Par,
-                          remainder: Option[Int],
-                          wildcard: Boolean)(
-      implicit lf: HasLocallyFree[T],
-      sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] = {
+  def listMatchSingle_[T](
+      tlist: Seq[T],
+      plist: Seq[T],
+      merger: (Par, Seq[T]) => Par,
+      remainder: Option[Int],
+      wildcard: Boolean
+  )(implicit lf: HasLocallyFree[T], sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] = {
     val exactMatch = !wildcard && remainder.isEmpty
     val plen       = plist.length
     val tlen       = tlist.length
@@ -266,13 +278,13 @@ object SpatialMatcher extends SpatialMatcherInstances {
     result
   }
 
-  private[this] def listMatch[T](targets: Seq[T],
-                                 patterns: Seq[T],
-                                 merger: (Par, Seq[T]) => Par,
-                                 remainder: Option[Int],
-                                 wildcard: Boolean)(
-      implicit lf: HasLocallyFree[T],
-      sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] = {
+  private[this] def listMatch[T](
+      targets: Seq[T],
+      patterns: Seq[T],
+      merger: (Par, Seq[T]) => Par,
+      remainder: Option[Int],
+      wildcard: Boolean
+  )(implicit lf: HasLocallyFree[T], sm: SpatialMatcher[T, T]): OptionalFreeMapWithCost[Unit] = {
 
     sealed trait Pattern
     case class Term(term: T)         extends Pattern
@@ -343,8 +355,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
 
   private def memoizeInHashMap[A, B, C](f: (A, B) => C): (A, B) => C = {
     val memo = mutable.HashMap[(A, B), C]()
-    (a, b) =>
-      memo.getOrElseUpdate((a, b), f(a, b))
+    (a, b) => memo.getOrElseUpdate((a, b), f(a, b))
   }
 
   private def aggregateUpdates(freeMaps: Seq[FreeMap]): OptionalFreeMapWithCost[FreeMap] =
@@ -365,23 +376,28 @@ object SpatialMatcher extends SpatialMatcherInstances {
   private def handleRemainder[T](
       remainderTargets: Seq[T],
       level: Int,
-      merger: (Par, Seq[T]) => Par)(implicit lf: HasLocallyFree[T]): OptionalFreeMapWithCost[Unit] =
+      merger: (Par, Seq[T]) => Par
+  )(implicit lf: HasLocallyFree[T]): OptionalFreeMapWithCost[Unit] =
     for {
-      remainderPar <- StateT.inspect[OptionWithCost, FreeMap, Par]((m: FreeMap) =>
-                       m.getOrElse(level, VectorPar()))
+      remainderPar <- StateT.inspect[OptionWithCost, FreeMap, Par](
+                       (m: FreeMap) => m.getOrElse(level, VectorPar())
+                     )
       //TODO: enforce sorted-ness of returned terms using types / by verifying the sorted-ness here
       remainderParUpdated = merger(remainderPar, remainderTargets)
-      _ <- StateT.modify[OptionWithCost, FreeMap]((m: FreeMap) =>
-            m + (level -> remainderParUpdated))
+      _ <- StateT.modify[OptionWithCost, FreeMap](
+            (m: FreeMap) => m + (level -> remainderParUpdated)
+          )
     } yield Unit
 
-  case class ParCount(sends: Int = 0,
-                      receives: Int = 0,
-                      news: Int = 0,
-                      exprs: Int = 0,
-                      matches: Int = 0,
-                      ids: Int = 0,
-                      bundles: Int = 0) {
+  case class ParCount(
+      sends: Int = 0,
+      receives: Int = 0,
+      news: Int = 0,
+      exprs: Int = 0,
+      matches: Int = 0,
+      ids: Int = 0,
+      bundles: Int = 0
+  ) {
     def min(other: ParCount): ParCount = binOp(math.min, other)
 
     def max(other: ParCount): ParCount = binOp(math.max, other)
@@ -592,52 +608,67 @@ trait SpatialMatcherInstances {
 
         def matchConnectiveWithBounds(
             target: Par,
-            labeledConnective: (Connective, (ParCount, ParCount), (ParCount, ParCount)))
-          : NonDetFreeMapWithCost[Par] = {
+            labeledConnective: (Connective, (ParCount, ParCount), (ParCount, ParCount))
+        ): NonDetFreeMapWithCost[Par] = {
           val (con, bounds, remainders) = labeledConnective
           for {
             sp <- NonDetFreeMapWithCost.liftF(
-                   subPars(target, bounds._1, bounds._2, remainders._1, remainders._2))
+                   subPars(target, bounds._1, bounds._2, remainders._1, remainders._2)
+                 )
             _ <- nonDetMatch(sp._1, con)
           } yield sp._2
         }
         for {
           remainder <- connectivesWithBounds.foldM(target)(matchConnectiveWithBounds)
-          _ <- listMatchSingle_[Send](remainder.sends,
-                                      pattern.sends,
-                                      (p, s) => p.withSends(s),
-                                      varLevel,
-                                      wildcard).toNonDet()
-          _ <- listMatchSingle_[Receive](remainder.receives,
-                                         pattern.receives,
-                                         (p, s) => p.withReceives(s),
-                                         varLevel,
-                                         wildcard).toNonDet()
-          _ <- listMatchSingle_[New](remainder.news,
-                                     pattern.news,
-                                     (p, s) => p.withNews(s),
-                                     varLevel,
-                                     wildcard).toNonDet()
-          _ <- listMatchSingle_[Expr](remainder.exprs,
-                                      noFrees(pattern.exprs),
-                                      (p, e) => p.withExprs(e),
-                                      varLevel,
-                                      wildcard).toNonDet()
-          _ <- listMatchSingle_[Match](remainder.matches,
-                                       pattern.matches,
-                                       (p, e) => p.withMatches(e),
-                                       varLevel,
-                                       wildcard).toNonDet()
-          _ <- listMatchSingle_[Bundle](remainder.bundles,
-                                        pattern.bundles,
-                                        (p, b) => p.withBundles(b),
-                                        varLevel,
-                                        wildcard).toNonDet()
-          _ <- listMatchSingle_[GPrivate](remainder.ids,
-                                          pattern.ids,
-                                          (p, i) => p.withIds(i),
-                                          varLevel,
-                                          wildcard).toNonDet()
+          _ <- listMatchSingle_[Send](
+                remainder.sends,
+                pattern.sends,
+                (p, s) => p.withSends(s),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[Receive](
+                remainder.receives,
+                pattern.receives,
+                (p, s) => p.withReceives(s),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[New](
+                remainder.news,
+                pattern.news,
+                (p, s) => p.withNews(s),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[Expr](
+                remainder.exprs,
+                noFrees(pattern.exprs),
+                (p, e) => p.withExprs(e),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[Match](
+                remainder.matches,
+                pattern.matches,
+                (p, e) => p.withMatches(e),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[Bundle](
+                remainder.bundles,
+                pattern.bundles,
+                (p, b) => p.withBundles(b),
+                varLevel,
+                wildcard
+              ).toNonDet()
+          _ <- listMatchSingle_[GPrivate](
+                remainder.ids,
+                pattern.ids,
+                (p, i) => p.withIds(i),
+                varLevel,
+                wildcard
+              ).toNonDet()
         } yield Unit
       }
   }
@@ -728,8 +759,10 @@ trait SpatialMatcherInstances {
             _ <- spatialMatch(t1, p1)
             _ <- spatialMatch(t2, p2)
           } yield Unit
-        case (EPercentPercentBody(EPercentPercent(t1, t2)),
-              EPercentPercentBody(EPercentPercent(p1, p2))) =>
+        case (
+            EPercentPercentBody(EPercentPercent(t1, t2)),
+            EPercentPercentBody(EPercentPercent(p1, p2))
+            ) =>
           for {
             _ <- spatialMatch(t1, p1)
             _ <- spatialMatch(t2, p2)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -55,8 +55,9 @@ package object matcher {
           }))
         })
 
-      def runWithCost(initCost: CostAccount)
-        : Either[OutOfPhlogistonsError.type, (CostAccount, Option[(FreeMap, A)])] =
+      def runWithCost(
+          initCost: CostAccount
+      ): Either[OutOfPhlogistonsError.type, (CostAccount, Option[(FreeMap, A)])] =
         s.run(Map.empty).value.run(initCost)
 
       def toNonDet(): NonDetFreeMapWithCost[A] =
@@ -116,8 +117,9 @@ package object matcher {
           }))
         })
 
-      def runWithCost(initCost: CostAccount)
-        : Either[OutOfPhlogistonsError.type, (CostAccount, Stream[(FreeMap, A)])] =
+      def runWithCost(
+          initCost: CostAccount
+      ): Either[OutOfPhlogistonsError.type, (CostAccount, Stream[(FreeMap, A)])] =
         s.run(Map.empty).value.run(initCost)
 
       def toDet(): OptionalFreeMapWithCost[A] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -52,7 +52,8 @@ object GroundNormalizeMatcher {
 
 object RemainderNormalizeMatcher {
   def handleProcVar[M[_]](pv: ProcVar, knownFree: DebruijnLevelMap[VarSort])(
-      implicit sync: Sync[M]): M[(Option[Var], DebruijnLevelMap[VarSort])] =
+      implicit sync: Sync[M]
+  ): M[(Option[Var], DebruijnLevelMap[VarSort])] =
     pv match {
       case pvw: ProcVarWildcard =>
         (Option(Var(Wildcard(Var.WildcardMsg()))), knownFree.addWildcard(pvw.line_num, pvw.col_num))
@@ -65,12 +66,14 @@ object RemainderNormalizeMatcher {
             (Option(Var(FreeVar(newBindingsPair._2))), newBindingsPair._1).pure[M]
           case Some((_, _, line, col)) =>
             sync.raiseError(
-              UnexpectedReuseOfProcContextFree(pvv.var_, line, col, pvv.line_num, pvv.col_num))
+              UnexpectedReuseOfProcContextFree(pvv.var_, line, col, pvv.line_num, pvv.col_num)
+            )
         }
     }
 
   def normalizeMatchProc[M[_]](r: ProcRemainder, knownFree: DebruijnLevelMap[VarSort])(
-      implicit err: Sync[M]): M[(Option[Var], DebruijnLevelMap[VarSort])] =
+      implicit err: Sync[M]
+  ): M[(Option[Var], DebruijnLevelMap[VarSort])] =
     r match {
       case _: ProcRemainderEmpty => (None: Option[Var], knownFree).pure[M]
       case pr: ProcRemainderVar =>
@@ -78,7 +81,8 @@ object RemainderNormalizeMatcher {
     }
 
   def normalizeMatchName[M[_]](nr: NameRemainder, knownFree: DebruijnLevelMap[VarSort])(
-      implicit err: Sync[M]): M[(Option[Var], DebruijnLevelMap[VarSort])] =
+      implicit err: Sync[M]
+  ): M[(Option[Var], DebruijnLevelMap[VarSort])] =
     nr match {
       case _: NameRemainderEmpty => (None: Option[Var], knownFree).pure[M]
       case nr: NameRemainderVar =>
@@ -88,33 +92,41 @@ object RemainderNormalizeMatcher {
 
 object CollectionNormalizeMatcher {
   def normalizeMatch[M[_]](c: Collection, input: CollectVisitInputs)(
-      implicit sync: Sync[M]): M[CollectVisitOutputs] = {
-    def foldMatch[T](knownFree: DebruijnLevelMap[VarSort],
-                     listproc: List[Proc],
-                     constructor: (Seq[Par], AlwaysEqual[BitSet], Boolean) => T)(
-        implicit toExpr: T => Expr): M[CollectVisitOutputs] = {
+      implicit sync: Sync[M]
+  ): M[CollectVisitOutputs] = {
+    def foldMatch[T](
+        knownFree: DebruijnLevelMap[VarSort],
+        listproc: List[Proc],
+        constructor: (Seq[Par], AlwaysEqual[BitSet], Boolean) => T
+    )(implicit toExpr: T => Expr): M[CollectVisitOutputs] = {
       val init = (Vector[Par](), knownFree, BitSet(), false)
       listproc
         .foldM(init) { (acc, proc) =>
           ProcNormalizeMatcher
             .normalizeMatch[M](proc, ProcVisitInputs(VectorPar(), input.env, acc._2))
             .map { result =>
-              (result.par +: acc._1,
-               result.knownFree,
-               acc._3 | result.par.locallyFree,
-               acc._4 || result.par.connectiveUsed)
+              (
+                result.par +: acc._1,
+                result.knownFree,
+                acc._3 | result.par.locallyFree,
+                acc._4 || result.par.connectiveUsed
+              )
             }
         }
         .map {
           case (ps, resultKnownFree, locallyFree, connectiveUsed) =>
-            CollectVisitOutputs(constructor(ps.reverse, locallyFree, connectiveUsed),
-                                resultKnownFree)
+            CollectVisitOutputs(
+              constructor(ps.reverse, locallyFree, connectiveUsed),
+              resultKnownFree
+            )
         }
     }
 
-    def foldMatchMap(knownFree: DebruijnLevelMap[VarSort],
-                     remainder: Option[Var],
-                     listProc: List[AbsynKeyValuePair]) = {
+    def foldMatchMap(
+        knownFree: DebruijnLevelMap[VarSort],
+        remainder: Option[Var],
+        listProc: List[AbsynKeyValuePair]
+    ) = {
       val init = (Vector[(Par, Par)](), knownFree, BitSet(), false)
       listProc
         .foldM(init) { (acc, e) =>
@@ -123,15 +135,19 @@ object CollectionNormalizeMatcher {
               for {
                 keyResult <- ProcNormalizeMatcher.normalizeMatch[M](
                               e.proc_1,
-                              ProcVisitInputs(VectorPar(), input.env, acc._2))
+                              ProcVisitInputs(VectorPar(), input.env, acc._2)
+                            )
                 valResult <- ProcNormalizeMatcher.normalizeMatch[M](
                               e.proc_2,
-                              ProcVisitInputs(VectorPar(), input.env, keyResult.knownFree))
+                              ProcVisitInputs(VectorPar(), input.env, keyResult.knownFree)
+                            )
               } yield
-                (Vector((keyResult.par, valResult.par)) ++ acc._1,
-                 valResult.knownFree,
-                 acc._3 | keyResult.par.locallyFree | valResult.par.locallyFree,
-                 acc._4 || keyResult.par.connectiveUsed || valResult.par.connectiveUsed)
+                (
+                  Vector((keyResult.par, valResult.par)) ++ acc._1,
+                  valResult.knownFree,
+                  acc._3 | keyResult.par.locallyFree | valResult.par.locallyFree,
+                  acc._4 || keyResult.par.connectiveUsed || valResult.par.connectiveUsed
+                )
           }
         }
         .map { folded =>
@@ -163,8 +179,9 @@ object CollectionNormalizeMatcher {
                   (ps, lf, cu) => {
                     val tmpEList = EList(ps, lf, cu, optionalRemainder)
                     tmpEList.withConnectiveUsed(
-                      tmpEList.connectiveUsed || optionalRemainder.isDefined)
-                }
+                      tmpEList.connectiveUsed || optionalRemainder.isDefined
+                    )
+                  }
 
               foldMatch(knownFree, cl.listproc_.toList, constructor(optionalRemainder))
           }
@@ -187,8 +204,9 @@ object CollectionNormalizeMatcher {
                     val tmpParSet =
                       ParSet(pars, connectiveUsed, Coeval.delay(locallyFree.get), optionalRemainder)
                     tmpParSet.copy(
-                      connectiveUsed = tmpParSet.connectiveUsed || optionalRemainder.isDefined)
-                }
+                      connectiveUsed = tmpParSet.connectiveUsed || optionalRemainder.isDefined
+                    )
+                  }
 
               foldMatch(knownFree, cs.listproc_.toList, constructor(optionalRemainder))
           }
@@ -206,7 +224,8 @@ object CollectionNormalizeMatcher {
 
 object NameNormalizeMatcher {
   def normalizeMatch[M[_]](n: Name, input: NameVisitInputs)(
-      implicit err: Sync[M]): M[NameVisitOutputs] =
+      implicit err: Sync[M]
+  ): M[NameVisitOutputs] =
     n match {
       case wc: NameWildcard =>
         val wildcardBindResult = input.knownFree.addWildcard(wc.line_num, wc.col_num)
@@ -227,7 +246,8 @@ object NameNormalizeMatcher {
                 NameVisitOutputs(ChanVar(FreeVar(newBindingsPair._2)), newBindingsPair._1).pure[M]
               case Some((_, _, line, col)) =>
                 err.raiseError(
-                  UnexpectedReuseOfNameContextFree(n.var_, line, col, n.line_num, n.col_num))
+                  UnexpectedReuseOfNameContextFree(n.var_, line, col, n.line_num, n.col_num)
+                )
             }
           }
         }
@@ -241,8 +261,10 @@ object NameNormalizeMatcher {
 
         ProcNormalizeMatcher
           .normalizeMatch[M](n.proc_, ProcVisitInputs(VectorPar(), input.env, input.knownFree))
-          .map(procVisitResult =>
-            NameVisitOutputs(collapseQuoteEval(procVisitResult.par), procVisitResult.knownFree))
+          .map(
+            procVisitResult =>
+              NameVisitOutputs(collapseQuoteEval(procVisitResult.par), procVisitResult.knownFree)
+          )
       }
     }
 
@@ -250,49 +272,60 @@ object NameNormalizeMatcher {
 
 object ProcNormalizeMatcher {
   def normalizeMatch[M[_]](p: Proc, input: ProcVisitInputs)(
-      implicit sync: Sync[M]): M[ProcVisitOutputs] = {
+      implicit sync: Sync[M]
+  ): M[ProcVisitOutputs] = {
     def unaryExp[T](subProc: Proc, input: ProcVisitInputs, constructor: Par => T)(
-        implicit toExprInstance: T => Expr): M[ProcVisitOutputs] =
+        implicit toExprInstance: T => Expr
+    ): M[ProcVisitOutputs] =
       normalizeMatch[M](subProc, input.copy(par = VectorPar()))
         .map(
           subResult =>
             ProcVisitOutputs(
               input.par.prepend(constructor(subResult.par), input.env.depth),
               subResult.knownFree
-          ))
+            )
+        )
 
     def binaryExp[T](
         subProcLeft: Proc,
         subProcRight: Proc,
         input: ProcVisitInputs,
-        constructor: (Par, Par) => T)(implicit toExprInstance: T => Expr): M[ProcVisitOutputs] =
+        constructor: (Par, Par) => T
+    )(implicit toExprInstance: T => Expr): M[ProcVisitOutputs] =
       for {
         leftResult <- normalizeMatch[M](subProcLeft, input.copy(par = VectorPar()))
         rightResult <- normalizeMatch[M](
                         subProcRight,
-                        input.copy(par = VectorPar(), knownFree = leftResult.knownFree))
+                        input.copy(par = VectorPar(), knownFree = leftResult.knownFree)
+                      )
       } yield
         ProcVisitOutputs(
           input.par.prepend(constructor(leftResult.par, rightResult.par), input.env.depth),
           rightResult.knownFree
         )
 
-    def normalizeIfElse(valueProc: Proc,
-                        trueBodyProc: Proc,
-                        falseBodyProc: Proc,
-                        input: ProcVisitInputs): M[ProcVisitOutputs] =
+    def normalizeIfElse(
+        valueProc: Proc,
+        trueBodyProc: Proc,
+        falseBodyProc: Proc,
+        input: ProcVisitInputs
+    ): M[ProcVisitOutputs] =
       for {
         targetResult <- normalizeMatch[M](valueProc, input)
         trueCaseBody <- normalizeMatch[M](
                          trueBodyProc,
-                         ProcVisitInputs(VectorPar(), input.env, targetResult.knownFree))
+                         ProcVisitInputs(VectorPar(), input.env, targetResult.knownFree)
+                       )
         falseCaseBody <- normalizeMatch[M](
                           falseBodyProc,
-                          ProcVisitInputs(VectorPar(), input.env, trueCaseBody.knownFree))
+                          ProcVisitInputs(VectorPar(), input.env, trueCaseBody.knownFree)
+                        )
         desugaredIf = Match(
           targetResult.par,
-          Vector(MatchCase(GBool(true), trueCaseBody.par, 0),
-                 MatchCase(GBool(false), falseCaseBody.par, 0)),
+          Vector(
+            MatchCase(GBool(true), trueCaseBody.par, 0),
+            MatchCase(GBool(false), falseCaseBody.par, 0)
+          ),
           targetResult.par.locallyFree | trueCaseBody.par.locallyFree | falseCaseBody.par.locallyFree,
           targetResult.par.connectiveUsed || trueCaseBody.par.connectiveUsed || falseCaseBody.par.connectiveUsed
         )
@@ -300,20 +333,27 @@ object ProcNormalizeMatcher {
 
     p match {
       case p: PNegation =>
-        normalizeMatch[M](p.proc_,
-                          ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]())).map(
+        normalizeMatch[M](
+          p.proc_,
+          ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]())
+        ).map(
           bodyResult =>
             ProcVisitOutputs(
               input.par.prepend(Connective(ConnNotBody(bodyResult.par)), input.env.depth),
-              input.knownFree))
+              input.knownFree
+            )
+        )
 
       case p: PConjunction =>
         for {
-          leftResult <- normalizeMatch[M](p.proc_1,
-                                          ProcVisitInputs(VectorPar(), input.env, input.knownFree))
+          leftResult <- normalizeMatch[M](
+                         p.proc_1,
+                         ProcVisitInputs(VectorPar(), input.env, input.knownFree)
+                       )
           rightResult <- normalizeMatch[M](
                           p.proc_2,
-                          ProcVisitInputs(VectorPar(), input.env, leftResult.knownFree))
+                          ProcVisitInputs(VectorPar(), input.env, leftResult.knownFree)
+                        )
           lp = leftResult.par
           resultConnective = lp.singleConnective() match {
             case Some(Connective(ConnAndBody(ConnectiveBody(ps)))) =>
@@ -322,17 +362,21 @@ object ProcNormalizeMatcher {
               Connective(ConnAndBody(ConnectiveBody(Vector(lp, rightResult.par))))
           }
         } yield
-          ProcVisitOutputs(input.par.prepend(resultConnective, input.env.depth),
-                           rightResult.knownFree)
+          ProcVisitOutputs(
+            input.par.prepend(resultConnective, input.env.depth),
+            rightResult.knownFree
+          )
 
       case p: PDisjunction =>
         for {
           leftResult <- normalizeMatch[M](
                          p.proc_1,
-                         ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]()))
+                         ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]())
+                       )
           rightResult <- normalizeMatch[M](
                           p.proc_2,
-                          ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]()))
+                          ProcVisitInputs(VectorPar(), input.env, DebruijnLevelMap[VarSort]())
+                        )
           lp = leftResult.par
           resultConnective = lp.singleConnective() match {
             case Some(Connective(ConnOrBody(ConnectiveBody(ps)))) =>
@@ -346,79 +390,102 @@ object ProcNormalizeMatcher {
       case p: PSimpleType =>
         p.simpletype_ match {
           case _: SimpleTypeBool =>
-            ProcVisitOutputs(input.par
-                               .prepend(Connective(ConnBool(true)), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree).pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(Connective(ConnBool(true)), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree
+            ).pure[M]
           case _: SimpleTypeInt =>
-            ProcVisitOutputs(input.par
-                               .prepend(Connective(ConnInt(true)), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree).pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(Connective(ConnInt(true)), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree
+            ).pure[M]
           case _: SimpleTypeString =>
-            ProcVisitOutputs(input.par
-                               .prepend(Connective(ConnString(true)), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree)
-              .pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(Connective(ConnString(true)), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree
+            ).pure[M]
           case _: SimpleTypeUri =>
-            ProcVisitOutputs(input.par
-                               .prepend(Connective(ConnUri(true)), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree).pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(Connective(ConnUri(true)), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree
+            ).pure[M]
           case _: SimpleTypeByteArray =>
-            ProcVisitOutputs(input.par
-                               .prepend(Connective(ConnByteArray(true)), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree).pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(Connective(ConnByteArray(true)), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree
+            ).pure[M]
         }
 
       case p: PGround =>
         ProcVisitOutputs(
           input.par.prepend(GroundNormalizeMatcher.normalizeMatch(p.ground_), input.env.depth),
-          input.knownFree).pure[M]
+          input.knownFree
+        ).pure[M]
 
       case p: PCollect =>
         CollectionNormalizeMatcher
           .normalizeMatch[M](p.collection_, CollectVisitInputs(input.env, input.knownFree))
-          .map(collectResult =>
-            ProcVisitOutputs(input.par.prepend(collectResult.expr, input.env.depth),
-                             collectResult.knownFree))
+          .map(
+            collectResult =>
+              ProcVisitOutputs(
+                input.par.prepend(collectResult.expr, input.env.depth),
+                collectResult.knownFree
+              )
+          )
 
       case p: PVar =>
         p.procvar_ match {
           case pvv: ProcVarVar =>
             input.env.get(pvv.var_) match {
               case Some((level, ProcSort, _, _)) =>
-                ProcVisitOutputs(input.par.prepend(EVar(BoundVar(level)), input.env.depth),
-                                 input.knownFree)
-                  .pure[M]
+                ProcVisitOutputs(
+                  input.par.prepend(EVar(BoundVar(level)), input.env.depth),
+                  input.knownFree
+                ).pure[M]
               case Some((_, NameSort, line, col)) =>
                 sync.raiseError(
-                  UnexpectedProcContext(pvv.var_, line, col, pvv.line_num, pvv.col_num))
+                  UnexpectedProcContext(pvv.var_, line, col, pvv.line_num, pvv.col_num)
+                )
               case None =>
                 input.knownFree.get(pvv.var_) match {
                   case None =>
                     val newBindingsPair =
                       input.knownFree.newBinding((pvv.var_, ProcSort, pvv.line_num, pvv.col_num))
-                    ProcVisitOutputs(input.par
-                                       .prepend(EVar(FreeVar(newBindingsPair._2)), input.env.depth)
-                                       .withConnectiveUsed(true),
-                                     newBindingsPair._1).pure[M]
+                    ProcVisitOutputs(
+                      input.par
+                        .prepend(EVar(FreeVar(newBindingsPair._2)), input.env.depth)
+                        .withConnectiveUsed(true),
+                      newBindingsPair._1
+                    ).pure[M]
                   case Some((_, _, line, col)) =>
                     sync.raiseError(
-                      UnexpectedReuseOfProcContextFree(pvv.var_,
-                                                       line,
-                                                       col,
-                                                       pvv.line_num,
-                                                       pvv.col_num))
+                      UnexpectedReuseOfProcContextFree(
+                        pvv.var_,
+                        line,
+                        col,
+                        pvv.line_num,
+                        pvv.col_num
+                      )
+                    )
                 }
             }
           case _: ProcVarWildcard =>
-            ProcVisitOutputs(input.par
-                               .prepend(EVar(Wildcard(Var.WildcardMsg())), input.env.depth)
-                               .withConnectiveUsed(true),
-                             input.knownFree.addWildcard(p.line_num, p.col_num)).pure[M]
+            ProcVisitOutputs(
+              input.par
+                .prepend(EVar(Wildcard(Var.WildcardMsg())), input.env.depth)
+                .withConnectiveUsed(true),
+              input.knownFree.addWildcard(p.line_num, p.col_num)
+            ).pure[M]
         }
 
       case p: PVarRef =>
@@ -430,18 +497,22 @@ object ProcNormalizeMatcher {
               case ProcSort =>
                 p.varrefkind_ match {
                   case _: VarRefKindProc =>
-                    ProcVisitOutputs(input.par.prepend(Connective(VarRefBody(VarRef(idx, depth))),
-                                                       input.env.depth),
-                                     input.knownFree).pure[M]
+                    ProcVisitOutputs(
+                      input.par
+                        .prepend(Connective(VarRefBody(VarRef(idx, depth))), input.env.depth),
+                      input.knownFree
+                    ).pure[M]
                   case _ =>
                     sync.raiseError(UnexpectedProcContext(p.var_, line, col, p.line_num, p.col_num))
                 }
               case NameSort =>
                 p.varrefkind_ match {
                   case _: VarRefKindName =>
-                    ProcVisitOutputs(input.par.prepend(Connective(VarRefBody(VarRef(idx, depth))),
-                                                       input.env.depth),
-                                     input.knownFree).pure[M]
+                    ProcVisitOutputs(
+                      input.par
+                        .prepend(Connective(VarRefBody(VarRef(idx, depth))), input.env.depth),
+                      input.knownFree
+                    ).pure[M]
                   case _ =>
                     sync.raiseError(UnexpectedNameContext(p.var_, line, col, p.line_num, p.col_num))
                 }
@@ -459,36 +530,47 @@ object ProcNormalizeMatcher {
 
         NameNormalizeMatcher
           .normalizeMatch[M](p.name_, NameVisitInputs(input.env, input.knownFree))
-          .map(nameMatchResult =>
-            ProcVisitOutputs(input.par ++ collapseEvalQuote(nameMatchResult.chan),
-                             nameMatchResult.knownFree))
+          .map(
+            nameMatchResult =>
+              ProcVisitOutputs(
+                input.par ++ collapseEvalQuote(nameMatchResult.chan),
+                nameMatchResult.knownFree
+              )
+          )
 
       case p: PMethod => {
         for {
           targetResult <- normalizeMatch[M](p.proc_, input.copy(par = Par()))
           target       = targetResult.par
-          initAcc = (List[Par](),
-                     ProcVisitInputs(Par(), input.env, targetResult.knownFree),
-                     BitSet(),
-                     false)
+          initAcc = (
+            List[Par](),
+            ProcVisitInputs(Par(), input.env, targetResult.knownFree),
+            BitSet(),
+            false
+          )
           argResults <- p.listproc_.toList.reverse.foldM(initAcc)((acc, e) => {
                          normalizeMatch[M](e, acc._2).map(
                            procMatchResult =>
-                             (procMatchResult.par :: acc._1,
-                              ProcVisitInputs(Par(), input.env, procMatchResult.knownFree),
-                              acc._3 | procMatchResult.par.locallyFree,
-                              acc._4 || procMatchResult.par.connectiveUsed))
+                             (
+                               procMatchResult.par :: acc._1,
+                               ProcVisitInputs(Par(), input.env, procMatchResult.knownFree),
+                               acc._3 | procMatchResult.par.locallyFree,
+                               acc._4 || procMatchResult.par.connectiveUsed
+                             )
+                         )
                        })
         } yield
           ProcVisitOutputs(
-            input.par.prepend(EMethod(
-                                p.var_,
-                                targetResult.par,
-                                argResults._1,
-                                target.locallyFree | argResults._3,
-                                target.connectiveUsed || argResults._4
-                              ),
-                              input.env.depth),
+            input.par.prepend(
+              EMethod(
+                p.var_,
+                targetResult.par,
+                argResults._1,
+                target.locallyFree | argResults._3,
+                target.connectiveUsed || argResults._4
+              ),
+              input.env.depth
+            ),
             argResults._2.knownFree
           )
       }
@@ -523,10 +605,14 @@ object ProcNormalizeMatcher {
 
         for {
           leftResult <- normalizeMatch[M](p.proc_1, input.copy(par = VectorPar()))
-          rightResult <- normalizeMatch[M](p.proc_2,
-                                           ProcVisitInputs(VectorPar(),
-                                                           input.env.pushDown(),
-                                                           DebruijnLevelMap[VarSort]()))
+          rightResult <- normalizeMatch[M](
+                          p.proc_2,
+                          ProcVisitInputs(
+                            VectorPar(),
+                            input.env.pushDown(),
+                            DebruijnLevelMap[VarSort]()
+                          )
+                        )
         } yield
           ProcVisitOutputs(
             input.par.prepend(EMatches(leftResult.par, rightResult.par), input.env.depth),
@@ -539,19 +625,30 @@ object ProcNormalizeMatcher {
         for {
           nameMatchResult <- NameNormalizeMatcher.normalizeMatch[M](
                               p.name_,
-                              NameVisitInputs(input.env, input.knownFree))
-          initAcc = (Vector[Par](),
-                     ProcVisitInputs(VectorPar(), input.env, nameMatchResult.knownFree),
-                     BitSet(),
-                     false)
+                              NameVisitInputs(input.env, input.knownFree)
+                            )
+          initAcc = (
+            Vector[Par](),
+            ProcVisitInputs(VectorPar(), input.env, nameMatchResult.knownFree),
+            BitSet(),
+            false
+          )
           dataResults <- p.listproc_.toList.reverse.foldM(initAcc)(
                           (acc, e) =>
                             normalizeMatch[M](e, acc._2).map(
                               procMatchResult =>
-                                (procMatchResult.par +: acc._1,
-                                 ProcVisitInputs(VectorPar(), input.env, procMatchResult.knownFree),
-                                 acc._3 | procMatchResult.par.locallyFree,
-                                 acc._4 || procMatchResult.par.connectiveUsed)))
+                                (
+                                  procMatchResult.par +: acc._1,
+                                  ProcVisitInputs(
+                                    VectorPar(),
+                                    input.env,
+                                    procMatchResult.knownFree
+                                  ),
+                                  acc._3 | procMatchResult.par.locallyFree,
+                                  acc._4 || procMatchResult.par.connectiveUsed
+                                )
+                            )
+                        )
           persistent = p.send_ match {
             case _: SendSingle   => false
             case _: SendMultiple => true
@@ -566,7 +663,8 @@ object ProcNormalizeMatcher {
                 ChannelLocallyFree
                   .locallyFree(nameMatchResult.chan, input.env.depth) | dataResults._3,
                 ChannelLocallyFree.connectiveUsed(nameMatchResult.chan) || dataResults._4
-              )),
+              )
+            ),
             dataResults._2.knownFree
           )
       }
@@ -577,8 +675,10 @@ object ProcNormalizeMatcher {
         // variables aren't free in the surrounding context: they're binders
         for {
           nameMatchResult <- NameNormalizeMatcher
-                              .normalizeMatch[M](p.name_,
-                                                 NameVisitInputs(input.env, input.knownFree))
+                              .normalizeMatch[M](
+                                p.name_,
+                                NameVisitInputs(input.env, input.knownFree)
+                              )
           initAcc = (Vector[Channel](), DebruijnLevelMap[VarSort](), BitSet())
           // Note that we go over these in the order they were given and reverse
           // down below. This is because it makes more sense to number the free
@@ -586,14 +686,19 @@ object ProcNormalizeMatcher {
           formalsResults <- p.listname_.toList.foldM(initAcc)(
                              (acc, n: Name) => {
                                NameNormalizeMatcher
-                                 .normalizeMatch[M](n,
-                                                    NameVisitInputs(input.env.pushDown(), acc._2))
+                                 .normalizeMatch[M](
+                                   n,
+                                   NameVisitInputs(input.env.pushDown(), acc._2)
+                                 )
                                  .map(
                                    result =>
-                                     (result.chan +: acc._1,
-                                      result.knownFree,
-                                      acc._3 | ChannelLocallyFree.locallyFree(result.chan,
-                                                                              input.env.depth + 1)))
+                                     (
+                                       result.chan +: acc._1,
+                                       result.knownFree,
+                                       acc._3 | ChannelLocallyFree
+                                         .locallyFree(result.chan, input.env.depth + 1)
+                                     )
+                                 )
                              }
                            )
           remainderResult <- RemainderNormalizeMatcher
@@ -602,16 +707,20 @@ object ProcNormalizeMatcher {
           boundCount = remainderResult._2.countNoWildcards
           bodyResult <- ProcNormalizeMatcher.normalizeMatch[M](
                          p.proc_,
-                         ProcVisitInputs(VectorPar(), newEnv, nameMatchResult.knownFree))
+                         ProcVisitInputs(VectorPar(), newEnv, nameMatchResult.knownFree)
+                       )
         } yield
           ProcVisitOutputs(
             input.par.prepend(
               Receive(
                 binds = List(
-                  ReceiveBind(formalsResults._1.reverse,
-                              nameMatchResult.chan,
-                              remainderResult._1,
-                              boundCount)),
+                  ReceiveBind(
+                    formalsResults._1.reverse,
+                    nameMatchResult.chan,
+                    remainderResult._1,
+                    boundCount
+                  )
+                ),
                 body = bodyResult.par,
                 persistent = true,
                 bindCount = boundCount,
@@ -622,7 +731,8 @@ object ProcNormalizeMatcher {
                     .map(x => x - boundCount)),
                 connectiveUsed = ChannelLocallyFree
                   .connectiveUsed(nameMatchResult.chan) || bodyResult.par.connectiveUsed
-              )),
+              )
+            ),
             bodyResult.knownFree
           )
       }
@@ -633,11 +743,9 @@ object ProcNormalizeMatcher {
         // We check for overlap at the end after sorting. We could check before, but it'd be an extra step.
 
         // We split this into parts. First we process all the sources, then we process all the bindings.
-        def processSources(sources: List[(List[Name], Name, NameRemainder)])
-          : M[(Vector[(List[Name], Channel, NameRemainder)],
-               DebruijnLevelMap[VarSort],
-               BitSet,
-               Boolean)] = {
+        def processSources(sources: List[(List[Name], Name, NameRemainder)]): M[
+          (Vector[(List[Name], Channel, NameRemainder)], DebruijnLevelMap[VarSort], BitSet, Boolean)
+        ] = {
           val initAcc =
             (Vector[(List[Name], Channel, NameRemainder)](), input.knownFree, BitSet(), false)
           sources
@@ -646,16 +754,20 @@ object ProcNormalizeMatcher {
                 .normalizeMatch[M](e._2, NameVisitInputs(input.env, acc._2))
                 .map(
                   sourceResult =>
-                    ((e._1, sourceResult.chan, e._3) +: acc._1,
-                     sourceResult.knownFree,
-                     acc._3 | ChannelLocallyFree.locallyFree(sourceResult.chan, input.env.depth),
-                     acc._4 || ChannelLocallyFree.connectiveUsed(sourceResult.chan)))
+                    (
+                      (e._1, sourceResult.chan, e._3) +: acc._1,
+                      sourceResult.knownFree,
+                      acc._3 | ChannelLocallyFree.locallyFree(sourceResult.chan, input.env.depth),
+                      acc._4 || ChannelLocallyFree.connectiveUsed(sourceResult.chan)
+                    )
+                )
             })
             .map(foldResult => (foldResult._1.reverse, foldResult._2, foldResult._3, foldResult._4))
         }
 
-        def processBindings(bindings: Vector[(List[Name], Channel, NameRemainder)])
-          : M[Vector[(Vector[Channel], Channel, Option[Var], DebruijnLevelMap[VarSort], BitSet)]] =
+        def processBindings(
+            bindings: Vector[(List[Name], Channel, NameRemainder)]
+        ): M[Vector[(Vector[Channel], Channel, Option[Var], DebruijnLevelMap[VarSort], BitSet)]] =
           bindings.traverse {
             case (names: List[Name], chan: Channel, nr: NameRemainder) => {
               val initAcc = (Vector[Channel](), DebruijnLevelMap[VarSort](), BitSet())
@@ -663,10 +775,14 @@ object ProcNormalizeMatcher {
                 .foldM(initAcc)((acc, n: Name) => {
                   NameNormalizeMatcher
                     .normalizeMatch[M](n, NameVisitInputs(input.env.pushDown(), acc._2))
-                    .map(result =>
-                      (result.chan +: acc._1,
-                       result.knownFree,
-                       acc._3 | ChannelLocallyFree.locallyFree(result.chan, input.env.depth + 1)))
+                    .map(
+                      result =>
+                        (
+                          result.chan +: acc._1,
+                          result.knownFree,
+                          acc._3 | ChannelLocallyFree.locallyFree(result.chan, input.env.depth + 1)
+                        )
+                    )
                 })
                 .flatMap {
                   case (patterns, knownFree, locallyFree) =>
@@ -674,11 +790,14 @@ object ProcNormalizeMatcher {
                       .normalizeMatchName[M](nr, knownFree)
                       .map(
                         remainderResult =>
-                          (patterns.reverse,
-                           chan,
-                           remainderResult._1,
-                           remainderResult._2,
-                           locallyFree))
+                          (
+                            patterns.reverse,
+                            chan,
+                            remainderResult._1,
+                            remainderResult._2,
+                            locallyFree
+                          )
+                      )
                 }
             }
           }
@@ -717,36 +836,47 @@ object ProcNormalizeMatcher {
           receipts <- ReceiveBindsSortMatcher
                        .preSortBinds[M, VarSort](bindingsTrimmed)
           mergedFrees <- receipts.toList.foldM[M, DebruijnLevelMap[VarSort]](
-                          DebruijnLevelMap[VarSort]())((env, receipt) =>
-                          env.merge(receipt._2) match {
-                            case (newEnv, Nil) => (newEnv: DebruijnLevelMap[VarSort]).pure[M]
-                            case (_, (shadowingVar, line, col) :: _) =>
-                              val Some((_, _, firstUsageLine, firstUsageCol)) =
-                                env.get(shadowingVar)
-                              sync.raiseError(
-                                UnexpectedReuseOfNameContextFree(shadowingVar,
-                                                                 firstUsageLine,
-                                                                 firstUsageCol,
-                                                                 line,
-                                                                 col))
-                        })
+                          DebruijnLevelMap[VarSort]()
+                        )(
+                          (env, receipt) =>
+                            env.merge(receipt._2) match {
+                              case (newEnv, Nil) => (newEnv: DebruijnLevelMap[VarSort]).pure[M]
+                              case (_, (shadowingVar, line, col) :: _) =>
+                                val Some((_, _, firstUsageLine, firstUsageCol)) =
+                                  env.get(shadowingVar)
+                                sync.raiseError(
+                                  UnexpectedReuseOfNameContextFree(
+                                    shadowingVar,
+                                    firstUsageLine,
+                                    firstUsageCol,
+                                    line,
+                                    col
+                                  )
+                                )
+                            }
+                        )
           bindCount  = mergedFrees.countNoWildcards
           binds      = receipts.map(receipt => receipt._1)
           updatedEnv = input.env.absorbFree(mergedFrees)._1
-          bodyResult <- normalizeMatch[M](p.proc_,
-                                          ProcVisitInputs(VectorPar(), updatedEnv, thisLevelFree))
+          bodyResult <- normalizeMatch[M](
+                         p.proc_,
+                         ProcVisitInputs(VectorPar(), updatedEnv, thisLevelFree)
+                       )
           connective = sourcesConnectives || bodyResult.par.connectiveUsed
         } yield
           ProcVisitOutputs(
             input.par.prepend(
-              Receive(binds,
-                      bodyResult.par,
-                      persistent,
-                      bindCount,
-                      sourcesLocallyFree | bindingsFree | (bodyResult.par.locallyFree
-                        .from(bindCount)
-                        .map(x => x - bindCount)),
-                      connective)),
+              Receive(
+                binds,
+                bodyResult.par,
+                persistent,
+                bindCount,
+                sourcesLocallyFree | bindingsFree | (bodyResult.par.locallyFree
+                  .from(bindCount)
+                  .map(x => x - bindCount)),
+                connective
+              )
+            ),
             bodyResult.knownFree
           )
 
@@ -780,10 +910,12 @@ object ProcNormalizeMatcher {
         normalizeMatch[M](p.proc_, ProcVisitInputs(VectorPar(), newEnv, input.knownFree))
           .map { bodyResult =>
             val resultNew =
-              New(newCount,
-                  bodyResult.par,
-                  uris,
-                  bodyResult.par.locallyFree.from(newCount).map(x => x - newCount))
+              New(
+                newCount,
+                bodyResult.par,
+                uris,
+                bodyResult.par.locallyFree.from(newCount).map(x => x - newCount)
+              )
             ProcVisitOutputs(input.par.prepend(resultNew), bodyResult.knownFree)
           }
       }
@@ -804,7 +936,9 @@ object ProcNormalizeMatcher {
           }
           sync.raiseError(
             UnexpectedBundleContent(
-              s"Bundle's content shouldn't have free variables or wildcards.$errMsg"))
+              s"Bundle's content shouldn't have free variables or wildcards.$errMsg"
+            )
+          )
         }
 
         import BundleOps._
@@ -840,29 +974,37 @@ object ProcNormalizeMatcher {
           cases        <- p.listcase_.toList.traverse(liftCase)
 
           initAcc = (Vector[MatchCase](), targetResult.knownFree, BitSet(), false)
-          casesResult <- cases.foldM(initAcc)((acc, caseImpl) =>
-                          caseImpl match {
-                            case (pattern, caseBody) => {
-                              for {
-                                patternResult <- normalizeMatch[M](
-                                                  pattern,
-                                                  ProcVisitInputs(VectorPar(),
-                                                                  input.env.pushDown(),
-                                                                  DebruijnLevelMap[VarSort]()))
-                                caseEnv    = input.env.absorbFree(patternResult.knownFree)._1
-                                boundCount = patternResult.knownFree.countNoWildcards
-                                caseBodyResult <- normalizeMatch[M](
-                                                   caseBody,
-                                                   ProcVisitInputs(VectorPar(), caseEnv, acc._2))
-                              } yield
-                                (MatchCase(patternResult.par, caseBodyResult.par, boundCount) +: acc._1,
-                                 caseBodyResult.knownFree,
-                                 acc._3 | patternResult.par.locallyFree | caseBodyResult.par.locallyFree
-                                   .from(boundCount)
-                                   .map(x => x - boundCount),
-                                 acc._4 || caseBodyResult.par.connectiveUsed)
+          casesResult <- cases.foldM(initAcc)(
+                          (acc, caseImpl) =>
+                            caseImpl match {
+                              case (pattern, caseBody) => {
+                                for {
+                                  patternResult <- normalizeMatch[M](
+                                                    pattern,
+                                                    ProcVisitInputs(
+                                                      VectorPar(),
+                                                      input.env.pushDown(),
+                                                      DebruijnLevelMap[VarSort]()
+                                                    )
+                                                  )
+                                  caseEnv    = input.env.absorbFree(patternResult.knownFree)._1
+                                  boundCount = patternResult.knownFree.countNoWildcards
+                                  caseBodyResult <- normalizeMatch[M](
+                                                     caseBody,
+                                                     ProcVisitInputs(VectorPar(), caseEnv, acc._2)
+                                                   )
+                                } yield
+                                  (
+                                    MatchCase(patternResult.par, caseBodyResult.par, boundCount) +: acc._1,
+                                    caseBodyResult.knownFree,
+                                    acc._3 | patternResult.par.locallyFree | caseBodyResult.par.locallyFree
+                                      .from(boundCount)
+                                      .map(x => x - boundCount),
+                                    acc._4 || caseBodyResult.par.connectiveUsed
+                                  )
+                              }
                             }
-                        })
+                        )
         } yield
           ProcVisitOutputs(
             input.par.prepend(
@@ -871,7 +1013,8 @@ object ProcNormalizeMatcher {
                 casesResult._1.reverse,
                 casesResult._3 | targetResult.par.locallyFree,
                 casesResult._4 || targetResult.par.connectiveUsed
-              )),
+              )
+            ),
             casesResult._2
           )
       }
@@ -896,9 +1039,11 @@ object ProcNormalizeMatcher {
   * @param env
   * @param knownFree
   */
-case class ProcVisitInputs(par: Par,
-                           env: IndexMapChain[VarSort],
-                           knownFree: DebruijnLevelMap[VarSort])
+case class ProcVisitInputs(
+    par: Par,
+    env: IndexMapChain[VarSort],
+    knownFree: DebruijnLevelMap[VarSort]
+)
 // Returns the update Par and an updated map of free variables.
 case class ProcVisitOutputs(par: Par, knownFree: DebruijnLevelMap[VarSort])
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -12,8 +12,12 @@ import coop.rchain.rspace.trace.{Consume, Produce}
 object StoragePrinter {
   def prettyPrint(store: RhoIStore): String = {
     val pars: Seq[Par] = store.toMap.map {
-      case ((channels: Seq[Channel],
-             row: Row[BindPattern, ListChannelWithRandom, TaggedContinuation])) => {
+      case (
+          (
+          channels: Seq[Channel],
+          row: Row[BindPattern, ListChannelWithRandom, TaggedContinuation]
+          )
+          ) => {
         def toSends(data: Seq[Datum[ListChannelWithRandom]]): Par = {
           val sends: Seq[Send] = data.flatMap {
             case Datum(as: ListChannelWithRandom, persist: Boolean, _: Produce) =>
@@ -31,10 +35,12 @@ object StoragePrinter {
 
         def toReceive(wks: Seq[WaitingContinuation[BindPattern, TaggedContinuation]]): Par = {
           val receives: Seq[Receive] = wks.map {
-            case WaitingContinuation(patterns: Seq[BindPattern],
-                                     continuation: TaggedContinuation,
-                                     persist: Boolean,
-                                     _: Consume) =>
+            case WaitingContinuation(
+                patterns: Seq[BindPattern],
+                continuation: TaggedContinuation,
+                persist: Boolean,
+                _: Consume
+                ) =>
               val receiveBinds: Seq[ReceiveBind] = (channels zip patterns).map {
                 case (channel, pattern) =>
                   ReceiveBind(pattern.patterns, channel, pattern.remainder, pattern.freeCount)
@@ -57,8 +63,10 @@ object StoragePrinter {
             toSends(data)
           case Row(Nil, wks: Seq[WaitingContinuation[BindPattern, TaggedContinuation]]) =>
             toReceive(wks)
-          case Row(data: Seq[Datum[ListChannelWithRandom]],
-                   wks: Seq[WaitingContinuation[BindPattern, TaggedContinuation]]) =>
+          case Row(
+              data: Seq[Datum[ListChannelWithRandom]],
+              wks: Seq[WaitingContinuation[BindPattern, TaggedContinuation]]
+              ) =>
             toSends(data) ++ toReceive(wks)
         }
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
@@ -15,30 +15,37 @@ import coop.rchain.rholang.interpreter.storage.implicits._
 
 trait TuplespaceAlg[F[_]] {
   def produce(chan: Channel, data: ListChannelWithRandom, persistent: Boolean): F[CostAccount]
-  def consume(binds: Seq[(BindPattern, Quote)],
-              body: ParWithRandom,
-              persistent: Boolean): F[CostAccount]
+  def consume(
+      binds: Seq[(BindPattern, Quote)],
+      body: ParWithRandom,
+      persistent: Boolean
+  ): F[CostAccount]
 }
 
 object TuplespaceAlg {
   def rspaceTuplespace[F[_], M[_]](
-      pureRSpace: PureRSpace[F,
-                             Channel,
-                             BindPattern,
-                             OutOfPhlogistonsError.type,
-                             ListChannelWithRandom,
-                             ListChannelWithRandom,
-                             TaggedContinuation],
-      dispatcher: => Dispatch[F, ListChannelWithRandom, TaggedContinuation])(
-      implicit F: Sync[F],
-      P: Parallel[F, M]): TuplespaceAlg[F] = new TuplespaceAlg[F] {
-    override def produce(channel: Channel,
-                         data: ListChannelWithRandom,
-                         persistent: Boolean): F[CostAccount] = {
+      pureRSpace: PureRSpace[
+        F,
+        Channel,
+        BindPattern,
+        OutOfPhlogistonsError.type,
+        ListChannelWithRandom,
+        ListChannelWithRandom,
+        TaggedContinuation
+      ],
+      dispatcher: => Dispatch[F, ListChannelWithRandom, TaggedContinuation]
+  )(implicit F: Sync[F], P: Parallel[F, M]): TuplespaceAlg[F] = new TuplespaceAlg[F] {
+    override def produce(
+        channel: Channel,
+        data: ListChannelWithRandom,
+        persistent: Boolean
+    ): F[CostAccount] = {
       // TODO: Handle the environment in the store
       def go(
-          res: Either[OutOfPhlogistonsError.type,
-                      Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]): F[CostAccount] =
+          res: Either[OutOfPhlogistonsError.type, Option[
+            (TaggedContinuation, Seq[ListChannelWithRandom])
+          ]]
+      ): F[CostAccount] =
         res match {
           case Right(Some((continuation, dataList))) =>
             val rspaceMatchCost =
@@ -48,8 +55,10 @@ object TuplespaceAlg {
                 .map(ca => ca.copy(cost = Cost(Integer.MAX_VALUE) - ca.cost))
                 .combineAll
             if (persistent) {
-              List(dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount(0)),
-                   produce(channel, data, persistent)).parSequence
+              List(
+                dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount(0)),
+                produce(channel, data, persistent)
+              ).parSequence
                 .map(_.combineAll + rspaceMatchCost)
             } else {
               dispatcher.dispatch(continuation, dataList) *> rspaceMatchCost.pure[F]
@@ -64,17 +73,20 @@ object TuplespaceAlg {
       } yield cost
     }
 
-    override def consume(binds: Seq[(BindPattern, Quote)],
-                         body: ParWithRandom,
-                         persistent: Boolean): F[CostAccount] =
+    override def consume(
+        binds: Seq[(BindPattern, Quote)],
+        body: ParWithRandom,
+        persistent: Boolean
+    ): F[CostAccount] =
       binds match {
         case Nil => F.raiseError(ReduceError("Error: empty binds"))
         case _ =>
           val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
           def go(
-              res: Either[OutOfPhlogistonsError.type,
-                          Option[(TaggedContinuation, Seq[ListChannelWithRandom])]])
-            : F[CostAccount] =
+              res: Either[OutOfPhlogistonsError.type, Option[
+                (TaggedContinuation, Seq[ListChannelWithRandom])
+              ]]
+          ): F[CostAccount] =
             res match {
               case Right(Some((continuation, dataList))) =>
                 val rspaceMatchCost =
@@ -82,15 +94,18 @@ object TuplespaceAlg {
                     .map(
                       _.cost
                         .map(CostAccount.fromProto(_))
-                        .getOrElse(CostAccount(0)))
+                        .getOrElse(CostAccount(0))
+                    )
                     .toList
                     .map(ca => ca.copy(cost = Cost(Integer.MAX_VALUE) - ca.cost))
                     .combineAll
 
                 dispatcher.dispatch(continuation, dataList)
                 if (persistent) {
-                  List(dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount(0)),
-                       consume(binds, body, persistent)).parSequence
+                  List(
+                    dispatcher.dispatch(continuation, dataList) *> F.pure(CostAccount(0)),
+                    consume(binds, body, persistent)
+                  ).parSequence
                     .map(_.combineAll + rspaceMatchCost)
                 } else {
                   dispatcher.dispatch(continuation, dataList) *> rspaceMatchCost.pure[F]
@@ -99,10 +114,12 @@ object TuplespaceAlg {
             }
 
           for {
-            res <- pureRSpace.consume(sources.map(q => Channel(q)).toList,
-                                      patterns.toList,
-                                      TaggedContinuation(ParBody(body)),
-                                      persist = persistent)
+            res <- pureRSpace.consume(
+                    sources.map(q => Channel(q)).toList,
+                    patterns.toList,
+                    TaggedContinuation(ParBody(body)),
+                    persist = persistent
+                  )
             cost <- go(res)
           } yield cost
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -24,17 +24,23 @@ object implicits {
       }
     }
 
-  implicit val matchListQuote: StorageMatch[BindPattern,
-                                            OutOfPhlogistonsError.type,
-                                            ListChannelWithRandom,
-                                            ListChannelWithRandom] =
-    new StorageMatch[BindPattern,
-                     OutOfPhlogistonsError.type,
-                     ListChannelWithRandom,
-                     ListChannelWithRandom] {
+  implicit val matchListQuote: StorageMatch[
+    BindPattern,
+    OutOfPhlogistonsError.type,
+    ListChannelWithRandom,
+    ListChannelWithRandom
+  ] =
+    new StorageMatch[
+      BindPattern,
+      OutOfPhlogistonsError.type,
+      ListChannelWithRandom,
+      ListChannelWithRandom
+    ] {
 
-      def get(pattern: BindPattern, data: ListChannelWithRandom)
-        : Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] =
+      def get(
+          pattern: BindPattern,
+          data: ListChannelWithRandom
+      ): Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] =
         SpatialMatcher
           .foldMatch(data.channels, pattern.patterns, pattern.remainder)
           .runWithCost(CostAccount(Integer.MAX_VALUE)) // FIXME -- must come from the input args
@@ -51,9 +57,11 @@ object implicits {
                         freeMap + (level -> VectorPar().addExprs(EList(flatRem.toVector)))
                       case _ => freeMap
                     }
-                    ListChannelWithRandom(toChannels(remainderMap, pattern.freeCount),
-                                          data.randomState,
-                                          Some(CostAccount.toProto(cost)))
+                    ListChannelWithRandom(
+                      toChannels(remainderMap, pattern.freeCount),
+                      data.randomState,
+                      Some(CostAccount.toProto(cost))
+                    )
                 }
           }
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -51,10 +51,12 @@ class CryptoChannelsSpec
   val parToExpr: Par => Expr                           = parToByteString andThen byteStringToExpr
 
   // this should consume from the `ack` channel effectively preparing tuplespace for next test
-  def clearStore(store: RhoIStore,
-                 reduce: Reduce[Task],
-                 ackChannel: Par,
-                 timeout: Duration = 3.seconds)(implicit env: Env[Par]): Unit = {
+  def clearStore(
+      store: RhoIStore,
+      reduce: Reduce[Task],
+      ackChannel: Par,
+      timeout: Duration = 3.seconds
+  )(implicit env: Env[Par]): Unit = {
     val consume = Receive(
       Seq(ReceiveBind(Seq(Channel(ChanVar(Var(Wildcard(WildcardMsg()))))), Quote(ackChannel))),
       Par()
@@ -65,7 +67,8 @@ class CryptoChannelsSpec
   def assertStoreContains(store: RhoIStore)(ackChannel: GString)(data: ListChannelWithRandom)(
       implicit
       serializeChannel: Serialize[Channel],
-      serializeChannels: Serialize[ListChannelWithRandom]): Assertion = {
+      serializeChannels: Serialize[ListChannelWithRandom]
+  ): Assertion = {
     val channel = Channel(Quote(ackChannel))
     val datum   = store.toMap(List(channel)).data.head
     assert(datum.a.channels == data.channels)
@@ -73,12 +76,15 @@ class CryptoChannelsSpec
     assert(!datum.persist)
   }
 
-  def hashingChannel(channelName: String,
-                     hashFn: Array[Byte] => Array[Byte],
-                     fixture: FixtureParam)(
+  def hashingChannel(
+      channelName: String,
+      hashFn: Array[Byte] => Array[Byte],
+      fixture: FixtureParam
+  )(
       implicit
       serializeChannel: Serialize[Channel],
-      serializeChannels: Serialize[ListChannelWithRandom]): Any = {
+      serializeChannels: Serialize[ListChannelWithRandom]
+  ): Any = {
     val (reduce, store) = fixture
 
     val serializeAndHash: (Array[Byte] => Array[Byte]) => Par => Array[Byte] =
@@ -134,7 +140,8 @@ class CryptoChannelsSpec
       val secp256k1VerifyhashChannel = Quote(GString("secp256k1Verify"))
 
       val pubKey = Base16.decode(
-        "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6")
+        "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6"
+      )
       val secKey = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
 
       val ackChannel        = GString("x")
@@ -154,13 +161,16 @@ class CryptoChannelsSpec
         val refVerify = Secp256k1.verify(parByteArray, signature, pubKey)
         assert(refVerify === true)
 
-        val send = Send(secp256k1VerifyhashChannel,
-                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
-                        persistent = false,
-                        BitSet())
+        val send = Send(
+          secp256k1VerifyhashChannel,
+          List(serializedPar, signaturePar, pubKeyPar, ackChannel),
+          persistent = false,
+          BitSet()
+        )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0))))
+          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+        )
         clearStore(store, reduce, ackChannel)
       }
   }
@@ -191,13 +201,16 @@ class CryptoChannelsSpec
         val refVerify = Ed25519.verify(parByteArray, signature, pubKey)
         assert(refVerify === true)
 
-        val send = Send(ed25519VerifyChannel,
-                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
-                        persistent = false,
-                        BitSet())
+        val send = Send(
+          ed25519VerifyChannel,
+          List(serializedPar, signaturePar, pubKeyPar, ackChannel),
+          persistent = false,
+          BitSet()
+        )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0))))
+          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+        )
         clearStore(store, reduce, ackChannel)
       }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/EnvTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/EnvTest.scala
@@ -24,6 +24,7 @@ class EnvSpec extends FlatSpec with Matchers {
     val target2: Env[Par] = Env.makeEnv(source3, source4)
     val result            = target1.merge(target2)
     result should be(
-      Env[Par](Map(0 -> source0, 1 -> source1, 2 -> source2, 3 -> source3, 4 -> source4), 5, 0))
+      Env[Par](Map(0 -> source0, 1 -> source1, 2 -> source2, 3 -> source3, 4 -> source4), 5, 0)
+    )
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -1179,18 +1179,21 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listCases.add(new CaseImpl(new PVarRef(new VarRefKindProc(), "x"), new PNil()))
     val proc = new PMatch(new PGround(new GroundInt("7")), listCases)
 
-    // format: off
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](proc, boundInputs).value
     val expectedResult = inputs.par
       .addMatches(
-        Match(target = GInt(7),
-              cases =
-                List(MatchCase(
-                  pattern = Connective(VarRefBody(VarRef(0, 1))).withLocallyFree(BitSet(0)),
-                  source = Par())),
-              locallyFree = BitSet(0)))
+        Match(
+          target = GInt(7),
+          cases = List(
+            MatchCase(
+              pattern = Connective(VarRefBody(VarRef(0, 1))).withLocallyFree(BitSet(0)),
+              source = Par()
+            )
+          ),
+          locallyFree = BitSet(0)
+        )
+      )
       .withLocallyFree(BitSet(0))
-    // format: on
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
     // Make sure that variable references in patterns are reflected

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -56,7 +56,8 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
   val inputs = ProcVisitInputs(
     Par(),
     IndexMapChain[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0))),
-    DebruijnLevelMap[VarSort]())
+    DebruijnLevelMap[VarSort]()
+  )
 
   "List" should "delegate" in {
     val listData = new ListProc()
@@ -68,9 +69,13 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value
     result.par should be(
       inputs.par.prepend(
-        EList(List[Par](EVar(BoundVar(1)), EEvalBody(ChanVar(BoundVar(0))), GInt(7)),
-              locallyFree = BitSet(0, 1)),
-        0))
+        EList(
+          List[Par](EVar(BoundVar(1)), EEvalBody(ChanVar(BoundVar(0))), GInt(7)),
+          locallyFree = BitSet(0, 1)
+        ),
+        0
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -82,15 +87,21 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](tuple, inputs).value
     result.par should be(
-      inputs.par.prepend(ETuple(List[Par](
-                                  EVar(FreeVar(0)),
-                                  EEvalBody(ChanVar(FreeVar(1)))
-                                ),
-                                locallyFree = BitSet(),
-                                connectiveUsed = true),
-                         0))
+      inputs.par.prepend(
+        ETuple(
+          List[Par](
+            EVar(FreeVar(0)),
+            EEvalBody(ChanVar(FreeVar(1)))
+          ),
+          locallyFree = BitSet(),
+          connectiveUsed = true
+        ),
+        0
+      )
+    )
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("Q", ProcSort, 0, 0), ("y", NameSort, 0, 0)))._1)
+      inputs.knownFree.newBindings(List(("Q", ProcSort, 0, 0), ("y", NameSort, 0, 0)))._1
+    )
   }
   "Tuple" should "propagate free variables" in {
     val tupleData = new ListProc()
@@ -115,11 +126,15 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
 
     result.par should be(
       inputs.par.prepend(
-        ParSet(Seq[Par](EPlus(EVar(BoundVar(1)), EVar(FreeVar(1))),
-                        GInt(7),
-                        GInt(8).prepend(EVar(FreeVar(2)), 0)),
-               connectiveUsed = true,
-               remainder = Some(FreeVar(0))),
+        ParSet(
+          Seq[Par](
+            EPlus(EVar(BoundVar(1)), EVar(FreeVar(1))),
+            GInt(7),
+            GInt(8).prepend(EVar(FreeVar(2)), 0)
+          ),
+          connectiveUsed = true,
+          remainder = Some(FreeVar(0))
+        ),
         depth = 0
       )
     )
@@ -134,7 +149,8 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
   "Map" should "delegate" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
-      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven"))))
+      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven")))
+    )
     mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("Q"))))
     val map = new PCollect(new CollectMap(mapData, new ProcRemainderVar(new ProcVarVar("Z"))))
 
@@ -142,14 +158,17 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     result.par should be(
       inputs.par.prepend(
         ParMap(
-          List[(Par, Par)]((GInt(7), GString("Seven")),
-                           (EVar(BoundVar(1)), EEvalBody(ChanVar(FreeVar(1))))),
+          List[(Par, Par)](
+            (GInt(7), GString("Seven")),
+            (EVar(BoundVar(1)), EEvalBody(ChanVar(FreeVar(1))))
+          ),
           locallyFree = BitSet(1),
           connectiveUsed = true,
           remainder = Some(Var(FreeVar(0)))
         ),
         depth = 0
-      ))
+      )
+    )
     val newBindings = List(
       ("Z", ProcSort, 0, 0),
       ("Q", NameSort, 0, 0)
@@ -210,7 +229,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   }
   "PEval" should "Collapse a quote" in {
     val pEval = new PEval(
-      new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))))
+      new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x"))))
+    )
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value
@@ -267,11 +287,14 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       )
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pPercentPercent, inputs).value
     result.par should be(
-      inputs.par.prepend(EPercentPercent(
-                           GString("Hi ${name}"),
-                           ParMap(seq = List[(Par, Par)]((GString("name"), GString("Alice"))))
-                         ),
-                         0))
+      inputs.par.prepend(
+        EPercentPercent(
+          GString("Hi ${name}"),
+          ParMap(seq = List[(Par, Par)]((GString("name"), GString("Alice"))))
+        ),
+        0
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -286,15 +309,19 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   }
 
   "PMinus" should "Delegate" in {
-    val pMinus = new PMinus(new PVar(new ProcVarVar("x")),
-                            new PMult(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("z"))))
+    val pMinus = new PMinus(
+      new PVar(new ProcVarVar("x")),
+      new PMult(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("z")))
+    )
     val boundInputs = inputs.copy(
       env = inputs.env
-        .newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0), ("z", ProcSort, 0, 0))))
+        .newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0), ("z", ProcSort, 0, 0)))
+    )
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pMinus, boundInputs).value
     result.par should be(
-      inputs.par.prepend(EMinus(EVar(BoundVar(2)), EMult(EVar(BoundVar(1)), EVar(BoundVar(0)))), 0))
+      inputs.par.prepend(EMinus(EVar(BoundVar(2)), EMult(EVar(BoundVar(1)), EVar(BoundVar(0)))), 0)
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -326,7 +353,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, inputs).value
     result.par should be(
-      inputs.par.prepend(Send(Quote(Par()), List[Par](GInt(7), GInt(8)), false, BitSet())))
+      inputs.par.prepend(Send(Quote(Par()), List[Par](GInt(7), GInt(8)), false, BitSet()))
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -339,7 +367,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, boundInputs).value
     result.par should be(
-      inputs.par.prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(7), GInt(8)), false, BitSet(0))))
+      inputs.par.prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(7), GInt(8)), false, BitSet(0)))
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -367,7 +396,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleBound, boundInputs).value
     result.par should be(
-      inputs.par.copy(exprs = List(EVar(BoundVar(0)), EVar(BoundVar(0))), locallyFree = BitSet(0)))
+      inputs.par.copy(exprs = List(EVar(BoundVar(0)), EVar(BoundVar(0))), locallyFree = BitSet(0))
+    )
     result.knownFree should be(inputs.knownFree)
   }
   "PPar" should "Not compile if both branches use the same free variable" in {
@@ -381,9 +411,11 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleFree, inputs).value
     result.par should be(
-      inputs.par.copy(exprs = List(EVar(FreeVar(1)), EVar(FreeVar(0))), connectiveUsed = true))
+      inputs.par.copy(exprs = List(EVar(FreeVar(1)), EVar(FreeVar(0))), connectiveUsed = true)
+    )
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1)
+      inputs.knownFree.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1
+    )
   }
 
   "PPar" should "normalize without StackOverflowError-s even for huge programs" in {
@@ -410,27 +442,37 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val bindCount = 3
     val listSend  = new ListProc()
     listSend.add(new PAdd(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y"))))
-    val pBasicContr = new PContr(new NameVar("add"),
-                                 listBindings,
-                                 new NameRemainderEmpty(),
-                                 new PSend(new NameVar("ret"), new SendSingle(), listSend))
+    val pBasicContr = new PContr(
+      new NameVar("add"),
+      listBindings,
+      new NameRemainderEmpty(),
+      new PSend(new NameVar("ret"), new SendSingle(), listSend)
+    )
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("add", NameSort, 0, 0)))
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pBasicContr, boundInputs).value
     result.par should be(
-      inputs.par.prepend(Receive(
-        List(
-          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1))), Quote(EVar(FreeVar(2)))),
-                      ChanVar(BoundVar(0)),
-                      freeCount = 3)),
-        Send(ChanVar(BoundVar(2)),
-             List[Par](EPlus(EVar(BoundVar(1)), EVar(BoundVar(0)))),
-             false,
-             BitSet(0, 1, 2)),
-        true, // persistent
-        bindCount,
-        BitSet(0)
-      )))
+      inputs.par.prepend(
+        Receive(
+          List(
+            ReceiveBind(
+              List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1))), Quote(EVar(FreeVar(2)))),
+              ChanVar(BoundVar(0)),
+              freeCount = 3
+            )
+          ),
+          Send(
+            ChanVar(BoundVar(2)),
+            List[Par](EPlus(EVar(BoundVar(1)), EVar(BoundVar(0)))),
+            false,
+            BitSet(0, 1, 2)
+          ),
+          true, // persistent
+          bindCount,
+          BitSet(0)
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -448,23 +490,32 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val bindCount = 1
     val listSend  = new ListProc()
     listSend.add(new PGround(new GroundInt("5")))
-    val pBasicContr = new PContr(new NameVar("ret5"),
-                                 listBindings,
-                                 new NameRemainderEmpty(),
-                                 new PSend(new NameVar("ret"), new SendSingle(), listSend))
+    val pBasicContr = new PContr(
+      new NameVar("ret5"),
+      listBindings,
+      new NameRemainderEmpty(),
+      new PSend(new NameVar("ret"), new SendSingle(), listSend)
+    )
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("ret5", NameSort, 0, 0)))
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pBasicContr, boundInputs).value
     result.par should be(
-      inputs.par.prepend(Receive(
-        List(ReceiveBind(List(ChanVar(FreeVar(0)), Quote(Par().copy(exprs = List(GInt(5))))),
-                         ChanVar(BoundVar(0)),
-                         freeCount = 1)),
-        Send(ChanVar(BoundVar(0)), List(Par().copy(exprs = List(GInt(5)))), false, BitSet(0)),
-        true, // persistent
-        bindCount,
-        BitSet(0)
-      )))
+      inputs.par.prepend(
+        Receive(
+          List(
+            ReceiveBind(
+              List(ChanVar(FreeVar(0)), Quote(Par().copy(exprs = List(GInt(5))))),
+              ChanVar(BoundVar(0)),
+              freeCount = 1
+            )
+          ),
+          Send(ChanVar(BoundVar(0)), List(Par().copy(exprs = List(GInt(5)))), false, BitSet(0)),
+          true, // persistent
+          bindCount,
+          BitSet(0)
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -475,7 +526,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings.add(new NameVar("y"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
 
@@ -487,15 +539,24 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value
     result.par should be(
-      inputs.par.prepend(Receive(
-        List(
-          ReceiveBind(List(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))), Quote(Par()), freeCount = 2)),
-        Send(ChanVar(BoundVar(1)), List[Par](EEvalBody(ChanVar(BoundVar(0)))), false, BitSet(0, 1)),
-        persistent = false,
-        bindCount,
-        BitSet(),
-        connectiveUsed = false
-      )))
+      inputs.par.prepend(
+        Receive(
+          List(
+            ReceiveBind(List(ChanVar(FreeVar(0)), ChanVar(FreeVar(1))), Quote(Par()), freeCount = 2)
+          ),
+          Send(
+            ChanVar(BoundVar(1)),
+            List[Par](EEvalBody(ChanVar(BoundVar(0)))),
+            false,
+            BitSet(0, 1)
+          ),
+          persistent = false,
+          bindCount,
+          BitSet(),
+          connectiveUsed = false
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
   "PInput" should "Handle a more complicated receive" in {
@@ -508,11 +569,15 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings2.add(new NameQuote(new PVar(new ProcVarVar("y2"))))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings2,
-                         new NameRemainderEmpty(),
-                         new NameQuote(new PGround(new GroundInt("1")))))
+      new LinearBindImpl(
+        listBindings2,
+        new NameRemainderEmpty(),
+        new NameQuote(new PGround(new GroundInt("1")))
+      )
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
 
@@ -520,34 +585,43 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listSend1.add(new PVar(new ProcVarVar("y2")))
     val listSend2 = new ListProc()
     listSend2.add(new PVar(new ProcVarVar("y1")))
-    val body = new PPar(new PSend(new NameVar("x1"), new SendSingle(), listSend1),
-                        new PSend(new NameVar("x2"), new SendSingle(), listSend2))
+    val body = new PPar(
+      new PSend(new NameVar("x1"), new SendSingle(), listSend1),
+      new PSend(new NameVar("x2"), new SendSingle(), listSend2)
+    )
     val pInput    = new PInput(receipt, body)
     val bindCount = 4
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pInput, inputs).value
     result.par should be(
-      inputs.par.prepend(Receive(
-        List(
-          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))),
-                      Quote(Par()),
-                      freeCount = 2),
-          ReceiveBind(List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))),
-                      Quote(GInt(1)),
-                      freeCount = 2)
-        ),
-        Par().copy(
-          sends = List(
-            Send(ChanVar(BoundVar(1)), List[Par](EVar(BoundVar(2))), false, BitSet(1, 2)),
-            Send(ChanVar(BoundVar(3)), List[Par](EVar(BoundVar(0))), false, BitSet(0, 3))
+      inputs.par.prepend(
+        Receive(
+          List(
+            ReceiveBind(
+              List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))),
+              Quote(Par()),
+              freeCount = 2
+            ),
+            ReceiveBind(
+              List(ChanVar(FreeVar(0)), Quote(EVar(FreeVar(1)))),
+              Quote(GInt(1)),
+              freeCount = 2
+            )
           ),
-          locallyFree = BitSet(0, 1, 2, 3)
-        ),
-        persistent = false,
-        bindCount,
-        BitSet(),
-        connectiveUsed = false
-      )))
+          Par().copy(
+            sends = List(
+              Send(ChanVar(BoundVar(1)), List[Par](EVar(BoundVar(2))), false, BitSet(1, 2)),
+              Send(ChanVar(BoundVar(3)), List[Par](EVar(BoundVar(0))), false, BitSet(0, 3))
+            ),
+            locallyFree = BitSet(0, 1, 2, 3)
+          ),
+          persistent = false,
+          bindCount,
+          BitSet(),
+          connectiveUsed = false
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -556,10 +630,13 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val listBindings = new ListName()
     listBindings.add(
       new NameQuote(
-        new PCollect(new CollectList(new ListProc(), new ProcRemainderVar(new ProcVarVar("a"))))))
+        new PCollect(new CollectList(new ListProc(), new ProcRemainderVar(new ProcVarVar("a"))))
+      )
+    )
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val bindCount    = 1
@@ -570,17 +647,24 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
         List(
           ReceiveBind(
             List(
-              Quote(Par(connectiveUsed = true,
-                        exprs = List(EList(connectiveUsed = true, remainder = Some(FreeVar(0))))))),
+              Quote(
+                Par(
+                  connectiveUsed = true,
+                  exprs = List(EList(connectiveUsed = true, remainder = Some(FreeVar(0))))
+                )
+              )
+            ),
             Quote(Par()),
-            freeCount = 1)
+            freeCount = 1
+          )
         ),
         Par(),
         persistent = false,
         bindCount,
         BitSet(),
         connectiveUsed = false
-      ))
+      )
+    )
 
     result.par should be(expected)
   }
@@ -595,11 +679,15 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings2.add(new NameQuote(new PVar(new ProcVarVar("y1"))))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings2,
-                         new NameRemainderEmpty(),
-                         new NameQuote(new PGround(new GroundInt("1")))))
+      new LinearBindImpl(
+        listBindings2,
+        new NameRemainderEmpty(),
+        new NameQuote(new PGround(new GroundInt("1")))
+      )
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
 
@@ -626,22 +714,27 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val pNew = new PNew(
       listNameDecl,
       new PPar(
-        new PPar(new PSend(new NameVar("x"), new SendSingle(), listData1),
-                 new PSend(new NameVar("y"), new SendSingle(), listData2)),
+        new PPar(
+          new PSend(new NameVar("x"), new SendSingle(), listData1),
+          new PSend(new NameVar("y"), new SendSingle(), listData2)
+        ),
         new PSend(new NameVar("z"), new SendSingle(), listData3)
       )
     )
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pNew, inputs).value
     result.par should be(
-      inputs.par.prepend(New(
-        3,
-        Send(ChanVar(BoundVar(2)), List[Par](GInt(7)), false, BitSet(2))
-          .prepend(Send(ChanVar(BoundVar(1)), List[Par](GInt(8)), false, BitSet(1)))
-          .prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(9)), false, BitSet(0))),
-        Vector.empty,
-        BitSet()
-      )))
+      inputs.par.prepend(
+        New(
+          3,
+          Send(ChanVar(BoundVar(2)), List[Par](GInt(7)), false, BitSet(2))
+            .prepend(Send(ChanVar(BoundVar(1)), List[Par](GInt(8)), false, BitSet(1)))
+            .prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(9)), false, BitSet(0))),
+          Vector.empty,
+          BitSet()
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -668,8 +761,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       new PPar(
         new PPar(
           new PPar(
-            new PPar(new PSend(new NameVar("x"), new SendSingle(), listData1),
-                     new PSend(new NameVar("y"), new SendSingle(), listData2)),
+            new PPar(
+              new PSend(new NameVar("x"), new SendSingle(), listData1),
+              new PSend(new NameVar("y"), new SendSingle(), listData2)
+            ),
             new PSend(new NameVar("r"), new SendSingle(), listData3)
           ),
           new PSend(new NameVar("out"), new SendSingle(), listData4)
@@ -680,18 +775,22 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pNew, inputs).value
     result.par should be(
-      inputs.par.prepend(New(
-        5,
-        Send(ChanVar(BoundVar(4)), List[Par](GInt(7)), false, BitSet(4))
-          .prepend(Send(ChanVar(BoundVar(3)), List[Par](GInt(8)), false, BitSet(3)))
-          .prepend(Send(ChanVar(BoundVar(1)), List[Par](GInt(9)), false, BitSet(1)))
-          .prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(10)), false, BitSet(0)))
-          .prepend(Send(ChanVar(BoundVar(2)), List[Par](GInt(11)), false, BitSet(2))),
-        Vector("rho:registry", "rho:stdout"),
-        BitSet()
-      )))
+      inputs.par.prepend(
+        New(
+          5,
+          Send(ChanVar(BoundVar(4)), List[Par](GInt(7)), false, BitSet(4))
+            .prepend(Send(ChanVar(BoundVar(3)), List[Par](GInt(8)), false, BitSet(3)))
+            .prepend(Send(ChanVar(BoundVar(1)), List[Par](GInt(9)), false, BitSet(1)))
+            .prepend(Send(ChanVar(BoundVar(0)), List[Par](GInt(10)), false, BitSet(0)))
+            .prepend(Send(ChanVar(BoundVar(2)), List[Par](GInt(11)), false, BitSet(2))),
+          Vector("rho:registry", "rho:stdout"),
+          BitSet()
+        )
+      )
+    )
     result.par.news(0).p.sends.map(x => x.locallyFree.get) should be(
-      List(BitSet(2), BitSet(0), BitSet(1), BitSet(3), BitSet(4)))
+      List(BitSet(2), BitSet(0), BitSet(1), BitSet(3), BitSet(4))
+    )
     result.par.news(0).p.locallyFree.get should be(BitSet(0, 1, 2, 3, 4))
   }
 
@@ -701,7 +800,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings.add(new NameQuote(new PVar(new ProcVarVar("x"))))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
 
@@ -724,16 +824,20 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val expectedResult =
       inputs.par
         .prepend(Send(Quote(Par()), List[Par](GInt(47)), false, BitSet()))
-        .prepend(Receive(
-          List(ReceiveBind(List(Quote(EVar(FreeVar(0)))), Quote(Par()), freeCount = 1)),
-          Match(EVar(BoundVar(0)),
-                List(MatchCase(GInt(42), Par()), MatchCase(EVar(FreeVar(0)), Par(), freeCount = 1)),
-                BitSet(0)),
-          persistent = false,
-          bindCount,
-          BitSet(),
-          connectiveUsed = false
-        ))
+        .prepend(
+          Receive(
+            List(ReceiveBind(List(Quote(EVar(FreeVar(0)))), Quote(Par()), freeCount = 1)),
+            Match(
+              EVar(BoundVar(0)),
+              List(MatchCase(GInt(42), Par()), MatchCase(EVar(FreeVar(0)), Par(), freeCount = 1)),
+              BitSet(0)
+            ),
+            persistent = false,
+            bindCount,
+            BitSet(),
+            connectiveUsed = false
+          )
+        )
 
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
@@ -745,7 +849,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listProc.add(new PVar(new ProcVarVar("y")))
     listProc.add(new PVar(new ProcVarWildcard()))
     listCases.add(
-      new CaseImpl(new PCollect(new CollectList(listProc, new ProcRemainderEmpty())), new PNil()))
+      new CaseImpl(new PCollect(new CollectList(listProc, new ProcRemainderEmpty())), new PNil())
+    )
     listCases.add(new CaseImpl(new PVar(new ProcVarWildcard()), new PNil()))
     val pMatch = new PMatch(new PVar(new ProcVarVar("x")), listCases)
 
@@ -760,12 +865,14 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
             MatchCase(
               EList(Seq[Par](EVar(FreeVar(0)), EVar(Wildcard(Var.WildcardMsg()))), BitSet(), true),
               Par(),
-              freeCount = 1),
+              freeCount = 1
+            ),
             MatchCase(EVar(Wildcard(Var.WildcardMsg())), Par())
           ),
           BitSet(0),
           false
-        ))
+        )
+      )
     result.par should be(expectedResult)
     result.par.matches.head.cases.head.freeCount should be(1)
   }
@@ -780,14 +887,18 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value
     result.par should be(
-      inputs.par.prepend(Match(
-        GBool(true),
-        List(MatchCase(GBool(true), Send(Quote(Par()), List[Par](GInt(47)), false, BitSet())),
-             MatchCase(GBool(false), Par())
-             // TODO: Fill in type error case
-        ),
-        BitSet()
-      )))
+      inputs.par.prepend(
+        Match(
+          GBool(true),
+          List(
+            MatchCase(GBool(true), Send(Quote(Par()), List[Par](GInt(47)), false, BitSet())),
+            MatchCase(GBool(false), Par())
+            // TODO: Fill in type error case
+          ),
+          BitSet()
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
 
@@ -802,9 +913,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     result.par should be(
       inputs.par.copy(
         matches = Seq(
-          Match(GBool(true),
-                Seq(MatchCase(GBool(true), GInt(10)), MatchCase(GBool(false), Par())))),
-        exprs = Seq(GInt(7)))
+          Match(GBool(true), Seq(MatchCase(GBool(true), GInt(10)), MatchCase(GBool(false), Par())))
+        ),
+        exprs = Seq(GInt(7))
+      )
     )
   }
 
@@ -831,31 +943,45 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value
     result.par should be(
-      inputs.par.prepend(Match(
-        EEq(GInt(47), GInt(47)),
-        List(
-          MatchCase(GBool(true),
-                    New(1,
-                        Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, BitSet(0)),
-                        Vector.empty,
-                        BitSet())),
-          MatchCase(GBool(false),
-                    New(1,
-                        Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, BitSet(0)),
-                        Vector.empty,
-                        BitSet()))
-          // TODO: Fill in type error case
-        ),
-        BitSet()
-      )))
+      inputs.par.prepend(
+        Match(
+          EEq(GInt(47), GInt(47)),
+          List(
+            MatchCase(
+              GBool(true),
+              New(
+                1,
+                Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, BitSet(0)),
+                Vector.empty,
+                BitSet()
+              )
+            ),
+            MatchCase(
+              GBool(false),
+              New(
+                1,
+                Send(ChanVar(BoundVar(0)), List[Par](GInt(47)), false, BitSet(0)),
+                Vector.empty,
+                BitSet()
+              )
+            )
+            // TODO: Fill in type error case
+          ),
+          BitSet()
+        )
+      )
+    )
     result.knownFree should be(inputs.knownFree)
   }
   "PMatch" should "Fail if a free variable is used twice in the target" in {
     // match 47 { case (y | y) => Nil }
     val listCases = new ListCase()
     listCases.add(
-      new CaseImpl(new PPar(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("y"))),
-                   new PNil()))
+      new CaseImpl(
+        new PPar(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("y"))),
+        new PNil()
+      )
+    )
     val pMatch = new PMatch(new PGround(new GroundInt("47")), listCases)
 
     an[UnexpectedReuseOfProcContextFree] should be thrownBy {
@@ -873,7 +999,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings.add(new NameQuote(pMatch))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val input        = new PInput(receipt, new PNil())
@@ -888,14 +1015,18 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
           List(
             ReceiveBind(
               List(
-                Quote(Match(matchTarget, List(MatchCase(GInt(47), Par())), connectiveUsed = true))),
+                Quote(Match(matchTarget, List(MatchCase(GInt(47), Par())), connectiveUsed = true))
+              ),
               Quote(Par()),
-              freeCount = 2)),
+              freeCount = 2
+            )
+          ),
           Par(),
           persistent = false,
           bindCount,
           connectiveUsed = false
-        ))
+        )
+      )
 
     result.par should be(expectedResult)
     result.knownFree should be(inputs.knownFree)
@@ -911,8 +1042,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
       val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
       val result      = ProcNormalizeMatcher.normalizeMatch[Coeval](pMethod, boundInputs).value
       val expectedResult =
-        inputs.par.prepend(EMethod(methodName, EVar(BoundVar(0)), List(GInt(0)), BitSet(0), false),
-                           0)
+        inputs.par
+          .prepend(EMethod(methodName, EVar(BoundVar(0)), List(GInt(0)), BitSet(0), false), 0)
       result.par === expectedResult && result.knownFree === inputs.knownFree
     }
     methods.forall(m => test(m))
@@ -939,8 +1070,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     */
   it should "throw an error when wildcard or free variable is found inside body of bundle" in {
     val pbundle =
-      new PBundle(new BundleReadWrite(),
-                  new PPar(new PVar(new ProcVarWildcard()), new PVar(new ProcVarVar("x"))))
+      new PBundle(
+        new BundleReadWrite(),
+        new PPar(new PVar(new ProcVarWildcard()), new PVar(new ProcVarVar("x")))
+      )
 
     an[UnexpectedBundleContent] should be thrownBy (
       ProcNormalizeMatcher.normalizeMatch[Coeval](pbundle, inputs).value
@@ -1013,12 +1146,14 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](proc, inputs).value
     val expectedResult = inputs.par
       .addConnectives(
-        Connective(ConnAndBody(ConnectiveBody(Vector(EVar(FreeVar(0)), EVar(FreeVar(1)))))))
+        Connective(ConnAndBody(ConnectiveBody(Vector(EVar(FreeVar(0)), EVar(FreeVar(1))))))
+      )
       .withConnectiveUsed(true)
 
     result.par should be(expectedResult)
     result.knownFree should be(
-      inputs.knownFree.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1)
+      inputs.knownFree.newBindings(List(("x", ProcSort, 0, 0), ("y", ProcSort, 0, 0)))._1
+    )
   }
 
   "PDisjunction" should "delegate, but not count any free variables inside" in {
@@ -1027,7 +1162,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](proc, inputs).value
     val expectedResult = inputs.par
       .addConnectives(
-        Connective(ConnOrBody(ConnectiveBody(Vector(EVar(FreeVar(0)), EVar(FreeVar(0)))))))
+        Connective(ConnOrBody(ConnectiveBody(Vector(EVar(FreeVar(0)), EVar(FreeVar(0))))))
+      )
       .withConnectiveUsed(true)
 
     result.par should be(expectedResult)
@@ -1070,7 +1206,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     listBindings.add(new NameQuote(new PVarRef(new VarRefKindName(), "x")))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
 
@@ -1111,15 +1248,20 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val resultByteArray = ProcNormalizeMatcher.normalizeMatch[Coeval](procByteArray, inputs).value
 
     resultBool.par should be(
-      Par(connectives = Seq(Connective(ConnBool(true))), connectiveUsed = true))
+      Par(connectives = Seq(Connective(ConnBool(true))), connectiveUsed = true)
+    )
     resultInt.par should be(
-      Par(connectives = Seq(Connective(ConnInt(true))), connectiveUsed = true))
+      Par(connectives = Seq(Connective(ConnInt(true))), connectiveUsed = true)
+    )
     resultString.par should be(
-      Par(connectives = Seq(Connective(ConnString(true))), connectiveUsed = true))
+      Par(connectives = Seq(Connective(ConnString(true))), connectiveUsed = true)
+    )
     resultUri.par should be(
-      Par(connectives = Seq(Connective(ConnUri(true))), connectiveUsed = true))
+      Par(connectives = Seq(Connective(ConnUri(true))), connectiveUsed = true)
+    )
     resultByteArray.par should be(
-      Par(connectives = Seq(Connective(ConnByteArray(true))), connectiveUsed = true))
+      Par(connectives = Seq(Connective(ConnByteArray(true))), connectiveUsed = true)
+    )
   }
 
   "1 matches _" should "normalize correctly" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -50,7 +50,8 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
   val inputs = ProcVisitInputs(
     Par(),
     IndexMapChain[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0))),
-    DebruijnLevelMap[VarSort]())
+    DebruijnLevelMap[VarSort]()
+  )
 
   "List" should "Print" in {
     val listData = new ListProc()
@@ -62,7 +63,8 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par
+      )
     result shouldBe "[x0, *x1, 7...free0]"
   }
 
@@ -76,20 +78,23 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](list, inputs).value.par
+      )
     result shouldBe "Set(7, x0, *x1...free0)"
   }
 
   "Map" should "Print" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
-      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven"))))
+      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven")))
+    )
     mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("x"))))
     val map = new PCollect(new CollectMap(mapData, new ProcRemainderVar(new ProcVarVar("ignored"))))
 
     val result =
       PrettyPrinter(0, 2).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
+      )
     result shouldBe "{7 : \"" + "Seven" + "\", x0 : *x1...free0}"
   }
 
@@ -133,7 +138,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
             GString("Hello, ${name}"),
             EMapBody(ParMap(List[(Par, Par)]((GString("name"), GString("Alice")))))
           )
-        ))
+        )
+      )
     )
     val result = PrettyPrinter().buildString(source)
     val target = """("Hello, ${name}" %% {"name" : "Alice"})"""
@@ -148,7 +154,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
             ESetBody(ParSet(List[Par](GInt(1), GInt(2), GInt(3)))),
             ESetBody(ParSet(List[Par](GInt(1), GInt(2))))
           )
-        ))
+        )
+      )
     )
     val result = PrettyPrinter().buildString(source)
     val target = "(Set(1, 2, 3) -- Set(1, 2))"
@@ -170,7 +177,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val cont         = new PEval(new NameVar("z"))
@@ -180,7 +188,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0 in {
         |  for( x1 <- x0 ) {
@@ -198,7 +207,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val cont         = new PPar(new PEval(new NameVar("y")), new PEval(new NameVar("z")))
@@ -208,7 +218,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0 in {
         |  for( x1, x2 <- x0 ) {
@@ -228,9 +239,11 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings1.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val cont         = new PPar(new PEval(new NameVar("y")), new PEval(new NameVar("z")))
@@ -240,7 +253,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0 in {
         |  for( x1 <- x0 ; x2 <- x0 ) {
@@ -262,13 +276,17 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings1.add(new NameVar("b"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("y")))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("y"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
-    val cont = new PPar(new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
-                        new PPar(new PEval(new NameVar("a")), new PEval(new NameVar("b"))))
+    val cont = new PPar(
+      new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
+      new PPar(new PEval(new NameVar("a")), new PEval(new NameVar("b")))
+    )
     val receive = new PInput(receipt, cont)
     val nameDec = new ListNameDecl()
     nameDec.add(new NameDeclSimpl("x"))
@@ -276,7 +294,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0, x1 in {
         |  for( x2, x3 <- x1 ; x4, x5 <- x0 ) {
@@ -300,16 +319,20 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings1.add(new NameVar("b"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("y")))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("y"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val sentData     = new ListProc()
     sentData.add(new PNil())
     val pSend = new PSend(new NameVar("b"), new SendSingle(), sentData)
-    val cont = new PPar(new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
-                        new PPar(new PEval(new NameVar("a")), pSend))
+    val cont = new PPar(
+      new PPar(new PEval(new NameVar("z")), new PEval(new NameVar("v"))),
+      new PPar(new PEval(new NameVar("a")), pSend)
+    )
     val receive = new PInput(receipt, cont)
     val nameDec = new ListNameDecl()
     nameDec.add(new NameDeclSimpl("x"))
@@ -317,7 +340,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0, x1 in {
         |  for( x2, x3 <- x1 ; x4, x5 <- x0 ) {
@@ -337,7 +361,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val cont         = new PEval(new NameVar("z"))
@@ -350,7 +375,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val source = new PNew(nameDec, body)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
+      )
     val target =
       """new x0 in {
         |  x0!(*x0) |
@@ -364,7 +390,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   "PNil" should "Print" in {
     val nil = new PNil()
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](nil, inputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](nil, inputs).value.par
+    )
     result shouldBe "Nil"
   }
 
@@ -373,7 +400,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pvar, boundInputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](pvar, boundInputs).value.par
+      )
     result shouldBe "x0"
   }
 
@@ -382,17 +410,20 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par
+      )
     result shouldBe "*x0"
   }
 
   "PEval" should "Recognize occurrences of the same variable during collapses" in {
     val pEval = new PEval(
-      new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))))
+      new NameQuote(new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x"))))
+    )
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](pEval, boundInputs).value.par
+      )
     result shouldBe
       """x0 |
         |x0""".stripMargin
@@ -404,7 +435,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     sentData.add(new PGround(new GroundInt("8")))
     val pSend = new PSend(new NameQuote(new PNil()), new SendSingle(), sentData)
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, inputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, inputs).value.par
+    )
     result shouldBe "@{Nil}!(7, 8)"
   }
 
@@ -416,7 +448,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, boundInputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](pSend, boundInputs).value.par
+      )
     result shouldBe "x0!(7, 8)"
   }
 
@@ -424,7 +457,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val parGround = new PPar(new PGround(new GroundInt("7")), new PGround(new GroundInt("8")))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](parGround, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](parGround, inputs).value.par
+      )
     result shouldBe
       """8 |
         |7""".stripMargin
@@ -434,7 +468,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val parDoubleBound = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("x")))
     val boundInputs    = inputs.copy(env = inputs.env.newBinding(("x", ProcSort, 0, 0)))
     val result = PrettyPrinter(0, 1).buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleBound, boundInputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleBound, boundInputs).value.par
+    )
     result shouldBe
       """x0 |
         |x0""".stripMargin
@@ -444,7 +479,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val parDoubleFree = new PPar(new PVar(new ProcVarVar("x")), new PVar(new ProcVarVar("y")))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleFree, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](parDoubleFree, inputs).value.par
+      )
     result shouldBe
       """free1 |
         |free0""".stripMargin
@@ -458,18 +494,22 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
-    val body = new PPar(new PVar(new ProcVarVar("y")),
-                        new PPar(new PEval(new NameVar("z")), new PVar(new ProcVarVar("u"))))
+    val body = new PPar(
+      new PVar(new ProcVarVar("y")),
+      new PPar(new PEval(new NameVar("z")), new PVar(new ProcVarVar("u")))
+    )
     val basicInput    = new PInput(receipt, body)
     val listBindings1 = new ListName()
     listBindings1.add(new NameVar("x"))
     listBindings1.add(new NameQuote(basicInput))
     val listLinearBinds1 = new ListLinearBind()
     listLinearBinds1.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple1 = new LinearSimple(listLinearBinds1)
     val receipt1      = new ReceiptLinear(linearSimple1)
     val listSend1     = new ListProc()
@@ -478,7 +518,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val basicInput1 = new PInput(receipt1, body1)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput1, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput1, inputs).value.par
+      )
     val target =
       """for( x0, @{for( @{y0}, y1 <- @{Nil} ) { y0 | x1 | *y1 }} <- @{Nil} ) {
         |  x0!(x1)
@@ -497,9 +538,11 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings2.add(new NameQuote(new PVar(new ProcVarVar("y2"))))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x")))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x"))
+    )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings2, new NameRemainderEmpty(), new NameVar("v")))
+      new LinearBindImpl(listBindings2, new NameRemainderEmpty(), new NameVar("v"))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val listSend1    = new ListProc()
@@ -510,24 +553,31 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings3.add(new NameVar("z"))
     val listLinearBinds2 = new ListLinearBind()
     listLinearBinds2.add(
-      new LinearBindImpl(listBindings3, new NameRemainderEmpty(), new NameVar("x1")))
+      new LinearBindImpl(listBindings3, new NameRemainderEmpty(), new NameVar("x1"))
+    )
     val receipt2 = new ReceiptLinear(new LinearSimple(listLinearBinds2))
-    val body = new PPar(new PSend(new NameVar("x1"), new SendSingle(), listSend1),
-                        new PSend(new NameVar("x2"), new SendSingle(), listSend2))
+    val body = new PPar(
+      new PSend(new NameVar("x1"), new SendSingle(), listSend1),
+      new PSend(new NameVar("x2"), new SendSingle(), listSend2)
+    )
     val listCases = new ListCase()
     listCases.add(new CaseImpl(new PGround(new GroundInt("42")), new PNil()))
     listCases.add(new CaseImpl(new PVar(new ProcVarVar("y")), new PVar(new ProcVarVar("y2"))))
-    val body3 = new PPar(body,
-                         new PInput(receipt2,
-                                    new PPar(new PEval(new NameVar("z")),
-                                             new PMatch(new PEval(new NameVar("z")), listCases))))
+    val body3 = new PPar(
+      body,
+      new PInput(
+        receipt2,
+        new PPar(new PEval(new NameVar("z")), new PMatch(new PEval(new NameVar("z")), listCases))
+      )
+    )
     val listNameDecl = new ListNameDecl()
     listNameDecl.add(new NameDeclSimpl("x"))
     listNameDecl.add(new NameDeclSimpl("v"))
     val pInput = new PNew(listNameDecl, new PInput(receipt, body3))
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](pInput, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](pInput, inputs).value.par
+      )
     result shouldBe
       """new x0, x1 in {
         |  for( x2, @{x3} <- x1 ; x4, @{x5} <- x0 ) {
@@ -560,8 +610,10 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val pNew = new PNew(
       listNameDecl,
       new PPar(
-        new PPar(new PSend(new NameVar("x"), new SendSingle(), listData1),
-                 new PSend(new NameVar("y"), new SendSingle(), listData2)),
+        new PPar(
+          new PSend(new NameVar("x"), new SendSingle(), listData1),
+          new PSend(new NameVar("y"), new SendSingle(), listData2)
+        ),
         new PSend(new NameVar("z"), new SendSingle(), listData3)
       )
     )
@@ -570,7 +622,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
         ProcNormalizeMatcher
           .normalizeMatch[Coeval](pNew, inputs)
           .value
-          .par)
+          .par
+      )
     result shouldBe
       """new x0, x1, x2 in {
         |  x2!(9) |
@@ -586,7 +639,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameQuote(new PVar(new ProcVarVar("x"))))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val listCases    = new ListCase()
@@ -601,7 +655,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       send47OnNil
     )
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pPar, inputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](pPar, inputs).value.par
+    )
     result shouldBe
       """@{Nil}!(47) |
         |for( @{x0} <- @{Nil} ) {
@@ -620,7 +675,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val basicInput = new PIf(condition, body)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par
+      )
     result shouldBe
       """match true {
         |  true => @{Nil}!(47) ;
@@ -650,7 +706,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val basicInput = new PIfElse(condition, pNewIf, pNewElse)
     val result =
       PrettyPrinter().buildString(
-        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par)
+        ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value.par
+      )
     result shouldBe
       """match (47 == 47) {
         |  true => new x0 in {
@@ -672,12 +729,14 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings.add(new NameQuote(pMatch))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil())))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameQuote(new PNil()))
+    )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val input        = new PInput(receipt, new PNil())
     val result = PrettyPrinter().buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](input, inputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](input, inputs).value.par
+    )
     result shouldBe """for( @{match x0 | x1 { 47 => Nil }} <- @{Nil} ) {
                       |  Nil
                       |}""".stripMargin
@@ -687,7 +746,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val pMatches = new PMatches(new PGround(new GroundInt("1")), new PVar(new ProcVarWildcard()))
 
     val result = PrettyPrinter(0, 1).buildString(
-      ProcNormalizeMatcher.normalizeMatch[Coeval](pMatches, inputs).value.par)
+      ProcNormalizeMatcher.normalizeMatch[Coeval](pMatches, inputs).value.par
+    )
 
     result shouldBe "(1 matches _)"
   }
@@ -729,7 +789,8 @@ class NamePrinterSpec extends FlatSpec with Matchers {
   "NameWildcard" should "Print" in {
     val nw = new NameWildcard()
     val result = PrettyPrinter().buildString(
-      NameNormalizeMatcher.normalizeMatch[Coeval](nw, inputs).value.chan)
+      NameNormalizeMatcher.normalizeMatch[Coeval](nw, inputs).value.chan
+    )
     result shouldBe "_"
   }
 
@@ -739,7 +800,8 @@ class NamePrinterSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        NameNormalizeMatcher.normalizeMatch[Coeval](nvar, boundInputs).value.chan)
+        NameNormalizeMatcher.normalizeMatch[Coeval](nvar, boundInputs).value.chan
+      )
     result shouldBe "x0"
   }
 
@@ -750,7 +812,8 @@ class NamePrinterSpec extends FlatSpec with Matchers {
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))
     val result =
       PrettyPrinter(0, 1).buildString(
-        NameNormalizeMatcher.normalizeMatch[Coeval](nqeval, boundInputs).value.chan)
+        NameNormalizeMatcher.normalizeMatch[Coeval](nqeval, boundInputs).value.chan
+      )
     result shouldBe "@{*x0 | *x0}"
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
@@ -45,7 +45,7 @@ class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
           ReceiveBind(
             List(Quote(GInt(3))),
             Quote(GInt(2)),
-            None,
+            None
           ),
           emptyMap
         ),
@@ -53,7 +53,7 @@ class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
           ReceiveBind(
             List(Quote(GInt(3))),
             Quote(GInt(2)),
-            Some(FreeVar(0)),
+            Some(FreeVar(0))
           ),
           emptyMap
         ),
@@ -61,7 +61,7 @@ class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
           ReceiveBind(
             List(Quote(GInt(1))),
             Quote(GInt(3)),
-            None,
+            None
           ),
           emptyMap
         ),
@@ -69,7 +69,7 @@ class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
           ReceiveBind(
             List(Quote(GInt(2))),
             Quote(GInt(3)),
-            None,
+            None
           ),
           emptyMap
         )

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -489,20 +489,32 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val splitRand0 = rand.splitByte(0)
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
-    // format: off
     val send =
-      Send(Quote(GString("channel")), List(Par(exprs = Seq(Expr(EListBody(EList(Seq(GInt(7), GInt(8), GInt(9)))))))), false, BitSet())
+      Send(
+        Quote(GString("channel")),
+        List(Par(exprs = Seq(Expr(EListBody(EList(Seq(GInt(7), GInt(8), GInt(9)))))))),
+        false,
+        BitSet()
+      )
     val receive = Receive(
       Seq(
-        ReceiveBind(Seq(Quote(Par(exprs = Seq(EListBody(EList(connectiveUsed = true, remainder = Some(FreeVar(0)))))))),
+        ReceiveBind(
+          Seq(
+            Quote(
+              Par(
+                exprs = Seq(EListBody(EList(connectiveUsed = true, remainder = Some(FreeVar(0)))))
+              )
+            )
+          ),
           Quote(GString("channel")),
-          freeCount = 1)),
+          freeCount = 1
+        )
+      ),
       Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
       false,
       1,
       BitSet()
     )
-    // format: on
     val sendFirstResult = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
@@ -955,18 +967,24 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val channel = Channel(Quote(GString("result")))
 
-    // format: off
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(EList(List(GInt(7), GInt(8), GInt(9))))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(
+                  Seq(Quote(EList(List(GInt(7), GInt(8), GInt(9))))),
+                  mergeRand
+                ),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
-    // format: on
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -1068,7 +1086,6 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val channel0 = Channel(Quote(GString("result0")))
     val channel1 = Channel(Quote(GString("result1")))
-    // format: off
     result should be(
       HashMap(
         List(channel0) ->
@@ -1076,21 +1093,33 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             List(
               Datum.create(
                 channel0,
-                ListChannelWithRandom(Seq(Quote(GPrivate(ByteString.copyFrom(Array[Byte](42))))), result0Rand),
-                false)),
-            List()),
+                ListChannelWithRandom(
+                  Seq(Quote(GPrivate(ByteString.copyFrom(Array[Byte](42))))),
+                  result0Rand
+                ),
+                false
+              )
+            ),
+            List()
+          ),
         List(channel1) ->
           Row(
             List(
               Datum.create(
                 channel1,
-                ListChannelWithRandom(Seq(Quote(GPrivate(ByteString.copyFrom(chosenName)))), result1Rand),
-                false)),
-            List())
+                ListChannelWithRandom(
+                  Seq(Quote(GPrivate(ByteString.copyFrom(chosenName)))),
+                  result1Rand
+                ),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
   }
-  // format: on
+
   "eval of nth method in send position" should "change what is sent" in {
     implicit val errorLog = new ErrorLog()
     implicit val costAccounting =
@@ -1123,7 +1152,6 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val channel = Channel(Quote(GString("result")))
 
-    // format: off
     result should be(
       HashMap(
         List(channel) ->
@@ -1131,13 +1159,19 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             List(
               Datum.create(
                 channel,
-                ListChannelWithRandom(Seq(
-                  Quote(Send(Quote(GString("result")), List(GString("Success")), false, BitSet()))), splitRand),
-                false)),
-            List())
+                ListChannelWithRandom(
+                  Seq(
+                    Quote(Send(Quote(GString("result")), List(GString("Success")), false, BitSet()))
+                  ),
+                  splitRand
+                ),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
-    // format: on
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -1290,18 +1324,24 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val channel = Channel(Quote(GString("result")))
 
-    // format: off
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                  ListChannelWithRandom(Seq(Quote(Expr(GByteArray(ByteString.copyFrom(testString.getBytes))))), splitRand),
-                  persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(
+                  Seq(Quote(Expr(GByteArray(ByteString.copyFrom(testString.getBytes))))),
+                  splitRand
+                ),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
-    // format: on
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -35,12 +35,14 @@ trait PersistentStoreTester {
   def withTestSpace[R](errorLog: ErrorLog)(f: TestFixture => R): R = {
     val dbDir               = Files.createTempDirectory("rholang-interpreter-test-")
     val context: RhoContext = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
-    val space = RSpace.create[Channel,
-                              BindPattern,
-                              OutOfPhlogistonsError.type,
-                              ListChannelWithRandom,
-                              ListChannelWithRandom,
-                              TaggedContinuation](context, Branch("test"))
+    val space = RSpace.create[
+      Channel,
+      BindPattern,
+      OutOfPhlogistonsError.type,
+      ListChannelWithRandom,
+      ListChannelWithRandom,
+      TaggedContinuation
+    ](context, Branch("test"))
     implicit val errLog = errorLog
     val reducer         = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
     try {
@@ -162,13 +164,20 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       HashMap(
         List(channel) ->
           Row(
-            List(Datum.create(
-              channel,
-              ListChannelWithRandom(Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))), splitRand),
-              false)),
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(
+                  Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))),
+                  splitRand
+                ),
+                false
+              )
+            ),
             List()
           )
-      ))
+      )
+    )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -181,7 +190,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val y = GString("y")
     val receive = Receive(
       Seq(ReceiveBind(Seq(Quote(Par())), Quote(Bundle(y, readFlag = false, writeFlag = true)))),
-      Par())
+      Par()
+    )
 
     val receiveResult = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
@@ -191,7 +201,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     }
     receiveResult should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
-      Vector(ReduceError("Trying to read from non-readable channel.")))
+      Vector(ReduceError("Trying to read from non-readable channel."))
+    )
 
     /* @bundle- { x } !(7) -> x!(7)
      */
@@ -208,7 +219,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     }
     sendResult should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
-      Vector(ReduceError("Trying to send on non-writeable channel.")))
+      Vector(ReduceError("Trying to send on non-writeable channel."))
+    )
   }
 
   "eval of Send" should "place something in the tuplespace." in {
@@ -235,13 +247,20 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       HashMap(
         List(channel) ->
           Row(
-            List(Datum.create(
-              channel,
-              ListChannelWithRandom(Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))), splitRand),
-              false)),
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(
+                  Seq(Quote(GInt(7)), Quote(GInt(8)), Quote(GInt(9))),
+                  splitRand
+                ),
+                false
+              )
+            ),
             List()
           )
-      ))
+      )
+    )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -269,7 +288,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       HashMap(
         List(channel) -> Row(
           List(Datum.create(channel, ListChannelWithRandom(Seq(Quote(GInt(7))), splitRand), false)),
-          List())))
+          List()
+        )
+      )
+    )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -281,13 +303,18 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         val receive =
-          Receive(Seq(
-                    ReceiveBind(Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
-                                Quote(GString("channel")))),
-                  Par(),
-                  false,
-                  3,
-                  BitSet())
+          Receive(
+            Seq(
+              ReceiveBind(
+                Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
+                Quote(GString("channel"))
+              )
+            ),
+            Par(),
+            false,
+            3,
+            BitSet()
+          )
         val interpreter  = reducer
         implicit val env = Env[Par]()
         val resultTask   = interpreter.eval(receive)(env, splitRand, costAccounting)
@@ -309,16 +336,22 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 .create[Channel, BindPattern, TaggedContinuation](
                   channels,
                   List(
-                    BindPattern(List(Channel(ChanVar(FreeVar(0))),
-                                     Channel(ChanVar(FreeVar(1))),
-                                     Channel(ChanVar(FreeVar(2)))),
-                                None)),
+                    BindPattern(
+                      List(
+                        Channel(ChanVar(FreeVar(0))),
+                        Channel(ChanVar(FreeVar(1))),
+                        Channel(ChanVar(FreeVar(2)))
+                      ),
+                      None
+                    )
+                  ),
                   TaggedContinuation(ParBody(ParWithRandom(Par(), splitRand))),
                   false
                 )
             )
           )
-      ))
+      )
+    )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -331,12 +364,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
      */
 
     val y = GString("y")
-    val receive = Receive(binds = Seq(
-                            ReceiveBind(
-                              patterns = Seq(Quote(Par())),
-                              source = Quote(Bundle(y, readFlag = true, writeFlag = false))
-                            )),
-                          body = Par())
+    val receive = Receive(
+      binds = Seq(
+        ReceiveBind(
+          patterns = Seq(Quote(Par())),
+          source = Quote(Bundle(y, readFlag = true, writeFlag = false))
+        )
+      ),
+      body = Par()
+    )
 
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
@@ -357,9 +393,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 channels,
                 List(BindPattern(List(Channel(Quote(Par()))), None)),
                 TaggedContinuation(ParBody(ParWithRandom(Par(), splitRand))),
-                false))
+                false
+              )
+            )
           )
-      ))
+      )
+    )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
@@ -374,9 +413,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive = Receive(
       Seq(
-        ReceiveBind(Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
-                    Quote(GString("channel")),
-                    freeCount = 3)),
+        ReceiveBind(
+          Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
+          Quote(GString("channel")),
+          freeCount = 3
+        )
+      ),
       Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
       false,
       3,
@@ -397,11 +439,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -419,11 +466,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -466,11 +518,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -488,11 +545,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -509,9 +571,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Send(Quote(EPlus(GInt(7), GInt(8))), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive = Receive(
       Seq(
-        ReceiveBind(Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
-                    Quote(GInt(15)),
-                    freeCount = 3)),
+        ReceiveBind(
+          Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
+          Quote(GInt(15)),
+          freeCount = 3
+        )
+      ),
       Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
       false,
       3,
@@ -533,11 +598,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -554,11 +624,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -613,7 +688,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 channels,
                 List(BindPattern(List(Quote(GInt(2))))),
                 TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
-                false)
+                false
+              )
             )
           )
       )
@@ -639,7 +715,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 channels,
                 List(BindPattern(List(Quote(GInt(2))))),
                 TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
-                false))
+                false
+              )
+            )
           )
       )
     )
@@ -649,9 +727,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
         val inspectTaskReceiveFirst = for {
-          _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env,
-                                                                             baseRand,
-                                                                             costAccounting)
+          _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(
+                env,
+                baseRand,
+                costAccounting
+              )
         } yield space.store.toMap
         Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
     }
@@ -665,7 +745,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                 channels,
                 List(BindPattern(List(Quote(GInt(2))))),
                 TaggedContinuation(ParBody(ParWithRandom(Par(), mergeRand))),
-                false))
+                false
+              )
+            )
           )
       )
     )
@@ -688,12 +770,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           List(
             MatchCase(
               pattern,
-              Send(Quote(GString("result")),
-                   List(EEvalBody(ChanVar(BoundVar(1))), EVar(BoundVar(0))),
-                   false,
-                   BitSet(0, 1)),
+              Send(
+                Quote(GString("result")),
+                List(EEvalBody(ChanVar(BoundVar(1))), EVar(BoundVar(0))),
+                false,
+                BitSet(0, 1)
+              ),
               freeCount = 2
-            )),
+            )
+          ),
           BitSet()
         )
         implicit val env = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
@@ -712,11 +797,15 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         List(channel) ->
           Row(
             List(
-              Datum.create(channel,
-                           ListChannelWithRandom(Seq(Quote(GPrivateBuilder("one")),
-                                                     Quote(GPrivateBuilder("zero"))),
-                                                 splitRand),
-                           false)),
+              Datum.create(
+                channel,
+                ListChannelWithRandom(
+                  Seq(Quote(GPrivateBuilder("one")), Quote(GPrivateBuilder("zero"))),
+                  splitRand
+                ),
+                false
+              )
+            ),
             List()
           )
       )
@@ -738,12 +827,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Send(Quote(GString("channel2")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive = Receive(
       Seq(
-        ReceiveBind(Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
-                    Quote(GString("channel1")),
-                    freeCount = 3),
-        ReceiveBind(Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
-                    Quote(GString("channel2")),
-                    freeCount = 3)
+        ReceiveBind(
+          Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
+          Quote(GString("channel1")),
+          freeCount = 3
+        ),
+        ReceiveBind(
+          Seq(ChanVar(FreeVar(0)), ChanVar(FreeVar(1)), ChanVar(FreeVar(2))),
+          Quote(GString("channel2")),
+          freeCount = 3
+        )
       ),
       Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
       false,
@@ -766,11 +859,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     sendFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -788,11 +886,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     receiveFirstResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -810,11 +913,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     interleavedResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), mergeRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -830,8 +938,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val send =
       Send(Quote(GString("channel")), List(GInt(7), GInt(8), GInt(9)), false, BitSet())
     val receive =
-      Receive(Seq(ReceiveBind(Seq(), Quote(GString("channel")), Some(FreeVar(0)), freeCount = 1)),
-              Send(Quote(GString("result")), Seq(EVar(BoundVar(0)))))
+      Receive(
+        Seq(ReceiveBind(Seq(), Quote(GString("channel")), Some(FreeVar(0)), freeCount = 1)),
+        Send(Quote(GString("result")), Seq(EVar(BoundVar(0))))
+      )
 
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
@@ -878,13 +988,18 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     directResult should be(expectedResult)
 
     val nthCallEvalToSend: Expr =
-      EMethod("nth",
-              EList(
-                List(GInt(7),
-                     Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
-                     GInt(9),
-                     GInt(10))),
-              List[Par](GInt(1)))
+      EMethod(
+        "nth",
+        EList(
+          List(
+            GInt(7),
+            Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
+            GInt(9),
+            GInt(10)
+          )
+        ),
+        List[Par](GInt(1))
+      )
     val indirectResult = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
@@ -900,11 +1015,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     indirectResult should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("Success"))), splitRand),
-                             false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("Success"))), splitRand),
+                false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -977,13 +1097,18 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val splitRand = rand.splitByte(0)
     val nthCallEvalToSend: Expr =
-      EMethod("nth",
-              EList(
-                List(GInt(7),
-                     Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
-                     GInt(9),
-                     GInt(10))),
-              List[Par](GInt(1)))
+      EMethod(
+        "nth",
+        EList(
+          List(
+            GInt(7),
+            Send(Quote(GString("result")), List(GString("Success")), false, BitSet()),
+            GInt(9),
+            GInt(10)
+          )
+        ),
+        List[Par](GInt(1))
+      )
     val send: Par =
       Send(Quote(GString("result")), List[Par](nthCallEvalToSend), false, BitSet())
     val result = withTestSpace(errorLog) {
@@ -1040,11 +1165,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
     val splitRand = rand.splitByte(0)
     import coop.rchain.models.serialization.implicits._
-    val proc = Receive(Seq(ReceiveBind(Seq(ChanVar(FreeVar(0))), Quote(GString("channel")))),
-                       Par(),
-                       false,
-                       1,
-                       BitSet())
+    val proc = Receive(
+      Seq(ReceiveBind(Seq(ChanVar(FreeVar(0))), Quote(GString("channel")))),
+      Par(),
+      false,
+      1,
+      BitSet()
+    )
     val serializedProcess =
       com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc).toArray)
     val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
@@ -1062,12 +1189,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(Expr(GByteArray(serializedProcess)))),
-                                                   splitRand),
-                             persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(Expr(GByteArray(serializedProcess)))), splitRand),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1097,12 +1228,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(Expr(GByteArray(serializedProcess)))),
-                                                   splitRand),
-                             persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(Expr(GByteArray(serializedProcess)))), splitRand),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1116,7 +1251,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       EMethod(
         "toByteArray",
         Par(sends = Seq(Send(Quote(GString("result")), List(GString("Success")), false, BitSet()))),
-        List[Par](GInt(1)))
+        List[Par](GInt(1))
+      )
 
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
@@ -1129,7 +1265,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     }
     result should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
-      Vector(ReduceError("Error: toByteArray does not take arguments")))
+      Vector(ReduceError("Error: toByteArray does not take arguments"))
+    )
   }
 
   "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
@@ -1179,18 +1316,25 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       bindCount = 1,
       p = Par(
         sends = List(
-          Send(chan = Channel(ChanVar(BoundVar(0))),
-               data = List(EEvalBody(ChanVar(BoundVar(0)))),
-               persistent = false)),
+          Send(
+            chan = Channel(ChanVar(BoundVar(0))),
+            data = List(EEvalBody(ChanVar(BoundVar(0)))),
+            persistent = false
+          )
+        ),
         receives = List(
           Receive(
             binds = List(
-              ReceiveBind(patterns = List(Quote(Connective(VarRefBody(VarRef(0, 1))))),
-                          source = ChanVar(BoundVar(0)),
-                          freeCount = 0)),
+              ReceiveBind(
+                patterns = List(Quote(Connective(VarRefBody(VarRef(0, 1))))),
+                source = ChanVar(BoundVar(0)),
+                freeCount = 0
+              )
+            ),
             body = Send(chan = Quote(GString("result")), data = List(GString("true"))),
             bindCount = 0
-          ))
+          )
+        )
       )
     )
 
@@ -1210,11 +1354,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand),
-                             persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
 
@@ -1231,8 +1380,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       p = Match(
         target = EVar(BoundVar(0)),
         cases = List(
-          MatchCase(pattern = Connective(VarRefBody(VarRef(0, 1))),
-                    source = Send(chan = Quote(GString("result")), data = List(GString("true")))))
+          MatchCase(
+            pattern = Connective(VarRefBody(VarRef(0, 1))),
+            source = Send(chan = Quote(GString("result")), data = List(GString("true")))
+          )
+        )
       )
     )
 
@@ -1251,11 +1403,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("true"))), splitRandResult),
-                             persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("true"))), splitRandResult),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
 
@@ -1277,14 +1434,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
               patterns = List(Channel(ChanVar(FreeVar(0)))),
               source = Channel(Quote(GInt(7))),
               freeCount = 1
-            )),
+            )
+          ),
           body = Match(
             GInt(10),
             List(
               MatchCase(
                 pattern = Connective(VarRefBody(VarRef(0, 1))),
                 source = Send(chan = Quote(GString("result")), data = List(GString("true")))
-              ))
+              )
+            )
           )
         )
       )
@@ -1306,11 +1465,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result should be(
       HashMap(
         List(channel) ->
-          Row(List(
-                Datum.create(channel,
-                             ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand),
-                             persist = false)),
-              List())
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListChannelWithRandom(Seq(Quote(GString("true"))), mergeRand),
+                persist = false
+              )
+            ),
+            List()
+          )
       )
     )
 
@@ -1482,7 +1646,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
                   List[(Par, Par)](
                     (GString("a"), GString("1 ${b}")),
                     (GString("b"), GString("2 ${a}"))
-                  ))
+                  )
+                )
               )
             )
           )
@@ -1600,8 +1765,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         )
         Await.result(inspectTask.runAsync, 3.seconds)
     }
-    val resultMap = EMapBody(ParMap(
-      List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")), (GInt(3), GString("c")))))
+    val resultMap = EMapBody(
+      ParMap(
+        List[(Par, Par)]((GInt(1), GString("a")), (GInt(2), GString("b")), (GInt(3), GString("c")))
+      )
+    )
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1635,9 +1803,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env.makeEnv[Par]()
         val map = EMapBody(
           ParMap(
-            List[(Par, Par)]((GInt(1), GString("a")),
-                             (GInt(2), GString("b")),
-                             (GInt(3), GString("c")))))
+            List[(Par, Par)](
+              (GInt(1), GString("a")),
+              (GInt(2), GString("b")),
+              (GInt(3), GString("c"))
+            )
+          )
+        )
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("keys", map))
         )
@@ -1646,7 +1818,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val resultSet = ESetBody(
       ParSet(
         List[Par](GInt(1), GInt(2), GInt(3))
-      ))
+      )
+    )
     result.exprs should be(Seq(Expr(resultSet)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
@@ -1660,9 +1833,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env.makeEnv[Par]()
         val map = EMapBody(
           ParMap(
-            List[(Par, Par)]((GInt(1), GString("a")),
-                             (GInt(2), GString("b")),
-                             (GInt(3), GString("c")))))
+            List[(Par, Par)](
+              (GInt(1), GString("a")),
+              (GInt(2), GString("b")),
+              (GInt(3), GString("c"))
+            )
+          )
+        )
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("size", map))
         )
@@ -1718,9 +1895,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env.makeEnv[Par]()
         val map = EMapBody(
           ParMap(
-            List[(Par, Par)]((GInt(1), GString("a")),
-                             (GInt(2), GString("b")),
-                             (GInt(3), GString("c")))))
+            List[(Par, Par)](
+              (GInt(1), GString("a")),
+              (GInt(2), GString("b")),
+              (GInt(3), GString("c"))
+            )
+          )
+        )
         val inspectTask = reducer.evalExpr(
           EMinusBody(EMinus(map, GInt(3)))
         )
@@ -1792,7 +1973,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           (GInt(2), GString("b")),
           (GInt(3), GString("c")),
           (GInt(4), GString("d"))
-        )))
+        )
+      )
+    )
     result.exprs should be(Seq(Expr(resultMap)))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -45,13 +45,17 @@ trait RegistryTester extends PersistentStoreTester {
     )
 
   def withRegistryAndTestSpace[R](
-      f: (Reduce[Task],
-          IdISpace[Channel,
-                   BindPattern,
-                   OutOfPhlogistonsError.type,
-                   ListChannelWithRandom,
-                   ListChannelWithRandom,
-                   TaggedContinuation]) => R
+      f: (
+          Reduce[Task],
+          IdISpace[
+            Channel,
+            BindPattern,
+            OutOfPhlogistonsError.type,
+            ListChannelWithRandom,
+            ListChannelWithRandom,
+            TaggedContinuation
+          ]
+      ) => R
   ): R =
     withTestSpace(errorLog) {
       case TestFixture(space, _) =>
@@ -76,8 +80,9 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val eightByteArray: Par       = GByteArray(ByteString.copyFrom(Array[Byte](0x08.toByte)))
   val ninetySevenByteArray: Par = GByteArray(ByteString.copyFrom(Array[Byte](0x97.toByte)))
   val branchName: Par = GPrivate(
-    ByteString.copyFrom(
-      Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e")))
+    ByteString
+      .copyFrom(Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e"))
+  )
   // format: off
   val rootSend: Send = Send(
     chan = Quote(Registry.registryRoot),
@@ -93,43 +98,65 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val efByteArray: Par        = GByteArray(ByteString.copyFrom(Array[Byte](0xef.toByte)))
   val emptyByteArray: Par     = GByteArray(ByteString.EMPTY)
   val branch1: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2")))
+    ByteString.copyFrom(Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2"))
+  )
   val branch2: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e")))
+    ByteString.copyFrom(Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e"))
+  )
   val branch3: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0")))
+    ByteString.copyFrom(Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0"))
+  )
   val branch4: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3")))
+    ByteString.copyFrom(Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3"))
+  )
   val branchSend: Send = Send(
     chan = Quote(branchName),
     data = Seq(
-      Expr(EMapBody(ParMap(Seq(
-        emptyByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))),
-        eNineByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9)))))))
-      ))))),
+      Expr(
+        EMapBody(
+          ParMap(
+            Seq(
+              emptyByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))
+              ),
+              eNineByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))
+              ),
+              sevenFiveByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))
+              )
+            )
+          )
+        )
+      )
+    ),
     persistent = false
   )
 
   val fullBranchSend: Send = Send(
     chan = Quote(branchName),
     data = Seq(
-      Expr(EMapBody(ParMap(Seq(
-        eNineByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))),
-        efByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))),
-        aThreeByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11)))))))
-      ))))),
+      Expr(
+        EMapBody(
+          ParMap(
+            Seq(
+              eNineByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))
+              ),
+              sevenFiveByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))
+              ),
+              efByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))
+              ),
+              aThreeByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11))))))
+              )
+            )
+          )
+        )
+      )
+    ),
     persistent = false
   )
 
@@ -169,27 +196,45 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "insert" should "successfully split" in {
@@ -306,91 +351,157 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result3")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result3"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result3"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result4")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result4"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result4"))),
+              ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result5")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result5"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result5"))),
+              ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result6")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result6"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result6"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result7")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result7"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result7"))),
+              ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result8")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result8"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result8"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result9")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result9"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result9"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result10")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result10"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result10"))),
+              ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "delete" should "successfully merge" in {
@@ -502,67 +613,115 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result3")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result3"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result3"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result4")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result4"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result4"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result5")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result5"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result5"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result6")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result6"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result6"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(List[Channel](Quote(Registry.registryRoot))) should be(
-      Some(Row(
-        List(Datum.create(Channel(Quote(Registry.registryRoot)),
-                          ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))),
-                                                rootRand),
-                          false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(
+            Datum.create(
+              Channel(Quote(Registry.registryRoot)),
+              ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))), rootRand),
+              false
+            )
+          ),
+          List()
+        )
+      )
+    )
   }
 
   "Public lookup" should "decode and then call lookup" in {
@@ -595,19 +754,31 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "Random Registry" should "use the random generator and insert" in {
@@ -657,18 +828,30 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -21,10 +21,12 @@ class SortSpec extends FlatSpec with Matchers {
   it should "discern maps with and without remainder" in {
     assertOrder[Expr](
       ParMap(Seq.empty),
-      ParMap(Seq.empty,
-             connectiveUsed = false,
-             locallyFree = BitSet(),
-             remainder = Some(Var(FreeVar(0))))
+      ParMap(
+        Seq.empty,
+        connectiveUsed = false,
+        locallyFree = BitSet(),
+        remainder = Some(Var(FreeVar(0)))
+      )
     )
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -89,10 +89,13 @@ class SendSubSpec extends FlatSpec with Matchers {
     implicit val env = Env.makeEnv(source0, source1)
     val result = substituteSend[Coeval]
       .substitute(
-        Send(Quote(Send(ChanVar(BoundVar(1)), List(Par()), false, BitSet(1))),
-             List(Par()),
-             false,
-             BitSet(1)))
+        Send(
+          Quote(Send(ChanVar(BoundVar(1)), List(Par()), false, BitSet(1))),
+          List(Par()),
+          false,
+          BitSet(1)
+        )
+      )
       .value
     result should be(
       Send(
@@ -107,10 +110,12 @@ class SendSubSpec extends FlatSpec with Matchers {
   "Send" should "substitute all Channels for Quotes" in {
     val source: Par  = GPrivateBuilder()
     implicit val env = Env.makeEnv(source)
-    val target = Send(ChanVar(BoundVar(0)),
-                      List(Send(ChanVar(BoundVar(0)), List(Par()), false, BitSet(0))),
-                      false,
-                      BitSet(0))
+    val target = Send(
+      ChanVar(BoundVar(0)),
+      List(Send(ChanVar(BoundVar(0)), List(Par()), false, BitSet(0))),
+      false,
+      BitSet(0)
+    )
     val _target =
       Send(Quote(source), List(Send(Quote(source), List(Par()), false, BitSet())), false, BitSet())
     val result = substituteSend[Coeval].substitute(target).value
@@ -151,32 +156,40 @@ class NewSubSpec extends FlatSpec with Matchers {
       New(1, Send(ChanVar(BoundVar(1)), List(Par()), false, BitSet(1)), Vector.empty, BitSet(0))
     val result = substituteNew[Coeval].substitute(target).value
     result should be(
-      New(1, Send(Quote(source), List(Par()), false, BitSet()), Vector.empty, BitSet()))
+      New(1, Send(Quote(source), List(Par()), false, BitSet()), Vector.empty, BitSet())
+    )
   }
 
   "New" should "only substitute all Channels in body of express" in {
     val source0: Par           = GPrivateBuilder()
     val source1: Par           = GPrivateBuilder()
     implicit val env: Env[Par] = Env.makeEnv(source0, source1)
-    val target = New(2,
-                     Send(ChanVar(BoundVar(3)),
-                          List(Send(ChanVar(BoundVar(2)), List(Par()), false, BitSet(2))),
-                          false,
-                          BitSet(2, 3)),
-                     Vector.empty,
-                     BitSet(0, 1))
+    val target = New(
+      2,
+      Send(
+        ChanVar(BoundVar(3)),
+        List(Send(ChanVar(BoundVar(2)), List(Par()), false, BitSet(2))),
+        false,
+        BitSet(2, 3)
+      ),
+      Vector.empty,
+      BitSet(0, 1)
+    )
 
     val result = substituteNew[Coeval].substitute(target).value
     result should be(
       New(
         2,
-        Send(Quote(source0),
-             List(Send(Quote(source1), List(Par()), false, BitSet())),
-             false,
-             BitSet()),
+        Send(
+          Quote(source0),
+          List(Send(Quote(source1), List(Par()), false, BitSet())),
+          false,
+          BitSet()
+        ),
         Vector.empty,
         BitSet()
-      ))
+      )
+    )
   }
 }
 
@@ -209,19 +222,24 @@ class BundleSubSpec extends FlatSpec with Matchers {
     val source1: Par           = GPrivateBuilder()
     implicit val env: Env[Par] = Env.makeEnv(source0, source1)
     val target = Bundle(
-      Send(ChanVar(BoundVar(1)),
-           List(Send(ChanVar(BoundVar(0)), List(Par()), false, BitSet(0))),
-           false,
-           BitSet(0, 1))
+      Send(
+        ChanVar(BoundVar(1)),
+        List(Send(ChanVar(BoundVar(0)), List(Par()), false, BitSet(0))),
+        false,
+        BitSet(0, 1)
+      )
     )
     val result = substituteBundle[Coeval].substitute(target).value
     result should be(
       Bundle(
-        Send(Quote(source0),
-             List(Send(Quote(source1), List(Par()), false, BitSet())),
-             false,
-             BitSet())
-      ))
+        Send(
+          Quote(source0),
+          List(Send(Quote(source1), List(Par()), false, BitSet())),
+          false,
+          BitSet()
+        )
+      )
+    )
   }
 
   it should "preserve bundles' polarities during substitution" in {
@@ -261,15 +279,22 @@ class VarRefSubSpec extends FlatSpec with Matchers {
     val source: Par  = GPrivateBuilder()
     implicit val env = Env.makeEnv(source).shift(1)
     val target: Par =
-      Match(target = EVar(BoundVar(0)),
-            cases = Seq(
-              MatchCase(pattern = Connective(VarRefBody(VarRef(index = 1, depth = 2))),
-                        source = Par(),
-                        freeCount = 0)))
+      Match(
+        target = EVar(BoundVar(0)),
+        cases = Seq(
+          MatchCase(
+            pattern = Connective(VarRefBody(VarRef(index = 1, depth = 2))),
+            source = Par(),
+            freeCount = 0
+          )
+        )
+      )
     val result = substitutePar[Coeval].substitute(target).value
     val expectedResult: Par =
-      Match(target = EVar(BoundVar(0)),
-            cases = Seq(MatchCase(pattern = source, source = Par(), freeCount = 0)))
+      Match(
+        target = EVar(BoundVar(0)),
+        cases = Seq(MatchCase(pattern = source, source = Par(), freeCount = 0))
+      )
 
     result should be(expectedResult)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlgSpec.scala
@@ -15,8 +15,9 @@ class CostAccountingAlgSpec extends FlatSpec with TripleEqualsSupport {
 
   val defaultCost = CostAccount(3, Cost(33))
 
-  def withCostAccAlg[T](initState: CostAccount = defaultCost)(
-      f: CostAccountingAlg[Task] => Task[T]): T = {
+  def withCostAccAlg[T](
+      initState: CostAccount = defaultCost
+  )(f: CostAccountingAlg[Task] => Task[T]): T = {
     val test = for {
       alg <- CostAccountingAlg.of[Task](initState)
       res <- f(alg)
@@ -52,7 +53,8 @@ class CostAccountingAlgSpec extends FlatSpec with TripleEqualsSupport {
   }
 
   it should "fail when tries to charge on the cost account that is already negative" in withCostAccAlg(
-    CostAccount(-100)) { alg =>
+    CostAccount(-100)
+  ) { alg =>
     val cost = Cost(1)
     val test = for {
       _ <- alg.charge(cost)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -801,34 +801,45 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   }
 
   "Matching a target with var ref and a pattern with a var ref" should "ignore locallyFree" in {
-    // format: off
     val target: Par = New(
       bindCount = 1,
       p = Par(
-        receives = List(Receive(
-          binds = List(
-            ReceiveBind(
-              patterns = List(Quote(
-                Connective(VarRefBody(VarRef(0, 1))).withLocallyFree(BitSet(0)))),
-              source = Quote(Par()))),
-          body = Par(),
-          persistent = false,
-          bindCount = 0,
-          locallyFree = BitSet(0))),
-        locallyFree = BitSet(0)))
+        receives = List(
+          Receive(
+            binds = List(
+              ReceiveBind(
+                patterns =
+                  List(Quote(Connective(VarRefBody(VarRef(0, 1))).withLocallyFree(BitSet(0)))),
+                source = Quote(Par())
+              )
+            ),
+            body = Par(),
+            persistent = false,
+            bindCount = 0,
+            locallyFree = BitSet(0)
+          )
+        ),
+        locallyFree = BitSet(0)
+      )
+    )
     val pattern: Par = New(
       bindCount = 1,
       p = Par(
-        receives = List(Receive(
-          binds = List(
-            ReceiveBind(
-              patterns = List(Quote(
-                Connective(VarRefBody(VarRef(0, 1))))),
-              source = Quote(Par()))),
-          body = Par(),
-          persistent = false,
-          bindCount = 0))))
-    // format: on
+        receives = List(
+          Receive(
+            binds = List(
+              ReceiveBind(
+                patterns = List(Quote(Connective(VarRefBody(VarRef(0, 1))))),
+                source = Quote(Par())
+              )
+            ),
+            body = Par(),
+            persistent = false,
+            bindCount = 0
+          )
+        )
+      )
+    )
     assertSpatialMatch(target, pattern, Some(Map.empty[Int, Par]))
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -30,14 +30,14 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   def assertSpatialMatch[T <: GeneratedMessage, P <: GeneratedMessage](
       target: T,
       pattern: P,
-      expectedCaptures: Option[FreeMap])(implicit sm: SpatialMatcher[T, P],
-                                         ts: Sortable[T],
-                                         ps: Sortable[P]): Assertion = {
+      expectedCaptures: Option[FreeMap]
+  )(implicit sm: SpatialMatcher[T, P], ts: Sortable[T], ps: Sortable[P]): Assertion = {
     println(explainMatch(target, pattern, expectedCaptures))
     assertSorted(target, "target")
     assertSorted(pattern, "pattern")
     expectedCaptures.foreach(
-      _.values.foreach((v: Par) => assertSorted(v, "expected captured term")))
+      _.values.foreach((v: Par) => assertSorted(v, "expected captured term"))
+    )
     val intermediate: Either[OutOfPhlogistonsError.type, (CostAccount, Option[(FreeMap, Unit)])] =
       spatialMatch(target, pattern).runWithCost(CostAccount(Integer.MAX_VALUE))
     assert(intermediate.isRight)
@@ -49,7 +49,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   private def explainMatch[P <: GeneratedMessage, T <: GeneratedMessage](
       target: T,
       pattern: P,
-      expectedCaptures: Option[FreeMap]): String = {
+      expectedCaptures: Option[FreeMap]
+  ): String = {
 
     def truncate(s: String): String = if (s.length > 120) s.substring(0, 120) + "..." else s
 
@@ -65,11 +66,13 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   }
 
   private def prettyCaptures[T <: GeneratedMessage, P <: GeneratedMessage](
-      expectedCaptures: Option[FreeMap]): Option[Map[Int, String]] =
+      expectedCaptures: Option[FreeMap]
+  ): Option[Map[Int, String]] =
     expectedCaptures.map(_.map(c => (c._1, printer.buildString(c._2))))
 
   private def assertSorted[T <: GeneratedMessage](term: T, termName: String)(
-      implicit ts: Sortable[T]): Assertion = {
+      implicit ts: Sortable[T]
+  ): Assertion = {
     val sortedTerm = Sortable[T].sortMatch[Coeval](term).value.term
     val clue       = s"Invalid test case - ${termName} is not sorted"
     assert(printer.buildString(term) == printer.buildString(sortedTerm), clue)
@@ -107,9 +110,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       .prepend(EList(List(GInt(7), GInt(8)), BitSet()), 0)
     val pattern: Par = EList(List(EVar(FreeVar(0)).withConnectiveUsed(true), GInt(9)), BitSet())
       .withConnectiveUsed(true)
-      .prepend(EList(List(GInt(7), EVar(FreeVar(1)).withConnectiveUsed(true)), BitSet())
-                 .withConnectiveUsed(true),
-               depth = 1)
+      .prepend(
+        EList(List(GInt(7), EVar(FreeVar(1)).withConnectiveUsed(true)), BitSet())
+          .withConnectiveUsed(true),
+        depth = 1
+      )
     assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> GInt(7), 1 -> GInt(8))))
   }
 
@@ -156,9 +161,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   "Matching extras with free variable" should "work" in {
     val target: Par  = GInt(9).prepend(GInt(8), depth = 0).prepend(GInt(7), depth = 0)
     val pattern: Par = EVar(FreeVar(0)).prepend(GInt(8), depth = 1)
-    assertSpatialMatch(target,
-                       pattern,
-                       Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
+    assertSpatialMatch(
+      target,
+      pattern,
+      Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0)))
+    )
   }
 
   "Matching a singleton list" should "work" in {
@@ -281,9 +288,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       EVar(Wildcard(Var.WildcardMsg()))
         .prepend(EVar(FreeVar(0)), depth = 1)
         .prepend(GInt(8), depth = 1)
-    assertSpatialMatch(target,
-                       pattern,
-                       Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0))))
+    assertSpatialMatch(
+      target,
+      pattern,
+      Some(Map[Int, Par](0 -> GInt(9).prepend(GInt(7), depth = 0)))
+    )
   }
   "Matching send with free variable in channel and variable position" should "capture both values" in {
     val sendTarget: Par =
@@ -321,11 +330,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     )
     val expectedResult =
       Some(
-        Map[Int, Par](0 -> GInt(8),
-                      1 -> Send(Quote(GPrivateBuilder("unforgeable")),
-                                List(GInt(9), GInt(10)),
-                                false,
-                                BitSet())))
+        Map[Int, Par](
+          0 -> GInt(8),
+          1 -> Send(Quote(GPrivateBuilder("unforgeable")), List(GInt(9), GInt(10)), false, BitSet())
+        )
+      )
     assertSpatialMatch(target, pattern, expectedResult)
     val targetPar: Par  = target
     val patternPar: Par = pattern
@@ -344,15 +353,19 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
 
   "Matching between New's" should "match the bodies if the new count is the same" in {
     val target: New =
-      New(2,
-          Par()
-            .prepend(Send(ChanVar(BoundVar(0)), Seq(GInt(43)), false, locallyFree = BitSet(0)))
-            .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), false)))
+      New(
+        2,
+        Par()
+          .prepend(Send(ChanVar(BoundVar(0)), Seq(GInt(43)), false, locallyFree = BitSet(0)))
+          .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), false))
+      )
     val pattern: New =
-      New(2,
-          Par()
-            .prepend(Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), false).withConnectiveUsed(true))
-            .prepend(EVar(Wildcard(WildcardMsg())), 1))
+      New(
+        2,
+        Par()
+          .prepend(Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), false).withConnectiveUsed(true))
+          .prepend(EVar(Wildcard(WildcardMsg())), 1)
+      )
 
     val expectedResult = Some(Map[Int, Par](0 -> GInt(42)))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -366,20 +379,25 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       Match(
         EList(Seq(GInt(4), GInt(20))),
         Seq(
-          MatchCase(EList(Seq(EVar(FreeVar(0)), EVar(FreeVar(1)))),
-                    Send(Quote(EVar(BoundVar(1))),
-                         Seq[Par](EVar(BoundVar(0))),
-                         false,
-                         locallyFree = BitSet(0, 1))),
+          MatchCase(
+            EList(Seq(EVar(FreeVar(0)), EVar(FreeVar(1)))),
+            Send(
+              Quote(EVar(BoundVar(1))),
+              Seq[Par](EVar(BoundVar(0))),
+              false,
+              locallyFree = BitSet(0, 1)
+            )
+          ),
           MatchCase(EVar(Wildcard(WildcardMsg())), Par())
         )
       )
     val pattern: Match =
       Match(
         EVar(FreeVar(0)),
-        Seq(MatchCase(EList(Seq(EVar(FreeVar(0)), EVar(FreeVar(1)))),
-                      EVar(Wildcard(WildcardMsg()))),
-            MatchCase(EVar(Wildcard(WildcardMsg())), EVar(FreeVar(1)))),
+        Seq(
+          MatchCase(EList(Seq(EVar(FreeVar(0)), EVar(FreeVar(1)))), EVar(Wildcard(WildcardMsg()))),
+          MatchCase(EVar(Wildcard(WildcardMsg())), EVar(FreeVar(1)))
+        ),
         connectiveUsed = true
       )
 
@@ -419,7 +437,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val pattern: Expr =
       ParSet(
         Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(FreeVar(1)), EVar(Wildcard(WildcardMsg()))),
-        connectiveUsed = true)
+        connectiveUsed = true
+      )
     //the captures and their order are somewhat arbitrary and could potentially by changed
     val expectedResult = Some(Map[Int, Par](0 -> GInt(4), 1 -> GInt(3)))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -429,8 +448,10 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     assertSpatialMatch(targetPar, patternPar, expectedResult)
 
     val nonMatchingPattern: Expr =
-      ParSet(Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg()))),
-             connectiveUsed = true)
+      ParSet(
+        Seq(GInt(2), GInt(5), EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg()))),
+        connectiveUsed = true
+      )
     assertSpatialMatch(target, nonMatchingPattern, None)
   }
 
@@ -457,9 +478,11 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val targetElements = Seq[Par](GInt(1), GInt(2), GInt(3), GInt(4), GInt(5))
     val target: Expr   = ParSet(targetElements)
     val pattern: Expr =
-      ParSet(Seq(GInt(1), GInt(4), EVar(FreeVar(0))),
-             connectiveUsed = true,
-             remainder = Var(FreeVar(1)))
+      ParSet(
+        Seq(GInt(1), GInt(4), EVar(FreeVar(0))),
+        connectiveUsed = true,
+        remainder = Var(FreeVar(1))
+      )
     //the captures and their order are somewhat arbitrary and could potentially by changed
     val expectedResult = Some(Map[Int, Par](0 -> GInt(2), 1 -> ParSet(Seq(GInt(3), GInt(5)))))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -513,7 +536,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
         Seq[(Par, Par)](
           (GInt(3), EVar(FreeVar(1))),
           (EVar(FreeVar(0)), EVar(Wildcard(WildcardMsg()))),
-          (EVar(Wildcard(WildcardMsg())), GInt(4)),
+          (EVar(Wildcard(WildcardMsg())), GInt(4))
         ),
         connectiveUsed = true,
         locallyFree = BitSet(0, 1),
@@ -526,10 +549,12 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val targetElements = Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(3), GInt(4)), (GInt(5), GInt(6)))
     val target: Expr   = ParMap(targetElements)
     val pattern: Expr =
-      ParMap(Seq[(Par, Par)]((GInt(3), GInt(4))),
-             connectiveUsed = true,
-             locallyFree = BitSet(),
-             remainder = Wildcard(WildcardMsg()))
+      ParMap(
+        Seq[(Par, Par)]((GInt(3), GInt(4))),
+        connectiveUsed = true,
+        locallyFree = BitSet(),
+        remainder = Wildcard(WildcardMsg())
+      )
     val expectedResult = Some(Map[Int, Par]())
     assertSpatialMatch(target, pattern, expectedResult)
 
@@ -537,16 +562,20 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val patternPar: Par = pattern
     assertSpatialMatch(targetPar, patternPar, expectedResult)
 
-    val allElementsAndWildcard: Expr = ParMap(targetElements,
-                                              connectiveUsed = true,
-                                              locallyFree = BitSet(),
-                                              remainder = Wildcard(WildcardMsg()))
+    val allElementsAndWildcard: Expr = ParMap(
+      targetElements,
+      connectiveUsed = true,
+      locallyFree = BitSet(),
+      remainder = Wildcard(WildcardMsg())
+    )
     assertSpatialMatch(target, allElementsAndWildcard, Some(Map[Int, Par]()))
 
-    val justWildcard: Expr = ParMap(Seq(),
-                                    connectiveUsed = true,
-                                    locallyFree = BitSet(),
-                                    remainder = Wildcard(WildcardMsg()))
+    val justWildcard: Expr = ParMap(
+      Seq(),
+      connectiveUsed = true,
+      locallyFree = BitSet(),
+      remainder = Wildcard(WildcardMsg())
+    )
     assertSpatialMatch(target, justWildcard, Some(Map[Int, Par]()))
   }
 
@@ -554,13 +583,18 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val targetElements = Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(3), GInt(4)), (GInt(5), GInt(6)))
     val target: Expr   = ParMap(targetElements)
     val pattern: Expr =
-      ParMap(Seq[(Par, Par)]((EVar(FreeVar(0)), GInt(4))),
-             connectiveUsed = true,
-             locallyFree = BitSet(),
-             remainder = FreeVar(1))
+      ParMap(
+        Seq[(Par, Par)]((EVar(FreeVar(0)), GInt(4))),
+        connectiveUsed = true,
+        locallyFree = BitSet(),
+        remainder = FreeVar(1)
+      )
     val expectedResult = Some(
-      Map[Int, Par](0 -> GInt(3),
-                    1 -> ParMap(Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(5), GInt(6))))))
+      Map[Int, Par](
+        0 -> GInt(3),
+        1 -> ParMap(Seq[(Par, Par)]((GInt(1), GInt(2)), (GInt(5), GInt(6))))
+      )
+    )
     assertSpatialMatch(target, pattern, expectedResult)
 
     val targetPar: Par  = target
@@ -591,11 +625,13 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val target: Bundle = Bundle(
       Par()
         .prepend(Send(Quote(GPrivateBuilder("0")), Seq(GInt(43)), persistent = false))
-        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false)))
+        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false))
+    )
     val pattern: Bundle = Bundle(
       Par()
         .prepend(Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), persistent = false))
-        .prepend(EVar(Wildcard(WildcardMsg())), 1))
+        .prepend(EVar(Wildcard(WildcardMsg())), 1)
+    )
 
     assertSpatialMatch(target, pattern, None)
   }
@@ -612,7 +648,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val target: Bundle = Bundle(
       Par()
         .prepend(Send(Quote(GPrivateBuilder("0")), Seq(GInt(43)), persistent = false))
-        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false)))
+        .prepend(Send(Quote(GInt(7)), Seq(GInt(42)), persistent = false))
+    )
 
     val pattern: Par = EVar(FreeVar(0))
 
@@ -629,10 +666,15 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val failTarget: Par = Send(Quote(GInt(7)), Seq(GInt(9)), persistent = false)
     // @7!(x) /\ @y!(8)
     val pattern: Connective = Connective(
-      ConnAndBody(ConnectiveBody(Seq(
-        Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), persistent = false, connectiveUsed = true),
-        Send(ChanVar(FreeVar(1)), Seq(GInt(8)), persistent = false, connectiveUsed = true)
-      ))))
+      ConnAndBody(
+        ConnectiveBody(
+          Seq(
+            Send(Quote(GInt(7)), Seq(EVar(FreeVar(0))), persistent = false, connectiveUsed = true),
+            Send(ChanVar(FreeVar(1)), Seq(GInt(8)), persistent = false, connectiveUsed = true)
+          )
+        )
+      )
+    )
 
     val expectedResult = Some(Map[Int, Par](0 -> GInt(8), 1 -> GInt(7)))
     assertSpatialMatch(target, pattern, expectedResult)
@@ -649,10 +691,15 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val failTarget: Par = Send(Quote(GInt(7)), Seq(GInt(9)), persistent = false)
     // @9!(x) \/ @x!(8)
     val pattern: Connective = Connective(
-      ConnOrBody(ConnectiveBody(Seq(
-        Send(Quote(GInt(9)), Seq(EVar(FreeVar(0))), persistent = false, connectiveUsed = true),
-        Send(ChanVar(FreeVar(0)), Seq(GInt(8)), persistent = false, connectiveUsed = true)
-      ))))
+      ConnOrBody(
+        ConnectiveBody(
+          Seq(
+            Send(Quote(GInt(9)), Seq(EVar(FreeVar(0))), persistent = false, connectiveUsed = true),
+            Send(ChanVar(FreeVar(0)), Seq(GInt(8)), persistent = false, connectiveUsed = true)
+          )
+        )
+      )
+    )
 
     val expectedResult = Some(Map.empty[Int, Par])
     assertSpatialMatch(target, pattern, expectedResult)
@@ -716,21 +763,35 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       ConnNotBody(
         Par()
           .addConnectives(nonNullConn, nonNullConn)
-          .withConnectiveUsed(true)))
+          .withConnectiveUsed(true)
+      )
+    )
     // x /\ y!(7)
     val capture: Connective =
       Connective(
-        ConnAndBody(ConnectiveBody(
-          Seq(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), Seq(GInt(7))).withConnectiveUsed(true)))))
+        ConnAndBody(
+          ConnectiveBody(
+            Seq(EVar(FreeVar(0)), Send(ChanVar(FreeVar(1)), Seq(GInt(7))).withConnectiveUsed(true))
+          )
+        )
+      )
     // ~{ ~Nil | ~Nil } & ~Nil
     val prime: Connective = Connective(
       ConnAndBody(
-        ConnectiveBody(Seq(nonNull, Par().addConnectives(singleFactor).withConnectiveUsed(true)))))
+        ConnectiveBody(Seq(nonNull, Par().addConnectives(singleFactor).withConnectiveUsed(true)))
+      )
+    )
     // x!(7) \/ x!(8)
     val alternative: Connective = Connective(
       ConnOrBody(
-        ConnectiveBody(Seq(Send(ChanVar(FreeVar(0)), Seq(GInt(7))).withConnectiveUsed(true),
-                           Send(ChanVar(FreeVar(0)), Seq(GInt(8))).withConnectiveUsed(true)))))
+        ConnectiveBody(
+          Seq(
+            Send(ChanVar(FreeVar(0)), Seq(GInt(7))).withConnectiveUsed(true),
+            Send(ChanVar(FreeVar(0)), Seq(GInt(8))).withConnectiveUsed(true)
+          )
+        )
+      )
+    )
     // x /\ y!(7) | ~{ ~Nil | ~Nil } & ~Nil | x!(7) \/ x!(8)
     val pattern: Par   = Par().addConnectives(capture, prime, alternative).withConnectiveUsed(true)
     val expectedResult = Some(Map[Int, Par](0 -> Send(Quote(GInt(2)), Seq(GInt(7))), 1 -> GInt(2)))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatchSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatchSpec.scala
@@ -14,7 +14,7 @@ class MaximumBipartiteMatchSpec extends FlatSpec with Matchers {
     // Full bipartite graph K(3,3)
     "D" -> Seq(4, 5),
     "E" -> Seq(4, 6),
-    "F" -> Seq(5, 6),
+    "F" -> Seq(5, 6)
   )
 
   type Edge = (String, Int)
@@ -56,7 +56,7 @@ class MaximumBipartiteMatchSpec extends FlatSpec with Matchers {
     assertMatch(mf, Seq("A", "A"), Seq(1), None)
     // format: off
     assertMatch(mf, Seq("A"), Seq(1, 1), Some(Seq(
-      edge("A", 1),
+      edge("A", 1)
     )))
     assertMatch(mf, Seq("A", "A"), Seq(1, 1), Some(Seq(
       edge("A", 1),
@@ -94,10 +94,12 @@ class MaximumBipartiteMatchSpec extends FlatSpec with Matchers {
     assert(edgesTested == Seq(("D", 4), ("E", 4), ("D", 5), ("F", 4), ("F", 5), ("D", 6), ("F", 6)))
   }
 
-  def assertMatch[P, T, R, F[_]: Monad](matchFunction: (P, T) => F[Option[R]],
-                                        left: Seq[P],
-                                        right: Seq[T],
-                                        expectedMatch: Option[Seq[(T, P, R)]]): Assertion = {
+  def assertMatch[P, T, R, F[_]: Monad](
+      matchFunction: (P, T) => F[Option[R]],
+      left: Seq[P],
+      right: Seq[T],
+      expectedMatch: Option[Seq[(T, P, R)]]
+  ): Assertion = {
     val mbm = MaximumBipartiteMatch(matchFunction)
     assert(mbm.findMatches(left, right) === expectedMatch)
   }

--- a/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/Vm.scala
@@ -19,14 +19,16 @@ object Vm {
     * `code` usually equals to `ctxt.code` and `pc` is initially
     * set to `ctxt.pc`.
     */
-  final case class State(var code: Code = null,
-                         var ctxt: Ctxt = null,
-                         var doNextThreadFlag: Boolean = false,
-                         var exitFlag: Boolean = false,
-                         var nextOpFlag: Boolean = false,
-                         var pc: Int = 0,
-                         var vmErrorFlag: Boolean = false,
-                         globalEnv: GlobalEnv)(val strandPool: StrandPool)
+  final case class State(
+      var code: Code = null,
+      var ctxt: Ctxt = null,
+      var doNextThreadFlag: Boolean = false,
+      var exitFlag: Boolean = false,
+      var nextOpFlag: Boolean = false,
+      var pc: Int = 0,
+      var vmErrorFlag: Boolean = false,
+      globalEnv: GlobalEnv
+  )(val strandPool: StrandPool)
 
   def run[E: StrandPoolExecutor](ctxt: Ctxt, state: StrandPool => State): Unit = {
     val strandPool = StrandPoolExecutor.instance[E]
@@ -492,7 +494,8 @@ class Vm(val ctxt0: Ctxt, val state0: State) extends RecursiveAction {
 
         state.ctxt.argvec.update(arg, env.slot.unsafeGet(offset))
         logger.debug(
-          s"Xfer ${env.slot.unsafeGet(offset)} from lex[$level, $offset] to argvec[$arg]")
+          s"Xfer ${env.slot.unsafeGet(offset)} from lex[$level, $offset] to argvec[$arg]"
+        )
         state.nextOpFlag = true
 
       /**
@@ -508,7 +511,8 @@ class Vm(val ctxt0: Ctxt, val state0: State) extends RecursiveAction {
 
         state.ctxt.setReg(reg, env.slot.unsafeGet(offset))
         logger.debug(
-          s"Xfer ${env.slot.unsafeGet(offset)} from lex[$level, $offset] to ${regName(reg)}")
+          s"Xfer ${env.slot.unsafeGet(offset)} from lex[$level, $offset] to ${regName(reg)}"
+        )
         state.nextOpFlag = true
 
       /**

--- a/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/ob/Ctxt.scala
@@ -9,19 +9,20 @@ import coop.rchain.roscala.Vm.State
 import Ctxt.logger
 
 //TODO make access to various fields thread safe
-class Ctxt(var tag: Location,
-           var nargs: Int,
-           val outstanding: AtomicInteger = new AtomicInteger(0),
-           var pc: Int,
-           var argvec: Tuple,
-           var env: Ob,
-           var code: Code,
-           var ctxt: Option[Ctxt],
-           var self2: Ob,
-           var selfEnv: Ob,
-           var rcvr: Ob,
-           var monitor: Monitor)
-    extends Ob {
+class Ctxt(
+    var tag: Location,
+    var nargs: Int,
+    val outstanding: AtomicInteger = new AtomicInteger(0),
+    var pc: Int,
+    var argvec: Tuple,
+    var env: Ob,
+    var code: Code,
+    var ctxt: Option[Ctxt],
+    var self2: Ob,
+    var selfEnv: Ob,
+    var rcvr: Ob,
+    var monitor: Monitor
+) extends Ob {
 
   private val _rslt = new AtomicReference[Ob](Niv)
   private val _trgt = new AtomicReference[Ob](Niv)
@@ -137,7 +138,7 @@ object Ctxt {
       self2 = Niv,
       selfEnv = Niv,
       rcvr = Niv,
-      monitor = null,
+      monitor = null
     )
 
   def apply(tuple: Tuple, continuation: Ctxt): Ctxt =
@@ -152,7 +153,7 @@ object Ctxt {
       self2 = continuation.self2,
       selfEnv = continuation.selfEnv,
       rcvr = continuation.rcvr,
-      monitor = continuation.monitor,
+      monitor = continuation.monitor
     )
 
   def apply(continuation: Ctxt): Ctxt =
@@ -167,7 +168,7 @@ object Ctxt {
       self2 = continuation.self2,
       selfEnv = continuation.selfEnv,
       rcvr = continuation.rcvr,
-      monitor = continuation.monitor,
+      monitor = continuation.monitor
     )
 
   /**
@@ -184,7 +185,7 @@ object Ctxt {
     self2 = Niv,
     selfEnv = Niv,
     rcvr = Niv,
-    monitor = null,
+    monitor = null
   )
 
   /**
@@ -201,7 +202,7 @@ object Ctxt {
     self2 = Niv,
     selfEnv = Niv,
     rcvr = Niv,
-    monitor = null,
+    monitor = null
   )
 
   /**
@@ -219,6 +220,6 @@ object Ctxt {
     self2 = Niv,
     selfEnv = Niv,
     rcvr = Niv,
-    monitor = null,
+    monitor = null
   )
 }

--- a/roscala/src/main/scala/coop/rchain/roscala/prim/Prim.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/prim/Prim.scala
@@ -423,12 +423,14 @@ object Prim {
     Deadthread
 
   def mismatch(ctxt: Ctxt, argNum: Int, typeName: String): Ob =
-    runtimeError(ctxt,
-                 "%d%s argument is not %s %s",
-                 argNum + 1,
-                 numberSuffix(argNum + 1),
-                 properPrep(typeName),
-                 typeName)
+    runtimeError(
+      ctxt,
+      "%d%s argument is not %s %s",
+      argNum + 1,
+      numberSuffix(argNum + 1),
+      properPrep(typeName),
+      typeName
+    )
 
   def nthPrim(n: Int): Prim = map(n)
 

--- a/roscala/src/main/scala/coop/rchain/roscala/prim/rblstring.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/prim/rblstring.scala
@@ -64,7 +64,8 @@ object rblstring {
 
       Right(
         RblString(
-          elem.foldLeft(init)((acc: String, el: Ob) => acc ++ el.asInstanceOf[RblString].value))
+          elem.foldLeft(init)((acc: String, el: Ob) => acc ++ el.asInstanceOf[RblString].value)
+        )
       )
     }
   }

--- a/roscala/src/main/scala/coop/rchain/roscala/prim/tuple.scala
+++ b/roscala/src/main/scala/coop/rchain/roscala/prim/tuple.scala
@@ -109,7 +109,9 @@ object tuple {
                   case None        => Fixnum(Int.MaxValue)
                 }
               } else
-                Fixnum(Int.MaxValue)))
+                Fixnum(Int.MaxValue)
+          )
+      )
     }
   }
 
@@ -132,17 +134,20 @@ object tuple {
       // Check and get arguments: Tuple, Fixnum, Fixnum
       checkTuple(0, value).flatMap(
         t => // Ensure arg0 is a Tuple
-          checkFixnum(1, value).flatMap(n => // Ensure arg1 is a Fixnum
-            checkFixnum(2, value).flatMap { m => // Ensure arg2 is a Fixnum
+          checkFixnum(1, value).flatMap(
+            n => // Ensure arg1 is a Fixnum
+              checkFixnum(2, value).flatMap { m => // Ensure arg2 is a Fixnum
 
-              val f = wrapper(_: Int => Option[Ob], _: Int, t.value.length)
-              for {
-                nv  <- f(t.nthLift, n.value)
-                mv  <- f(t.nthLift, m.value)
-                t1  <- f(t.setNthLift(_, mv), n.value)
-                res <- f(t1.asInstanceOf[Tuple].setNthLift(_, nv), m.value)
-              } yield res.asInstanceOf[Tuple]
-          }))
+                val f = wrapper(_: Int => Option[Ob], _: Int, t.value.length)
+                for {
+                  nv  <- f(t.nthLift, n.value)
+                  mv  <- f(t.nthLift, m.value)
+                  t1  <- f(t.setNthLift(_, mv), n.value)
+                  res <- f(t1.asInstanceOf[Tuple].setNthLift(_, nv), m.value)
+                } yield res.asInstanceOf[Tuple]
+              }
+          )
+      )
 
     }
   }

--- a/roscala/src/test/scala/coop/rchain/roscala/VmSpecUtils.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/VmSpecUtils.scala
@@ -11,7 +11,8 @@ trait VmSpecUtils extends FlatSpec with Matchers {
   def runBehaviour[E: StrandPoolExecutor]: Unit
 
   private def registerVmTest[E: StrandPoolExecutor](v: ResultOfStringPassedToVerb, testFun: => Any)(
-      implicit pos: source.Position) =
+      implicit pos: source.Position
+  ) =
     registerTest(s"${v.verb.trim} ${v.rest.trim} using $strandPoolName")(testFun)
 
   implicit class ResultOfStringPassedToVerbOps(v: ResultOfStringPassedToVerb) {

--- a/roscala/src/test/scala/coop/rchain/roscala/actor/EnabledSetSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/actor/EnabledSetSpec.scala
@@ -696,13 +696,17 @@ class EnabledSetSpec extends VmSpecUtils {
         * The `buf` slot of the actor instance should at this point
         * be `[1 2 3]`.
         */
-      fixture.fifo.meta.map(Symbol("buf")).get shouldBe LexVariable(level = 0,
-                                                                    offset = 0,
-                                                                    indirect = true)
+      fixture.fifo.meta.map(Symbol("buf")).get shouldBe LexVariable(
+        level = 0,
+        offset = 0,
+        indirect = true
+      )
       fixture.fifo.extension.slot.unsafeGet(0).asInstanceOf[Tuple].numberOfElements() shouldBe 3
-      fixture.fifo.extension.slot.unsafeGet(0).asInstanceOf[Tuple].value shouldBe Array(Fixnum(1),
-                                                                                        Fixnum(2),
-                                                                                        Fixnum(3))
+      fixture.fifo.extension.slot.unsafeGet(0).asInstanceOf[Tuple].value shouldBe Array(
+        Fixnum(1),
+        Fixnum(2),
+        Fixnum(3)
+      )
     }
   }
 }

--- a/roscala/src/test/scala/coop/rchain/roscala/prim/FixnumSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/prim/FixnumSpec.scala
@@ -22,7 +22,7 @@ class FixnumSpec extends FlatSpec with Matchers {
     self2 = null,
     selfEnv = null,
     rcvr = null,
-    monitor = null,
+    monitor = null
   )
 
   ctxt.trgt = null

--- a/roscala/src/test/scala/coop/rchain/roscala/prim/RblFloatBehaviour.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/prim/RblFloatBehaviour.scala
@@ -24,7 +24,7 @@ class RblFloatSpec extends FlatSpec with Matchers {
     self2 = null,
     selfEnv = null,
     rcvr = null,
-    monitor = null,
+    monitor = null
   )
 
   ctxt.trgt = null

--- a/roscala/src/test/scala/coop/rchain/roscala/prim/RblStringSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/prim/RblStringSpec.scala
@@ -16,7 +16,7 @@ class RblStringSpec extends FlatSpec with Matchers {
     self2 = null,
     selfEnv = null,
     rcvr = null,
-    monitor = null,
+    monitor = null
   )
 
   ctxt.trgt = null
@@ -688,14 +688,16 @@ class RblStringSpec extends FlatSpec with Matchers {
   "string-split" should "correctly tokenize a full string" in {
     val sep = ".,-=/*"
     val str = "aZ,bY.cX-dW=eV/fU*gT"
-    val res = Tuple(RblString("aZ"),
-                    RblString("bY"),
-                    RblString("cX"),
-                    RblString("dW"),
-                    RblString("eV"),
-                    RblString("fU"),
-                    RblString("gT"),
-                    Niv)
+    val res = Tuple(
+      RblString("aZ"),
+      RblString("bY"),
+      RblString("cX"),
+      RblString("dW"),
+      RblString("eV"),
+      RblString("fU"),
+      RblString("gT"),
+      Niv
+    )
 
     val parms   = Tuple(RblString(str), RblString(sep), Fixnum(33))
     val newCtxt = reAssignCtxtArgs(ctxt, 2, parms)

--- a/roscala/src/test/scala/coop/rchain/roscala/prim/TupleSpec.scala
+++ b/roscala/src/test/scala/coop/rchain/roscala/prim/TupleSpec.scala
@@ -18,7 +18,7 @@ class TupleSpec extends FlatSpec with Matchers {
     self2 = null,
     selfEnv = null,
     rcvr = null,
-    monitor = null,
+    monitor = null
   )
 
   ctxt.rslt = null
@@ -54,7 +54,8 @@ class TupleSpec extends FlatSpec with Matchers {
     val ret = tplConsStar.fnSimple(newCtxt)
     ret.isRight should be(true)
     ret.right.get.value should be(
-      Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(tup)))).value)
+      Tuple.cons(Fixnum(1), Tuple.cons(Fixnum(2), Tuple.cons(Fixnum(3), Tuple(tup)))).value
+    )
   }
 
   "tplConsStar" should "correctly cons 0 Obs with a Tuple" in {
@@ -161,9 +162,11 @@ class TupleSpec extends FlatSpec with Matchers {
   it should "fail for out of bounds arguments" in {
     val tup = Array[Ob](Fixnum(1), Fixnum(2), Fixnum(3), Fixnum(4), Fixnum(5), Fixnum(6))
     val newCtxt =
-      reAssignCtxtArgs(ctxt,
-                       3,
-                       Tuple.rcons(Tuple.rcons(Tuple(Tuple(tup)), Fixnum(-100)), Fixnum(100)))
+      reAssignCtxtArgs(
+        ctxt,
+        3,
+        Tuple.rcons(Tuple.rcons(Tuple(Tuple(tup)), Fixnum(-100)), Fixnum(100))
+      )
     tplXchg.fnSimple(newCtxt) should be('left)
   }
 

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -21,10 +21,12 @@ class BasicBench {
     val space = state.testSpace
 
     space
-      .consume(List("ch1", "ch2"),
-               List(StringMatch("bad"), StringMatch("finger")),
-               new StringsCaptor,
-               false)
+      .consume(
+        List("ch1", "ch2"),
+        List(StringMatch("bad"), StringMatch("finger")),
+        new StringsCaptor,
+        false
+      )
 
     val r1 = space.produce("ch1", "bad", false)
 
@@ -53,8 +55,10 @@ object BasicBench {
       LMDBStore.create[String, Pattern, String, StringsCaptor](context, Branch("bench"))
 
     val testSpace: IdISpace[String, Pattern, Nothing, String, String, StringsCaptor] =
-      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore,
-                                                                             Branch("bench"))
+      RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](
+        testStore,
+        Branch("bench")
+      )
 
     @TearDown
     def tearDown(): Unit = {

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
@@ -21,7 +21,8 @@ class EvalBench {
     throw new RuntimeException(
       errors
         .map(_.toString())
-        .mkString("Errors received during evaluation:\n", "\n", "\n"))
+        .mkString("Errors received during evaluation:\n", "\n", "\n")
+    )
   }
 
   def createTest(state: EvalBenchStateBase): Task[Vector[Throwable]] = {
@@ -39,7 +40,8 @@ class EvalBench {
   def reduceMVCEPPST(state: MVCEPPBenchState): Unit = {
     val runTask = createTest(state).executeOn(state.singleThreadedScheduler, forceAsync = false)
     processErrors(
-      runTask.runSyncUnsafe(Duration.Inf)(state.singleThreadedScheduler, CanBlock.permit))
+      runTask.runSyncUnsafe(Duration.Inf)(state.singleThreadedScheduler, CanBlock.permit)
+    )
   }
 
   @Benchmark
@@ -56,7 +58,8 @@ object EvalBench {
   class MVCEPPBenchState extends EvalBenchStateBase {
     val singleThreadedScheduler: Scheduler = TrampolineScheduler.apply(
       Scheduler.singleThread(name = "mvcepp-1"),
-      ExecutionModel.SynchronousExecution)
+      ExecutionModel.SynchronousExecution
+    )
 
     override val rhoScriptSource: String = "/rholang/mvcepp.rho"
   }

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -42,7 +42,8 @@ trait EvalBenchStateBase {
   def resourceFileReader(path: String): InputStreamReader =
     new InputStreamReader(
       Option(getClass.getResourceAsStream(path))
-        .getOrElse(throw new FileNotFoundException(path)))
+        .getOrElse(throw new FileNotFoundException(path))
+    )
 }
 
 object EvalBenchStateBase {
@@ -55,11 +56,13 @@ object EvalBenchStateBase {
     dbDir.getParent.toFile.listFiles
       .filter(dir => dir.isDirectory && (dir.toPath != dbDir))
       .filter(_.getName.startsWith("rchain-storage-test-"))
-      .foreach(dir =>
-        try {
-          println(s"deleting... $dir")
-          dir.toPath.recursivelyDelete()
-        } catch {
-          case _: Exception =>
-      })
+      .foreach(
+        dir =>
+          try {
+            println(s"deleting... $dir")
+            dir.toPath.recursivelyDelete()
+          } catch {
+            case _: Exception =>
+          }
+      )
 }

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -97,8 +97,10 @@ class LMDBBench extends RSpaceBench {
     val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
-                                                                                  Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testStore,
+      Branch.MASTER
+    )
   }
 
   @TearDown
@@ -121,8 +123,10 @@ class InMemBench extends RSpaceBench {
     assert(context.trieStore.toMap.isEmpty)
     val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
-                                                                                  Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testStore,
+      Branch.MASTER
+    )
   }
 
   @TearDown
@@ -150,8 +154,10 @@ class MixedBench extends RSpaceBench {
     assert(context.trieStore.toMap.isEmpty)
     val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
-                                                                                  Branch.MASTER)
+    space = RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testStore,
+      Branch.MASTER
+    )
   }
 
   @TearDown

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
@@ -107,7 +107,8 @@ object WideEvalBenchState {
       throw new RuntimeException(
         errors
           .map(_.toString())
-          .mkString("Errors received during evaluation:\n", "\n", "\n"))
+          .mkString("Errors received during evaluation:\n", "\n", "\n")
+      )
     }
     errors
   }
@@ -122,5 +123,6 @@ object WideEvalBenchState {
   def resourceFileReader(path: String): InputStreamReader =
     new InputStreamReader(
       Option(getClass.getResourceAsStream(path))
-        .getOrElse(throw new FileNotFoundException(path)))
+        .getOrElse(throw new FileNotFoundException(path))
+    )
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -10,11 +10,13 @@ import scodec.Codec
 
 trait Context[C, P, A, K] {
   def close(): Unit
-  def createStore(branch: Branch)(implicit
-                                  sc: Serialize[C],
-                                  sp: Serialize[P],
-                                  sa: Serialize[A],
-                                  sk: Serialize[K]): IStore[C, P, A, K]
+  def createStore(branch: Branch)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): IStore[C, P, A, K]
 }
 
 private[rspace] class LMDBContext[C, P, A, K] private[rspace] (
@@ -22,10 +24,12 @@ private[rspace] class LMDBContext[C, P, A, K] private[rspace] (
     val path: Path,
     val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]]
 ) extends Context[C, P, A, K] {
-  override def createStore(branch: Branch)(implicit sc: Serialize[C],
-                                           sp: Serialize[P],
-                                           sa: Serialize[A],
-                                           sk: Serialize[K]): IStore[C, P, A, K] =
+  override def createStore(branch: Branch)(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): IStore[C, P, A, K] =
     LMDBStore.create[C, P, A, K](this, branch)
 
   def close(): Unit = {
@@ -35,14 +39,19 @@ private[rspace] class LMDBContext[C, P, A, K] private[rspace] (
 }
 
 private[rspace] class InMemoryContext[C, P, A, K] private[rspace] (
-    val trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]],
-                              Blake2b256Hash,
-                              GNAT[C, P, A, K]]
+    val trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], Blake2b256Hash, GNAT[
+      C,
+      P,
+      A,
+      K
+    ]]
 ) extends Context[C, P, A, K] {
-  override def createStore(branch: Branch)(implicit sc: Serialize[C],
-                                           sp: Serialize[P],
-                                           sa: Serialize[A],
-                                           sk: Serialize[K]): IStore[C, P, A, K] =
+  override def createStore(branch: Branch)(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): IStore[C, P, A, K] =
     InMemoryStore.create(trieStore, branch)
 
   def close(): Unit = {}
@@ -53,10 +62,12 @@ private[rspace] class MixedContext[C, P, A, K] private[rspace] (
     val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]]
 ) extends Context[C, P, A, K] {
 
-  override def createStore(branch: Branch)(implicit sc: Serialize[C],
-                                           sp: Serialize[P],
-                                           sa: Serialize[A],
-                                           sk: Serialize[K]): IStore[C, P, A, K] =
+  override def createStore(branch: Branch)(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): IStore[C, P, A, K] =
     InMemoryStore.create(trieStore, branch)
 
   def close(): Unit = {
@@ -67,9 +78,11 @@ private[rspace] class MixedContext[C, P, A, K] private[rspace] (
 
 object Context {
 
-  def env(path: Path,
-          mapSize: Long,
-          flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)): Env[ByteBuffer] =
+  def env(
+      path: Path,
+      mapSize: Long,
+      flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+  ): Env[ByteBuffer] =
     Env
       .create()
       .setMapSize(mapSize)
@@ -82,19 +95,23 @@ object Context {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): LMDBContext[C, P, A, K] = {
+      sk: Serialize[K]
+  ): LMDBContext[C, P, A, K] = {
     val flags = if (noTls) List(EnvFlags.MDB_NOTLS) else List.empty
     create(path, mapSize, flags)
   }
 
-  def create[C, P, A, K](path: Path,
-                         mapSize: Long,
-                         flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS))(
+  def create[C, P, A, K](
+      path: Path,
+      mapSize: Long,
+      flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): LMDBContext[C, P, A, K] = {
+      sk: Serialize[K]
+  ): LMDBContext[C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -113,14 +130,17 @@ object Context {
     new InMemoryContext(trieStore)
   }
 
-  def createMixed[C, P, A, K](path: Path,
-                              mapSize: Long,
-                              flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS))(
+  def createMixed[C, P, A, K](
+      path: Path,
+      mapSize: Long,
+      flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): MixedContext[C, P, A, K] = {
+      sk: Serialize[K]
+  ): MixedContext[C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -134,14 +154,17 @@ object Context {
     new MixedContext[C, P, A, K](env, trieStore)
   }
 
-  def createFineGrained[C, P, A, K](path: Path,
-                                    mapSize: Long,
-                                    flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS))(
+  def createFineGrained[C, P, A, K](
+      path: Path,
+      mapSize: Long,
+      flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): LMDBContext[C, P, A, K] = {
+      sk: Serialize[K]
+  ): LMDBContext[C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -40,10 +40,12 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
+      implicit m: Match[P, E, A, R]
+  ): F[Either[E, Option[(K, Seq[R])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]]
+      implicit m: Match[P, E, A, R]
+  ): F[Option[(K, Seq[R])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
     * given channel.
@@ -69,7 +71,8 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
+      implicit m: Match[P, E, A, R]
+  ): F[Either[E, Option[(K, Seq[R])]]]
 
   /** Creates a checkpoint.
     *

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -43,20 +43,28 @@ trait IStore[C, P, A, K] {
 
   private[rspace] def removeDatum(txn: Transaction, channel: Seq[C], index: Int): Unit
 
-  private[rspace] def installWaitingContinuation(txn: Transaction,
-                                                 channels: Seq[C],
-                                                 continuation: WaitingContinuation[P, K]): Unit
+  private[rspace] def installWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K]
+  ): Unit
 
-  private[rspace] def putWaitingContinuation(txn: Transaction,
-                                             channels: Seq[C],
-                                             continuation: WaitingContinuation[P, K]): Unit
+  private[rspace] def putWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K]
+  ): Unit
 
-  private[rspace] def getWaitingContinuation(txn: Transaction,
-                                             channels: Seq[C]): Seq[WaitingContinuation[P, K]]
+  private[rspace] def getWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C]
+  ): Seq[WaitingContinuation[P, K]]
 
-  private[rspace] def removeWaitingContinuation(txn: Transaction,
-                                                channels: Seq[C],
-                                                index: Int): Unit
+  private[rspace] def removeWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      index: Int
+  ): Unit
 
   private[rspace] def getPatterns(txn: Transaction, channels: Seq[C]): Seq[Seq[P]]
 
@@ -134,8 +142,10 @@ trait IStore[C, P, A, K] {
       }
       .toList
 
-  private[rspace] def bulkInsert(txn: Transaction,
-                                 gnats: Seq[(Blake2b256Hash, GNAT[C, P, A, K])]): Unit
+  private[rspace] def bulkInsert(
+      txn: Transaction,
+      gnats: Seq[(Blake2b256Hash, GNAT[C, P, A, K])]
+  ): Unit
 
   private[rspace] def clear(txn: Transaction): Unit
 

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
@@ -108,10 +108,13 @@ trait LMDBOps extends CloseOps {
         }
 
     def put[V](txn: Txn[ByteBuffer], key: Blake2b256Hash, data: V)(
-        implicit codecV: Codec[V]): Unit =
-      if (!dbi.put(txn,
-                   key.bytes.toDirectByteBuffer,
-                   codecV.encode(data).map(_.bytes.toDirectByteBuffer).get)) {
+        implicit codecV: Codec[V]
+    ): Unit =
+      if (!dbi.put(
+            txn,
+            key.bytes.toDirectByteBuffer,
+            codecV.encode(data).map(_.bytes.toDirectByteBuffer).get
+          )) {
         throw new Exception(s"could not persist: $data")
       }
 
@@ -120,18 +123,24 @@ trait LMDBOps extends CloseOps {
         throw new Exception(s"could not delete: $key")
       }
 
-    def get[K, V](txn: Txn[ByteBuffer], key: K)(implicit codecK: Codec[K],
-                                                codecV: Codec[V]): Option[V] =
+    def get[K, V](
+        txn: Txn[ByteBuffer],
+        key: K
+    )(implicit codecK: Codec[K], codecV: Codec[V]): Option[V] =
       Option(dbi.get(txn, codecK.encode(key).get.bytes.toDirectByteBuffer))
         .map { bytes =>
           codecV.decode(BitVector(bytes)).map(_.value).get
         }
 
-    def put[K, V](txn: Txn[ByteBuffer], key: K, data: V)(implicit codecK: Codec[K],
-                                                         codecV: Codec[V]): Unit =
-      if (!dbi.put(txn,
-                   codecK.encode(key).get.bytes.toDirectByteBuffer,
-                   codecV.encode(data).map(_.bytes.toDirectByteBuffer).get)) {
+    def put[K, V](txn: Txn[ByteBuffer], key: K, data: V)(
+        implicit codecK: Codec[K],
+        codecV: Codec[V]
+    ): Unit =
+      if (!dbi.put(
+            txn,
+            codecK.encode(key).get.bytes.toDirectByteBuffer,
+            codecV.encode(data).map(_.bytes.toDirectByteBuffer).get
+          )) {
         throw new Exception(s"could not persist: $data")
       }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -13,7 +13,8 @@ object RSpace {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): ISpace[Id, C, P, E, A, R, K] =
+      sk: Serialize[K]
+  ): ISpace[Id, C, P, E, A, R, K] =
     context match {
       case ctx: LMDBContext[C, P, A, K] =>
         create(LMDBStore.create[C, P, A, K](ctx, branch), branch)
@@ -26,19 +27,26 @@ object RSpace {
     }
 
   def createInMemory[C, P, E, A, R, K](
-      trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]],
-                            Blake2b256Hash,
-                            GNAT[C, P, A, K]],
-      branch: Branch)(implicit
-                      sc: Serialize[C],
-                      sp: Serialize[P],
-                      sa: Serialize[A],
-                      sk: Serialize[K]): ISpace[Id, C, P, E, A, R, K] = {
+      trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], Blake2b256Hash, GNAT[
+        C,
+        P,
+        A,
+        K
+      ]],
+      branch: Branch
+  )(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): ISpace[Id, C, P, E, A, R, K] = {
 
     val mainStore = InMemoryStore
       .create[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
         trieStore,
-        branch)
+        branch
+      )
     create(mainStore, branch)
   }
 
@@ -47,7 +55,8 @@ object RSpace {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): ISpace[Id, C, P, E, A, R, K] = {
+      sk: Serialize[K]
+  ): ISpace[Id, C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -74,7 +83,8 @@ object RSpace {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): ISpace[Id, C, P, E, A, R, K] = {
+      sk: Serialize[K]
+  ): ISpace[Id, C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec

--- a/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
@@ -40,7 +40,8 @@ object Serialize {
             Attempt.fromEither(
               value
                 .traverse[Either[Throwable, ?], A]((vec: ByteVector) => instance.decode(vec))
-                .leftMap((thw: Throwable) => Err(thw.getMessage)))
+                .leftMap((thw: Throwable) => Err(thw.getMessage))
+            )
           }
     }
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -62,8 +62,12 @@ private[rspace] trait SpaceMatcher[C, P, E, A, R, K] extends IdISpace[C, P, E, A
           case Right(Some(mat)) =>
             Right(
               Some(
-                (DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex),
-                 prefix ++ remaining)))
+                (
+                  DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex),
+                  prefix ++ remaining
+                )
+              )
+            )
         }
     }
 
@@ -89,8 +93,8 @@ private[rspace] trait SpaceMatcher[C, P, E, A, R, K] extends IdISpace[C, P, E, A
   private[rspace] final def extractDataCandidates(
       channelPatternPairs: Seq[(C, P)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
-      acc: Seq[Either[E, Option[DataCandidate[C, R]]]])(
-      implicit m: Match[P, E, A, R]): Seq[Either[E, Option[DataCandidate[C, R]]]] =
+      acc: Seq[Either[E, Option[DataCandidate[C, R]]]]
+  )(implicit m: Match[P, E, A, R]): Seq[Either[E, Option[DataCandidate[C, R]]]] =
     channelPatternPairs match {
       case Nil =>
         acc.reverse
@@ -107,9 +111,11 @@ private[rspace] trait SpaceMatcher[C, P, E, A, R, K] extends IdISpace[C, P, E, A
           case Left(e) =>
             (Left(e) +: acc).reverse
           case Right(Some((cand, rem))) =>
-            extractDataCandidates(tail,
-                                  channelToIndexedData.updated(channel, rem),
-                                  Right(Some(cand)) +: acc)
+            extractDataCandidates(
+              tail,
+              channelToIndexedData.updated(channel, rem),
+              Right(Some(cand)) +: acc
+            )
           case Right(None) =>
             extractDataCandidates(tail, channelToIndexedData, Right(None) +: acc)
         }
@@ -121,8 +127,8 @@ private[rspace] trait SpaceMatcher[C, P, E, A, R, K] extends IdISpace[C, P, E, A
   private[rspace] final def extractFirstMatch(
       channels: Seq[C],
       matchCandidates: Seq[(WaitingContinuation[P, K], Int)],
-      channelToIndexedData: Map[C, Seq[(Datum[A], Int)]])(
-      implicit m: Match[P, E, A, R]): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
+      channelToIndexedData: Map[C, Seq[(Datum[A], Int)]]
+  )(implicit m: Match[P, E, A, R]): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
     matchCandidates match {
       case Nil =>
         Right(None)

--- a/rspace/src/main/scala/coop/rchain/rspace/StableHashProvider.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StableHashProvider.scala
@@ -16,13 +16,15 @@ object StableHashProvider {
     Blake2b256Hash.create(
       channels
         .map(c => codecC.encode(c).get.bytes)
-        .sorted(util.ordByteVector))
+        .sorted(util.ordByteVector)
+    )
 
   def hash[C, P, K](channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
       implicit
       serializeC: Serialize[C],
       serializeP: Serialize[P],
-      serializeK: Serialize[K]) = {
+      serializeK: Serialize[K]
+  ) = {
     val (encodedChannels, encodedPatterns) = channels
       .zip(patterns)
       .map { case (channel, pattern) => (serializeC.encode(channel), serializeP.encode(pattern)) }
@@ -31,15 +33,23 @@ object StableHashProvider {
 
     Blake2b256Hash.create(
       encodedChannels ++ encodedPatterns
-        ++ List(serializeK.encode(continuation),
-                (ignore(7) ~> bool).encode(persist).map(_.bytes).get))
+        ++ List(
+          serializeK.encode(continuation),
+          (ignore(7) ~> bool).encode(persist).map(_.bytes).get
+        )
+    )
   }
 
-  def hash[C, A](channel: C, datum: A, persist: Boolean)(implicit
-                                                         serializeC: Serialize[C],
-                                                         serializeA: Serialize[A]) =
+  def hash[C, A](channel: C, datum: A, persist: Boolean)(
+      implicit
+      serializeC: Serialize[C],
+      serializeA: Serialize[A]
+  ) =
     Blake2b256Hash.create(
-      Seq(serializeC.encode(channel),
-          serializeA.encode(datum),
-          (ignore(7) ~> bool).encode(persist).map(_.bytes).get))
+      Seq(
+        serializeC.encode(channel),
+        serializeA.encode(datum),
+        (ignore(7) ~> bool).encode(persist).map(_.bytes).get
+      )
+    )
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
@@ -2,15 +2,17 @@ package coop.rchain.rspace.concurrent
 
 trait TwoStepLock[K] {
   def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => Seq[K])(thunk: => W)(
-      implicit o: Ordering[K]): W
+      implicit o: Ordering[K]
+  ): W
 }
 
 class DefaultTwoStepLock[K] extends TwoStepLock[K] {
   private[this] val phaseA: MultiLock[K] = new DefaultMultiLock[K]
   private[this] val phaseB: MultiLock[K] = new DefaultMultiLock[K]
 
-  override def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => Seq[K])(thunk: => W)(
-      implicit o: Ordering[K]): W =
+  override def acquire[R, S, W](
+      keysA: Seq[K]
+  )(phaseTwo: () => Seq[K])(thunk: => W)(implicit o: Ordering[K]): W =
     phaseA.acquire(keysA) {
       val keysB = phaseTwo
       phaseB.acquire(keysB()) {

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -91,7 +91,11 @@ object AddressBookExample {
         val baos = new ByteArrayOutputStream()
         try {
           val oos = new ObjectOutputStream(baos)
-          try { oos.writeObject(channel) } finally { oos.close() }
+          try {
+            oos.writeObject(channel)
+          } finally {
+            oos.close()
+          }
           ByteVector.view(baos.toByteArray)
         } finally {
           baos.close()
@@ -103,7 +107,11 @@ object AddressBookExample {
           val bais = new ByteArrayInputStream(bytes.toArray)
           try {
             val ois = new ObjectInputStream(bais)
-            try { Right(ois.readObject.asInstanceOf[Channel]) } finally { ois.close() }
+            try {
+              Right(ois.readObject.asInstanceOf[Channel])
+            } finally {
+              ois.close()
+            }
           } finally {
             bais.close()
           }
@@ -153,20 +161,26 @@ object AddressBookExample {
   import implicits._
 
   // Let's define some Entries
-  val alice = Entry(name = Name("Alice", "Lincoln"),
-                    address = Address("777 Ford St.", "Crystal Lake", "Idaho", "223322"),
-                    email = "alicel@ringworld.net",
-                    phone = "787-555-1212")
+  val alice = Entry(
+    name = Name("Alice", "Lincoln"),
+    address = Address("777 Ford St.", "Crystal Lake", "Idaho", "223322"),
+    email = "alicel@ringworld.net",
+    phone = "787-555-1212"
+  )
 
-  val bob = Entry(name = Name("Bob", "Lahblah"),
-                  address = Address("1000 Main St", "Crystal Lake", "Idaho", "223322"),
-                  email = "blablah@tenex.net",
-                  phone = "698-555-1212")
+  val bob = Entry(
+    name = Name("Bob", "Lahblah"),
+    address = Address("1000 Main St", "Crystal Lake", "Idaho", "223322"),
+    email = "blablah@tenex.net",
+    phone = "698-555-1212"
+  )
 
-  val carol = Entry(name = Name("Carol", "Lahblah"),
-                    address = Address("22 Goldwater Way", "Herbert", "Nevada", "334433"),
-                    email = "carol@blablah.org",
-                    phone = "232-555-1212")
+  val carol = Entry(
+    name = Name("Carol", "Lahblah"),
+    address = Address("22 Goldwater Way", "Herbert", "Nevada", "334433"),
+    email = "carol@blablah.org",
+    phone = "232-555-1212"
+  )
 
   def exampleOne(): Unit = {
 
@@ -183,10 +197,12 @@ object AddressBookExample {
 
     val cres =
       space
-        .consume(Seq(Channel("friends")),
-                 Seq(CityMatch(city = "Crystal Lake")),
-                 new Printer,
-                 persist = true)
+        .consume(
+          Seq(Channel("friends")),
+          Seq(CityMatch(city = "Crystal Lake")),
+          new Printer,
+          persist = true
+        )
         .right
         .get // it should be fine to do that -- type of left side is Nothing (no invalid states)
 
@@ -228,10 +244,12 @@ object AddressBookExample {
 
     val consumer = () =>
       space
-        .consume(Seq(Channel("friends")),
-                 Seq(NameMatch(last = "Lahblah")),
-                 new Printer,
-                 persist = false)
+        .consume(
+          Seq(Channel("friends")),
+          Seq(NameMatch(last = "Lahblah")),
+          new Printer,
+          persist = false
+        )
         .right
         .get
 
@@ -255,10 +273,12 @@ object AddressBookExample {
 
     val cres =
       space
-        .consume(Seq(Channel("friends")),
-                 Seq(CityMatch(city = "Crystal Lake")),
-                 new Printer,
-                 persist = false)
+        .consume(
+          Seq(Channel("friends")),
+          Seq(CityMatch(city = "Crystal Lake")),
+          new Printer,
+          persist = false
+        )
         .right
         .get
 
@@ -280,7 +300,8 @@ object AddressBookExample {
     assert(produceAlice.isEmpty)
 
     println(
-      "Rollback example: Let's reset RSpace to the state from before running the produce operations")
+      "Rollback example: Let's reset RSpace to the state from before running the produce operations"
+    )
     space.reset(checkpointHash)
 
     println("Rollback example: Again, first produce result should return some data")
@@ -293,7 +314,8 @@ object AddressBookExample {
   }
 
   private[this] def withSpace(
-      f: IdISpace[Channel, Pattern, Nothing, Entry, Entry, Printer] => Unit) = {
+      f: IdISpace[Channel, Pattern, Nothing, Entry, Entry, Printer] => Unit
+  ) = {
     // Here we define a temporary place to put the store's files
     val storePath = Files.createTempDirectory("rspace-address-book-example-")
     // Let's define our store

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -15,35 +15,44 @@ object internal {
   final case class Datum[A](a: A, persist: Boolean, source: Produce)
 
   object Datum {
-    def create[C, A](channel: C, a: A, persist: Boolean)(implicit
-                                                         serializeC: Serialize[C],
-                                                         serializeA: Serialize[A]): Datum[A] =
+    def create[C, A](channel: C, a: A, persist: Boolean)(
+        implicit
+        serializeC: Serialize[C],
+        serializeA: Serialize[A]
+    ): Datum[A] =
       Datum(a, persist, Produce.create(channel, a, persist))
   }
 
   final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
 
-  final case class WaitingContinuation[P, K](patterns: Seq[P],
-                                             continuation: K,
-                                             persist: Boolean,
-                                             source: Consume)
+  final case class WaitingContinuation[P, K](
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      source: Consume
+  )
 
   object WaitingContinuation {
     def create[C, P, K](channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
         implicit
         serializeC: Serialize[C],
         serializeP: Serialize[P],
-        serializeK: Serialize[K]): WaitingContinuation[P, K] =
-      WaitingContinuation(patterns,
-                          continuation,
-                          persist,
-                          Consume.create(channels, patterns, continuation, persist))
+        serializeK: Serialize[K]
+    ): WaitingContinuation[P, K] =
+      WaitingContinuation(
+        patterns,
+        continuation,
+        persist,
+        Consume.create(channels, patterns, continuation, persist)
+      )
   }
 
-  final case class ProduceCandidate[C, P, A, K](channels: Seq[C],
-                                                continuation: WaitingContinuation[P, K],
-                                                continuationIndex: Int,
-                                                dataCandidates: Seq[DataCandidate[C, A]])
+  final case class ProduceCandidate[C, P, A, K](
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K],
+      continuationIndex: Int,
+      dataCandidates: Seq[DataCandidate[C, A]]
+  )
 
   final case class Row[P, A, K](data: Seq[Datum[A]], wks: Seq[WaitingContinuation[P, K]])
 
@@ -59,10 +68,12 @@ object internal {
   case object Insert     extends Operation
   case object Delete     extends Operation
 
-  final case class TrieUpdate[C, P, A, K](count: Long,
-                                          operation: Operation,
-                                          channelsHash: Blake2b256Hash,
-                                          gnat: GNAT[C, P, A, K])
+  final case class TrieUpdate[C, P, A, K](
+      count: Long,
+      operation: Operation,
+      channelsHash: Blake2b256Hash,
+      gnat: GNAT[C, P, A, K]
+  )
 
   implicit val codecByteVector: Codec[ByteVector] =
     variableSizeBytesLong(int64, bytes)
@@ -73,16 +84,20 @@ object internal {
   implicit def codecDatum[A](implicit codecA: Codec[A]): Codec[Datum[A]] =
     (codecA :: bool :: Codec[Produce]).as[Datum[A]]
 
-  implicit def codecWaitingContinuation[P, K](implicit
-                                              codecP: Codec[P],
-                                              codecK: Codec[K]): Codec[WaitingContinuation[P, K]] =
+  implicit def codecWaitingContinuation[P, K](
+      implicit
+      codecP: Codec[P],
+      codecK: Codec[K]
+  ): Codec[WaitingContinuation[P, K]] =
     (codecSeq(codecP) :: codecK :: bool :: Codec[Consume]).as[WaitingContinuation[P, K]]
 
-  implicit def codecGNAT[C, P, A, K](implicit
-                                     codecC: Codec[C],
-                                     codecP: Codec[P],
-                                     codecA: Codec[A],
-                                     codecK: Codec[K]): Codec[GNAT[C, P, A, K]] =
+  implicit def codecGNAT[C, P, A, K](
+      implicit
+      codecC: Codec[C],
+      codecP: Codec[P],
+      codecA: Codec[A],
+      codecK: Codec[K]
+  ): Codec[GNAT[C, P, A, K]] =
     (codecSeq(codecC) ::
       codecSeq(codecDatum(codecA)) ::
       codecSeq(codecWaitingContinuation(codecP, codecK))).as[GNAT[C, P, A, K]]

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -8,13 +8,16 @@ import scala.collection.immutable.Seq
 
 trait PureRSpace[F[_], C, P, E, A, R, K] {
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
+      implicit m: Match[P, E, A, R]
+  ): F[Either[E, Option[(K, Seq[R])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]]
+      implicit m: Match[P, E, A, R]
+  ): F[Option[(K, Seq[R])]]
 
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]]
+      implicit m: Match[P, E, A, R]
+  ): F[Either[E, Option[(K, Seq[R])]]]
 
   def createCheckpoint(): F[Checkpoint]
 
@@ -30,15 +33,18 @@ object PureRSpace {
     def of[C, P, E, A, R, K](space: IdISpace[C, P, E, A, R, K]): PureRSpace[F, C, P, E, A, R, K] =
       new PureRSpace[F, C, P, E, A, R, K] {
         def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-            implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
+            implicit m: Match[P, E, A, R]
+        ): F[Either[E, Option[(K, Seq[R])]]] =
           F.delay(space.consume(channels, patterns, continuation, persist))
 
         def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-            implicit m: Match[P, E, A, R]): F[Option[(K, Seq[R])]] =
+            implicit m: Match[P, E, A, R]
+        ): F[Option[(K, Seq[R])]] =
           F.delay(space.install(channels, patterns, continuation))
 
         def produce(channel: C, data: A, persist: Boolean)(
-            implicit m: Match[P, E, A, R]): F[Either[E, Option[(K, Seq[R])]]] =
+            implicit m: Match[P, E, A, R]
+        ): F[Either[E, Option[(K, Seq[R])]]] =
           F.delay(space.produce(channel, data, persist))
 
         def createCheckpoint(): F[Checkpoint] = F.delay(space.createCheckpoint())

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
@@ -17,8 +17,10 @@ import scala.util.Random
 import kamon._
 import kamon.trace.Tracer.SpanBuilder
 
-abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A, K],
-                                                      val branch: Branch)(
+abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](
+    val store: IStore[C, P, A, K],
+    val branch: Branch
+)(
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
@@ -29,19 +31,23 @@ abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A,
 
   private val lock: TwoStepLock[Blake2b256Hash] = new DefaultTwoStepLock()
 
-  protected[this] def consumeLock(channels: Seq[C])(
-      thunk: => Either[E, Option[(K, Seq[R])]]): Either[E, Option[(K, Seq[R])]] = {
+  protected[this] def consumeLock(
+      channels: Seq[C]
+  )(thunk: => Either[E, Option[(K, Seq[R])]]): Either[E, Option[(K, Seq[R])]] = {
     val hashes = channels.map(ch => StableHashProvider.hash(ch))
     lock.acquire(hashes)(() => hashes)(thunk)
   }
 
-  protected[this] def produceLock(channel: C)(
-      thunk: => Either[E, Option[(K, Seq[R])]]): Either[E, Option[(K, Seq[R])]] =
-    lock.acquire(Seq(StableHashProvider.hash(channel)))(() =>
-      store.withTxn(store.createTxnRead()) { txn =>
-        val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
-        groupedChannels.flatten.map(StableHashProvider.hash(_))
-    })(thunk)
+  protected[this] def produceLock(
+      channel: C
+  )(thunk: => Either[E, Option[(K, Seq[R])]]): Either[E, Option[(K, Seq[R])]] =
+    lock.acquire(Seq(StableHashProvider.hash(channel)))(
+      () =>
+        store.withTxn(store.createTxnRead()) { txn =>
+          val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
+          groupedChannels.flatten.map(StableHashProvider.hash(_))
+        }
+    )(thunk)
 
   protected[this] val logger: Logger
   protected[this] val installSpan: SpanBuilder
@@ -58,10 +64,12 @@ abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A,
         install(txn, channels, patterns, continuation)(_match)
     }
 
-  private[this] def install(txn: store.Transaction,
-                            channels: Seq[C],
-                            patterns: Seq[P],
-                            continuation: K)(implicit m: Match[P, E, A, R]): Option[(K, Seq[R])] = {
+  private[this] def install(
+      txn: store.Transaction,
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K
+  )(implicit m: Match[P, E, A, R]): Option[(K, Seq[R])] = {
     if (channels.length =!= patterns.length) {
       val msg = "channels.length must equal patterns.length"
       logger.error(msg)
@@ -97,7 +105,8 @@ abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A,
         store.installWaitingContinuation(
           txn,
           channels,
-          WaitingContinuation(patterns, continuation, persist = true, consumeRef))
+          WaitingContinuation(patterns, continuation, persist = true, consumeRef)
+        )
         for (channel <- channels) store.addJoin(txn, channel, channels)
         logger.debug(s"""|storing <(patterns, continuation): ($patterns, $continuation)>
                            |at <channels: $channels>""".stripMargin.replace('\n', ' '))
@@ -109,15 +118,18 @@ abstract class FineGrainedRSpaceOps[C, P, E, A, R, K](val store: IStore[C, P, A,
   }
 
   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, E, A, R]): Option[(K, Seq[R])] =
+      implicit m: Match[P, E, A, R]
+  ): Option[(K, Seq[R])] =
     Kamon.withSpan(installSpan.start(), finishSpan = true) {
       store.withTxn(store.createTxnWrite()) { txn =>
         install(txn, channels, patterns, continuation)
       }
     }
 
-  override def retrieve(root: Blake2b256Hash,
-                        channelsHash: Blake2b256Hash): Option[GNAT[C, P, A, K]] =
+  override def retrieve(
+      root: Blake2b256Hash,
+      channelsHash: Blake2b256Hash
+  ): Option[GNAT[C, P, A, K]] =
     history.lookup(store.trieStore, root, channelsHash)
 
   override def reset(root: Blake2b256Hash): Unit =

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
@@ -38,7 +38,8 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
   protected[this] val installSpan = Kamon.buildSpan("replayrspace.install")
 
   def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
+      implicit m: Match[P, E, A, R]
+  ): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
       if (channels.length =!= patterns.length) {
         val msg = "channels.length must equal patterns.length"
@@ -61,14 +62,17 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
             .sequence
         }
 
-        def storeWaitingContinuation(replays: ReplayData,
-                                     consumeRef: Consume,
-                                     maybeCommRef: Option[COMM]): None.type = {
+        def storeWaitingContinuation(
+            replays: ReplayData,
+            consumeRef: Consume,
+            maybeCommRef: Option[COMM]
+        ): None.type = {
           store.withTxn(store.createTxnWrite()) { txn =>
             store.putWaitingContinuation(
               txn,
               channels,
-              WaitingContinuation(patterns, continuation, persist, consumeRef))
+              WaitingContinuation(patterns, continuation, persist, consumeRef)
+            )
             for (channel <- channels) store.addJoin(txn, channel, channels)
           }
           logger.debug(s"""|consume: no data found,
@@ -78,10 +82,12 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
           None
         }
 
-        def handleMatches(mats: Seq[DataCandidate[C, R]],
-                          replays: ReplayData,
-                          consumeRef: Consume,
-                          comms: Multiset[COMM]): Option[(K, Seq[R])] = {
+        def handleMatches(
+            mats: Seq[DataCandidate[C, R]],
+            replays: ReplayData,
+            consumeRef: Consume,
+            comms: Multiset[COMM]
+        ): Option[(K, Seq[R])] = {
           consumeCommCounter.increment()
           val commRef = COMM(consumeRef, mats.map(_.datum.source))
           assert(comms.contains(commRef), "COMM Event was not contained in the trace")
@@ -143,13 +149,16 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
     }
 
   def produce(channel: C, data: A, persist: Boolean)(
-      implicit m: Match[P, E, A, R]): Either[E, Option[(K, Seq[R])]] =
+      implicit m: Match[P, E, A, R]
+  ): Either[E, Option[(K, Seq[R])]] =
     Kamon.withSpan(produceSpan.start(), finishSpan = true) {
       produceLock(channel) {
         @tailrec
-        def runMatcher(comm: COMM,
-                       produceRef: Produce,
-                       groupedChannels: Seq[Seq[C]]): Option[ProduceCandidate[C, P, R, K]] =
+        def runMatcher(
+            comm: COMM,
+            produceRef: Produce,
+            groupedChannels: Seq[Seq[C]]
+        ): Option[ProduceCandidate[C, P, R, K]] =
           groupedChannels match {
             case Nil => None
             case channels :: remaining =>
@@ -180,9 +189,11 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
               }
           }
 
-        def storeDatum(replays: ReplayData,
-                       produceRef: Produce,
-                       maybeCommRef: Option[COMM]): None.type = {
+        def storeDatum(
+            replays: ReplayData,
+            produceRef: Produce,
+            maybeCommRef: Option[COMM]
+        ): None.type = {
           store.withTxn(store.createTxnWrite()) { txn =>
             store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
           }
@@ -192,15 +203,19 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
           None
         }
 
-        def handleMatch(mat: ProduceCandidate[C, P, R, K],
-                        replays: ReplayData,
-                        produceRef: Produce,
-                        comms: Multiset[COMM]): Option[(K, Seq[R])] =
+        def handleMatch(
+            mat: ProduceCandidate[C, P, R, K],
+            replays: ReplayData,
+            produceRef: Produce,
+            comms: Multiset[COMM]
+        ): Option[(K, Seq[R])] =
           mat match {
-            case ProduceCandidate(channels,
-                                  WaitingContinuation(_, continuation, persistK, consumeRef),
-                                  continuationIndex,
-                                  dataCandidates) =>
+            case ProduceCandidate(
+                channels,
+                WaitingContinuation(_, continuation, persistK, consumeRef),
+                continuationIndex,
+                dataCandidates
+                ) =>
               produceCommCounter.increment()
               val commRef = COMM(consumeRef, dataCandidates.map(_.datum.source))
               assert(comms.contains(commRef), "COMM Event was not contained in the trace")
@@ -236,7 +251,8 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
 
           @tailrec
           def getCommOrProduceCandidate(
-              comms: Seq[COMM]): Either[COMM, ProduceCandidate[C, P, R, K]] =
+              comms: Seq[COMM]
+          ): Either[COMM, ProduceCandidate[C, P, R, K]] =
             comms match {
               case Nil =>
                 val msg = "comms must not be empty"
@@ -271,8 +287,10 @@ class FineGrainedReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branc
       }
     }
 
-  private def replaysLessCommRef(replays: ReplayData,
-                                 commRef: COMM): MultisetMultiMap[IOEvent, COMM] =
+  private def replaysLessCommRef(
+      replays: ReplayData,
+      commRef: COMM
+  ): MultisetMultiMap[IOEvent, COMM] =
     commRef.produces.foldLeft(replays.removeBinding(commRef.consume, commRef)) {
       case (updatedReplays, produceRef) =>
         updatedReplays.removeBinding(produceRef, commRef)
@@ -302,7 +320,8 @@ object FineGrainedReplayRSpace {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): FineGrainedReplayRSpace[C, P, E, A, R, K] = {
+      sk: Serialize[K]
+  ): FineGrainedReplayRSpace[C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -62,11 +62,15 @@ object Produce {
   def unapply(arg: Produce): Option[(Blake2b256Hash, Blake2b256Hash)] =
     Some((arg.channelsHash, arg.hash))
 
-  def create[C, A](channel: C, datum: A, persist: Boolean)(implicit
-                                                           serializeC: Serialize[C],
-                                                           serializeA: Serialize[A]): Produce =
-    new Produce(StableHashProvider.hash(Seq(channel))(serializeC.toCodec),
-                StableHashProvider.hash(channel, datum, persist))
+  def create[C, A](channel: C, datum: A, persist: Boolean)(
+      implicit
+      serializeC: Serialize[C],
+      serializeA: Serialize[A]
+  ): Produce =
+    new Produce(
+      StableHashProvider.hash(Seq(channel))(serializeC.toCodec),
+      StableHashProvider.hash(channel, datum, persist)
+    )
 
   def fromHash(channelsHash: Blake2b256Hash, hash: Blake2b256Hash): Produce =
     new Produce(channelsHash, hash)
@@ -97,9 +101,12 @@ object Consume {
       implicit
       serializeC: Serialize[C],
       serializeP: Serialize[P],
-      serializeK: Serialize[K]): Consume =
-    new Consume(StableHashProvider.hash(channels)(serializeC.toCodec),
-                StableHashProvider.hash(channels, patterns, continuation, persist))
+      serializeK: Serialize[K]
+  ): Consume =
+    new Consume(
+      StableHashProvider.hash(channels)(serializeC.toCodec),
+      StableHashProvider.hash(channels, patterns, continuation, persist)
+    )
 
   def fromHash(channelsHash: Blake2b256Hash, hash: Blake2b256Hash): Consume =
     new Consume(channelsHash, hash)

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -82,5 +82,5 @@ package object util {
       veccmp(a._1, b._1) match {
         case 0 => veccmp(a._2, b._2)
         case c => c
-    }
+      }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -36,8 +36,10 @@ trait HistoryActionsTests
   /**
     * Helper for testing purposes only.
     */
-  private[this] def getRootHash(store: IStore[String, Pattern, String, StringsCaptor],
-                                branch: Branch): Blake2b256Hash =
+  private[this] def getRootHash(
+      store: IStore[String, Pattern, String, StringsCaptor],
+      branch: Branch
+  ): Blake2b256Hash =
     store.withTxn(store.createTxnRead()) { txn =>
       store.withTrieTxn(txn) { trieTxn =>
         store.trieStore.getRoot(trieTxn, branch).get
@@ -45,7 +47,8 @@ trait HistoryActionsTests
     }
   "createCheckpoint on an empty store" should "return the expected hash" in withTestSpace { space =>
     space.createCheckpoint().root shouldBe Blake2b256Hash.fromHex(
-      "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3")
+      "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3"
+    )
   }
 
   "consume then createCheckpoint" should "return the expected hash and the TrieStore should contain the expected value" in
@@ -55,7 +58,9 @@ trait HistoryActionsTests
         channels,
         List.empty[Datum[String]],
         List(
-          WaitingContinuation.create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+          WaitingContinuation.create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+        )
+      )
 
       val channelsHash: Blake2b256Hash = space.store.hashChannels(gnat.channels)
 
@@ -67,12 +72,16 @@ trait HistoryActionsTests
         Node(
           PointerBlock
             .create()
-            .updated(List((JByte.toUnsignedInt(channelsHash.bytes.head), NodePointer(skipHash))))))
+            .updated(List((JByte.toUnsignedInt(channelsHash.bytes.head), NodePointer(skipHash))))
+        )
+      )
 
-      space.consume(gnat.channels,
-                    gnat.wks.head.patterns,
-                    gnat.wks.head.continuation,
-                    gnat.wks.head.persist)
+      space.consume(
+        gnat.channels,
+        gnat.wks.head.patterns,
+        gnat.wks.head.continuation,
+        gnat.wks.head.persist
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 
@@ -91,35 +100,45 @@ trait HistoryActionsTests
     withTestSpace { space =>
       val gnat1 = {
         val channels = List("ch1")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
       val channelsHash1: Blake2b256Hash = space.store.hashChannels(gnat1.channels)
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       val gnat2 = {
         val channels = List("ch2")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
       val channelsHash2: Blake2b256Hash = space.store.hashChannels(gnat2.channels)
 
-      space.consume(gnat2.channels,
-                    gnat2.wks.head.patterns,
-                    gnat2.wks.head.continuation,
-                    gnat2.wks.head.persist)
+      space.consume(
+        gnat2.channels,
+        gnat2.wks.head.patterns,
+        gnat2.wks.head.continuation,
+        gnat2.wks.head.persist
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash1) shouldBe None
 
@@ -150,9 +169,11 @@ trait HistoryActionsTests
         val gnats: Seq[TestGNAT] =
           data.map {
             case (channel, datum) =>
-              GNAT(List(channel),
-                   List(datum),
-                   List.empty[WaitingContinuation[Pattern, StringsCaptor]])
+              GNAT(
+                List(channel),
+                List(datum),
+                List.empty[WaitingContinuation[Pattern, StringsCaptor]]
+              )
           }.toList
 
         gnats.foreach {
@@ -224,7 +245,8 @@ trait HistoryActionsTests
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 
       space.createCheckpoint().root shouldBe Blake2b256Hash.fromHex(
-        "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3")
+        "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3"
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
     }
@@ -235,17 +257,22 @@ trait HistoryActionsTests
 
       val gnat1 = {
         val channels = List("ch1")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       space.store.isEmpty shouldBe false
 
@@ -270,17 +297,22 @@ trait HistoryActionsTests
 
       val gnat1 = {
         val channels = List("ch1", "ch2")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard, Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard, Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       val root1 = space.createCheckpoint().root
 
@@ -417,10 +449,12 @@ trait HistoryActionsTests
 
     val Checkpoint(_, log) = space.createCheckpoint()
 
-    log should contain theSameElementsInOrderAs Seq(commEvent,
-                                                    expectedProduce2,
-                                                    expectedProduce1,
-                                                    expectedConsume)
+    log should contain theSameElementsInOrderAs Seq(
+      commEvent,
+      expectedProduce2,
+      expectedProduce1,
+      expectedConsume
+    )
   }
 
   "an install" should "not be persisted to the history trie" in withTestSpace { space =>
@@ -474,9 +508,12 @@ trait HistoryActionsTests
     val afterProduce = space.createCheckpoint()
     val produceEvent = Produce.create(channel, datum, false)
     afterProduce.log should contain theSameElementsAs (Seq(
-      COMM(Consume.create[String, Pattern, StringsCaptor](key, patterns, continuation, true),
-           List(produceEvent)),
-      produceEvent))
+      COMM(
+        Consume.create[String, Pattern, StringsCaptor](key, patterns, continuation, true),
+        List(produceEvent)
+      ),
+      produceEvent
+    ))
   }
 }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -73,7 +73,8 @@ trait IStoreTests
           }
           store.removeDatum(txn, key, index - 1)
           store.getData(txn, key) should contain theSameElementsAs (data.filterNot(
-            _.a == datumValue + (size - index)))
+            _.a == datumValue + (size - index)
+          ))
           store.clear(txn)
         }
     }
@@ -222,11 +223,15 @@ trait IStoreTests
   it should "remove all operations from history with the same hash when last operation is delete" in withTestSpace {
     space =>
       forAll("gnat1", "gnat2") {
-        (gnat1: GNAT[String, Pattern, String, StringsCaptor],
-         gnat2: GNAT[String, Pattern, String, StringsCaptor]) =>
+        (
+            gnat1: GNAT[String, Pattern, String, StringsCaptor],
+            gnat2: GNAT[String, Pattern, String, StringsCaptor]
+        ) =>
           val store = space.store
-          val gnat1Ops = List(TrieUpdate(0, Insert, store.hashChannels(gnat1.channels), gnat1),
-                              TrieUpdate(1, Delete, store.hashChannels(gnat1.channels), gnat1))
+          val gnat1Ops = List(
+            TrieUpdate(0, Insert, store.hashChannels(gnat1.channels), gnat1),
+            TrieUpdate(1, Delete, store.hashChannels(gnat1.channels), gnat1)
+          )
           val gnat2Ops = List(TrieUpdate(2, Insert, store.hashChannels(gnat2.channels), gnat2))
           val history  = gnat1Ops ++ gnat2Ops
           store.collapse(history) shouldBe gnat2Ops
@@ -241,7 +246,7 @@ trait IStoreTests
           TrieUpdate(0, Insert, store.hashChannels(gnat1.channels), gnat1),
           TrieUpdate(1, Insert, store.hashChannels(gnat1.channels), gnat1),
           TrieUpdate(2, Insert, store.hashChannels(gnat1.channels), gnat1),
-          TrieUpdate(3, Delete, store.hashChannels(gnat1.channels), gnat1),
+          TrieUpdate(3, Delete, store.hashChannels(gnat1.channels), gnat1)
         )
         store.collapse(gnatOps) shouldBe empty
       }
@@ -265,9 +270,11 @@ trait IStoreTests
         val store      = space.store
         val lastInsert = TrieUpdate(2, Insert, store.hashChannels(gnat.channels), gnat)
 
-        val history = List(TrieUpdate(0, Insert, store.hashChannels(gnat.channels), gnat),
-                           lastInsert,
-                           TrieUpdate(1, Delete, store.hashChannels(gnat.channels), gnat))
+        val history = List(
+          TrieUpdate(0, Insert, store.hashChannels(gnat.channels), gnat),
+          lastInsert,
+          TrieUpdate(1, Delete, store.hashChannels(gnat.channels), gnat)
+        )
         store.collapse(history) shouldBe List(lastInsert)
       }
   }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -31,18 +31,20 @@ trait ReplayRSpaceTests
       channelsCreator: Int => List[C],
       patterns: List[P],
       continuationCreator: Int => K,
-      persist: Boolean)(implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, Seq[R])]] =
+      persist: Boolean
+  )(implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
       space.consume(channelsCreator(i), patterns, continuationCreator(i), persist).right.get
     }
 
-  def produceMany[C, P, A, R, K](space: IdISpace[C, P, Nothing, A, R, K],
-                                 range: Range,
-                                 shuffle: Boolean,
-                                 channelCreator: Int => C,
-                                 datumCreator: Int => A,
-                                 persist: Boolean)(
-      implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, immutable.Seq[R])]] =
+  def produceMany[C, P, A, R, K](
+      space: IdISpace[C, P, Nothing, A, R, K],
+      range: Range,
+      shuffle: Boolean,
+      channelCreator: Int => C,
+      datumCreator: Int => A,
+      persist: Boolean
+  )(implicit matcher: Match[P, Nothing, A, R]): List[Option[(K, immutable.Seq[R])]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).map { i: Int =>
       space.produce(channelCreator(i), datumCreator(i), persist).right.get
     }
@@ -808,18 +810,21 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      oC: Ordering[C]): S
+      oC: Ordering[C]
+  ): S
 }
 
 trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   override def withTestSpaces[S](
-      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S)(
+      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      oC: Ordering[C]): S = {
+      oC: Ordering[C]
+  ): S = {
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.create[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
@@ -839,13 +844,15 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
 
 trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   override def withTestSpaces[S](
-      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S)(
+      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      oC: Ordering[C]): S = {
+      oC: Ordering[C]
+  ): S = {
 
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
     val space     = RSpace.createInMemory[C, P, E, A, A, K](trieStore, Branch.REPLAY)
@@ -863,13 +870,15 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
 
 trait FineGrainedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   override def withTestSpaces[S](
-      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S)(
+      f: (IdISpace[C, P, E, A, A, K], IReplaySpace[Id, C, P, E, A, A, K]) => S
+  )(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      oC: Ordering[C]): S = {
+      oC: Ordering[C]
+  ): S = {
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.createFineGrained[C, P, A, K](dbDir, 1024L * 1024L * 4096L)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -82,7 +82,8 @@ trait StorageActionsTests
       store.getPatterns(txn, key) shouldBe Nil
       store.getData(txn, key) should contain theSameElementsAs List(
         Datum.create(key.head, "datum1", false),
-        Datum.create(key.head, "datum2", false))
+        Datum.create(key.head, "datum2", false)
+      )
       store.getWaitingContinuation(txn, key) shouldBe Nil
     }
 
@@ -115,7 +116,8 @@ trait StorageActionsTests
   "consuming with a list of patterns that is a different length than the list of channels" should
     "throw" in withTestSpace { space =>
     an[IllegalArgumentException] shouldBe thrownBy(
-      space.consume(List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false))
+      space.consume(List("ch1", "ch2"), List(Wildcard), new StringsCaptor, persist = false)
+    )
 
     val store = space.store
 
@@ -223,7 +225,8 @@ trait StorageActionsTests
       store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
       store.getPatterns(txn, produceKey1) shouldBe Nil
       store.getData(txn, produceKey1) shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false))
+        Datum.create(produceKey1.head, "datum1", persist = false)
+      )
       store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
     }
 
@@ -239,7 +242,8 @@ trait StorageActionsTests
       store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
       store.getPatterns(txn, produceKey1) shouldBe Nil
       store.getData(txn, produceKey1) shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false))
+        Datum.create(produceKey1.head, "datum1", persist = false)
+      )
       store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
       store.getChannels(txn, consumeKeyHash) shouldBe consumeKey
       store.getPatterns(txn, consumeKey) shouldBe List(consumePattern)
@@ -374,9 +378,11 @@ trait StorageActionsTests
 
     continuations.foreach(runK)
 
-    captor.results should contain theSameElementsAs List(List("datum3"),
-                                                         List("datum2"),
-                                                         List("datum1"))
+    captor.results should contain theSameElementsAs List(
+      List("datum3"),
+      List("datum2"),
+      List("datum1")
+    )
 
     store.isEmpty shouldBe true
   }
@@ -441,10 +447,12 @@ trait StorageActionsTests
     "return a continuation with both pieces of data" in withTestSpace { space =>
     val store = space.store
 
-    val r1 = space.consume(List("ch1", "ch2"),
-                           List(Wildcard, Wildcard),
-                           new StringsCaptor,
-                           persist = false)
+    val r1 = space.consume(
+      List("ch1", "ch2"),
+      List(Wildcard, Wildcard),
+      new StringsCaptor,
+      persist = false
+    )
     val r2 = space.produce("ch1", "datum1", persist = false)
     val r3 = space.produce("ch2", "datum2", persist = false)
 
@@ -466,10 +474,12 @@ trait StorageActionsTests
 
     val channels = List("ch1", "ch1")
 
-    val r1 = space.consume(channels,
-                           List(StringMatch("datum1"), StringMatch("datum1")),
-                           new StringsCaptor,
-                           persist = false)
+    val r1 = space.consume(
+      channels,
+      List(StringMatch("datum1"), StringMatch("datum1")),
+      new StringsCaptor,
+      persist = false
+    )
 
     val r2 = space.produce("ch1", "datum1", persist = false)
     val r3 = space.produce("ch1", "datum1", persist = false)
@@ -491,14 +501,18 @@ trait StorageActionsTests
 
     val channels = List("ch1", "ch2")
 
-    val r1 = space.consume(channels,
-                           List(StringMatch("datum1"), StringMatch("datum2")),
-                           new StringsCaptor,
-                           persist = false)
-    val r2 = space.consume(channels,
-                           List(StringMatch("datum3"), StringMatch("datum4")),
-                           new StringsCaptor,
-                           persist = false)
+    val r1 = space.consume(
+      channels,
+      List(StringMatch("datum1"), StringMatch("datum2")),
+      new StringsCaptor,
+      persist = false
+    )
+    val r2 = space.consume(
+      channels,
+      List(StringMatch("datum3"), StringMatch("datum4")),
+      new StringsCaptor,
+      persist = false
+    )
 
     val r3 = space.produce("ch1", "datum3", persist = false)
     val r4 = space.produce("ch2", "datum4", persist = false)
@@ -581,10 +595,12 @@ trait StorageActionsTests
     withTestSpace { space =>
       val store = space.store
 
-      space.consume(List("ch1", "ch2"),
-                    List(Wildcard, Wildcard),
-                    new StringsCaptor,
-                    persist = false)
+      space.consume(
+        List("ch1", "ch2"),
+        List(Wildcard, Wildcard),
+        new StringsCaptor,
+        persist = false
+      )
       space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
       val r3 = space.produce("ch1", "datum1", persist = false)
@@ -1040,7 +1056,8 @@ trait StorageActionsTests
 
   "createCheckpoint on an empty store" should "return the expected hash" in withTestSpace { space =>
     space.createCheckpoint().root shouldBe Blake2b256Hash.fromHex(
-      "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3")
+      "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3"
+    )
   }
 
   "consume then createCheckpoint" should "return the expected hash and the TrieStore should contain the expected value" in
@@ -1050,7 +1067,9 @@ trait StorageActionsTests
         channels,
         List.empty[Datum[String]],
         List(
-          WaitingContinuation.create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+          WaitingContinuation.create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+        )
+      )
 
       val channelsHash: Blake2b256Hash = space.store.hashChannels(gnat.channels)
 
@@ -1062,12 +1081,16 @@ trait StorageActionsTests
         Node(
           PointerBlock
             .create()
-            .updated(List((JByte.toUnsignedInt(channelsHash.bytes.head), NodePointer(skipHash))))))
+            .updated(List((JByte.toUnsignedInt(channelsHash.bytes.head), NodePointer(skipHash))))
+        )
+      )
 
-      space.consume(gnat.channels,
-                    gnat.wks.head.patterns,
-                    gnat.wks.head.continuation,
-                    gnat.wks.head.persist)
+      space.consume(
+        gnat.channels,
+        gnat.wks.head.patterns,
+        gnat.wks.head.continuation,
+        gnat.wks.head.persist
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 
@@ -1082,35 +1105,45 @@ trait StorageActionsTests
     withTestSpace { space =>
       val gnat1 = {
         val channels = List("ch1")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
       val channelsHash1: Blake2b256Hash = space.store.hashChannels(gnat1.channels)
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       val gnat2 = {
         val channels = List("ch2")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
       val channelsHash2: Blake2b256Hash = space.store.hashChannels(gnat2.channels)
 
-      space.consume(gnat2.channels,
-                    gnat2.wks.head.patterns,
-                    gnat2.wks.head.continuation,
-                    gnat2.wks.head.persist)
+      space.consume(
+        gnat2.channels,
+        gnat2.wks.head.patterns,
+        gnat2.wks.head.continuation,
+        gnat2.wks.head.persist
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash1) shouldBe None
 
@@ -1134,9 +1167,11 @@ trait StorageActionsTests
           val gnats: Seq[TestGNAT] =
             data.map {
               case (channel, datum) =>
-                GNAT(List(channel),
-                     List(datum),
-                     List.empty[WaitingContinuation[Pattern, StringsCaptor]])
+                GNAT(
+                  List(channel),
+                  List(datum),
+                  List.empty[WaitingContinuation[Pattern, StringsCaptor]]
+                )
             }.toList
 
           gnats.foreach {
@@ -1204,7 +1239,8 @@ trait StorageActionsTests
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
 
       space.createCheckpoint().root shouldBe Blake2b256Hash.fromHex(
-        "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3")
+        "ff3c5e70a028b7956791a6b3d8db9cd11f469e0088db22dd3afbc86997fe86a3"
+      )
 
       history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
     }
@@ -1215,17 +1251,22 @@ trait StorageActionsTests
 
       val gnat1 = {
         val channels = List("ch1")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       space.store.isEmpty shouldBe false
 
@@ -1250,17 +1291,22 @@ trait StorageActionsTests
 
       val gnat1 = {
         val channels = List("ch1", "ch2")
-        GNAT(channels,
-             List.empty[Datum[String]],
-             List(
-               WaitingContinuation
-                 .create(channels, List[Pattern](Wildcard, Wildcard), new StringsCaptor, false)))
+        GNAT(
+          channels,
+          List.empty[Datum[String]],
+          List(
+            WaitingContinuation
+              .create(channels, List[Pattern](Wildcard, Wildcard), new StringsCaptor, false)
+          )
+        )
       }
 
-      space.consume(gnat1.channels,
-                    gnat1.wks.head.patterns,
-                    gnat1.wks.head.continuation,
-                    gnat1.wks.head.persist)
+      space.consume(
+        gnat1.channels,
+        gnat1.wks.head.patterns,
+        gnat1.wks.head.continuation,
+        gnat1.wks.head.persist
+      )
 
       val root1 = space.createCheckpoint().root
 
@@ -1403,14 +1449,18 @@ trait StorageActionsTests
 
     val Checkpoint(_, log) = space.createCheckpoint()
 
-    log should contain theSameElementsInOrderAs Seq(commEvent,
-                                                    expectedProduce2,
-                                                    expectedProduce1,
-                                                    expectedConsume)
+    log should contain theSameElementsInOrderAs Seq(
+      commEvent,
+      expectedProduce2,
+      expectedProduce1,
+      expectedConsume
+    )
 
     log match {
-      case COMM(chkCommConsume1: Consume,
-                (chkCommProduce1: Produce) :: (chkCommProduce2: Produce) :: Nil)
+      case COMM(
+            chkCommConsume1: Consume,
+            (chkCommProduce1: Produce) :: (chkCommProduce2: Produce) :: Nil
+          )
             :: (chkProduce2: Produce) :: (chkProduce1: Produce) :: (chkConsume: Consume) :: Nil =>
         chkCommConsume1.channelsHash shouldBe expectedConsume.channelsHash
         chkCommProduce1.channelsHash shouldBe expectedProduce1.channelsHash
@@ -1446,10 +1496,12 @@ trait StorageActionsTests
 
     val Checkpoint(_, log) = space.createCheckpoint()
 
-    log should contain theSameElementsInOrderAs Seq(commEvent,
-                                                    expectedProduce2,
-                                                    expectedProduce1,
-                                                    expectedConsume)
+    log should contain theSameElementsInOrderAs Seq(
+      commEvent,
+      expectedProduce2,
+      expectedProduce1,
+      expectedConsume
+    )
   }
 
   "an install" should "not allow installing after a produce operation" in withTestSpace { space =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -78,9 +78,11 @@ trait StorageExamplesTests
     val r1 = space
       .consume(
         List(Channel("colleagues"), Channel("friends"), Channel("friends")),
-        List(CityMatch(city = "Crystal Lake"),
-             CityMatch(city = "Crystal Lake"),
-             CityMatch(city = "Crystal Lake")),
+        List(
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake"),
+          CityMatch(city = "Crystal Lake")
+        ),
         new EntriesCaptor,
         persist = false
       )
@@ -293,19 +295,17 @@ class InMemoryStoreStorageExamplesTestsBase
       implicits.serializeChannel.toCodec,
       implicits.serializePattern.toCodec,
       implicits.serializeInfo.toCodec,
-      implicits.serializeEntriesCaptor.toCodec)
+      implicits.serializeEntriesCaptor.toCodec
+    )
 
     val branch = Branch("inmem")
 
     val trieStore =
       InMemoryTrieStore.create[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]()
 
-    val testStore = InMemoryStore.create[
-      InMemTransaction[history.State[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]],
-      Channel,
-      Pattern,
-      Entry,
-      EntriesCaptor](trieStore, branch)
+    val testStore = InMemoryStore.create[InMemTransaction[
+      history.State[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]
+    ], Channel, Pattern, Entry, EntriesCaptor](trieStore, branch)
 
     val testSpace =
       RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore, branch)
@@ -337,8 +337,10 @@ class LMDBStoreStorageExamplesTestBase
     val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
     val testSpace =
-      RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore,
-                                                                            Branch.MASTER)
+      RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+        testStore,
+        Branch.MASTER
+      )
     try {
       testStore.withTxn(testStore.createTxnWrite())(txn => testStore.clear(txn))
       f(testSpace)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -40,10 +40,12 @@ trait StorageTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with Option
     */
   def withTestSpace[S](f: T => S): S
 
-  def validateIndexedStates(space: T,
-                            indexedStates: Seq[(State, Int)],
-                            reportName: String,
-                            differenceReport: Boolean = false): Boolean = {
+  def validateIndexedStates(
+      space: T,
+      indexedStates: Seq[(State, Int)],
+      reportName: String,
+      differenceReport: Boolean = false
+  ): Boolean = {
     final case class SetRow(data: Set[Datum[A]], wks: Set[WaitingContinuation[P, K]])
 
     def convertMap(m: Map[Seq[C], Row[P, A, K]]): Map[Seq[C], SetRow] =
@@ -89,7 +91,8 @@ trait StorageTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with Option
                   case Some(row) =>
                     if (row != expectedRow) {
                       logger.error(
-                        s"key [$expectedChannels] invalid actual value: $row !== $expectedRow")
+                        s"key [$expectedChannels] invalid actual value: $row !== $expectedRow"
+                      )
                     }
                   case None => logger.error(s"key [$expectedChannels] not found in actual records")
                 }
@@ -102,7 +105,8 @@ trait StorageTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with Option
                   case Some(row) =>
                     if (row != actualRow) {
                       logger.error(
-                        s"key[$actualChannels] invalid actual value: $actualRow !== $row")
+                        s"key[$actualChannels] invalid actual value: $actualRow !== $row"
+                      )
                     }
                   case None => logger.error(s"key [$actualChannels] not found in expected records")
                 }
@@ -128,12 +132,9 @@ class InMemoryStoreTestsBase
     val trieStore =
       InMemoryTrieStore.create[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]()
 
-    val testStore = InMemoryStore.create[
-      InMemTransaction[history.State[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]],
-      String,
-      Pattern,
-      String,
-      StringsCaptor](trieStore, branch)
+    val testStore = InMemoryStore.create[InMemTransaction[
+      history.State[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]
+    ], String, Pattern, String, StringsCaptor](trieStore, branch)
 
     val testSpace =
       RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, branch)
@@ -212,7 +213,8 @@ class MixedStoreTestsBase
     val testStore = InMemoryStore
       .create[org.lmdbjava.Txn[java.nio.ByteBuffer], String, Pattern, String, StringsCaptor](
         env.trieStore,
-        testBranch)
+        testBranch
+      )
 
     val testSpace =
       RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, testBranch)
@@ -254,8 +256,10 @@ class FineGrainedTestsBase
     val testStore =
       LMDBStore.create[String, Pattern, String, StringsCaptor](env, testBranch)
     val testSpace =
-      new FineGrainedRSpace[String, Pattern, Nothing, String, String, StringsCaptor](testStore,
-                                                                                     testBranch)
+      new FineGrainedRSpace[String, Pattern, Nothing, String, String, StringsCaptor](
+        testStore,
+        testBranch
+      )
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -20,9 +20,11 @@ class TwoStepLockTest extends FlatSpec with Matchers {
     r.unsafeRunSync
   }
 
-  def acquireLock(lock: TwoStepLock[String],
-                  a: List[String],
-                  b: List[String],
-                  update: => Unit): Task[Unit] =
+  def acquireLock(
+      lock: TwoStepLock[String],
+      a: List[String],
+      b: List[String],
+      update: => Unit
+  ): Task[Unit] =
     Task { lock.acquire(a)(() => b)(update) }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
@@ -415,17 +415,20 @@ object HistoryActionsTests {
   def insertAll[T, K, V](store: ITrieStore[T, K, V], branch: Branch, pairs: Seq[(K, V)])(
       implicit
       codecK: Codec[K],
-      codecV: Codec[V]): Unit =
+      codecV: Codec[V]
+  ): Unit =
     pairs.foreach { case (k, v) => insert(store, branch, k, v) }
 
   def deleteAll[T, K, V](store: ITrieStore[T, K, V], branch: Branch, pairs: Seq[(K, V)])(
       implicit
       codecK: Codec[K],
-      codecV: Codec[V]): Unit =
+      codecV: Codec[V]
+  ): Unit =
     pairs.foreach { case (k, v) => delete(store, branch, k, v) }
 
   def lookupAll[T, K, V](store: ITrieStore[T, K, V], branch: Branch, pairs: Seq[(K, V)])(
-      implicit codecK: Codec[K]): Seq[(K, V)] =
+      implicit codecK: Codec[K]
+  ): Seq[(K, V)] =
     pairs.flatMap { case (k, _) => lookup(store, branch, k).map((v: V) => (k, v)).toList }
 }
 
@@ -436,7 +439,8 @@ trait LMDBWithTestTrieStore[K]
   val mapSize: Long = 1024L * 1024L * 1024L
 
   override def withTestTrieStore[R](
-      f: (ITrieStore[Txn[ByteBuffer], K, ByteVector], Branch) => R): R = {
+      f: (ITrieStore[Txn[ByteBuffer], K, ByteVector], Branch) => R
+  ): R = {
     val env        = Context.env(dbDir, mapSize, Nil)
     val testTrie   = LMDBTrieStore.create[K, ByteVector](env, dbDir)
     val testBranch = Branch("test")
@@ -459,8 +463,11 @@ trait InMemoryWithTestTrieStore[K]
   this: Suite =>
 
   override def withTestTrieStore[R](
-      f: (ITrieStore[InMemTransaction[State[K, scodec.bits.ByteVector]], K, ByteVector],
-          Branch) => R): R = {
+      f: (
+          ITrieStore[InMemTransaction[State[K, scodec.bits.ByteVector]], K, ByteVector],
+          Branch
+      ) => R
+  ): R = {
     val testTrie   = InMemoryTrieStore.create[K, ByteVector]()
     val testBranch = Branch("test")
     //no need to clear new instance
@@ -475,8 +482,7 @@ trait InMemoryWithTestTrieStore[K]
 
 class InMemoryHistoryActionsTests
     extends HistoryActionsTests[InMemTransaction[State[TestKey4, scodec.bits.ByteVector]]]
-    with GenerativeHistoryActionsTests[InMemTransaction[State[TestKey4, scodec.bits.ByteVector]],
-                                       TestKey4]
+    with GenerativeHistoryActionsTests[InMemTransaction[State[TestKey4, scodec.bits.ByteVector]], TestKey4]
     with InMemoryWithTestTrieStore[TestKey4] {
   implicit val arbitraryMap = ArbitraryInstances.arbitraryNonEmptyMapTestKeyByteVector
 }
@@ -498,8 +504,8 @@ class LMDBHistoryActionsTestsKey32
 
 class InMemoryHistoryActionsTestsKey32
     extends GenerativeHistoryActionsTests[InMemTransaction[
-                                            State[TestKey32, scodec.bits.ByteVector]],
-                                          TestKey32]
+      State[TestKey32, scodec.bits.ByteVector]
+    ], TestKey32]
     with InMemoryWithTestTrieStore[TestKey32] {
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey32]  = TestKey32.codecTestKey

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
@@ -26,10 +26,13 @@ class TrieStructureTests
     }
 
   def withTrieTxnAndStore[R](
-      f: (ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector],
+      f: (
+          ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector],
           Branch,
           Txn[ByteBuffer],
-          Trie[TestKey4, ByteVector]) => R): R =
+          Trie[TestKey4, ByteVector]
+      ) => R
+  ): R =
     withTestTrieStore { (store, branch) =>
       store.withTxn(store.createTxnRead()) { txn =>
         val trieOpt = store.get(txn, store.getRoot(txn, branch).get)
@@ -118,10 +121,12 @@ class TrieStructureTests
       insert(store, branch, key2, val2)
 
       store.withTxn(store.createTxnWrite()) { txn =>
-        store.putRoot(txn,
-                      branch,
-                      Blake2b256Hash
-                        .fromHex(SingleElementData.rootHex))
+        store.putRoot(
+          txn,
+          branch,
+          Blake2b256Hash
+            .fromHex(SingleElementData.rootHex)
+        )
       }
 
       assertSingleElementTrie(store)
@@ -234,13 +239,15 @@ class TrieStructureTests
   }
 
   private[this] def assertSingleElementTrie(
-      implicit store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]) = {
+      implicit store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]
+  ) = {
     import SingleElementData._
     store.withTxn(store.createTxnRead()) { implicit txn =>
       expectNode(rootHex, Seq((1, NodePointer(skipHex))))
       val expectedSkipHash = Blake2b256Hash.fromHex(skipHex)
       store.get(txn, expectedSkipHash) shouldBe Some(
-        Skip(ByteVector(0, 0, 0), LeafPointer(leafHex)))
+        Skip(ByteVector(0, 0, 0), LeafPointer(leafHex))
+      )
 
       val expectedLeafHash = Blake2b256Hash.fromHex(leafHex)
       store.get(txn, expectedLeafHash) shouldBe Some(Leaf(key1, val1))
@@ -249,7 +256,8 @@ class TrieStructureTests
   }
 
   private[this] def assertCommonPrefixTrie(
-      implicit store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]) = {
+      implicit store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]
+  ) = {
     import CommonPrefixData._
     store.withTxn(store.createTxnRead()) { implicit txn =>
       expectNode(rootHex, Seq((1, NodePointer(level1Hex))))
@@ -269,12 +277,15 @@ class TrieStructureTests
   private[this] implicit def liftHexToBlake(hex: String): Blake2b256Hash =
     Blake2b256Hash.fromHex(hex)
 
-  private[this] def expectNode(currentHex: String, childHexes: Seq[(Int, Pointer)])(
-      implicit txn: Txn[ByteBuffer],
-      store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]) =
-    store.get(txn,
-              Blake2b256Hash
-                .fromHex(currentHex)) match {
+  private[this] def expectNode(
+      currentHex: String,
+      childHexes: Seq[(Int, Pointer)]
+  )(implicit txn: Txn[ByteBuffer], store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]) =
+    store.get(
+      txn,
+      Blake2b256Hash
+        .fromHex(currentHex)
+    ) match {
       case Some(Node(PointerBlock(vector))) =>
         vector should have size 256
         val expectedPointers = childHexes.map {
@@ -290,10 +301,13 @@ class TrieStructureTests
 
   def expectSkip(currentHex: String, expectedAffix: ByteVector, expectedPointer: NonEmptyPointer)(
       implicit txn: Txn[ByteBuffer],
-      store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]) =
-    store.get(txn,
-              Blake2b256Hash
-                .fromHex(currentHex)) match {
+      store: ITrieStore[Txn[ByteBuffer], TestKey4, ByteVector]
+  ) =
+    store.get(
+      txn,
+      Blake2b256Hash
+        .fromHex(currentHex)
+    ) match {
       case Some(Skip(affix, pointer)) =>
         affix shouldBe expectedAffix
         pointer shouldBe expectedPointer

--- a/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/ArbitraryInstances.scala
@@ -22,10 +22,12 @@ object ArbitraryInstances {
   val arbNonEmptyString =
     Arbitrary(Gen.nonEmptyListOf[Char](Arbitrary.arbChar.arbitrary).map(_.mkString))
 
-  implicit def arbitraryDatum[C, T](chan: C)(implicit
-                                             arbT: Arbitrary[T],
-                                             serializeC: Serialize[C],
-                                             serializeT: Serialize[T]): Arbitrary[Datum[T]] =
+  implicit def arbitraryDatum[C, T](chan: C)(
+      implicit
+      arbT: Arbitrary[T],
+      serializeC: Serialize[C],
+      serializeT: Serialize[T]
+  ): Arbitrary[Datum[T]] =
     Arbitrary(for {
       t <- arbT.arbitrary
       b <- Arbitrary.arbitrary[Boolean]
@@ -47,9 +49,11 @@ object ArbitraryInstances {
         .map(maybeHashes => PointerBlock.fromVector(maybeHashes.toVector))
     })
 
-  implicit def arbitaryTrie[K, V](implicit
-                                  arbK: Arbitrary[K],
-                                  arbV: Arbitrary[V]): Arbitrary[Trie[K, V]] = {
+  implicit def arbitaryTrie[K, V](
+      implicit
+      arbK: Arbitrary[K],
+      arbV: Arbitrary[V]
+  ): Arbitrary[Trie[K, V]] = {
     val genNode: Gen[Trie[K, V]] = Arbitrary.arbitrary[PointerBlock].map(pb => Node(pb))
 
     val genLeaf: Gen[Trie[K, V]] =
@@ -75,10 +79,13 @@ object ArbitraryInstances {
     Arbitrary(
       Gen
         .sized { size =>
-          Gen.containerOfN[Seq, (TestKey4, ByteVector)](if (size > 2) size else 2,
-                                                        Arbitrary.arbitrary[(TestKey4, ByteVector)])
+          Gen.containerOfN[Seq, (TestKey4, ByteVector)](
+            if (size > 2) size else 2,
+            Arbitrary.arbitrary[(TestKey4, ByteVector)]
+          )
         }
-        .map(_.toMap))
+        .map(_.toMap)
+    )
   }
 
   implicit val arbitraryTestKey32: Arbitrary[TestKey32] =
@@ -89,16 +96,21 @@ object ArbitraryInstances {
     })
 
   implicit val arbitraryNonEmptyMapTestKey32ByteVector: Arbitrary[Map[TestKey32, ByteVector]] = {
-    Arbitrary(Gen
-      .sized { size =>
-        Gen.containerOfN[Seq, (TestKey32, ByteVector)](if (size > 2) size else 2,
-                                                       Arbitrary.arbitrary[(TestKey32, ByteVector)])
-      }
-      .map(_.toMap))
+    Arbitrary(
+      Gen
+        .sized { size =>
+          Gen.containerOfN[Seq, (TestKey32, ByteVector)](
+            if (size > 2) size else 2,
+            Arbitrary.arbitrary[(TestKey32, ByteVector)]
+          )
+        }
+        .map(_.toMap)
+    )
   }
 
   implicit def arbitraryNonEmptyMapStringDatumString(
-      implicit serializeString: Serialize[String]): Arbitrary[Map[String, Datum[String]]] =
+      implicit serializeString: Serialize[String]
+  ): Arbitrary[Map[String, Datum[String]]] =
     Arbitrary(
       Gen
         .sized { size =>
@@ -107,13 +119,14 @@ object ArbitraryInstances {
             dat <- arbitraryDatum[String, String](str).arbitrary
           } yield (str, dat))
         }
-        .map(_.toMap))
+        .map(_.toMap)
+    )
 
   def arbitraryWaitingContinuation(chans: List[String])(
       implicit
       serializeString: Serialize[String],
       serializePattern: Serialize[Pattern],
-      serializeStringsCaptor: Serialize[StringsCaptor],
+      serializeStringsCaptor: Serialize[StringsCaptor]
   ): Arbitrary[WaitingContinuation[Pattern, StringsCaptor]] =
     Arbitrary(
       for {
@@ -122,19 +135,22 @@ object ArbitraryInstances {
       } yield WaitingContinuation.create(chans, pats, new StringsCaptor, boolean)
     )
 
-  implicit def arbitraryGnat(implicit
-                             serializeString: Serialize[String],
-                             serializePattern: Serialize[Pattern],
-                             serializeStringsCaptor: Serialize[StringsCaptor])
-    : Arbitrary[GNAT[String, Pattern, String, StringsCaptor]] =
+  implicit def arbitraryGnat(
+      implicit
+      serializeString: Serialize[String],
+      serializePattern: Serialize[Pattern],
+      serializeStringsCaptor: Serialize[StringsCaptor]
+  ): Arbitrary[GNAT[String, Pattern, String, StringsCaptor]] =
     Arbitrary(Gen.sized { size =>
       val constrainedSize = if (size > 1) size else 1
       for {
         chans <- Gen.containerOfN[List, String](constrainedSize, Arbitrary.arbitrary[String])
         data <- Gen.nonEmptyContainerOf[List, Datum[String]](
-                 arbitraryDatum[String, String](chans.head).arbitrary)
+                 arbitraryDatum[String, String](chans.head).arbitrary
+               )
         wks <- Gen.nonEmptyContainerOf[List, WaitingContinuation[Pattern, StringsCaptor]](
-                arbitraryWaitingContinuation(chans).arbitrary)
+                arbitraryWaitingContinuation(chans).arbitrary
+              )
       } yield GNAT(chans, data, wks)
     })
 
@@ -142,8 +158,8 @@ object ArbitraryInstances {
       implicit
       serializeString: Serialize[String],
       serializePattern: Serialize[Pattern],
-      serializeStringsCaptor: Serialize[StringsCaptor])
-    : Arbitrary[Map[List[String], WaitingContinuation[Pattern, StringsCaptor]]] =
+      serializeStringsCaptor: Serialize[StringsCaptor]
+  ): Arbitrary[Map[List[String], WaitingContinuation[Pattern, StringsCaptor]]] =
     Arbitrary(Gen.sized { size =>
       val constrainedSize = if (size > 1) size else 1
       Gen

--- a/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
@@ -24,9 +24,12 @@ class EventTests extends FlatSpec with Matchers with GeneratorDrivenPropertyChec
 
       val expectedHash =
         Blake2b256Hash.create(
-          List(Serialize[String].encode(channel),
-               Serialize[String].encode(data),
-               (cignore(7) ~> bool).encode(persist).map(_.bytes).get))
+          List(
+            Serialize[String].encode(channel),
+            Serialize[String].encode(data),
+            (cignore(7) ~> bool).encode(persist).map(_.bytes).get
+          )
+        )
 
       actual.hash shouldBe expectedHash
     }
@@ -52,8 +55,11 @@ class EventTests extends FlatSpec with Matchers with GeneratorDrivenPropertyChec
       val expectedHash =
         Blake2b256Hash.create(
           encodedChannels ++ encodedPatterns
-            ++ List(Serialize[StringsCaptor].encode(continuation),
-                    (cignore(7) ~> bool).encode(persist).map(_.bytes).get))
+            ++ List(
+              Serialize[StringsCaptor].encode(continuation),
+              (cignore(7) ~> bool).encode(persist).map(_.bytes).get
+            )
+        )
 
       actual.hash shouldBe expectedHash
     }

--- a/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_.scala
@@ -26,7 +26,8 @@ object ApplicativeError_ extends ApplicativeError_Instances {
 trait ApplicativeError_Instances {
 
   implicit def applicativeError[F[_], E](
-      implicit F: ApplicativeError[F, E]): ApplicativeError_[F, E] = new ApplicativeError_[F, E] {
+      implicit F: ApplicativeError[F, E]
+  ): ApplicativeError_[F, E] = new ApplicativeError_[F, E] {
     def raiseError[A](e: E): F[A] = ApplicativeError[F, E].raiseError(e)
     def handleErrorWith[A](fa: F[A])(f: E => F[A]): F[A] =
       ApplicativeError[F, E].handleErrorWith(fa)(f)

--- a/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
@@ -2,14 +2,16 @@ package coop.rchain.catscontrib
 
 import cats._, cats.data._, cats.implicits._
 
-final class ApplicativeError_Ops[F[_], E, A](self: F[A])(implicit err: ApplicativeError_[F, E],
-                                                         ev: Applicative[F]) {
+final class ApplicativeError_Ops[F[_], E, A](self: F[A])(
+    implicit err: ApplicativeError_[F, E],
+    ev: Applicative[F]
+) {
   def attempt: F[Either[E, A]] = err.attempt(self)
 }
 
 trait ToApplicativeError_Ops {
-  implicit def ToApplicativeError_Ops[F[_], E, A](fa: F[A])(
-      implicit err: ApplicativeError_[F, E],
-      ev: Applicative[F]): ApplicativeError_Ops[F, E, A] =
+  implicit def ToApplicativeError_Ops[F[_], E, A](
+      fa: F[A]
+  )(implicit err: ApplicativeError_[F, E], ev: Applicative[F]): ApplicativeError_Ops[F, E, A] =
     new ApplicativeError_Ops[F, E, A](fa)
 }

--- a/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
@@ -79,8 +79,8 @@ sealed trait CaptureInstances0 {
 }
 
 private class TransCapture[F[_]: Monad: Capture, T[_[_], _]: MonadTrans](
-    tuu: TransUnsafeUncapture[T, F])
-    extends Capture[T[F, ?]] {
+    tuu: TransUnsafeUncapture[T, F]
+) extends Capture[T[F, ?]] {
   def capture[A](a: => A) =
     MonadTrans[T].liftM(Capture[F].capture(a))
   def unsafeUncapture[A](fa: T[F, A]): A = Capture[F].unsafeUncapture(tuu.unsafeUnlift[A](fa))

--- a/shared/src/main/scala/coop/rchain/catscontrib/Futurable.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Futurable.scala
@@ -21,7 +21,8 @@ trait FuturableInstances extends FuturableInstances0 {
 
 sealed trait FuturableInstances0 {
   implicit def eitherTFuturable[F[_]: Monad: Futurable, E](
-      implicit ec: ExecutionContext): Futurable[EitherT[F, E, ?]] =
+      implicit ec: ExecutionContext
+  ): Futurable[EitherT[F, E, ?]] =
     new Futurable[EitherT[F, E, ?]] {
       case class ToFutureException(e: E) extends RuntimeException
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/SyncInstances.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/SyncInstances.scala
@@ -7,8 +7,10 @@ import monix.eval.Task
 
 object SyncInstances {
 
-  def syncEffect[E](toThrowable: E => Throwable,
-                    fromThrowable: Throwable => E): Sync[EitherT[Task, E, ?]] = {
+  def syncEffect[E](
+      toThrowable: E => Throwable,
+      fromThrowable: Throwable => E
+  ): Sync[EitherT[Task, E, ?]] = {
     type Effect[A] = EitherT[Task, E, A]
     new Sync[Effect] {
       def suspend[A](thunk: => Effect[A]): Effect[A] =
@@ -25,8 +27,9 @@ object SyncInstances {
 
       def pure[A](x: A): Effect[A] = implicitly[Applicative[Effect]].pure(x)
 
-      def bracketCase[A, B](acquire: Effect[A])(use: A => Effect[B])(
-          release: (A, ExitCase[Throwable]) => Effect[Unit]): Effect[B] =
+      def bracketCase[A, B](
+          acquire: Effect[A]
+      )(use: A => Effect[B])(release: (A, ExitCase[Throwable]) => Effect[Unit]): Effect[B] =
         acquire flatMap { state =>
           try {
             use(state)

--- a/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
@@ -14,7 +14,9 @@ package object implicits {
       def pure[A](x: A): cats.Id[A] = x
 
       def handleErrorWith[A](fa: cats.Id[A])(f: Throwable => cats.Id[A]): cats.Id[A] =
-        try { fa } catch {
+        try {
+          fa
+        } catch {
           case NonFatal(e) => f(e)
         }
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
@@ -7,7 +7,8 @@ import scala.math.Ordering
 
 object ListContrib {
   def sortBy[A, K: Monoid](list: IndexedSeq[A], map: collection.Map[A, K])(
-      implicit ord: Ordering[K]) =
+      implicit ord: Ordering[K]
+  ) =
     list.sortBy(map.getOrElse(_, Monoid[K].empty))(ord)
 
   // From https://hygt.github.io/2018/08/05/Cats-findM-collectFirstM.html

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -16,7 +16,8 @@ object TaskContrib {
     def nonCancelingTimeout(after: FiniteDuration): Task[A] =
       nonCancelingTimeoutTo(
         after,
-        Task.raiseError(new TimeoutException(s"Task timed-out after $after of inactivity")))
+        Task.raiseError(new TimeoutException(s"Task timed-out after $after of inactivity"))
+      )
 
     def nonCancelingTimeoutTo[B >: A](after: FiniteDuration, backup: Task[B]): Task[B] =
       Task.racePair(task, Task.unit.delayExecution(after)).flatMap {

--- a/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
+++ b/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
@@ -70,14 +70,18 @@ object GrpcMonix {
       }
     }
 
-  def liftByGrpcOperator[I, O](observable: Observable[I],
-                               operator: GrpcOperator[I, O]): Observable[O] =
+  def liftByGrpcOperator[I, O](
+      observable: Observable[I],
+      operator: GrpcOperator[I, O]
+  ): Observable[O] =
     observable.liftByOperator(
       grpcOperatorToMonixOperator(operator)
     )
 
-  def unliftByTransformer[I, O](transformer: Transformer[I, O],
-                                subscriber: Subscriber[O]): Subscriber[I] =
+  def unliftByTransformer[I, O](
+      transformer: Transformer[I, O],
+      subscriber: Subscriber[O]
+  ): Subscriber[I] =
     new Subscriber[I] {
       private[this] val subject = PublishSubject[I]()
       transformer(subject).subscribe(subscriber)

--- a/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
+++ b/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
@@ -18,8 +18,11 @@ package object codecs {
             if (xs.size == cnt)
               Attempt.successful(xs)
             else
-              Attempt.failure(Err(
-                s"Insufficient number of elements: decoded ${xs.size} but should have decoded $cnt"))
+              Attempt.failure(
+                Err(
+                  s"Insufficient number of elements: decoded ${xs.size} but should have decoded $cnt"
+                )
+              )
         },
         xs => (xs.size, xs)
       )

--- a/shared/src/main/scala/coop/rchain/shared/Cell.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Cell.scala
@@ -48,17 +48,21 @@ object Cell extends CellInstances0 {
 trait CellInstances0 {
   implicit def eitherTCell[E, F[_]: Monad, S](
       implicit
-      fCell: Cell[F, S]): Cell[EitherT[F, E, ?], S] =
+      fCell: Cell[F, S]
+  ): Cell[EitherT[F, E, ?], S] =
     new Cell[EitherT[F, E, ?], S] {
       def modify(f: S => EitherT[F, E, S]): EitherT[F, E, Unit] =
         EitherT(
           fCell
-            .modify(s =>
-              f(s).value >>= {
-                case Right(ns) => ns.pure[F]
-                case Left(_)   => s.pure[F]
-            })
-            .map(Right(_).leftCast[E]))
+            .modify(
+              s =>
+                f(s).value >>= {
+                  case Right(ns) => ns.pure[F]
+                  case Left(_)   => s.pure[F]
+                }
+            )
+            .map(Right(_).leftCast[E])
+        )
 
       def read: EitherT[F, E, S] = EitherT(fCell.read.map(Right(_).leftCast[E]))
     }

--- a/shared/src/main/scala/coop/rchain/shared/ConstApplicativeAsk.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ConstApplicativeAsk.scala
@@ -10,10 +10,11 @@ class ConstApplicativeAsk[F[_]: Applicative, E](e: E) extends ApplicativeAsk[F, 
 }
 
 // TODO make availalble on catscontrib
-class EitherTApplicativeAsk[F[_], E, Err](implicit
-                                          ev1: ApplicativeAsk[F, E],
-                                          ev2: Monad[F])
-    extends ApplicativeAsk[EitherT[F, Err, ?], E] {
+class EitherTApplicativeAsk[F[_], E, Err](
+    implicit
+    ev1: ApplicativeAsk[F, E],
+    ev2: Monad[F]
+) extends ApplicativeAsk[EitherT[F, Err, ?], E] {
   val applicative: Applicative[EitherT[F, Err, ?]] = Applicative[EitherT[F, Err, ?]]
 
   def ask: EitherT[F, Err, E] = EitherT(ev1.ask.map(Right(_)))

--- a/shared/src/main/scala/coop/rchain/shared/StreamT.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StreamT.scala
@@ -90,9 +90,9 @@ sealed abstract class StreamT[F[_], +A] { self =>
     case _: SNil[F] => b.pure[F]
   }
 
-  def foldRight[B](lb: Eval[B])(f: (A, Eval[F[B]]) => Eval[F[B]])(
-      implicit monad: Monad[F],
-      traverse: Traverse[F]): Eval[F[B]] = self match {
+  def foldRight[B](lb: Eval[B])(
+      f: (A, Eval[F[B]]) => Eval[F[B]]
+  )(implicit monad: Monad[F], traverse: Traverse[F]): Eval[F[B]] = self match {
     case SCons(curr, lazyTail) =>
       val mappedLazyTail = lazyTail.flatMap { tailF =>
         monad.map(tailF)(_.foldRight(lb)(f)).flatSequence
@@ -138,8 +138,9 @@ sealed abstract class StreamT[F[_], +A] { self =>
     case SLazy(lazyTail)    => StreamT.delay(lazyTail.map(_.map(_.tail)))
     case _: SNil[F] =>
       StreamT.delay(
-        Eval.now(
-          applicativeError.raiseError[StreamT[F, A]](new Exception("Tail on empty StreamT!"))))
+        Eval
+          .now(applicativeError.raiseError[StreamT[F, A]](new Exception("Tail on empty StreamT!")))
+      )
   }
 
   def take(n: Int)(implicit functor: Functor[F]): StreamT[F, A] =
@@ -238,7 +239,8 @@ object StreamT {
   private def flatMapHelper[F[_], A, B, BB <: B](
       f: A => StreamT[F, B],
       lazyTail: STail[F, A],
-      mappedLazyTail: STail[F, BB])(implicit monad: Monad[F]): STail[F, B] =
+      mappedLazyTail: STail[F, BB]
+  )(implicit monad: Monad[F]): STail[F, B] =
     for {
       tailF       <- lazyTail
       mappedTailF <- mappedLazyTail

--- a/shared/src/main/scala/coop/rchain/shared/StringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StringOps.scala
@@ -19,7 +19,7 @@ object StringOps {
             expr
           } else {
             s"($expr)"
-        },
+          },
         _ => expr
       )
   }

--- a/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
@@ -15,17 +15,19 @@ class CellSpec extends FunSpec with Matchers with BeforeAndAfterEach {
 
   describe("Cell") {
     it("should allow thread-safe concurrent state modification") {
-      run(cell =>
-        for {
-          f1  <- justIncrement(cell).fork
-          f2  <- justIncrement(cell).fork
-          f3  <- justIncrement(cell).fork
-          _   <- f1.join
-          _   <- f2.join
-          _   <- f3.join
-          res <- cell.read
-          _   <- Task.delay(res shouldBe 3)
-        } yield ())
+      run(
+        cell =>
+          for {
+            f1  <- justIncrement(cell).fork
+            f2  <- justIncrement(cell).fork
+            f3  <- justIncrement(cell).fork
+            _   <- f1.join
+            _   <- f2.join
+            _   <- f3.join
+            res <- cell.read
+            _   <- Task.delay(res shouldBe 3)
+          } yield ()
+      )
     }
 
     /**
@@ -36,30 +38,34 @@ class CellSpec extends FunSpec with Matchers with BeforeAndAfterEach {
 
       val external: TrieMap[String, Int] = TrieMap.empty[String, Int]
 
-      run(cell =>
-        for {
-          f1  <- incrementAndStore("worker1", cell, external).fork
-          f2  <- incrementAndStore("worker2", cell, external).fork
-          f3  <- incrementAndStore("worker3", cell, external).fork
-          _   <- f1.join
-          _   <- f2.join
-          _   <- f3.join
-          res <- cell.read
-          _   <- Task.delay(res shouldBe 3)
-          _   <- Task.delay(external.keys should contain allOf ("worker1", "worker2", "worker3"))
-          _   <- Task.delay(external.values should contain allOf (1, 2, 3))
-        } yield ())
+      run(
+        cell =>
+          for {
+            f1  <- incrementAndStore("worker1", cell, external).fork
+            f2  <- incrementAndStore("worker2", cell, external).fork
+            f3  <- incrementAndStore("worker3", cell, external).fork
+            _   <- f1.join
+            _   <- f2.join
+            _   <- f3.join
+            res <- cell.read
+            _   <- Task.delay(res shouldBe 3)
+            _   <- Task.delay(external.keys should contain allOf ("worker1", "worker2", "worker3"))
+            _   <- Task.delay(external.values should contain allOf (1, 2, 3))
+          } yield ()
+      )
     }
 
     it("should restore state after a failed modify") {
-      run(cell =>
-        for {
-          _   <- justIncrement(cell)
-          _   <- failWithError(cell).attempt
-          _   <- justIncrement(cell)
-          res <- cell.read
-          _   <- Task.delay(res shouldBe 2)
-        } yield ())
+      run(
+        cell =>
+          for {
+            _   <- justIncrement(cell)
+            _   <- failWithError(cell).attempt
+            _   <- justIncrement(cell)
+            res <- cell.read
+            _   <- Task.delay(res shouldBe 2)
+          } yield ()
+      )
     }
   }
 
@@ -77,11 +83,13 @@ class CellSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       cell: Cell[Task, Int],
       external: TrieMap[String, Int]
   ): Task[Unit] =
-    cell.modify(i =>
-      for {
-        newI <- increment(i)
-        _    <- Task.delay(external += (name -> newI))
-      } yield newI)
+    cell.modify(
+      i =>
+        for {
+          newI <- increment(i)
+          _    <- Task.delay(external += (name -> newI))
+        } yield newI
+    )
 
   private val increment: Int => Task[Int] = (i: Int) => Task.delay(i + 1)
 

--- a/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
@@ -59,7 +59,8 @@ class StreamTSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
     }
 
     it(
-      "should allow taking the longest prefix of this StreamT whose elements satisfy the predicate") {
+      "should allow taking the longest prefix of this StreamT whose elements satisfy the predicate"
+    ) {
       forAll { list: List[Int] =>
         val stream: StreamT[Id, Int] = StreamT.fromList[Id, Int](list)
 
@@ -124,7 +125,8 @@ class StreamTSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChec
           0L,
           Eval.now(pure(StreamT.cons(1L, Eval.later(pure(fibs.zip(fibs.tail(mErrId)).map {
             case (a, b) => a + b
-          }))))))
+          })))))
+        )
 
       fibs.take(8).toList[Long] shouldBe List(0L, 1L, 1L, 2L, 3L, 5L, 8L, 13L)
     }


### PR DESCRIPTION
## Overview
Scalafmt 1.6's biggest change is changing the default for exactly the setting we were discussing, `align.openParenDefnSite`, and its sibling, `align.openParenCallSite`, to false. This means instead of:

```scala
class IntStringLong(int: Int,
                    string: String,
                    long: Long)
```
we get
```scala
class IntStringLong(
    int: Int,
    string: String,
    long: Long
)
```
which has the advantages of:
 - making it clear to what the closing brace belongs
 - less churn when editing at the end of arguments list
 - no more 'search space exploded' errors
 - less indent in general

Similarly, the `openParenCallSite` setting changes from:

```scala
function(arg1, // align by (
         arg2,
         arg3)
```
we get
```scala
function(
  arg1, // no align by (
  arg2,
  arg3
)

```

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.