### PR TITLE
 Make Either.rho use the registry

### DIFF
--- a/casper/src/main/rholang/Either.rho
+++ b/casper/src/main/rholang/Either.rho
@@ -3,11 +3,20 @@
 //Requires ListOps
 //Represents Either[A, B] as ("Left", A) or ("Right", B)
 
-new rl(`rho:registry:lookup`), ListOpsCh in {
+//Registry info:
+//  sk: 7545b56525751bf79daa6cf3ee5757632ea6f37bfa61e93aafc4449d8510df9b
+//  pk: 89a6d9c47f360e8ce145f8fe3c773786dc86bd0e70d19643d02b0eb126473c55
+//  user == pk
+//  timestamp: 1539794228064
+//Resulting unforgable name: Either == Unforgeable(0x9521551b4a8ae2cf0ba83aaf6996652b81d6a83d70985bc6f16ac6eb35f2f2dd)
+//  ==> signature data == 2a3eaa013b0a0d2a0b10feffffffffffffffff010a2a5a280a243a220a209521551b4a8ae2cf0ba83aaf6996652b81d6a83d70985bc6f16ac6eb35f2f2dd1001
+//  ==> signature == 29c68a1d8e792eeaf88158cfcb9a6038ebdfea81c7193025c41f3f3b6731e53c3d593b8d773df11caee97d5933623eb9fa60992cab75b770cacfb873f6182c0a
+//URI derived from pk == `rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`
+new Either, rs(`rho:registry:insertSigned:ed25519`), uriOut, rl(`rho:registry:lookup`), ListOpsCh in {
   rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
   for(@(_, ListOps) <- ListOpsCh) {
     //Right-biased flatMap; f must also return an Either
-    contract @("Either", "flatMap")(@either, f, return) = {
+    contract Either(@"flatMap", @either, f, return) = {
       match either {
         ("Right", value) => { f!(value, *return) }
         ("Left", _)      => { return!(either) }
@@ -15,7 +24,7 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
     } |
 
     //Right-biased map to transform an Either
-    contract @("Either", "map")(@either, f, return) = {
+    contract Either(@"map", @either, f, return) = {
       match either {
         ("Right", value) => {
           new mappedResultCh in {
@@ -37,13 +46,20 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
     //  r2 <- f2(r1)
     //  ...
     //} yield fn
-    contract @("Either", "compose")(@input, @functions, return) = {
+    contract Either(@"compose", @input, @functions, return) = {
       new combinator in {
         contract combinator(@head, @accumulatedValue, return) = {
-          @("Either", "flatMap")!(accumulatedValue, head, *return)
+          Either!("flatMap", accumulatedValue, head, *return)
         } |
         @ListOps!("fold", functions, ("Right", input), *combinator, *return)
       }
     }
-  }
+  } |
+  
+  rs!(
+    "89a6d9c47f360e8ce145f8fe3c773786dc86bd0e70d19643d02b0eb126473c55".hexToBytes(), 
+    (9223372036854775807, bundle+{*Either}), 
+    "29c68a1d8e792eeaf88158cfcb9a6038ebdfea81c7193025c41f3f3b6731e53c3d593b8d773df11caee97d5933623eb9fa60992cab75b770cacfb873f6182c0a".hexToBytes(), 
+    *uriOut
+  )
 }

--- a/casper/src/main/rholang/MakePoS.rho
+++ b/casper/src/main/rholang/MakePoS.rho
@@ -1,8 +1,9 @@
 //scalapackage coop.rchain.rholang.proofofstake
 
-new rl(`rho:registry:lookup`), ListOpsCh in {
+new rl(`rho:registry:lookup`), ListOpsCh, EitherCh in {
   rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
-  for(@(_, ListOps) <- ListOpsCh) {
+  rl!(`rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`, *EitherCh) |
+  for(@(_, ListOps) <- ListOpsCh; @(_, Either) <- EitherCh) {
     contract @"MakePoS"(@purse, @minimumBond, @maximumBond, @initBonds, return) = {
       new this, bondsCh, joiningFeeCh, clonePurse, depositPurse, updateBonds, feeDistribution in {
         bondsCh!(initBonds) |
@@ -137,7 +138,7 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
                   for(_, ret <- depositClonePurse) {
                     depositPurse!(bondPurse, bondAmount, *ret)
                   } |
-                  @("Either", "compose")!(bondPurse, [
+                  @Either!("compose", bondPurse, [
                                         (*this, "validateBondAmount"), 
                                         (*this, "validateBondingRate"),
                                         *validatePublicKey,

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -34,7 +34,12 @@ object StandardDeploys {
     "1d325ed35924b606264d4beaee7f78214aaecb23f6f3816055bc8bbe94280b5a",
     1539711168714L
   )
-  def either: Deploy            = toDeploy(Either, "", 0L)
+  def either: Deploy =
+    toDeploy(
+      Either,
+      "89a6d9c47f360e8ce145f8fe3c773786dc86bd0e70d19643d02b0eb126473c55",
+      1539794228064L
+    )
   def nonNegativeNumber: Deploy = toDeploy(NonNegativeNumber, "", 0L)
   def makeMint: Deploy          = toDeploy(MakeMint, "", 0L)
   def makePoS: Deploy           = toDeploy(MakePoS, "", 0L)

--- a/casper/src/test/rholang/EitherTest.rho
+++ b/casper/src/test/rholang/EitherTest.rho
@@ -1,69 +1,74 @@
 //scalapackage coop.rchain.rholang.collection
 
-contract @"double"(@x, ret) = { ret!(2 * x) } |
-contract @"divide"(@x, @y, ret) = {
-  if(y == 0) { ret!(("Left", "Div by zero!")) }
-  else { ret!(("Right", x / y)) }
-} |
-contract @"100over"(@x, ret) = { @"divide"!(100, x, *ret) } |
-contract @"50over"(@x, ret) = { @"divide"!(50, x, *ret) } |
-contract @"10over"(@x, ret) = { @"divide"!(10, x, *ret) } |
-contract @"8over"(@x, ret) = { @"divide"!(8, x, *ret) } |
+new rl(`rho:registry:lookup`), EitherCh in {
+  rl!(`rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`, *EitherCh) |
+  for(@(_, Either) <- EitherCh) {
+    contract @"double"(@x, ret) = { ret!(2 * x) } |
+    contract @"divide"(@x, @y, ret) = {
+      if(y == 0) { ret!(("Left", "Div by zero!")) }
+      else { ret!(("Right", x / y)) }
+    } |
+    contract @"100over"(@x, ret) = { @"divide"!(100, x, *ret) } |
+    contract @"50over"(@x, ret) = { @"divide"!(50, x, *ret) } |
+    contract @"10over"(@x, ret) = { @"divide"!(10, x, *ret) } |
+    contract @"8over"(@x, ret) = { @"divide"!(8, x, *ret) } |
 
-//Requires Either, TestSet
-contract @"doubleMap"(@either, ret) = {
-  new fn in {
-    contract fn(ret) = { @("Either", "map")!(either, "double", *ret) } |
-    ret!(*fn)
+    //Requires Either, TestSet
+    contract @"doubleMap"(@either, ret) = {
+      new fn in {
+        contract fn(ret) = { @Either!("map", either, "double", *ret) } |
+        ret!(*fn)
+      }
+    } |
+    @"doubleMap"!(("Right", 3), "RightMapTest") |
+    @"doubleMap"!(("Left", "message"), "LeftMapTest") |
+
+    @"TestSet"!(
+      "map should transform Right and preserve Left",
+      [
+        ["RightMapTest", ("Right", 6)],
+        ["LeftMapTest", ("Left", "message")]
+      ]
+    ) |
+
+    contract @"10overFlatMap"(@either, ret) = {
+      new fn in {
+        contract fn(ret) = { @Either!("flatMap", either, "10over", *ret) } |
+        ret!(*fn)
+      }
+    } |
+    @"10overFlatMap"!(("Right", 5), "FlatMapTest1") |
+    @"10overFlatMap"!(("Left", "message"), "FlatMapTest2") |
+    @"10overFlatMap"!(("Right", 0), "FlatMapTest3") |
+
+    @"TestSet"!(
+      "flatMap should transform Right and preserve Left",
+      [
+        ["FlatMapTest1", ("Right", 2)],
+        ["FlatMapTest2", ("Left", "message")],
+        ["FlatMapTest3", ("Left", "Div by zero!")]
+      ]
+    ) |
+
+    contract @"composeTest"(@input, @functions, ret) = {
+      new fn in {
+        contract fn(ret) = { @Either!("compose", input, functions, *ret) } |
+        ret!(*fn)
+      }
+    } |
+    @"composeTest"!(5, ["10over", "8over"], "ComposeTest1") |
+    @"composeTest"!(15, ["10over", "8over"], "ComposeTest2") |
+    @"composeTest"!(5, ["100over", "8over", "10over"], "ComposeTest3") |
+    @"composeTest"!(5, ["50over", "10over", "8over"], "ComposeTest4") |
+
+    @"TestSet"!(
+      "compose should sequence Either-valued functions together",
+      [
+        ["ComposeTest1", ("Right", 4)],
+        ["ComposeTest2", ("Left", "Div by zero!")],
+        ["ComposeTest3", ("Left", "Div by zero!")],
+        ["ComposeTest4", ("Right", 8)],
+      ]
+    )
   }
-} |
-@"doubleMap"!(("Right", 3), "RightMapTest") |
-@"doubleMap"!(("Left", "message"), "LeftMapTest") |
-
-@"TestSet"!(
-  "map should transform Right and preserve Left",
-  [
-    ["RightMapTest", ("Right", 6)],
-    ["LeftMapTest", ("Left", "message")]
-  ]
-) |
-
-contract @"10overFlatMap"(@either, ret) = {
-  new fn in {
-    contract fn(ret) = { @("Either", "flatMap")!(either, "10over", *ret) } |
-    ret!(*fn)
-  }
-} |
-@"10overFlatMap"!(("Right", 5), "FlatMapTest1") |
-@"10overFlatMap"!(("Left", "message"), "FlatMapTest2") |
-@"10overFlatMap"!(("Right", 0), "FlatMapTest3") |
-
-@"TestSet"!(
-  "flatMap should transform Right and preserve Left",
-  [
-    ["FlatMapTest1", ("Right", 2)],
-    ["FlatMapTest2", ("Left", "message")],
-    ["FlatMapTest3", ("Left", "Div by zero!")]
-  ]
-) |
-
-contract @"composeTest"(@input, @functions, ret) = {
-  new fn in {
-    contract fn(ret) = { @("Either", "compose")!(input, functions, *ret) } |
-    ret!(*fn)
-  }
-} |
-@"composeTest"!(5, ["10over", "8over"], "ComposeTest1") |
-@"composeTest"!(15, ["10over", "8over"], "ComposeTest2") |
-@"composeTest"!(5, ["100over", "8over", "10over"], "ComposeTest3") |
-@"composeTest"!(5, ["50over", "10over", "8over"], "ComposeTest4") |
-
-@"TestSet"!(
-  "compose should sequence Either-valued functions together",
-  [
-    ["ComposeTest1", ("Right", 4)],
-    ["ComposeTest2", ("Left", "Div by zero!")],
-    ["ComposeTest3", ("Left", "Div by zero!")],
-    ["ComposeTest4", ("Right", 8)],
-  ]
-)
+}

--- a/casper/src/test/rholang/EitherTest.rho
+++ b/casper/src/test/rholang/EitherTest.rho
@@ -1,27 +1,31 @@
 //scalapackage coop.rchain.rholang.collection
 
-new rl(`rho:registry:lookup`), EitherCh in {
+new 
+  rl(`rho:registry:lookup`), EitherCh,
+  double, divide, divide100by, divide50by, divide10by,
+  divide8by, doubleMap, divide10byFlatMap, composeTest
+in {
   rl!(`rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`, *EitherCh) |
   for(@(_, Either) <- EitherCh) {
-    contract @"double"(@x, ret) = { ret!(2 * x) } |
-    contract @"divide"(@x, @y, ret) = {
+    contract double(@x, ret) = { ret!(2 * x) } |
+    contract divide(@x, @y, ret) = {
       if(y == 0) { ret!(("Left", "Div by zero!")) }
       else { ret!(("Right", x / y)) }
     } |
-    contract @"100over"(@x, ret) = { @"divide"!(100, x, *ret) } |
-    contract @"50over"(@x, ret) = { @"divide"!(50, x, *ret) } |
-    contract @"10over"(@x, ret) = { @"divide"!(10, x, *ret) } |
-    contract @"8over"(@x, ret) = { @"divide"!(8, x, *ret) } |
+    contract divide100by(@x, ret) = { divide!(100, x, *ret) } |
+    contract divide50by(@x, ret) = { divide!(50, x, *ret) } |
+    contract divide10by(@x, ret) = { divide!(10, x, *ret) } |
+    contract divide8by(@x, ret) = { divide!(8, x, *ret) } |
 
     //Requires Either, TestSet
-    contract @"doubleMap"(@either, ret) = {
+    contract doubleMap(@either, ret) = {
       new fn in {
-        contract fn(ret) = { @Either!("map", either, "double", *ret) } |
+        contract fn(ret) = { @Either!("map", either, *double, *ret) } |
         ret!(*fn)
       }
     } |
-    @"doubleMap"!(("Right", 3), "RightMapTest") |
-    @"doubleMap"!(("Left", "message"), "LeftMapTest") |
+    doubleMap!(("Right", 3), "RightMapTest") |
+    doubleMap!(("Left", "message"), "LeftMapTest") |
 
     @"TestSet"!(
       "map should transform Right and preserve Left",
@@ -31,15 +35,15 @@ new rl(`rho:registry:lookup`), EitherCh in {
       ]
     ) |
 
-    contract @"10overFlatMap"(@either, ret) = {
+    contract divide10byFlatMap(@either, ret) = {
       new fn in {
-        contract fn(ret) = { @Either!("flatMap", either, "10over", *ret) } |
+        contract fn(ret) = { @Either!("flatMap", either, *divide10by, *ret) } |
         ret!(*fn)
       }
     } |
-    @"10overFlatMap"!(("Right", 5), "FlatMapTest1") |
-    @"10overFlatMap"!(("Left", "message"), "FlatMapTest2") |
-    @"10overFlatMap"!(("Right", 0), "FlatMapTest3") |
+    divide10byFlatMap!(("Right", 5), "FlatMapTest1") |
+    divide10byFlatMap!(("Left", "message"), "FlatMapTest2") |
+    divide10byFlatMap!(("Right", 0), "FlatMapTest3") |
 
     @"TestSet"!(
       "flatMap should transform Right and preserve Left",
@@ -50,16 +54,16 @@ new rl(`rho:registry:lookup`), EitherCh in {
       ]
     ) |
 
-    contract @"composeTest"(@input, @functions, ret) = {
+    contract composeTest(@input, @functions, ret) = {
       new fn in {
         contract fn(ret) = { @Either!("compose", input, functions, *ret) } |
         ret!(*fn)
       }
     } |
-    @"composeTest"!(5, ["10over", "8over"], "ComposeTest1") |
-    @"composeTest"!(15, ["10over", "8over"], "ComposeTest2") |
-    @"composeTest"!(5, ["100over", "8over", "10over"], "ComposeTest3") |
-    @"composeTest"!(5, ["50over", "10over", "8over"], "ComposeTest4") |
+    composeTest!(5, [*divide10by, *divide8by], "ComposeTest1") |
+    composeTest!(15, [*divide10by, *divide8by], "ComposeTest2") |
+    composeTest!(5, [*divide100by, *divide8by, *divide10by], "ComposeTest3") |
+    composeTest!(5, [*divide50by, *divide10by, *divide8by], "ComposeTest4") |
 
     @"TestSet"!(
       "compose should sequence Either-valued functions together",

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.genesis.contracts
 
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rholang.collection.{Either, EitherTest}
+import coop.rchain.rholang.collection.EitherTest
 
 import monix.execution.Scheduler.Implicits.global
 
@@ -11,7 +11,7 @@ class EitherSpec extends FlatSpec with Matchers {
   val runtime = TestSetUtil.runtime
   val tests   = TestSetUtil.getTests("./casper/src/test/rholang/EitherTest.rho").toList
 
-  TestSetUtil.runTests(EitherTest, List(Either), runtime)
+  TestSetUtil.runTestsWithDeploys(EitherTest, List(StandardDeploys.either), runtime)
   val tuplespace = StoragePrinter.prettyPrint(runtime.space.store)
 
   "Either rholang contract" should tests.head in {

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakePoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakePoSSpec.scala
@@ -1,5 +1,7 @@
 package coop.rchain.casper.genesis.contracts
 
+import coop.rchain.casper.util.ProtoUtil.compiledSourceDeploy
+import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.collection.Either
 import coop.rchain.rholang.math.NonNegativeNumber
@@ -14,7 +16,14 @@ class MakePoSSpec extends FlatSpec with Matchers {
   val runtime = TestSetUtil.runtime
   val tests   = TestSetUtil.getTests("./casper/src/test/rholang/MakePoSTest.rho").toList
 
-  TestSetUtil.runTests(MakePoSTest, List(NonNegativeNumber, MakeMint, Either, MakePoS), runtime)
+  val deploys = List(
+    //TODO: Replace all compiledSourceDeploy with StandardDeploys when they are ready
+    compiledSourceDeploy(NonNegativeNumber, 1L, accounting.MAX_VALUE),
+    compiledSourceDeploy(MakeMint, 2L, accounting.MAX_VALUE),
+    StandardDeploys.either,
+    compiledSourceDeploy(MakePoS, 3L, accounting.MAX_VALUE)
+  )
+  TestSetUtil.runTestsWithDeploys(MakePoSTest, deploys, runtime)
   val tuplespace = StoragePrinter.prettyPrint(runtime.space.store)
 
   "MakePoS rholang contract" should tests.head in {

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -53,6 +53,16 @@ object TestSetUtil {
       case Left(ex)    => throw ex
     }
 
+  def runTestsWithDeploys(tests: CompiledRholangSource, otherLibs: Seq[Deploy], runtime: Runtime)(
+      implicit scheduler: Scheduler
+  ): Unit = {
+    val rand = Blake2b512Random(128)
+    evalDeploy(StandardDeploys.listOps, runtime)(implicitly)
+    eval(TestSet.code, runtime)(implicitly, rand.splitShort(0))
+    otherLibs.foreach(evalDeploy(_, runtime))
+    eval(tests.code, runtime)(implicitly, rand.splitShort(1))
+  }
+
   def runTests(
       tests: CompiledRholangSource,
       otherLibs: Seq[CompiledRholangSource],


### PR DESCRIPTION
## Overview
The next step towards getting rid of all forgable names in our Rholang source code. This one serves as a good example for the pattern that needs to be followed to change other rholang sources e.g. NonNegativeNumber, MakeMint, etc.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-915

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
