### PR TITLE
Fix non-deterministic failure when generating Secp256k1 key pair

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -1,14 +1,14 @@
 package coop.rchain.crypto.signatures
 
-import coop.rchain.crypto.{PrivateKey, PublicKey}
-import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.util.SecureRandomUtil
-
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPrivateKey
 import java.security.spec.ECGenParameterSpec
 
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.util.SecureRandomUtil
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import org.bitcoin._
+import com.google.common.base.Strings
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object Secp256k1 {
@@ -37,7 +37,9 @@ object Secp256k1 {
     kpg.initialize(new ECGenParameterSpec(curveName), SecureRandomUtil.secureRandomNonBlocking)
     val kp = kpg.generateKeyPair
 
-    val sec = Base16.decode(kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16))
+    val padded =
+      Strings.padStart(kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16), 64, '0')
+    val sec = Base16.decode(padded)
     val pub = Secp256k1.toPublic(sec)
 
     (PrivateKey(sec), PublicKey(pub))

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Spec.scala
@@ -1,0 +1,13 @@
+package coop.rchain.crypto.signatures
+
+import org.scalatest.FlatSpec
+
+class Secp256k1Spec extends FlatSpec {
+
+  "Secp256k1" should "generate valid key pair" in {
+    assert((1 to 1000).forall { _ =>
+      Secp256k1.newKeyPair
+      true
+    })
+  }
+}


### PR DESCRIPTION
From time to time `kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16)` was returning 62 chars length string, which after decoding in base16 returned 31 bytes long array which failed the precondition check. We left-pad the input string to 64 characters with 0.

## Overview
Provide a brief description of what this PR does, and why it's needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
