### PR TITLE
Casper: Fix non deterministic test.

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -82,7 +82,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
   "computeState" should "charge deploys separately" in {
     val terms = List(
       """for(@x <- @"w") { @"z"!("Got x") }""",
-      """for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) } | @"x"!(1) | @"y"!(10)"""
+      """for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!(10) }"""
     )
 
     def deployCost(p: Seq[InternalProcessedDeploy]): Long = p.map(_.cost.cost).sum


### PR DESCRIPTION
## Overview
Because order of evaluating rholang terms is non deterministic original
version of the test might have produce the COMM event.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
