### PR TITLE
Stacksafe (de)seralization of protobuffs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val models = (project in file("models"))
     libraryDependencies ++= commonDependencies ++ protobufDependencies ++ Seq(
       catsCore,
       magnolia,
+      scalapbCompiler,
       scalacheck,
       scalacheckShapeless,
       scalapbRuntimegGrpc

--- a/build.sbt
+++ b/build.sbt
@@ -148,7 +148,8 @@ lazy val models = (project in file("models"))
       scalapbRuntimegGrpc
     ),
     PB.targets in Compile := Seq(
-      scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value,
+      coop.rchain.scalapb.StacksafeScalapbGenerator
+        .gen(flatPackage = true) -> (sourceManaged in Compile).value,
       grpcmonix.generators
         .GrpcMonixGenerator(flatPackage = true) -> (sourceManaged in Compile).value
     )

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -15,10 +15,10 @@ import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.{BindPattern, Par}
 import coop.rchain.models.rholang.sorter.Sortable
-import coop.rchain.rspace.StableHashProvider
+import coop.rchain.rspace.{Serialize, StableHashProvider}
 import coop.rchain.rspace.trace.{COMM, Consume, Produce}
 import coop.rchain.shared.{Log, SyncLock}
-import coop.rchain.models.serialization.implicits.serializePar
+import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.rholang.interpreter.{PrettyPrinter => RholangPrettyPrinter}
 import coop.rchain.models.rholang.sorter.Sortable._
 import scodec.Codec
@@ -107,7 +107,7 @@ object BlockAPI {
           length = blocksWithActiveName.length
         )
 
-    implicit val channelCodec: Codec[Par] = serializePar.toCodec
+    implicit val channelCodec: Codec[Par] = Serialize[Par].toCodec
     MultiParentCasperRef.withCasper[F, ListeningNameDataResponse](
       casperResponse(_, channelCodec),
       ListeningNameDataResponse(status = "Error: Casper instance not available")
@@ -140,7 +140,7 @@ object BlockAPI {
           length = blocksWithActiveName.length
         )
 
-    implicit val channelCodec: Codec[Par] = serializePar.toCodec
+    implicit val channelCodec: Codec[Par] = Serialize[Par].toCodec
     MultiParentCasperRef.withCasper[F, ListeningNameContinuationResponse](
       casperResponse(_, channelCodec),
       ListeningNameContinuationResponse(status = "Error: Casper instance not available")

--- a/models/src/main/scala/coop/rchain/models/Memo.scala
+++ b/models/src/main/scala/coop/rchain/models/Memo.scala
@@ -16,7 +16,7 @@ class Memo[A](f: => Coeval[A]) {
             case e: Eager[A] => e
             case _ =>
               thunk.map { r =>
-                thunk = null
+                thunk = null //allow GC-ing the thunk
                 result = Coeval.now(r)
                 r
               }

--- a/models/src/main/scala/coop/rchain/models/Memo.scala
+++ b/models/src/main/scala/coop/rchain/models/Memo.scala
@@ -1,0 +1,26 @@
+package coop.rchain.models
+import monix.eval.Coeval
+import monix.eval.Coeval.Eager
+
+class Memo[A](f: => Coeval[A]) {
+
+  private[this] var thunk             = f
+  private[this] var result: Coeval[A] = _
+
+  def get: Coeval[A] =
+    result match {
+      case e: Eager[A] => e
+      case _ =>
+        Coeval.defer {
+          result match {
+            case e: Eager[A] => e
+            case _ =>
+              thunk.map { r =>
+                thunk = null
+                result = Coeval.now(r)
+                r
+              }
+          }
+        }
+    }
+}

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -1,7 +1,8 @@
 package coop.rchain.models
+import java.io.{PrintWriter, StringWriter}
+
 import com.google.protobuf.ByteString
 import monix.eval.Coeval
-import monix.eval.Coeval.Now
 
 import scala.annotation.switch
 import scala.collection.immutable.{BitSet, HashSet}
@@ -38,7 +39,11 @@ trait PrettyInstances extends PrettyDerivation {
 
   // obviously won't print compiling code,
   // but seeing the stacktrace is more important in this case
-  implicit val PrettyThrowable = fromToString[Throwable]
+  implicit val PrettyThrowable: Pretty[Throwable] = (value: Throwable, indentLevel: Int) => {
+    val stackTrace = new StringWriter()
+    value.printStackTrace(new PrintWriter(stackTrace))
+    "\n" + stackTrace.toString
+  }
 
   implicit val PrettyByteString: Pretty[ByteString] = (value: ByteString, indentLevel: Int) =>
     "ByteString.copyFrom(Array[Byte]" + parenthesised(value.toByteArray, indentLevel) + ")"

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -1,15 +1,139 @@
 package coop.rchain.models
-import cats.{Applicative, Monad}
 import cats.effect.Sync
 import cats.implicits._
+import cats.{Applicative, Monad}
 import com.google.protobuf.Descriptors.FieldDescriptor
 import com.google.protobuf.{ByteString, CodedOutputStream, Descriptors, MessageLite}
 import scalapb.GeneratedMessage
 import scalapb.compiler.{DescriptorPimps, GeneratorParams, Types}
+import scalapb.{GeneratedMessage, WireType}
 
 object ProtoM extends DescriptorPimps {
 
   def params: GeneratorParams = ??? //required by DescriptorPimps, but we don't use it transitively
+
+  def toByteArray[M[_]: Sync](message: GeneratedMessage): M[Array[Byte]] =
+    for {
+      size  <- ProtoM.serializedSize[M](message)
+      array = new Array[Byte](size)
+      out   = CodedOutputStream.newInstance(array)
+      _     <- ProtoM.writeTo[M](out, message)
+      _     <- Sync[M].catchNonFatal { out.checkNoSpaceLeft() }
+    } yield array
+
+  def writeTo[M[_]: Sync](
+      out: CodedOutputStream,
+      message: GeneratedMessage
+  ): M[Unit] = {
+    val companion       = message.companion
+    val descriptor      = companion.javaDescriptor
+    val defaultInstance = companion.defaultInstance.asInstanceOf[GeneratedMessage]
+    for {
+      _ <- raiseUnsupportedIf(descriptor.preservesUnknownFields, "Unknown fields are not supported")
+      _ <- descriptor.fields
+            .sortBy(_.getNumber)
+            .toList
+            .traverse[M, Unit](f => {
+              val fieldValue = message.getField(f)
+              val default    = defaultInstance.getField(f)
+              if (fieldValue != default)
+                writeField(out, fieldValue, f)
+              else Monad[M].pure(())
+            })
+    } yield ()
+  }
+
+  private def writeField[M[_]: Sync](
+      out: CodedOutputStream,
+      value: Any,
+      field: FieldDescriptor
+  ): M[Unit] =
+    if (field.isRepeated) {
+      writeRepeatedField(out, value, field)
+    } else if (field.isRequired || field.isSingular || field.isOptional) {
+      writeSingleField(out, value, field)
+    } else {
+      Sync[M].raiseError(new RuntimeException("This cannot be!"))
+    }
+
+  private def writeRepeatedField[M[_]: Sync](
+      out: CodedOutputStream,
+      value: Any,
+      field: FieldDescriptor
+  ): M[Unit] =
+    for {
+      _ <- raiseUnsupportedIf[M](field.isPacked, "Packed fields are unsupported")
+
+      container = value.asInstanceOf[Seq[Any]].toList
+      _         <- container.traverse(writeSingleField(out, _, field))
+    } yield ()
+
+  private def writeSingleField[M[_]: Sync](
+      out: CodedOutputStream,
+      value: Any,
+      field: Descriptors.FieldDescriptor
+  ): M[Unit] =
+    if (field.isMessage) {
+      for {
+        _         <- writeTag(out, field, WireType.WIRETYPE_LENGTH_DELIMITED)
+        valueSize <- serializedSize(value.asInstanceOf[GeneratedMessage])
+        _         <- writeUInt32NoTag(out, valueSize)
+        _         <- writeTo(out, value.asInstanceOf[GeneratedMessage])
+      } yield ()
+    } else if (field.isEnum)
+      Sync[M].raiseError(
+        new UnsupportedOperationException(
+          s"Enums are not supported, got $value of type ${value.getClass}"
+        )
+      )
+    else {
+      writeScalarValue(value, field, out)
+    }
+
+  private def writeTag[M[_]: Sync](
+      out: CodedOutputStream,
+      field: FieldDescriptor,
+      wireType: Int
+  ): M[Unit] =
+    Sync[M].delay { out.writeTag(field.getNumber, wireType) }
+
+  private def writeUInt32NoTag[M[_]: Sync](out: CodedOutputStream, valueSize: Int): M[Unit] =
+    Sync[M].delay { out.writeUInt32NoTag(valueSize) }
+
+  private def writeScalarValue[M[_]: Sync](
+      value: Any,
+      field: FieldDescriptor,
+      out: CodedOutputStream
+  ): M[Unit] =
+    Sync[M].catchNonFatal {
+
+      import FieldDescriptor.Type._
+
+      // format: off
+      field.getType match {
+        case DOUBLE   => out.writeDouble    (field.getNumber, value.asInstanceOf[Double])
+        case FLOAT    => out.writeFloat     (field.getNumber, value.asInstanceOf[Float])
+        case INT64    => out.writeInt64     (field.getNumber, value.asInstanceOf[Long])
+        case UINT64   => out.writeUInt64    (field.getNumber, value.asInstanceOf[Long])
+        case INT32    => out.writeInt32     (field.getNumber, value.asInstanceOf[Int])
+        case FIXED64  => out.writeFixed64   (field.getNumber, value.asInstanceOf[Long])
+        case FIXED32  => out.writeFixed32   (field.getNumber, value.asInstanceOf[Int])
+        case BOOL     => out.writeBool      (field.getNumber, value.asInstanceOf[Boolean])
+        case STRING   => out.writeString    (field.getNumber, value.asInstanceOf[String])
+        case GROUP    => out.writeGroup     (field.getNumber, value.asInstanceOf[MessageLite])
+        case MESSAGE  => out.writeMessage   (field.getNumber, value.asInstanceOf[MessageLite])
+        case BYTES    => out.writeBytes     (field.getNumber, value.asInstanceOf[ByteString])
+        case UINT32   => out.writeUInt32    (field.getNumber, value.asInstanceOf[Int])
+        case ENUM     => throw new UnsupportedOperationException(
+          s"Enums are not supported, got $value of type ${value.getClass}"
+        )
+        case SFIXED32 => out.writeSFixed32  (field.getNumber, value.asInstanceOf[Int])
+        case SFIXED64 => out.writeSFixed64  (field.getNumber, value.asInstanceOf[Long])
+        case SINT32   => out.writeSInt32    (field.getNumber, value.asInstanceOf[Int])
+        case SINT64   => out.writeSInt64    (field.getNumber, value.asInstanceOf[Long])
+      }
+      // format: on
+    }
 
   def serializedSize[M[_]: Sync](
       message: GeneratedMessage

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -1,0 +1,113 @@
+package coop.rchain.models
+import cats.{Applicative, Monad}
+import cats.effect.Sync
+import cats.implicits._
+import com.google.protobuf.Descriptors.FieldDescriptor
+import com.google.protobuf.{ByteString, CodedOutputStream, Descriptors, MessageLite}
+import scalapb.GeneratedMessage
+import scalapb.compiler.{DescriptorPimps, GeneratorParams, Types}
+
+object ProtoM extends DescriptorPimps {
+
+  def params: GeneratorParams = ??? //required by DescriptorPimps, but we don't use it transitively
+
+  def serializedSize[M[_]: Sync](
+      message: GeneratedMessage
+  ): M[Int] = {
+    val companion       = message.companion
+    val descriptor      = companion.javaDescriptor
+    val defaultInstance = companion.defaultInstance.asInstanceOf[GeneratedMessage]
+    for {
+      _ <- raiseUnsupportedIf(descriptor.preservesUnknownFields, "Unknown fields are not supported")
+      fieldSizes <- descriptor.fields.toList.traverse[M, Int](f => {
+                     val fieldValue = message.getField(f)
+                     val default    = defaultInstance.getField(f)
+                     if (fieldValue != default)
+                       fieldSize(fieldValue, f)
+                     else Monad[M].pure(0)
+                   })
+    } yield fieldSizes.sum
+  }
+
+  private def fieldSize[M[_]: Sync](value: Any, field: Descriptors.FieldDescriptor): M[Int] =
+    if (field.isRepeated) {
+      repeatedSize(value, field)
+    } else if (field.isRequired || field.isSingular || field.isOptional) {
+      singleFieldSize(value, field)
+    } else {
+      Sync[M].raiseError(new RuntimeException("This cannot be!"))
+    }
+
+  private def repeatedSize[M[_]: Sync](value: Any, field: Descriptors.FieldDescriptor): M[Int] =
+    for {
+      _ <- raiseUnsupportedIf[M](field.isPacked, "Packed fields are unsupported")
+
+      container = value.asInstanceOf[Seq[Any]].toList
+      // format: off
+      containerSize <- Types.fixedSize(field.getType) match {
+        case Some(size) =>
+          val tagSize = CodedOutputStream.computeTagSize(field.getNumber)
+          Applicative[M].pure(((size + tagSize) * container.size))
+        case None =>
+          val elementSizes: M[List[Int]] = container.traverse(singleFieldSize(_, field))
+          elementSizes.map(_.sum)
+      }
+      // format: on
+    } yield containerSize
+
+  private def singleFieldSize[M[_]: Sync](value: Any, field: Descriptors.FieldDescriptor): M[Int] =
+    if (field.isMessage) {
+      for {
+        valueSize     <- serializedSize(value.asInstanceOf[GeneratedMessage])
+        valueSizeSize = CodedOutputStream.computeUInt32SizeNoTag(valueSize)
+        tagSize       = CodedOutputStream.computeTagSize(field.getNumber)
+      } yield tagSize + valueSizeSize + valueSize
+    } else if (field.isEnum)
+      Sync[M].raiseError(
+        new UnsupportedOperationException(
+          s"Enums are not supported, got $value of type ${value.getClass}"
+        )
+      )
+    else {
+      scalarValueSize(value, field)
+    }
+
+  private def scalarValueSize[M[_]: Sync](value: Any, field: FieldDescriptor): M[Int] =
+    Sync[M].catchNonFatal {
+
+      import FieldDescriptor.Type._
+      import com.google.protobuf.CodedOutputStream._
+
+      // format: off
+      field.getType match {
+        case DOUBLE   => computeDoubleSize     (field.getNumber, value.asInstanceOf[Double])
+        case FLOAT    => computeFloatSize      (field.getNumber, value.asInstanceOf[Float])
+        case INT64    => computeInt64Size      (field.getNumber, value.asInstanceOf[Long])
+        case UINT64   => computeUInt64Size     (field.getNumber, value.asInstanceOf[Long])
+        case INT32    => computeInt32Size      (field.getNumber, value.asInstanceOf[Int])
+        case FIXED64  => computeFixed64Size    (field.getNumber, value.asInstanceOf[Long])
+        case FIXED32  => computeFixed32Size    (field.getNumber, value.asInstanceOf[Int])
+        case BOOL     => computeBoolSize       (field.getNumber, value.asInstanceOf[Boolean])
+        case STRING   => computeStringSize     (field.getNumber, value.asInstanceOf[String])
+        case GROUP    => computeGroupSize      (field.getNumber, value.asInstanceOf[MessageLite])
+        case MESSAGE  => computeMessageSize    (field.getNumber, value.asInstanceOf[MessageLite])
+        case BYTES    => computeBytesSize      (field.getNumber, value.asInstanceOf[ByteString])
+        case UINT32   => computeUInt32Size     (field.getNumber, value.asInstanceOf[Int])
+        case ENUM     => throw new UnsupportedOperationException(
+          s"Enums are not supported, got $value of type ${value.getClass}"
+        )          
+        case SFIXED32 => computeSFixed32Size   (field.getNumber, value.asInstanceOf[Int])
+        case SFIXED64 => computeSFixed64Size   (field.getNumber, value.asInstanceOf[Long])
+        case SINT32   => computeSInt32Size     (field.getNumber, value.asInstanceOf[Int])
+        case SINT64   => computeSInt64Size     (field.getNumber, value.asInstanceOf[Long])
+      }
+      // format: on
+    }
+
+  private def raiseUnsupportedIf[M[_]: Sync](condition: => Boolean, message: String): M[Unit] =
+    if (condition) {
+      Sync[M].raiseError(new UnsupportedOperationException(message))
+    } else {
+      Applicative[M].pure(())
+    }
+}

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -56,7 +56,11 @@ object ProtoM extends DescriptorPimps {
     } else if (field.isRequired || field.isSingular || field.isOptional) {
       writeSingleField(out, value, field)
     } else {
-      Sync[Coeval].raiseError(new RuntimeException("This cannot be!"))
+      Sync[Coeval].raiseError(
+        new RuntimeException(
+          "This cannot be! A field that's none of: repeated, required, singluar, optional. Did protobuf spec change?"
+        )
+      )
     }
 
   private def writeRepeatedField(
@@ -65,8 +69,7 @@ object ProtoM extends DescriptorPimps {
       field: FieldDescriptor
   ): Coeval[Unit] =
     for {
-      _ <- raiseUnsupportedIf[Coeval](field.isPacked, "Packed fields are unsupported")
-
+      _         <- raiseUnsupportedIf[Coeval](field.isPacked, "Packed fields are unsupported")
       container = value.asInstanceOf[Seq[Any]].toList
       _         <- container.traverse(writeSingleField(out, _, field))
     } yield ()
@@ -165,7 +168,11 @@ object ProtoM extends DescriptorPimps {
     } else if (field.isRequired || field.isSingular || field.isOptional) {
       singleFieldSize(value, field)
     } else {
-      Sync[Coeval].raiseError(new RuntimeException("This cannot be!"))
+      Sync[Coeval].raiseError(
+        new RuntimeException(
+          "This cannot be! A field that's none of: repeated, required, singluar, optional. Did protobuf spec change?"
+        )
+      )
     }
 
   private def repeatedSize(value: Any, field: Descriptors.FieldDescriptor): Coeval[Int] =

--- a/models/src/main/scala/coop/rchain/models/SafeParser.scala
+++ b/models/src/main/scala/coop/rchain/models/SafeParser.scala
@@ -1,0 +1,22 @@
+package coop.rchain.models
+import cats.effect.Sync
+import com.google.protobuf.CodedInputStream
+
+object SafeParser {
+
+  def readMessage[F[_]: Sync, A](input: CodedInputStream, message: StacksafeMessage[A]): F[A] = {
+    import cats.implicits._
+
+    val length   = input.readRawVarint32()
+    val oldLimit = input.pushLimit(length)
+
+    message
+      .mergeFromM[F](input)
+      .map(result => {
+        input.checkLastTagWas(0)
+        input.popLimit(oldLimit)
+        result
+      })
+  }
+
+}

--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models
+
+trait StacksafeMessage extends scalapb.GeneratedMessage {}

--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -1,6 +1,9 @@
 package coop.rchain.models
+import cats.effect.Sync
+import com.google.protobuf.CodedInputStream
+import scalapb.Message
 
-trait StacksafeMessage extends scalapb.GeneratedMessage {
+trait StacksafeMessage[A] extends scalapb.GeneratedMessage with Message[A] {
 
   val serializedSizeM: Memo[Int]
 

--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -7,4 +7,6 @@ trait StacksafeMessage[A] extends scalapb.GeneratedMessage with Message[A] {
 
   val serializedSizeM: Memo[Int]
 
+  def mergeFromM[F[_]: Sync](input: CodedInputStream): F[A]
+
 }

--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -1,3 +1,7 @@
 package coop.rchain.models
 
-trait StacksafeMessage extends scalapb.GeneratedMessage {}
+trait StacksafeMessage extends scalapb.GeneratedMessage {
+
+  val serializedSizeM: Memo[Int]
+
+}

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -3,18 +3,16 @@ package coop.rchain.models.serialization
 import cats.implicits._
 import coop.rchain.models._
 import coop.rchain.rspace.Serialize
-import scodec.bits.ByteVector
-
+import monix.eval.Coeval
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scodec.bits.ByteVector
 
 object implicits {
   def mkProtobufInstance[T <: GeneratedMessage with Message[T]: GeneratedMessageCompanion] =
     new Serialize[T] {
 
-      override def encode(a: T): ByteVector = {
-        val comp: GeneratedMessageCompanion[T] = implicitly
-        ByteVector.view(comp.toByteArray(a))
-      }
+      override def encode(a: T): ByteVector =
+        ByteVector.view(ProtoM.toByteArray[Coeval](a).value())
 
       override def decode(bytes: ByteVector): Either[Throwable, T] = {
         val comp: GeneratedMessageCompanion[T] = implicitly

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -8,7 +8,7 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 import scodec.bits.ByteVector
 
 object implicits {
-  def mkProtobufInstance[T <: StacksafeMessage with Message[T]: GeneratedMessageCompanion] =
+  def mkProtobufInstance[T <: StacksafeMessage[T]: GeneratedMessageCompanion] =
     new Serialize[T] {
 
       override def encode(a: T): ByteVector =

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -8,11 +8,11 @@ import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 import scodec.bits.ByteVector
 
 object implicits {
-  def mkProtobufInstance[T <: GeneratedMessage with Message[T]: GeneratedMessageCompanion] =
+  def mkProtobufInstance[T <: StacksafeMessage with Message[T]: GeneratedMessageCompanion] =
     new Serialize[T] {
 
       override def encode(a: T): ByteVector =
-        ByteVector.view(ProtoM.toByteArray[Coeval](a).value())
+        ByteVector.view(ProtoM.toByteArray(a).value())
 
       override def decode(bytes: ByteVector): Either[Throwable, T] = {
         val comp: GeneratedMessageCompanion[T] = implicitly

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -8,7 +8,8 @@ import scalapb.GeneratedMessageCompanion
 import scodec.bits.ByteVector
 
 object implicits {
-  def mkProtobufInstance[T <: StacksafeMessage[T]: GeneratedMessageCompanion] =
+
+  implicit def mkProtobufInstance[T <: StacksafeMessage[T]: GeneratedMessageCompanion] =
     new Serialize[T] {
 
       override def encode(a: T): ByteVector =
@@ -21,13 +22,4 @@ object implicits {
       }
     }
 
-  implicit val serializePar: Serialize[Par]         = mkProtobufInstance
-  implicit val serializeVar: Serialize[Var]         = mkProtobufInstance
-  implicit val serializeSend: Serialize[Send]       = mkProtobufInstance
-  implicit val serializeReceive: Serialize[Receive] = mkProtobufInstance
-  implicit val serializeNew: Serialize[New]         = mkProtobufInstance
-  implicit val serializeExpr: Serialize[Expr]       = mkProtobufInstance
-  implicit val serializeMatch: Serialize[Match]     = mkProtobufInstance
-  implicit val serializeESet: Serialize[ESet]       = mkProtobufInstance
-  implicit val serializeEMap: Serialize[EMap]       = mkProtobufInstance
 }

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -1,10 +1,10 @@
 package coop.rchain.models.serialization
 
-import cats.implicits._
+import com.google.protobuf.CodedInputStream
 import coop.rchain.models._
 import coop.rchain.rspace.Serialize
 import monix.eval.Coeval
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import scalapb.GeneratedMessageCompanion
 import scodec.bits.ByteVector
 
 object implicits {
@@ -15,8 +15,9 @@ object implicits {
         ByteVector.view(ProtoM.toByteArray(a).value())
 
       override def decode(bytes: ByteVector): Either[Throwable, T] = {
-        val comp: GeneratedMessageCompanion[T] = implicitly
-        Either.catchNonFatal(comp.parseFrom(bytes.toArray))
+        val companion = implicitly[GeneratedMessageCompanion[T]]
+        val buffer    = CodedInputStream.newInstance(bytes.toArray)
+        companion.defaultInstance.mergeFromM[Coeval](buffer).runAttempt()
       }
     }
 

--- a/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/serialization/implicits.scala
@@ -8,24 +8,27 @@ import scodec.bits.ByteVector
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
 
 object implicits {
-  def mkProtobufInstance[T <: GeneratedMessage with Message[T]](
-      comp: GeneratedMessageCompanion[T]
-  ) = new Serialize[T] {
+  def mkProtobufInstance[T <: GeneratedMessage with Message[T]: GeneratedMessageCompanion] =
+    new Serialize[T] {
 
-    override def encode(a: T): ByteVector =
-      ByteVector.view(comp.toByteArray(a))
+      override def encode(a: T): ByteVector = {
+        val comp: GeneratedMessageCompanion[T] = implicitly
+        ByteVector.view(comp.toByteArray(a))
+      }
 
-    override def decode(bytes: ByteVector): Either[Throwable, T] =
-      Either.catchNonFatal(comp.parseFrom(bytes.toArray))
-  }
+      override def decode(bytes: ByteVector): Either[Throwable, T] = {
+        val comp: GeneratedMessageCompanion[T] = implicitly
+        Either.catchNonFatal(comp.parseFrom(bytes.toArray))
+      }
+    }
 
-  implicit val serializePar: Serialize[Par]         = mkProtobufInstance(Par)
-  implicit val serializeVar: Serialize[Var]         = mkProtobufInstance(Var)
-  implicit val serializeSend: Serialize[Send]       = mkProtobufInstance(Send)
-  implicit val serializeReceive: Serialize[Receive] = mkProtobufInstance(Receive)
-  implicit val serializeNew: Serialize[New]         = mkProtobufInstance(New)
-  implicit val serializeExpr: Serialize[Expr]       = mkProtobufInstance(Expr)
-  implicit val serializeMatch: Serialize[Match]     = mkProtobufInstance(Match)
-  implicit val serializeESet: Serialize[ESet]       = mkProtobufInstance(ESet)
-  implicit val serializeEMap: Serialize[EMap]       = mkProtobufInstance(EMap)
+  implicit val serializePar: Serialize[Par]         = mkProtobufInstance
+  implicit val serializeVar: Serialize[Var]         = mkProtobufInstance
+  implicit val serializeSend: Serialize[Send]       = mkProtobufInstance
+  implicit val serializeReceive: Serialize[Receive] = mkProtobufInstance
+  implicit val serializeNew: Serialize[New]         = mkProtobufInstance
+  implicit val serializeExpr: Serialize[Expr]       = mkProtobufInstance
+  implicit val serializeMatch: Serialize[Match]     = mkProtobufInstance
+  implicit val serializeESet: Serialize[ESet]       = mkProtobufInstance
+  implicit val serializeEMap: Serialize[EMap]       = mkProtobufInstance
 }

--- a/models/src/test/scala/coop/rchain/models/MemoSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/MemoSpec.scala
@@ -1,0 +1,22 @@
+package coop.rchain.models
+import monix.eval.Coeval
+import org.scalatest.{FlatSpec, Matchers}
+
+class MemoSpec extends FlatSpec with Matchers {
+
+  behavior of "Memo"
+
+  it should "memoize the result" in {
+    var timesExecuted = 0
+    val random = new Memo[Int](Coeval.delay {
+      timesExecuted += 1
+      9
+    })
+    assert(timesExecuted == 0)
+    assert(random.get.value() == 9)
+    assert(timesExecuted == 1)
+    assert(random.get.value() == 9)
+    assert(timesExecuted == 1)
+  }
+
+}

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -32,7 +32,7 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
   roundTripSerialization[ESet]
   roundTripSerialization[EMap]
 
-  def roundTripSerialization[A <: StacksafeMessage: Serialize: Arbitrary: Shrink: Pretty](
+  def roundTripSerialization[A <: StacksafeMessage[A]: Serialize: Arbitrary: Shrink: Pretty](
       implicit tag: ClassTag[A]
   ): Unit =
     it must s"work for ${tag.runtimeClass.getSimpleName}" in {
@@ -50,10 +50,10 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
     assertEqual(result, expected)
   }
 
-  def stacksafeSizeSameAsReference[A <: StacksafeMessage](a: A): Assertion =
+  def stacksafeSizeSameAsReference[A <: StacksafeMessage[A]](a: A): Assertion =
     assert(ProtoM.serializedSize(a).value() == a.serializedSize)
 
-  def stacksafeWriteToSameAsReference[A <: StacksafeMessage](a: A): Assertion =
+  def stacksafeWriteToSameAsReference[A <: StacksafeMessage[A]](a: A): Assertion =
     assert(ProtoM.toByteArray(a).value sameElements a.toByteArray)
 
 }

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -41,7 +41,7 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
       }
     }
 
-  def roundTripSerialization[A: Serialize: Arbitrary: Shrink: Pretty](a: A): Assertion = {
+  def roundTripSerialization[A: Serialize: Pretty](a: A): Assertion = {
     val bytes    = Serialize[A].encode(a)
     val result   = Serialize[A].decode(bytes)
     val expected = Right(a)

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -41,6 +41,7 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
       forAll { a: A =>
         roundTripSerialization(a)
         stacksafeSizeSameAsReference(a)
+        stacksafeWriteToSameAsReference(a)
       }
     }
 
@@ -53,6 +54,9 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
 
   def stacksafeSizeSameAsReference[A <: GeneratedMessage](a: A): Assertion =
     assert(ProtoM.serializedSize[Coeval](a).value() == a.serializedSize)
+
+  def stacksafeWriteToSameAsReference[A <: GeneratedMessage](a: A): Assertion =
+    assert(ProtoM.toByteArray[Coeval](a).value sameElements a.toByteArray)
 
 }
 

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -7,11 +7,9 @@ import coop.rchain.models.Connective.ConnectiveInstance.{Empty => _}
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.testImplicits._
 import coop.rchain.rspace.Serialize
-import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
-import scalapb.GeneratedMessage
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
@@ -34,7 +32,7 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
   roundTripSerialization[ESet]
   roundTripSerialization[EMap]
 
-  def roundTripSerialization[A <: GeneratedMessage: Serialize: Arbitrary: Shrink: Pretty](
+  def roundTripSerialization[A <: StacksafeMessage: Serialize: Arbitrary: Shrink: Pretty](
       implicit tag: ClassTag[A]
   ): Unit =
     it must s"work for ${tag.runtimeClass.getSimpleName}" in {
@@ -52,11 +50,11 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
     assertEqual(result, expected)
   }
 
-  def stacksafeSizeSameAsReference[A <: GeneratedMessage](a: A): Assertion =
-    assert(ProtoM.serializedSize[Coeval](a).value() == a.serializedSize)
+  def stacksafeSizeSameAsReference[A <: StacksafeMessage](a: A): Assertion =
+    assert(ProtoM.serializedSize(a).value() == a.serializedSize)
 
-  def stacksafeWriteToSameAsReference[A <: GeneratedMessage](a: A): Assertion =
-    assert(ProtoM.toByteArray[Coeval](a).value sameElements a.toByteArray)
+  def stacksafeWriteToSameAsReference[A <: StacksafeMessage](a: A): Assertion =
+    assert(ProtoM.toByteArray(a).value sameElements a.toByteArray)
 
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,7 @@ object Dependencies {
   val scalacheckNoTest    = "org.scalacheck"             %% "scalacheck"                % "1.13.5"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
+  val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntimegGrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -1,0 +1,113 @@
+package coop.rchain.scalapb
+
+import com.google.protobuf.Descriptors.{
+  Descriptor,
+  FieldDescriptor,
+  FileDescriptor,
+  OneofDescriptor
+}
+import com.google.protobuf.ExtensionRegistry
+import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
+import protocbridge.{Artifact, JvmGenerator, ProtocCodeGenerator}
+import scalapb.compiler._
+import scalapb.options.compiler.Scalapb
+
+object StacksafeScalapbGenerator extends ProtocCodeGenerator {
+
+  //copied and adapted from scalapb pakage object
+  def gen(
+      flatPackage: Boolean = false,
+      javaConversions: Boolean = false,
+      grpc: Boolean = true,
+      singleLineToProtoString: Boolean = false,
+      asciiFormatToString: Boolean = false
+  ): (JvmGenerator, Seq[String]) =
+    (
+      JvmGenerator("scala", StacksafeScalapbGenerator),
+      Seq(
+        "flat_package"                -> flatPackage,
+        "java_conversions"            -> javaConversions,
+        "grpc"                        -> grpc,
+        "single_line_to_proto_string" -> singleLineToProtoString,
+        "ascii_format_to_string"      -> asciiFormatToString
+      ).collect { case (name, v) if v => name }
+    )
+
+  //Copied and adpated from scalapb.ScalaPbCodeGenerator
+  def run(req: Array[Byte]): Array[Byte] = {
+    val registry = ExtensionRegistry.newInstance()
+    Scalapb.registerAllExtensions(registry)
+    val request = CodeGeneratorRequest.parseFrom(req, registry)
+    StacksafeProtobufGenerator.handleCodeGeneratorRequest(request).toByteArray
+  }
+
+  //Copied and adpated from scalapb.ScalaPbCodeGenerator
+  override def suggestedDependencies: Seq[Artifact] = Seq(
+    Artifact(
+      "com.thesamet.scalapb",
+      "scalapb-runtime",
+      scalapb.compiler.Version.scalapbVersion,
+      crossVersion = true
+    )
+  )
+}
+
+//copied and adapted from scalapb.compiler.ProtobufGenerator companion object
+object StacksafeProtobufGenerator {
+
+  import scala.collection.JavaConverters._
+
+  def parseParameters(params: String): Either[String, GeneratorParams] =
+    params
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .foldLeft[Either[String, GeneratorParams]](Right(GeneratorParams())) {
+        case (Right(params), "java_conversions") => Right(params.copy(javaConversions = true))
+        case (Right(params), "flat_package")     => Right(params.copy(flatPackage = true))
+        case (Right(params), "grpc")             => Right(params.copy(grpc = true))
+        case (Right(params), "single_line_to_proto_string") =>
+          Right(params.copy(singleLineToProtoString = true))
+        case (Right(params), "ascii_format_to_string") =>
+          Right(params.copy(asciiFormatToString = true))
+        case (Right(params), p) => Left(s"Unrecognized parameter: '$p'")
+        case (x, _)             => x
+      }
+
+  def handleCodeGeneratorRequest(request: CodeGeneratorRequest): CodeGeneratorResponse = {
+    val b = CodeGeneratorResponse.newBuilder
+    parseParameters(request.getParameter) match {
+      case Right(params) =>
+        try {
+          val generator = new StacksafeProtobufGenerator(params)
+          import generator.FileDescriptorPimp
+          val filesByName: Map[String, FileDescriptor] =
+            request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
+              case (acc, fp) =>
+                val deps = fp.getDependencyList.asScala.map(acc)
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+            }
+          val validator = new ProtoValidation(params)
+          filesByName.values.foreach(validator.validateFile)
+          request.getFileToGenerateList.asScala.foreach { name =>
+            val file = filesByName(name)
+            val responseFiles =
+              if (file.scalaOptions.getSingleFile)
+                generator.generateSingleScalaFileForFileDescriptor(file)
+              else generator.generateMultipleScalaFilesForFileDescriptor(file)
+            b.addAllFile(responseFiles.asJava)
+          }
+        } catch {
+          case e: GeneratorException =>
+            b.setError(e.message)
+        }
+      case Left(error) =>
+        b.setError(error)
+    }
+    b.build
+  }
+
+}
+
+//copied and adapted from scalapb.compiler.ProtobufGenerator
+class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenerator(params) {}

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -121,4 +121,14 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
     new FunctionalPrinter(Vector(extended), printer.indentLevel)
   }
 
+  override def generateSerializedSize(
+      message: Descriptor
+  )(fp: FunctionalPrinter): FunctionalPrinter =
+    super
+      .generateSerializedSize(message)(fp)
+      .newline
+      .add(
+        "@transient val serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))"
+      )
+      .newline
 }

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -110,4 +110,15 @@ object StacksafeProtobufGenerator {
 }
 
 //copied and adapted from scalapb.compiler.ProtobufGenerator
-class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenerator(params) {}
+class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenerator(params) {
+
+  override def printMessage(printer: FunctionalPrinter, message: Descriptor): FunctionalPrinter = {
+    val value = super.printMessage(printer, message).result()
+    val extended = value.replace(
+      " extends scalapb.GeneratedMessage ",
+      " extends coop.rchain.models.StacksafeMessage with scalapb.GeneratedMessage "
+    )
+    new FunctionalPrinter(Vector(extended), printer.indentLevel)
+  }
+
+}

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -115,8 +115,8 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
   override def printMessage(printer: FunctionalPrinter, message: Descriptor): FunctionalPrinter = {
     val value = super.printMessage(printer, message).result()
     val extended = value.replace(
-      " extends scalapb.GeneratedMessage ",
-      " extends coop.rchain.models.StacksafeMessage with scalapb.GeneratedMessage "
+      " extends scalapb.GeneratedMessage with scalapb.Message[",
+      " extends coop.rchain.models.StacksafeMessage["
     )
     new FunctionalPrinter(Vector(extended), printer.indentLevel)
   }

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -131,4 +131,19 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
         "@transient val serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))"
       )
       .newline
+
+  override def generateMergeFrom(
+      message: Descriptor
+  )(originalPrinter: FunctionalPrinter): FunctionalPrinter = {
+
+    val printer = super.generateMergeFrom(message)(originalPrinter)
+
+    generateMergeFromM(message)(printer)
+  }
+
+  private def generateMergeFromM(
+      message: Descriptor
+  )(printer: FunctionalPrinter): FunctionalPrinter =
+    printer //do nothing for now
+
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -9,7 +9,7 @@ trait Chargeable[A] {
 object Chargeable {
   def apply[T](implicit ev: Chargeable[T]): Chargeable[T] = ev
 
-  implicit def fromProtobuf[T <: StacksafeMessage] =
+  implicit def fromProtobuf[T <: StacksafeMessage[_]] =
     new Chargeable[T] {
       override def cost(a: T): Long = ProtoM.serializedSize(a).value.toLong
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rholang.interpreter.accounting
 
+import coop.rchain.models.ProtoM
+import monix.eval.Coeval
 import scalapb.GeneratedMessage
 
 trait Chargeable[A] {
@@ -11,6 +13,6 @@ object Chargeable {
 
   implicit def fromProtobuf[T <: GeneratedMessage] =
     new Chargeable[T] {
-      override def cost(a: T): Long = a.serializedSize.toLong
+      override def cost(a: T): Long = ProtoM.serializedSize[Coeval](a).value.toLong
     }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -1,8 +1,6 @@
 package coop.rchain.rholang.interpreter.accounting
 
-import coop.rchain.models.ProtoM
-import monix.eval.Coeval
-import scalapb.GeneratedMessage
+import coop.rchain.models.{ProtoM, StacksafeMessage}
 
 trait Chargeable[A] {
   def cost(a: A): Long
@@ -11,8 +9,8 @@ trait Chargeable[A] {
 object Chargeable {
   def apply[T](implicit ev: Chargeable[T]): Chargeable[T] = ev
 
-  implicit def fromProtobuf[T <: GeneratedMessage] =
+  implicit def fromProtobuf[T <: StacksafeMessage] =
     new Chargeable[T] {
-      override def cost(a: T): Long = ProtoM.serializedSize[Coeval](a).value.toLong
+      override def cost(a: T): Long = ProtoM.serializedSize(a).value.toLong
     }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -21,7 +21,7 @@ trait Costs {
   final val SUM_COST: Cost         = Cost(3)
   final val SUBTRACTION_COST: Cost = Cost(3)
 
-  def equalityCheckCost[T <: StacksafeMessage, P <: StacksafeMessage](x: T, y: P): Cost =
+  def equalityCheckCost[T <: StacksafeMessage[_], P <: StacksafeMessage[_]](x: T, y: P): Cost =
     Cost(
       scala.math.min(ProtoM.serializedSize(x).value, ProtoM.serializedSize(y).value)
     )
@@ -63,7 +63,7 @@ trait Costs {
   // serializing any Par into a Array[Byte]:
   // + allocates byte array of the same size as `serializedSize`
   // + then it copies all elements of the Par
-  def toByteArrayCost[T <: StacksafeMessage](a: T): Cost =
+  def toByteArrayCost[T <: StacksafeMessage[_]](a: T): Cost =
     Cost(ProtoM.serializedSize(a).value)
   //TODO: adjust the cost of size method
   def sizeMethodCost(size: Int): Cost = Cost(size)
@@ -92,11 +92,11 @@ trait Costs {
 
   final val MATCH_EVAL_COST = Cost(12)
 
-  implicit def toStorageCostOps[A <: StacksafeMessage](a: Seq[A]) = new StorageCostOps(a: _*)
+  implicit def toStorageCostOps[A <: StacksafeMessage[_]](a: Seq[A]) = new StorageCostOps(a: _*)
 
-  implicit def toStorageCostOps[A <: StacksafeMessage](a: A) = new StorageCostOps(a)
+  implicit def toStorageCostOps[A <: StacksafeMessage[_]](a: A) = new StorageCostOps(a)
 
-  class StorageCostOps[A <: StacksafeMessage](a: A*) {
+  class StorageCostOps[A <: StacksafeMessage[_]](a: A*) {
     def storageCost: Cost = Cost(a.map(a => ProtoM.serializedSize(a).value).sum)
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -1,10 +1,7 @@
 package coop.rchain.rholang.interpreter.accounting
 
 import com.google.protobuf.ByteString
-import coop.rchain.models.Par
-import coop.rchain.models.ProtoM
-import monix.eval.Coeval
-import scalapb.GeneratedMessage
+import coop.rchain.models.{Par, ProtoM, StacksafeMessage}
 
 //TODO(mateusz.gorski): Adjust the costs of operations
 final case class Cost(value: Long) extends AnyVal {
@@ -24,9 +21,9 @@ trait Costs {
   final val SUM_COST: Cost         = Cost(3)
   final val SUBTRACTION_COST: Cost = Cost(3)
 
-  def equalityCheckCost[T <: GeneratedMessage, P <: GeneratedMessage](x: T, y: P): Cost =
+  def equalityCheckCost[T <: StacksafeMessage, P <: StacksafeMessage](x: T, y: P): Cost =
     Cost(
-      scala.math.min(ProtoM.serializedSize[Coeval](x).value, ProtoM.serializedSize[Coeval](y).value)
+      scala.math.min(ProtoM.serializedSize(x).value, ProtoM.serializedSize(y).value)
     )
 
   final val BOOLEAN_AND_COST = Cost(2)
@@ -66,8 +63,8 @@ trait Costs {
   // serializing any Par into a Array[Byte]:
   // + allocates byte array of the same size as `serializedSize`
   // + then it copies all elements of the Par
-  def toByteArrayCost[T <: GeneratedMessage](a: T): Cost =
-    Cost(ProtoM.serializedSize[Coeval](a).value)
+  def toByteArrayCost[T <: StacksafeMessage](a: T): Cost =
+    Cost(ProtoM.serializedSize(a).value)
   //TODO: adjust the cost of size method
   def sizeMethodCost(size: Int): Cost = Cost(size)
   // slice(from, to) needs to drop `from` elements and then append `to - from` elements
@@ -95,12 +92,12 @@ trait Costs {
 
   final val MATCH_EVAL_COST = Cost(12)
 
-  implicit def toStorageCostOps[A <: GeneratedMessage](a: Seq[A]) = new StorageCostOps(a: _*)
+  implicit def toStorageCostOps[A <: StacksafeMessage](a: Seq[A]) = new StorageCostOps(a: _*)
 
-  implicit def toStorageCostOps[A <: GeneratedMessage](a: A) = new StorageCostOps(a)
+  implicit def toStorageCostOps[A <: StacksafeMessage](a: A) = new StorageCostOps(a)
 
-  class StorageCostOps[A <: GeneratedMessage](a: A*) {
-    def storageCost: Cost = Cost(a.map(a => ProtoM.serializedSize[Coeval](a).value).sum)
+  class StorageCostOps[A <: StacksafeMessage](a: A*) {
+    def storageCost: Cost = Cost(a.map(a => ProtoM.serializedSize(a).value).sum)
   }
 
   // Even though we use Long for phlo limit we can't use Long.MaxValue here.

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -199,7 +199,7 @@ class SerializationStackSafetySpec extends FlatSpec with Matchers {
     val par = hugePar(maxRecursionDepth)
 
     noException shouldBe thrownBy {
-      ProtoM.serializedSize[Coeval](par).value
+      ProtoM.serializedSize(par).value
     }
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -203,7 +203,8 @@ class SerializationStackSafetySpec extends FlatSpec with Matchers {
       ProtoM.serializedSize(par).value
 
       import coop.rchain.models.serialization.implicits._
-      Serialize[Par].encode(par)
+      val encoded = Serialize[Par].encode(par)
+      Serialize[Par].decode(encoded)
     }
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -8,6 +8,7 @@ import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.{Connective, Par, ProtoM}
 import coop.rchain.rholang.StackSafetySpec.findMaxRecursionDepth
 import coop.rchain.rholang.interpreter.{Interpreter, PrettyPrinter, Runtime}
+import coop.rchain.rspace.Serialize
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Assertions, FlatSpec, Matchers}
@@ -200,6 +201,9 @@ class SerializationStackSafetySpec extends FlatSpec with Matchers {
 
     noException shouldBe thrownBy {
       ProtoM.serializedSize(par).value
+
+      import coop.rchain.models.serialization.implicits._
+      Serialize[Par].encode(par)
     }
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
@@ -20,6 +20,8 @@ trait Serialize[A] {
 
 object Serialize {
 
+  def apply[A](implicit ev: Serialize[A]): Serialize[A] = ev
+
   implicit class RichSerialize[A](instance: Serialize[A]) {
 
     def toCodec: Codec[A] = new Codec[A] {
@@ -45,7 +47,5 @@ object Serialize {
           }
     }
   }
-
-  def apply[A](implicit ev: Serialize[A]): Serialize[A] = ev
 
 }


### PR DESCRIPTION
## Overview
Title says it all :)

The `serializedSize` and `writeTo` methods were implemented as standalone interpreters over the generated proto classes (see the ProtoM class).

The `mergeFrom` method (used for reading) was implemented by modifying the scalapb code generator, because the interpreter approach was not viable (I tried hard, believe me).

See 8c8096d for what needed to be changed in the scalapb generator for `mergeFrom`.

### JIRA issue:
RHOL-854

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.