### PR TITLE
CORE-1124 make double lock implementation the default

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -44,7 +44,7 @@ object Configuration {
   private val DefaultTimeout                    = 2000
   private val DefaultGenesisValidator           = false
   private val DefaultMapSize: Long              = 1024L * 1024L * 1024L
-  private val DefaultStoreType: StoreType       = LMDB
+  private val DefaultStoreType: StoreType       = FineGrainedLMDB
   private val DefaultCasperBlockStoreSize: Long = 1024L * 1024L * 1024L
   private val DefaultNumValidators              = 5
   private val DefaultValidatorSigAlgorithm      = "ed25519"

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -42,9 +42,9 @@ class Runtime private (val reducer: Reduce[Task],
 
 object Runtime {
 
-  type RhoISpace       = CPARK[IdISpace]
+  type RhoISpace          = CPARK[IdISpace]
   type RhoPureSpace[F[_]] = TCPARK[F, PureRSpace]
-  type RhoReplayISpace = CPARK[IdIReplaySpace]
+  type RhoReplayISpace    = CPARK[IdIReplaySpace]
 
   type RhoIStore  = CPAK[IStore]
   type RhoContext = CPAK[Context]
@@ -118,6 +118,9 @@ object Runtime {
         )
     }
 
+  /**
+    * TODO this needs to go away when double locking is good enough
+    */
   def setupRSpace(dataDir: Path,
                   mapSize: Long,
                   storeType: StoreType): (RhoContext, RhoISpace, RhoReplayISpace) = {

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -1,10 +1,12 @@
 package coop.rchain.rspace
 
+import cats.Id
 import cats.implicits._
 import com.google.common.collect.Multiset
 import com.typesafe.scalalogging.Logger
 import coop.rchain.catscontrib._
-import coop.rchain.rspace.history.{Branch, ITrieStore, InMemoryTrieStore}
+import coop.rchain.rspace.IReplaySpace.IdIReplaySpace
+import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace.{Produce, _}
 import coop.rchain.shared.SyncVarOps._
@@ -15,7 +17,6 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
-import scala.util.Random
 import kamon._
 
 class ReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
@@ -25,7 +26,7 @@ class ReplayRSpace[C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
     serializeA: Serialize[A],
     serializeK: Serialize[K]
 ) extends RSpaceOps[C, P, E, A, R, K](store, branch)
-    with IReplaySpace[cats.Id, C, P, E, A, R, K] {
+    with IdIReplaySpace[C, P, E, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]
 
@@ -306,6 +307,10 @@ trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
   }
 }
 
+object IReplaySpace {
+  type IdIReplaySpace[C, P, E, A, R, K] = IReplaySpace[Id, C, P, E, A, R, K]
+}
+
 object ReplayRSpace {
 
   def create[C, P, E, A, R, K](context: Context[C, P, A, K], branch: Branch)(
@@ -313,7 +318,7 @@ object ReplayRSpace {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]): ReplayRSpace[C, P, E, A, R, K] = {
+      sk: Serialize[K]): IReplaySpace[Id, C, P, E, A, R, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec

--- a/shared/src/main/scala/coop/rchain/shared/StoreType.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StoreType.scala
@@ -11,6 +11,7 @@ object StoreType {
     case "mixed" => Some(Mixed)
     case "inmem" => Some(InMem)
     case "lmdb"  => Some(LMDB)
+    case "fine"  => Some(FineGrainedLMDB)
     case _       => None
   }
 }


### PR DESCRIPTION
## Overview
Make the fine grained mechanism the default with the option to switch to lmdb based locking with config option.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/projects/CORE/issues/CORE-1124

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
