### PR TITLE
ci: Clone Git repository in straightforward way

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,14 @@ __sbtenv: &sbtenv
 
 clone:
   git-clone:
-    image: plugins/git:next
+    image: rchain/buildenv:latest
+    commands: |
+      set -ex
+      git clone -b ${DRONE_TAG:-$DRONE_BRANCH} $DRONE_REMOTE_URL .
+      if [ x$DRONE_PULL_REQUEST != x ]; then
+          git fetch origin refs/pull/$DRONE_PULL_REQUEST/head
+          EMAIL=ci git merge --no-edit FETCH_HEAD
+      fi
 
 pipeline:
 


### PR DESCRIPTION
Just clone destination branch and in case of PR, merge in the requested
branch. Drone's Git plugins don't do that.