### PR TITLE
Do not dump tuplespace output for show-blocks

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -226,7 +226,7 @@ object BlockAPI {
         estimates  <- MultiParentCasper[F].estimator(dag)
         tip        = estimates.head
         mainChain  <- ProtoUtil.getMainChain[F](tip, IndexedSeq.empty[BlockMessage])
-        blockInfos <- mainChain.toList.traverse(getFullBlockInfo[F])
+        blockInfos <- mainChain.toList.traverse(getBlockInfoWithoutTuplespace[F])
       } yield
         BlocksResponse(status = "Success", blocks = blockInfos, length = blockInfos.length.toLong)
 

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -22,7 +22,7 @@ service DeployService {
   rpc addBlock(BlockMessage) returns (DeployServiceResponse) {}
   rpc createBlock(google.protobuf.Empty) returns (DeployServiceResponse) {}
   rpc showBlock(BlockQuery) returns (BlockQueryResponse) {}
-  rpc showBlocks(google.protobuf.Empty) returns (stream BlockInfo) {}
+  rpc showBlocks(google.protobuf.Empty) returns (stream BlockInfoWithoutTuplespace) {}
   rpc listenForDataAtName(Channel) returns (ListeningNameDataResponse) {}
   rpc listenForContinuationAtName(Channels) returns (ListeningNameContinuationResponse) {}
 }
@@ -98,7 +98,7 @@ message WaitingContinuationInfo {
 
 message BlocksResponse {
   string status = 1;
-  repeated BlockInfo blocks = 2;
+  repeated BlockInfoWithoutTuplespace blocks = 2;
   int64 length = 3;
 }
 

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -33,7 +33,7 @@ private[api] object DeployGrpcService {
       override def showBlock(q: BlockQuery): Task[BlockQueryResponse] =
         BlockAPI.getBlockQueryResponse[F](q).toTask
 
-      override def showBlocks(request: Empty): Observable[BlockInfo] =
+      override def showBlocks(request: Empty): Observable[BlockInfoWithoutTuplespace] =
         Observable
           .fromTask(BlockAPI.getBlocksResponse[F].toTask)
           .flatMap(b => Observable.fromIterable(b.blocks))


### PR DESCRIPTION
This output has made show-blocks both slow and unreadable.
Users can still use show-block if they want to full tuplespace output.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

https://rchain.atlassian.net/browse/RHOL-872