### PR TITLE
Expose randomness on lastBlock in Blake2b512Random

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -23,7 +23,7 @@ import monix.eval.Coeval
 import SpatialMatcher.spatialMatchAndCharge
 
 import scala.collection.immutable.BitSet
-import scala.util.Try
+import scala.util.{Random, Try}
 
 // Notes: Caution, a type annotation is often needed for Env.
 
@@ -236,7 +236,9 @@ object Reduce {
 
       val starts = jobs.map(_.size).scanLeft(0)(_ + _).toVector
 
-      jobs.zipWithIndex
+      Random
+        .shuffle(jobs)
+        .zipWithIndex
         .map {
           case (job, jobIdx) => {
             def mkRand(termIdx: Int) = split(starts.last, starts(jobIdx), rand)(termIdx)


### PR DESCRIPTION
For whatever reason, the output of `StableHashProvider.hash(channel, datum, persist)` is different when rspace and replay rspace is run, and this causes the replay to fail. @goral09 and I dug into the details and it looks like the lastBlock portion of the Blake2b512Random of the random state of datum changes.

Just boot up the node in standalone mode to reproduce: I used `rnode run -s --has-faucet --validator-private-key c1f2321a3d410c53aad79640dd4b926faaff4d20c2cee6b5178581478a526da1 --host localhost`. You may have to restart the node a couple times until the genesis block validation fails.