### PR TITLE
RHOL-870 bonding bug fix

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockDag.scala
@@ -23,7 +23,6 @@ final case class BlockDag(
     childMap: Map[BlockHash, Set[BlockHash]],
     latestMessages: Map[Validator, BlockMessage],
     latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
-    currentSeqNum: Map[Validator, Int],
     dataLookup: BlockMetadata.Lookup,
     topoSort: Vector[Vector[BlockHash]],
     sortOffset: Long
@@ -40,7 +39,6 @@ object BlockDag {
       HashMap.empty[BlockHash, HashSet[BlockHash]],
       HashMap.empty[BlockHash, BlockMessage],
       HashMap.empty[Validator, LatestMessages],
-      HashMap.empty[Validator, Int],
       HashMap.empty[BlockHash, BlockMetadata],
       Vector.empty[Vector[BlockHash]],
       0L

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -438,6 +438,8 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
         )
       case InvalidUnslashableBlock =>
         handleInvalidBlockEffect(status, block)
+      case InvalidFollows =>
+        handleInvalidBlockEffect(status, block)
       case InvalidBlockNumber =>
         handleInvalidBlockEffect(status, block)
       case InvalidParents =>

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -503,8 +503,6 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
             acc.updated(p, currChildren + hash)
         }
 
-        val newSeqNum = bd.currentSeqNum.updated(block.sender, block.seqNum)
-
         bd.copy(
           //Assume that a non-equivocating validator must include
           //its own latest message in the justification. Therefore,
@@ -516,7 +514,6 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
           latestMessagesOfLatestMessages = bd.latestMessagesOfLatestMessages
             .updated(block.sender, toLatestMessageHashes(block.justifications)),
           childMap = newChildMap,
-          currentSeqNum = newSeqNum,
           dataLookup = updatedLookup,
           topoSort = updatedSort
         )

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -507,15 +507,23 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
 
         //Block which contains newly bonded validators will not
         //have those validators in its justification
-        val newValidaors =
+        val newValidators =
           bonds(block).map(_.validator).toSet.diff(block.justifications.map(_.validator).toSet)
-        val newLatestMessages = newValidaors.foldLeft(
+        val newLatestMessages = newValidators.foldLeft(
           //update creator of the block
           bd.latestMessages.updated(block.sender, block)
         ) {
           //Update new validators with block in which
           //they were bonded (i.e. this block)
           case (acc, v) => acc.updated(v, block)
+        }
+
+        val lmJustifications = toLatestMessageHashes(block.justifications)
+        //ditto for latestMessagesOfLatestMessages
+        val newLatestLatestMessages = newValidators.foldLeft(
+          bd.latestMessagesOfLatestMessages.updated(block.sender, lmJustifications)
+        ) {
+          case (acc, v) => acc.updated(v, lmJustifications)
         }
 
         bd.copy(
@@ -526,8 +534,7 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
           // to whatever block we have fetched latest among the blocks that
           // constitute the equivocation.
           latestMessages = newLatestMessages,
-          latestMessagesOfLatestMessages = bd.latestMessagesOfLatestMessages
-            .updated(block.sender, toLatestMessageHashes(block.justifications)),
+          latestMessagesOfLatestMessages = newLatestLatestMessages,
           childMap = newChildMap,
           dataLookup = updatedLookup,
           topoSort = updatedSort

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -444,28 +444,28 @@ object Validate {
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDag
-  ): F[Either[InvalidBlock, ValidBlock]] =
+  ): F[Either[InvalidBlock, ValidBlock]] = {
+    val justifiedValidators = b.justifications.map(_.validator).toSet
+    val mainParentHash      = ProtoUtil.parentHashes(b).head
     for {
-      latestMessages     <- ProtoUtil.toLatestMessage[F](b.justifications, dag)
-      validators         = latestMessages.keySet
-      creatorLatestBlock = latestMessages.getOrElse(b.sender, genesis)
-      creatorBonds       = ProtoUtil.bonds(creatorLatestBlock).map(_.validator).toSet
-      result             = creatorBonds == validators
-      status <- if (result) {
+      mainParent       <- ProtoUtil.unsafeGetBlock[F](mainParentHash)
+      bondedValidators = ProtoUtil.bonds(mainParent).map(_.validator).toSet
+      status <- if (bondedValidators == justifiedValidators) {
                  Applicative[F].pure(Right(Valid))
                } else {
-                 val justifications =
-                   b.justifications.map(it => PrettyPrinter.buildString(it.validator)).mkString(",")
+                 val justifiedValidatorsPP = justifiedValidators.map(PrettyPrinter.buildString(_))
+                 val bondedValidatorsPP    = bondedValidators.map(PrettyPrinter.buildString(_))
                  for {
                    _ <- Log[F].warn(
                          ignore(
                            b,
-                           s"the justifications of block are ${justifications}, do not follow from bonds of creator justification block"
+                           s"the justified validators, ${justifiedValidatorsPP}, do not match the bonded validators, ${bondedValidatorsPP}."
                          )
                        )
                  } yield Left(InvalidFollows)
                }
     } yield status
+  }
 
   /*
    * When we switch between equivocation forks for a slashed validator, we will potentially get a

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -358,7 +358,7 @@ object ProtoUtil {
     }
 
     val sender = ByteString.copyFrom(pk)
-    val seqNum = dag.currentSeqNum.getOrElse(sender, 0) + 1
+    val seqNum = dag.latestMessages.get(sender).fold(0)(_.seqNum) + 1
 
     val blockHash = hashSignedBlock(header, sender, sigAlgorithm, seqNum, shardId, block.extraBytes)
 

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -442,7 +442,7 @@ class ValidateTest
       )
 
       log.warns.size should be(1)
-      log.warns.forall(_.contains("not follow from bonds of creator justification block")) should be(
+      log.warns.forall(_.contains("do not match the bonded validators")) should be(
         true
       )
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -62,7 +62,7 @@ trait BlockGenerator {
       chain             <- blockDagState[F].get
       now               <- Time[F].currentMillis
       nextId            = chain.currentId + 1
-      nextCreatorSeqNum = chain.latestMessages.get(creator).fold(0)(_.seqNum) + 1
+      nextCreatorSeqNum = chain.latestMessages.get(creator).fold(-1)(_.seqNum) + 1
       postState = RChainState()
         .withTuplespace(tsHash)
         .withBonds(bonds)

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -62,7 +62,7 @@ trait BlockGenerator {
       chain             <- blockDagState[F].get
       now               <- Time[F].currentMillis
       nextId            = chain.currentId + 1
-      nextCreatorSeqNum = chain.currentSeqNum.getOrElse(creator, -1) + 1
+      nextCreatorSeqNum = chain.latestMessages.get(creator).fold(0)(_.seqNum) + 1
       postState = RChainState()
         .withTuplespace(tsHash)
         .withBonds(bonds)
@@ -102,16 +102,14 @@ trait BlockGenerator {
       }: _*)
       childMap = chain.childMap
         .++[(BlockHash, Set[BlockHash]), Map[BlockHash, Set[BlockHash]]](updatedChildren)
-      updatedSeqNumbers = chain.currentSeqNum.updated(creator, nextCreatorSeqNum)
-      updatedSort       = TopologicalSortUtil.update(chain.topoSort, chain.sortOffset, block)
-      updatedLookup     = chain.dataLookup.updated(block.blockHash, BlockMetadata.fromBlock(block))
+      updatedSort   = TopologicalSortUtil.update(chain.topoSort, chain.sortOffset, block)
+      updatedLookup = chain.dataLookup.updated(block.blockHash, BlockMetadata.fromBlock(block))
       newChain = IndexedBlockDag(
         idToBlocks,
         childMap,
         latestMessages,
         latestMessagesOfLatestMessages,
         nextId,
-        updatedSeqNumbers,
         updatedLookup,
         updatedSort,
         chain.sortOffset

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -133,7 +133,11 @@ class HashSetCasperTestNode[F[_]](
 object HashSetCasperTestNode {
   type Effect[A] = EitherT[Task, CommError, A]
 
-  def standaloneF[F[_]](genesis: BlockMessage, sk: Array[Byte], storageSize: Long = 1024L * 1024)(
+  def standaloneF[F[_]](
+      genesis: BlockMessage,
+      sk: Array[Byte],
+      storageSize: Long = 1024L * 1024 * 10
+  )(
       implicit scheduler: Scheduler,
       errorHandler: ErrorHandler[F],
       syncF: Sync[F],
@@ -157,13 +161,13 @@ object HashSetCasperTestNode {
     )
     result.initialize.map(_ => result)
   }
-  def standalone(genesis: BlockMessage, sk: Array[Byte], storageSize: Long = 1024L * 1024)(
+  def standalone(genesis: BlockMessage, sk: Array[Byte], storageSize: Long = 1024L * 1024 * 10)(
       implicit scheduler: Scheduler
   ): HashSetCasperTestNode[Id] = {
     implicit val errorHandlerEff = errorHandler
     standaloneF[Id](genesis, sk, storageSize)
   }
-  def standaloneEff(genesis: BlockMessage, sk: Array[Byte], storageSize: Long = 1024L * 1024)(
+  def standaloneEff(genesis: BlockMessage, sk: Array[Byte], storageSize: Long = 1024L * 1024 * 10)(
       implicit scheduler: Scheduler
   ): HashSetCasperTestNode[Effect] =
     standaloneF[Effect](genesis, sk, storageSize)(
@@ -176,7 +180,7 @@ object HashSetCasperTestNode {
   def networkF[F[_]](
       sks: IndexedSeq[Array[Byte]],
       genesis: BlockMessage,
-      storageSize: Long = 1024L * 1024
+      storageSize: Long = 1024L * 1024 * 10
   )(
       implicit scheduler: Scheduler,
       errorHandler: ErrorHandler[F],
@@ -234,7 +238,7 @@ object HashSetCasperTestNode {
   def network(
       sks: IndexedSeq[Array[Byte]],
       genesis: BlockMessage,
-      storageSize: Long = 1024L * 1024
+      storageSize: Long = 1024L * 1024 * 10
   )(implicit scheduler: Scheduler): IndexedSeq[HashSetCasperTestNode[Id]] = {
     implicit val errorHandlerEff = errorHandler
     networkF[Id](sks, genesis, storageSize)
@@ -242,7 +246,7 @@ object HashSetCasperTestNode {
   def networkEff(
       sks: IndexedSeq[Array[Byte]],
       genesis: BlockMessage,
-      storageSize: Long = 1024L * 1024
+      storageSize: Long = 1024L * 1024 * 10
   )(implicit scheduler: Scheduler): Effect[IndexedSeq[HashSetCasperTestNode[Effect]]] =
     networkF[Effect](sks, genesis, storageSize)(
       scheduler,

--- a/casper/src/test/scala/coop/rchain/casper/helper/IndexedBlockDag.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/IndexedBlockDag.scala
@@ -10,7 +10,6 @@ case class IndexedBlockDag(dag: BlockDag, idToBlocks: Map[Int, BlockMessage], cu
   def latestMessages: Map[Validator, BlockMessage] = dag.latestMessages
   def latestMessagesOfLatestMessages: Map[Validator, LatestMessages] =
     dag.latestMessagesOfLatestMessages
-  def currentSeqNum: Map[Validator, Int]  = dag.currentSeqNum
   def dataLookup: BlockMetadata.Lookup    = dag.dataLookup
   def topoSort: Vector[Vector[BlockHash]] = dag.topoSort
   def sortOffset: Long                    = dag.sortOffset
@@ -31,7 +30,6 @@ object IndexedBlockDag {
       latestMessages: Map[Validator, BlockMessage],
       latestMessagesOfLatestMessages: Map[Validator, LatestMessages],
       currentId: Int,
-      currentSeqNum: Map[Validator, Int],
       dataLookup: BlockMetadata.Lookup,
       topoSort: Vector[Vector[BlockHash]],
       sortOffset: Long
@@ -40,7 +38,6 @@ object IndexedBlockDag {
       childMap,
       latestMessages,
       latestMessagesOfLatestMessages,
-      currentSeqNum,
       dataLookup,
       topoSort,
       sortOffset


### PR DESCRIPTION
## Overview
Ensure the node latest messages are updated when a validator set change happens. This fixes a problem where after bonding all blocks were failing the validation. The logic of the validation is also updated to compare the validators in the justification to those bonded in the parent block as these should match for a valid block created by a protocol-following node.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-870

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
