### PR TITLE
Simplify API of cost alg; spatial matcher accepts Cost

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -52,7 +52,7 @@ message ListChannelWithRandom {
     repeated Channel channels = 1;
     bytes randomState = 2 [(scalapb.field).type = "coop.rchain.crypto.hash.Blake2b512Random"];
     // cost of performing the spatial match
-    PCost cost = 3;
+    uint64 cost = 3;
 }
 
 // While we use vars in both positions, when producing the normalized

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -129,11 +129,11 @@ object Reduce {
                  .fromEither(
                    SpatialMatcher
                      .spatialMatch(target, pattern)
-                     .runWithCost(phlosAvailable)
+                     .runWithCost(phlosAvailable.cost)
                  )
                  .flatMap {
                    case (phlosLeft, result) =>
-                     val matchCost = phlosAvailable.cost - phlosLeft.cost
+                     val matchCost = phlosAvailable.cost - phlosLeft
                      costAlg.charge(matchCost).map(_ => result)
                  }
                  .onError {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -133,13 +133,13 @@ object Reduce {
                  )
                  .flatMap {
                    case (phlosLeft, result) =>
-                     val phloUsed = phlosLeft.copy(cost = phlosAvailable.cost - phlosLeft.cost)
-                     costAlg.charge(phloUsed).map(_ => result)
+                     val matchCost = phlosAvailable.cost - phlosLeft.cost
+                     costAlg.charge(matchCost).map(_ => result)
                  }
                  .onError {
                    case OutOfPhlogistonsError =>
                      // if we run out of phlos during the match we have to zero phlos available
-                     costAlg.get().flatMap(costAlg.charge(_))
+                     costAlg.get().flatMap(ca => costAlg.charge(ca.cost))
                  }
     } yield result
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -236,7 +236,7 @@ class RegistryImpl[F[_]](
     })
 
   private def singleSend(data: Channel, chan: Quote, rand: Blake2b512Random): F[Unit] =
-    handleResult(space.produce(chan, ListChannelWithRandom(Seq(data), rand, None), false))
+    handleResult(space.produce(chan, ListChannelWithRandom(Seq(data), rand), false))
 
   private def succeed(result: Par, ret: Channel, rand: Blake2b512Random): F[Unit] =
     ret match {
@@ -279,7 +279,7 @@ class RegistryImpl[F[_]](
       _ <- handleResult(
             space.produce(
               Quote(channel),
-              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand),
               false
             )
           )
@@ -306,7 +306,7 @@ class RegistryImpl[F[_]](
       _ <- handleResult(
             space.produce(
               Quote(channel),
-              ListChannelWithRandom(Seq(key, value, ret, Channel(dataSource)), rand, None),
+              ListChannelWithRandom(Seq(key, value, ret, Channel(dataSource)), rand),
               false
             )
           )
@@ -332,7 +332,7 @@ class RegistryImpl[F[_]](
       _ <- handleResult(
             space.produce(
               Quote(channel),
-              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand),
               false
             )
           )
@@ -363,14 +363,14 @@ class RegistryImpl[F[_]](
       _ <- handleResult(
             space.produce(
               Quote(keyChannel),
-              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand, None),
+              ListChannelWithRandom(Seq(key, ret, Channel(dataSource)), rand),
               false
             )
           )
       _ <- handleResult(
             space.produce(
               Quote(parentChannel),
-              ListChannelWithRandom(Seq(parentKey, parentData, parentReplace), parentRand, None),
+              ListChannelWithRandom(Seq(parentKey, parentData, parentReplace), parentRand),
               false
             )
           )
@@ -787,7 +787,7 @@ class RegistryImpl[F[_]](
                     space.produce(
                       Quote(curryChan),
                       // This re-use of rand is fine because we throw it away in the callback below.
-                      ListChannelWithRandom(Seq(Quote(uriPar), value, ret), rand, None),
+                      ListChannelWithRandom(Seq(Quote(uriPar), value, ret), rand),
                       false
                     )
                   )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -13,7 +13,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime._
-import coop.rchain.rholang.interpreter.accounting.CostAccount
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.IReplaySpace
@@ -125,7 +125,7 @@ object Runtime {
   }
 
   // because only we do installs
-  private val MATCH_UNLIMITED_PHLOS = matchListQuote(CostAccount(Integer.MAX_VALUE))
+  private val MATCH_UNLIMITED_PHLOS = matchListQuote(Cost(Integer.MAX_VALUE))
 
   private def introduceSystemProcesses(
       space: RhoISpace,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -8,10 +8,10 @@ import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray}
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.rholang.interpreter.storage.implicits.matchListQuote
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.accounting.CostAccount
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rholang.interpreter.storage.implicits.matchListQuote
 import monix.eval.Task
 
 import scala.util.Try
@@ -20,7 +20,7 @@ object SystemProcesses {
 
   private val prettyPrinter = PrettyPrinter()
 
-  private val MATCH_UNLIMITED_PHLOS = matchListQuote(CostAccount(Integer.MAX_VALUE))
+  private val MATCH_UNLIMITED_PHLOS = matchListQuote(Cost(Integer.MAX_VALUE))
 
   def stdout: Seq[ListChannelWithRandom] => Task[Unit] = {
     case (Seq(ListChannelWithRandom(Seq(arg), _, _))) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingAlg.scala
@@ -8,7 +8,6 @@ import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
 trait CostAccountingAlg[F[_]] {
   def charge(cost: Cost): F[Unit]
-  def charge(cost: CostAccount): F[Unit]
   def get(): F[CostAccount]
   def set(cost: CostAccount): F[Unit]
   def refund(refund: Cost): F[Unit]
@@ -28,8 +27,6 @@ object CostAccountingAlg {
   private class CostAccountingAlgImpl[F[_]](state: Ref[F, CostAccount])(implicit F: Sync[F])
       extends CostAccountingAlg[F] {
     override def charge(cost: Cost): F[Unit] = chargeInternal(_ - cost)
-
-    override def charge(cost: CostAccount): F[Unit] = chargeInternal(_ - cost)
 
     private def chargeInternal(f: CostAccount => CostAccount): F[Unit] =
       for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -10,7 +10,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits.{VectorPar, _}
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, _}
+import coop.rchain.rholang.interpreter.accounting.{Cost, _}
 import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
 import coop.rchain.rholang.interpreter.matcher.OptionalFreeMapWithCost._
 import coop.rchain.rholang.interpreter.matcher.SpatialMatcher._
@@ -508,7 +508,7 @@ trait SpatialMatcherInstances {
               case Nil => OptionalFreeMapWithCost.emptyMap
               case p +: rem =>
                 OptionalFreeMapWithCost[Unit]((s: FreeMap) => {
-                  OptionT(StateT((c: CostAccount) => {
+                  OptionT(StateT((c: Cost) => {
                     spatialMatch(target, p).run(s).value.run(c).flatMap {
                       case (cost, None) =>
                         firstMatch(target, rem).run(s).value.run(cost)
@@ -522,7 +522,7 @@ trait SpatialMatcherInstances {
         }
         case ConnNotBody(p) =>
           OptionalFreeMapWithCost[Unit]((s: FreeMap) => {
-            OptionT(StateT((c: CostAccount) => {
+            OptionT(StateT((c: Cost) => {
               spatialMatch(target, p).run(s).value.run(c).map {
                 case (cost, None)         => (cost, Some((s, Unit)))
                 case (cost, Some((_, _))) => (cost, None)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -87,12 +87,14 @@ object ChargingRSpace {
         result match {
           case Left(oope) =>
             // if we run out of phlos during the match we have to zero phlos available
-            costAlg.get().flatMap(costAlg.charge(_)) >> Sync[F].raiseError(oope)
+            costAlg.get().flatMap(ca => costAlg.charge(ca.cost)) >> Sync[F].raiseError(oope)
           case Right(Some((_, dataList))) =>
-            val rspaceMatchCost = dataList
-              .map(_.cost.map(CostAccount.fromProto(_)).get)
-              .toList
-              .combineAll
+            val rspaceMatchCost = Cost(
+              dataList
+                .map(_.cost)
+                .toList
+                .combineAll
+            )
 
             costAlg
               .charge(rspaceMatchCost)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -44,7 +44,7 @@ object ChargingRSpace {
         val storageCost = storageCostConsume(channels, patterns, continuation)
         for {
           _       <- costAlg.charge(storageCost)
-          matchF  <- costAlg.get().map(matchListQuote(_))
+          matchF  <- costAlg.get().map(ca => matchListQuote(ca.cost))
           consRes <- Sync[F].delay(space.consume(channels, patterns, continuation, persist)(matchF))
           _       <- handleResult(consRes, storageCost, persist)
         } yield consRes
@@ -57,7 +57,7 @@ object ChargingRSpace {
       ): F[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
         Sync[F].delay(
           space.install(channels, patterns, continuation)(
-            matchListQuote(CostAccount(Integer.MAX_VALUE))
+            matchListQuote(Cost(Integer.MAX_VALUE))
           )
         )
 
@@ -71,7 +71,7 @@ object ChargingRSpace {
         val storageCost = storageCostProduce(channel, data)
         for {
           _       <- costAlg.charge(storageCost)
-          matchF  <- costAlg.get().map(matchListQuote(_))
+          matchF  <- costAlg.get().map(ca => matchListQuote(ca.cost))
           prodRes <- Sync[F].delay(space.produce(channel, data, persist)(matchF))
           _       <- handleResult(prodRes, storageCost, persist)
         } yield prodRes

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
-import coop.rchain.rholang.interpreter.accounting.CostAccount
+import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.matcher.OptionalFreeMapWithCost._
 import coop.rchain.rholang.interpreter.matcher._
@@ -24,7 +24,7 @@ object implicits {
       }
     }
 
-  def matchListQuote(init: CostAccount): StorageMatch[
+  def matchListQuote(init: Cost): StorageMatch[
     BindPattern,
     OutOfPhlogistonsError.type,
     ListChannelWithRandom,
@@ -37,8 +37,7 @@ object implicits {
       ListChannelWithRandom
     ] {
 
-      private def calcUsed(init: CostAccount, left: CostAccount): CostAccount =
-        CostAccount(left.idx - init.idx, init.cost - left.cost)
+      private def calcUsed(init: Cost, left: Cost): Cost = init - left
 
       def get(
           pattern: BindPattern,
@@ -64,7 +63,7 @@ object implicits {
                     ListChannelWithRandom(
                       toChannels(remainderMap, pattern.freeCount),
                       data.randomState,
-                      cost.cost.value
+                      cost.value
                     )
                 }
           }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -64,7 +64,7 @@ object implicits {
                     ListChannelWithRandom(
                       toChannels(remainderMap, pattern.freeCount),
                       data.randomState,
-                      Some(CostAccount.toProto(cost))
+                      cost.cost.value
                     )
                 }
           }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -107,7 +107,7 @@ class CryptoChannelsSpec
       // 2. hash input array
       // 3. send result on supplied ack channel
       Await.result(reduce.eval(send).runAsync, 3.seconds)
-      storeContainsTest(ListChannelWithRandom(Seq(Quote(expected)), rand, Some(PCost(0, 0))))
+      storeContainsTest(ListChannelWithRandom(Seq(Quote(expected)), rand, 0))
       clearStore(store, reduce, ackChannel)
     }
   }
@@ -167,7 +167,7 @@ class CryptoChannelsSpec
         )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, 0)
         )
         clearStore(store, reduce, ackChannel)
       }
@@ -207,7 +207,7 @@ class CryptoChannelsSpec
         )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, Some(PCost(0, 0)))
+          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, 0)
         )
         clearStore(store, reduce, ackChannel)
       }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -8,7 +8,7 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
 import coop.rchain.models.{ListChannelWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount, CostAccountingAlg}
 import coop.rchain.rholang.interpreter.storage.TuplespaceAlg
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.pure.PureRSpace
@@ -22,7 +22,7 @@ object RholangOnlyDispatcher {
       ft: FunctorTell[M, Throwable]
   ): (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M]) = {
     // This is safe because test
-    implicit val matchCost = matchListQuote(CostAccount(Integer.MAX_VALUE))
+    implicit val matchCost = matchListQuote(Cost(Integer.MAX_VALUE))
     val pureSpace          = PureRSpace[M].of(tuplespace)
     lazy val tuplespaceAlg = TuplespaceAlg.rspaceTuplespace(pureSpace, dispatcher)
     lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -38,8 +38,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     expectedCaptures.foreach(
       _.values.foreach((v: Par) => assertSorted(v, "expected captured term"))
     )
-    val intermediate: Either[OutOfPhlogistonsError.type, (CostAccount, Option[(FreeMap, Unit)])] =
-      spatialMatch(target, pattern).runWithCost(CostAccount(Integer.MAX_VALUE))
+    val intermediate: Either[OutOfPhlogistonsError.type, (Cost, Option[(FreeMap, Unit)])] =
+      spatialMatch(target, pattern).runWithCost(Cost(Integer.MAX_VALUE))
     assert(intermediate.isRight)
     val result = intermediate.right.get._2.map(_._1)
     assert(prettyCaptures(result) == prettyCaptures(expectedCaptures))
@@ -923,7 +923,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
     val pattern: Par =
       EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
-    val res = spatialMatch(target, pattern).runWithCost(CostAccount(0, Cost(0)))
+    val res = spatialMatch(target, pattern).runWithCost(Cost(0))
     res should be(Left(OutOfPhlogistonsError))
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -148,7 +148,7 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
 object ChargingRSpaceTest {
   val RSPACE_MATCH_PCOST     = 100L
   val RSPACE_MATCH_COST      = Cost(RSPACE_MATCH_PCOST)
-  val NilPar                    = ListChannelWithRandom().withChannels(Seq(Channel(Quote(Par()))))
+  val NilPar                 = ListChannelWithRandom().withChannels(Seq(Channel(Quote(Par()))))
   val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
 
   private def byteName(b: Byte): GPrivate = GPrivate(ByteString.copyFrom(Array[Byte](b)))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -56,7 +56,7 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
     val consumeStorageCost                               = ChargingRSpace.storageCostConsume(channels, patterns, cont)
     val data                                             = NilPar
     val produceStorageCost                               = ChargingRSpace.storageCostProduce(channels.head, data)
-    val minimumPhlos                                     = produceStorageCost + consumeStorageCost + RSPACE_MATCH_COST.cost
+    val minimumPhlos                                     = produceStorageCost + consumeStorageCost + RSPACE_MATCH_COST
 
     setInitPhlos(costAlg, minimumPhlos)
 
@@ -102,7 +102,7 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
       val firstProdCost                                    = ChargingRSpace.storageCostProduce(channels(0), data)
       val secondProdCost                                   = ChargingRSpace.storageCostProduce(channels(1), data)
       val joinCost                                         = ChargingRSpace.storageCostConsume(channels, patterns, cont)
-      val minimumPhlos                                     = firstProdCost + secondProdCost + joinCost + (RSPACE_MATCH_COST.cost * 2)
+      val minimumPhlos                                     = firstProdCost + secondProdCost + joinCost + (RSPACE_MATCH_COST * 2)
 
       setInitPhlos(costAlg, minimumPhlos)
 
@@ -146,10 +146,10 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
 }
 
 object ChargingRSpaceTest {
-  val RSPACE_MATCH_PCOST: PCost = PCost(1, 100)
-  val RSPACE_MATCH_COST         = CostAccount.fromProto(RSPACE_MATCH_PCOST)
+  val RSPACE_MATCH_PCOST     = 100L
+  val RSPACE_MATCH_COST      = Cost(RSPACE_MATCH_PCOST)
   val NilPar                    = ListChannelWithRandom().withChannels(Seq(Channel(Quote(Par()))))
-  val rand: Blake2b512Random    = Blake2b512Random(Array.empty[Byte])
+  val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
 
   private def byteName(b: Byte): GPrivate = GPrivate(ByteString.copyFrom(Array[Byte](b)))
 


### PR DESCRIPTION
## Overview
Simplify API of cost alg (remove one of the `charge` methods); spatial matcher accepts and returns `Cost` instead of `CostAccount`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
