### PR TITLE
CORE-1394 Introduce a way to fetch bootstrap that was used to connect to p2p

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -6,6 +6,7 @@ import coop.rchain.comm.PeerNode
 
 case class RPConf(
     local: PeerNode,
+    bootstrap: Option[PeerNode],
     defaultTimeout: FiniteDuration,
     clearConnections: ClearConnetionsConf
 )

--- a/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/ClearConnectionsSpec.scala
@@ -136,7 +136,8 @@ class ClearConnectionsSpec
       RPConf(
         clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = FiniteDuration(1, MILLISECONDS),
-        local = peer("src")
+        local = peer("src"),
+        bootstrap = None
       )
     )
 

--- a/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/connect/FindAndConnectSpec.scala
@@ -118,7 +118,8 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
       RPConf(
         clearConnections = ClearConnetionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = defaultTimeout,
-        local = peer("src")
+        local = peer("src"),
+        bootstrap = None
       )
     )
 

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -52,7 +52,7 @@ object EffectsTestInstances {
       defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS),
       clearConnections: ClearConnetionsConf = ClearConnetionsConf(1, 1)
   ) =
-    new ConstApplicativeAsk[F, RPConf](RPConf(local, defaultTimeout, clearConnections))
+    new ConstApplicativeAsk[F, RPConf](RPConf(local, None, defaultTimeout, clearConnections))
 
   class TransportLayerStub[F[_]: Capture: Applicative] extends TransportLayer[F] {
     case class Request(peer: PeerNode, msg: Protocol)


### PR DESCRIPTION
## Overview

If we start in standalone, the bootstrap in conf will return None. If
we started booting up from some --bootstrap, then that PeerNode will
be returned within Option.

*Motivation:*
This change is required by Casper team to provide a better mechanism
to request an approved block. Casper would like to ask bootstrap node
for that information

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1394
