### PR TITLE
Cap storage content when printed.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,9 @@ stages:
 test:integration-test-for-p2p-network:
   stage: test 
   tags:
-    - preloaded-ubuntu1804 
+    - preloaded-ubuntu1804
+  before_script:
+    - export PRETTY_PRINTER_OUTPUT_TRIM_AFTER=150
   script:
     - ./scripts/install_bnfc.sh
     - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile node/docker:publishLocal

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
   - language: nix
     env: SUBPROJECT=rosette
   - language: scala
-    env: SUBPROJECT=core
+    env:
+      - SUBPROJECT=core
     scala: 2.12.4
     sbt_args: -no-colors
     install:

--- a/shared/src/main/scala/coop/rchain/shared/Printer.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Printer.scala
@@ -1,0 +1,12 @@
+package coop.rchain.shared
+import scala.util.Try
+
+object Printer {
+  final val OUTPUT_CAPPED = Try(System.getenv("PRETTY_PRINTER_OUTPUT_TRIM_AFTER"))
+    .map(Integer.parseInt(_))
+    .toOption
+    .flatMap {
+      case n if n >= 0 => Some(n)
+      case _           => None
+    }
+}


### PR DESCRIPTION
To cap storage content set env variable `PRETTY_PRINTER_OUTPUT_TRIM` to true/1/on/yes.

## Overview
Provide a brief description of what this PR does, and why it's needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
