### PR TITLE
 Make TestSet.rho use the registry

### DIFF
--- a/casper/src/test/rholang/BasicWalletTest.rho
+++ b/casper/src/test/rholang/BasicWalletTest.rho
@@ -1,7 +1,10 @@
 //scalapackage coop.rchain.rholang.wallet
 
 //requires BasicWallet, MakeMint, TestSet, ListOps
-new rl(`rho:registry:lookup`), TestSetCh in {
+new
+  rl(`rho:registry:lookup`), TestSetCh,
+  test1, test2, test3, test4, test5
+in {
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
   for(@(_, TestSet) <- TestSetCh) {
     @"sk"!("1388803416a5869f3d4682fb3fae738278287b80d1a5a52ddf89be8eb9dac59d") |
@@ -78,22 +81,24 @@ new rl(`rho:registry:lookup`), TestSetCh in {
       
       
         @"newWallet"!("fake21564", "badAlgorithm") |
-        @TestSet!(
+        @TestSet!("define",
           "A wallet should not be created if the signature algorithm is unknown.",
           [
             ["badAlgorithm", []]
-          ]
+          ],
+          *test1
         ) |
       
         @"BasicWallet"!(ethereumPurse, "secp256k1", "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "ethWallet") |  
         for(@[ethWallet] <- @"ethWallet") {
           @"ethWallet"!([ethWallet]) |
           @"getBalance"!(ethWallet, "ethWalletBalance") |
-          @TestSet!(
+          @TestSet!("define",
             "Wallets should accept Secp256k1 keys.",
             [
               ["ethWalletBalance", 74]
-            ]
+            ],
+            *test2
           )      
         } |
 
@@ -106,38 +111,41 @@ new rl(`rho:registry:lookup`), TestSetCh in {
             @"transfer"!(wallet, 60, 0, invalidSig, Nil, "failTransfer") |
             @"transfer"!(wallet, 60, 0, sig0, "wPurse", "transfer0Nonce") |
             @"transfer"!(wallet, 10, 1, sig1, Nil, "transfer1Nonce") |
-          @TestSet!(
+          @TestSet!("define",
             "Wallet deposit should work as expected.",
             [
               ["walletBalance", 100],
               ["overdrawDep", false],
               ["depWallet", true],
               ["walletBalance", 130]
-            ]
+            ],
+            *test3
           ) |
           
-          @TestSet!("after", "Wallet deposit should work as expected.", {
-            @TestSet!(
+          @TestSet!("after", *test3, {
+            @TestSet!("define",
               "Wallet transfer should not accept invalid signatures or nonces.",
               [
                 ["failTransfer", "Invalid signature or nonce"], //bad signature
                 ["transfer1Nonce", "Invalid signature or nonce"] //nonce out of order
-              ]
+              ],
+              *test4
             ) |
             
-            @TestSet!("after", "Wallet transfer should not accept invalid signatures or nonces.", {
+            @TestSet!("after", *test4, {
               for(doTransfer <- @"transfer0Nonce") {
                 @"transfer0Nonce"!(*doTransfer) |
                 doTransfer!("status") | for(@wPurse <- @"wPurse"; @"Success" <- @"status") {
                   @"getBalance"!(wPurse, "purseBalance") |
                   @"getNonce"!(wallet, "walletNonce") |
-                  @TestSet!(
+                  @TestSet!("define",
                     "Wallet transfer should work as expected.",
                     [
                       ["purseBalance", 60],
                       ["walletBalance", 70],
                       ["walletNonce", 0]
-                    ]
+                    ],
+                    *test5
                   )
                 }
               }

--- a/casper/src/test/rholang/BasicWalletTest.rho
+++ b/casper/src/test/rholang/BasicWalletTest.rho
@@ -1,145 +1,150 @@
 //scalapackage coop.rchain.rholang.wallet
 
 //requires BasicWallet, MakeMint, TestSet, ListOps
-@"sk"!("1388803416a5869f3d4682fb3fae738278287b80d1a5a52ddf89be8eb9dac59d") |
-@"pk"!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
-@"sig0"!("04f9a5f223fdf61ceaa290d04df2c171892d46cee31faad55061896b16340558d27e6b27d55a7133ec6ebf07433a059d1e3c2fd2ea864ad01de69e05f860180e") |
-@"sig1"!("ed1d624af32b9ec1d252c1df8faac112e1a5b9839ca4ba4027105453e8b23c71768fb80bd324c3605a8412cb51c1d86b641538e276965a5b2a742a10d136770c") |
-@"invalidSig"!("b8cea97ee7afdab7eb6ebabe8fde9ca8f9dbd3b877e8fe6b6cfd4bcef5cfdcfccec9fd8de9e39df4b6f5a2f7b6d9da8cffef48fab85faddbaab8ebca4af4ab07") |
+new rl(`rho:registry:lookup`), TestSetCh in {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
+  for(@(_, TestSet) <- TestSetCh) {
+    @"sk"!("1388803416a5869f3d4682fb3fae738278287b80d1a5a52ddf89be8eb9dac59d") |
+    @"pk"!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
+    @"sig0"!("04f9a5f223fdf61ceaa290d04df2c171892d46cee31faad55061896b16340558d27e6b27d55a7133ec6ebf07433a059d1e3c2fd2ea864ad01de69e05f860180e") |
+    @"sig1"!("ed1d624af32b9ec1d252c1df8faac112e1a5b9839ca4ba4027105453e8b23c71768fb80bd324c3605a8412cb51c1d86b641538e276965a5b2a742a10d136770c") |
+    @"invalidSig"!("b8cea97ee7afdab7eb6ebabe8fde9ca8f9dbd3b877e8fe6b6cfd4bcef5cfdcfccec9fd8de9e39df4b6f5a2f7b6d9da8cffef48fab85faddbaab8ebca4af4ab07") |
 
-contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
-  new deposit in {
-    contract deposit(return) = {
-      @(wallet, "deposit")!(amount, otherPurse, *return)
-    } |
-    return!(*deposit)
-  }
-} |
-
-contract @"transfer"(@wallet, @amount, @nonce, @sig, destination, contractReturn) = {
-  new transfer, status in {
-    contract transfer(return) = {
-      //send to known channel so that I can make the right signature
-      @(wallet, "transfer")!(amount, nonce, sig, "myWithdraw", *status) |
-      for(@result <- status){ 
-        match result {
-          "Success" => {for(@purse <- @"myWithdraw"){ destination!(purse) }}
-          _         => { Nil }
+    contract @"deposit"(@wallet, @amount, @otherPurse, return) = {
+      new deposit in {
+        contract deposit(return) = {
+          @(wallet, "deposit")!(amount, otherPurse, *return)
         } |
-        return!(result) 
+        return!(*deposit)
       }
     } |
-    contractReturn!(*transfer)
-  }
-} |
 
-contract @"getBalance"(@wallet, return) = {
-  new getBalance in {
-    contract getBalance(return) = {
-      @(wallet, "getBalance")!(*return)
-    } |
-    return!(*getBalance)
-  }
-} |
-
-contract @"getNonce"(@wallet, return) = {
-  new getNonce in {
-    contract getNonce(return) = {
-      @(wallet, "getNonce")!(*return)
-    } |
-    return!(*getNonce)
-  }
-} |
-
-@"MakeMint"!("mint") | for(@mint <- @"mint") {
-  @(mint, "makePurse")!(100, "purse") |
-  @(mint, "makePurse")!(30, "otherPurse") |
-  @(mint, "makePurse")!(74, "ethereumPurse") |
-  for(
-    @purse <- @"purse"; 
-    @otherPurse <- @"otherPurse"; 
-    @ethereumPurse <- @"ethereumPurse"; 
-    @pk <- @"pk";
-    @sig0 <- @"sig0";
-    @sig1 <- @"sig1";
-    @invalidSig <- @"invalidSig"
-  ) {
-    contract @"newWallet"(@algorithm, return) = {
-      new makeWallet in {
-        contract makeWallet(return) = {
-          @"BasicWallet"!(purse, algorithm, pk, *return)
+    contract @"transfer"(@wallet, @amount, @nonce, @sig, destination, contractReturn) = {
+      new transfer, status in {
+        contract transfer(return) = {
+          //send to known channel so that I can make the right signature
+          @(wallet, "transfer")!(amount, nonce, sig, "myWithdraw", *status) |
+          for(@result <- status){ 
+            match result {
+              "Success" => {for(@purse <- @"myWithdraw"){ destination!(purse) }}
+              _         => { Nil }
+            } |
+            return!(result) 
+          }
         } |
-        return!(*makeWallet)
+        contractReturn!(*transfer)
       }
     } |
-  
-  
-    @"newWallet"!("fake21564", "badAlgorithm") |
-    @"TestSet"!(
-      "A wallet should not be created if the signature algorithm is unknown.",
-      [
-        ["badAlgorithm", []]
-      ]
-    ) |
-  
-    @"BasicWallet"!(ethereumPurse, "secp256k1", "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "ethWallet") |  
-    for(@[ethWallet] <- @"ethWallet") {
-      @"ethWallet"!([ethWallet]) |
-      @"getBalance"!(ethWallet, "ethWalletBalance") |
-      @"TestSet"!(
-        "Wallets should accept Secp256k1 keys.",
-        [
-          ["ethWalletBalance", 74]
-        ]
-      )      
+
+    contract @"getBalance"(@wallet, return) = {
+      new getBalance in {
+        contract getBalance(return) = {
+          @(wallet, "getBalance")!(*return)
+        } |
+        return!(*getBalance)
+      }
     } |
 
-    @"BasicWallet"!(purse, "ed25519", pk, "wallet") |
-    for(@[wallet] <- @"wallet") {
-        @"wallet"!([wallet]) |
-        @"getBalance"!(wallet, "walletBalance") |
-        @"deposit"!(wallet, 300, otherPurse, "overdrawDep") |
-        @"deposit"!(wallet, 30, otherPurse, "depWallet") |
-        @"transfer"!(wallet, 60, 0, invalidSig, Nil, "failTransfer") |
-        @"transfer"!(wallet, 60, 0, sig0, "wPurse", "transfer0Nonce") |
-        @"transfer"!(wallet, 10, 1, sig1, Nil, "transfer1Nonce") |
-      @"TestSet"!(
-        "Wallet deposit should work as expected.",
-        [
-          ["walletBalance", 100],
-          ["overdrawDep", false],
-          ["depWallet", true],
-          ["walletBalance", 130]
-        ]
-      ) |
+    contract @"getNonce"(@wallet, return) = {
+      new getNonce in {
+        contract getNonce(return) = {
+          @(wallet, "getNonce")!(*return)
+        } |
+        return!(*getNonce)
+      }
+    } |
+
+    @"MakeMint"!("mint") | for(@mint <- @"mint") {
+      @(mint, "makePurse")!(100, "purse") |
+      @(mint, "makePurse")!(30, "otherPurse") |
+      @(mint, "makePurse")!(74, "ethereumPurse") |
+      for(
+        @purse <- @"purse"; 
+        @otherPurse <- @"otherPurse"; 
+        @ethereumPurse <- @"ethereumPurse"; 
+        @pk <- @"pk";
+        @sig0 <- @"sig0";
+        @sig1 <- @"sig1";
+        @invalidSig <- @"invalidSig"
+      ) {
+        contract @"newWallet"(@algorithm, return) = {
+          new makeWallet in {
+            contract makeWallet(return) = {
+              @"BasicWallet"!(purse, algorithm, pk, *return)
+            } |
+            return!(*makeWallet)
+          }
+        } |
       
-      @("TestSet", "after")!("Wallet deposit should work as expected.", {
-        @"TestSet"!(
-          "Wallet transfer should not accept invalid signatures or nonces.",
+      
+        @"newWallet"!("fake21564", "badAlgorithm") |
+        @TestSet!(
+          "A wallet should not be created if the signature algorithm is unknown.",
           [
-            ["failTransfer", "Invalid signature or nonce"], //bad signature
-            ["transfer1Nonce", "Invalid signature or nonce"] //nonce out of order
+            ["badAlgorithm", []]
           ]
         ) |
-        
-        @("TestSet", "after")!("Wallet transfer should not accept invalid signatures or nonces.", {
-          for(doTransfer <- @"transfer0Nonce") {
-            @"transfer0Nonce"!(*doTransfer) |
-            doTransfer!("status") | for(@wPurse <- @"wPurse"; @"Success" <- @"status") {
-              @"getBalance"!(wPurse, "purseBalance") |
-              @"getNonce"!(wallet, "walletNonce") |
-              @"TestSet"!(
-                "Wallet transfer should work as expected.",
-                [
-                  ["purseBalance", 60],
-                  ["walletBalance", 70],
-                  ["walletNonce", 0]
-                ]
-              )
-            }
-          }
-        })
-      })
+      
+        @"BasicWallet"!(ethereumPurse, "secp256k1", "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "ethWallet") |  
+        for(@[ethWallet] <- @"ethWallet") {
+          @"ethWallet"!([ethWallet]) |
+          @"getBalance"!(ethWallet, "ethWalletBalance") |
+          @TestSet!(
+            "Wallets should accept Secp256k1 keys.",
+            [
+              ["ethWalletBalance", 74]
+            ]
+          )      
+        } |
+
+        @"BasicWallet"!(purse, "ed25519", pk, "wallet") |
+        for(@[wallet] <- @"wallet") {
+            @"wallet"!([wallet]) |
+            @"getBalance"!(wallet, "walletBalance") |
+            @"deposit"!(wallet, 300, otherPurse, "overdrawDep") |
+            @"deposit"!(wallet, 30, otherPurse, "depWallet") |
+            @"transfer"!(wallet, 60, 0, invalidSig, Nil, "failTransfer") |
+            @"transfer"!(wallet, 60, 0, sig0, "wPurse", "transfer0Nonce") |
+            @"transfer"!(wallet, 10, 1, sig1, Nil, "transfer1Nonce") |
+          @TestSet!(
+            "Wallet deposit should work as expected.",
+            [
+              ["walletBalance", 100],
+              ["overdrawDep", false],
+              ["depWallet", true],
+              ["walletBalance", 130]
+            ]
+          ) |
+          
+          @TestSet!("after", "Wallet deposit should work as expected.", {
+            @TestSet!(
+              "Wallet transfer should not accept invalid signatures or nonces.",
+              [
+                ["failTransfer", "Invalid signature or nonce"], //bad signature
+                ["transfer1Nonce", "Invalid signature or nonce"] //nonce out of order
+              ]
+            ) |
+            
+            @TestSet!("after", "Wallet transfer should not accept invalid signatures or nonces.", {
+              for(doTransfer <- @"transfer0Nonce") {
+                @"transfer0Nonce"!(*doTransfer) |
+                doTransfer!("status") | for(@wPurse <- @"wPurse"; @"Success" <- @"status") {
+                  @"getBalance"!(wPurse, "purseBalance") |
+                  @"getNonce"!(wallet, "walletNonce") |
+                  @TestSet!(
+                    "Wallet transfer should work as expected.",
+                    [
+                      ["purseBalance", 60],
+                      ["walletBalance", 70],
+                      ["walletNonce", 0]
+                    ]
+                  )
+                }
+              }
+            })
+          })
+        }
+      }
     }
   }
 }

--- a/casper/src/test/rholang/EitherTest.rho
+++ b/casper/src/test/rholang/EitherTest.rho
@@ -3,7 +3,8 @@
 new 
   rl(`rho:registry:lookup`), EitherCh, TestSetCh,
   double, divide, divide100by, divide50by, divide10by,
-  divide8by, doubleMap, divide10byFlatMap, composeTest
+  divide8by, doubleMap, divide10byFlatMap, composeTest,
+  test1, test2, test3
 in {
   rl!(`rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`, *EitherCh) |
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
@@ -27,12 +28,13 @@ in {
     doubleMap!(("Right", 3), "RightMapTest") |
     doubleMap!(("Left", "message"), "LeftMapTest") |
 
-    @TestSet!(
+    @TestSet!("define",
       "map should transform Right and preserve Left",
       [
         ["RightMapTest", ("Right", 6)],
         ["LeftMapTest", ("Left", "message")]
-      ]
+      ],
+      *test1
     ) |
 
     contract divide10byFlatMap(@either, ret) = {
@@ -45,13 +47,14 @@ in {
     divide10byFlatMap!(("Left", "message"), "FlatMapTest2") |
     divide10byFlatMap!(("Right", 0), "FlatMapTest3") |
 
-    @TestSet!(
+    @TestSet!("define",
       "flatMap should transform Right and preserve Left",
       [
         ["FlatMapTest1", ("Right", 2)],
         ["FlatMapTest2", ("Left", "message")],
         ["FlatMapTest3", ("Left", "Div by zero!")]
-      ]
+      ],
+      *test2
     ) |
 
     contract composeTest(@input, @functions, ret) = {
@@ -65,14 +68,15 @@ in {
     composeTest!(5, [*divide100by, *divide8by, *divide10by], "ComposeTest3") |
     composeTest!(5, [*divide50by, *divide10by, *divide8by], "ComposeTest4") |
 
-    @TestSet!(
+    @TestSet!("define",
       "compose should sequence Either-valued functions together",
       [
         ["ComposeTest1", ("Right", 4)],
         ["ComposeTest2", ("Left", "Div by zero!")],
         ["ComposeTest3", ("Left", "Div by zero!")],
         ["ComposeTest4", ("Right", 8)],
-      ]
+      ],
+      *test3
     )
   }
 }

--- a/casper/src/test/rholang/EitherTest.rho
+++ b/casper/src/test/rholang/EitherTest.rho
@@ -1,12 +1,13 @@
 //scalapackage coop.rchain.rholang.collection
 
 new 
-  rl(`rho:registry:lookup`), EitherCh,
+  rl(`rho:registry:lookup`), EitherCh, TestSetCh,
   double, divide, divide100by, divide50by, divide10by,
   divide8by, doubleMap, divide10byFlatMap, composeTest
 in {
   rl!(`rho:id:j6trahbxycumerwpr5qype7j43b7eqh8auebwsa9nn68if47gswh73`, *EitherCh) |
-  for(@(_, Either) <- EitherCh) {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
+  for(@(_, Either) <- EitherCh; @(_, TestSet) <- TestSetCh) {
     contract double(@x, ret) = { ret!(2 * x) } |
     contract divide(@x, @y, ret) = {
       if(y == 0) { ret!(("Left", "Div by zero!")) }
@@ -17,7 +18,6 @@ in {
     contract divide10by(@x, ret) = { divide!(10, x, *ret) } |
     contract divide8by(@x, ret) = { divide!(8, x, *ret) } |
 
-    //Requires Either, TestSet
     contract doubleMap(@either, ret) = {
       new fn in {
         contract fn(ret) = { @Either!("map", either, *double, *ret) } |
@@ -27,7 +27,7 @@ in {
     doubleMap!(("Right", 3), "RightMapTest") |
     doubleMap!(("Left", "message"), "LeftMapTest") |
 
-    @"TestSet"!(
+    @TestSet!(
       "map should transform Right and preserve Left",
       [
         ["RightMapTest", ("Right", 6)],
@@ -45,7 +45,7 @@ in {
     divide10byFlatMap!(("Left", "message"), "FlatMapTest2") |
     divide10byFlatMap!(("Right", 0), "FlatMapTest3") |
 
-    @"TestSet"!(
+    @TestSet!(
       "flatMap should transform Right and preserve Left",
       [
         ["FlatMapTest1", ("Right", 2)],
@@ -65,7 +65,7 @@ in {
     composeTest!(5, [*divide100by, *divide8by, *divide10by], "ComposeTest3") |
     composeTest!(5, [*divide50by, *divide10by, *divide8by], "ComposeTest4") |
 
-    @"TestSet"!(
+    @TestSet!(
       "compose should sequence Either-valued functions together",
       [
         ["ComposeTest1", ("Right", 4)],

--- a/casper/src/test/rholang/MakeMintTest.rho
+++ b/casper/src/test/rholang/MakeMintTest.rho
@@ -1,108 +1,113 @@
 //scalapackage coop.rchain.rholang.mint
 
 //requires MakeMint, TestSet
-contract @"getBalance"(@purse, return) = {
-  new getBalance in {
-    contract getBalance(return) = {
-      @(purse, "getBalance")!(*return)
-    } |
-    return!(*getBalance)
-  }
-} |
-contract @"deposit"(@dest, @amount, @src, return) = {
-  new deposit in {
-    contract deposit(return) = {
-      @(dest, "deposit")!(amount, src, *return)
-    } |
-    return!(*deposit)
-  }
-} |
-contract @"split"(@purse, @amount, destCh, return) = {
-  new split in {
-    contract split(return) = {
-      @(purse, "split")!(amount, *destCh) |
-      for(@value <- destCh) {
-        match value {
-          [] => { return!(false) }
-          _  => { return!(true) }
+new rl(`rho:registry:lookup`), TestSetCh in {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
+  for(@(_, TestSet) <- TestSetCh) {
+    contract @"getBalance"(@purse, return) = {
+      new getBalance in {
+        contract getBalance(return) = {
+          @(purse, "getBalance")!(*return)
         } |
-        destCh!(value)
+        return!(*getBalance)
       }
     } |
-    return!(*split)
-  }
-} |
-@"MakeMint"!("mintA") | @"MakeMint"!("mintB") |
-for(@mintA <- @"mintA"; @mintB <- @"mintB") {
-  @(mintA, "makePurse")!(100, "aliceAPurse") | @(mintB, "makePurse")!(50, "bobBPurse") |
-  for(@aliceAPurse <- @"aliceAPurse"; @bobBPurse <- @"bobBPurse") {
-    @"getBalance"!(aliceAPurse, "aliceAPurseBalance") |
-    @"getBalance"!(bobBPurse, "bobBPurseBalance") |
-    @"TestSet"!(
-      "Purses should be created with the given balance.",
-      [
-        ["aliceAPurseBalance", 100],
-        ["bobBPurseBalance", 50]
-      ]
-    ) |
-    
-    
-    @("TestSet", "after")!("Purses should be created with the given balance.", {
-      @"deposit"!(aliceAPurse, 10, bobBPurse, "ccDep1") |
-      @"deposit"!(bobBPurse, 10, aliceAPurse, "ccDep2") |
-      @"TestSet"!( //cannot deposit tokens across different mints
-        "Cross-currency deposits should fail.",
-        [
-          ["ccDep1", "hanging return"],
-          ["ccDep2", "hanging return"],
-        ]
-      )
-    }) |
-    
-    
-    @("TestSet", "after")!("Cross-currency deposits should fail.", {
-      @(aliceAPurse, "sprout")!("bobAPurse") |
-      @(bobBPurse, "sprout")!("aliceBPurse") |
-      for(@aliceBPurse <- @"aliceBPurse"; @bobAPurse <- @"bobAPurse") {
-        @"getBalance"!(aliceBPurse, "aliceBPurseBalance") |
-        @"getBalance"!(bobAPurse, "bobAPurseBalance") |
-        @"deposit"!(aliceBPurse, 10, bobBPurse, "bDep") |
-        @"deposit"!(bobAPurse, 20, aliceAPurse, "aDep1") |
-        @"deposit"!(bobAPurse, 30, aliceAPurse, "aDep2") |
-        @"TestSet"!(
-          "Deposit should work as expected.",
+    contract @"deposit"(@dest, @amount, @src, return) = {
+      new deposit in {
+        contract deposit(return) = {
+          @(dest, "deposit")!(amount, src, *return)
+        } |
+        return!(*deposit)
+      }
+    } |
+    contract @"split"(@purse, @amount, destCh, return) = {
+      new split in {
+        contract split(return) = {
+          @(purse, "split")!(amount, *destCh) |
+          for(@value <- destCh) {
+            match value {
+              [] => { return!(false) }
+              _  => { return!(true) }
+            } |
+            destCh!(value)
+          }
+        } |
+        return!(*split)
+      }
+    } |
+    @"MakeMint"!("mintA") | @"MakeMint"!("mintB") |
+    for(@mintA <- @"mintA"; @mintB <- @"mintB") {
+      @(mintA, "makePurse")!(100, "aliceAPurse") | @(mintB, "makePurse")!(50, "bobBPurse") |
+      for(@aliceAPurse <- @"aliceAPurse"; @bobBPurse <- @"bobBPurse") {
+        @"getBalance"!(aliceAPurse, "aliceAPurseBalance") |
+        @"getBalance"!(bobBPurse, "bobBPurseBalance") |
+        @TestSet!(
+          "Purses should be created with the given balance.",
           [
-            ["bDep", true], //10 from Bob to Alice
-            ["aliceBPurseBalance", 10], //0 + 10 = 10
-            ["bobBPurseBalance", 40], // 50 - 10 = 40
-            
-            ["aDep1", true], //20 from Alice to Bob
-            ["bobAPurseBalance", 20], //0 + 20 = 20
-            ["aliceAPurseBalance", 80], // 100 - 20 = 80
-            
-            ["aDep2", true], //30 from Alice to Bob again
-            ["bobAPurseBalance", 50], //20 + 30 = 50
-            ["aliceAPurseBalance", 50], // 80 - 30 = 50
+            ["aliceAPurseBalance", 100],
+            ["bobBPurseBalance", 50]
           ]
-        )
-      } |
-      
-      @("TestSet", "after")!("Deposit should work as expected.", {
-        @"split"!(aliceAPurse, 500, "failPurse", "splitFail") |
-        @(aliceAPurse, "split")!(5, "aliceAPurse5") |
-        for(@[aliceAPurse5] <- @"aliceAPurse5"){
-          @"aliceAPurse5"!([aliceAPurse5]) |
-          @"getBalance"!(aliceAPurse5, "aliceAPurse5Balance") |
-          @"TestSet"!(
-            "Split should work as expected.",
+        ) |
+        
+        
+        @TestSet!("after", "Purses should be created with the given balance.", {
+          @"deposit"!(aliceAPurse, 10, bobBPurse, "ccDep1") |
+          @"deposit"!(bobBPurse, 10, aliceAPurse, "ccDep2") |
+          @TestSet!( //cannot deposit tokens across different mints
+            "Cross-currency deposits should fail.",
             [
-              ["splitFail", false], //cannot split with more than you have
-              ["aliceAPurse5Balance", 5], //0 + 5 = 5
-              ["aliceAPurseBalance", 45] // 50 - 5 = 45
+              ["ccDep1", "hanging return"],
+              ["ccDep2", "hanging return"],
             ]
           )
-        }
-      })
-    })
+        }) |
+        
+        
+        @TestSet!("after", "Cross-currency deposits should fail.", {
+          @(aliceAPurse, "sprout")!("bobAPurse") |
+          @(bobBPurse, "sprout")!("aliceBPurse") |
+          for(@aliceBPurse <- @"aliceBPurse"; @bobAPurse <- @"bobAPurse") {
+            @"getBalance"!(aliceBPurse, "aliceBPurseBalance") |
+            @"getBalance"!(bobAPurse, "bobAPurseBalance") |
+            @"deposit"!(aliceBPurse, 10, bobBPurse, "bDep") |
+            @"deposit"!(bobAPurse, 20, aliceAPurse, "aDep1") |
+            @"deposit"!(bobAPurse, 30, aliceAPurse, "aDep2") |
+            @TestSet!(
+              "Deposit should work as expected.",
+              [
+                ["bDep", true], //10 from Bob to Alice
+                ["aliceBPurseBalance", 10], //0 + 10 = 10
+                ["bobBPurseBalance", 40], // 50 - 10 = 40
+                
+                ["aDep1", true], //20 from Alice to Bob
+                ["bobAPurseBalance", 20], //0 + 20 = 20
+                ["aliceAPurseBalance", 80], // 100 - 20 = 80
+                
+                ["aDep2", true], //30 from Alice to Bob again
+                ["bobAPurseBalance", 50], //20 + 30 = 50
+                ["aliceAPurseBalance", 50], // 80 - 30 = 50
+              ]
+            )
+          } |
+          
+          @TestSet!("after", "Deposit should work as expected.", {
+            @"split"!(aliceAPurse, 500, "failPurse", "splitFail") |
+            @(aliceAPurse, "split")!(5, "aliceAPurse5") |
+            for(@[aliceAPurse5] <- @"aliceAPurse5"){
+              @"aliceAPurse5"!([aliceAPurse5]) |
+              @"getBalance"!(aliceAPurse5, "aliceAPurse5Balance") |
+              @TestSet!(
+                "Split should work as expected.",
+                [
+                  ["splitFail", false], //cannot split with more than you have
+                  ["aliceAPurse5Balance", 5], //0 + 5 = 5
+                  ["aliceAPurseBalance", 45] // 50 - 5 = 45
+                ]
+              )
+            }
+          })
+        })
+      }
+    }
   }
 }

--- a/casper/src/test/rholang/MakeMintTest.rho
+++ b/casper/src/test/rholang/MakeMintTest.rho
@@ -1,7 +1,10 @@
 //scalapackage coop.rchain.rholang.mint
 
 //requires MakeMint, TestSet
-new rl(`rho:registry:lookup`), TestSetCh in {
+new
+  rl(`rho:registry:lookup`), TestSetCh,
+  test1, test2, test3, test4
+in {
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
   for(@(_, TestSet) <- TestSetCh) {
     contract @"getBalance"(@purse, return) = {
@@ -41,29 +44,31 @@ new rl(`rho:registry:lookup`), TestSetCh in {
       for(@aliceAPurse <- @"aliceAPurse"; @bobBPurse <- @"bobBPurse") {
         @"getBalance"!(aliceAPurse, "aliceAPurseBalance") |
         @"getBalance"!(bobBPurse, "bobBPurseBalance") |
-        @TestSet!(
+        @TestSet!("define",
           "Purses should be created with the given balance.",
           [
             ["aliceAPurseBalance", 100],
             ["bobBPurseBalance", 50]
-          ]
+          ],
+          *test1
         ) |
         
         
-        @TestSet!("after", "Purses should be created with the given balance.", {
+        @TestSet!("after", *test1, {
           @"deposit"!(aliceAPurse, 10, bobBPurse, "ccDep1") |
           @"deposit"!(bobBPurse, 10, aliceAPurse, "ccDep2") |
-          @TestSet!( //cannot deposit tokens across different mints
+          @TestSet!("define", //cannot deposit tokens across different mints
             "Cross-currency deposits should fail.",
             [
               ["ccDep1", "hanging return"],
               ["ccDep2", "hanging return"],
-            ]
+            ],
+            *test2
           )
         }) |
         
         
-        @TestSet!("after", "Cross-currency deposits should fail.", {
+        @TestSet!("after", *test2, {
           @(aliceAPurse, "sprout")!("bobAPurse") |
           @(bobBPurse, "sprout")!("aliceBPurse") |
           for(@aliceBPurse <- @"aliceBPurse"; @bobAPurse <- @"bobAPurse") {
@@ -72,7 +77,7 @@ new rl(`rho:registry:lookup`), TestSetCh in {
             @"deposit"!(aliceBPurse, 10, bobBPurse, "bDep") |
             @"deposit"!(bobAPurse, 20, aliceAPurse, "aDep1") |
             @"deposit"!(bobAPurse, 30, aliceAPurse, "aDep2") |
-            @TestSet!(
+            @TestSet!("define",
               "Deposit should work as expected.",
               [
                 ["bDep", true], //10 from Bob to Alice
@@ -86,23 +91,25 @@ new rl(`rho:registry:lookup`), TestSetCh in {
                 ["aDep2", true], //30 from Alice to Bob again
                 ["bobAPurseBalance", 50], //20 + 30 = 50
                 ["aliceAPurseBalance", 50], // 80 - 30 = 50
-              ]
+              ],
+              *test3
             )
           } |
           
-          @TestSet!("after", "Deposit should work as expected.", {
+          @TestSet!("after", *test3, {
             @"split"!(aliceAPurse, 500, "failPurse", "splitFail") |
             @(aliceAPurse, "split")!(5, "aliceAPurse5") |
             for(@[aliceAPurse5] <- @"aliceAPurse5"){
               @"aliceAPurse5"!([aliceAPurse5]) |
               @"getBalance"!(aliceAPurse5, "aliceAPurse5Balance") |
-              @TestSet!(
+              @TestSet!("define",
                 "Split should work as expected.",
                 [
                   ["splitFail", false], //cannot split with more than you have
                   ["aliceAPurse5Balance", 5], //0 + 5 = 5
                   ["aliceAPurseBalance", 45] // 50 - 5 = 45
-                ]
+                ],
+                *test4
               )
             }
           })

--- a/casper/src/test/rholang/MakePoSTest.rho
+++ b/casper/src/test/rholang/MakePoSTest.rho
@@ -2,7 +2,10 @@
 
 //requires MakePoS, MakeMint, TestSet, ListOps, Either
 
-new rl(`rho:registry:lookup`), TestSetCh in {
+new 
+  rl(`rho:registry:lookup`), TestSetCh,
+  test1, test2
+in {
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
   for(@(_, TestSet) <- TestSetCh) {
     @"pk"!!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
@@ -55,20 +58,21 @@ new rl(`rho:registry:lookup`), TestSetCh in {
           @"balance"!(tooBigBondPurse, "tooBigBalance") |
           @"bond"!(pos, pk, "ed25519Verify", tooSmallBondPurse, Nil, "tooSmallBond") |
           @"bond"!(pos, pk, "ed25519Verify", tooBigBondPurse, Nil, "tooBigBond") |
-          @TestSet!(
+          @TestSet!("define",
             "PoS bond should not accept bounds outside the min/max",
             [
               ["tooSmallBond", (false, "Bond less than minimum!")],
               ["tooBigBond", (false, "Bond greater than maximum!")],
               ["tooSmallBalance", 1],
               ["tooBigBalance", 500]
-            ]
+            ],
+            *test1
           ) |
 
           @"balance"!(bondPurse, "bondPurseBalance") |
           @"bond"!(pos, pk, "ed25519Verify", bondPurse, Nil, "justRightBond") |
           @"getBonds"!(pos, "posBonds") |
-          @TestSet!(
+          @TestSet!("define",
             "PoS bond should work for correct purses",
             [
               ["bondPurseBalance", 50],
@@ -78,7 +82,8 @@ new rl(`rho:registry:lookup`), TestSetCh in {
                 "someKey" : (37 + minimumBond, "verify", "reward", 1), 
                 pk        : (50 - minimumBond, "ed25519Verify", Nil, initBonds.size() + 1)
               }]
-            ]
+            ],
+            *test2
           )
         }
       }

--- a/casper/src/test/rholang/MakePoSTest.rho
+++ b/casper/src/test/rholang/MakePoSTest.rho
@@ -2,81 +2,86 @@
 
 //requires MakePoS, MakeMint, TestSet, ListOps, Either
 
-@"pk"!!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
-@"minimumBond"!!(5) |
-@"maximumBond"!!(100) |
-@"initBonds"!!({"someKey" : (37, "verify", "reward", 1)}) |
+new rl(`rho:registry:lookup`), TestSetCh in {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
+  for(@(_, TestSet) <- TestSetCh) {
+    @"pk"!!("79d16233dedf8e8e4cc25272b2b98ac096dac9239ade20dcee5987a1c1d101c7") |
+    @"minimumBond"!!(5) |
+    @"maximumBond"!!(100) |
+    @"initBonds"!!({"someKey" : (37, "verify", "reward", 1)}) |
 
-contract @"bond"(@pos, @publicKey, @sigVerify, @givenBondPurse, @rewardsForwarder, return) = {
-  new bond in {
-    contract bond(return) = {
-      @(pos, "bond")!(publicKey, sigVerify, givenBondPurse, rewardsForwarder, *return)
+    contract @"bond"(@pos, @publicKey, @sigVerify, @givenBondPurse, @rewardsForwarder, return) = {
+      new bond in {
+        contract bond(return) = {
+          @(pos, "bond")!(publicKey, sigVerify, givenBondPurse, rewardsForwarder, *return)
+        } |
+        return!(*bond)
+      }
     } |
-    return!(*bond)
-  }
-} |
 
-contract @"getBonds"(@pos, return) = {
-  new getBonds in {
-    contract getBonds(return) = { @(pos, "getBonds")!(*return) } |
-    return!(*getBonds)
-  }
-} |
+    contract @"getBonds"(@pos, return) = {
+      new getBonds in {
+        contract getBonds(return) = { @(pos, "getBonds")!(*return) } |
+        return!(*getBonds)
+      }
+    } |
 
-contract @"balance"(@purse, return) = {
-  new balance in {
-    contract balance(return) = { @(purse, "getBalance")!(*return) } |
-    return!(*balance)
-  }
-} |
+    contract @"balance"(@purse, return) = {
+      new balance in {
+        contract balance(return) = { @(purse, "getBalance")!(*return) } |
+        return!(*balance)
+      }
+    } |
 
-@"MakeMint"!("mint") | for(@mint <- @"mint") {
-  @(mint, "makePurse")!(0, "posPurse") |
-  @(mint, "makePurse")!(50, "bondPurse") |
-  @(mint, "makePurse")!(500, "tooBigBondPurse") |
-  @(mint, "makePurse")!(1, "tooSmallBondPurse") |
-  for(
-    @posPurse <- @"posPurse";
-    @bondPurse <- @"bondPurse";
-    @tooBigBondPurse <- @"tooBigBondPurse";
-    @tooSmallBondPurse <- @"tooSmallBondPurse";
-    @pk <- @"pk";
-    @minimumBond <- @"minimumBond";
-    @maximumBond <- @"maximumBond";
-    @initBonds <- @"initBonds"
-  ) {
-    @"MakePoS"!(posPurse, minimumBond, maximumBond, initBonds, "pos") | 
-    for(@pos <- @"pos") {
-      
-      @"balance"!(tooSmallBondPurse, "tooSmallBalance") |
-      @"balance"!(tooBigBondPurse, "tooBigBalance") |
-      @"bond"!(pos, pk, "ed25519Verify", tooSmallBondPurse, Nil, "tooSmallBond") |
-      @"bond"!(pos, pk, "ed25519Verify", tooBigBondPurse, Nil, "tooBigBond") |
-      @"TestSet"!(
-        "PoS bond should not accept bounds outside the min/max",
-        [
-          ["tooSmallBond", (false, "Bond less than minimum!")],
-          ["tooBigBond", (false, "Bond greater than maximum!")],
-          ["tooSmallBalance", 1],
-          ["tooBigBalance", 500]
-        ]
-      ) |
+    @"MakeMint"!("mint") | for(@mint <- @"mint") {
+      @(mint, "makePurse")!(0, "posPurse") |
+      @(mint, "makePurse")!(50, "bondPurse") |
+      @(mint, "makePurse")!(500, "tooBigBondPurse") |
+      @(mint, "makePurse")!(1, "tooSmallBondPurse") |
+      for(
+        @posPurse <- @"posPurse";
+        @bondPurse <- @"bondPurse";
+        @tooBigBondPurse <- @"tooBigBondPurse";
+        @tooSmallBondPurse <- @"tooSmallBondPurse";
+        @pk <- @"pk";
+        @minimumBond <- @"minimumBond";
+        @maximumBond <- @"maximumBond";
+        @initBonds <- @"initBonds"
+      ) {
+        @"MakePoS"!(posPurse, minimumBond, maximumBond, initBonds, "pos") | 
+        for(@pos <- @"pos") {
+          
+          @"balance"!(tooSmallBondPurse, "tooSmallBalance") |
+          @"balance"!(tooBigBondPurse, "tooBigBalance") |
+          @"bond"!(pos, pk, "ed25519Verify", tooSmallBondPurse, Nil, "tooSmallBond") |
+          @"bond"!(pos, pk, "ed25519Verify", tooBigBondPurse, Nil, "tooBigBond") |
+          @TestSet!(
+            "PoS bond should not accept bounds outside the min/max",
+            [
+              ["tooSmallBond", (false, "Bond less than minimum!")],
+              ["tooBigBond", (false, "Bond greater than maximum!")],
+              ["tooSmallBalance", 1],
+              ["tooBigBalance", 500]
+            ]
+          ) |
 
-      @"balance"!(bondPurse, "bondPurseBalance") |
-      @"bond"!(pos, pk, "ed25519Verify", bondPurse, Nil, "justRightBond") |
-      @"getBonds"!(pos, "posBonds") |
-      @"TestSet"!(
-        "PoS bond should work for correct purses",
-        [
-          ["bondPurseBalance", 50],
-          ["justRightBond", (true, "Bond successful!")],
-          ["bondPurseBalance", 0],
-          ["posBonds", {
-            "someKey" : (37 + minimumBond, "verify", "reward", 1), 
-            pk        : (50 - minimumBond, "ed25519Verify", Nil, initBonds.size() + 1)
-          }]
-        ]
-      )
+          @"balance"!(bondPurse, "bondPurseBalance") |
+          @"bond"!(pos, pk, "ed25519Verify", bondPurse, Nil, "justRightBond") |
+          @"getBonds"!(pos, "posBonds") |
+          @TestSet!(
+            "PoS bond should work for correct purses",
+            [
+              ["bondPurseBalance", 50],
+              ["justRightBond", (true, "Bond successful!")],
+              ["bondPurseBalance", 0],
+              ["posBonds", {
+                "someKey" : (37 + minimumBond, "verify", "reward", 1), 
+                pk        : (50 - minimumBond, "ed25519Verify", Nil, initBonds.size() + 1)
+              }]
+            ]
+          )
+        }
+      }
     }
   }
 }

--- a/casper/src/test/rholang/NonNegativeNumberTest.rho
+++ b/casper/src/test/rholang/NonNegativeNumberTest.rho
@@ -1,111 +1,113 @@
 //scalapackage coop.rchain.rholang.math
 
 //requires NonNegativeNumber, TestSet
-new value, add, sub in {
-  contract value(@nn, return) = {
-    new nnValue in {
-      contract nnValue(return) = {
-        @(nn, "value")!(*return)
-      } |
-      return!(*nnValue)
+new
+  rl(`rho:registry:lookup`), TestSetCh,
+  value, add, sub
+in {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
+  for(@(_, TestSet) <- TestSetCh) {
+    contract value(@nn, return) = {
+      new nnValue in {
+        contract nnValue(return) = {
+          @(nn, "value")!(*return)
+        } |
+        return!(*nnValue)
+      }
+    } |
+    contract add(@nn, @x, return) = {
+      new nnAdd in {
+        contract nnAdd(return) = {
+          @(nn, "add")!(x, *return)
+        } |
+        return!(*nnAdd)
+      }
+    } |
+    contract sub(@nn, @x, return) = {
+      new nnSub in {
+        contract nnSub(return) = {
+          @(nn, "sub")!(x, *return)
+        } |
+        return!(*nnSub)
+      }
+    } |
+
+    @"NonNegativeNumber"!(-5, "negBal") |
+    @"NonNegativeNumber"!(15, "properBal") |
+    @"NonNegativeNumber"!(100, "addTest") |
+    @"NonNegativeNumber"!(100, "subTest") |
+    @"NonNegativeNumber"!(9223372036854775757, "overflowTest") |
+
+    for(
+      @negBal <- @"negBal"; 
+      @properBal <- @"properBal"; 
+      @addTest <- @"addTest"; 
+      @subTest <- @"subTest";
+      @overflowTest <- @"overflowTest"
+    ) {
+      value!(negBal, "negBalValue") |
+      @TestSet!(
+        "Initially negative balances are be converted to 0.",
+        [
+          ["negBalValue", 0]
+        ]
+      ) |
+
+      value!(properBal, "properBalValue") |
+      @TestSet!(
+        "Positive initial balances are preserved.",
+        [
+          ["properBalValue", 15]
+        ]
+      ) | 
+
+      add!(properBal, -1, "properBalAddNeg") |
+      sub!(properBal, -1, "properBalSubNeg") |
+      @TestSet!(
+        "Adding or subtracting a negative number fails.",
+        [
+          ["properBalAddNeg", false],
+          ["properBalSubNeg", false]
+        ]
+      ) |
+
+      sub!(properBal, 27, "properBalSubBig") |
+      @TestSet!(
+        "Subtracting an amount larger than the balance fails.",
+        [
+          ["properBalSubBig", false]
+        ]
+      ) |
+
+      add!(addTest, 50, "addTest50") |
+      value!(addTest, "addTestValue") |
+      @TestSet!(
+        "Adding a positive number works.",
+        [
+          ["addTestValue", 100],
+          ["addTest50", true],
+          ["addTestValue", 150]
+        ]
+      ) |
+
+      sub!(subTest, 30, "subTest30") |
+      value!(subTest, "subTestValue") |
+      @TestSet!(
+        "Subtracting a positive number less than or equal to the balance works",
+        [
+          ["subTestValue", 100],
+          ["subTest30", true],
+          ["subTestValue", 70]
+        ]
+      ) |
+      
+      add!(overflowTest, 100, "overflowTestAdd") |
+      @TestSet!(
+        "Addition overflow is prevented",
+        [
+          ["overflowTestAdd", false]
+        ]
+      )
     }
-  } |
-  contract add(@nn, @x, return) = {
-    new nnAdd in {
-      contract nnAdd(return) = {
-        @(nn, "add")!(x, *return)
-      } |
-      return!(*nnAdd)
-    }
-  } |
-  contract sub(@nn, @x, return) = {
-    new nnSub in {
-      contract nnSub(return) = {
-        @(nn, "sub")!(x, *return)
-      } |
-      return!(*nnSub)
-    }
-  } |
-
-  @"NonNegativeNumber"!(-5, "negBal") |
-  @"NonNegativeNumber"!(15, "properBal") |
-  @"NonNegativeNumber"!(100, "addTest") |
-  @"NonNegativeNumber"!(100, "subTest") |
-  // Somehow putting the literal value of `Long.MaxValue - 50` below makes `sbt casper/test:compile` fail.
-  // Just as if the tools underneath used a version of rholang that can't parse 64bit ints
-  // The number below is:
-  // (2^31 * 2^31) + (2^31 * 2^31 - 1 - 50) = (2^62 + 2^62 - 1 - 50) = 2^63 - 1 - 50 = Long.MaxValue - 50
-  @"NonNegativeNumber"!((2147483647 + 1) * (2147483647 + 1) + ((2147483647 + 1) * (2147483647 + 1) - 1 - 50), "overflowTest") |
-
-  for(
-    @negBal <- @"negBal"; 
-    @properBal <- @"properBal"; 
-    @addTest <- @"addTest"; 
-    @subTest <- @"subTest";
-    @overflowTest <- @"overflowTest"
-  ) {
-    value!(negBal, "negBalValue") |
-    @"TestSet"!(
-      "Initially negative balances are be converted to 0.",
-      [
-        ["negBalValue", 0]
-      ]
-    ) |
-
-    value!(properBal, "properBalValue") |
-    @"TestSet"!(
-      "Positive initial balances are preserved.",
-      [
-        ["properBalValue", 15]
-      ]
-    ) | 
-
-    add!(properBal, -1, "properBalAddNeg") |
-    sub!(properBal, -1, "properBalSubNeg") |
-    @"TestSet"!(
-      "Adding or subtracting a negative number fails.",
-      [
-        ["properBalAddNeg", false],
-        ["properBalSubNeg", false]
-      ]
-    ) |
-
-    sub!(properBal, 27, "properBalSubBig") |
-    @"TestSet"!(
-      "Subtracting an amount larger than the balance fails.",
-      [
-        ["properBalSubBig", false]
-      ]
-    ) |
-
-    add!(addTest, 50, "addTest50") |
-    value!(addTest, "addTestValue") |
-    @"TestSet"!(
-      "Adding a positive number works.",
-      [
-        ["addTestValue", 100],
-        ["addTest50", true],
-        ["addTestValue", 150]
-      ]
-    ) |
-
-    sub!(subTest, 30, "subTest30") |
-    value!(subTest, "subTestValue") |
-    @"TestSet"!(
-      "Subtracting a positive number less than or equal to the balance works",
-      [
-        ["subTestValue", 100],
-        ["subTest30", true],
-        ["subTestValue", 70]
-      ]
-    ) |
-    
-    add!(overflowTest, 100, "overflowTestAdd") |
-    @"TestSet"!(
-      "Addition overflow is prevented",
-      [
-        ["overflowTestAdd", false]
-      ]
-    )
   }
 }

--- a/casper/src/test/rholang/NonNegativeNumberTest.rho
+++ b/casper/src/test/rholang/NonNegativeNumberTest.rho
@@ -3,7 +3,8 @@
 //requires NonNegativeNumber, TestSet
 new
   rl(`rho:registry:lookup`), TestSetCh,
-  value, add, sub
+  value, add, sub, test1, test2, test3,
+  test4, test5, test6, test7
 in {
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *TestSetCh) |
   for(@(_, TestSet) <- TestSetCh) {
@@ -46,67 +47,74 @@ in {
       @overflowTest <- @"overflowTest"
     ) {
       value!(negBal, "negBalValue") |
-      @TestSet!(
+      @TestSet!("define",
         "Initially negative balances are be converted to 0.",
         [
           ["negBalValue", 0]
-        ]
+        ],
+        *test1
       ) |
 
       value!(properBal, "properBalValue") |
-      @TestSet!(
+      @TestSet!("define",
         "Positive initial balances are preserved.",
         [
           ["properBalValue", 15]
-        ]
+        ],
+        *test2
       ) | 
 
       add!(properBal, -1, "properBalAddNeg") |
       sub!(properBal, -1, "properBalSubNeg") |
-      @TestSet!(
+      @TestSet!("define",
         "Adding or subtracting a negative number fails.",
         [
           ["properBalAddNeg", false],
           ["properBalSubNeg", false]
-        ]
+        ],
+        *test3
       ) |
 
       sub!(properBal, 27, "properBalSubBig") |
-      @TestSet!(
+      @TestSet!("define",
         "Subtracting an amount larger than the balance fails.",
         [
           ["properBalSubBig", false]
-        ]
+        ],
+        *test4
       ) |
 
       add!(addTest, 50, "addTest50") |
       value!(addTest, "addTestValue") |
-      @TestSet!(
+      @TestSet!("define",
         "Adding a positive number works.",
         [
           ["addTestValue", 100],
           ["addTest50", true],
           ["addTestValue", 150]
-        ]
+        ],
+        *test5
       ) |
 
       sub!(subTest, 30, "subTest30") |
       value!(subTest, "subTestValue") |
-      @TestSet!(
+      @TestSet!("define",
         "Subtracting a positive number less than or equal to the balance works",
         [
           ["subTestValue", 100],
           ["subTest30", true],
           ["subTestValue", 70]
-        ]
+        ],
+        *test6
       ) |
       
       add!(overflowTest, 100, "overflowTestAdd") |
-      @TestSet!(
+      @TestSet!("define",
         "Addition overflow is prevented",
         [
           ["overflowTestAdd", false]
-        ]
+        ],
+        *test7
       )
     }
   }

--- a/casper/src/test/rholang/TestSet.rho
+++ b/casper/src/test/rholang/TestSet.rho
@@ -1,11 +1,22 @@
 //scalapackage coop.rchain.rholang.unittest
 
-//requires ListOps
-
-new rl(`rho:registry:lookup`), ListOpsCh in {
+//Registry info:
+//  sk: adf1e344dd34979255aeaaf5703a586fba52246d9940ef58572572db339316d3
+//  pk: 4ae94eb0b2d7df529f7ae68863221d5adda402fc54303a3d90a8a7a279326828
+//  user == pk
+//  timestamp: 1539808849271
+//Resulting unforgable name: TestSet == Unforgeable(0xbc4bad752f043b9e488ddfc1c69370a89700f4852f318a79d0b50d88f44e1210)
+//  ==> signature data == 2a3eaa013b0a0d2a0b10feffffffffffffffff010a2a5a280a243a220a20bc4bad752f043b9e488ddfc1c69370a89700f4852f318a79d0b50d88f44e12101001
+//  ==> signature == 07aa40b3bcb61b91816d7f7763ed3b7abccfeb99688ecec75cd76099f1552010bc523980fb476c990b982a46a9f36649097b8c02b590ae72a2bac4a7a790490b
+//URI derived from pk == `rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`
+new
+  TestSet, rs(`rho:registry:insertSigned:ed25519`), 
+  rl(`rho:registry:lookup`), ListOpsCh,
+  runWithTimeout, uriOut
+in {
   rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
   for(@(_, ListOps) <- ListOpsCh) {
-    contract @"runWithTimeout"(function, @t, return) = {
+    contract runWithTimeout(function, @t, return) = {
       new result, ticksCh in {
         ticksCh!(t) |
         for(@ticks <= ticksCh) {
@@ -19,7 +30,7 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
         }
       }
     } |
-    contract @"TestSet"(desc, @tests) = {
+    contract TestSet(desc, @tests) = {
       new addTests, execTests, testsCh in {
         contract execTests(return) = {
           new combinator in {
@@ -49,7 +60,7 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
                       for (function <- @functionCh) {
                         @functionCh!(*function) | //put back for possible re-use
                         new result in {
-                          @"runWithTimeout"!(*function, 1000, *result) |
+                          runWithTimeout!(*function, 1000, *result) |
                           for(@r <- result) {
                             match r {
                               [result] => {
@@ -75,7 +86,7 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
         execTests!(*desc)
       }
     } |
-    contract @("TestSet", "after")(desc, continuation) = {
+    contract TestSet(@"after", desc, continuation) = {
       for(@result <- desc) {
         if (result) {
           desc!(result) | { *continuation }
@@ -84,5 +95,12 @@ new rl(`rho:registry:lookup`), ListOpsCh in {
         }
       }
     }
-  }
+  } |
+  
+  rs!(
+    "4ae94eb0b2d7df529f7ae68863221d5adda402fc54303a3d90a8a7a279326828".hexToBytes(), 
+    (9223372036854775807, bundle+{*TestSet}), 
+    "07aa40b3bcb61b91816d7f7763ed3b7abccfeb99688ecec75cd76099f1552010bc523980fb476c990b982a46a9f36649097b8c02b590ae72a2bac4a7a790490b".hexToBytes(), 
+    *uriOut
+  )
 }

--- a/casper/src/test/rholang/TestSet.rho
+++ b/casper/src/test/rholang/TestSet.rho
@@ -30,7 +30,7 @@ in {
         }
       }
     } |
-    contract TestSet(desc, @tests) = {
+    contract TestSet(@"define", @desc, @tests, return) = {
       new addTests, execTests, testsCh in {
         contract execTests(return) = {
           new combinator in {
@@ -83,15 +83,25 @@ in {
           }
         } |
         addTests!(tests) |
-        execTests!(*desc)
+        new testsResult in {
+          execTests!(*testsResult) |
+          for(@result <- testsResult) {
+            return!(("${desc} == ${result}" %% {"desc" : desc, "result" : result}, result))
+          }
+        }
       }
     } |
-    contract TestSet(@"after", desc, continuation) = {
-      for(@result <- desc) {
-        if (result) {
-          desc!(result) | { *continuation }
-        } else {
-          desc!(result)
+    contract TestSet(@"after", testReturn, continuation) = {
+      for(@value <- testReturn) {
+        match value {
+          (_, result) => {
+            if (result) {
+              testReturn!(value) | { *continuation }
+            } else {
+              testReturn!(value)
+            }
+          }
+          _ => { testReturn!(value) }
         }
       }
     }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -105,10 +105,10 @@ object TestSetUtil {
     */
   def getTests(src: String): Iterator[String] =
     Source.fromFile(src).getLines().sliding(2).collect {
-      case Seq(line1, line2) if line1.contains("@TestSet!") && !line1.contains("\"after\",") =>
-        line2.trim.dropRight(1)
+      case Seq(line1, line2) if line1.contains("@TestSet!(\"define\",") =>
+        line2.split('"')(1)
     }
 
   def testPassed(test: String, tuplespace: String): Boolean =
-    tuplespace.contains(s"@{$test}!(true)")
+    tuplespace.contains(s"$test == true")
 }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -11,6 +11,7 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.collection.ListOps
 import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.unittest.TestSet
 import coop.rchain.shared.StoreType.InMem
@@ -21,6 +22,23 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 object TestSetUtil {
+
+  val testSetDeploy: Deploy = {
+    val deployData = DeployData(
+      user = ProtoUtil.stringToByteString(
+        "4ae94eb0b2d7df529f7ae68863221d5adda402fc54303a3d90a8a7a279326828"
+      ),
+      timestamp = 1539808849271L,
+      term = TestSet.code,
+      phloLimit = Some(accounting.MAX_VALUE)
+    )
+
+    Deploy(
+      term = Some(TestSet.term),
+      raw = Some(deployData)
+    )
+
+  }
 
   def runtime(implicit scheduler: Scheduler): Runtime = {
     val runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
@@ -58,7 +76,7 @@ object TestSetUtil {
   ): Unit = {
     val rand = Blake2b512Random(128)
     evalDeploy(StandardDeploys.listOps, runtime)(implicitly)
-    eval(TestSet.code, runtime)(implicitly, rand.splitShort(0))
+    evalDeploy(testSetDeploy, runtime)(implicitly)
     otherLibs.foreach(evalDeploy(_, runtime))
     eval(tests.code, runtime)(implicitly, rand.splitShort(1))
   }
@@ -71,7 +89,7 @@ object TestSetUtil {
     //load "libraries" required for all tests
     val rand = Blake2b512Random(128)
     evalDeploy(StandardDeploys.listOps, runtime)(implicitly)
-    eval(TestSet.code, runtime)(implicitly, rand.splitShort(1))
+    evalDeploy(testSetDeploy, runtime)(implicitly)
 
     //load "libraries" required for this particular set of tests
     otherLibs.zipWithIndex.foreach {
@@ -87,7 +105,7 @@ object TestSetUtil {
     */
   def getTests(src: String): Iterator[String] =
     Source.fromFile(src).getLines().sliding(2).collect {
-      case Seq(line1, line2) if line1.contains("TestSet\"!") =>
+      case Seq(line1, line2) if line1.contains("@TestSet!") && !line1.contains("\"after\",") =>
         line2.trim.dropRight(1)
     }
 


### PR DESCRIPTION
## Overview
Continuing to eradicate forgable names. `TestSet.rho` used to put the result of the test directly on the description (e.g. `@"x should y"!(true)`), so this needed to be changed, in addition to making `TestSet` use the registry.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-916

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
