### PR TITLE
Core 1321 dynamic ip

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -65,7 +65,7 @@ class BlockApproverProtocol(
       validCandidate match {
         case Right(_) =>
           for {
-            local <- RPConfAsk[F].reader(_.local)
+            local <- RPConfAsk[F].reader(_.local())
             serializedApproval = BlockApproverProtocol
               .getApproval(candidate, validatorId)
               .toByteString

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -189,7 +189,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         peer: PeerNode,
         br: ApprovedBlockRequest
     ): F[Option[Packet]] =
-      RPConfAsk[F].reader(_.local).map(noApprovedBlockAvailable(_).some)
+      RPConfAsk[F].reader(_.local()).map(noApprovedBlockAvailable(_).some)
 
     override def handleBlockApproval(ba: BlockApproval): F[Option[Packet]] =
       nonePacket
@@ -228,7 +228,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         peer: PeerNode,
         br: ApprovedBlockRequest
     ): F[Option[Packet]] =
-      RPConfAsk[F].reader(_.local).map(noApprovedBlockAvailable(_).some)
+      RPConfAsk[F].reader(_.local()).map(noApprovedBlockAvailable(_).some)
 
     override def handleUnapprovedBlock(peer: PeerNode, ub: UnapprovedBlock): F[Option[Packet]] =
       nonePacket
@@ -360,7 +360,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
 
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Option[Packet]] =
       for {
-        local      <- RPConfAsk[F].reader(_.local)
+        local      <- RPConfAsk[F].reader(_.local())
         block      <- BlockStore[F].get(br.hash) // TODO: Refactor
         serialized = block.map(_.toByteString)
         maybeMsg = serialized.map(

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -55,7 +55,7 @@ object CommUtil {
   ): F[Unit] =
     for {
       peers <- ConnectionsCell[F].read
-      local <- RPConfAsk[F].reader(_.local)
+      local <- RPConfAsk[F].reader(_.local())
       msg   = packet(local, pType, serializedMessage)
       _     <- TransportLayer[F].broadcast(peers, msg)
     } yield ()
@@ -66,7 +66,7 @@ object CommUtil {
   ): F[Unit] =
     for {
       peers <- ConnectionsCell[F].read
-      local <- RPConfAsk[F].reader(_.local)
+      local <- RPConfAsk[F].reader(_.local())
       msg   = Blob(local, Packet(pType.id, serializedMessage))
       _     <- TransportLayer[F].stream(peers, msg)
     } yield ()
@@ -125,7 +125,7 @@ object CommUtil {
     for {
       a     <- LastApprovedBlock[F].get
       peers <- ConnectionsCell[F].read
-      local <- RPConfAsk[F].reader(_.local)
+      local <- RPConfAsk[F].reader(_.local())
       _     <- a.fold(askPeers(peers, local))(_ => ().pure[F])
     } yield ()
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -67,7 +67,7 @@ class HashSetCasperTestNode[F[_]](
   implicit val blockStore =
     LMDBBlockStore.create[F](LMDBBlockStore.Config(path = dir, mapSize = storageSize))
   implicit val turanOracleEffect = SafetyOracle.turanOracle[F]
-  implicit val rpConfAsk         = createRPConfAsk[F](local)
+  implicit val rpConfAsk         = createRPConfAsk[F](() => local)
 
   val activeRuntime                  = Runtime.create(storageDirectory, storageSize)
   val runtimeManager                 = RuntimeManager.fromRuntime(activeRuntime)

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
@@ -336,7 +336,7 @@ object ApproveBlockProtocolTest {
     implicit val time            = TestTime.instance
     implicit val transportLayer  = new TransportLayerStub[Task]
     val src: PeerNode            = peerNode("src", 40400)
-    implicit val rpConfAsk       = createRPConfAsk[Task](src)
+    implicit val rpConfAsk       = createRPConfAsk[Task](() => src)
     implicit val ctx             = monix.execution.Scheduler.Implicits.global
     implicit val connectionsCell = Cell.mvarCell[Connections](List(src)).unsafeRunSync
     implicit val lab             = LastApprovedBlock.unsafe[Task](None)

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -74,7 +74,7 @@ class CasperPacketHandlerSpec extends WordSpec {
     implicit val connectionsCell: ConnectionsCell[Task] =
       Cell.unsafe[Task, Connections](List(local))
     implicit val transportLayer = new TransportLayerStub[Task]
-    implicit val rpConf         = createRPConfAsk[Task](local)
+    implicit val rpConf         = createRPConfAsk[Task](() => local)
     implicit val time           = TestTime.instance
     implicit val log            = new LogStub[Task]
     implicit val errHandler = new ApplicativeError_[Task, CommError] {

--- a/comm/src/main/scala/coop/rchain/comm/PeerNode.scala
+++ b/comm/src/main/scala/coop/rchain/comm/PeerNode.scala
@@ -35,7 +35,8 @@ final case class PeerNode(id: NodeIdentifier, endpoint: Endpoint) {
 
 object PeerNode {
 
-  import scala.util.matching.Regex, Regex._
+  def from(id: NodeIdentifier, host: String, protocol: Int, discovery: Int): PeerNode =
+    PeerNode(id, Endpoint(host, protocol, discovery))
 
   def fromAddress(str: String): Either[CommError, PeerNode] = {
     // TODO toInt, not URL, scheme not rnode, renameflag to discovery-port
@@ -44,14 +45,18 @@ object PeerNode {
     val maybePeer = maybeUrl flatMap (
         url =>
           for {
-            scheme    <- url.schemeOption
-            key       <- url.user
+            _         <- url.schemeOption
+            id        <- url.user
             host      <- url.hostOption
             discovery <- url.query.param("discovery").flatMap(v => Try(v.toInt).toOption)
             protocol  <- url.query.param("protocol").flatMap(v => Try(v.toInt).toOption)
-          } yield PeerNode(NodeIdentifier(key), Endpoint(host.value, protocol, discovery))
+          } yield from(NodeIdentifier(id), host.value, protocol, discovery)
       )
 
     maybePeer.fold[Either[CommError, PeerNode]](Left(ParseError(s"bad address: $str")))(Right(_))
   }
+}
+
+trait LocalPeerNode {
+  def apply(): PeerNode
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -14,7 +14,7 @@ import com.google.protobuf.ByteString
 import scala.concurrent.duration._
 import com.google.protobuf.ByteString
 
-class GrpcKademliaRPC(src: PeerNode, port: Int, timeout: FiniteDuration)(
+class GrpcKademliaRPC(localPeerNode: LocalPeerNode, port: Int, timeout: FiniteDuration)(
     implicit
     scheduler: Scheduler,
     metrics: Metrics[Task],
@@ -29,7 +29,7 @@ class GrpcKademliaRPC(src: PeerNode, port: Int, timeout: FiniteDuration)(
       channel <- clientChannel(peer)
       pongErr <- KademliaGrpcMonix
                   .stub(channel)
-                  .sendPing(Ping().withSender(node(src)))
+                  .sendPing(Ping().withSender(node(localPeerNode())))
                   .nonCancelingTimeout(timeout)
                   .attempt
       _ <- Task.delay(channel.shutdown())
@@ -41,7 +41,7 @@ class GrpcKademliaRPC(src: PeerNode, port: Int, timeout: FiniteDuration)(
       _ <- Metrics[Task].incrementCounter("protocol-lookup-send")
       lookup = Lookup()
         .withId(ByteString.copyFrom(key.toArray))
-        .withSender(node(src))
+        .withSender(node(localPeerNode()))
       channel <- clientChannel(peer)
       responseErr <- KademliaGrpcMonix
                       .stub(channel)

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -14,24 +14,22 @@ import coop.rchain.shared._
 
 object KademliaNodeDiscovery {
   def create[F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](
-      src: PeerNode,
+      id: NodeIdentifier,
       defaultTimeout: FiniteDuration
   )(init: Option[PeerNode]): F[KademliaNodeDiscovery[F]] =
     for {
-      knd <- new KademliaNodeDiscovery[F](src, defaultTimeout).pure[F]
+      knd <- new KademliaNodeDiscovery[F](id, defaultTimeout).pure[F]
       _   <- init.fold(().pure[F])(p => knd.addNode(p))
     } yield knd
 
 }
 
 private[discovery] class KademliaNodeDiscovery[F[_]: Monad: Capture: Log: Time: Metrics: KademliaRPC](
-    src: PeerNode,
+    id: NodeIdentifier,
     timeout: FiniteDuration
 ) extends NodeDiscovery[F] {
 
-  private val table = PeerTable(src)
-
-  private val id: NodeIdentifier = src.id
+  private val table = PeerTable[PeerNode](id.key)
 
   // TODO inline usage
   private[discovery] def addNode(peer: PeerNode): F[Unit] =

--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -63,7 +63,7 @@ object HandleMessages {
       packet: Packet
   ): F[CommunicationResponse] =
     for {
-      local               <- RPConfAsk[F].reader(_.local)
+      local               <- RPConfAsk[F].reader(_.local())
       maybeResponsePacket <- PacketHandler[F].handlePacket(remote, packet)
     } yield
       maybeResponsePacket
@@ -89,7 +89,7 @@ object HandleMessages {
       } yield handledWithMessage(ProtocolHelper.protocolHandshakeResponse(local))
 
     for {
-      local        <- RPConfAsk[F].reader(_.local)
+      local        <- RPConfAsk[F].reader(_.local())
       hbrErr       <- TransportLayer[F].roundTrip(peer, ProtocolHelper.heartbeat(local), defaultTimeout)
       commResponse <- hbrErr.fold(error => notHandledHandshake(error), _ => handledHandshake(local))
     } yield commResponse
@@ -99,7 +99,7 @@ object HandleMessages {
       peer: PeerNode,
       heartbeat: Heartbeat
   ): F[CommunicationResponse] =
-    RPConfAsk[F].reader(_.local) map (
+    RPConfAsk[F].reader(_.local()) map (
         local => handledWithMessage(ProtocolHelper.heartbeatResponse(local))
     )
 

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -1,10 +1,11 @@
 package coop.rchain.comm.rp
 
-import coop.rchain.comm.PeerNode
 import scala.concurrent.duration._
 
+import coop.rchain.comm.LocalPeerNode
+
 case class RPConf(
-    local: PeerNode,
+    local: LocalPeerNode,
     defaultTimeout: FiniteDuration,
     clearConnections: ClearConnetionsConf
 )

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -17,7 +17,7 @@ import coop.rchain.comm.protocol.routing.RoutingGrpcMonix.TransportLayerStub
 import monix.eval._, monix.execution._, monix.reactive._
 import scala.concurrent.TimeoutException
 
-class TcpTransportLayer(host: String, port: Int, cert: String, key: String, maxMessageSize: Int)(
+class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: Int)(
     implicit scheduler: Scheduler,
     cell: TcpTransportLayer.TransportCell[Task],
     log: Log[Task]

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -136,7 +136,7 @@ class ClearConnectionsSpec
       RPConf(
         clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = FiniteDuration(1, MILLISECONDS),
-        local = peer("src")
+        local = () => peer("src")
       )
     )
 

--- a/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ConnectSpec.scala
@@ -30,7 +30,7 @@ class ConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach with App
   implicit val transportLayerEff = new TransportLayerStub[Effect]
   implicit val packetHandler     = new PacketHandler.NOPPacketHandler[Effect]
   implicit val connectionsCell   = Cell.unsafe[Effect, Connections](Connect.Connections.empty)
-  implicit val rpConfAsk         = createRPConfAsk[Effect](peerNode("src", 40400))
+  implicit val rpConfAsk         = createRPConfAsk[Effect](() => peerNode("src", 40400))
 
   override def beforeEach(): Unit = {
     nodeDiscoveryEff.reset()

--- a/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
@@ -118,7 +118,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
       RPConf(
         clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = defaultTimeout,
-        local = peer("src")
+        local = () => peer("src")
       )
     )
 

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -38,7 +38,7 @@ class DistanceSpec extends FlatSpec with Matchers {
   "A PeerNode of width n bytes" should "have distance to itself equal to 8n" in {
     for (i <- 1 to 64) {
       val home = PeerNode(NodeIdentifier(b.rand(i)), endpoint)
-      val nt   = PeerTable(home)
+      val nt   = PeerTable[PeerNode](home.key)
       nt.distance(home) should be(Some(8 * nt.width))
     }
   }
@@ -60,7 +60,7 @@ class DistanceSpec extends FlatSpec with Matchers {
       }
 
     def testKey(key: Array[Byte]): Boolean = {
-      val table = PeerTable(PeerNode(NodeIdentifier(key), endpoint))
+      val table = PeerTable[PeerNode](key)
       oneOffs(key).map(table.distance(_)) == (0 until 8 * width).map(Option[Int])
     }
 
@@ -83,22 +83,22 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     s"An empty table of width $width" should "have no peers" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       assert(table.table.forall(_.isEmpty))
     }
 
     it should "return no peers" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       table.peers.size should be(0)
     }
 
     it should "return no values on lookup" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       table.lookup(b.rand(width)).size should be(0)
     }
 
     s"A table of width $width" should "add a key at most once" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       val toAdd = oneOffs(kr).head
       val dist  = table.distance(toAdd).get
       for (i <- 1 to 10) {
@@ -108,7 +108,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     s"A table of width $width with peers at all distances" should "have no empty buckets" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       for (k <- oneOffs(kr.toArray)) {
         table.updateLastSeen[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
@@ -116,7 +116,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     it should s"return min(k, ${8 * width}) peers on lookup" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       for (k <- oneOffs(kr.toArray)) {
         table.updateLastSeen[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
@@ -124,7 +124,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     it should "not return sought peer on lookup" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       for (k <- oneOffs(kr.toArray)) {
         table.updateLastSeen[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
@@ -134,7 +134,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     it should s"return ${8 * width} peers when sequenced" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       for (k <- oneOffs(kr.toArray)) {
         table.updateLastSeen[Id](PeerNode(NodeIdentifier(k), endpoint))
       }
@@ -142,7 +142,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     it should "find each added peer" in {
-      val table = PeerTable(PeerNode(NodeIdentifier(kr), endpoint))
+      val table = PeerTable[PeerNode](kr)
       for (k <- oneOffs(kr.toArray)) {
         table.updateLastSeen[Id](PeerNode(NodeIdentifier(k), endpoint))
       }

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -21,11 +21,11 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   val DISTANCE_4 = Some(4)
   val DISTANCE_6 = Some(6)
 
-  var table       = PeerTable(local, 3)
+  var table       = PeerTable[PeerNode](local.key, 3)
   var pingedPeers = mutable.MutableList.empty[PeerNode]
 
   override def beforeEach(): Unit = {
-    table = PeerTable(local, 3)
+    table = PeerTable[PeerNode](local.key, 3)
     pingedPeers = mutable.MutableList.empty[PeerNode]
     // peer1-4 distance is 4
     table.distance(peer1) shouldBe DISTANCE_4

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -40,7 +40,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
 
   def createTransportLayer(env: TcpTlsEnvironment): Task[TransportLayer[Task]] =
     Cell.mvarCell(TransportState.empty).map { cell =>
-      new TcpTransportLayer(env.host, env.port, env.cert, env.key, maxMessageSize)(
+      new TcpTransportLayer(env.port, env.cert, env.key, maxMessageSize)(
         scheduler,
         cell,
         log

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -48,7 +48,7 @@ object EffectsTestInstances {
   }
 
   def createRPConfAsk[F[_]: Applicative](
-      local: PeerNode,
+      local: LocalPeerNode,
       defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS),
       clearConnections: ClearConnetionsConf = ClearConnetionsConf(1, 1)
   ) =

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -96,7 +96,8 @@ object Main {
   private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] =
     for {
       host   <- conf.fetchHost
-      result <- new NodeRuntime(conf, host, scheduler).main.value
+      id     <- NodeEnvironment.create(conf)
+      result <- new NodeRuntime(conf, host, id, scheduler).main.value
       _ <- result match {
             case Right(_) =>
               Task.unit

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -95,9 +95,9 @@ object Main {
 
   private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] =
     for {
-      host   <- conf.fetchHost
       id     <- NodeEnvironment.create(conf)
-      result <- new NodeRuntime(conf, host, id, scheduler).main.value
+      local  <- conf.fetchLocalPeerNode(id)
+      result <- new NodeRuntime(conf, local, scheduler).main.value
       _ <- result match {
             case Right(_) =>
               Task.unit

--- a/node/src/main/scala/coop/rchain/node/NodeEnvironment.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeEnvironment.scala
@@ -1,0 +1,101 @@
+package coop.rchain.node
+
+import scala.util._
+
+import coop.rchain.comm.NodeIdentifier
+import coop.rchain.comm.transport.{CertificateHelper, CertificatePrinter}
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.node.configuration.Configuration
+
+import monix.eval.Task
+
+object NodeEnvironment {
+
+  def create(conf: Configuration): Task[NodeIdentifier] =
+    Task.delay {
+      val dataDirFile = conf.server.dataDir.toFile
+
+      if (!dataDirFile.exists()) {
+        if (!dataDirFile.mkdir()) {
+          println(
+            s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
+          )
+          System.exit(-1)
+        }
+      }
+
+      // Check if data_dir has read/write access
+      if (!dataDirFile.isDirectory || !dataDirFile.canRead || !dataDirFile.canWrite) {
+        println(
+          s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
+        )
+        System.exit(-1)
+      }
+
+      println(s"Using data_dir: ${dataDirFile.getAbsolutePath}")
+
+      // Generate certificate if not provided as option or in the data dir
+      if (!conf.tls.customCertificateLocation
+          && !conf.tls.certificate.toFile.exists()) {
+        println(s"No certificate found at path ${conf.tls.certificate}")
+        println("Generating a X.509 certificate for the node")
+
+        import coop.rchain.shared.Resources._
+        // If there is a key, use it for the certificate
+        if (conf.tls.key.toFile.exists()) {
+          println(s"Using secret key ${conf.tls.key}")
+          Try(CertificateHelper.readKeyPair(conf.tls.key.toFile)) match {
+            case Success(keyPair) =>
+              withResource(new java.io.PrintWriter(conf.tls.certificate.toFile)) {
+                _.write(CertificatePrinter.print(CertificateHelper.generate(keyPair)))
+              }
+            case Failure(e) =>
+              println(s"Invalid secret key: ${e.getMessage}")
+          }
+        } else {
+          println("Generating a PEM secret key for the node")
+          val keyPair = CertificateHelper.generateKeyPair(conf.tls.secureRandomNonBlocking)
+          withResource(new java.io.PrintWriter(conf.tls.certificate.toFile)) { pw =>
+            pw.write(CertificatePrinter.print(CertificateHelper.generate(keyPair)))
+          }
+          withResource(new java.io.PrintWriter(conf.tls.key.toFile)) { pw =>
+            pw.write(CertificatePrinter.printPrivateKey(keyPair.getPrivate))
+          }
+        }
+      }
+
+      if (!conf.tls.certificate.toFile.exists()) {
+        println(s"Certificate file ${conf.tls.certificate} not found")
+        System.exit(-1)
+      }
+
+      if (!conf.tls.key.toFile.exists()) {
+        println(s"Secret key file ${conf.tls.certificate} not found")
+        System.exit(-1)
+      }
+
+      val name: String = {
+        val publicKey = Try(CertificateHelper.fromFile(conf.tls.certificate.toFile)) match {
+          case Success(c) => Some(c.getPublicKey)
+          case Failure(e) =>
+            println(s"Failed to read the X.509 certificate: ${e.getMessage}")
+            System.exit(1)
+            None
+          case _ => None
+        }
+
+        val publicKeyHash = publicKey
+          .flatMap(CertificateHelper.publicAddress)
+          .map(Base16.encode)
+
+        if (publicKeyHash.isEmpty) {
+          println("Certificate must contain a secp256r1 EC Public Key")
+          System.exit(1)
+        }
+
+        publicKeyHash.get
+      }
+
+      NodeIdentifier(name)
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -141,6 +141,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val run = new Subcommand("run") {
 
+    val dynamicHostAddress = opt[Flag](descr = "Host IP address changes dynamically")
+
     val noUpnp = opt[Flag](descr = "Use this flag to disable UpNp.")
 
     val defaultTimeout =

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -12,6 +12,7 @@ case class Server(
     port: Int,
     httpPort: Int,
     kademliaPort: Int,
+    dynamicHostAddress: Boolean,
     noUpnp: Boolean,
     defaultTimeout: Int,
     bootstrap: PeerNode,

--- a/node/src/main/scala/coop/rchain/node/configuration/toml/TomlConfiguration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/toml/TomlConfiguration.scala
@@ -61,7 +61,7 @@ object TomlConfiguration {
 
   def from(file: File): Either[TomlConfigurationError, Configuration] =
     if (file.exists())
-      withResource(Source.fromFile(file))(f => from(f.getLines().mkString("\n")))
+      withResource(Source.fromFile(file))(f => from(f.mkString))
     else Either.left(ConfigurationFileNotFound(file.getAbsolutePath))
 
   private def rewriteKeysToCamelCase(tbl: Value.Tbl): Value.Tbl = {

--- a/node/src/main/scala/coop/rchain/node/configuration/toml/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/toml/model.scala
@@ -18,6 +18,7 @@ case class Server(
     port: Option[Int],
     httpPort: Option[Int],
     kademliaPort: Option[Int],
+    dynamicHostAddress: Option[Boolean],
     noUpnp: Option[Boolean],
     defaultTimeout: Option[Int],
     bootstrap: Option[PeerNode],

--- a/node/src/main/scala/coop/rchain/node/node.scala
+++ b/node/src/main/scala/coop/rchain/node/node.scala
@@ -21,7 +21,6 @@ import coop.rchain.comm.discovery._
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.rp._
 import coop.rchain.comm.transport._
-import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.Metrics
 import coop.rchain.node.api._
 import coop.rchain.node.configuration.Configuration
@@ -38,10 +37,8 @@ import org.http4s.server.{Server => Http4sServer}
 import org.http4s.server.blaze._
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
-import monix.execution.schedulers.SchedulerService
 
-class NodeRuntime(conf: Configuration, host: String, scheduler: Scheduler) {
+class NodeRuntime(conf: Configuration, host: String, id: NodeIdentifier, scheduler: Scheduler) {
 
   private val loopScheduler = Scheduler.fixedPool("loop", 4)
   private val grpcScheduler = Scheduler.cached("grpc-io", 4, 64)
@@ -51,95 +48,12 @@ class NodeRuntime(conf: Configuration, host: String, scheduler: Scheduler) {
   implicit def eiterTrpConfAsk(implicit ev: RPConfAsk[Task]): RPConfAsk[Effect] =
     new EitherTApplicativeAsk[Task, RPConf, CommError]
 
-  private val dataDirFile = conf.server.dataDir.toFile
-
-  if (!dataDirFile.exists()) {
-    if (!dataDirFile.mkdir()) {
-      println(
-        s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
-      )
-      System.exit(-1)
-    }
-  }
-
-  // Check if data_dir has read/write access
-  if (!dataDirFile.isDirectory || !dataDirFile.canRead || !dataDirFile.canWrite) {
-    println(
-      s"The data dir must be a directory and have read and write permissions:\n${dataDirFile.getAbsolutePath}"
-    )
-    System.exit(-1)
-  }
-
-  println(s"Using data_dir: ${dataDirFile.getAbsolutePath}")
-
-  // Generate certificate if not provided as option or in the data dir
-  if (!conf.tls.customCertificateLocation
-      && !conf.tls.certificate.toFile.exists()) {
-    println(s"No certificate found at path ${conf.tls.certificate}")
-    println("Generating a X.509 certificate for the node")
-
-    import coop.rchain.shared.Resources._
-    // If there is a private key, use it for the certificate
-    if (conf.tls.key.toFile.exists()) {
-      println(s"Using secret key ${conf.tls.key}")
-      Try(CertificateHelper.readKeyPair(conf.tls.key.toFile)) match {
-        case Success(keyPair) =>
-          withResource(new java.io.PrintWriter(conf.tls.certificate.toFile)) {
-            _.write(CertificatePrinter.print(CertificateHelper.generate(keyPair)))
-          }
-        case Failure(e) =>
-          println(s"Invalid secret key: ${e.getMessage}")
-      }
-    } else {
-      println("Generating a PEM secret key for the node")
-      val keyPair = CertificateHelper.generateKeyPair(conf.tls.secureRandomNonBlocking)
-      withResource(new java.io.PrintWriter(conf.tls.certificate.toFile)) { pw =>
-        pw.write(CertificatePrinter.print(CertificateHelper.generate(keyPair)))
-      }
-      withResource(new java.io.PrintWriter(conf.tls.key.toFile)) { pw =>
-        pw.write(CertificatePrinter.printPrivateKey(keyPair.getPrivate))
-      }
-    }
-  }
-
-  if (!conf.tls.certificate.toFile.exists()) {
-    println(s"Certificate file ${conf.tls.certificate} not found")
-    System.exit(-1)
-  }
-
-  if (!conf.tls.key.toFile.exists()) {
-    println(s"Secret key file ${conf.tls.certificate} not found")
-    System.exit(-1)
-  }
-
-  private val name: String = {
-    val publicKey = Try(CertificateHelper.fromFile(conf.tls.certificate.toFile)) match {
-      case Success(c) => Some(c.getPublicKey)
-      case Failure(e) =>
-        println(s"Failed to read the X.509 certificate: ${e.getMessage}")
-        System.exit(1)
-        None
-      case _ => None
-    }
-
-    val publicKeyHash = publicKey
-      .flatMap(CertificateHelper.publicAddress)
-      .map(Base16.encode)
-
-    if (publicKeyHash.isEmpty) {
-      println("Certificate must contain a secp256r1 EC Public Key")
-      System.exit(1)
-    }
-
-    publicKeyHash.get
-  }
-
   import ApplicativeError_._
 
   /** Configuration */
   private val port              = conf.server.port
   private val kademliaPort      = conf.server.kademliaPort
-  private val address           = s"rnode://$name@$host?protocol=$port&discovery=$kademliaPort"
+  private val address           = s"rnode://${id.toString}@$host?protocol=$port&discovery=$kademliaPort"
   private val storagePath       = conf.server.dataDir.resolve("rspace")
   private val casperStoragePath = storagePath.resolve("casper")
   private val storageSize       = conf.server.mapSize

--- a/node/src/test/scala/coop/rchain/node/configuration/toml/TomlConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/toml/TomlConfigurationSpec.scala
@@ -1,6 +1,5 @@
 package coop.rchain.node.configuration.toml
 
-import coop.rchain.shared.StoreType
 import java.nio.file.Paths
 
 import coop.rchain.comm.PeerNode
@@ -18,6 +17,7 @@ class TomlConfigurationSpec extends FunSuite with Matchers {
       |host = "localhost"
       |port = 10
       |http-port = 12
+      |dynamic-host-address = false
       |no-upnp = false
       |default-timeout = 1000
       |bootstrap = "rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404"
@@ -48,7 +48,7 @@ class TomlConfigurationSpec extends FunSuite with Matchers {
       |approve-genesis-duration = "30min"
       |approve-genesis-interval = "1min"
       |deploy-timestamp = 1
-    """.stripMargin
+      |""".stripMargin
 
   test("Parse TOML configuration string") {
     val result: Either[TomlConfigurationError, Configuration] = TomlConfiguration.from(config)
@@ -67,6 +67,7 @@ class TomlConfigurationSpec extends FunSuite with Matchers {
     root.server.flatMap(_.host) shouldEqual Some("localhost")
     root.server.flatMap(_.port) shouldEqual Some(10)
     root.server.flatMap(_.httpPort) shouldEqual Some(12)
+    root.server.flatMap(_.dynamicHostAddress) shouldEqual Some(false)
     root.server.flatMap(_.noUpnp) shouldEqual Some(false)
     root.server.flatMap(_.defaultTimeout) shouldEqual Some(1000)
     root.server.flatMap(_.bootstrap) shouldEqual Some(bootstrap)


### PR DESCRIPTION
## Overview
Introduce a new configuration and command line flag `--dynamic-host-address`. If this flag is enabled node checks every minute if the local IP address has changed. This option gets ignored if the `--host` is set manually.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-1321

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
This is a straightforward solution for an edge case. When the node's IP change then in all subsequent calls to other nodes the new IP address gets propagated. Eventually, all entries with the old IP address will disappear from the Kademlia and RChain protocol tables.