### PR TITLE
CORE-1128 A node provides its gitHash

### DIFF
--- a/node/src/main/scala/coop/rchain/node/VersionInfo.scala
+++ b/node/src/main/scala/coop/rchain/node/VersionInfo.scala
@@ -1,0 +1,5 @@
+package coop.rchain.node
+
+object VersionInfo {
+  val get: String = s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+}

--- a/node/src/main/scala/coop/rchain/node/VersionInfo.scala
+++ b/node/src/main/scala/coop/rchain/node/VersionInfo.scala
@@ -1,5 +1,14 @@
 package coop.rchain.node
 
+import cats.effect.IO
+import org.http4s._
+import org.http4s.dsl.io._
+
 object VersionInfo {
-  val get: String = s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+  val get: String =
+    s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+
+  def service = HttpService[IO] {
+    case GET -> Root => Ok(get)
+  }
 }

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -191,6 +191,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
                      BlazeBuilder[IO]
                        .bindHttp(conf.server.httpPort, "0.0.0.0")
                        .mountService(prometheusService, "/metrics")
+                       .mountService(VersionInfo.service, "/version")
                        .start
                    }.toEffect
       _ <- Task.delay {

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -269,9 +269,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
   ): Effect[Unit] = {
 
     val info: Effect[Unit] = for {
-      _ <- Log[Effect].info(
-            s"RChain Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
-          )
+      _ <- Log[Effect].info(VersionInfo.get)
       _ <- if (conf.server.standalone) Log[Effect].info(s"Starting stand-alone node.")
           else Log[Effect].info(s"Starting node that will bootstrap from ${conf.server.bootstrap}")
     } yield ()


### PR DESCRIPTION
## Overview
After this change, node will provide its version information (version and git hash) via Http Server for you to curl :)

When accessing http endpoint via `http://localhost:40403/version` you will get 

```
RChain Node 0.6.4 (6cecefe4d80c0de2aaec321ed90324b3246ce9ae)
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1128