### PR TITLE
Limit -Ybackend-parallelism to 16

### DIFF
--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -26,7 +26,11 @@ object CompilerSettings {
       "-feature",
       "-language:_",
       "-unchecked",
-      "-Ybackend-parallelism", getRuntime.availableProcessors().toString
+      /*
+       * With > 16: [error] invalid setting for -Ybackend-parallelism must be between 1 and 16
+       * https://github.com/scala/scala/blob/v2.12.6/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala#L240
+       */
+      "-Ybackend-parallelism", getRuntime.availableProcessors().min(16).toString
     )
     // format: on
 


### PR DESCRIPTION
With > 16: [error] invalid setting for -Ybackend-parallelism must be between 1 and 16
  https://github.com/scala/scala/blob/v2.12.6/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala#L240