### PR TITLE
RHOL-885: Restrict connectives in the pattern of the receive

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnLevelMap.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnLevelMap.scala
@@ -1,4 +1,5 @@
 package coop.rchain.rholang.interpreter
+import coop.rchain.models.Connective.ConnectiveInstance
 
 // Parameterized over T, the kind of typing discipline we are enforcing.
 
@@ -10,7 +11,7 @@ class DebruijnLevelMap[T](
     val next: Int,
     val env: Map[String, (Int, T, Int, Int)],
     val wildcards: List[(Int, Int)],
-    val logicalConnectives: List[(String, Int, Int)]
+    val logicalConnectives: List[(ConnectiveInstance, Int, Int)]
 ) {
 
   def newBinding(binding: (String, T, Int, Int)): (DebruijnLevelMap[T], Int) =
@@ -63,7 +64,11 @@ class DebruijnLevelMap[T](
     DebruijnLevelMap(next, env, newWildcards, logicalConnectives)
   }
 
-  def addLogicalConnective(connective: String, line: Int, col: Int): DebruijnLevelMap[T] = {
+  def addLogicalConnective[C <: ConnectiveInstance](
+      connective: C,
+      line: Int,
+      col: Int
+  ): DebruijnLevelMap[T] = {
     val newConnectives = logicalConnectives :+ ((connective, line, col))
     DebruijnLevelMap(next, env, wildcards, newConnectives)
   }
@@ -95,7 +100,7 @@ object DebruijnLevelMap {
       next: Int,
       env: Map[String, (Int, T, Int, Int)],
       wildcards: List[(Int, Int)],
-      logicalConnectives: List[(String, Int, Int)]
+      logicalConnectives: List[(ConnectiveInstance, Int, Int)]
   ): DebruijnLevelMap[T] =
     new DebruijnLevelMap(next, env, wildcards, logicalConnectives)
 
@@ -104,11 +109,6 @@ object DebruijnLevelMap {
       0,
       Map[String, (Int, T, Int, Int)](),
       List[(Int, Int)](),
-      List[(String, Int, Int)]()
+      List[(ConnectiveInstance, Int, Int)]()
     )
-
-  def unapply[T](
-      db: DebruijnLevelMap[T]
-  ): Option[(Int, Map[String, (Int, T, Int, Int)], List[(Int, Int)])] =
-    Some((db.next, db.env, db.wildcards))
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -86,6 +86,11 @@ object errors {
 
   final case class SubstituteError(message: String) extends InterpreterError(message)
 
+  final case class PatternReceiveError(connectives: String)
+      extends InterpreterError(
+        s"Invalid pattern in the receive: $connectives. Only logical AND is allowed."
+      )
+
   final case class SetupError(message: String) extends InterpreterError(message)
 
   final case class UnrecognizedInterpreterError(throwable: Throwable)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -776,6 +776,28 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     }
   }
 
+  "PInput" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
+    an[PatternReceiveError] should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(new StringReader("""new x in { for(@{Nil \/ Nil} <- x) { Nil } }"""))
+        .value()
+    }
+
+    an[PatternReceiveError] should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(new StringReader("""new x in { for(@{~Nil} <- x) { Nil } }"""))
+        .value()
+    }
+  }
+
+  "PInput" should "compile when logical AND is used in the pattern of the receive" in {
+    noException should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(new StringReader("""new x in { for(@{Nil /\ Nil} <- x) { Nil } }"""))
+        .value()
+    }
+  }
+
   "PNew" should "Bind new variables" in {
     val listNameDecl = new ListNameDecl()
     listNameDecl.add(new NameDeclSimpl("x"))


### PR DESCRIPTION
## Overview
Relative to #1640 

Restricts logical connectives in the pattern of the receive to AND only. 

All connectives are allowed when consume is used in the pattern.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
