### PR TITLE
Rholang: Initialize the registry for RholangCLI and the REPL

### DIFF
--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -359,6 +359,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
     _              <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
     oracle         = SafetyOracle.turanOracle[Effect](Monad[Effect])
     runtime        = Runtime.create(storagePath, storageSize, storeType)
+    _              <- runtime.injectEmptyRegistryRoot[Effect]()
     casperRuntime  = Runtime.create(casperStoragePath, storageSize, storeType)
     runtimeManager = RuntimeManager.fromRuntime(casperRuntime)
     casperPacketHandler <- CasperPacketHandler

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -359,7 +359,7 @@ class NodeRuntime(conf: Configuration, host: String)(implicit scheduler: Schedul
     _              <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
     oracle         = SafetyOracle.turanOracle[Effect](Monad[Effect])
     runtime        = Runtime.create(storagePath, storageSize, storeType)
-    _              <- runtime.injectEmptyRegistryRoot[Effect]()
+    _              <- runtime.injectEmptyRegistryRoot[Effect]
     casperRuntime  = Runtime.create(casperStoragePath, storageSize, storeType)
     runtimeManager = RuntimeManager.fromRuntime(casperRuntime)
     casperPacketHandler <- CasperPacketHandler

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -817,6 +817,8 @@ object Registry {
       .copyFrom(Base16.decode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697"))
   )
 
+  val emptyMap: Par = EMapBody(ParMap(SortedParMap.empty))
+
   def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
 
   val testingUrnMap: Map[String, Par] = Map(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -52,6 +52,7 @@ object RholangCLI {
     val conf = new Conf(args)
 
     val runtime = Runtime.create(conf.data_dir(), conf.map_size())
+    Await.result(runtime.injectEmptyRegistryRoot[Task]().runAsync, 5.seconds)
 
     try {
       if (conf.files.supplied) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -52,7 +52,7 @@ object RholangCLI {
     val conf = new Conf(args)
 
     val runtime = Runtime.create(conf.data_dir(), conf.map_size())
-    Await.result(runtime.injectEmptyRegistryRoot[Task]().runAsync, 5.seconds)
+    Await.result(runtime.injectEmptyRegistryRoot[Task].runAsync, 5.seconds)
 
     try {
       if (conf.files.supplied) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -86,6 +86,8 @@ object errors {
 
   final case class SubstituteError(message: String) extends InterpreterError(message)
 
+  final case class SetupError(message: String) extends InterpreterError(message)
+
   final case class UnrecognizedInterpreterError(throwable: Throwable)
       extends InterpreterError("Unrecognized interpreter error", throwable)
 


### PR DESCRIPTION
## Overview
This PR makes the registry available to the REPL and RholangCLI. It also introduces a mechanism that should allow casper to initialize the registry at genesis.

