### PR TITLE
Fix minor typo in k grammar

### DIFF
--- a/rholang/src/main/k/rholang/name-equivalence.k
+++ b/rholang/src/main/k/rholang/name-equivalence.k
@@ -9,6 +9,6 @@ imports FREE
 //        2. any `| Nil` , except the same caveat as (1)
 //        3. arithmetic expressions on the top level
 //        4. alpha equivalence
-//        5. added evals/quots, e.g. the names @{@Nil!(0)} and @{*@{@Nil!(0)}} are equivalent.
+//        5. added evals/quotes, e.g. the names @{@Nil!(0)} and @{*@{@Nil!(0)}} are equivalent.
 
 endmodule


### PR DESCRIPTION
## Overview
Fixes a typo quot -> quote in k framework stuff @differentialderek 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
No JIRA issue just a little typo
