### PR TITLE
Remove explicit Travis email notification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,9 @@ test:integration-test-for-p2p-network:
     - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile node/docker:publishLocal
     - sudo python3.6 -m pip install argparse docker pexpect requests
     - sudo ./scripts/p2p-test-tool.py -b -t -p 2 -m 2048m
-  except:
-    - testing
+  only:
+    - master
+    - dev
 
 test:integration-test-for-artifact-creation:
   stage: test 
@@ -23,8 +24,9 @@ test:integration-test-for-artifact-creation:
   script:
     - ./scripts/install_bnfc.sh
     - sudo sbt -Dsbt.log.noformat=true clean rholang/bnfc:generate casper/test:compile node/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball 
-  except:
-    - testing
+  only:
+    - master
+    - dev
 
 deploy:deploy-rnode-to-dockerhub:
   stage: deploy 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,3 @@ deploy:
     - /^release-.*$/ 
   on:
     tags: true
-
-notifications:
-  email:
-    recipients: rchain-makers@pyrofex.net
-    on_success: never
-    on_failure: always


### PR DESCRIPTION
Travis notifies ahtor of commit that failed to build by default.