### PR TITLE
Fix tags warning

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/package.scala
+++ b/comm/src/main/scala/coop/rchain/comm/package.scala
@@ -3,9 +3,6 @@ package coop.rchain
 import cats.mtl.ApplicativeAsk
 
 package object comm {
-  trait TcpConnTag
-  trait KademliaConnTag
-
   type PeerNodeAsk[F[_]] = ApplicativeAsk[F, PeerNode]
 
   object PeerNodeAsk {

--- a/comm/src/main/scala/coop/rchain/comm/tags.scala
+++ b/comm/src/main/scala/coop/rchain/comm/tags.scala
@@ -1,0 +1,4 @@
+package coop.rchain.comm
+
+trait TcpConnTag
+trait KademliaConnTag


### PR DESCRIPTION
Fix following compiler warning:
```
[warn] /Users/rabbit/projects/rchain/comm/src/main/scala/coop/rchain/comm/package.scala:4:9: it is not recommended to define classes/objects inside of package objects.
[warn] If possible, define trait TcpConnTag in package comm instead.
[warn]   trait TcpConnTag
[warn]    
```