### PR TITLE
RHOL-966: Fix dropping asterisk when pretty printing sent name

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -27,7 +27,7 @@ object PrettyPrinter {
 case class PrettyPrinter(
     freeShift: Int,
     boundShift: Int,
-    newsShiftIdx: Vector[Int],
+    newsShiftIndices: Vector[Int],
     freeId: String,
     baseId: String,
     rotation: Int,
@@ -190,7 +190,7 @@ case class PrettyPrinter(
         val introducedNewsShiftIdx = (0 until n.bindCount).map(i => i + boundShift)
         pure("new " + buildVariables(n.bindCount) + " in {\n" + indentStr * (indent + 1)) |+| this
           .copy(boundShift = boundShift + n.bindCount)
-          .copy(newsShiftIdx = newsShiftIdx ++ introducedNewsShiftIdx)
+          .copy(newsShiftIndices = newsShiftIndices ++ introducedNewsShiftIdx)
           .buildStringM(n.p, indent + 1) |+|
           pure("\n" + (indentStr * indent) + "}")
 
@@ -293,7 +293,7 @@ case class PrettyPrinter(
     def isName(p: GeneratedMessage): Boolean =
       p match {
         case Par(_, _, _, List(Expr(EVarBody(EVar(Var(BoundVar(i)))))), _, _, _, _, _, _) =>
-          if (newsShiftIdx.contains(boundShift - i - 1)) true else false
+          if (newsShiftIndices.contains(boundShift - i - 1)) true else false
         case _ => false
       }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -120,8 +120,7 @@ case class PrettyPrinter(
     remainder.fold(pure(""))(v => pure("...") |+| buildStringM(v))
 
   private def buildStringM(v: Var): Coeval[String] = {
-    def isNewVar(level: Int): Boolean =
-      if (newsShiftIndices.contains(boundShift - level - 1)) true else false
+    def isNewVar(level: Int): Boolean = newsShiftIndices.contains(boundShift - level - 1)
 
     v.varInstance match {
       case FreeVar(level) => pure(s"$freeId${freeShift + level}")
@@ -196,8 +195,10 @@ case class PrettyPrinter(
       case n: New =>
         val introducedNewsShiftIdx = (0 until n.bindCount).map(i => i + boundShift)
         pure("new " + buildVariables(n.bindCount) + " in {\n" + indentStr * (indent + 1)) |+| this
-          .copy(boundShift = boundShift + n.bindCount)
-          .copy(newsShiftIndices = newsShiftIndices ++ introducedNewsShiftIdx)
+          .copy(
+            boundShift = boundShift + n.bindCount,
+            newsShiftIndices = newsShiftIndices ++ introducedNewsShiftIdx
+          )
           .buildStringM(n.p, indent + 1) |+|
           pure("\n" + (indentStr * indent) + "}")
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -194,7 +194,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0 in {
-        |  for( @{x1} <- @{x0} ) {
+        |  for( @{x1} <- @{*x0} ) {
         |    x1
         |  }
         |}""".stripMargin
@@ -224,7 +224,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0 in {
-        |  for( @{x1}, @{x2} <- @{x0} ) {
+        |  for( @{x1}, @{x2} <- @{*x0} ) {
         |    x2 |
         |    x1
         |  }
@@ -259,7 +259,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0 in {
-        |  for( @{x1} <- @{x0} ; @{x2} <- @{x0} ) {
+        |  for( @{x1} <- @{*x0} ; @{x2} <- @{*x0} ) {
         |    x2 |
         |    x1
         |  }
@@ -300,7 +300,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0, x1 in {
-        |  for( @{x2}, @{x3} <- @{x1} ; @{x4}, @{x5} <- @{x0} ) {
+        |  for( @{x2}, @{x3} <- @{*x1} ; @{x4}, @{x5} <- @{*x0} ) {
         |    x3 |
         |    x2 |
         |    x5 |
@@ -346,7 +346,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0, x1 in {
-        |  for( @{x2}, @{x3} <- @{x1} ; @{x4}, @{x5} <- @{x0} ) {
+        |  for( @{x2}, @{x3} <- @{*x1} ; @{x4}, @{x5} <- @{*x0} ) {
         |    @{x3}!(Nil) |
         |    x2 |
         |    x5 |
@@ -381,8 +381,8 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     val target =
       """new x0 in {
-        |  @{x0}!(x0) |
-        |  for( @{x1} <- @{x0} ) {
+        |  @{*x0}!(*x0) |
+        |  for( @{x1} <- @{*x0} ) {
         |    x1
         |  }
         |}""".stripMargin
@@ -429,6 +429,15 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     result shouldBe
       """x0 |
         |x0""".stripMargin
+  }
+
+  it should "Print asterisk for variable introduced by new" in {
+    val result = prettyPrint("new x in { *x }")
+    val target =
+      """new x0 in {
+        |  *x0
+        |}""".stripMargin
+    result shouldBe target
   }
 
   it should "Print asterisk for sent name introduced by new" in {
@@ -614,7 +623,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     result shouldBe
       """new x0, x1 in {
-        |  for( @{x2}, @{x3} <- @{x1} ; @{x4}, @{x5} <- @{x0} ) {
+        |  for( @{x2}, @{x3} <- @{*x1} ; @{x4}, @{x5} <- @{*x0} ) {
         |    @{x2}!(x5) |
         |    @{x4}!(x3) |
         |    for( @{x6} <- @{x4} ) {
@@ -660,9 +669,9 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     result shouldBe
       """new x0, x1, x2 in {
-        |  @{x2}!(9) |
-        |  @{x1}!(8) |
-        |  @{x0}!(7)
+        |  @{*x2}!(9) |
+        |  @{*x1}!(8) |
+        |  @{*x0}!(7)
         |}""".stripMargin
   }
 
@@ -745,10 +754,10 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     result shouldBe
       """match (47 == 47) {
         |  true => new x0 in {
-        |    @{x0}!(47)
+        |    @{*x0}!(47)
         |  } ;
         |  false => new x0 in {
-        |    @{x0}!(47)
+        |    @{*x0}!(47)
         |  }
         |}""".stripMargin
   }


### PR DESCRIPTION
## Overview
I introduced a field called `newsShiftIdx` to the `PrettyPrinter` class in order to remember at which `boundShift` there was a name created with `new`.
With that we can check for a given `Send` if we need to print an asterisk or not.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-966

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR