### PR TITLE
Change default yourkit profiling setting from tracing to sampling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val compilerSettings = CompilerSettings.options ++ Seq(
 lazy val profilerSettings = Seq(
   javaOptions in run ++= sys.env
     .get("YOURKIT_AGENT")
-    .map(agent => s"-agentpath:$agent=onexit=snapshot,tracing")
+    .map(agent => s"-agentpath:$agent=onexit=snapshot,sampling")
     .toSeq,
   javaOptions in reStart ++= (javaOptions in run).value
 )


### PR DESCRIPTION
Tracing is super slow while sampling should give you most of the things you want while it is much faster.
Therefore better to have as a default.