### PR TITLE
RHOL-688, adds toUtf8Bytes to Rholang to turn UTF-8 strings into byte…

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -873,7 +873,7 @@ object Reduce {
           args: Seq[Par]
       )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.nonEmpty) {
-          s.raiseError(ReduceError("Error: toByteArray does not take arguments"))
+          s.raiseError(MethodArgumentNumberMismatch("toByteArray", 0, args.length))
         } else {
           for {
             exprEvaled <- evalExpr(p)
@@ -891,7 +891,7 @@ object Reduce {
           args: Seq[Par]
       )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.nonEmpty) {
-          s.raiseError(ReduceError("Error: hexToBytes does not take arguments"))
+          s.raiseError(MethodArgumentNumberMismatch("hexToBytes", 0, args.length))
         } else {
           p.singleExpr() match {
             case Some(Expr(GString(encoded))) =>
@@ -907,8 +907,8 @@ object Reduce {
                         ba => Applicative[M].pure[Par](Expr(GByteArray(ba)))
                       )
               } yield res
-            case _ =>
-              s.raiseError(ReduceError("Error: hexToBytes can be called only on single strings."))
+            case Some(Expr(other)) =>
+              s.raiseError(MethodNotDefined("hexToBytes", other.typ))
           }
         }
     }
@@ -920,15 +920,15 @@ object Reduce {
           args: Seq[Par]
       )(implicit env: Env[Par], costAccountingAlg: CostAccountingAlg[M]): M[Par] =
         if (args.nonEmpty) {
-          s.raiseError(ReduceError("Error: toUtf8Bytes does not take arguments"))
+          s.raiseError(MethodArgumentNumberMismatch("toUtf8Bytes", 0, args.length))
         } else {
           p.singleExpr() match {
             case Some(Expr(GString(encoded))) =>
               for {
                 _ <- costAccountingAlg.charge(hexToByteCost(encoded))
               } yield Expr(GByteArray(ByteString.copyFrom(encoded.getBytes("UTF-8"))))
-            case _ =>
-              s.raiseError(ReduceError("Error: toUtf8Bytes can be called only on single strings."))
+            case Some(Expr(other)) =>
+              s.raiseError(MethodNotDefined("toUtf8Bytes", other.typ))
           }
         }
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -923,10 +923,10 @@ object Reduce {
           s.raiseError(MethodArgumentNumberMismatch("toUtf8Bytes", 0, args.length))
         } else {
           p.singleExpr() match {
-            case Some(Expr(GString(encoded))) =>
+            case Some(Expr(GString(utf8string))) =>
               for {
-                _ <- costAccountingAlg.charge(hexToByteCost(encoded))
-              } yield Expr(GByteArray(ByteString.copyFrom(encoded.getBytes("UTF-8"))))
+                _ <- costAccountingAlg.charge(hexToByteCost(utf8string))
+              } yield Expr(GByteArray(ByteString.copyFrom(utf8string.getBytes("UTF-8"))))
             case Some(Expr(other)) =>
               s.raiseError(MethodNotDefined("toUtf8Bytes", other.typ))
           }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -1268,6 +1268,89 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
   }
 
+  it should "return an error when `toUtf8Bytes` is called with arguments" in {
+    implicit val errorLog = new ErrorLog()
+    val toUtfBytesWithArgumentsCall: EMethod =
+      EMethod(
+        "toUtf8Bytes",
+        Par(sends = Seq(Send(GString("result"), List(GString("Success")), false, BitSet()))),
+        List[Par](GInt(1))
+      )
+
+    val result = withTestSpace(errorLog) {
+      case TestFixture(space, reducer) =>
+        implicit val env = Env[Par]()
+        val nthTask      = reducer.eval(toUtfBytesWithArgumentsCall)
+        val inspectTask = for {
+          _ <- nthTask
+        } yield space.store.toMap
+        Await.result(inspectTask.runAsync, 3.seconds)
+    }
+    result should be(HashMap.empty)
+    errorLog.readAndClearErrorVector should be(
+      Vector(ReduceError("Error: toUtf8Bytes does not take arguments"))
+    )
+  }
+
+  it should "return an error when `toUtf8Bytes` is evaluated on a non String" in {
+    implicit val errorLog = new ErrorLog()
+    val toUtfBytesCall    = EMethod("toUtf8Bytes", GInt(44), List[Par]())
+
+    val result = withTestSpace(errorLog) {
+      case TestFixture(space, reducer) =>
+        implicit val env = Env[Par]()
+        val nthTask      = reducer.eval(toUtfBytesCall)
+        val inspectTask = for {
+          _ <- nthTask
+        } yield space.store.toMap
+        Await.result(inspectTask.runAsync, 3.seconds)
+    }
+    result should be(HashMap.empty)
+    errorLog.readAndClearErrorVector should be(
+      Vector(ReduceError("Error: toUtf8Bytes can be called only on single strings."))
+    )
+  }
+
+  "eval of `toUtf8Bytes`" should "transform string to UTF-8 byte array (not the rholang term)" in {
+    import coop.rchain.models.serialization.implicits._
+    implicit val errorLog         = new ErrorLog()
+    val splitRand                 = rand.splitByte(0)
+    val testString                = "testing testing"
+    val proc: Par                 = GString(testString)
+    val toUtf8BytesCall           = EMethod("toUtf8Bytes", proc, List[Par]())
+    def wrapWithSend(p: Par): Par = Send(GString("result"), List[Par](p), false, BitSet())
+    val result = withTestSpace(errorLog) {
+      case TestFixture(space, reducer) =>
+        val env         = Env[Par]()
+        val task        = reducer.eval(wrapWithSend(toUtf8BytesCall))(env, splitRand)
+        val inspectTask = for { _ <- task } yield space.store.toMap
+        Await.result(inspectTask.runAsync, 3.seconds)
+    }
+
+    val channel: Par = GString("result")
+
+    result should be(
+      HashMap(
+        List(channel) ->
+          Row(
+            List(
+              Datum.create(
+                channel,
+                ListParWithRandom(
+                  Seq(Expr(GByteArray(ByteString.copyFrom(testString.getBytes)))),
+                  splitRand
+                ),
+                persist = false
+              )
+            ),
+            List()
+          )
+      )
+    )
+
+    errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
+  }
+
   "variable references" should "be substituted before being used." in {
     implicit val errorLog = new ErrorLog()
     val splitRandResult   = rand.splitByte(3)


### PR DESCRIPTION
… arrays

## Overview
This adds `toUtf8Bytes` to Rholang to turn UTF-8 strings into `GByteArray`. This is useful if you want to pass a string directly into one of the hash functions in Rholang.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-688

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] You assigned one person to review this PR (How to do this?)

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
