### PR TITLE
Use different type as data and result for RSpace match 

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -51,6 +51,11 @@ message PCost {
 message ListChannelWithRandom {
     repeated Channel channels = 1;
     bytes randomState = 2 [(scalapb.field).type = "coop.rchain.crypto.hash.Blake2b512Random"];
+}
+
+message ListChannelWithRandomAndPhlos {
+    repeated Channel channels = 1;
+    bytes randomState = 2 [(scalapb.field).type = "coop.rchain.crypto.hash.Blake2b512Random"];
     // cost of performing the spatial match
     uint64 cost = 3;
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -42,25 +42,25 @@ trait Registry[F[_]] {
 
   def testInstall(): F[Unit]
 
-  def lookup(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def lookup(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def lookupCallback(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def lookupCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def insert(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def insert(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def insertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def insertCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def delete(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def delete(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def deleteRootCallback(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def deleteRootCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def deleteCallback(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def deleteCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def publicLookup(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def publicLookup(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def publicRegisterRandom(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def publicRegisterRandom(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 
-  def publicRegisterInsertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit]
+  def publicRegisterInsertCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit]
 }
 
 class RegistryImpl[F[_]](
@@ -227,7 +227,7 @@ class RegistryImpl[F[_]](
   private def parByteArray(bs: ByteString): Par = GByteArray(bs)
 
   private def handleResult[E <: Throwable](
-      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]]
+      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])]]]
   ): F[Unit] =
     resultF.flatMap({
       case Right(Some((continuation, dataList))) => dispatcher.dispatch(continuation, dataList)
@@ -385,9 +385,9 @@ class RegistryImpl[F[_]](
     } yield ()
   }
 
-  def lookup(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def lookup(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, ret), rand, cost)) =>
+      case Seq(ListChannelWithRandomAndPhlos(Seq(key, ret), rand, cost)) =>
         try {
           val Channel(Quote(keyPar))    = key
           val Some(Expr(GByteArray(_))) = keyPar.singleExpr
@@ -403,11 +403,11 @@ class RegistryImpl[F[_]](
   // Result there, return it.
   // Further lookup needed, recurse.
 
-  def lookupCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def lookupCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
       case Seq(
-          ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
-          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ListChannelWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandomAndPhlos(Seq(data), dataRand, dataCost)
           ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
@@ -452,9 +452,9 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def insert(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def insert(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, value, ret), rand, cost)) =>
+      case Seq(ListChannelWithRandomAndPhlos(Seq(key, value, ret), rand, cost)) =>
         try {
           val Channel(Quote(keyPar))    = key
           val Some(Expr(GByteArray(_))) = keyPar.singleExpr
@@ -465,11 +465,11 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def insertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def insertCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
       case Seq(
-          ListChannelWithRandom(Seq(key, value, ret, replaceChan), callRand, callCost),
-          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ListChannelWithRandomAndPhlos(Seq(key, value, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandomAndPhlos(Seq(data), dataRand, dataCost)
           ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
@@ -559,9 +559,9 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def delete(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def delete(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, ret), rand, cost)) =>
+      case Seq(ListChannelWithRandomAndPhlos(Seq(key, ret), rand, cost)) =>
         try {
           val Channel(Quote(keyPar))    = key
           val Some(Expr(GByteArray(_))) = keyPar.singleExpr
@@ -572,11 +572,11 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def deleteRootCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def deleteRootCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
       case Seq(
-          ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
-          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ListChannelWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandomAndPhlos(Seq(data), dataRand, dataCost)
           ) =>
         def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
         try {
@@ -625,12 +625,16 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def deleteCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def deleteCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
       case Seq(
-          ListChannelWithRandom(Seq(key, ret, replaceChan), callRand, callCost),
-          ListChannelWithRandom(Seq(parentKey, parentData, parentReplace), parentRand, parentCost),
-          ListChannelWithRandom(Seq(data), dataRand, dataCost)
+          ListChannelWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, callCost),
+          ListChannelWithRandomAndPhlos(
+            Seq(parentKey, parentData, parentReplace),
+            parentRand,
+            parentCost
+          ),
+          ListChannelWithRandomAndPhlos(Seq(data), dataRand, dataCost)
           ) =>
         def localFail() =
           replace(parentData, parentReplace, parentRand).flatMap(
@@ -726,9 +730,9 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicLookup(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def publicLookup(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(key, ret), rand, cost)) =>
+      case Seq(ListChannelWithRandomAndPhlos(Seq(key, ret), rand, cost)) =>
         def localFail() = fail(ret, rand)
         try {
           val Channel(Quote(keyPar)) = key
@@ -745,7 +749,7 @@ class RegistryImpl[F[_]](
                 ((bytes(32).toShort & 0xff) | ((bytes(33).toShort & 0xfc) << 6)).toShort
               if (crc == CRC14.compute(bytes.view.slice(0, 32))) {
                 val args = RootSeq(
-                  ListChannelWithRandom(
+                  ListChannelWithRandomAndPhlos(
                     Seq(Quote(parByteArray(ByteString.copyFrom(bytes, 0, 32))), ret),
                     rand
                   )
@@ -765,9 +769,9 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicRegisterRandom(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def publicRegisterRandom(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
-      case Seq(ListChannelWithRandom(Seq(value, ret), rand, cost)) =>
+      case Seq(ListChannelWithRandomAndPhlos(Seq(value, ret), rand, cost)) =>
         def localFail() = fail(ret, rand)
         try {
           val Channel(Quote(valPar)) = value
@@ -780,7 +784,10 @@ class RegistryImpl[F[_]](
             val resultChan: Par = GPrivate(ByteString.copyFrom(rand.next()))
             val uriPar: Par     = GUri(buildURI(bytes))
             val args = RootSeq(
-              ListChannelWithRandom(Seq(Quote(partialKey), Quote(valPar), Quote(resultChan)), rand)
+              ListChannelWithRandomAndPhlos(
+                Seq(Quote(partialKey), Quote(valPar), Quote(resultChan)),
+                rand
+              )
             )
             for {
               _ <- handleResult(
@@ -809,11 +816,11 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicRegisterInsertCallback(args: RootSeq[ListChannelWithRandom]): F[Unit] =
+  def publicRegisterInsertCallback(args: RootSeq[ListChannelWithRandomAndPhlos]): F[Unit] =
     args match {
       case Seq(
-          ListChannelWithRandom(Seq(urn, expectedValue, ret), _, callCost),
-          ListChannelWithRandom(Seq(value), valRand, valCost)
+          ListChannelWithRandomAndPhlos(Seq(urn, expectedValue, ret), _, callCost),
+          ListChannelWithRandomAndPhlos(Seq(value), valRand, valCost)
           ) =>
         ret match {
           case Channel(retQ @ Quote(_)) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -53,8 +53,8 @@ object Runtime {
   type RhoIStore  = CPAK[IStore]
   type RhoContext = CPAK[Context]
 
-  type RhoDispatch[F[_]] = Dispatch[F, ListChannelWithRandom, TaggedContinuation]
-  type RhoSysFunction    = Function1[Seq[ListChannelWithRandom], Task[Unit]]
+  type RhoDispatch[F[_]] = Dispatch[F, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  type RhoSysFunction    = Function1[Seq[ListChannelWithRandomAndPhlos], Task[Unit]]
   type RhoDispatchMap    = Map[Long, RhoSysFunction]
 
   private type CPAK[F[_, _, _, _]] =
@@ -66,7 +66,7 @@ object Runtime {
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
-      ListChannelWithRandom,
+      ListChannelWithRandomAndPhlos,
       TaggedContinuation
     ]
 
@@ -77,7 +77,7 @@ object Runtime {
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
-      ListChannelWithRandom,
+      ListChannelWithRandomAndPhlos,
       TaggedContinuation
     ]
 
@@ -131,7 +131,7 @@ object Runtime {
       space: RhoISpace,
       replaySpace: RhoISpace,
       processes: immutable.Seq[(Name, Arity, Remainder, Ref)]
-  ): Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
+  ): Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])]] =
     processes.flatMap {
       case (name, arity, remainder, ref) =>
         val channels = List(Channel(Quote(name)))
@@ -165,7 +165,7 @@ object Runtime {
         BindPattern,
         OutOfPhlogistonsError.type,
         ListChannelWithRandom,
-        ListChannelWithRandom,
+        ListChannelWithRandomAndPhlos,
         TaggedContinuation
       ](context, Branch.MASTER)
       val replaySpace: RhoReplayISpace = ReplayRSpace.create[
@@ -174,7 +174,7 @@ object Runtime {
         BindPattern,
         OutOfPhlogistonsError.type,
         ListChannelWithRandom,
-        ListChannelWithRandom,
+        ListChannelWithRandomAndPhlos,
         TaggedContinuation
       ](context, Branch.REPLAY)
       (context, space, replaySpace)
@@ -199,7 +199,7 @@ object Runtime {
           BindPattern,
           OutOfPhlogistonsError.type,
           ListChannelWithRandom,
-          ListChannelWithRandom,
+          ListChannelWithRandomAndPhlos,
           TaggedContinuation
         ](store, Branch.MASTER)
         val replaySpace: RhoReplayISpace = FineGrainedReplayRSpace.create[
@@ -208,7 +208,7 @@ object Runtime {
           BindPattern,
           OutOfPhlogistonsError.type,
           ListChannelWithRandom,
-          ListChannelWithRandom,
+          ListChannelWithRandomAndPhlos,
           TaggedContinuation
         ](context, Branch.REPLAY)
         (context, space, replaySpace)
@@ -293,7 +293,7 @@ object Runtime {
       )
     }
 
-    val res: Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
+    val res: Seq[Option[(TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])]] =
       introduceSystemProcesses(space, replaySpace, procDefs)
 
     assert(res.forall(_.isEmpty))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -22,18 +22,20 @@ object SystemProcesses {
 
   private val MATCH_UNLIMITED_PHLOS = matchListQuote(Cost(Integer.MAX_VALUE))
 
-  def stdout: Seq[ListChannelWithRandom] => Task[Unit] = {
-    case (Seq(ListChannelWithRandom(Seq(arg), _, _))) =>
+  def stdout: Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case (Seq(ListChannelWithRandomAndPhlos(Seq(arg), _, _))) =>
       Task.now(Console.println(prettyPrinter.buildString(arg)))
   }
 
   private implicit class ProduceOps(
       res: Id[
-        Either[OutOfPhlogistonsError.type, Option[(TaggedContinuation, Seq[ListChannelWithRandom])]]
+        Either[OutOfPhlogistonsError.type, Option[
+          (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
+        ]]
       ]
   ) {
     def foldResult(
-        dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
+        dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
     ): Task[Unit] =
       res.fold(err => Task.raiseError(OutOfPhlogistonsError), _.fold(Task.unit) {
         case (cont, channels) => _dispatch(dispatcher)(cont, channels)
@@ -42,35 +44,35 @@ object SystemProcesses {
 
   def stdoutAck(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
-    case Seq(ListChannelWithRandom(Seq(arg, ack), rand, cost)) =>
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case Seq(ListChannelWithRandomAndPhlos(Seq(arg, ack), rand, cost)) =>
       Task.now(Console.println(prettyPrinter.buildString(arg))).flatMap { (_: Unit) =>
         space
           .produce(
             ack,
-            ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand, cost),
+            ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand),
             false
           )(MATCH_UNLIMITED_PHLOS)
           .foldResult(dispatcher)
       }
   }
 
-  def stderr: Seq[ListChannelWithRandom] => Task[Unit] = {
-    case (Seq(ListChannelWithRandom(Seq(arg), _, _))) =>
+  def stderr: Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case (Seq(ListChannelWithRandomAndPhlos(Seq(arg), _, _))) =>
       Task.now(Console.err.println(prettyPrinter.buildString(arg)))
   }
 
   def stderrAck(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
-    case Seq(ListChannelWithRandom(Seq(arg, ack), rand, cost)) =>
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case Seq(ListChannelWithRandomAndPhlos(Seq(arg, ack), rand, _)) =>
       Task.now(Console.err.println(prettyPrinter.buildString(arg))).flatMap { (_: Unit) =>
         space
           .produce(
             ack,
-            ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand, cost),
+            ListChannelWithRandom(Seq(Channel(Quote(Par.defaultInstance))), rand),
             false
           )(MATCH_UNLIMITED_PHLOS)
           .foldResult(dispatcher)
@@ -93,20 +95,20 @@ object SystemProcesses {
 
   def secp256k1Verify(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
     case Seq(
-        ListChannelWithRandom(
+        ListChannelWithRandomAndPhlos(
           Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack),
           rand,
-          cost
+          _
         )
         ) =>
       Task.fromTry(Try(Secp256k1.verify(data, signature, pub))).flatMap { verified =>
         space
           .produce(
             ack,
-            ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand, cost),
+            ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand),
             false
           )(MATCH_UNLIMITED_PHLOS)
           .foldResult(dispatcher)
@@ -115,20 +117,20 @@ object SystemProcesses {
 
   def ed25519Verify(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
     case Seq(
-        ListChannelWithRandom(
+        ListChannelWithRandomAndPhlos(
           Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack),
           rand,
-          cost
+          _
         )
         ) =>
       Task.fromTry(Try(Ed25519.verify(data, signature, pub))).flatMap { verified =>
         space
           .produce(
             ack,
-            ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand, cost),
+            ListChannelWithRandom(Seq(Channel(Quote(Expr(GBool(verified))))), rand),
             false
           )(MATCH_UNLIMITED_PHLOS)
           .foldResult(dispatcher)
@@ -141,17 +143,16 @@ object SystemProcesses {
 
   def sha256Hash(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
-    case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case Seq(ListChannelWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)) =>
       Task.fromTry(Try(Sha256.hash(input))).flatMap { hash =>
         space
           .produce(
             ack,
             ListChannelWithRandom(
               Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))),
-              rand,
-              cost
+              rand
             ),
             false
           )(MATCH_UNLIMITED_PHLOS)
@@ -163,17 +164,16 @@ object SystemProcesses {
 
   def keccak256Hash(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
-    case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case Seq(ListChannelWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)) =>
       Task.fromTry(Try(Keccak256.hash(input))).flatMap { hash =>
         space
           .produce(
             ack,
             ListChannelWithRandom(
               Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))),
-              rand,
-              cost
+              rand
             ),
             false
           )(MATCH_UNLIMITED_PHLOS)
@@ -185,17 +185,16 @@ object SystemProcesses {
 
   def blake2b256Hash(
       space: RhoISpace,
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  ): Seq[ListChannelWithRandom] => Task[Unit] = {
-    case Seq(ListChannelWithRandom(Seq(IsByteArray(input), ack), rand, cost)) =>
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  ): Seq[ListChannelWithRandomAndPhlos] => Task[Unit] = {
+    case Seq(ListChannelWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)) =>
       Task.fromTry(Try(Blake2b256.hash(input))).flatMap { hash =>
         space
           .produce(
             ack,
             ListChannelWithRandom(
               Seq(Channel(Quote(Expr(GByteArray(ByteString.copyFrom(hash)))))),
-              rand,
-              cost
+              rand
             ),
             false
           )(MATCH_UNLIMITED_PHLOS)
@@ -206,8 +205,8 @@ object SystemProcesses {
   }
 
   private def _dispatch(
-      dispatcher: Dispatch[Task, ListChannelWithRandom, TaggedContinuation]
-  )(cont: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): Task[Unit] =
+      dispatcher: Dispatch[Task, ListChannelWithRandomAndPhlos, TaggedContinuation]
+  )(cont: TaggedContinuation, dataList: Seq[ListChannelWithRandomAndPhlos]): Task[Unit] =
     dispatcher.dispatch(cont, dataList)
 
   private def illegalArgumentException(msg: String): Task[Unit] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -3,7 +3,6 @@ package coop.rchain.rholang.interpreter
 import cats.Parallel
 import cats.effect.Sync
 import cats.mtl.FunctorTell
-import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
@@ -11,9 +10,7 @@ import coop.rchain.models._
 import cats.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
-import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rholang.interpreter.storage.{ChargingRSpace, TuplespaceAlg}
-import coop.rchain.rspace.pure.PureRSpace
 trait Dispatch[M[_], A, K] {
   def dispatch(continuation: K, dataList: Seq[A]): M[Unit]
 }
@@ -21,7 +18,7 @@ trait Dispatch[M[_], A, K] {
 object Dispatch {
 
   // TODO: Make this function total
-  def buildEnv(dataList: Seq[ListChannelWithRandom]): Env[Par] =
+  def buildEnv(dataList: Seq[ListChannelWithRandomAndPhlos]): Env[Par] =
     Env.makeEnv(
       dataList
         .flatMap(_.channels)
@@ -34,11 +31,14 @@ object Dispatch {
 
 class RholangAndScalaDispatcher[M[_]] private (
     reducer: => ChargingReducer[M],
-    _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]]
+    _dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandomAndPhlos], M[Unit]]]
 )(implicit s: Sync[M])
-    extends Dispatch[M, ListChannelWithRandom, TaggedContinuation] {
+    extends Dispatch[M, ListChannelWithRandomAndPhlos, TaggedContinuation] {
 
-  def dispatch(continuation: TaggedContinuation, dataList: Seq[ListChannelWithRandom]): M[Unit] =
+  def dispatch(
+      continuation: TaggedContinuation,
+      dataList: Seq[ListChannelWithRandomAndPhlos]
+  ): M[Unit] =
     for {
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
@@ -47,8 +47,11 @@ class RholangAndScalaDispatcher[M[_]] private (
                 reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
               case ScalaBodyRef(ref) =>
                 _dispatchTable.get(ref) match {
-                  case Some(f) => f(dataList)
-                  case None    => s.raiseError(new Exception(s"dispatch: no function for $ref"))
+                  case Some(f) =>
+                    f(
+                      dataList.map(dl => ListChannelWithRandomAndPhlos(dl.channels, dl.randomState))
+                    )
+                  case None => s.raiseError(new Exception(s"dispatch: no function for $ref"))
                 }
               case Empty =>
                 s.unit
@@ -61,17 +64,21 @@ object RholangAndScalaDispatcher {
 
   def create[M[_], F[_]](
       tuplespace: RhoISpace,
-      dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandom], M[Unit]]],
+      dispatchTable: => Map[Long, Function1[Seq[ListChannelWithRandomAndPhlos], M[Unit]]],
       urnMap: Map[String, Par]
   )(
       implicit
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable]
-  ): (Dispatch[M, ListChannelWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
+  ): (
+      Dispatch[M, ListChannelWithRandomAndPhlos, TaggedContinuation],
+      ChargingReducer[M],
+      Registry[M]
+  ) = {
     lazy val chargingRSpace = ChargingRSpace.pureRSpace(s, costAlg, tuplespace)
     lazy val tuplespaceAlg  = TuplespaceAlg.rspaceTuplespace(chargingRSpace, dispatcher)
-    lazy val dispatcher: Dispatch[M, ListChannelWithRandom, TaggedContinuation] =
+    lazy val dispatcher: Dispatch[M, ListChannelWithRandomAndPhlos, TaggedContinuation] =
       new RholangAndScalaDispatcher(chargingReducer, dispatchTable)
     implicit lazy val reducer: Reduce[M] =
       new Reduce.DebruijnInterpreter[M, F](tuplespaceAlg, urnMap)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -11,6 +11,7 @@ import cats.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccountingAlg}
 import coop.rchain.rholang.interpreter.storage.{ChargingRSpace, TuplespaceAlg}
+
 trait Dispatch[M[_], A, K] {
   def dispatch(continuation: K, dataList: Seq[A]): M[Unit]
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -39,7 +39,7 @@ object ChargingRSpace {
           continuation: TaggedContinuation,
           persist: Boolean
       ): F[Either[errors.OutOfPhlogistonsError.type, Option[
-        (TaggedContinuation, Seq[ListChannelWithRandom])
+        (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
       ]]] = {
         val storageCost = storageCostConsume(channels, patterns, continuation)
         for {
@@ -54,7 +54,7 @@ object ChargingRSpace {
           channels: Seq[Channel],
           patterns: Seq[BindPattern],
           continuation: TaggedContinuation
-      ): F[Option[(TaggedContinuation, Seq[ListChannelWithRandom])]] =
+      ): F[Option[(TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])]] =
         Sync[F].delay(
           space.install(channels, patterns, continuation)(
             matchListQuote(Cost(Integer.MAX_VALUE))
@@ -66,7 +66,7 @@ object ChargingRSpace {
           data: ListChannelWithRandom,
           persist: Boolean
       ): F[Either[errors.OutOfPhlogistonsError.type, Option[
-        (TaggedContinuation, Seq[ListChannelWithRandom])
+        (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
       ]]] = {
         val storageCost = storageCostProduce(channel, data)
         for {
@@ -79,7 +79,7 @@ object ChargingRSpace {
 
       private def handleResult(
           result: Either[OutOfPhlogistonsError.type, Option[
-            (TaggedContinuation, Seq[ListChannelWithRandom])
+            (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
           ]],
           storageCost: Cost,
           persist: Boolean

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/TuplespaceAlg.scala
@@ -30,10 +30,10 @@ object TuplespaceAlg {
         BindPattern,
         OutOfPhlogistonsError.type,
         ListChannelWithRandom,
-        ListChannelWithRandom,
+        ListChannelWithRandomAndPhlos,
         TaggedContinuation
       ],
-      dispatcher: => Dispatch[F, ListChannelWithRandom, TaggedContinuation]
+      dispatcher: => Dispatch[F, ListChannelWithRandomAndPhlos, TaggedContinuation]
   )(implicit F: Sync[F], P: Parallel[F, M]): TuplespaceAlg[F] = new TuplespaceAlg[F] {
     override def produce(
         channel: Channel,
@@ -43,7 +43,7 @@ object TuplespaceAlg {
       // TODO: Handle the environment in the store
       def go(
           res: Either[OutOfPhlogistonsError.type, Option[
-            (TaggedContinuation, Seq[ListChannelWithRandom])
+            (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
           ]]
       ): F[Unit] =
         res match {
@@ -80,7 +80,7 @@ object TuplespaceAlg {
           val (patterns: Seq[BindPattern], sources: Seq[Quote]) = binds.unzip
           def go(
               res: Either[OutOfPhlogistonsError.type, Option[
-                (TaggedContinuation, Seq[ListChannelWithRandom])
+                (TaggedContinuation, Seq[ListChannelWithRandomAndPhlos])
               ]]
           ): F[Unit] =
             res match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -28,13 +28,13 @@ object implicits {
     BindPattern,
     OutOfPhlogistonsError.type,
     ListChannelWithRandom,
-    ListChannelWithRandom
+    ListChannelWithRandomAndPhlos
   ] =
     new StorageMatch[
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
-      ListChannelWithRandom
+      ListChannelWithRandomAndPhlos
     ] {
 
       private def calcUsed(init: Cost, left: Cost): Cost = init - left
@@ -42,7 +42,7 @@ object implicits {
       def get(
           pattern: BindPattern,
           data: ListChannelWithRandom
-      ): Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandom]] =
+      ): Either[OutOfPhlogistonsError.type, Option[ListChannelWithRandomAndPhlos]] =
         SpatialMatcher
           .foldMatch(data.channels, pattern.patterns, pattern.remainder)
           .runWithCost(init)
@@ -60,7 +60,7 @@ object implicits {
                         freeMap + (level -> VectorPar().addExprs(EList(flatRem.toVector)))
                       case _ => freeMap
                     }
-                    ListChannelWithRandom(
+                    ListChannelWithRandomAndPhlos(
                       toChannels(remainderMap, pattern.freeCount),
                       data.randomState,
                       cost.value

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -107,7 +107,7 @@ class CryptoChannelsSpec
       // 2. hash input array
       // 3. send result on supplied ack channel
       Await.result(reduce.eval(send).runAsync, 3.seconds)
-      storeContainsTest(ListChannelWithRandom(Seq(Quote(expected)), rand, 0))
+      storeContainsTest(ListChannelWithRandom(Seq(Quote(expected)), rand))
       clearStore(store, reduce, ackChannel)
     }
   }
@@ -167,7 +167,7 @@ class CryptoChannelsSpec
         )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand, 0)
+          ListChannelWithRandom(Seq(Quote(Expr(GBool(true)))), rand)
         )
         clearStore(store, reduce, ackChannel)
       }
@@ -207,7 +207,7 @@ class CryptoChannelsSpec
         )
         Await.result(reduce.eval(send).runAsync, 3.seconds)
         storeContainsTest(
-          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand, 0)
+          ListChannelWithRandom(List(Quote(Expr(GBool(true)))), rand)
         )
         clearStore(store, reduce, ackChannel)
       }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -43,7 +43,7 @@ trait PersistentStoreTester {
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
-      ListChannelWithRandom,
+      ListChannelWithRandomAndPhlos,
       TaggedContinuation
     ](context, Branch("test"))
     implicit val errLog = errorLog

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -51,7 +51,7 @@ trait RegistryTester extends PersistentStoreTester {
             BindPattern,
             OutOfPhlogistonsError.type,
             ListChannelWithRandom,
-            ListChannelWithRandom,
+            ListChannelWithRandomAndPhlos,
             TaggedContinuation
           ]
       ) => R

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -181,10 +181,10 @@ object ChargingRSpaceTest {
           BindPattern,
           errors.OutOfPhlogistonsError.type,
           ListChannelWithRandom,
-          ListChannelWithRandom
+          ListChannelWithRandomAndPhlos
         ]
     ): Id[Either[errors.OutOfPhlogistonsError.type, Option[
-      (TaggedContinuation, immutable.Seq[ListChannelWithRandom])
+      (TaggedContinuation, immutable.Seq[ListChannelWithRandomAndPhlos])
     ]]] =
       rspace
         .consume(channels, patterns, continuation, persist)
@@ -195,10 +195,10 @@ object ChargingRSpaceTest {
           BindPattern,
           errors.OutOfPhlogistonsError.type,
           ListChannelWithRandom,
-          ListChannelWithRandom
+          ListChannelWithRandomAndPhlos
         ]
     ): Id[Either[errors.OutOfPhlogistonsError.type, Option[
-      (TaggedContinuation, immutable.Seq[ListChannelWithRandom])
+      (TaggedContinuation, immutable.Seq[ListChannelWithRandomAndPhlos])
     ]]] =
       rspace
         .produce(channel, data, persist)
@@ -216,11 +216,11 @@ object ChargingRSpaceTest {
           BindPattern,
           errors.OutOfPhlogistonsError.type,
           ListChannelWithRandom,
-          ListChannelWithRandom
+          ListChannelWithRandomAndPhlos
         ]
-    ): Id[Option[(TaggedContinuation, immutable.Seq[ListChannelWithRandom])]] = ???
-    override def createCheckpoint(): Id[Checkpoint]                           = ???
-    override def reset(root: Blake2b256Hash): Id[Unit]                        = ???
+    ): Id[Option[(TaggedContinuation, immutable.Seq[ListChannelWithRandomAndPhlos])]] = ???
+    override def createCheckpoint(): Id[Checkpoint]                                   = ???
+    override def reset(root: Blake2b256Hash): Id[Unit]                                = ???
     override def retrieve(
         root: Blake2b256Hash,
         channelsHash: Blake2b256Hash
@@ -244,7 +244,7 @@ object ChargingRSpaceTest {
       BindPattern,
       OutOfPhlogistonsError.type,
       ListChannelWithRandom,
-      ListChannelWithRandom,
+      ListChannelWithRandomAndPhlos,
       TaggedContinuation
     ](context, Branch("test"))
     space


### PR DESCRIPTION
## Overview
`ListChannelWithData` was used as an input to `get` function as well as its result. It means that we required that user passes in a `cost` when it wants to _produce_ something but this was wrong because the cost is known only after doing the match.  Since we have two types: one for argument and one for result this PR makes use of that and sets cost only on the match result.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
