### PR TITLE
[No-Ticket] Updated Windows build docs and rnode.toml

### DIFF
--- a/docs/windows/WindowsBuild.md
+++ b/docs/windows/WindowsBuild.md
@@ -1,6 +1,7 @@
 # RNode windows build
 ## Important
-Currently some errors inside coop.rchain.kalium-0.8.1-SNAPSHOT.jar blocks starting of the node. We will update this guide as soon as those issues will be fixed.
+During windows build you may see the following error: "java.util.regex.PatternSyntaxException: Unclosed group near index 9". This is an issue inside scalamft formatter, https://github.com/scalameta/sbt-scalafmt/issues/5
+To fix it just disable scalafmt: find "scalafmtOnCompile := true" line in the "build.sbt" file, and replace "true" with "false".
 
 ## 1. Install Haskell Platform
 https://www.haskell.org/platform/

--- a/docs/windows/rnode.toml
+++ b/docs/windows/rnode.toml
@@ -1,13 +1,13 @@
 [server]
 host = "localhost"
 port = 44010
-metrics-port = 44011
+http-port = 44011
 no-upnp = false
 default-timeout = 5000
 # to choose right address please read:
 # https://rchain.atlassian.net/wiki/spaces/CORE/pages/501842019/RNode+bootstrap+addresses
-bootstrap = "rnode://c61769b39d368cbcbc9499634e030386c79d5b02@52.119.8.108:40400"
-standalone = true
+bootstrap = "rnode://c61769b39d368cbcbc9499634e030386c79d5b02@52.119.8.108?protocol=40400&discovery=40404"
+standalone = false
 data-dir = "C:/RChain/data"
 map-size = 200000000
 in-memory-store = false
@@ -28,4 +28,3 @@ key = "C:/RChain/ssl/node.key.pem"
 # private-key = "99999"
 # sig-algorithm = "ed25519"
 # wallets-file = "/validator/wallet"
-


### PR DESCRIPTION
## Overview
Latest rnode from dev branch can be built and run on windows, however docs and .toml file were outdated.