### PR TITLE
RHOL-862: Prohibit interception of standard output and error

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -271,10 +271,10 @@ object Runtime {
     }
 
     val urnMap: Map[String, Par] = Map(
-      "rho:io:stdout"                -> FixedChannels.STDOUT,
-      "rho:io:stdoutAck"             -> FixedChannels.STDOUT_ACK,
-      "rho:io:stderr"                -> FixedChannels.STDERR,
-      "rho:io:stderrAck"             -> FixedChannels.STDERR_ACK,
+      "rho:io:stdout"                -> Bundle(FixedChannels.STDOUT, writeFlag = true),
+      "rho:io:stdoutAck"             -> Bundle(FixedChannels.STDOUT_ACK, writeFlag = true),
+      "rho:io:stderr"                -> Bundle(FixedChannels.STDERR, writeFlag = true),
+      "rho:io:stderrAck"             -> Bundle(FixedChannels.STDERR_ACK, writeFlag = true),
       "rho:registry:lookup"          -> FixedChannels.REG_LOOKUP,
       "rho:registry:insertArbitrary" -> FixedChannels.REG_INSERT_RANDOM
     )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -275,8 +275,8 @@ object Runtime {
       "rho:io:stdoutAck"             -> Bundle(FixedChannels.STDOUT_ACK, writeFlag = true),
       "rho:io:stderr"                -> Bundle(FixedChannels.STDERR, writeFlag = true),
       "rho:io:stderrAck"             -> Bundle(FixedChannels.STDERR_ACK, writeFlag = true),
-      "rho:registry:lookup"          -> FixedChannels.REG_LOOKUP,
-      "rho:registry:insertArbitrary" -> FixedChannels.REG_INSERT_RANDOM
+      "rho:registry:lookup"          -> Bundle(FixedChannels.REG_LOOKUP, writeFlag = true),
+      "rho:registry:insertArbitrary" -> Bundle(FixedChannels.REG_INSERT_RANDOM, writeFlag = true)
     )
 
     lazy val dispatchTable: RhoDispatchMap =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -14,35 +14,37 @@ class RuntimeSpec extends FlatSpec with Matchers {
 
   val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
-  val reduceError = "ReduceError: Trying to read from non-readable channel."
+  val channelReadOnlyError = "ReduceError: Trying to read from non-readable channel."
 
   "rho:io:stdout" should "not get intercepted" in {
-    val intercept =
-      """new s(`rho:io:stdout`) in { for(x <- s) { Nil } }"""
-
-    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
+    checkError("""new s(`rho:io:stdout`) in { for(x <- s) { Nil } }""", channelReadOnlyError)
   }
 
   "rho:io:stdoutAck" should "not get intercepted" in {
-    val intercept =
-      """new s(`rho:io:stdoutAck`) in { for(x <- s) { Nil } }"""
-
-    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
+    checkError("""new s(`rho:io:stdoutAck`) in { for(x <- s) { Nil } }""", channelReadOnlyError)
   }
 
   "rho:io:stderr" should "not get intercepted" in {
-    val intercept =
-      """new s(`rho:io:stderr`) in { for(x <- s) { Nil } }"""
-
-    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
+    checkError("""new s(`rho:io:stderr`) in { for(x <- s) { Nil } }""", channelReadOnlyError)
   }
 
   "rho:io:stderrAck" should "not get intercepted" in {
-    val intercept =
-      """new s(`rho:io:stderrAck`) in { for(x <- s) { Nil } }"""
-
-    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
+    checkError("""new s(`rho:io:stderrAck`) in { for(x <- s) { Nil } }""", channelReadOnlyError)
   }
+
+  "rho:registry:lookup" should "not get intercepted" in {
+    checkError("""new l(`rho:registry:lookup`) in { for(x <- l) { Nil } }""", channelReadOnlyError)
+  }
+
+  "rho:registry:insertArbitrary" should "not get intercepted" in {
+    checkError(
+      """new i(`rho:registry:insertArbitrary`) in { for(x <- i) { Nil } }""",
+      channelReadOnlyError
+    )
+  }
+
+  private def checkError(rho: String, error: String): Unit =
+    failure(rho).getMessage.stripLineEnd should endWith(error)
 
   private def failure(rho: String): Throwable =
     execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -1,0 +1,61 @@
+package coop.rchain.rholang.interpreter
+import java.io.StringReader
+import java.nio.file.Files
+
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class RuntimeSpec extends FlatSpec with Matchers {
+  val mapSize     = 10L * 1024L * 1024L
+  val tmpPrefix   = "rspace-store-"
+  val maxDuration = 5.seconds
+
+  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
+
+  "rho:io:stdout" should "not get intercepted" in {
+    val intercept =
+      """new stdout(`rho:io:stdout`) in { stdout!("foo", "bar") | for (...@x <- stdout) { stdout!(x) } }"""
+
+    failure(intercept).getMessage.stripLineEnd should endWith(
+      "ReduceError: Trying to read from non-readable channel."
+    )
+  }
+
+  "rho:io:stdoutAck" should "not get intercepted" in {
+    val intercept =
+      """new ackCh, stdoutAck(`rho:io:stdoutAck`) in { stdoutAck!("foo") | for (@x <- stdoutAck) { stdoutAck!(x, *ackCh) } }"""
+
+    failure(intercept).getMessage.stripLineEnd should endWith(
+      "ReduceError: Trying to read from non-readable channel."
+    )
+  }
+
+  "rho:io:stderr" should "not get intercepted" in {
+    val intercept =
+      """new stderr(`rho:io:stderr`) in { stderr!("foo", "bar") | for (...@x <- stderr) { stderr!(x) } }"""
+
+    failure(intercept).getMessage.stripLineEnd should endWith(
+      "ReduceError: Trying to read from non-readable channel."
+    )
+  }
+
+  "rho:io:stderrAck" should "not get intercepted" in {
+    val intercept =
+      """new ackCh, stderrAck(`rho:io:stderrAck`) in { stderrAck!("foo") | for (@x <- stderrAck) { stderrAck!(x, *ackCh) } }"""
+
+    failure(intercept).getMessage.stripLineEnd should endWith(
+      "ReduceError: Trying to read from non-readable channel."
+    )
+  }
+
+  private def failure(rho: String): Throwable =
+    execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))
+
+  private def execute(source: String): Either[Throwable, Runtime] =
+    Interpreter
+      .execute(runtime, new StringReader(source))
+      .attempt
+      .runSyncUnsafe(maxDuration)
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -14,40 +14,34 @@ class RuntimeSpec extends FlatSpec with Matchers {
 
   val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
+  val nonReadableErr = "ReduceError: Trying to read from non-readable channel."
+
   "rho:io:stdout" should "not get intercepted" in {
     val intercept =
       """new stdout(`rho:io:stdout`) in { stdout!("foo", "bar") | for (...@x <- stdout) { stdout!(x) } }"""
 
-    failure(intercept).getMessage.stripLineEnd should endWith(
-      "ReduceError: Trying to read from non-readable channel."
-    )
+    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
   }
 
   "rho:io:stdoutAck" should "not get intercepted" in {
     val intercept =
       """new ackCh, stdoutAck(`rho:io:stdoutAck`) in { stdoutAck!("foo") | for (@x <- stdoutAck) { stdoutAck!(x, *ackCh) } }"""
 
-    failure(intercept).getMessage.stripLineEnd should endWith(
-      "ReduceError: Trying to read from non-readable channel."
-    )
+    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
   }
 
   "rho:io:stderr" should "not get intercepted" in {
     val intercept =
       """new stderr(`rho:io:stderr`) in { stderr!("foo", "bar") | for (...@x <- stderr) { stderr!(x) } }"""
 
-    failure(intercept).getMessage.stripLineEnd should endWith(
-      "ReduceError: Trying to read from non-readable channel."
-    )
+    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
   }
 
   "rho:io:stderrAck" should "not get intercepted" in {
     val intercept =
       """new ackCh, stderrAck(`rho:io:stderrAck`) in { stderrAck!("foo") | for (@x <- stderrAck) { stderrAck!(x, *ackCh) } }"""
 
-    failure(intercept).getMessage.stripLineEnd should endWith(
-      "ReduceError: Trying to read from non-readable channel."
-    )
+    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
   }
 
   private def failure(rho: String): Throwable =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -1,10 +1,15 @@
 package coop.rchain.rholang.interpreter
-import java.io.StringReader
 import java.nio.file.Files
 
+import coop.rchain.models.Expr.ExprInstance.EVarBody
+import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
+import coop.rchain.models._
+import coop.rchain.rholang.interpreter.Interpreter.EvaluateResult
+import coop.rchain.rholang.interpreter.errors.ReduceError
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.collection.immutable.BitSet
 import scala.concurrent.duration._
 
 class RuntimeSpec extends FlatSpec with Matchers {
@@ -14,42 +19,362 @@ class RuntimeSpec extends FlatSpec with Matchers {
 
   val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
-  val nonReadableErr = "ReduceError: Trying to read from non-readable channel."
+  val nonReadableErr = ReduceError("Trying to read from non-readable channel.")
 
   "rho:io:stdout" should "not get intercepted" in {
-    val intercept =
-      """new stdout(`rho:io:stdout`) in { stdout!("foo", "bar") | for (...@x <- stdout) { stdout!(x) } }"""
+    // new s(`rho:io:stdout`) in { for (x <- s) { Nil } }
+    val interceptNormalized = Par(
+      List(),
+      List(),
+      List(
+        New(
+          1,
+          Par(
+            List(),
+            List(
+              Receive(
+                List(
+                  ReceiveBind(
+                    List(
+                      Par(
+                        List(),
+                        List(),
+                        List(),
+                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
+                        List(),
+                        List(),
+                        List(),
+                        List(),
+                        AlwaysEqual(BitSet()),
+                        true
+                      )
+                    ),
+                    Par(
+                      List(),
+                      List(),
+                      List(),
+                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
+                      List(),
+                      List(),
+                      List(),
+                      List(),
+                      AlwaysEqual(BitSet(0)),
+                      false
+                    ),
+                    None,
+                    1
+                  )
+                ),
+                Par(
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  Vector(),
+                  List(),
+                  List(),
+                  AlwaysEqual(BitSet()),
+                  false
+                ),
+                false,
+                1,
+                AlwaysEqual(BitSet(0)),
+                false
+              )
+            ),
+            List(),
+            List(),
+            List(),
+            Vector(),
+            List(),
+            List(),
+            AlwaysEqual(BitSet(0)),
+            false
+          ),
+          Vector("rho:io:stdout"),
+          AlwaysEqual(BitSet())
+        )
+      ),
+      List(),
+      List(),
+      Vector(),
+      List(),
+      List(),
+      AlwaysEqual(BitSet()),
+      false
+    )
 
-    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
+    failure(interceptNormalized) should contain(nonReadableErr)
   }
 
   "rho:io:stdoutAck" should "not get intercepted" in {
-    val intercept =
-      """new ackCh, stdoutAck(`rho:io:stdoutAck`) in { stdoutAck!("foo") | for (@x <- stdoutAck) { stdoutAck!(x, *ackCh) } }"""
+    // new s(`rho:io:stdoutAck`) in { for (x <- s) { Nil } }
+    val interceptNormalized = Par(
+      List(),
+      List(),
+      List(
+        New(
+          1,
+          Par(
+            List(),
+            List(
+              Receive(
+                List(
+                  ReceiveBind(
+                    List(
+                      Par(
+                        List(),
+                        List(),
+                        List(),
+                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
+                        List(),
+                        List(),
+                        List(),
+                        List(),
+                        AlwaysEqual(BitSet()),
+                        true
+                      )
+                    ),
+                    Par(
+                      List(),
+                      List(),
+                      List(),
+                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
+                      List(),
+                      List(),
+                      List(),
+                      List(),
+                      AlwaysEqual(BitSet(0)),
+                      false
+                    ),
+                    None,
+                    1
+                  )
+                ),
+                Par(
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  Vector(),
+                  List(),
+                  List(),
+                  AlwaysEqual(BitSet()),
+                  false
+                ),
+                false,
+                1,
+                AlwaysEqual(BitSet(0)),
+                false
+              )
+            ),
+            List(),
+            List(),
+            List(),
+            Vector(),
+            List(),
+            List(),
+            AlwaysEqual(BitSet(0)),
+            false
+          ),
+          Vector("rho:io:stdoutAck"),
+          AlwaysEqual(BitSet())
+        )
+      ),
+      List(),
+      List(),
+      Vector(),
+      List(),
+      List(),
+      AlwaysEqual(BitSet()),
+      false
+    )
 
-    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
+    failure(interceptNormalized) should contain(nonReadableErr)
   }
 
   "rho:io:stderr" should "not get intercepted" in {
-    val intercept =
-      """new stderr(`rho:io:stderr`) in { stderr!("foo", "bar") | for (...@x <- stderr) { stderr!(x) } }"""
+    // new s(`rho:io:stderr`) in { for(x <- s) { Nil } }
+    val interceptNormalized = Par(
+      List(),
+      List(),
+      List(
+        New(
+          1,
+          Par(
+            List(),
+            List(
+              Receive(
+                List(
+                  ReceiveBind(
+                    List(
+                      Par(
+                        List(),
+                        List(),
+                        List(),
+                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
+                        List(),
+                        List(),
+                        List(),
+                        List(),
+                        AlwaysEqual(BitSet()),
+                        true
+                      )
+                    ),
+                    Par(
+                      List(),
+                      List(),
+                      List(),
+                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
+                      List(),
+                      List(),
+                      List(),
+                      List(),
+                      AlwaysEqual(BitSet(0)),
+                      false
+                    ),
+                    None,
+                    1
+                  )
+                ),
+                Par(
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  Vector(),
+                  List(),
+                  List(),
+                  AlwaysEqual(BitSet()),
+                  false
+                ),
+                false,
+                1,
+                AlwaysEqual(BitSet(0)),
+                false
+              )
+            ),
+            List(),
+            List(),
+            List(),
+            Vector(),
+            List(),
+            List(),
+            AlwaysEqual(BitSet(0)),
+            false
+          ),
+          Vector("rho:io:stderr"),
+          AlwaysEqual(BitSet())
+        )
+      ),
+      List(),
+      List(),
+      Vector(),
+      List(),
+      List(),
+      AlwaysEqual(BitSet()),
+      false
+    )
 
-    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
+    failure(interceptNormalized) should contain(nonReadableErr)
   }
 
   "rho:io:stderrAck" should "not get intercepted" in {
-    val intercept =
-      """new ackCh, stderrAck(`rho:io:stderrAck`) in { stderrAck!("foo") | for (@x <- stderrAck) { stderrAck!(x, *ackCh) } }"""
+    // new s(`rho:io:stderrAck`) in { for (x <- s) { Nil } }
+    val interceptNormalized = Par(
+      List(),
+      List(),
+      List(
+        New(
+          1,
+          Par(
+            List(),
+            List(
+              Receive(
+                List(
+                  ReceiveBind(
+                    List(
+                      Par(
+                        List(),
+                        List(),
+                        List(),
+                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
+                        List(),
+                        List(),
+                        List(),
+                        List(),
+                        AlwaysEqual(BitSet()),
+                        true
+                      )
+                    ),
+                    Par(
+                      List(),
+                      List(),
+                      List(),
+                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
+                      List(),
+                      List(),
+                      List(),
+                      List(),
+                      AlwaysEqual(BitSet(0)),
+                      false
+                    ),
+                    None,
+                    1
+                  )
+                ),
+                Par(
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  List(),
+                  Vector(),
+                  List(),
+                  List(),
+                  AlwaysEqual(BitSet()),
+                  false
+                ),
+                false,
+                1,
+                AlwaysEqual(BitSet(0)),
+                false
+              )
+            ),
+            List(),
+            List(),
+            List(),
+            Vector(),
+            List(),
+            List(),
+            AlwaysEqual(BitSet(0)),
+            false
+          ),
+          Vector("rho:io:stderrAck"),
+          AlwaysEqual(BitSet())
+        )
+      ),
+      List(),
+      List(),
+      Vector(),
+      List(),
+      List(),
+      AlwaysEqual(BitSet()),
+      false
+    )
 
-    failure(intercept).getMessage.stripLineEnd should endWith(nonReadableErr)
+    failure(interceptNormalized) should contain(nonReadableErr)
   }
 
-  private def failure(rho: String): Throwable =
-    execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))
+  private def failure(normalized: Par): Vector[Throwable] =
+    evaluate(normalized).right.get.errors
 
-  private def execute(source: String): Either[Throwable, Runtime] =
+  private def evaluate(normalized: Par): Either[Throwable, EvaluateResult] =
     Interpreter
-      .execute(runtime, new StringReader(source))
+      .evaluate(runtime, normalized)
       .attempt
       .runSyncUnsafe(maxDuration)
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -1,15 +1,10 @@
 package coop.rchain.rholang.interpreter
+import java.io.StringReader
 import java.nio.file.Files
 
-import coop.rchain.models.Expr.ExprInstance.EVarBody
-import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar}
-import coop.rchain.models._
-import coop.rchain.rholang.interpreter.Interpreter.EvaluateResult
-import coop.rchain.rholang.interpreter.errors.ReduceError
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.collection.immutable.BitSet
 import scala.concurrent.duration._
 
 class RuntimeSpec extends FlatSpec with Matchers {
@@ -19,362 +14,42 @@ class RuntimeSpec extends FlatSpec with Matchers {
 
   val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
-  val nonReadableErr = ReduceError("Trying to read from non-readable channel.")
+  val reduceError = "ReduceError: Trying to read from non-readable channel."
 
   "rho:io:stdout" should "not get intercepted" in {
-    // new s(`rho:io:stdout`) in { for (x <- s) { Nil } }
-    val interceptNormalized = Par(
-      List(),
-      List(),
-      List(
-        New(
-          1,
-          Par(
-            List(),
-            List(
-              Receive(
-                List(
-                  ReceiveBind(
-                    List(
-                      Par(
-                        List(),
-                        List(),
-                        List(),
-                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
-                        List(),
-                        List(),
-                        List(),
-                        List(),
-                        AlwaysEqual(BitSet()),
-                        true
-                      )
-                    ),
-                    Par(
-                      List(),
-                      List(),
-                      List(),
-                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
-                      List(),
-                      List(),
-                      List(),
-                      List(),
-                      AlwaysEqual(BitSet(0)),
-                      false
-                    ),
-                    None,
-                    1
-                  )
-                ),
-                Par(
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  Vector(),
-                  List(),
-                  List(),
-                  AlwaysEqual(BitSet()),
-                  false
-                ),
-                false,
-                1,
-                AlwaysEqual(BitSet(0)),
-                false
-              )
-            ),
-            List(),
-            List(),
-            List(),
-            Vector(),
-            List(),
-            List(),
-            AlwaysEqual(BitSet(0)),
-            false
-          ),
-          Vector("rho:io:stdout"),
-          AlwaysEqual(BitSet())
-        )
-      ),
-      List(),
-      List(),
-      Vector(),
-      List(),
-      List(),
-      AlwaysEqual(BitSet()),
-      false
-    )
+    val intercept =
+      """new s(`rho:io:stdout`) in { for(x <- s) { Nil } }"""
 
-    failure(interceptNormalized) should contain(nonReadableErr)
+    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
   }
 
   "rho:io:stdoutAck" should "not get intercepted" in {
-    // new s(`rho:io:stdoutAck`) in { for (x <- s) { Nil } }
-    val interceptNormalized = Par(
-      List(),
-      List(),
-      List(
-        New(
-          1,
-          Par(
-            List(),
-            List(
-              Receive(
-                List(
-                  ReceiveBind(
-                    List(
-                      Par(
-                        List(),
-                        List(),
-                        List(),
-                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
-                        List(),
-                        List(),
-                        List(),
-                        List(),
-                        AlwaysEqual(BitSet()),
-                        true
-                      )
-                    ),
-                    Par(
-                      List(),
-                      List(),
-                      List(),
-                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
-                      List(),
-                      List(),
-                      List(),
-                      List(),
-                      AlwaysEqual(BitSet(0)),
-                      false
-                    ),
-                    None,
-                    1
-                  )
-                ),
-                Par(
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  Vector(),
-                  List(),
-                  List(),
-                  AlwaysEqual(BitSet()),
-                  false
-                ),
-                false,
-                1,
-                AlwaysEqual(BitSet(0)),
-                false
-              )
-            ),
-            List(),
-            List(),
-            List(),
-            Vector(),
-            List(),
-            List(),
-            AlwaysEqual(BitSet(0)),
-            false
-          ),
-          Vector("rho:io:stdoutAck"),
-          AlwaysEqual(BitSet())
-        )
-      ),
-      List(),
-      List(),
-      Vector(),
-      List(),
-      List(),
-      AlwaysEqual(BitSet()),
-      false
-    )
+    val intercept =
+      """new s(`rho:io:stdoutAck`) in { for(x <- s) { Nil } }"""
 
-    failure(interceptNormalized) should contain(nonReadableErr)
+    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
   }
 
   "rho:io:stderr" should "not get intercepted" in {
-    // new s(`rho:io:stderr`) in { for(x <- s) { Nil } }
-    val interceptNormalized = Par(
-      List(),
-      List(),
-      List(
-        New(
-          1,
-          Par(
-            List(),
-            List(
-              Receive(
-                List(
-                  ReceiveBind(
-                    List(
-                      Par(
-                        List(),
-                        List(),
-                        List(),
-                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
-                        List(),
-                        List(),
-                        List(),
-                        List(),
-                        AlwaysEqual(BitSet()),
-                        true
-                      )
-                    ),
-                    Par(
-                      List(),
-                      List(),
-                      List(),
-                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
-                      List(),
-                      List(),
-                      List(),
-                      List(),
-                      AlwaysEqual(BitSet(0)),
-                      false
-                    ),
-                    None,
-                    1
-                  )
-                ),
-                Par(
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  Vector(),
-                  List(),
-                  List(),
-                  AlwaysEqual(BitSet()),
-                  false
-                ),
-                false,
-                1,
-                AlwaysEqual(BitSet(0)),
-                false
-              )
-            ),
-            List(),
-            List(),
-            List(),
-            Vector(),
-            List(),
-            List(),
-            AlwaysEqual(BitSet(0)),
-            false
-          ),
-          Vector("rho:io:stderr"),
-          AlwaysEqual(BitSet())
-        )
-      ),
-      List(),
-      List(),
-      Vector(),
-      List(),
-      List(),
-      AlwaysEqual(BitSet()),
-      false
-    )
+    val intercept =
+      """new s(`rho:io:stderr`) in { for(x <- s) { Nil } }"""
 
-    failure(interceptNormalized) should contain(nonReadableErr)
+    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
   }
 
   "rho:io:stderrAck" should "not get intercepted" in {
-    // new s(`rho:io:stderrAck`) in { for (x <- s) { Nil } }
-    val interceptNormalized = Par(
-      List(),
-      List(),
-      List(
-        New(
-          1,
-          Par(
-            List(),
-            List(
-              Receive(
-                List(
-                  ReceiveBind(
-                    List(
-                      Par(
-                        List(),
-                        List(),
-                        List(),
-                        List(Expr(EVarBody(EVar(Var(FreeVar(0)))))),
-                        List(),
-                        List(),
-                        List(),
-                        List(),
-                        AlwaysEqual(BitSet()),
-                        true
-                      )
-                    ),
-                    Par(
-                      List(),
-                      List(),
-                      List(),
-                      List(Expr(EVarBody(EVar(Var(BoundVar(0)))))),
-                      List(),
-                      List(),
-                      List(),
-                      List(),
-                      AlwaysEqual(BitSet(0)),
-                      false
-                    ),
-                    None,
-                    1
-                  )
-                ),
-                Par(
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  List(),
-                  Vector(),
-                  List(),
-                  List(),
-                  AlwaysEqual(BitSet()),
-                  false
-                ),
-                false,
-                1,
-                AlwaysEqual(BitSet(0)),
-                false
-              )
-            ),
-            List(),
-            List(),
-            List(),
-            Vector(),
-            List(),
-            List(),
-            AlwaysEqual(BitSet(0)),
-            false
-          ),
-          Vector("rho:io:stderrAck"),
-          AlwaysEqual(BitSet())
-        )
-      ),
-      List(),
-      List(),
-      Vector(),
-      List(),
-      List(),
-      AlwaysEqual(BitSet()),
-      false
-    )
+    val intercept =
+      """new s(`rho:io:stderrAck`) in { for(x <- s) { Nil } }"""
 
-    failure(interceptNormalized) should contain(nonReadableErr)
+    failure(intercept).getMessage.stripLineEnd should endWith(reduceError)
   }
 
-  private def failure(normalized: Par): Vector[Throwable] =
-    evaluate(normalized).right.get.errors
+  private def failure(rho: String): Throwable =
+    execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))
 
-  private def evaluate(normalized: Par): Either[Throwable, EvaluateResult] =
+  private def execute(source: String): Either[Throwable, Runtime] =
     Interpreter
-      .evaluate(runtime, normalized)
+      .execute(runtime, new StringReader(source))
       .attempt
       .runSyncUnsafe(maxDuration)
 }


### PR DESCRIPTION
## Overview
Prohibits interception of `stdout`, `stdoutAck`, `stderr` and `stderrAck` by making them write-only bundles.
Stole test functions from `InterpreterSpec` and created a `RuntimeSpec`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-862

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR