### PR TITLE
Removed extraneous pairCh from MakeMint.rho

### DIFF
--- a/casper/src/main/rholang/MakeMint.rho
+++ b/casper/src/main/rholang/MakeMint.rho
@@ -10,7 +10,7 @@ contract @("MakeMint", "int2NN")(@x, return) = {
   }
 } |
 contract @"MakeMint"(return) = {
-  new pairCh, thisMint, internalMakePurse in {
+  new thisMint, internalMakePurse in {
     contract @(*thisMint, "makePurse")(@init, return) = {
       new balanceCh in {
         @("MakeMint", "int2NN")!(init, *balanceCh) | for(@balance <- balanceCh) {


### PR DESCRIPTION
## Overview
There is an extra unforgeable name created on line 13 of makeMint.rho that is never used. This PR removes that name.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-1228

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
This is my first PR against rchain/rchain. I've tried to follow all the policies, but please be kind if I missed or messed up any of them.

I was unable to assign a reviewer, but perhaps @birchmd is interested?
