### PR TITLE
Share same cost accounting state between dispatcher an reducer

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -11,9 +11,9 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.models._
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rholang.interpreter.{ErrorLog, Reduce, Runtime}
+import coop.rchain.rholang.interpreter.{ChargingReducer, ErrorLog, Runtime}
 import coop.rchain.rspace.internal.{Datum, WaitingContinuation}
 import coop.rchain.rspace.trace.Produce
 import coop.rchain.rspace.{Blake2b256Hash, ReplayException}
@@ -23,6 +23,7 @@ import monix.execution.Scheduler
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.SyncVar
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 //runtime is a SyncVar for thread-safety, as all checkpoints share the same "hot store"
@@ -143,11 +144,11 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
       terms match {
         case deploy +: rem =>
           runtime.space.reset(hash)
-          val availablePhlos             = CostAccount(Integer.MAX_VALUE)
-          implicit val costAccountingAlg = CostAccountingAlg.unsafe[Task](availablePhlos) //FIXME this needs to come from the deploy params
-          val (phlosLeft, errors)        = injAttempt(deploy, runtime.reducer, runtime.errorLog)
-          val cost                       = phlosLeft.copy(cost = availablePhlos.cost.value - phlosLeft.cost)
-          val newCheckpoint              = runtime.space.createCheckpoint()
+          val availablePhlos = Cost(Integer.MAX_VALUE) // FIXME: This needs to come from the deploy params
+          runtime.reducer.setAvailablePhlos(availablePhlos).runSyncUnsafe(1.second)
+          val (phlosLeft, errors) = injAttempt(deploy, runtime.reducer, runtime.errorLog)
+          val cost                = phlosLeft.copy(cost = availablePhlos.value - phlosLeft.cost)
+          val newCheckpoint       = runtime.space.createCheckpoint()
           val deployResult = InternalProcessedDeploy(deploy,
                                                      cost,
                                                      newCheckpoint.log,
@@ -170,12 +171,12 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
                      hash: Blake2b256Hash): Either[(Option[Deploy], Failed), StateHash] =
       terms match {
         case InternalProcessedDeploy(deploy, _, log, status) +: rem =>
-          val availablePhlos             = CostAccount(Integer.MAX_VALUE)
-          implicit val costAccountingAlg = CostAccountingAlg.unsafe[Task](availablePhlos) // FIXME: This needs to come from the deploy params
+          val availablePhlos = Cost(Integer.MAX_VALUE) // FIXME: This needs to come from the deploy params
+          runtime.replayReducer.setAvailablePhlos(availablePhlos).runSyncUnsafe(1.second)
           runtime.replaySpace.rig(hash, log.toList)
           //TODO: compare replay deploy cost to given deploy cost
           val (phlosLeft, errors) = injAttempt(deploy, runtime.replayReducer, runtime.errorLog)
-          val cost                = phlosLeft.copy(cost = availablePhlos.cost.value - phlosLeft.cost)
+          val cost                = phlosLeft.copy(cost = availablePhlos.value - phlosLeft.cost)
           DeployStatus.fromErrors(errors) match {
             case int: InternalErrors => Left(Some(deploy) -> int)
             case replayStatus =>
@@ -198,21 +199,20 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     doReplayEval(terms, Blake2b256Hash.fromByteArray(initHash.toByteArray))
   }
 
-  private def injAttempt(deploy: Deploy, reducer: Reduce[Task], errorLog: ErrorLog)(
-      implicit scheduler: Scheduler,
-      costAlg: CostAccountingAlg[Task]): (PCost, Vector[Throwable]) = {
+  private def injAttempt(deploy: Deploy, reducer: ChargingReducer[Task], errorLog: ErrorLog)(
+      implicit scheduler: Scheduler): (PCost, Vector[Throwable]) = {
     implicit val rand: Blake2b512Random = Blake2b512Random(
       DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.raw.get)))
     Try(reducer.inj(deploy.term.get).unsafeRunSync) match {
       case Success(_) =>
         val errors = errorLog.readAndClearErrorVector()
-        val cost   = CostAccount.toProto(costAlg.get().unsafeRunSync)
+        val cost   = CostAccount.toProto(reducer.getAvailablePhlos().unsafeRunSync)
         cost -> errors
 
       case Failure(ex) =>
         val otherErrors = errorLog.readAndClearErrorVector()
         val errors      = otherErrors :+ ex
-        val cost        = CostAccount.toProto(costAlg.get().unsafeRunSync)
+        val cost        = CostAccount.toProto(reducer.getAvailablePhlos().unsafeRunSync)
         cost -> errors
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -1,21 +1,20 @@
 package coop.rchain.casper.genesis.contracts
 
+import java.nio.file.Paths
+
 import coop.rchain.casper.util.rholang.InterpreterUtil.mkTerm
-import coop.rchain.catscontrib.Capture.taskCapture
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.collection.ListOps
-import coop.rchain.rholang.unittest.TestSet
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.collection.ListOps
+import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.unittest.TestSet
 import coop.rchain.shared.StoreType.InMem
-import java.nio.file.Paths
-
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import monix.eval.Task
 import monix.execution.Scheduler
 
+import scala.concurrent.duration._
 import scala.io.Source
 
 object TestSetUtil {
@@ -23,13 +22,11 @@ object TestSetUtil {
   def runtime(name: String): Runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
 
   def eval_term(term: Par, runtime: Runtime)(implicit scheduler: Scheduler,
-                                             rand: Blake2b512Random,
-                                             costAccountingAlg: CostAccountingAlg[Task]): Unit =
+                                             rand: Blake2b512Random): Unit =
     runtime.reducer.inj(term).unsafeRunSync
 
   def eval(code: String, runtime: Runtime)(implicit scheduler: Scheduler,
-                                           rand: Blake2b512Random,
-                                           costAccountingAlg: CostAccountingAlg[Task]): Unit =
+                                           rand: Blake2b512Random): Unit =
     mkTerm(code) match {
       case Right(term) => eval_term(term, runtime)
       case Left(ex)    => throw ex
@@ -39,20 +36,18 @@ object TestSetUtil {
                otherLibs: Seq[CompiledRholangSource],
                runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
-    val rand              = Blake2b512Random(128)
-    val costAccountingAlg = CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
-    eval(ListOps.code, runtime)(implicitly, rand.splitShort(0), costAccountingAlg)
-    eval(TestSet.code, runtime)(implicitly, rand.splitShort(1), costAccountingAlg)
+    val rand = Blake2b512Random(128)
+    runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runSyncUnsafe(1.second)
+    eval(ListOps.code, runtime)(implicitly, rand.splitShort(0))
+    eval(TestSet.code, runtime)(implicitly, rand.splitShort(1))
 
     //load "libraries" required for this particular set of tests
     otherLibs.zipWithIndex.foreach {
       case (lib, idx) =>
-        eval(lib.code, runtime)(implicitly, rand.splitShort((idx + 2).toShort), costAccountingAlg)
+        eval(lib.code, runtime)(implicitly, rand.splitShort((idx + 2).toShort))
     }
 
-    eval(tests.code, runtime)(implicitly,
-                              rand.splitShort((otherLibs.length + 2).toShort),
-                              costAccountingAlg)
+    eval(tests.code, runtime)(implicitly, rand.splitShort((otherLibs.length + 2).toShort))
   }
 
   /**

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -21,20 +21,26 @@ object TestSetUtil {
 
   def runtime(name: String): Runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
 
-  def eval_term(term: Par, runtime: Runtime)(implicit scheduler: Scheduler,
-                                             rand: Blake2b512Random): Unit =
+  def eval_term(
+      term: Par,
+      runtime: Runtime
+  )(implicit scheduler: Scheduler, rand: Blake2b512Random): Unit =
     runtime.reducer.inj(term).unsafeRunSync
 
-  def eval(code: String, runtime: Runtime)(implicit scheduler: Scheduler,
-                                           rand: Blake2b512Random): Unit =
+  def eval(
+      code: String,
+      runtime: Runtime
+  )(implicit scheduler: Scheduler, rand: Blake2b512Random): Unit =
     mkTerm(code) match {
       case Right(term) => eval_term(term, runtime)
       case Left(ex)    => throw ex
     }
 
-  def runTests(tests: CompiledRholangSource,
-               otherLibs: Seq[CompiledRholangSource],
-               runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
+  def runTests(
+      tests: CompiledRholangSource,
+      otherLibs: Seq[CompiledRholangSource],
+      runtime: Runtime
+  )(implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
     val rand = Blake2b512Random(128)
     runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runSyncUnsafe(1.second)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -8,17 +8,10 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sort.Sortable
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import coop.rchain.rholang.interpreter.errors.{
-  InterpreterError,
-  LexerError,
-  SyntaxError,
-  TopLevelFreeVariablesNotAllowedError,
-  TopLevelWildcardsNotAllowedError,
-  UnrecognizedInterpreterError
-}
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
+import coop.rchain.rholang.interpreter.errors.{InterpreterError, LexerError, SyntaxError, TopLevelFreeVariablesNotAllowedError, TopLevelWildcardsNotAllowedError, UnrecognizedInterpreterError}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.{Yylex, parser}
 import monix.eval.{Coeval, Task}
 
 private class FailingTask[T](task: Task[Either[Throwable, T]]) {
@@ -100,15 +93,15 @@ object Interpreter {
 
   def evaluate(runtime: Runtime, normalizedTerm: Par): Task[EvaluateResult] = {
     implicit val rand      = Blake2b512Random(128)
-    val evaluatePhlosLimit = CostAccount(Integer.MAX_VALUE)
+    val evaluatePhlosLimit = Cost(Integer.MAX_VALUE)
     for {
-      checkpoint     <- Task.now(runtime.space.createCheckpoint())
-      costAccounting <- CostAccountingAlg.of[Task](evaluatePhlosLimit)
-      _              <- runtime.reducer.inj(normalizedTerm)(rand, costAccounting)
-      errors         <- Task.now(runtime.readAndClearErrorVector())
-      leftPhlos      <- costAccounting.get()
-      cost           = leftPhlos.copy(cost = evaluatePhlosLimit.cost - leftPhlos.cost)
-      _              <- Task.now(if (errors.nonEmpty) runtime.space.reset(checkpoint.root))
+      checkpoint <- Task.now(runtime.space.createCheckpoint())
+      _          <- runtime.reducer.setAvailablePhlos(evaluatePhlosLimit)
+      _          <- runtime.reducer.inj(normalizedTerm)(rand)
+      errors     <- Task.now(runtime.readAndClearErrorVector())
+      leftPhlos  <- runtime.reducer.getAvailablePhlos()
+      cost       = leftPhlos.copy(cost = evaluatePhlosLimit - leftPhlos.cost)
+      _          <- Task.now(if (errors.nonEmpty) runtime.space.reset(checkpoint.root))
     } yield EvaluateResult(cost, errors)
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -9,9 +9,16 @@ import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sort.Sortable
 import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
-import coop.rchain.rholang.interpreter.errors.{InterpreterError, LexerError, SyntaxError, TopLevelFreeVariablesNotAllowedError, TopLevelWildcardsNotAllowedError, UnrecognizedInterpreterError}
+import coop.rchain.rholang.interpreter.errors.{
+  InterpreterError,
+  LexerError,
+  SyntaxError,
+  TopLevelFreeVariablesNotAllowedError,
+  TopLevelWildcardsNotAllowedError,
+  UnrecognizedInterpreterError
+}
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{Yylex, parser}
+import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
 import monix.eval.{Coeval, Task}
 
 private class FailingTask[T](task: Task[Either[Throwable, T]]) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -51,6 +51,30 @@ trait Reduce[M[_]] {
                                 costAccountingAlg: CostAccountingAlg[M]): M[Par]
 }
 
+// TODO:
+// In a perfect world we would an algebra of an interpreter encoded in the terms of
+// rholang's elimination and have the `ChargingReducer` forward the calls to the plain algebra
+// and charge accordingly. This would eliminate the "charge" calls from the algebra of a language.
+class ChargingReducer[M[_]](implicit R: Reduce[M], C: CostAccountingAlg[M]) {
+  def getAvailablePhlos(): M[CostAccount] =
+    C.get()
+
+  def setAvailablePhlos(limit: Cost): M[Unit] =
+    C.set(CostAccount(0, limit))
+
+  def eval(par: Par)(implicit env: Env[Par], rand: Blake2b512Random): M[Unit] =
+    R.eval(par)
+
+  def inj(par: Par)(implicit rand: Blake2b512Random): M[Unit] =
+    R.inj(par)
+
+  def evalExpr(par: Par)(implicit env: Env[Par]): M[Par] =
+    R.evalExpr(par)
+
+  def evalExprToPar(expr: Expr)(implicit env: Env[Par]): M[Par] =
+    R.evalExprToPar(expr)
+}
+
 object Reduce {
 
   private def substituteAndCharge[A: Chargeable, M[_]: Substitute[?[_], A]: Sync](

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -2,7 +2,6 @@ package coop.rchain.rholang.interpreter
 
 import java.nio.file.{Files, Path}
 
-import cats.Id
 import cats.mtl.FunctorTell
 import com.google.protobuf.ByteString
 import coop.rchain.models.Channel.ChannelInstance.{ChanVar, Quote}
@@ -26,8 +25,8 @@ import monix.eval.Task
 
 import scala.collection.immutable
 
-class Runtime private (val reducer: Reduce[Task],
-                       val replayReducer: Reduce[Task],
+class Runtime private (val reducer: ChargingReducer[Task],
+                       val replayReducer: ChargingReducer[Task],
                        val space: RhoISpace,
                        val replaySpace: RhoReplayISpace,
                        var errorLog: ErrorLog,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -25,12 +25,14 @@ import monix.eval.Task
 
 import scala.collection.immutable
 
-class Runtime private (val reducer: ChargingReducer[Task],
-                       val replayReducer: ChargingReducer[Task],
-                       val space: RhoISpace,
-                       val replaySpace: RhoReplayISpace,
-                       var errorLog: ErrorLog,
-                       val context: RhoContext) {
+class Runtime private (
+    val reducer: ChargingReducer[Task],
+    val replayReducer: ChargingReducer[Task],
+    val space: RhoISpace,
+    val replaySpace: RhoReplayISpace,
+    var errorLog: ErrorLog,
+    val context: RhoContext
+) {
   def readAndClearErrorVector(): Vector[Throwable] = errorLog.readAndClearErrorVector()
   def close(): Unit = {
     space.close()
@@ -56,21 +58,25 @@ object Runtime {
     F[Channel, BindPattern, ListChannelWithRandom, TaggedContinuation]
 
   private type CPARK[F[_, _, _, _, _, _]] =
-    F[Channel,
-      BindPattern,
-      OutOfPhlogistonsError.type,
-      ListChannelWithRandom,
-      ListChannelWithRandom,
-      TaggedContinuation]
-
-  private type TCPARK[M[_], F[_[_], _, _, _, _, _, _]] =
-    F[M,
+    F[
       Channel,
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
       ListChannelWithRandom,
-      TaggedContinuation]
+      TaggedContinuation
+    ]
+
+  private type TCPARK[M[_], F[_[_], _, _, _, _, _, _]] =
+    F[
+      M,
+      Channel,
+      BindPattern,
+      OutOfPhlogistonsError.type,
+      ListChannelWithRandom,
+      ListChannelWithRandom,
+      TaggedContinuation
+    ]
 
   type Name      = Par
   type Arity     = Int
@@ -99,17 +105,21 @@ object Runtime {
     val REG_PUBLIC_REGISTER_INSERT_CALLBACK: Long = 19L
   }
 
-  private def introduceSystemProcesses(space: RhoISpace,
-                                       replaySpace: RhoISpace,
-                                       processes: immutable.Seq[(Name, Arity, Remainder, Ref)])
-    : Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
+  private def introduceSystemProcesses(
+      space: RhoISpace,
+      replaySpace: RhoISpace,
+      processes: immutable.Seq[(Name, Arity, Remainder, Ref)]
+  ): Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
     processes.flatMap {
       case (name, arity, remainder, ref) =>
         val channels = List(Channel(Quote(name)))
         val patterns = List(
-          BindPattern((0 until arity).map[Channel, Seq[Channel]](i => ChanVar(FreeVar(i))),
-                      remainder,
-                      freeCount = arity))
+          BindPattern(
+            (0 until arity).map[Channel, Seq[Channel]](i => ChanVar(FreeVar(i))),
+            remainder,
+            freeCount = arity
+          )
+        )
         val continuation = TaggedContinuation(ScalaBodyRef(ref))
         Seq(
           space.install(channels, patterns, continuation),
@@ -120,9 +130,11 @@ object Runtime {
   /**
     * TODO this needs to go away when double locking is good enough
     */
-  def setupRSpace(dataDir: Path,
-                  mapSize: Long,
-                  storeType: StoreType): (RhoContext, RhoISpace, RhoReplayISpace) = {
+  def setupRSpace(
+      dataDir: Path,
+      mapSize: Long,
+      storeType: StoreType
+  ): (RhoContext, RhoISpace, RhoReplayISpace) = {
     def createCoarseRSpace(context: RhoContext): (RhoContext, RhoISpace, RhoReplayISpace) = {
       val space: RhoISpace             = RSpace.create(context, Branch.MASTER)
       val replaySpace: RhoReplayISpace = ReplayRSpace.create(context, Branch.REPLAY)
@@ -160,9 +172,11 @@ object Runtime {
     val errorLog                                  = new ErrorLog()
     implicit val ft: FunctorTell[Task, Throwable] = errorLog
 
-    def dispatchTableCreator(space: RhoISpace,
-                             dispatcher: RhoDispatch[Task],
-                             registry: Registry[Task]): RhoDispatchMap = {
+    def dispatchTableCreator(
+        space: RhoISpace,
+        dispatcher: RhoDispatch[Task],
+        registry: Registry[Task]
+    ): RhoDispatchMap = {
       import BodyRefs._
       Map(
         STDOUT                     -> SystemProcesses.stdout,
@@ -188,10 +202,12 @@ object Runtime {
 
     def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
 
-    val urnMap: Map[String, Par] = Map("rho:io:stdout" -> byteName(0),
-                                       "rho:io:stdoutAck" -> byteName(1),
-                                       "rho:io:stderr"    -> byteName(2),
-                                       "rho:io:stderrAck" -> byteName(3))
+    val urnMap: Map[String, Par] = Map(
+      "rho:io:stdout"    -> byteName(0),
+      "rho:io:stdoutAck" -> byteName(1),
+      "rho:io:stderr"    -> byteName(2),
+      "rho:io:stderrAck" -> byteName(3)
+    )
 
     lazy val dispatchTable: RhoDispatchMap =
       dispatchTableCreator(space, dispatcher, registry)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
@@ -10,6 +10,7 @@ trait CostAccountingAlg[F[_]] {
   def charge(cost: Cost): F[Unit]
   def charge(cost: CostAccount): F[Unit]
   def get(): F[CostAccount]
+  def set(cost: CostAccount): F[Unit]
 }
 
 object CostAccountingAlg {
@@ -37,6 +38,8 @@ object CostAccountingAlg {
       } yield ()
 
     override def get: F[CostAccount] = state.get
+    override def set(cost: CostAccount): F[Unit] =
+      state.set(cost)
     private val failOnOutOfPhlo: F[Unit] =
       FlatMap[F].ifM(state.get.map(_.cost.value < 0))(F.raiseError(OutOfPhlogistonsError), F.unit)
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -27,7 +27,8 @@ object Dispatch {
         .map({
           case Channel(Quote(p)) => p
           case Channel(_)        => Par() // Should never happen
-        }): _*)
+        }): _*
+    )
 }
 
 class RholangOnlyDispatcher[M[_]] private (reducer: => ChargingReducer[M])(implicit s: Sync[M])
@@ -54,8 +55,8 @@ object RholangOnlyDispatcher {
       implicit
       parallel: Parallel[M, F],
       s: Sync[M],
-      ft: FunctorTell[M, Throwable])
-    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M]) = {
+      ft: FunctorTell[M, Throwable]
+  ): (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
@@ -70,8 +71,8 @@ object RholangOnlyDispatcher {
 
 class RholangAndScalaDispatcher[M[_]] private (
     reducer: => ChargingReducer[M],
-    _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
-    implicit s: Sync[M])
+    _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]]
+)(implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
@@ -98,11 +99,13 @@ object RholangAndScalaDispatcher {
   def create[M[_], F[_]](
       tuplespace: RhoISpace,
       dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]],
-      urnMap: Map[String, Par])(implicit
-                                parallel: Parallel[M, F],
-                                s: Sync[M],
-                                ft: FunctorTell[M, Throwable])
-    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
+      urnMap: Map[String, Par]
+  )(
+      implicit
+      parallel: Parallel[M, F],
+      s: Sync[M],
+      ft: FunctorTell[M, Throwable]
+  ): (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -2,6 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import cats.Parallel
 import cats.effect.Sync
+import cats.implicits._
 import cats.mtl.FunctorTell
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
@@ -9,7 +10,6 @@ import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBo
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import cats.implicits._
 import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rspace.pure.PureRSpace
 
@@ -30,24 +30,16 @@ object Dispatch {
         }): _*)
 }
 
-class RholangOnlyDispatcher[M[_]] private (reducer: => Reduce[M])(implicit s: Sync[M])
+class RholangOnlyDispatcher[M[_]] private (reducer: => ChargingReducer[M])(implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
-      costAccountingAlg <- CostAccountingAlg.of(
-                            dataList
-                              .flatMap(_.cost)
-                              .map(CostAccount.fromProto(_))
-                              .toList
-                              .combineAll)
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
                 val env     = Dispatch.buildEnv(dataList)
                 val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
-                reducer.eval(parWithRand.body)(env,
-                                               Blake2b512Random.merge(randoms),
-                                               costAccountingAlg)
+                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
               case ScalaBodyRef(_) =>
                 s.unit
               case Empty =>
@@ -63,38 +55,32 @@ object RholangOnlyDispatcher {
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable])
-    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], Reduce[M]) = {
+    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
-      new RholangOnlyDispatcher(reducer)
-    lazy val reducer: Reduce[M] =
+      new RholangOnlyDispatcher(chargingReducer)
+    implicit lazy val costAlg = CostAccountingAlg.unsafe[M](CostAccount(0))
+    implicit lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)
-    (dispatcher, reducer)
+    lazy val chargingReducer = new ChargingReducer[M]()
+    (dispatcher, chargingReducer)
   }
 }
 
 class RholangAndScalaDispatcher[M[_]] private (
-    reducer: => Reduce[M],
+    reducer: => ChargingReducer[M],
     _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]])(
     implicit s: Sync[M])
     extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
 
   def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
     for {
-      costAccountingAlg <- CostAccountingAlg.of(
-                            dataList
-                              .flatMap(_.cost)
-                              .map(CostAccount.fromProto(_))
-                              .toList
-                              .combineAll)
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
                 val env     = Dispatch.buildEnv(dataList)
                 val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
-                reducer.eval(parWithRand.body)(env,
-                                               Blake2b512Random.merge(randoms),
-                                               costAccountingAlg)
+                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
               case ScalaBodyRef(ref) =>
                 _dispatchTable.get(ref) match {
                   case Some(f) => f(dataList)
@@ -116,14 +102,16 @@ object RholangAndScalaDispatcher {
                                 parallel: Parallel[M, F],
                                 s: Sync[M],
                                 ft: FunctorTell[M, Throwable])
-    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], Reduce[M], Registry[M]) = {
+    : (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
-      new RholangAndScalaDispatcher(reducer, dispatchTable)
-    lazy val reducer: Reduce[M] =
+      new RholangAndScalaDispatcher(chargingReducer, dispatchTable)
+    implicit lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)
+    implicit lazy val costAlg      = CostAccountingAlg.unsafe[M](CostAccount(0))
+    lazy val chargingReducer       = new ChargingReducer[M]
     lazy val registry: Registry[M] = new RegistryImpl(pureSpace, dispatcher)
-    (dispatcher, reducer, registry)
+    (dispatcher, chargingReducer, registry)
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -22,7 +22,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Assertion, Matchers, Outcome, fixture}
+import org.scalatest.{fixture, Assertion, Matchers, Outcome}
 
 import scala.collection.immutable.BitSet
 import scala.concurrent.Await
@@ -49,10 +49,12 @@ class CryptoChannelsSpec
   val parToExpr: Par => Expr                           = parToByteString andThen byteStringToExpr
 
   // this should consume from the `ack` channel effectively preparing tuplespace for next test
-  def clearStore(store: RhoIStore,
-                 reduce: ChargingReducer[Task],
-                 ackChannel: Par,
-                 timeout: Duration = 3.seconds)(implicit env: Env[Par]): Unit = {
+  def clearStore(
+      store: RhoIStore,
+      reduce: ChargingReducer[Task],
+      ackChannel: Par,
+      timeout: Duration = 3.seconds
+  )(implicit env: Env[Par]): Unit = {
     val consume = Receive(
       Seq(ReceiveBind(Seq(Channel(ChanVar(Var(Wildcard(WildcardMsg()))))), Quote(ackChannel))),
       Par()
@@ -63,7 +65,8 @@ class CryptoChannelsSpec
   def assertStoreContains(store: RhoIStore)(ackChannel: GString)(data: ListChannelWithRandom)(
       implicit
       serializeChannel: Serialize[Channel],
-      serializeChannels: Serialize[ListChannelWithRandom]): Assertion = {
+      serializeChannels: Serialize[ListChannelWithRandom]
+  ): Assertion = {
     val channel = Channel(Quote(ackChannel))
     val datum   = store.toMap(List(channel)).data.head
     assert(datum.a.channels == data.channels)
@@ -71,12 +74,15 @@ class CryptoChannelsSpec
     assert(!datum.persist)
   }
 
-  def hashingChannel(channelName: String,
-                     hashFn: Array[Byte] => Array[Byte],
-                     fixture: FixtureParam)(
+  def hashingChannel(
+      channelName: String,
+      hashFn: Array[Byte] => Array[Byte],
+      fixture: FixtureParam
+  )(
       implicit
       serializeChannel: Serialize[Channel],
-      serializeChannels: Serialize[ListChannelWithRandom]): Any = {
+      serializeChannels: Serialize[ListChannelWithRandom]
+  ): Any = {
     val (reduce, store) = fixture
 
     val serializeAndHash: (Array[Byte] => Array[Byte]) => Par => Array[Byte] =
@@ -132,7 +138,8 @@ class CryptoChannelsSpec
       val secp256k1VerifyhashChannel = Quote(GString("secp256k1Verify"))
 
       val pubKey = Base16.decode(
-        "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6")
+        "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6"
+      )
       val secKey = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
 
       val ackChannel        = GString("x")
@@ -152,13 +159,16 @@ class CryptoChannelsSpec
         val refVerify = Secp256k1.verify(parByteArray, signature, pubKey)
         assert(refVerify === true)
 
-        val send = Send(secp256k1VerifyhashChannel,
-                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
-                        persistent = false,
-                        BitSet())
+        val send = Send(
+          secp256k1VerifyhashChannel,
+          List(serializedPar, signaturePar, pubKeyPar, ackChannel),
+          persistent = false,
+          BitSet()
+        )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0))))
+          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+        )
         clearStore(store, reduce, ackChannel)
       }
   }
@@ -189,13 +199,16 @@ class CryptoChannelsSpec
         val refVerify = Ed25519.verify(parByteArray, signature, pubKey)
         assert(refVerify === true)
 
-        val send = Send(ed25519VerifyChannel,
-                        List(serializedPar, signaturePar, pubKeyPar, ackChannel),
-                        persistent = false,
-                        BitSet())
+        val send = Send(
+          ed25519VerifyChannel,
+          List(serializedPar, signaturePar, pubKeyPar, ackChannel),
+          persistent = false,
+          BitSet()
+        )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0))))
+          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+        )
         clearStore(store, reduce, ackChannel)
       }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -44,13 +44,17 @@ trait RegistryTester extends PersistentStoreTester {
     )
 
   def withRegistryAndTestSpace[R](
-      f: (ChargingReducer[Task],
-          IdISpace[Channel,
-                   BindPattern,
-                   OutOfPhlogistonsError.type,
-                   ListChannelWithRandom,
-                   ListChannelWithRandom,
-                   TaggedContinuation]) => R
+      f: (
+          ChargingReducer[Task],
+          IdISpace[
+            Channel,
+            BindPattern,
+            OutOfPhlogistonsError.type,
+            ListChannelWithRandom,
+            ListChannelWithRandom,
+            TaggedContinuation
+          ]
+      ) => R
   ): R =
     withTestSpace(errorLog) {
       case TestFixture(space, _) =>
@@ -76,8 +80,9 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val eightByteArray: Par       = GByteArray(ByteString.copyFrom(Array[Byte](0x08.toByte)))
   val ninetySevenByteArray: Par = GByteArray(ByteString.copyFrom(Array[Byte](0x97.toByte)))
   val branchName: Par = GPrivate(
-    ByteString.copyFrom(
-      Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e")))
+    ByteString
+      .copyFrom(Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e"))
+  )
   // format: off
   val rootSend: Send = Send(
     chan = Quote(Registry.registryRoot),
@@ -93,43 +98,65 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val efByteArray: Par        = GByteArray(ByteString.copyFrom(Array[Byte](0xef.toByte)))
   val emptyByteArray: Par     = GByteArray(ByteString.EMPTY)
   val branch1: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2")))
+    ByteString.copyFrom(Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2"))
+  )
   val branch2: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e")))
+    ByteString.copyFrom(Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e"))
+  )
   val branch3: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0")))
+    ByteString.copyFrom(Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0"))
+  )
   val branch4: Par = GByteArray(
-    ByteString.copyFrom(
-      Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3")))
+    ByteString.copyFrom(Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3"))
+  )
   val branchSend: Send = Send(
     chan = Quote(branchName),
     data = Seq(
-      Expr(EMapBody(ParMap(Seq(
-        emptyByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))),
-        eNineByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9)))))))
-      ))))),
+      Expr(
+        EMapBody(
+          ParMap(
+            Seq(
+              emptyByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), emptyByteArray, GInt(7))))))
+              ),
+              eNineByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))
+              ),
+              sevenFiveByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))
+              )
+            )
+          )
+        )
+      )
+    ),
     persistent = false
   )
 
   val fullBranchSend: Send = Send(
     chan = Quote(branchName),
     data = Seq(
-      Expr(EMapBody(ParMap(Seq(
-        eNineByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))),
-        sevenFiveByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))),
-        efByteArray -> Par(exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))),
-        aThreeByteArray -> Par(
-          exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11)))))))
-      ))))),
+      Expr(
+        EMapBody(
+          ParMap(
+            Seq(
+              eNineByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch1, GInt(8))))))
+              ),
+              sevenFiveByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch2, GInt(9))))))
+              ),
+              efByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch3, GInt(10))))))
+              ),
+              aThreeByteArray -> Par(
+                exprs = Seq(Expr(ETupleBody(ETuple(Seq(GInt(0), branch4, GInt(11))))))
+              )
+            )
+          )
+        )
+      )
+    ),
     persistent = false
   )
 
@@ -169,27 +196,45 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(7))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), randResult2),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "insert" should "successfully split" in {
@@ -306,91 +351,157 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result1Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result2Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result3")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result3"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result3"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result3Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result4")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result4"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result4"))),
+              ListChannelWithRandom(Seq(Quote(GInt(11))), result4Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result5")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result5"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result5"))),
+              ListChannelWithRandom(Seq(Quote(GInt(7))), result5Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result6")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result6"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result6"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result6Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result7")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result7"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result7"))),
+              ListChannelWithRandom(Seq(Quote(GInt(11))), result7Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result8")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result8"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result8"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result8Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result9")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result9"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result9"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result9Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result10")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result10"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result10"))),
+              ListChannelWithRandom(Seq(Quote(GInt(12))), result10Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "delete" should "successfully merge" in {
@@ -502,67 +613,115 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result0Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result1Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result2")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result2"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result2"))),
+              ListChannelWithRandom(Seq(Quote(GInt(10))), result2Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result3")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result3"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result3"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result3Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result4")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result4"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result4"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), result4Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result5")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result5"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result5"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result5Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result6")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result6"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result6"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), result6Rand),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(List[Channel](Quote(Registry.registryRoot))) should be(
-      Some(Row(
-        List(Datum.create(Channel(Quote(Registry.registryRoot)),
-                          ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))),
-                                                rootRand),
-                          false)),
-        List()
-      )))
+      Some(
+        Row(
+          List(
+            Datum.create(
+              Channel(Quote(Registry.registryRoot)),
+              ListChannelWithRandom(Seq(Quote(EMapBody(ParMap(SortedParMap.empty)))), rootRand),
+              false
+            )
+          ),
+          List()
+        )
+      )
+    )
   }
 
   "Public lookup" should "decode and then call lookup" in {
@@ -595,19 +754,31 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GInt(8))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(GInt(9))), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 
   "Random Registry" should "use the random generator and insert" in {
@@ -657,18 +828,30 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     result.get(resultChanList("result0")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result0"))),
-                            ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result0"))),
+              ListChannelWithRandom(Seq(Quote(GUri(expectedUri))), randResult0),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
     result.get(resultChanList("result1")) should be(
       Some(
         Row(
-          List(Datum.create(Channel(Quote(GString("result1"))),
-                            ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
-                            false)),
+          List(
+            Datum.create(
+              Channel(Quote(GString("result1"))),
+              ListChannelWithRandom(Seq(Quote(expectedBundle)), randResult1),
+              false
+            )
+          ),
           List()
-        )))
+        )
+      )
+    )
   }
 }

--- a/roscala/macros/src/main/scala/coop/rchain/roscala/macros/Prim.scala
+++ b/roscala/macros/src/main/scala/coop/rchain/roscala/macros/Prim.scala
@@ -29,8 +29,10 @@ object TypeMismatchMacro {
           }"""
 
         case _ =>
-          c.abort(c.enclosingPosition,
-                  "Annotation @checkTypeMismatch can only be used on Prim.fnSimple")
+          c.abort(
+            c.enclosingPosition,
+            "Annotation @checkTypeMismatch can only be used on Prim.fnSimple"
+          )
       }
 
     c.Expr[Any](result)

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/EvalBench.scala
@@ -27,7 +27,7 @@ class EvalBench {
   def createTest(state: EvalBenchStateBase): Task[Vector[Throwable]] = {
     val par = state.term.getOrElse(throw new Error("Failed to prepare executable rholang term"))
     state.runtime.reducer
-      .inj(par)(state.rand, state.costAccountAlg)
+      .inj(par)(state.rand)
       .map(_ => state.runtime.readAndClearErrorVector())
   }
 

--- a/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
+++ b/rspace-bench/src/main/scala/coop/rchain/rspace/bench/WideBench.scala
@@ -3,20 +3,20 @@ import java.io.{FileNotFoundException, InputStreamReader}
 import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
 
+import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import coop.rchain.rspace.bench.WideBench.{CoarseBenchState, FineBenchState, WideBenchState}
+import coop.rchain.shared.StoreType
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
-import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.shared.StoreType
 
 import scala.concurrent.Await
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, _}
 
 class WideBench {
 
@@ -68,8 +68,7 @@ object WideBench {
 
     lazy val runtime: Runtime  = Runtime.create(dbDir, mapSize)
     def rand: Blake2b512Random = Blake2b512Random(128)
-    val costAccountAlg: CostAccountingAlg[Task] =
-      CostAccountingAlg.unsafe[Task](CostAccount(Integer.MAX_VALUE))
+    runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runSyncUnsafe(1.second)
     var setupTerm: Option[Par] = None
     var term: Option[Par]      = None
 
@@ -115,7 +114,7 @@ object WideEvalBenchState {
   def createTest(t: Option[Par], state: WideBenchState): Task[Vector[Throwable]] = {
     val par = t.getOrElse(throw new Error("Failed to prepare executable rholang term"))
     state.runtime.reducer
-      .inj(par)(state.rand, state.costAccountAlg)
+      .inj(par)(state.rand)
       .map(_ => state.runtime.readAndClearErrorVector())
   }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -303,9 +303,10 @@ class InMemoryStoreStorageExamplesTestsBase
     val trieStore =
       InMemoryTrieStore.create[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]()
 
-    val testStore = InMemoryStore.create[InMemTransaction[
-      history.State[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]
-    ], Channel, Pattern, Entry, EntriesCaptor](trieStore, branch)
+    val testStore = InMemoryStore
+      .create[InMemTransaction[
+        history.State[Blake2b256Hash, GNAT[Channel, Pattern, Entry, EntriesCaptor]]
+      ], Channel, Pattern, Entry, EntriesCaptor](trieStore, branch)
 
     val testSpace =
       RSpace.create[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](testStore, branch)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -132,9 +132,10 @@ class InMemoryStoreTestsBase
     val trieStore =
       InMemoryTrieStore.create[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]()
 
-    val testStore = InMemoryStore.create[InMemTransaction[
-      history.State[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]
-    ], String, Pattern, String, StringsCaptor](trieStore, branch)
+    val testStore = InMemoryStore
+      .create[InMemTransaction[
+        history.State[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]
+      ], String, Pattern, String, StringsCaptor](trieStore, branch)
 
     val testSpace =
       RSpace.create[String, Pattern, Nothing, String, String, StringsCaptor](testStore, branch)


### PR DESCRIPTION
## Overview
When we leave RSpace with a matching data in dispatcher we need to continue burning the same phlos. If we have a cost accounting algebra dependency at method call level this won't work. We already share same Reduce instance in Dispatch so it makes sense to move the state inside to Reduce. Since cost algebra is not available at method call anymore, we need a way to set new phlo limit, which is known only when we know deploy params.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
