### PR TITLE
Add Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,102 @@
+branches:
+  - dev
+  - master
+  - release-*
+  - testing*
+
+# Common parts
+
+# FYI: There's no merging of arrays in YAML. At least not in the Go library
+# Drone uses to parse YAML. So if you mix in &sbtenv and want to add
+# additional volumes, as in package step, you need to specify all volumes.
+
+__buildenv: &buildenv
+  image: rchain/buildenv:latest-java8
+
+__sbtenv: &sbtenv
+  <<: *buildenv
+  environment:
+    - _JAVA_OPTIONS=-Xms2G -Xmx4G -XX:MaxMetaspaceSize=1G
+  volumes:
+    - /var/cache/rchain-build/.sbt:/root/.sbt
+    - /var/cache/rchain-build/.ivy2:/root/.ivy2
+
+# Build definition
+
+clone:
+  git-clone:
+    image: plugins/git:next
+
+pipeline:
+
+  # pr
+
+  sbt-update:
+    <<: *sbtenv
+    commands:
+      - sbt update
+
+  compile:
+    <<: *sbtenv
+    commands:
+      - sbt rholang/bnfc:generate compile test:compile it:compile
+
+  run-unit-tests:
+    <<: *sbtenv
+    commands:
+      - sbt test it:test
+
+  run-code-analysis:
+    <<: *sbtenv
+    commands:
+      - sbt scalafmtCheck coverage
+      - ./scripts/ci/codecov-upload
+
+  # push
+
+  package:
+    <<: *sbtenv
+    commands:
+      - sbt node/docker:publishLocal node/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball
+    volumes:
+      - /var/cache/rchain-build/.sbt:/root/.sbt
+      - /var/cache/rchain-build/.ivy2:/root/.ivy2
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      event: push
+
+  run-integration-tests:
+    <<: *buildenv
+    commands:
+      - ./scripts/ci/run-p2p-test
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+    when:
+      event: push
+
+  publish:
+    <<: *buildenv
+    commands:
+      - ./scripts/ci/publish-artifacts
+    secrets:
+      - docker_username
+      - docker_password
+      - ssh_private_key
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    when:
+      event: push
+
+  notify:
+    <<: *buildenv
+    commands:
+      - ./scripts/ci/send-email
+    secrets:
+      - email_host
+      - email_username
+      - email_password
+      - email_recipients
+    when:
+      event: push
+      status: [ changed, failure ]

--- a/scripts/ci/codecov-upload
+++ b/scripts/ci/codecov-upload
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+for d in block-storage casper crypto comm rholang roscala node rspace shared; do
+	codecov -X gcov -s ./$d -c -F ${d//-}
+done

--- a/scripts/ci/publish-artifacts
+++ b/scripts/ci/publish-artifacts
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -eo pipefail
+
+if [[ -n $DRONE_TAG ]]; then
+	REF=$DRONE_TAG
+	TAG=1
+elif [[ -n $DRONE_BRANCH ]]; then
+	REF=$DRONE_BRANCH
+	TAG=0
+else
+	# Like, really. It'll overwrite your SSH key.
+	echo "This script doesn't work outside of Drone" >&2
+	exit 1
+fi
+
+# Upload packages to repo.pyr8.io
+
+(
+umask 077
+mkdir -p ~/.ssh
+echo "$SSH_PRIVATE_KEY" | base64 -d | tr -d '\r' >~/.ssh/id_rsa
+)
+
+# We don't check host keys because artifacts are public.
+rsync -avrz --delete \
+	-e "ssh -p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+	node/target/rnode_*_all.deb \
+	node/target/rpm/RPMS/noarch/rnode-*.noarch.rpm \
+	node/target/universal/*.tgz \
+	inbound@dispatch.pyr8.io:/home/inbound/cd/artifacts/$REF/
+
+# Upload Docker image
+
+builtin echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+docker tag coop.rchain/rnode:latest rchain/rnode:$REF
+docker push rchain/rnode:$REF
+if [[ $TAG == 1 ]]; then
+	docker tag coop.rchain/rnode:latest rchain/rnode:latest
+	docker push rchain/rnode:latest
+fi

--- a/scripts/ci/run-p2p-test
+++ b/scripts/ci/run-p2p-test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NET=t$DRONE_BUILD_NUMBER.rchain.coop
+PEERCMD="run --bootstrap rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.${NET}?protocol=40400&discovery=40404"
+
+python3 -u ./scripts/p2p-test-tool.py -bt -p2 -m2048m -n$NET --peer-command "$PEERCMD"
+rc=$?
+./scripts/p2p-test-tool.py -n$NET -r
+exit $rc

--- a/scripts/ci/send-email
+++ b/scripts/ci/send-email
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+import os
+from smtplib import SMTP
+from email.mime.text import MIMEText
+
+repo = os.environ['DRONE_REPO_NAME']
+if 'DRONE_TAG' in os.environ:
+    ref = os.environ['DRONE_TAG']
+else:
+    ref = os.environ['DRONE_BRANCH']
+bn = os.environ['DRONE_BUILD_NUMBER']
+
+msg = MIMEText(
+f'''See {os.environ['DRONE_BUILD_LINK']}
+
+-- 
+Hi Developer. Whaaat's happening? Listen. I'm gonna need you to fix
+your broken code. So if you could just go ahead and make sure it
+builds again, that'd be terrific. OK? Thanks!
+''')
+msg['From'] = 'Pyrofex Drone <noreply-ci@pyr8.io>'
+msg['To'] = os.environ['EMAIL_RECIPIENTS']
+msg['Subject'] = f'''Build {bn} of {repo}:{ref} FAILED'''
+
+with SMTP(os.environ['EMAIL_HOST'], 587) as smtp:
+    smtp.starttls()
+    smtp.login(os.environ['EMAIL_USERNAME'], os.environ['EMAIL_PASSWORD'])
+    smtp.send_message(msg)
+    smtp.quit()

--- a/scripts/p2p-test-tool.py
+++ b/scripts/p2p-test-tool.py
@@ -10,6 +10,7 @@ import subprocess
 import argparse
 import docker
 import os
+import shutil
 import tempfile
 import requests
 import re
@@ -130,7 +131,8 @@ args = parser.parse_args()
 client = docker.from_env()
 RNODE_CMD = '/opt/docker/bin/rnode'
 # bonds_file = f'/tmp/bonds.{args.network}' alternate when dynamic bonds.txt creation/manpiulation file works
-bonds_file = os.path.dirname(os.path.realpath(__file__)) + '/demo-bonds.txt'
+src_bonds_file = os.path.dirname(os.path.realpath(__file__)) + '/demo-bonds.txt'
+bonds_file = f'/tmp/rnode_{args.network}_bonds.txt'
 container_bonds_file = f'{args.rnode_directory}/genesis/bonds.txt'
 
 
@@ -446,6 +448,7 @@ def create_empty_bonds_file():
 
 def boot_p2p_network():
     try:
+        shutil.copyfile(src_bonds_file, bonds_file)
         client.networks.create(args.network, driver="bridge")
         print("Starting bootstrap node.")
         # create_empty_bonds_file() # disabled until python generated keys work
@@ -631,8 +634,8 @@ def create_bootstrap_node():
         "VkEqI2rycmgp03DXsStJ7IGdBQ==\n"
         "-----END CERTIFICATE-----\n"
     )
-    tmp_file_key = '/tmp/node.key.pem'
-    tmp_file_cert = '/tmp/node.certificate.pem'
+    tmp_file_key = '/tmp/rnode_{args.network}_node.key.pem'
+    tmp_file_cert = '/tmp/rnode_{args.network}_node.certificate.pem'
     with open(tmp_file_key, 'w') as f:
         f.write(bootstrap_node_demo_key)
     with open(tmp_file_cert, 'w') as f:


### PR DESCRIPTION
This adds Drone CI configuration and scripts. There are small tweaks to p2p-test-tool to allow concurrent executions. After this gets merged, PRs will be tested until unit tests and merges will be tested until the end.

CI can be reached https://drone.pyr8.io/ here. Members of rchain GitHub organization should have access.

There's a problem with some unit test failing. Pipeline is set to continue even if some unit tests fail for now. Please see e.g. https://drone.pyr8.io/woky/rchain-testci/83/5 for failures.

EDIT: There're no test failures. See comments in RHOL-898.