### PR TITLE
#CORE-1367 A lock free implementation of IStore.

### DIFF
--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBench.scala
@@ -1,24 +1,16 @@
 package coop.rchain.rspace.bench.wide
 
-import coop.rchain.rspace.bench._
-import coop.rchain.rholang.interpreter.ChargingReducer
-import java.io.{FileNotFoundException, InputStreamReader}
-import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeUnit
 
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.accounting.Cost
-import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
+import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared.StoreType
-import monix.eval.Task
-import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
 import scala.concurrent.Await
-import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.duration.Duration
 
 class WideBench {
 
@@ -34,11 +26,29 @@ class WideBench {
     val result             = state.runTask.unsafeRunSync
     bh.consume(processErrors(result))
   }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.SingleShotTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  @Fork(value = 1)
+  @Threads(1)
+  @Warmup(iterations = 2)
+  @Measurement(iterations = 5)
+  def inmemWideReduceFine(bh: Blackhole, state: InMemBenchState): Unit = {
+    implicit val scheduler = state.scheduler
+    val result             = state.runTask.unsafeRunSync
+    bh.consume(processErrors(result))
+  }
 }
 
 @State(Scope.Benchmark)
 class FineBenchState extends WideBenchState {
   override def createRuntime() = Runtime.create(dbDir, mapSize, StoreType.LMDB)
+}
+
+@State(Scope.Benchmark)
+class InMemBenchState extends WideBenchState {
+  override def createRuntime() = Runtime.create(dbDir, mapSize, StoreType.Mixed)
 }
 
 abstract class WideBenchState extends WideBenchBaseState {

--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -68,7 +68,7 @@ private[rspace] class MixedContext[C, P, A, K] private[rspace] (
       sa: Serialize[A],
       sk: Serialize[K]
   ): IStore[C, P, A, K] =
-    InMemoryStore.create(trieStore, branch)
+    LockFreeInMemoryStore.create(trieStore, branch)
 
   def close(): Unit = {
     trieStore.close()

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -10,6 +10,10 @@ import scodec.Codec
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Seq
 
+/**
+  * This implementation of Transaction exists only to satisfy the requirements of IStore.
+  * Ideally this can be dropped after InMemoryStore is removed.
+  */
 class NoopTxn[S] extends InMemTransaction[S] {
   override def commit(): Unit                   = ()
   override def abort(): Unit                    = ()
@@ -19,6 +23,12 @@ class NoopTxn[S] extends InMemTransaction[S] {
   override def name: String                     = "noop"
 }
 
+/**
+  * This store is an optimized version of IStore.
+  * It does not handle high level locking.
+  *
+  * It should be used with RSpace that solves high level locking (e.g. FineGrainedRSpace).
+  */
 class LockFreeInMemoryStore[T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -1,0 +1,253 @@
+package coop.rchain.rspace
+
+import coop.rchain.rspace.history.{Branch, ITrieStore}
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.util.canonicalize
+import coop.rchain.shared.SeqOps.{dropIndex, removeFirst}
+import kamon._
+import scodec.Codec
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.immutable.Seq
+
+class NoopTxn[S] extends InMemTransaction[S] {
+  override def commit(): Unit                   = ()
+  override def abort(): Unit                    = ()
+  override def close(): Unit                    = ()
+  override def readState[R](f: S => R): R       = ???
+  override def writeState[R](f: S => (S, R)): R = ???
+  override def name: String                     = "noop"
+}
+
+class LockFreeInMemoryStore[T, C, P, A, K](
+    val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
+    val trieBranch: Branch
+)(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K])
+    extends IStore[C, P, A, K]
+    with CloseOps {
+
+  protected[rspace] type Transaction = InMemTransaction[State[C, P, A, K]]
+
+  override private[rspace] def createTxnRead(): Transaction = {
+    failIfClosed()
+    new NoopTxn[State[C, P, A, K]]
+  }
+  override private[rspace] def createTxnWrite(): Transaction = {
+    failIfClosed()
+    new NoopTxn[State[C, P, A, K]]
+  }
+  override private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R) = f(txn)
+  override def close(): Unit                                                     = super.close()
+
+  type TrieTransaction = T
+
+  private implicit val codecC: Codec[C] = sc.toCodec
+  private implicit val codecP: Codec[P] = sp.toCodec
+  private implicit val codecA: Codec[A] = sa.toCodec
+  private implicit val codecK: Codec[K] = sk.toCodec
+
+  private val stateGNAT: TrieMap[Blake2b256Hash, GNAT[C, P, A, K]] =
+    TrieMap[Blake2b256Hash, GNAT[C, P, A, K]]()
+  private val stateJoin: TrieMap[C, Seq[Seq[C]]] = TrieMap[C, Seq[Seq[C]]]()
+
+  private[this] val refine       = Map("path" -> "inmem")
+  private[this] val entriesGauge = Kamon.gauge("entries").refine(refine)
+
+  private[rspace] def updateGauges() =
+    entriesGauge.set(stateGNAT.readOnlySnapshot.size.toLong)
+
+  private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash =
+    StableHashProvider.hash(channels)
+
+  override def withTrieTxn[R](txn: Transaction)(f: TrieTransaction => R): R =
+    trieStore.withTxn(trieStore.createTxnWrite()) { ttxn =>
+      f(ttxn)
+    }
+
+  private[rspace] def getChannels(txn: Transaction, key: Blake2b256Hash): Seq[C] =
+    stateGNAT.get(key).map(_.channels).getOrElse(Seq.empty)
+
+  private[rspace] def getData(txn: Transaction, channels: Seq[C]): Seq[Datum[A]] =
+    stateGNAT.get(hashChannels(channels)).map(_.data).getOrElse(Seq.empty)
+
+  private[this] def getMutableWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C]
+  ): Seq[WaitingContinuation[P, K]] =
+    stateGNAT
+      .get(hashChannels(channels))
+      .map(_.wks)
+      .getOrElse(Seq.empty)
+
+  private[rspace] def getWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C]
+  ): Seq[WaitingContinuation[P, K]] =
+    getMutableWaitingContinuation(txn, channels)
+      .map { wk =>
+        wk.copy(continuation = InMemoryStore.roundTrip(wk.continuation))
+      }
+
+  def getPatterns(txn: Transaction, channels: Seq[C]): Seq[Seq[P]] =
+    getMutableWaitingContinuation(txn, channels).map(_.patterns)
+
+  private[rspace] def getJoin(txn: Transaction, channel: C): Seq[Seq[C]] =
+    stateJoin.getOrElse(channel, Seq.empty)
+
+  private[rspace] def joinMap: Map[Blake2b256Hash, Seq[Seq[C]]] =
+    stateJoin.map {
+      case (k, v) => (Blake2b256Hash.create(Codec[C].encode(k).map(_.toByteArray).get), v)
+    }.toMap
+
+  private[rspace] def putDatum(txn: Transaction, channels: Seq[C], datum: Datum[A]): Unit = {
+    val hash = hashChannels(channels)
+    val v = stateGNAT
+      .get(hash)
+      .map { gnat =>
+        gnat.copy(data = datum +: gnat.data)
+      }
+      .getOrElse(GNAT(channels = channels, data = Seq(datum), wks = Seq.empty))
+    stateGNAT.put(hash, v)
+    trieInsert(hash, v)
+  }
+
+  private[rspace] def putWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K]
+  ): Unit = {
+    val hash = hashChannels(channels)
+    val v = stateGNAT
+      .get(hash)
+      .map { gnat =>
+        gnat.copy(wks = continuation +: gnat.wks)
+      }
+      .getOrElse(GNAT(channels = channels, data = Seq.empty, wks = Seq(continuation)))
+    stateGNAT.put(hash, v)
+    trieInsert(hash, v)
+  }
+
+  private[rspace] def addJoin(txn: Transaction, channel: C, channels: Seq[C]): Unit =
+    stateJoin
+      .get(channel) match {
+      case Some(joins) if !joins.contains(channels) => stateJoin.put(channel, channels +: joins)
+      case None                                     => stateJoin.put(channel, Seq(channels))
+      case _                                        => ()
+    }
+
+  private[rspace] def removeDatum(txn: Transaction, channels: Seq[C], index: Int): Unit = {
+    val hash = hashChannels(channels)
+    stateGNAT
+      .get(hash)
+      .map { gnat =>
+        gnat.copy(data = dropIndex(gnat.data, index))
+      }
+      .foreach { v =>
+        if (!isOrphaned(v)) {
+          stateGNAT.put(hash, v)
+          trieInsert(hash, v)
+        } else {
+          stateGNAT.remove(hash)
+          trieDelete(hash, v)
+        }
+      }
+  }
+
+  private[rspace] def removeWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      index: Int
+  ): Unit = {
+    val hash = hashChannels(channels)
+    stateGNAT
+      .get(hash)
+      .map { gnat =>
+        gnat.copy(wks = dropIndex(gnat.wks, index))
+      }
+      .foreach { v =>
+        if (!isOrphaned(v)) {
+          stateGNAT.put(hash, v)
+          trieInsert(hash, v)
+        } else {
+          stateGNAT.remove(hash)
+          trieDelete(hash, v)
+        }
+      }
+  }
+
+  private[rspace] def removeJoin(txn: Transaction, channel: C, channels: Seq[C]): Unit = {
+    val gnatOpt = stateGNAT.get(hashChannels(channels))
+    if (gnatOpt.isEmpty || gnatOpt.get.wks.isEmpty) {
+      stateJoin
+        .get(channel)
+        .map(removeFirst(_)(_ == channels))
+        .filter(_.nonEmpty) match {
+        case Some(value) => stateJoin.put(channel, value)
+        case None        => stateJoin.remove(channel)
+      }
+
+    }
+  }
+
+  private[rspace] def clear(txn: Transaction): Unit = {
+    stateJoin.clear()
+    stateGNAT.clear()
+  }
+
+  def isEmpty: Boolean = stateGNAT.isEmpty && stateJoin.isEmpty
+
+  def toMap: Map[Seq[C], Row[P, A, K]] =
+    stateGNAT.readOnlySnapshot.map {
+      case (_, GNAT(cs, data, wks)) => (cs, Row(data, wks))
+    }.toMap
+
+  private[this] def isOrphaned(gnat: GNAT[C, P, A, K]): Boolean =
+    gnat.data.isEmpty && gnat.wks.isEmpty
+
+  protected def processTrieUpdate(update: TrieUpdate[C, P, A, K]): Unit =
+    update match {
+      case TrieUpdate(_, Insert, channelsHash, gnat) =>
+        history.insert(trieStore, trieBranch, channelsHash, canonicalize(gnat))
+      case TrieUpdate(_, Delete, channelsHash, gnat) =>
+        history.delete(trieStore, trieBranch, channelsHash, canonicalize(gnat))
+    }
+
+  private[rspace] def bulkInsert(
+      txn: Transaction,
+      gnats: Seq[(Blake2b256Hash, GNAT[C, P, A, K])]
+  ): Unit =
+    gnats.foreach {
+      case (hash, gnat @ GNAT(channels, _, wks)) =>
+        stateGNAT.put(hash, gnat)
+        for {
+          wk      <- wks
+          channel <- channels
+        } {
+          addJoin(txn, channel, channels)
+        }
+    }
+
+  private[rspace] def installWaitingContinuation(
+      txn: Transaction,
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K]
+  ): Unit = {
+    val key  = hashChannels(channels)
+    val gnat = GNAT[C, P, A, K](channels, Seq.empty, Seq(continuation))
+    stateGNAT.put(key, gnat)
+  }
+}
+
+object LockFreeInMemoryStore {
+
+  def create[T, C, P, A, K](
+      trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
+      branch: Branch
+  )(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): LockFreeInMemoryStore[T, C, P, A, K] =
+    new LockFreeInMemoryStore[T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -22,38 +22,13 @@ object RSpace {
         create(LMDBStore.create[C, P, A, K](ctx, branch), branch)
 
       case ctx: InMemoryContext[C, P, A, K] =>
-        createInMemory(ctx.trieStore, branch)
+        create(InMemoryStore.create(ctx.trieStore, branch), branch)
 
       case ctx: MixedContext[C, P, A, K] =>
-        create(InMemoryStore.create(ctx.trieStore, branch), branch)
+        create(LockFreeInMemoryStore.create(ctx.trieStore, branch), branch)
     }
 
-  def createInMemory[F[_], C, P, E, A, R, K](
-      trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], Blake2b256Hash, GNAT[
-        C,
-        P,
-        A,
-        K
-      ]],
-      branch: Branch
-  )(
-      implicit
-      sc: Serialize[C],
-      sp: Serialize[P],
-      sa: Serialize[A],
-      sk: Serialize[K],
-      syncF: Sync[F]
-  ): F[ISpace[F, C, P, E, A, R, K]] = {
-
-    val mainStore = InMemoryStore
-      .create[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
-        trieStore,
-        branch
-      )
-    create(mainStore, branch)
-  }
-
-  def create[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
+  private[rspace] def create[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rspace.spaces
 
-import cats.Monad
 import cats.effect.Sync
 import coop.rchain.rspace._
 import cats.implicits._
@@ -12,7 +11,6 @@ import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace.{Produce, _}
 import scodec.Codec
 
-import scala.Function.const
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
@@ -403,7 +401,7 @@ object FineGrainedReplayRSpace {
         InMemoryStore.create(memContext.trieStore, branch)
 
       case mixedContext: MixedContext[C, P, A, K] =>
-        InMemoryStore.create(mixedContext.trieStore, branch)
+        LockFreeInMemoryStore.create(mixedContext.trieStore, branch)
     }
 
     val replaySpace = new FineGrainedReplayRSpace[F, C, P, E, A, R, K](mainStore, branch)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rspace
 
-import coop.rchain.rspace.spaces.FineGrainedRSpace
 import java.nio.file.{Files, Path}
 
 import cats.Id
@@ -12,9 +11,8 @@ import coop.rchain.rspace.ISpace.IdISpace
 import scala.collection.JavaConverters._
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
-import coop.rchain.rspace.history.{initialize, Branch, ITrieStore, InMemoryTrieStore, LMDBTrieStore}
+import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.test._
 import coop.rchain.shared.PathOps._
 import org.scalatest._
 
@@ -133,16 +131,14 @@ class InMemoryStoreTestsBase
     implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
     val branch                                = Branch("inmem")
 
-    val trieStore =
-      InMemoryTrieStore.create[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]()
-
-    val testStore = InMemoryStore
-      .create[InMemTransaction[
-        history.State[Blake2b256Hash, GNAT[String, Pattern, String, StringsCaptor]]
-      ], String, Pattern, String, StringsCaptor](trieStore, branch)
+    val ctx: Context[String, Pattern, String, StringsCaptor] = Context.createInMemory()
 
     val testSpace =
-      RSpace.create[Id, String, Pattern, Nothing, String, String, StringsCaptor](testStore, branch)
+      RSpace.create[Id, String, Pattern, Nothing, String, String, StringsCaptor](ctx, branch)
+
+    val testStore = testSpace.store
+    val trieStore = testStore.trieStore
+
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)
@@ -178,12 +174,14 @@ class LMDBStoreTestsBase
 
     val testBranch = Branch("test")
     val env        = Context.create[String, Pattern, String, StringsCaptor](dbDir, mapSize)
-    val testStore  = LMDBStore.create[String, Pattern, String, StringsCaptor](env, testBranch)
+
     val testSpace =
       RSpace.create[Id, String, Pattern, Nothing, String, String, StringsCaptor](
-        testStore,
+        env,
         testBranch
       )
+
+    val testStore = testSpace.store
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)
@@ -220,17 +218,15 @@ class MixedStoreTestsBase
 
     val testBranch = Branch("test")
     val env        = Context.createMixed[String, Pattern, String, StringsCaptor](dbDir, mapSize)
-    val testStore = InMemoryStore
-      .create[org.lmdbjava.Txn[java.nio.ByteBuffer], String, Pattern, String, StringsCaptor](
-        env.trieStore,
-        testBranch
-      )
 
     val testSpace =
       RSpace.create[Id, String, Pattern, Nothing, String, String, StringsCaptor](
-        testStore,
+        env,
         testBranch
       )
+
+    val testStore = testSpace.store
+
     testStore.withTxn(testStore.createTxnWrite()) { txn =>
       testStore.withTrieTxn(txn) { trieTxn =>
         testStore.clear(txn)


### PR DESCRIPTION
## Overview
A lock free InMemory implementation of IStore that takes advantage of double locking.

```
[info] Benchmark                      Mode  Cnt     Score      Error  Units
[info] WideBench.inmemWideReduceFine    ss    5   247.959 ±   86.176  ms/op
[info] WideBench.wideReduceFine         ss    5  2882.660 ± 1478.468  ms/op
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/projects/CORE/issues/CORE-1367

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
