### PR TITLE
Fix non-deterministic test failure caused by lack of reAttempt

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -1,12 +1,22 @@
 package coop.rchain.casper
 
-sealed trait BlockStatus
+sealed trait BlockStatus {
+  val inDag: Boolean
+}
 
-case object Processing                   extends BlockStatus
-case class BlockException(ex: Throwable) extends BlockStatus
+case object Processing extends BlockStatus {
+  override val inDag: Boolean = false
+}
+case class BlockException(ex: Throwable) extends BlockStatus {
+  override val inDag: Boolean = false
+}
 
-sealed trait ValidBlock   extends BlockStatus
-sealed trait InvalidBlock extends BlockStatus
+sealed trait ValidBlock extends BlockStatus {
+  override val inDag: Boolean = true
+}
+sealed trait InvalidBlock extends BlockStatus {
+  override val inDag: Boolean = true
+}
 sealed trait Slashable
 
 case object Valid extends ValidBlock

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -554,21 +554,75 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
       dependencyFreeBlocks = blockBuffer
         .filter(block => dependencyFree.contains(block.blockHash))
         .toList
-      attempts <- dependencyFreeBlocks.traverse(b => attemptAdd(b))
+      attempts <- dependencyFreeBlocks.traverse { b =>
+                   for {
+                     status <- attemptAdd(b)
+                   } yield (b, status)
+                 }
       _ <- if (attempts.isEmpty) {
             ().pure[F]
           } else {
-            Capture[F].capture {
-              dependencyFreeBlocks.map {
-                blockBuffer -= _
-              }
-            } *>
-              blockBufferDependencyDagState.set(dependencyFree.foldLeft(blockBufferDependencyDag) {
-                case (acc, hash) =>
-                  DoublyLinkedDagOperations.remove(acc, hash)
-              }) *> reAttemptBuffer
+            for {
+              _ <- removeAdded(blockBufferDependencyDag, attempts)
+              _ <- reAttemptBuffer
+            } yield ()
           }
     } yield ()
+
+  private def removeAdded(
+      blockBufferDependencyDag: DoublyLinkedDag[BlockHash],
+      attempts: List[(BlockMessage, BlockStatus)]
+  ): F[Unit] =
+    for {
+      successfulAdds <- attempts
+                         .filter {
+                           case (_, status) => successfulAddStatus(status)
+                         }
+                         .pure[F]
+      _ <- unsafeRemoveFromBlockBuffer(successfulAdds)
+      _ <- removeFromBlockBufferDependencyDag(blockBufferDependencyDag, successfulAdds)
+    } yield ()
+
+  private def unsafeRemoveFromBlockBuffer(
+      successfulAdds: List[(BlockMessage, BlockStatus)]
+  ): F[Unit] =
+    Sync[F].delay {
+      successfulAdds.map {
+        blockBuffer -= _._1
+      }
+      ()
+    }
+
+  private def removeFromBlockBufferDependencyDag(
+      blockBufferDependencyDag: DoublyLinkedDag[BlockHash],
+      successfulAdds: List[(BlockMessage, BlockStatus)]
+  ): F[Unit] =
+    blockBufferDependencyDagState.set(
+      successfulAdds.foldLeft(blockBufferDependencyDag) {
+        case (acc, successfulAdd) =>
+          DoublyLinkedDagOperations.remove(acc, successfulAdd._1.blockHash)
+      }
+    )
+
+  private def successfulAddStatus(status: BlockStatus): Boolean =
+    status == Valid ||
+      status == AdmissibleEquivocation ||
+      status == IgnorableEquivocation ||
+      status == InvalidUnslashableBlock ||
+      status == MissingBlocks ||
+      status == InvalidBlockNumber ||
+      status == InvalidRepeatDeploy ||
+      status == InvalidParents ||
+      status == InvalidFollows ||
+      status == InvalidSequenceNumber ||
+      status == InvalidShardId ||
+      status == JustificationRegression ||
+      status == NeglectedInvalidBlock ||
+      status == NeglectedEquivocation ||
+      status == InvalidTransaction ||
+      status == InvalidBondsCache ||
+      status == InvalidBlockHash ||
+      status == InvalidDeployCount
 
   def getRuntimeManager: F[Option[RuntimeManager]] = Applicative[F].pure(Some(runtimeManager))
 }


### PR DESCRIPTION
There are two problems this PR fixes:

1) We previously removed block hashes that were dependency free that
weren't yet in the block buffer. Thus when the block B actually came in
any block that depended on B might have not been triggered to be added.

2) We forgot that when we added the "processing" BlockStatus that now this
makes it such that some blocks may fail on reAttempt even though they
are dependencyFree. So while it is a bit ugly, we whitelist instead of
blacklist which blocks get successfully added during a reAttempt call.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

https://rchain.atlassian.net/browse/RHOL-944