### PR TITLE
CORE-1244 Change streamBlob(Blob) to stream(Packet)

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlobHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlobHandler.scala
@@ -1,8 +1,0 @@
-package coop.rchain.casper.util.comm
-
-import coop.rchain.comm.protocol.routing._
-import cats._, cats.data._, cats.implicits._
-
-object BlobHandler {
-  def handleBlob[F[_]: Applicative]: Blob => F[Unit] = (blob: Blob) => ().pure[F] // FIX-ME
-}

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -89,7 +89,7 @@ object CommUtil {
                       (maybeSender, maybePacket) match {
                         case (Some(sender), Some(packet)) =>
                           for {
-                            _ <- HandleMessages.handlePacket[F](sender, packet)
+                            _ <- PacketHandler[F].handlePacket(sender, packet)
                             l <- LastApprovedBlock[F].get
                             _ <- l.fold(askPeers(rest, local))(_ => ().pure[F])
                           } yield ()

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -34,14 +34,14 @@ class TransportLayerTestImpl[F[_]: Monad](
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]] =
     peers.toList.traverse(send(_, msg)).map(_.toSeq)
 
-  // FIX-ME handleBlob not handled (pun)
+  // FIX-ME handleStreamed not handled (pun)
   def receive(
       dispatch: Protocol => F[CommunicationResponse],
-      handleBlob: Blob => F[Unit]
+      handleStreamed: Packet => F[Unit]
   ): F[Unit] =
     TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))
 
-  def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???
+  def stream(peers: Seq[PeerNode], packet: Packet): F[Unit] = ???
 
   def disconnect(peer: PeerNode): F[Unit] = ???
 

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -37,11 +37,12 @@ class TransportLayerTestImpl[F[_]: Monad](
   // FIX-ME handleStreamed not handled (pun)
   def receive(
       dispatch: Protocol => F[CommunicationResponse],
-      handleStreamed: Packet => F[Unit]
+      handleStreamed: Blob => F[Unit]
   ): F[Unit] =
     TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))
 
-  def stream(peers: Seq[PeerNode], packet: Packet): F[Unit] = ???
+  // FIX-ME
+  def stream(peers: Seq[PeerNode], blob: Blob): F[Unit] = ???
 
   def disconnect(peer: PeerNode): F[Unit] = ???
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -68,8 +68,8 @@ class TcpServerObservable(
           }
 
       def stream(request: TLBlob): Task[TLBlobResponse] = Task.delay {
-        request.blob
-          .map(blob => subjectBlobMessage.onNext(BlobMessage(blob)))
+        request.packet
+          .map(packet => subjectBlobMessage.onNext(StreamMessage(packet)))
         TLBlobResponse()
       }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -68,8 +68,11 @@ class TcpServerObservable(
           }
 
       def stream(request: TLBlob): Task[TLBlobResponse] = Task.delay {
-        request.packet
-          .map(packet => subjectBlobMessage.onNext(StreamMessage(packet)))
+        (request.sender, request.packet) mapN { (sender, packet) =>
+          subjectBlobMessage.onNext(
+            StreamMessage(Blob(ProtocolHelper.toPeerNode(sender), packet))
+          )
+        }
         TLBlobResponse()
       }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -14,9 +14,9 @@ trait TransportLayer[F[_]] {
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]]
   def receive(
       dispatch: Protocol => F[CommunicationResponse],
-      handleBlob: Blob => F[Unit]
+      handleStreamed: Packet => F[Unit]
   ): F[Unit]
-  def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit]
+  def stream(peers: Seq[PeerNode], packet: Packet): F[Unit]
   def disconnect(peer: PeerNode): F[Unit]
   def shutdown(msg: Protocol): F[Unit]
 }
@@ -53,9 +53,12 @@ sealed abstract class TransportLayerInstances {
       ): EitherT[F, CommError, Seq[CommErr[Unit]]] =
         EitherT.liftF(evF.broadcast(peers, msg))
 
+      def stream(peers: Seq[PeerNode], packet: Packet): EitherT[F, CommError, Unit] =
+        EitherT.liftF(evF.stream(peers, packet))
+
       def receive(
           dispatch: Protocol => EitherT[F, CommError, CommunicationResponse],
-          handleBlob: Blob => EitherT[F, CommError, Unit]
+          handleStreamed: Packet => EitherT[F, CommError, Unit]
       ): EitherT[F, CommError, Unit] = {
         val dis: Protocol => F[CommunicationResponse] = msg =>
           dispatch(msg).value.flatMap {
@@ -65,17 +68,14 @@ sealed abstract class TransportLayerInstances {
               ).pure[F]
             case Right(m) => m.pure[F]
           }
-        val hb: Blob => F[Unit] = msg =>
-          handleBlob(msg).value.flatMap {
+        val hb: Packet => F[Unit] = msg =>
+          handleStreamed(msg).value.flatMap {
             case Left(err) =>
-              Log[F].error(s"Error while handling Blob message. Error: ${err.message}")
+              Log[F].error(s"Error while handling streamed Packet message. Error: ${err.message}")
             case Right(_) => ().pure[F]
           }
         EitherT.liftF(evF.receive(dis, hb))
       }
-
-      def streamBlob(peers: Seq[PeerNode], msg: Blob): EitherT[F, CommError, Unit] =
-        EitherT.liftF(evF.streamBlob(peers, msg))
 
       def disconnect(peer: PeerNode): EitherT[F, CommError, Unit] =
         EitherT.liftF(evF.disconnect(peer))

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -8,15 +8,17 @@ import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.shared._
 import coop.rchain.comm.protocol.routing._
 
+case class Blob(sender: PeerNode, packet: Packet)
+
 trait TransportLayer[F[_]] {
   def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]]
   def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]]
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]]
   def receive(
       dispatch: Protocol => F[CommunicationResponse],
-      handleStreamed: Packet => F[Unit]
+      handleStreamed: Blob => F[Unit]
   ): F[Unit]
-  def stream(peers: Seq[PeerNode], packet: Packet): F[Unit]
+  def stream(peers: Seq[PeerNode], blob: Blob): F[Unit]
   def disconnect(peer: PeerNode): F[Unit]
   def shutdown(msg: Protocol): F[Unit]
 }
@@ -53,12 +55,12 @@ sealed abstract class TransportLayerInstances {
       ): EitherT[F, CommError, Seq[CommErr[Unit]]] =
         EitherT.liftF(evF.broadcast(peers, msg))
 
-      def stream(peers: Seq[PeerNode], packet: Packet): EitherT[F, CommError, Unit] =
-        EitherT.liftF(evF.stream(peers, packet))
+      def stream(peers: Seq[PeerNode], blob: Blob): EitherT[F, CommError, Unit] =
+        EitherT.liftF(evF.stream(peers, blob))
 
       def receive(
           dispatch: Protocol => EitherT[F, CommError, CommunicationResponse],
-          handleStreamed: Packet => EitherT[F, CommError, Unit]
+          handleStreamed: Blob => EitherT[F, CommError, Unit]
       ): EitherT[F, CommError, Unit] = {
         val dis: Protocol => F[CommunicationResponse] = msg =>
           dispatch(msg).value.flatMap {
@@ -68,8 +70,8 @@ sealed abstract class TransportLayerInstances {
               ).pure[F]
             case Right(m) => m.pure[F]
           }
-        val hb: Packet => F[Unit] = msg =>
-          handleStreamed(msg).value.flatMap {
+        val hb: Blob => F[Unit] = (b) =>
+          handleStreamed(b).value.flatMap {
             case Left(err) =>
               Log[F].error(s"Error while handling streamed Packet message. Error: ${err.message}")
             case Right(_) => ().pure[F]

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -2,7 +2,7 @@ package coop.rchain.comm.transport
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import coop.rchain.comm.protocol.routing.{Blob, Protocol}
+import coop.rchain.comm.protocol.routing.{Packet, Protocol}
 
 import monix.eval.Callback
 
@@ -10,7 +10,7 @@ trait ServerMessage
 // TODO rename to AksMesage and TellMesssage
 final case class Ask(msg: Protocol, sender: SenderHandle) extends ServerMessage
 final case class Tell(msg: Protocol)                      extends ServerMessage
-final case class BlobMessage(blob: Blob)                  extends ServerMessage
+final case class StreamMessage(packet: Packet)            extends ServerMessage
 
 trait SenderHandle {
   def reply(msg: CommunicationResponse): Unit

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -2,15 +2,15 @@ package coop.rchain.comm.transport
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import coop.rchain.comm.protocol.routing.{Packet, Protocol}
+import coop.rchain.comm.protocol.routing.Protocol
 
 import monix.eval.Callback
 
 trait ServerMessage
 // TODO rename to AksMesage and TellMesssage
-final case class Ask(msg: Protocol, sender: SenderHandle) extends ServerMessage
+final case class Ask(msg: Protocol, handle: SenderHandle) extends ServerMessage
 final case class Tell(msg: Protocol)                      extends ServerMessage
-final case class StreamMessage(packet: Packet)            extends ServerMessage
+final case class StreamMessage(blob: Blob)                extends ServerMessage
 
 trait SenderHandle {
   def reply(msg: CommunicationResponse): Unit

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -41,7 +41,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
 
   trait Runtime[A] {
     protected def protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse]
-    protected def streamDispatcher: Dispatcher[F, Packet, Unit]
+    protected def streamDispatcher: Dispatcher[F, Blob, Unit]
     def run(): Result
     trait Result {
       def localNode: PeerNode
@@ -52,7 +52,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class TwoNodesRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(transportLayer: TransportLayer[F], local: PeerNode, remote: PeerNode): F[A]
 
@@ -89,7 +89,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class TwoNodesRemoteDeadRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(transportLayer: TransportLayer[F], local: PeerNode, remote: PeerNode): F[A]
 
@@ -119,7 +119,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class ThreeNodesRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(
         transportLayer: TransportLayer[F],
@@ -205,7 +205,6 @@ final class Dispatcher[F[_]: Applicative, R, S](
 ) {
   def dispatch(peer: PeerNode): R => F[S] =
     p => {
-      println(s"received $p")
       delay.foreach(Thread.sleep)
       if (!ignore(p))
         receivedMessages.synchronized(receivedMessages += ((peer, p)))
@@ -245,9 +244,8 @@ object Dispatcher {
       ignore = _.message.isDisconnect
     )
 
-  def devNullPacketDispatcher[F[_]: Applicative]: Dispatcher[F, Packet, Unit] =
-    new Dispatcher[F, Packet, Unit](
+  def devNullPacketDispatcher[F[_]: Applicative]: Dispatcher[F, Blob, Unit] =
+    new Dispatcher[F, Blob, Unit](
       kp(())
     )
-
 }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -10,7 +10,7 @@ import cats._
 import cats.implicits._
 
 import coop.rchain.comm._
-import coop.rchain.comm.protocol.routing.{Blob, Protocol}
+import coop.rchain.comm.protocol.routing.{Packet, Protocol}
 import coop.rchain.comm.CommError.CommErr
 import coop.rchain.comm.rp.ProtocolHelper
 
@@ -41,7 +41,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
 
   trait Runtime[A] {
     protected def protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse]
-    protected def blobDispatcher: Dispatcher[F, Blob, Unit]
+    protected def streamDispatcher: Dispatcher[F, Packet, Unit]
     def run(): Result
     trait Result {
       def localNode: PeerNode
@@ -52,7 +52,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class TwoNodesRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val blobDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullBlobDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(transportLayer: TransportLayer[F], local: PeerNode, remote: PeerNode): F[A]
 
@@ -66,7 +66,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             remote   = e2.peer
             _ <- remoteTl.receive(
                   protocolDispatcher.dispatch(remote),
-                  blobDispatcher.dispatch(remote)
+                  streamDispatcher.dispatch(remote)
                 )
             r <- execute(localTl, local, remote)
             _ <- remoteTl.shutdown(ProtocolHelper.disconnect(remote))
@@ -89,7 +89,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class TwoNodesRemoteDeadRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val blobDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullBlobDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(transportLayer: TransportLayer[F], local: PeerNode, remote: PeerNode): F[A]
 
@@ -119,7 +119,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
   abstract class ThreeNodesRuntime[A](
       val protocolDispatcher: Dispatcher[F, Protocol, CommunicationResponse] =
         Dispatcher.withoutMessageDispatcher[F],
-      val blobDispatcher: Dispatcher[F, Blob, Unit] = Dispatcher.devNullBlobDispatcher[F]
+      val streamDispatcher: Dispatcher[F, Packet, Unit] = Dispatcher.devNullPacketDispatcher[F]
   ) extends Runtime[A] {
     def execute(
         transportLayer: TransportLayer[F],
@@ -139,9 +139,9 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             remote1   = e2.peer
             remote2   = e3.peer
             _ <- remoteTl1
-                  .receive(protocolDispatcher.dispatch(remote1), blobDispatcher.dispatch(remote1))
+                  .receive(protocolDispatcher.dispatch(remote1), streamDispatcher.dispatch(remote1))
             _ <- remoteTl2
-                  .receive(protocolDispatcher.dispatch(remote2), blobDispatcher.dispatch(remote2))
+                  .receive(protocolDispatcher.dispatch(remote2), streamDispatcher.dispatch(remote2))
             r <- execute(localTl, local, remote1, remote2)
             _ <- remoteTl1.shutdown(ProtocolHelper.disconnect(remote1))
             _ <- remoteTl2.shutdown(ProtocolHelper.disconnect(remote2))
@@ -245,8 +245,8 @@ object Dispatcher {
       ignore = _.message.isDisconnect
     )
 
-  def devNullBlobDispatcher[F[_]: Applicative]: Dispatcher[F, Blob, Unit] =
-    new Dispatcher[F, Blob, Unit](
+  def devNullPacketDispatcher[F[_]: Applicative]: Dispatcher[F, Packet, Unit] =
+    new Dispatcher[F, Packet, Unit](
       kp(())
     )
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -6,7 +6,7 @@ import cats._
 import cats.implicits._
 
 import coop.rchain.comm._, rp.ProtocolHelper
-import coop.rchain.comm.protocol.routing.{Blob, Protocol}
+import coop.rchain.comm.protocol.routing.{Packet, Protocol}
 import coop.rchain.casper.protocol.{BlockApproval => CasperBlockApproval}
 import coop.rchain.comm.CommError.CommErr
 
@@ -245,16 +245,17 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
               local: PeerNode,
               remote: PeerNode
           ): F[Unit] =
-            transportLayer.streamBlob(
+            transportLayer.stream(
               List(remote),
-              Blob().withBlockApproval(CasperBlockApproval(sig = None))
+              Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter"))
             )
 
           run()
 
-          blobDispatcher.received should have length 1
-          val (_, blob) = blobDispatcher.received.head
-          blob.message.isBlockApproval shouldBe (true)
+          streamDispatcher.received should have length 1
+          val (_, packet) = streamDispatcher.received.head
+          packet.typeId shouldBe ("N/A")
+          packet.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
         }
       }
 
@@ -266,18 +267,20 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
               remote1: PeerNode,
               remote2: PeerNode
           ): F[Unit] =
-            transportLayer.streamBlob(
+            transportLayer.stream(
               List(remote1, remote2),
-              Blob().withBlockApproval(CasperBlockApproval(sig = None))
+              Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter"))
             )
 
           run()
 
-          blobDispatcher.received should have length 2
-          val (_, blob1) = blobDispatcher.received(0)
-          val (_, blob2) = blobDispatcher.received(1)
-          blob1.message.isBlockApproval shouldBe (true)
-          blob2.message.isBlockApproval shouldBe (true)
+          streamDispatcher.received should have length 2
+          val (_, packet1) = streamDispatcher.received(0)
+          val (_, packet2) = streamDispatcher.received(1)
+          packet1.typeId shouldBe ("N/A")
+          packet1.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
+          packet2.typeId shouldBe ("N/A")
+          packet2.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
         }
       }
     }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -247,15 +247,15 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
           ): F[Unit] =
             transportLayer.stream(
               List(remote),
-              Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter"))
+              Blob(local, Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter")))
             )
 
           run()
 
           streamDispatcher.received should have length 1
-          val (_, packet) = streamDispatcher.received.head
-          packet.typeId shouldBe ("N/A")
-          packet.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
+          val (_, blob) = streamDispatcher.received.head
+          blob.packet.typeId shouldBe ("N/A")
+          blob.packet.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
         }
       }
 
@@ -269,18 +269,18 @@ abstract class TransportLayerSpec[F[_]: Monad, E <: Environment]
           ): F[Unit] =
             transportLayer.stream(
               List(remote1, remote2),
-              Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter"))
+              Blob(local, Packet("N/A", ProtocolHelper.toProtocolBytes("points don't matter")))
             )
 
           run()
 
           streamDispatcher.received should have length 2
-          val (_, packet1) = streamDispatcher.received(0)
-          val (_, packet2) = streamDispatcher.received(1)
-          packet1.typeId shouldBe ("N/A")
-          packet1.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
-          packet2.typeId shouldBe ("N/A")
-          packet2.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
+          val (_, blob1) = streamDispatcher.received(0)
+          val (_, blob2) = streamDispatcher.received(1)
+          blob1.packet.typeId shouldBe ("N/A")
+          blob1.packet.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
+          blob2.packet.typeId shouldBe ("N/A")
+          blob2.packet.content shouldBe (ProtocolHelper.toProtocolBytes("points don't matter"))
         }
       }
     }

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -93,11 +93,11 @@ object EffectsTestInstances {
       Seq()
     }
 
-    def streamBlob(peers: Seq[PeerNode], msg: Blob): F[Unit] = ???
+    def stream(peers: Seq[PeerNode], packet: Packet): F[Unit] = ???
 
     def receive(
         dispatch: Protocol => F[CommunicationResponse],
-        handleBlob: Blob => F[Unit]
+        handleStreamed: Packet => F[Unit]
     ): F[Unit] = ???
 
     def disconnect(peer: PeerNode): F[Unit] = ???

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -93,11 +93,11 @@ object EffectsTestInstances {
       Seq()
     }
 
-    def stream(peers: Seq[PeerNode], packet: Packet): F[Unit] = ???
+    def stream(peers: Seq[PeerNode], blob: Blob): F[Unit] = ???
 
     def receive(
         dispatch: Protocol => F[CommunicationResponse],
-        handleStreamed: Packet => F[Unit]
+        handleStreamed: Blob => F[Unit]
     ): F[Unit] = ???
 
     def disconnect(peer: PeerNode): F[Unit] = ???

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -81,7 +81,8 @@ message TLResponse {
 }
 
 message TLBlob {
-  Packet packet = 1;
+  Node   sender = 1;
+  Packet packet = 2;
 }
 
 message TLBlobResponse {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -54,16 +54,6 @@ message Protocol {
     }
 }
 
-message Blob {
-  string blobType = 1;
-  oneof message {
-    coop.rchain.casper.protocol.BlockMessage  blockMessage      = 2; 
-    coop.rchain.casper.protocol.ApprovedBlock  approvedBlock    = 3;
-    coop.rchain.casper.protocol.UnapprovedBlock unapprovedBlock = 4;
-    coop.rchain.casper.protocol.BlockApproval blockApproval     = 5;
-  }
-}
-
 service TransportLayer {
   rpc Tell (TLRequest) returns (TLResponse) {}
   rpc Ask (TLRequest) returns (TLResponse) {}
@@ -91,7 +81,7 @@ message TLResponse {
 }
 
 message TLBlob {
-  Blob blob = 1;
+  Packet packet = 1;
 }
 
 message TLBlobResponse {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -58,7 +58,7 @@ service TransportLayer {
   rpc Tell (TLRequest) returns (TLResponse) {}
   rpc Ask (TLRequest) returns (TLResponse) {}
   // this eventually will become streamed API, for now regular call
-  rpc Stream (TLBlob) returns (TLBlobResponse) {}
+  rpc Stream (stream Chunk) returns (ChunkResponse) {}
 }
 
 message TLRequest {
@@ -80,11 +80,22 @@ message TLResponse {
   }
 }
 
-message TLBlob {
+message ChunkHeader {
   Node   sender = 1;
-  Packet packet = 2;
+  string typeId = 2;
 }
 
-message TLBlobResponse {
+message ChunkData {
+  bytes contentData = 1;
+}
+
+message Chunk {
+  oneof content {
+    ChunkHeader header = 1;
+    ChunkData   data   = 2;
+  }
+}
+
+message ChunkResponse {
 
 }

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import coop.rchain.blockstorage.{BlockStore, LMDBBlockStore}
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper.util.comm.{BlobHandler, CasperPacketHandler}
+import coop.rchain.casper.util.comm.CasperPacketHandler
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.{LastApprovedBlock, MultiParentCasperRef, SafetyOracle}
 import coop.rchain.catscontrib.Catscontrib._
@@ -299,7 +299,7 @@ class NodeRuntime(conf: Configuration, host: String, scheduler: Scheduler) {
       _       <- startReportJvmMetrics.toEffect
       _ <- TransportLayer[Effect].receive(
             pm => HandleMessages.handle[Effect](pm, defaultTimeout),
-            BlobHandler.handleBlob[Effect]
+            packet => packetHandler.handlePacket(null, packet).as(()) // FIX-ME
           )
       _ <- NodeDiscovery[Task].discover.executeOn(loopScheduler).start.toEffect
       _ <- Log[Effect].info(s"Listening for traffic on $address.")

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -299,7 +299,7 @@ class NodeRuntime(conf: Configuration, host: String, scheduler: Scheduler) {
       _       <- startReportJvmMetrics.toEffect
       _ <- TransportLayer[Effect].receive(
             pm => HandleMessages.handle[Effect](pm, defaultTimeout),
-            packet => packetHandler.handlePacket(null, packet).as(()) // FIX-ME
+            blob => packetHandler.handlePacket(blob.sender, blob.packet).as(())
           )
       _ <- NodeDiscovery[Task].discover.executeOn(loopScheduler).start.toEffect
       _ <- Log[Effect].info(s"Listening for traffic on $address.")


### PR DESCRIPTION
## Overview

### Change streamBlob(Blob) to stream(Packet)

This change is made after conversations that I had with Micheal
Birch. Comm needs to stay totally NOT aware of abstraction that is
using it. We Achieved this by introducing `Packet` and
`PacketHandler`. `Packet` contains arbitrary data and `PacketHandler`
is a typeclass (an interface) for the user of Comm to implement -
giving comm information how to handle incomminb messages that are not
part of the initial RChain Protocol.

Introducing `Blob` was breaking that design concept. It was pushing a
cycle into dependency graph (comm needs to know casper, casper needs
to know comm), which in a long run is highly potential source of
errors and confusion.

Having dedicated method `def stream(peers: Seq[PeerNode], packet:
Packet)` allows us also take adventage of existing logic hidden in
`PacketHandler`. It's going to be Casper to decide if he wants to send
packet normally via `roundTrip`, `send` or `broadcast` (wrapped in
`Protocol`) or if he wants to stream it via `stream`.

Please not that `def stream(Seq[PeerNode], Packet)` is still not
sending messages in stream manner - that is a change to come

### Change Packet ... back to Blob wtf?!

So as it turned out, when we pass `Packet` to a `PacketHandler`, we
also need to provide a `PeerNode` representing a sender. In `Protocol`
that information was in `Header`. Something similar was needed for
`stream`, thus the following changes


### Change TL.stream to send messages in stream manner

So far `TransportLayer.stream` was not really streaming data (just
sending it as is). With this change data is finally streamed.

## Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1244