### PR TITLE
Handle any exceptions that bubble up to the GRPC server

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -73,15 +73,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     result
   }
 
-  def computeBonds(hash: StateHash)(implicit scheduler: Scheduler): Seq[Bond] =
-    Try(unsafeComputeBonds(hash)) match {
-      case Success(value) => value
-      case Failure(ex) =>
-        ex.printStackTrace()
-        throw ex
-    }
-
-  private def unsafeComputeBonds(hash: StateHash)(implicit scheduler: Scheduler): Seq[Bond] = {
+  def computeBonds(hash: StateHash)(implicit scheduler: Scheduler): Seq[Bond] = {
     // TODO: Switch to a read only name
     val bondsQuery =
       """for(@pos <- @"proofOfStake"){ @(pos, "getBonds")!("__SCALA__") }"""

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -2,6 +2,7 @@ package coop.rchain.node.api
 
 import cats.effect.Sync
 
+import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.SafetyOracle
@@ -24,7 +25,10 @@ private[api] object DeployGrpcService {
     new CasperMessageGrpcMonix.DeployService {
 
       private def defer[A](task: F[A]): Task[A] =
-        Task.defer(task.toTask).executeOn(worker)
+        Task.defer(task.toTask).executeOn(worker).attempt.flatMap {
+          case Left(ex)      => Task.delay(ex.printStackTrace()) *> Task.raiseError[A](ex)
+          case Right(result) => Task.pure(result)
+        }
 
       override def doDeploy(d: DeployData): Task[DeployServiceResponse] =
         defer(BlockAPI.deploy[F](d))


### PR DESCRIPTION
This allows us to get useful stack traces on the server side.
We can clean up any Try/Catch call within the Casper codebase now.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

https://rchain.atlassian.net/browse/RHOL-917