### PR TITLE
CORE-1392 Fix block message size with temporary solution

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -62,10 +62,12 @@ object Configuration {
   private val DefaultRequiredSigns              = 0
   private val DefaultApprovalProtocolDuration   = 5.minutes
   private val DefaultApprovalProtocolInterval   = 5.seconds
-  private val DefaultMaxMessageSize: Int        = 4 * 1024 * 1024
+  // TODO this temporarly makes the allowed message size to be  256 MB on startup
+  // This will be rolled back after CORE-1394 and Kents changes
+  private val DefaultMaxMessageSize: Int = 256 * 1024 * 1024
   // within range HTTP2 RFC 7540
-  private val MaxMessageSizeMinimumValue: Int = 1 * 1024 * 1024
-  private val MaxMessageSizeMaximumValue: Int = 10 * 1024 * 1024
+  private val MaxMessageSizeMinimumValue: Int = 10 * 1024 * 1024
+  private val MaxMessageSizeMaximumValue: Int = DefaultMaxMessageSize * 4
   private val DefaultMinimumBond: Long        = 1L
   private val DefaultMaximumBond: Long        = Long.MaxValue
   private val DefaultHasFaucet: Boolean       = false


### PR DESCRIPTION
# Overview

Duing the genesis ceremony, Casper sends a request and awaits a
response (in a synchronous manner) that can (and most likely isvery
big.
The proper solution for this problem is on its way, but temporarly we
will extend max message size to be 256 MB (with ability to extend to
1GB via configuration). This change should be reverted back, once a
prope solution (using stream API) will be in place

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1392