### PR TITLE
Stacksafety refactors

### DIFF
--- a/models/src/main/scala/coop/rchain/models/ParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMap.scala
@@ -15,11 +15,12 @@ case class ParMap(
 ) {
 
   override def equals(o: scala.Any): Boolean = o match {
-    case parMap: ParMap => this.ps == parMap.ps && this.remainder == parMap.remainder
-    case _              => false
+    case parMap: ParMap =>
+      this.ps == parMap.ps && this.remainder == parMap.remainder && this.connectiveUsed == parMap.connectiveUsed
+    case _ => false
   }
 
-  override def hashCode(): Int = Objects.hash(ps, remainder)
+  override def hashCode(): Int = Objects.hash(ps, remainder, Boolean.box(connectiveUsed))
 }
 
 object ParMap {

--- a/models/src/main/scala/coop/rchain/models/ParSet.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSet.scala
@@ -17,11 +17,12 @@ case class ParSet(
   override def equals(o: scala.Any): Boolean = o match {
     case parSet: ParSet =>
       this.ps == parSet.ps &&
-        this.remainder == parSet.remainder
+        this.remainder == parSet.remainder &&
+        this.connectiveUsed == parSet.connectiveUsed
     case _ => false
   }
 
-  override def hashCode(): Int = Objects.hash(ps, remainder)
+  override def hashCode(): Int = Objects.hash(ps, remainder, Boolean.box(connectiveUsed))
 }
 
 object ParSet {

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -72,9 +72,9 @@ private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
           )
       case GByteArray(ba) =>
         ScoredTerm(g, Node(Score.EBYTEARR, Leaf(ba.toStringUtf8))).pure[F]
-      case _ => //TODO(mateusz.gorski): rethink it
+      case expr => //TODO(mateusz.gorski): rethink it
         Sync[F].raiseError(
-          new IllegalArgumentException("GroundSortMatcher passed unknown Expr instance")
+          new IllegalArgumentException(s"GroundSortMatcher passed unknown Expr instance:\n$expr")
         )
     }
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/GroundSortMatcher.scala
@@ -72,6 +72,11 @@ private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
           )
       case GByteArray(ba) =>
         ScoredTerm(g, Node(Score.EBYTEARR, Leaf(ba.toStringUtf8))).pure[F]
+
+      //TODO get rid of Empty nodes in Protobuf unless they represent sth indeed optional
+      case Empty =>
+        ScoredTerm(g, Node(Score.ABSENT)).pure[F]
+
       case expr => //TODO(mateusz.gorski): rethink it
         Sync[F].raiseError(
           new IllegalArgumentException(s"GroundSortMatcher passed unknown Expr instance:\n$expr")

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -15,6 +15,7 @@ object testImplicits {
     BitSet.fromBitMask(bitMask)
   implicit val arbBitSet: Arbitrary[BitSet] = Arbitrary(genBitSet)
 
+  //FIXME this is broken, and makes our tests blind for mishandling Option
   // The ScalaPB generators have quirks in which required objects
   // become Options. See https://github.com/scalapb/ScalaPB/issues/40 .
   // We override so that we cannot get None for these required objects.
@@ -27,7 +28,42 @@ object testImplicits {
   implicit def coeval[A: Arbitrary]: Arbitrary[Coeval[A]] =
     Arbitrary(Arbitrary.arbitrary[A].map(a => Coeval.delay(a)))
 
-  implicit val arbPar = implicitly[Arbitrary[Par]]
+  //Par and Expr (or Par at least) need to be first here, or else the compiler dies terribly.
+  implicit val ParArbitrary                = implicitly[Arbitrary[Par]]
+  implicit val ExprArbitrary               = implicitly[Arbitrary[Expr]]
+  implicit val BindPatternArbitrary        = implicitly[Arbitrary[BindPattern]]
+  implicit val BundleArbitrary             = implicitly[Arbitrary[Bundle]]
+  implicit val ConnectiveArbitrary         = implicitly[Arbitrary[Connective]]
+  implicit val ConnectiveBodyArbitrary     = implicitly[Arbitrary[ConnectiveBody]]
+  implicit val EListArbitrary              = implicitly[Arbitrary[EList]]
+  implicit val EMapArbitrary               = implicitly[Arbitrary[EMap]]
+  implicit val EMatchesArbitrary           = implicitly[Arbitrary[EMatches]]
+  implicit val EMethodArbitrary            = implicitly[Arbitrary[EMethod]]
+  implicit val ENeqArbitrary               = implicitly[Arbitrary[ENeq]]
+  implicit val ENotArbitrary               = implicitly[Arbitrary[ENot]]
+  implicit val EOrArbitrary                = implicitly[Arbitrary[EOr]]
+  implicit val ESetArbitrary               = implicitly[Arbitrary[ESet]]
+  implicit val ETupleArbitrary             = implicitly[Arbitrary[ETuple]]
+  implicit val EVarArbitrary               = implicitly[Arbitrary[EVar]]
+  implicit val GPrivateArbitrary           = implicitly[Arbitrary[GPrivate]]
+  implicit val KeyValuePairArbitrary       = implicitly[Arbitrary[KeyValuePair]]
+  implicit val ListBindPatternsArbitrary   = implicitly[Arbitrary[ListBindPatterns]]
+  implicit val MatchArbitrary              = implicitly[Arbitrary[Match]]
+  implicit val MatchCaseArbitrary          = implicitly[Arbitrary[MatchCase]]
+  implicit val NewArbitrary                = implicitly[Arbitrary[New]]
+  implicit val ParWithRandomArbitrary      = implicitly[Arbitrary[ParWithRandom]]
+  implicit val PCostArbitrary              = implicitly[Arbitrary[PCost]]
+  implicit val ReceiveArbitrary            = implicitly[Arbitrary[Receive]]
+  implicit val ReceiveBindArbitrary        = implicitly[Arbitrary[ReceiveBind]]
+  implicit val SendArbitrary               = implicitly[Arbitrary[Send]]
+  implicit val TaggedContinuationArbitrary = implicitly[Arbitrary[TaggedContinuation]]
+  implicit val VarArbitrary                = implicitly[Arbitrary[Var]]
+  implicit val VarRefArbitrary             = implicitly[Arbitrary[VarRef]]
+  implicit val ParSetArbitrary             = implicitly[Arbitrary[ParSet]]
+  implicit val ParMapArbitrary             = implicitly[Arbitrary[ParMap]]
+
+  implicit def alwaysEqualArbitrary[A: Arbitrary]: Arbitrary[AlwaysEqual[A]] =
+    Arbitrary(Arbitrary.arbitrary[A].map(AlwaysEqual(_)))
 
   implicit val arbParTreeset: Arbitrary[SortedParHashSet] =
     Arbitrary(
@@ -37,5 +73,5 @@ object testImplicits {
     )
 
   implicit def arbParTupleSeq: Arbitrary[Seq[(Par, Par)]] =
-    Arbitrary(Gen.listOf(Gen.zip(arbPar.arbitrary, arbPar.arbitrary)))
+    Arbitrary(Gen.listOf(Gen.zip(ParArbitrary.arbitrary, ParArbitrary.arbitrary)))
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -1,7 +1,6 @@
 package coop.rchain.rholang.interpreter.accounting
 
-import coop.rchain.models.Par
-import scalapb.{GeneratedMessage, Message}
+import scalapb.GeneratedMessage
 
 trait Chargeable[A] {
   def cost(a: A): Int
@@ -10,12 +9,8 @@ trait Chargeable[A] {
 object Chargeable {
   def apply[T](implicit ev: Chargeable[T]): Chargeable[T] = ev
 
-  implicit def fromProtobuf[T <: GeneratedMessage with Message[T]] =
+  implicit def fromProtobuf[T <: GeneratedMessage] =
     new Chargeable[T] {
       override def cost(a: T): Int = a.serializedSize
     }
-
-  implicit val chargeableQuote: Chargeable[Par] = new Chargeable[Par] {
-    override def cost(a: Par): Int = a.serializedSize
-  }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter.accounting
 
 import coop.rchain.casper.protocol.PhloLimit
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.GeneratedMessage
 
 //TODO(mateusz.gorski): Adjust the costs of operations
 final case class Cost(value: Long) extends AnyVal {
@@ -20,9 +20,7 @@ trait Costs {
   final val SUM_COST: Cost         = Cost(3)
   final val SUBTRACTION_COST: Cost = Cost(3)
 
-  def equalityCheckCost[T <: GeneratedMessage with Message[T], P <: GeneratedMessage with Message[
-    P
-  ]](x: T, y: P): Cost =
+  def equalityCheckCost[T <: GeneratedMessage, P <: GeneratedMessage](x: T, y: P): Cost =
     Cost(scala.math.min(x.serializedSize, y.serializedSize))
 
   final val BOOLEAN_AND_COST = Cost(2)
@@ -48,10 +46,7 @@ trait Costs {
   // serializing any Par into a Array[Byte]:
   // + allocates byte array of the same size as `serializedSize`
   // + then it copies all elements of the Par
-  def toByteArrayCost[T <: GeneratedMessage with Message[T]](
-      a: T
-  )(implicit comp: GeneratedMessageCompanion[T]): Cost =
-    Cost(a.serializedSize)
+  def toByteArrayCost[T <: GeneratedMessage](a: T): Cost = Cost(a.serializedSize)
 
   //TODO(mateusz.gorski): adjust the cost of the nth method call.
   def nthMethodCost(nth: Int): Cost = Cost(nth)
@@ -71,17 +66,11 @@ trait Costs {
 
   final val MATCH_EVAL_COST = Cost(12)
 
-  implicit def toStorageCostOps[A <: GeneratedMessage with Message[A]](a: Seq[A])(
-      implicit gm: GeneratedMessageCompanion[A]
-  ) = new StorageCostOps(a: _*)(gm)
+  implicit def toStorageCostOps[A <: GeneratedMessage](a: Seq[A]) = new StorageCostOps(a: _*)
 
-  implicit def toStorageCostOps[A <: GeneratedMessage with Message[A]](a: A)(
-      implicit gm: GeneratedMessageCompanion[A]
-  ) = new StorageCostOps(a)(gm)
+  implicit def toStorageCostOps[A <: GeneratedMessage](a: A) = new StorageCostOps(a)
 
-  class StorageCostOps[A <: GeneratedMessage with Message[A]](a: A*)(
-      gm: GeneratedMessageCompanion[A]
-  ) {
+  class StorageCostOps[A <: GeneratedMessage](a: A*) {
     def storageCost: Cost = Cost(a.map(a => a.serializedSize).sum)
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -82,7 +82,7 @@ trait Costs {
   class StorageCostOps[A <: GeneratedMessage with Message[A]](a: A*)(
       gm: GeneratedMessageCompanion[A]
   ) {
-    def storageCost: Cost = Cost(a.map(a => gm.toByteArray(a).size).sum)
+    def storageCost: Cost = Cost(a.map(a => a.serializedSize).sum)
   }
 
   final val MAX_VALUE = PhloLimit(Long.MaxValue)


### PR DESCRIPTION
## Overview
Title says it all :)

One notable change is 
1974667 Use `.serializedSize` instead of serializing to get message storage cost

This has a potential of improving performance of rspace (or, rather, our usages of it).

### JIRA issue:
RHOL-664

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.