### PR TITLE
Par sorter fix, Pretty typeclass for printing to Scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,6 +139,7 @@ lazy val models = (project in file("models"))
   .settings(
     libraryDependencies ++= commonDependencies ++ protobufDependencies ++ Seq(
       catsCore,
+      magnolia,
       scalacheck,
       scalacheckShapeless,
       scalapbRuntimegGrpc

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -14,13 +14,13 @@ import coop.rchain.casper._
 import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.{BindPattern, Par}
-import coop.rchain.models.rholang.sort.Sortable
+import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rspace.StableHashProvider
 import coop.rchain.rspace.trace.{COMM, Consume, Produce}
 import coop.rchain.shared.{Log, SyncLock}
 import coop.rchain.models.serialization.implicits.serializePar
 import coop.rchain.rholang.interpreter.{PrettyPrinter => RholangPrettyPrinter}
-import coop.rchain.models.rholang.sort.Sortable._
+import coop.rchain.models.rholang.sorter.Sortable._
 import scodec.Codec
 
 import scala.collection.immutable

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -1,0 +1,187 @@
+package coop.rchain.models
+import com.google.protobuf.ByteString
+import monix.eval.Coeval
+import monix.eval.Coeval.Now
+
+import scala.annotation.switch
+import scala.collection.immutable.{BitSet, HashSet}
+
+/**
+  * A typeclass for pretty-printing objects to compiling Scala code.
+  *
+  * A fairly complete implementation covering all rholang AST classes
+  * is derived generically using Magnolia (some leaf instances were needed ofc).
+  *
+  * @tparam A the type of values this instance provides pretty-printing for
+  */
+trait Pretty[A] {
+  def pretty(value: A, indentLevel: Int): String
+}
+
+object Pretty extends PrettyInstances {
+
+  def apply[A: Pretty](implicit ev: Pretty[A]): Pretty[A] = ev
+
+  def pretty[A](value: A)(implicit ev: Pretty[A]) = ev.pretty(value, 0)
+
+}
+
+trait PrettyInstances extends PrettyDerivation {
+  import PrettyUtils._
+
+  implicit val PrettyString  = singleLine(literalize(_: String))
+  implicit val PrettyBoolean = fromToString[Boolean]
+  implicit val PrettyByte    = fromToString[Byte]
+  implicit val PrettyInt     = fromToString[Int]
+  implicit val PrettyLong    = fromToString[Long]
+  implicit val PrettyBitSet  = fromToString[BitSet]
+
+  // obviously won't print compiling code,
+  // but seeing the stacktrace is more important in this case
+  implicit val PrettyThrowable = fromToString[Throwable]
+
+  implicit val PrettyByteString: Pretty[ByteString] = (value: ByteString, indentLevel: Int) =>
+    "ByteString.copyFrom(Array[Byte]" + parenthesised(value.toByteArray, indentLevel) + ")"
+
+  implicit def prettyArray[A: Pretty]: Pretty[Array[A]] = "Array" + parenthesised(_, _)
+
+  implicit def prettySeq[A: Pretty]     = fromIterable[Seq[A], A]("Seq")
+  implicit def prettySet[A: Pretty]     = fromIterable[Set[A], A]("Set")
+  implicit def prettyHashSet[A: Pretty] = fromIterable[HashSet[A], A]("HashSet")
+  implicit def prettySortedParHashSet   = fromIterable[SortedParHashSet, Par]("SortedParHashSet(Seq")
+  implicit def prettySortedParMap       = fromIterable[SortedParMap, (Par, Par)]("SortedParMap(Map")
+
+  implicit def prettyPair[A: Pretty, B: Pretty]: Pretty[(A, B)] =
+    (value: (A, B), indentLevel: Int) => {
+      val prettyA = Pretty[A].pretty(value._1, indentLevel)
+      val prettyB = Pretty[B].pretty(value._2, indentLevel)
+      s"$prettyA -> $prettyB"
+    }
+
+  implicit def prettyMap[A: Pretty, B: Pretty]: Pretty[Map[A, B]] =
+    (value: Map[A, B], indentLevel: Int) => {
+      val pairs = value
+        .map(
+          kv => {
+            val key   = Pretty[A].pretty(kv._1, indentLevel + 1)
+            val value = Pretty[B].pretty(kv._2, indentLevel + 1)
+            s"$key -> $value"
+          }
+        )
+      "Map" + parenthesisedStrings(pairs, indentLevel)
+    }
+
+  implicit def prettyAlwaysEqual[A: Pretty]: Pretty[AlwaysEqual[A]] =
+    (value: AlwaysEqual[A], indentLevel: Int) =>
+      s"AlwaysEqual(${Pretty[A].pretty(value.item, indentLevel)})"
+
+  implicit def prettyCoeval[A: Pretty]: Pretty[Coeval[A]] =
+    (value: Coeval[A], indentLevel: Int) =>
+      value match {
+        case Now(a: A)    => s"Coeval.Now(${Pretty[A].pretty(a, indentLevel)})"
+        case _: Coeval[_] => s"Coeval(???)"
+      }
+
+  implicit val PrettyPar: Pretty[Par] = gen[Par]
+
+  def singleLine[A](print: A => String): Pretty[A] = (value: A, indentLevel: Int) => print(value)
+
+  def fromToString[A]: Pretty[A] = (value: A, indentLevel: Int) => value.toString
+
+  def fromIterable[F <: Iterable[A], A: Pretty](prefix: String): Pretty[F] = {
+    val prefixParensCount = prefix.count(_ == '(')
+    prefix + parenthesised(_, _) + (")" * prefixParensCount)
+  }
+}
+
+trait PrettyDerivation {
+  import PrettyUtils._
+  import magnolia._
+
+  type Typeclass[T] = Pretty[T]
+
+  def combine[T](ctx: CaseClass[Pretty, T]): Pretty[T] = new Pretty[T] {
+
+    override def pretty(value: T, indentLevel: Int): String =
+      if (ctx.isObject) {
+        s"${ctx.typeName.short}"
+      } else {
+        s"${ctx.typeName.short}${nonDefaultParameters(value, indentLevel)}"
+      }
+
+    private def nonDefaultParameters(value: T, indentLevel: Int): String = {
+      val nonDefaultParameters =
+        ctx.parameters.filter(p => !p.default.contains(p.dereference(value)))
+
+      val paramStrings = nonDefaultParameters.map(
+        p => s"${p.label} = ${p.typeclass.pretty(p.dereference(value), indentLevel + 1)}"
+      )
+
+      parenthesisedStrings(paramStrings, indentLevel)
+    }
+  }
+
+  def dispatch[T](ctx: SealedTrait[Pretty, T]): Pretty[T] =
+    new Pretty[T] {
+      override def pretty(value: T, indentLevel: Int): String =
+        // format: off
+        ctx.dispatch(value) {
+          sub => sub.typeclass.pretty(sub.cast(value), indentLevel)
+        }
+        // format: on
+    }
+
+  implicit def gen[T]: Pretty[T] = macro Magnolia.gen[T]
+}
+
+object PrettyUtils {
+
+  def parenthesised[A: Pretty](values: Iterable[A], indentLevel: Int): String =
+    parenthesisedStrings(values.map(Pretty[A].pretty(_, indentLevel + 1)), indentLevel)
+
+  def parenthesisedStrings(paramStrings: Iterable[String], indentLevel: Int): String =
+    if (paramStrings.isEmpty) {
+      "()"
+    } else {
+      paramStrings.mkString(
+        "(\n" + indent(indentLevel + 1),
+        ",\n" + indent(indentLevel + 1),
+        "\n" + indent(indentLevel) + ")"
+      )
+    }
+
+  private def indent(indentLevel: Int) =
+    ("  " * (indentLevel))
+
+  /**
+    * Convert a string to a C&P-able literal. Basically
+    * copied verbatim from the uPickle source code.
+    */
+  def literalize(s: IndexedSeq[Char], unicode: Boolean = true): String = {
+    val sb = new StringBuilder
+    sb.append('"')
+    var i   = 0
+    val len = s.length
+    while (i < len) {
+      escapeChar(s(i), sb)
+      i += 1
+    }
+    sb.append('"')
+
+    sb.result()
+  }
+
+  private def escapeChar(c: Char, sb: StringBuilder, unicode: Boolean = true): StringBuilder =
+    (c: @switch) match {
+      case '"'  => sb.append("\\\"")
+      case '\\' => sb.append("\\\\")
+      case '\b' => sb.append("\\b")
+      case '\f' => sb.append("\\f")
+      case '\n' => sb.append("\\n")
+      case '\r' => sb.append("\\r")
+      case '\t' => sb.append("\\t")
+      case c =>
+        if (c < ' ' || (c > '~' && unicode)) sb.append("\\u%04x" format c.toInt)
+        else sb.append(c)
+    }
+}

--- a/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParHashSet.scala
@@ -3,7 +3,7 @@ package coop.rchain.models
 import scala.collection.generic.CanBuildFrom
 import scala.collection.immutable.HashSet
 import scala.collection.{mutable, SetLike}
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 
 //Enforce ordering and uniqueness.
 // - uniqueness is handled by using HashSet.

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -1,7 +1,7 @@
 package coop.rchain.models
 
 import scala.collection.MapLike
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 
 case class SortedParMap(private val ps: Map[Par, Par])
     extends Map[Par, Par]

--- a/models/src/main/scala/coop/rchain/models/rholang/sort/package.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sort/package.scala
@@ -1,3 +1,0 @@
-package coop.rchain.models.rholang
-
-package object sort extends ScoreTree

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/BoolSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/BoolSortMatcher.scala
@@ -1,10 +1,10 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Expr.ExprInstance.GBool
 import cats.implicits._
 
-private[sort] object BoolSortMatcher extends Sortable[GBool] {
+private[sorter] object BoolSortMatcher extends Sortable[GBool] {
   def sortMatch[F[_]: Sync](g: GBool): F[ScoredTerm[GBool]] =
     if (g.value) {
       ScoredTerm(g, Leaves(Score.BOOL, 0)).pure[F]

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/BundleSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/BundleSortMatcher.scala
@@ -1,10 +1,10 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.models.{Bundle, Expr}
 
-private[sort] object BundleSortMatcher extends Sortable[Bundle] {
+private[sorter] object BundleSortMatcher extends Sortable[Bundle] {
   def sortMatch[F[_]: Sync](b: Bundle): F[ScoredTerm[Bundle]] = {
 
     val score: Int = if (b.writeFlag && b.readFlag) {

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Connective.ConnectiveInstance._
@@ -6,7 +6,7 @@ import coop.rchain.models.{Connective, Par, VarRef}
 import coop.rchain.models.rholang.implicits._
 import cats.implicits._
 
-private[sort] object ConnectiveSortMatcher extends Sortable[Connective] {
+private[sorter] object ConnectiveSortMatcher extends Sortable[Connective] {
   def sortMatch[F[_]: Sync](c: Connective): F[ScoredTerm[Connective]] =
     c.connectiveInstance match {
       case ConnAndBody(cb) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Expr.ExprInstance
@@ -7,7 +7,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import cats.implicits._
 
-private[sort] object ExprSortMatcher extends Sortable[Expr] {
+private[sorter] object ExprSortMatcher extends Sortable[Expr] {
 
   def sortMatch[F[_]: Sync](e: Expr): F[ScoredTerm[Expr]] = {
     def constructExpr(exprInstance: ExprInstance, score: Tree[ScoreAtom]) =

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/GroundSortMatcher.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Expr.ExprInstance
@@ -7,7 +7,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.models._
 import cats.implicits._
 
-private[sort] object GroundSortMatcher extends Sortable[ExprInstance] {
+private[sorter] object GroundSortMatcher extends Sortable[ExprInstance] {
   def sortMatch[F[_]: Sync](g: ExprInstance): F[ScoredTerm[ExprInstance]] =
     g match {
       case gb: GBool =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
@@ -1,10 +1,10 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.{Expr, Match, MatchCase}
 import cats.implicits._
 
-private[sort] object MatchSortMatcher extends Sortable[Match] {
+private[sorter] object MatchSortMatcher extends Sortable[Match] {
   def sortMatch[F[_]: Sync](m: Match): F[ScoredTerm[Match]] = {
 
     def sortCase(matchCase: MatchCase): F[ScoredTerm[MatchCase]] =

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
@@ -1,10 +1,10 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.{Expr, New}
 import cats.implicits._
 
-private[sort] object NewSortMatcher extends Sortable[New] {
+private[sorter] object NewSortMatcher extends Sortable[New] {
   def sortMatch[F[_]: Sync](n: New): F[ScoredTerm[New]] =
     for {
       sortedPar <- Sortable.sortMatch(n.p)

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
@@ -31,9 +31,14 @@ private[sorter] object ParSortMatcher extends Sortable[Par] {
       )
       parScore = Node(
         Score.PAR,
-        sends.map(_.score) ++ receives.map(_.score) ++ exprs.map(_.score) ++ news
-          .map(_.score) ++ matches.map(_.score) ++ bundles.map(_.score) ++ ids
-          .map(_.score) ++ connectives.map(_.score): _*
+        sends.map(_.score) ++
+          receives.map(_.score) ++
+          exprs.map(_.score) ++
+          news.map(_.score) ++
+          matches.map(_.score) ++
+          bundles.map(_.score) ++
+          connectives.map(_.score) ++
+          ids.map(_.score): _*
       )
     } yield ScoredTerm(sortedPar, parScore)
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
@@ -7,22 +7,24 @@ import cats.implicits._
 private[sorter] object ParSortMatcher extends Sortable[Par] {
   def sortMatch[F[_]: Sync](par: Par): F[ScoredTerm[Par]] =
     for {
-      sends       <- par.sends.toList.traverse(Sortable[Send].sortMatch[F])
-      receives    <- par.receives.toList.traverse(Sortable[Receive].sortMatch[F])
-      exprs       <- par.exprs.toList.traverse(Sortable[Expr].sortMatch[F])
-      news        <- par.news.toList.traverse(Sortable[New].sortMatch[F])
-      matches     <- par.matches.toList.traverse(Sortable[Match].sortMatch[F])
-      bundles     <- par.bundles.toList.traverse(Sortable[Bundle].sortMatch[F])
-      connectives <- par.connectives.toList.traverse(Sortable[Connective].sortMatch[F])
-      ids         = par.ids.map(g => ScoredTerm(g, Node(Score.PRIVATE, Leaf(g.id)))).sorted
+      sends    <- par.sends.toList.traverse(Sortable[Send].sortMatch[F]).map(_.sorted)
+      receives <- par.receives.toList.traverse(Sortable[Receive].sortMatch[F]).map(_.sorted)
+      exprs    <- par.exprs.toList.traverse(Sortable[Expr].sortMatch[F]).map(_.sorted)
+      news     <- par.news.toList.traverse(Sortable[New].sortMatch[F]).map(_.sorted)
+      matches  <- par.matches.toList.traverse(Sortable[Match].sortMatch[F]).map(_.sorted)
+      bundles  <- par.bundles.toList.traverse(Sortable[Bundle].sortMatch[F]).map(_.sorted)
+      connectives <- par.connectives.toList
+                      .traverse(Sortable[Connective].sortMatch[F])
+                      .map(_.sorted)
+      ids = par.ids.map(g => ScoredTerm(g, Node(Score.PRIVATE, Leaf(g.id)))).sorted
       sortedPar = Par(
-        sends = sends.sorted.map(_.term),
-        receives = receives.sorted.map(_.term),
-        exprs = exprs.sorted.map(_.term),
-        news = news.sorted.map(_.term),
-        matches = matches.sorted.map(_.term),
-        bundles = bundles.sorted.map(_.term),
-        connectives = connectives.sorted.map(_.term),
+        sends = sends.map(_.term),
+        receives = receives.map(_.term),
+        exprs = exprs.map(_.term),
+        news = news.map(_.term),
+        matches = matches.map(_.term),
+        bundles = bundles.map(_.term),
+        connectives = connectives.map(_.term),
         ids = ids.map(_.term),
         locallyFree = par.locallyFree,
         connectiveUsed = par.connectiveUsed

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
@@ -1,10 +1,10 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models._
 import cats.implicits._
 
-private[sort] object ParSortMatcher extends Sortable[Par] {
+private[sorter] object ParSortMatcher extends Sortable[Par] {
   def sortMatch[F[_]: Sync](par: Par): F[ScoredTerm[Par]] =
     for {
       sends       <- par.sends.toList.traverse(Sortable[Send].sortMatch[F])

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.{Par, Receive, ReceiveBind, Var}

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.ByteString.ByteIterator

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
@@ -1,11 +1,11 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.{Par, Send}
 import coop.rchain.models.rholang.implicits._
 import cats.implicits._
 
-private[sort] object SendSortMatcher extends Sortable[Send] {
+private[sorter] object SendSortMatcher extends Sortable[Send] {
   def sortMatch[F[_]: Sync](s: Send): F[ScoredTerm[Send]] =
     for {
       sortedChan <- Sortable.sortMatch(s.chan)

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/Sortable.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/Sortable.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 import cats.effect.Sync
 import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance.GBool

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/VarSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/VarSortMatcher.scala
@@ -1,4 +1,4 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Var
@@ -6,7 +6,7 @@ import coop.rchain.models.Var.VarInstance.{BoundVar, Empty, FreeVar, Wildcard}
 import cats.implicits._
 import cats.syntax._
 
-private[sort] object VarSortMatcher extends Sortable[Var] {
+private[sorter] object VarSortMatcher extends Sortable[Var] {
   def sortMatch[F[_]: Sync](v: Var): F[ScoredTerm[Var]] =
     v.varInstance match {
       case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level)).pure[F]

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -1,8 +1,8 @@
-package coop.rchain.models.rholang.sort
+package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
 import coop.rchain.models.Par
-import coop.rchain.models.rholang.sort.ScoredTerm._
+import coop.rchain.models.rholang.sorter.ScoredTerm._
 import monix.eval.Coeval
 import cats.implicits._
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/package.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/package.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models.rholang
+
+package object sorter extends ScoreTree

--- a/models/src/test/scala/coop/rchain/models/LazyClue.scala
+++ b/models/src/test/scala/coop/rchain/models/LazyClue.scala
@@ -1,0 +1,12 @@
+package coop.rchain.models
+
+/**
+  * A workaround around scalatest's `assert` and `withClue` taking strict (non-lazy) parameters.
+  */
+class LazyClue(string: => String) {
+  override def toString: String = string
+}
+
+object LazyClue {
+  def apply(string: => String) = new LazyClue(string)
+}

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -2,6 +2,8 @@ package coop.rchain.models
 
 import com.google.protobuf.ByteString
 import coop.rchain.models.BitSetBytesMapper._
+import coop.rchain.models.Connective.ConnectiveInstance.{Empty => _}
+import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.testImplicits._
 import coop.rchain.rspace.Serialize
@@ -21,24 +23,58 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
   behavior of "Round-trip serialization"
 
   roundTripSerialization[Par]
+  roundTripSerialization[Expr]
   roundTripSerialization[Var]
   roundTripSerialization[Send]
   roundTripSerialization[Receive]
   roundTripSerialization[New]
-  //FIXME disabled till fixed
-  //roundTripSerialization[Expr]
   roundTripSerialization[Match]
   roundTripSerialization[ESet]
   roundTripSerialization[EMap]
 
-  def roundTripSerialization[A: Serialize: Arbitrary](implicit tag: ClassTag[A]): Unit =
+  def isExcluded(a: Any): Boolean = {
+    //This won't prevent such cases from being generated
+    //within the deeply-nested ast trees, but will make it much less likely.
+    //FIXME eradicate.
+    val exclusions: PartialFunction[Any, Boolean] = {
+      case Expr(EMapBody(_)) => true
+    }
+    exclusions.applyOrElse(a, { x: Any =>
+      false
+    })
+  }
+
+  def roundTripSerialization[A: Serialize: Arbitrary: Pretty](implicit tag: ClassTag[A]): Unit =
     it must s"work for ${tag.runtimeClass.getSimpleName}" in {
       forAll { a: A =>
-        val bytes  = Serialize[A].encode(a)
-        val result = Serialize[A].decode(bytes)
-        result should be(Right(a))
+        whenever(!isExcluded(a)) {
+          roundTripSerialization(a)
+        }
       }
     }
+
+  def roundTripSerialization[A: Serialize: Arbitrary: Pretty](a: A): Assertion = {
+    val bytes    = Serialize[A].encode(a)
+    val result   = Serialize[A].decode(bytes)
+    val expected = Right(a)
+
+    assert(
+      result == expected,
+      LazyClue(
+        s"""
+         |
+         |Actual value:
+         |
+         |${Pretty.pretty(result)}
+         |
+         |was not equal to expected:
+         |
+         |${Pretty.pretty(expected)}
+         |
+         |""".stripMargin
+      )
+    )
+  }
 }
 
 class BitSetBytesMapperTest extends FlatSpec with PropertyChecks with Matchers {

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -9,7 +9,7 @@ import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.BoundVar
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -4,6 +4,7 @@ import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
+import coop.rchain.models.rholang.SortTest.sort
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sorter._
 import monix.eval.Coeval
@@ -76,7 +77,7 @@ class VarSortMatcherSpec extends FlatSpec with Matchers {
       locallyFree = BitSet(0, 1, 2),
       connectiveUsed = true
     )
-    val result = SortTest.sort(parVars)
+    val result = sort(parVars)
     result.term should be(sortedParVars.get)
   }
 }
@@ -90,7 +91,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(GInt(2), GInt(1), GInt(-1), GInt(-2), GInt(0)))
     val sortedParGround: Option[Par] =
       Par(exprs = List(GInt(-2), GInt(-1), GInt(0), GInt(1), GInt(2)))
-    val result = SortTest.sort(parGround)
+    val result = sort(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -99,7 +100,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(GUri("https://www.rchain.coop/"), GInt(47), GString("Hello"), GBool(true)))
     val sortedParGround: Option[Par] =
       Par(exprs = List(GBool(true), GInt(47), GString("Hello"), GUri("https://www.rchain.coop/")))
-    val result = SortTest.sort(parGround)
+    val result = sort(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -122,7 +123,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           ParSet(Seq[Par](GInt(1), GInt(2)))
         )
       )
-    val result = SortTest.sort(parGround)
+    val result = sort(parGround)
     result.term should be(sortedParGround)
   }
 
@@ -138,14 +139,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     val sortedParGround: Par =
       ParMap(Seq[(Par, Par)]((GInt(1), GInt(1)), (GInt(2), GInt(1))))
 
-    val result = SortTest.sort(parGround)
+    val result = sort(parGround)
     result.term should be(sortedParGround)
   }
 
   it should "keep order when adding numbers" in {
     val parExpr: Par =
       EPlus(EPlus(GInt(1), GInt(3)), GInt(2))
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(parExpr.get)
   }
 
@@ -168,7 +169,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EMinus(GInt(4), GInt(3))
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -195,7 +196,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           ENeq(GInt(1), GInt(5))
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -216,7 +217,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EMethod("nth", EVar(BoundVar(2)), List(GInt(1)), locallyFree = BitSet(2))
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -239,7 +240,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EMethod("nth", EVar(BoundVar(2)), List(GInt(2), GInt(3)), locallyFree = BitSet(2))
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -262,7 +263,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Send(GInt(5), List(GInt(3)), true, BitSet())
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -341,7 +342,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Receive(List(ReceiveBind(List(GInt(0)), GInt(3))), Par(), true, 0, BitSet())
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -378,7 +379,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           Match(GInt(5), List(MatchCase(GInt(5), GInt(5)), MatchCase(GInt(4), GInt(4))), BitSet())
         )
       )
-    val result = SortTest.sort(parMatch)
+    val result = sort(parMatch)
     result.term should be(sortedParMatch.get)
   }
 
@@ -403,7 +404,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           New(bindCount = 2, p = Par())
         )
       )
-    val result = SortTest.sort(parNew)
+    val result = sort(parNew)
     result.term should be(sortedParNew.get)
   }
 
@@ -412,7 +413,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       Par(exprs = List(EVar(FreeVar(2)), EVar(FreeVar(1)), EVar(BoundVar(2)), EVar(BoundVar(1))))
     val sortedParGround: Option[Par] =
       Par(exprs = List(EVar(BoundVar(1)), EVar(BoundVar(2)), EVar(FreeVar(1)), EVar(FreeVar(2))))
-    val result = SortTest.sort(parGround)
+    val result = sort(parGround)
     result.term should be(sortedParGround.get)
   }
 
@@ -437,7 +438,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
           EOr(GBool(false), GBool(true))
         )
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr.get)
   }
 
@@ -464,7 +465,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
       )
 
     val bundle = Bundle(parExpr)
-    val result = SortTest.sort(bundle)
+    val result = sort(bundle)
     result.term should be(Bundle(sortedParExpr))
   }
 
@@ -497,7 +498,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
         readFlag = true
       )
     )
-    val result = SortTest.sort(nestedBundle)
+    val result = sort(nestedBundle)
     result.term should be(
       Bundle(
         Bundle(
@@ -570,7 +571,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
         ),
         connectiveUsed = true
       )
-    val result = SortTest.sort(parExpr)
+    val result = sort(parExpr)
     result.term should be(sortedParExpr)
   }
 }

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -16,23 +16,26 @@ object SortTest {
 }
 
 class ScoredTermSpec extends FlatSpec with Matchers {
-  "ScoredTerm" should "Sort so that shorter nodes come first" in {
+
+  behavior of "ScoredTerm"
+
+  it should "sort so that shorter nodes come first" in {
     val unsortedTerms =
       Seq(ScoredTerm("foo", Leaves(1, 2, 2, 3)), ScoredTerm("bar", Leaves(1, 2, 2)))
     val sortedTerms = Seq(ScoredTerm("bar", Leaves(1, 2, 2)), ScoredTerm("foo", Leaves(1, 2, 2, 3)))
     unsortedTerms.sorted should be(sortedTerms)
   }
-  "ScoredTerm" should "Sort so that smaller leafs stay first" in {
+  it should "sort so that smaller leafs stay first" in {
     val unsortedTerms = Seq(ScoredTerm("foo", Leaf(1)), ScoredTerm("bar", Leaf(2)))
     val sortedTerms   = Seq(ScoredTerm("foo", Leaf(1)), ScoredTerm("bar", Leaf(2)))
     unsortedTerms.sorted should be(sortedTerms)
   }
-  "ScoredTerm" should "Sort so that smaller leafs are put first" in {
+  it should "sort so that smaller leafs are put first" in {
     val unsortedTerms = Seq(ScoredTerm("foo", Leaf(2)), ScoredTerm("bar", Leaf(1)))
     val sortedTerms   = Seq(ScoredTerm("bar", Leaf(1)), ScoredTerm("foo", Leaf(2)))
     unsortedTerms.sorted should be(sortedTerms)
   }
-  "ScoredTerm" should "Sort so that smaller nodes are put first" in {
+  it should "sort so that smaller nodes are put first" in {
     val unsortedTerms = Seq(
       ScoredTerm("foo", Node(Seq(Leaves(1, 2), Leaves(2, 2)))),
       ScoredTerm("bar", Node(Seq(Leaves(1, 1), Leaves(2, 2))))
@@ -79,7 +82,10 @@ class VarSortMatcherSpec extends FlatSpec with Matchers {
 }
 
 class ParSortMatcherSpec extends FlatSpec with Matchers {
-  "Par" should "Sort so that smaller integers come first" in {
+
+  behavior of "Par"
+
+  it should "sort so that smaller integers come first" in {
     val parGround =
       Par(exprs = List(GInt(2), GInt(1), GInt(-1), GInt(-2), GInt(0)))
     val sortedParGround: Option[Par] =
@@ -88,7 +94,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround.get)
   }
 
-  "Par" should "Sort in order of boolean, int, string, uri" in {
+  it should "sort in order of boolean, int, string, uri" in {
     val parGround =
       Par(exprs = List(GUri("https://www.rchain.coop/"), GInt(47), GString("Hello"), GBool(true)))
     val sortedParGround: Option[Par] =
@@ -97,7 +103,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround.get)
   }
 
-  "Par" should "Sort and deduplicate sets insides" in {
+  it should "sort and deduplicate sets insides" in {
     val parGround: Par =
       ParSet(
         Seq[Par](
@@ -120,7 +126,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround)
   }
 
-  "Par" should "Sort map insides by key and last write should win" in {
+  it should "sort map insides by key and last write should win" in {
     val parGround: Par =
       ParMap(
         Seq[(Par, Par)](
@@ -136,14 +142,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround)
   }
 
-  "Par" should "Keep order when adding numbers" in {
+  it should "keep order when adding numbers" in {
     val parExpr: Par =
       EPlus(EPlus(GInt(1), GInt(3)), GInt(2))
     val result = SortTest.sort(parExpr)
     result.term should be(parExpr.get)
   }
 
-  "Par" should "Sort according to PEMDAS" in {
+  it should "sort according to PEMDAS" in {
     val parExpr =
       Par(
         exprs = List(
@@ -166,7 +172,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "Sort comparisons in order of LT, LTE, GT, GTE, EQ, NEQ" in {
+  it should "sort comparisons in order of LT, LTE, GT, GTE, EQ, NEQ" in {
     val parExpr =
       Par(
         exprs = List(
@@ -193,7 +199,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "sort methods after other expressions" in {
+  it should "sort methods after other expressions" in {
     val parExpr =
       Par(
         exprs = List(
@@ -214,7 +220,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "sort methods based on methodName, target, and arguments" in {
+  it should "sort methods based on methodName, target, and arguments" in {
     val parExpr =
       Par(
         exprs = List(
@@ -237,7 +243,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "Sort Sends based on their persistence, channel, data" in {
+  it should "sort Sends based on their persistence, channel, data" in {
     val parExpr =
       Par(
         sends = List(
@@ -260,7 +266,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "Sort Receives based on persistence, channels, patterns and then body" in {
+  it should "sort Receives based on persistence, channels, patterns and then body" in {
     val parExpr =
       Par(
         receives = List(
@@ -339,7 +345,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr.get)
   }
 
-  "Par" should "Sort Match based on their value and then cases" in {
+  it should "sort Match based on their value and then cases" in {
     val parMatch =
       Par(
         matches = List(
@@ -376,7 +382,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParMatch.get)
   }
 
-  "Par" should "Sort News based on bindCount, uri's and then body" in {
+  it should "sort News based on bindCount, uri's and then body" in {
     val parNew =
       Par(
         news = List(
@@ -401,7 +407,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParNew.get)
   }
 
-  "Par" should "Sort EVars based on their type and then levels" in {
+  it should "sort EVars based on their type and then levels" in {
     val parGround =
       Par(exprs = List(EVar(FreeVar(2)), EVar(FreeVar(1)), EVar(BoundVar(2)), EVar(BoundVar(1))))
     val sortedParGround: Option[Par] =
@@ -410,7 +416,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround.get)
   }
 
-  "Par" should "Sort exprs in order of ground, vars, arithmetic, comparisons, logical" in {
+  it should "sort exprs in order of ground, vars, arithmetic, comparisons, logical" in {
     val parExpr =
       Par(
         exprs = List(

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.rholang.sort._
+import coop.rchain.models.rholang.sorter._
 import monix.eval.Coeval
 import org.scalatest._
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -143,6 +143,18 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParGround)
   }
 
+  it should "use sorted subtrees and their scores in results" in {
+    val s1  = Send(Par())
+    val s2  = Send(Par(receives = List(Receive(List(), Par()))))
+    val p21 = Par(sends = List(s2, s1))
+    val p12 = Par(sends = List(s1, s2))
+
+    assume(p12 == sort(p12).term)
+    assume(p21 != sort(p21).term)
+    assert(sort(p12).term == sort(p21).term)
+    assert(sort(p12) == sort(p21)) //compare .score and all the other properties
+  }
+
   it should "keep order when adding numbers" in {
     val parExpr: Par =
       EPlus(EPlus(GInt(1), GInt(3)), GInt(2))

--- a/models/src/test/scala/coop/rchain/models/testImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/testImplicits.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.Expr.ExprInstance
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.Gen.{const, frequency, resize, sized}
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 
 import scala.collection.immutable.BitSet
 import monix.eval.Coeval

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,6 +58,7 @@ object Dependencies {
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "0.8.0"
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.6"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
+  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.9.1"
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.+"
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
-import coop.rchain.models.rholang.sort.Sortable
+import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
 import coop.rchain.rholang.interpreter.errors.{
   InterpreterError,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ReceiveBindsSortMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ReceiveBindsSortMatcher.scala
@@ -2,9 +2,9 @@ package coop.rchain.rholang.interpreter
 
 import cats.effect.Sync
 import coop.rchain.models.{Par, ReceiveBind, Var}
-import coop.rchain.models.rholang.sort.ReceiveSortMatcher.sortBind
+import coop.rchain.models.rholang.sorter.ReceiveSortMatcher.sortBind
 import cats.implicits._
-import coop.rchain.models.rholang.sort._
+import coop.rchain.models.rholang.sorter._
 import coop.rchain.models.rholang.implicits._
 
 object ReceiveBindsSortMatcher {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.rholang.sort._
+import coop.rchain.models.rholang.sorter._
 import coop.rchain.rholang.interpreter.accounting.{Chargeable, Cost, CostAccountingAlg}
 import coop.rchain.rholang.interpreter.errors.SubstituteError
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -22,7 +22,7 @@ import coop.rchain.models.rholang.implicits._
 import scala.collection.immutable.{BitSet, Vector}
 import scala.collection.convert.ImplicitConversionsToScala._
 import monix.eval.Coeval
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 
 sealed trait VarSort
 case object ProcSort extends VarSort

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -10,7 +10,7 @@ import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{
   _
 }
 import org.scalatest._
-import coop.rchain.models.rholang.sort.ordering._
+import coop.rchain.models.rholang.sorter.ordering._
 
 import scala.collection.immutable.BitSet
 import coop.rchain.models.Connective.ConnectiveInstance._

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -2,9 +2,9 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.rholang.sort.Sortable
+import coop.rchain.models.rholang.sorter.Sortable
 import org.scalatest.{FlatSpec, Matchers}
-import coop.rchain.models.rholang.sort.ScoredTerm
+import coop.rchain.models.rholang.sorter.ScoredTerm
 import monix.eval.Coeval
 
 import scala.collection.immutable.BitSet

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -7,7 +7,7 @@ import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
-import coop.rchain.models.rholang.sort.Sortable
+import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.PrettyPrinter
 import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccount}
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError


### PR DESCRIPTION
## Overview
Fixes a bug in Sorter where scores of unsorted trees were used in results.

This was caught by a generative test exercising roundtrip serialization.
We should probably have generative tests for the Sorter too.

Also provided is the `Pretty` typeclass, for pretty-printing objects to compiling Scala code. This is then used in the generative `RhoTypesTest` for having immediately actionable output on test failures.

### JIRA issue:
n/a

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.