### PR TITLE
test the metrics by running curl against the endpoint

### DIFF
--- a/integration-testing/src/tools/rnode.py
+++ b/integration-testing/src/tools/rnode.py
@@ -39,6 +39,11 @@ class Node:
         logging.info(f"Bootstrap address: `{address}`")
         return address
 
+    def get_metrics(self):
+        cmd = f'curl -s http://localhost:40403/metrics'
+
+        return self.exec_run(cmd=cmd)
+
     def cleanup(self):
         log_file = f"{self.container.name}.log"
         

--- a/integration-testing/src/tools/wait.py
+++ b/integration-testing/src/tools/wait.py
@@ -88,9 +88,7 @@ def network_converged(bootstrap_node, expected_peers):
     rx = re.compile("^peers (\d+).0\s*$", re.MULTILINE | re.DOTALL)
 
     def go():
-        cmd = f'curl -s http://localhost:40403/metrics'
-
-        exit_code, output = bootstrap_node.exec_run(cmd=cmd)
+        exit_code, output = bootstrap_node.get_metrics()
 
         m = rx.search(output)
 

--- a/integration-testing/test/complete_connected/test_basics.py
+++ b/integration-testing/test/complete_connected/test_basics.py
@@ -6,9 +6,8 @@ from tools.profiling import profile
 def test_metrics_api_socket(started_complete_network):
     for node  in started_complete_network.nodes:
         logging.info(f"Test metrics api socket for {node.name}")
-        cmd = f"nmap -sS -n -p T:40403 -oG - {node.name}"
-        r = node.container.exec_run(cmd=cmd, user='root').output.decode("utf-8")
-        expect("40403/open/tcp" in r, f"Port 40403/tcp is not open in container {node.name}")
+        exit_code, output = node.get_metrics()
+        expect(exit_code == 0, "Could not get the metrics for node {node.name}")
 
     assert_expectations()
 


### PR DESCRIPTION
## Overview
The original implementation only checked for the open port which is not enough. This version checks the metrics endpoint by running curl against it.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-847

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
