### PR TITLE
Provide attemptAndLog and use it when handling TransportLayer messages

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -212,13 +212,13 @@ class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxM
 
     def dispatchInternal: ServerMessage => Task[Unit] = {
       // TODO: consider logging on failure (Left)
-      case Tell(protocol) => dispatch(protocol).attempt.void
+      case Tell(protocol) => dispatch(protocol).attemptAndLog.void
       case Ask(protocol, handle) if !handle.complete =>
         dispatch(protocol).attempt.map {
           case Left(e)         => handle.failWith(e)
           case Right(response) => handle.reply(response)
         }.void
-      case StreamMessage(blob) => handleStreamed(blob)
+      case StreamMessage(blob) => handleStreamed(blob).attemptAndLog
       case _                   => Task.unit // sender timeout
     }
 

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -12,7 +12,7 @@ import coop.rchain.casper.protocol.{DeployData, DeployServiceResponse, _}
 import coop.rchain.catscontrib.Taskable
 import coop.rchain.models.Par
 import coop.rchain.shared._
-
+import coop.rchain.catscontrib.TaskContrib._
 import com.google.protobuf.empty.Empty
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -25,10 +25,7 @@ private[api] object DeployGrpcService {
     new CasperMessageGrpcMonix.DeployService {
 
       private def defer[A](task: F[A]): Task[A] =
-        Task.defer(task.toTask).executeOn(worker).attempt.flatMap {
-          case Left(ex)      => Task.delay(ex.printStackTrace()) *> Task.raiseError[A](ex)
-          case Right(result) => Task.pure(result)
-        }
+        Task.defer(task.toTask).executeOn(worker).attemptAndLog
 
       override def doDeploy(d: DeployData): Task[DeployServiceResponse] =
         defer(BlockAPI.deploy[F](d))

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeoutException
 
 import monix.eval.Task
 import monix.execution.Scheduler
-
+import cats.implicits._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -26,6 +26,12 @@ object TaskContrib {
         case Right(_) =>
           backup
       }
+
+    // TODO should also push stacktrace to logs (not only console as it is doing right now)
+    def attemptAndLog: Task[A] = task.attempt.flatMap {
+      case Left(ex)      => Task.delay(ex.printStackTrace()) *> Task.raiseError[A](ex)
+      case Right(result) => Task.pure(result)
+    }
 
   }
 }


### PR DESCRIPTION
## Overview
This means that for every message that goes through TransportLayer, while
being handled, if that handler (God forbid) throws an exception, it
will be caught on the server side and printed to the console (the
whole stacktrace)
