### PR TITLE
renamed some symbols in rholang bnfc

### DIFF
--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -1,7 +1,8 @@
 -- Custom integer token according to https://github.com/BNFC/bnfc/issues/153#issuecomment-152612231
 -- notice this shadows the built-in Integer token, which might be a problem if we need integers
 -- in the grammar for other purposes than the integer literal.
-position token Long digit+;
+
+position token LongLiteral digit+;
 
 -- A program is just a process. We put the coercions first, because that's what
 -- bnfc uses to determine the starting production.
@@ -122,18 +123,20 @@ separator nonempty Case "" ;
 -- Name Declarations.
 -- Eventually will have IOPairs.
 NameDeclSimpl. NameDecl ::= Var ;
-NameDeclUrn. NameDecl ::= Var "(" Uri ")" ;
+NameDeclUrn. NameDecl ::= Var "(" UriLiteral ")" ;
 separator nonempty NameDecl "," ;
 
 -- Booleans:
-BoolTrue.   Bool ::= "true" ;
-BoolFalse.  Bool ::= "false" ;
+BoolTrue.   BoolLiteral ::= "true" ;
+BoolFalse.  BoolLiteral ::= "false" ;
 -- Ground types:
-GroundBool.    Ground ::= Bool ;
-GroundInt.     Ground ::= Long ;
-GroundString.  Ground ::= String ;
-GroundUri.     Ground ::= Uri ;
-token Uri ('`' ((char - ["\\`"]) | ('\\' ["`\\"]))* '`') ;
+-- The "Literal" suffix avoids collisions with Simple Types
+GroundBool.    Ground ::= BoolLiteral ;
+GroundInt.     Ground ::= LongLiteral ;
+GroundString.  Ground ::= StringLiteral ;
+GroundUri.     Ground ::= UriLiteral ;
+token StringLiteral ( '"' ((char - ["\"\\"]) | ('\\' ["\"\\nt"]))* '"' );
+token UriLiteral ('`' ((char - ["\\`"]) | ('\\' ["`\\"]))* '`') ;
 -- Collections:
 CollectList.   Collection ::= "[" [Proc] ProcRemainder "]" ;
 CollectTuple.  Collection ::= Tuple;
@@ -161,7 +164,6 @@ SimpleTypeInt. SimpleType ::= "Int" ;
 SimpleTypeString. SimpleType ::= "String" ;
 SimpleTypeUri. SimpleType ::= "Uri" ;
 SimpleTypeByteArray. SimpleType ::= "ByteArray" ;
-
 
 token Var (((letter | '\'') (letter | digit | '_' | '\'')*)|(('_') (letter | digit | '_' | '\'')+)) ;
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -29,7 +29,7 @@ case object ProcSort extends VarSort
 case object NameSort extends VarSort
 
 object BoolNormalizeMatcher {
-  def normalizeMatch(b: Bool): GBool =
+  def normalizeMatch(b: BoolLiteral): GBool =
     b match {
       case _: BoolTrue  => GBool(true)
       case _: BoolFalse => GBool(false)
@@ -39,10 +39,11 @@ object BoolNormalizeMatcher {
 object GroundNormalizeMatcher {
   def normalizeMatch(g: AbsynGround): Expr =
     g match {
-      case gb: GroundBool   => BoolNormalizeMatcher.normalizeMatch(gb.bool_)
-      case gi: GroundInt    => GInt(gi.long_.toLong) //TODO raise NumberFormatException in a pure way
-      case gs: GroundString => GString(gs.string_)
-      case gu: GroundUri    => GUri(stripUri(gu.uri_))
+      case gb: GroundBool => BoolNormalizeMatcher.normalizeMatch(gb.boolliteral_)
+      case gi: GroundInt =>
+        GInt(gi.longliteral_.toLong) //TODO raise NumberFormatException in a pure way
+      case gs: GroundString => GString(gs.stringliteral_)
+      case gu: GroundUri    => GUri(stripUri(gu.uriliteral_))
     }
   // This is necessary to remove the backticks. We don't use a regular
   // expression because they're always there.
@@ -898,7 +899,13 @@ object ProcNormalizeMatcher {
         val newTaggedBindings = p.listnamedecl_.toVector.map {
           case n: NameDeclSimpl => (None, n.var_, NameSort, n.line_num, n.col_num)
           case n: NameDeclUrn =>
-            (Some(GroundNormalizeMatcher.stripUri(n.uri_)), n.var_, NameSort, n.line_num, n.col_num)
+            (
+              Some(GroundNormalizeMatcher.stripUri(n.uriliteral_)),
+              n.var_,
+              NameSort,
+              n.line_num,
+              n.col_num
+            )
         }
         // This sorts the None's first, and the uris by lexicographical order.
         // We do this here because the sorting affects the numbering of variables inside the body.

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -42,12 +42,15 @@ object GroundNormalizeMatcher {
       case gb: GroundBool => BoolNormalizeMatcher.normalizeMatch(gb.boolliteral_)
       case gi: GroundInt =>
         GInt(gi.longliteral_.toLong) //TODO raise NumberFormatException in a pure way
-      case gs: GroundString => GString(gs.stringliteral_)
+      case gs: GroundString => GString(stripString(gs.stringliteral_))
       case gu: GroundUri    => GUri(stripUri(gu.uriliteral_))
     }
   // This is necessary to remove the backticks. We don't use a regular
   // expression because they're always there.
   def stripUri(raw: String): String = raw.substring(1, raw.length - 1)
+  // Similarly, we need to remove quotes from strings, since we are using
+  // a custom string token
+  def stripString(raw: String): String = raw.substring(1, raw.length - 1)
 }
 
 object RemainderNormalizeMatcher {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -42,7 +42,7 @@ class GroundMatcherSpec extends FlatSpec with Matchers {
     GroundNormalizeMatcher.normalizeMatch(gi) should be(expectedResult)
   }
   "GroundString" should "Compile as GString" in {
-    val gs                   = new GroundString("String")
+    val gs                   = new GroundString("\"String\"")
     val expectedResult: Expr = GString("String")
     GroundNormalizeMatcher.normalizeMatch(gs) should be(expectedResult)
   }
@@ -149,7 +149,10 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
   "Map" should "delegate" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
-      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven")))
+      new KeyValuePairImpl(
+        new PGround(new GroundInt("7")),
+        new PGround(new GroundString("\"Seven\""))
+      )
     )
     mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("Q"))))
     val map = new PCollect(new CollectMap(mapData, new ProcRemainderVar(new ProcVarVar("Z"))))
@@ -276,13 +279,13 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     val mapData = new ListKeyValuePair()
     mapData.add(
       new KeyValuePairImpl(
-        new PGround(new GroundString("name")),
-        new PGround(new GroundString("Alice"))
+        new PGround(new GroundString("\"name\"")),
+        new PGround(new GroundString("\"Alice\""))
       )
     )
     val pPercentPercent =
       new PPercentPercent(
-        new PGround(new GroundString("Hi ${name}")),
+        new PGround(new GroundString("\"Hi ${name}\"")),
         new PCollect(new CollectMap(mapData, new ProcRemainderEmpty()))
       )
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pPercentPercent, inputs).value
@@ -327,8 +330,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PPlusPlus" should "Delegate" in {
     val pPlusPlus = new PPlusPlus(
-      new PGround(new GroundString("abc")),
-      new PGround(new GroundString("def"))
+      new PGround(new GroundString("\"abc\"")),
+      new PGround(new GroundString("\"def\""))
     )
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pPlusPlus, inputs).value
     result.par should be(inputs.par.prepend(EPlusPlus(GString("abc"), GString("def")), 0))
@@ -337,8 +340,8 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PMinusMinus" should "Delegate" in {
     val pMinusMinus = new PMinusMinus(
-      new PGround(new GroundString("abc")),
-      new PGround(new GroundString("def"))
+      new PGround(new GroundString("\"abc\"")),
+      new PGround(new GroundString("\"def\""))
     )
     val result = ProcNormalizeMatcher.normalizeMatch[Coeval](pMinusMinus, inputs).value
     result.par should be(inputs.par.prepend(EMinusMinus(GString("abc"), GString("def")), 0))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -32,7 +32,7 @@ class GroundPrinterSpec extends FlatSpec with Matchers {
   }
 
   "GroundString" should "Print as \"" + "String" + "\"" in {
-    val gs             = new GroundString("String")
+    val gs             = new GroundString("\"String\"")
     val target: String = "\"" + "String" + "\""
     PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch(gs)) shouldBe target
   }
@@ -85,7 +85,10 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
   "Map" should "Print" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
-      new KeyValuePairImpl(new PGround(new GroundInt("7")), new PGround(new GroundString("Seven")))
+      new KeyValuePairImpl(
+        new PGround(new GroundInt("7")),
+        new PGround(new GroundString("\"Seven\""))
+      )
     )
     mapData.add(new KeyValuePairImpl(new PVar(new ProcVarVar("P")), new PEval(new NameVar("x"))))
     val map = new PCollect(new CollectMap(mapData, new ProcRemainderVar(new ProcVarVar("ignored"))))


### PR DESCRIPTION
## Overview
Cryptofex needs a C++ parser generated from BNFC. Unfortunately there is a bug with this backend. This bug is caused by having Token symbols with the same content as non-terminal symbol names.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
This is not an Rchain issue. This is a cryptofex issue. I [filed a bug with BNFC](https://github.com/BNFC/bnfc/issues/235)


### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.

If this disrupts Rchain, we can always maintain our own version until the bug is fixed by BNFC.
