### PR TITLE
Rholang: Fix contracts to not accept logical OR and NOT in the receive pattern.

### DIFF
--- a/rholang/examples/tut-rcon-or.rho
+++ b/rholang/examples/tut-rcon-or.rho
@@ -1,10 +1,9 @@
 new orExample, stdout(`rho:io:stdout`) in {
-  contract orExample(@{record /\ {{@"name"!(_) | @"age"!(_) | _} \/ {@"nombre"!(_) | @"edad"!(_)}}}) = {
+  contract orExample(@record) = {
     match record {
-      {@"name"!(name) | @"age"!(age) | _} => stdout!(["Hello, ", name, " aged ", age])
-      {@"nombre"!(nombre) | @"edad"!(edad) | _} => stdout!(["Hola, ", nombre, " con ", edad, " años."])
+     {{"name" : {name /\ String},  "age": {age /\ {Int \/ String}}}} => stdout!(["Hello, ", name, " aged ", age])
     }
   } |
-  orExample!(@"name"!("Joe") | @"age"!(40)) |
-  orExample!(@"nombre"!("Jose") | @"edad"!(41))
+  orExample!({"name" : "Joe", "age": 40}) |
+  orExample!({"name": "Bob", "age": "41"})
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -798,6 +798,34 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     }
   }
 
+  "PContr" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
+    an[PatternReceiveError] should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(
+          new StringReader("""new x in { contract x(@{ y /\ {Nil \/ Nil}}) = { Nil } }""")
+        )
+        .value()
+    }
+
+    an[PatternReceiveError] should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(
+          new StringReader("""new x in { contract x(@{ y /\ ~Nil}) = { Nil } }""")
+        )
+        .value()
+    }
+  }
+
+  "PContr" should "compile when logical AND is used in the pattern of the receive" in {
+    noException should be thrownBy {
+      Interpreter
+        .buildNormalizedTerm(
+          new StringReader("""new x in { contract x(@{ y /\ {Nil /\ Nil}}) = { Nil } }""")
+        )
+        .value()
+    }
+  }
+
   "PNew" should "Bind new variables" in {
     val listNameDecl = new ListNameDecl()
     listNameDecl.add(new NameDeclSimpl("x"))


### PR DESCRIPTION
## Overview
Given recent changes to the patterns in the receive old `tut-rcon-or.rho` example won't pass. I've changed it to one that uses logical OR in the `match` construct. Example may not be as compelling as the previous one but shows how to use it.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
n/a

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
