### PR TITLE
Add docker as a requirement for genesis-test script

### DIFF
--- a/scripts/genesis-test/requirements.txt
+++ b/scripts/genesis-test/requirements.txt
@@ -2,3 +2,4 @@ pynacl
 cryptography
 eth-hash[pycryptodome]
 oyaml
+docker


### PR DESCRIPTION
`docker` package is needed by `deploy-setup` script.