### PR TITLE
CORE-1244 stream blob

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlobHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlobHandler.scala
@@ -1,0 +1,8 @@
+package coop.rchain.casper.util.comm
+
+import coop.rchain.comm.protocol.routing._
+import cats._, cats.data._, cats.implicits._
+
+object BlobHandler {
+  def handleBlob[F[_]: Applicative]: Blob => F[Unit] = (blob: Blob) => ().pure[F] // FIX-ME
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -7,7 +7,7 @@ import cats.data.EitherT
 import cats.effect.concurrent.Ref
 import cats.effect.Sync
 import cats.implicits._
-
+import coop.rchain.catscontrib.ski._
 import coop.rchain.blockstorage.LMDBBlockStore
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
@@ -117,7 +117,8 @@ class HashSetCasperTestNode[F[_]](
         )
         .void
 
-  def receive(): F[Unit] = tle.receive(p => handle[F](p, defaultTimeout))
+  // FIX-ME
+  def receive(): F[Unit] = tle.receive(p => handle[F](p, defaultTimeout), kp(().pure[F]))
 
   def tearDown(): Unit = {
     tearDownNode()

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -37,6 +37,8 @@ class TransportLayerTestImpl[F[_]: Monad](
   def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] =
     TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))
 
+  def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???
+
   def disconnect(peer: PeerNode): F[Unit] = ???
 
   def shutdown(msg: Protocol): F[Unit] = ???

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -34,7 +34,11 @@ class TransportLayerTestImpl[F[_]: Monad](
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]] =
     peers.toList.traverse(send(_, msg)).map(_.toSeq)
 
-  def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] =
+  // FIX-ME handleBlob not handled (pun)
+  def receive(
+      dispatch: Protocol => F[CommunicationResponse],
+      handleBlob: Blob => F[Unit]
+  ): F[Unit] =
     TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))
 
   def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -24,15 +24,17 @@ class TcpServerObservable(
     maxMessageSize: Int,
     tellBufferSize: Int = 1024,
     askBufferSize: Int = 128,
+    blobBufferSize: Int = 32,
     askTimeout: FiniteDuration = 5.second
 ) extends Observable[ServerMessage] {
 
   def unsafeSubscribeFn(subscriber: Subscriber[ServerMessage]): Cancelable = {
     implicit val scheduler: Scheduler = subscriber.scheduler
 
-    val subjectTell = ConcurrentSubject.publishToOne[ServerMessage](DropNew(tellBufferSize))
-    val subjectAsk  = ConcurrentSubject.publishToOne[ServerMessage](DropNew(askBufferSize))
-    val merged      = Observable.merge(subjectTell, subjectAsk)(BackPressure(10))
+    val subjectTell        = ConcurrentSubject.publishToOne[ServerMessage](DropNew(tellBufferSize))
+    val subjectAsk         = ConcurrentSubject.publishToOne[ServerMessage](DropNew(askBufferSize))
+    val subjectBlobMessage = ConcurrentSubject.publishToOne[ServerMessage](DropNew(blobBufferSize))
+    val merged             = Observable.merge(subjectTell, subjectAsk, subjectBlobMessage)(BackPressure(10))
 
     val service = new RoutingGrpcMonix.TransportLayer {
 
@@ -61,7 +63,11 @@ class TcpServerObservable(
             }
           }
 
-      def stream(request: TLBlob): Task[TLBlobResponse] = TLBlobResponse().pure[Task]
+      def stream(request: TLBlob): Task[TLBlobResponse] = Task.delay {
+        request.blob
+          .map(blob => subjectBlobMessage.onNext(BlobMessage(blob)))
+        TLBlobResponse()
+      }
 
       private def returnProtocol(protocol: Protocol): TLResponse =
         TLResponse(TLResponse.Payload.Protocol(protocol))

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -121,13 +121,13 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
     * This implmementation is temporary, it sequentially sends blob to each peers.
     * TODO Provide solution that stacks blob on a queue that is later consumed
     */
-  def streamBlob(peers: Seq[PeerNode], msg: Blob): Task[Unit] =
+  def streamBlob(peers: Seq[PeerNode], blob: Blob): Task[Unit] =
     peers.toList
       .traverse(
         peer =>
           withClient(peer, enforce = false) { stub =>
-            stub.stream(TLBlob())
-          }.attempt.map {
+            stub.stream(TLBlob().withBlob(blob))
+          }.attempt.flatMap {
             case Left(error) => log.debug(s"Error while streaming blob, error: $error")
             case Right(_)    => Task.unit
           }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -198,7 +198,8 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
   }
 
   def receive(
-      dispatch: Protocol => Task[CommunicationResponse]
+      dispatch: Protocol => Task[CommunicationResponse],
+      handleBlob: Blob => Task[Unit]
   ): Task[Unit] =
     cell.modify { s =>
       for {
@@ -209,7 +210,7 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
                      )
                    case _ =>
                      val parallelism = Runtime.getRuntime.availableProcessors()
-                     receiveInternal(parallelism)(dispatch, kp(Task.unit)) // FIX-ME
+                     receiveInternal(parallelism)(dispatch, handleBlob)
                  }
       } yield s.copy(server = Some(server))
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -207,6 +207,8 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
 
     }
 
+  def streamBlob(peers: Seq[PeerNode], msg: Blob): Task[Unit] = ???
+
   def shutdown(msg: Protocol): Task[Unit] = {
     def shutdownServer: Task[Unit] = cell.modify { s =>
       for {

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -14,6 +14,7 @@ trait TransportLayer[F[_]] {
   def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]]
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]]
   def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit]
+  def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit]
   def disconnect(peer: PeerNode): F[Unit]
   def shutdown(msg: Protocol): F[Unit]
 }
@@ -63,6 +64,9 @@ sealed abstract class TransportLayerInstances {
           }
         EitherT.liftF(evF.receive(dis))
       }
+
+      def streamBlob(peers: Seq[PeerNode], msg: Blob): EitherT[F, CommError, Unit] =
+        EitherT.liftF(evF.streamBlob(peers, msg))
 
       def disconnect(peer: PeerNode): EitherT[F, CommError, Unit] =
         EitherT.liftF(evF.disconnect(peer))

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -5,14 +5,16 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.FiniteDuration
 
-import coop.rchain.comm.protocol.routing.Protocol
+import coop.rchain.comm.protocol.routing.{Blob, Protocol}
 
 import monix.eval.Task
 import monix.execution.Scheduler
 
 trait ServerMessage
+// TODO rename to AksMesage and TellMesssage
 final case class Ask(msg: Protocol, sender: SenderHandle) extends ServerMessage
 final case class Tell(msg: Protocol)                      extends ServerMessage
+final case class BlobMessage(blob: Blob)                  extends ServerMessage
 
 trait SenderHandle {
   def reply(msg: CommunicationResponse): Boolean

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -45,8 +45,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
     trait Result {
       def localNode: PeerNode
       def apply(): A
-      def receivedMessages: Seq[(PeerNode, Protocol)] = dispatcher.received
-      def lastProcessedMessageTimestamp: Long         = dispatcher.lastProcessedTimestamp
+      def protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] = dispatcher
     }
   }
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -193,7 +193,6 @@ final class Dispatcher[F[_]: Applicative, R, S](
 ) {
   def dispatch(peer: PeerNode): R => F[S] =
     p => {
-      processed = System.currentTimeMillis()
       delay.foreach(Thread.sleep)
       // Ignore Disconnect messages to not skew the tests
       if (!ignore(p))
@@ -201,9 +200,7 @@ final class Dispatcher[F[_]: Applicative, R, S](
       response(peer).pure[F]
     }
   def received: Seq[(PeerNode, R)] = receivedMessages
-  def lastProcessedTimestamp: Long = processed
   private val receivedMessages     = mutable.MutableList.empty[(PeerNode, R)]
-  private var processed            = 0L
 }
 
 object Dispatcher {

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -5,12 +5,12 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.concurrent.duration._
-
+import coop.rchain.catscontrib.ski._
 import cats._
 import cats.implicits._
 
 import coop.rchain.comm._
-import coop.rchain.comm.protocol.routing.Protocol
+import coop.rchain.comm.protocol.routing.{Blob, Protocol}
 import coop.rchain.comm.CommError.CommErr
 import coop.rchain.comm.rp.ProtocolHelper
 
@@ -63,7 +63,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             remoteTl <- createTransportLayer(e2)
             local    = e1.peer
             remote   = e2.peer
-            _        <- remoteTl.receive(dispatcher.dispatch(remote))
+            _        <- remoteTl.receive(dispatcher.dispatch(remote), kp(().pure[F])) // TODO
             r        <- execute(localTl, local, remote)
             _        <- remoteTl.shutdown(ProtocolHelper.disconnect(remote))
             _        <- localTl.shutdown(ProtocolHelper.disconnect(local))
@@ -126,8 +126,8 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             local     = e1.peer
             remote1   = e2.peer
             remote2   = e3.peer
-            _         <- remoteTl1.receive(dispatcher.dispatch(remote1))
-            _         <- remoteTl2.receive(dispatcher.dispatch(remote2))
+            _         <- remoteTl1.receive(dispatcher.dispatch(remote1), kp(().pure[F])) // TODO test blobs
+            _         <- remoteTl2.receive(dispatcher.dispatch(remote2), kp(().pure[F]))
             r         <- execute(localTl, local, remote1, remote2)
             _         <- remoteTl1.shutdown(ProtocolHelper.disconnect(remote1))
             _         <- remoteTl2.shutdown(ProtocolHelper.disconnect(remote2))

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -41,8 +41,8 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
                 protocol1.message shouldBe 'heartbeatResponse
             }
 
-            result.receivedMessages should have length 1
-            val (_, protocol2)           = result.receivedMessages.head
+            result.protocolDispatcher.received should have length 1
+            val (_, protocol2)           = result.protocolDispatcher.received.head
             val sender: Option[PeerNode] = ProtocolHelper.sender(protocol2)
             sender shouldBe 'defined
             sender.get shouldEqual result.localNode
@@ -134,30 +134,12 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
 
           val result: TwoNodesResult = run()
 
-          result.receivedMessages should have length 1
-          val (_, protocol2)           = result.receivedMessages.head
+          result.protocolDispatcher.received should have length 1
+          val (_, protocol2)           = result.protocolDispatcher.received.head
           val sender: Option[PeerNode] = ProtocolHelper.sender(protocol2)
           sender shouldBe 'defined
           sender.get shouldEqual result.localNode
           protocol2.message shouldBe 'heartbeat
-        }
-
-      "wait for a response" in
-        new TwoNodesRuntime[Long](Dispatcher.withoutMessageDispatcher[F]) {
-          def execute(
-              transportLayer: TransportLayer[F],
-              local: PeerNode,
-              remote: PeerNode
-          ): F[Long] =
-            for {
-              _ <- sendHeartbeat(transportLayer, local, remote)
-              t = System.currentTimeMillis()
-            } yield t
-
-          val result: TwoNodesResult = run()
-
-          val sent = result()
-          sent should be > result.lastProcessedMessageTimestamp
         }
     }
 
@@ -173,8 +155,8 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
 
           val result: ThreeNodesResult = run()
 
-          result.receivedMessages should have length 2
-          val Seq((r1, p1), (r2, p2))   = result.receivedMessages
+          result.protocolDispatcher.received should have length 2
+          val Seq((r1, p1), (r2, p2))   = result.protocolDispatcher.received
           val sender1: Option[PeerNode] = ProtocolHelper.sender(p1)
           val sender2: Option[PeerNode] = ProtocolHelper.sender(p2)
           sender1 shouldBe 'defined
@@ -209,7 +191,7 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
                 e.getMessage shouldEqual "The transport layer has been shut down"
             }
 
-            result.receivedMessages shouldBe 'empty
+            result.protocolDispatcher.received shouldBe 'empty
           }
       }
 
@@ -228,7 +210,7 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
 
             val result: TwoNodesResult = run()
 
-            result.receivedMessages shouldBe 'empty
+            result.protocolDispatcher.received shouldBe 'empty
           }
       }
 
@@ -248,9 +230,10 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
 
             val result: ThreeNodesResult = run()
 
-            result.receivedMessages shouldBe 'empty
+            result.protocolDispatcher.received shouldBe 'empty
           }
       }
+
     }
   }
 }

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -93,6 +93,8 @@ object EffectsTestInstances {
       Seq()
     }
 
+    def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???
+
     def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] = ???
 
     def disconnect(peer: PeerNode): F[Unit] = ???

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -95,7 +95,10 @@ object EffectsTestInstances {
 
     def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???
 
-    def receive(dispatch: Protocol => F[CommunicationResponse]): F[Unit] = ???
+    def receive(
+        dispatch: Protocol => F[CommunicationResponse],
+        handleBlob: Blob => F[Unit]
+    ): F[Unit] = ???
 
     def disconnect(peer: PeerNode): F[Unit] = ???
 

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -8,7 +8,7 @@ import cats.effect._
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockStore, LMDBBlockStore}
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper.util.comm.CasperPacketHandler
+import coop.rchain.casper.util.comm.{BlobHandler, CasperPacketHandler}
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.{LastApprovedBlock, MultiParentCasperRef, SafetyOracle}
 import coop.rchain.catscontrib.Catscontrib._
@@ -290,10 +290,13 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
       _       <- addShutdownHook(servers, runtime, casperRuntime).toEffect
       _       <- startServers(servers)
       _       <- startReportJvmMetrics.toEffect
-      _       <- TransportLayer[Effect].receive(pm => HandleMessages.handle[Effect](pm, defaultTimeout))
-      _       <- NodeDiscovery[Task].discover.fork.toEffect
-      _       <- Log[Effect].info(s"Listening for traffic on $address.")
-      _       <- loop.forever
+      _ <- TransportLayer[Effect].receive(
+            pm => HandleMessages.handle[Effect](pm, defaultTimeout),
+            BlobHandler.handleBlob[Effect]
+          )
+      _ <- NodeDiscovery[Task].discover.fork.toEffect
+      _ <- Log[Effect].info(s"Listening for traffic on $address.")
+      _ <- loop.forever
     } yield ()
   }
 


### PR DESCRIPTION
## Overview
* Add streamBlob method
    
    This method is not yet implemented. It will eventually alow sending
    Blob messages in a stream manner. Blobs will be put on a queue where
    they will be consumed by senders.

* Added BlockMessage to ServerMessage
    
    This way our queue that handles messages on the server side can be
    reused for Blob messages

* Extend receive method in TransportLayer with handleBlob
    
    After this change when starting up stransport layer, caller has to
    provide handler lambda `handleBlob` that will know how to handle
    incoming blobs.
    In `node.scala` this work is provided by new BlobHandler (not yet
    implemented).


* Provide temporary request-response implementation of streamBlob
    
    In future this will store blobs on a queue that will be send in stream
    manner. For now - in order to have a working implementation - we are
    providing simplest sequential implementation

* Remove latch from TransortLayerSpec

*   Change Dispatcher in test to be more parametric
    
    Dispatcher is used to mock dispatch method in
    TransportLayerSpec. Since we are extending TrasnportLayer.receive
    method with new handleBlob - which will have to be testes as well - it
    seems a good idea to reuse existing Dispatcher logic in tests. In
    order to do so, Dispatcher must become more polymorphic

* Extract protocolDispatcher in Result, simplify the Result
    
    Int TransportLayerSpec `Result` type will have to differencate between `protocolDispatcher` (for
    `Protocol` messages) and `blobDispatcher`. Two methods were removed
    from `Result` (they were only pushing forward the calls to
    dispatcher). Alternatively `protocolDispatcher` was exposed externally
    via `Result`.

* Remove proccessed timestampe from TransportLayerSpec - no longer used


* Provide tests for streamBlob
    
    ```
    [info]   when streamBlob
    [info]   - should send a blob and receive by (single) remote side (72 milliseconds)
    [info]   - should send a blob and receive by (multiple) remote side (54 milliseconds)
    ```


    








### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1244