### PR TITLE
Remove "faucet" and "proofOfStake" forgable names

### DIFF
--- a/casper/src/main/rholang/SystemInstancesRegistry.rho
+++ b/casper/src/main/rholang/SystemInstancesRegistry.rho
@@ -1,0 +1,50 @@
+//scalapackage coop.rchain.rholang.registry
+
+//The purpose of this contract is to allow users to
+//look up the various instances of system contracts that
+//were created in the genesis block.
+
+//Registry info:
+//  sk: 7f2a3526664f04096067654705776950e2e475a1479d3569d8d7423e27bad603
+//  pk: 08a0f8fccace949453dcb6a885e9f50dd96a58ed51c49fc2e346aa4d42ffb7c1
+//  user == pk
+//  timestamp: 1540563894858
+//Resulting unforgable name: Unforgeable(0xeaf4d685675c199b2a2cceef521dacaaa711cd70c7d082c20d154507e5c58407) 
+//  ==> signature data == 2a3eaa013b0a0d2a0b10feffffffffffffffff010a2a5a280a243a220a20eaf4d685675c199b2a2cceef521dacaaa711cd70c7d082c20d154507e5c584071001
+//  ==> signature == fbf76226c16f1327058fba896fe4d43f69b3707981ae7b8498de6fcbc36c4bbe66885904dde6a8a4f5cdf8e74f035f8e505b895a381833d3ecfb717748bc8b0d
+//URI derived from pk == `rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`
+new
+  SystemInstancesRegistry, rs(`rho:registry:insertSigned:ed25519`), uriOut,
+  faucetStore, posStore, revStore
+in {
+  contract SystemInstancesRegistry(@"lookup", @systemContract, return) = {
+    match systemContract {
+      "faucet"     => { for(@value <- faucetStore)    { return!(value) | faucetStore!(value) } }
+      "pos"        => { for(@value <- posStore)       { return!(value) | posStore!(value) } }
+      "rev"        => { for(@value <- revStore)       { return!(value) | revStore!(value) } }
+      _            => { return!(Nil) }
+    }
+  } |
+
+  //one time use only call for registering a faucet instance
+  for(@"register", @"faucet", @value <- SystemInstancesRegistry) {
+    faucetStore!(value)
+  } |
+  
+  //one time use only call for registering a proof-of-stake instance
+  for(@"register", @"pos", @value <- SystemInstancesRegistry) {
+    posStore!(value)
+  } |
+  
+  //one time use only call for registering a rev-mint instance
+  for(@"register", @"rev", @value <- SystemInstancesRegistry) {
+    revStore!(value)
+  } |
+  
+  rs!(
+    "08a0f8fccace949453dcb6a885e9f50dd96a58ed51c49fc2e346aa4d42ffb7c1".hexToBytes(), 
+    (9223372036854775807, bundle+{*SystemInstancesRegistry}), 
+    "fbf76226c16f1327058fba896fe4d43f69b3707981ae7b8498de6fcbc36c4bbe66885904dde6a8a4f5cdf8e74f035f8e505b895a381833d3ecfb717748bc8b0d".hexToBytes(), 
+    *uriOut
+  )
+}

--- a/casper/src/main/rholang/WalletCheck.rho
+++ b/casper/src/main/rholang/WalletCheck.rho
@@ -46,7 +46,7 @@ in {
           for (@done <- doneStore) {
             if (done) {
               doneStore!(done) |
-              @statusOut!([false, "Already claimed wallet"])
+              @statusOut!((false, "Already claimed wallet"))
             } else {
 
               // Verify signature 

--- a/casper/src/main/rholang/WalletCheck.rho
+++ b/casper/src/main/rholang/WalletCheck.rho
@@ -15,11 +15,13 @@
 //URI derived from pk == `rho:id:oqez475nmxx9ktciscbhps18wnmnwtm6egziohc3rkdzekkmsrpuyt`
 new
   WalletCheck, rs(`rho:registry:insertSigned:ed25519`), uriOut,
-  rl(`rho:registry:lookup`), BasicWalletCh, claimContractStore
+  rl(`rho:registry:lookup`), BasicWalletCh, claimContractStore,
+  walletStore
 in {
   rl!(`rho:id:3yicxut5xtx5tnmnneta7actof4yse3xangw4awzt8c8owqmddgyms`, *BasicWalletCh) |
   for(@(_, BasicWallet) <- BasicWalletCh) {
     claimContractStore!({}) |
+    walletStore!({}) |
   
     // create: makes a wallet check
     //
@@ -65,14 +67,14 @@ in {
                             // Create the wallet
                             @BasicWallet!(purse, "secp256k1", "04" ++ pubKey, *walletOut) |
 
-                            // Advertise the private name on a forgeable one
-                            // TODO: This is completely insecure.  Once the
-                            //   registry is done, use that.
                             for (@[wallet] <- walletOut) {
-                              @pubKey!!(wallet) |
+                              //record the claimed wallet in the store for later retrieval
+                              for(@wallets <- walletStore) {
+                                walletStore!(wallets.set(pubKey, wallet))
+                              } |
                             
                               // Return success
-                              @statusOut!([true, wallet])
+                              @statusOut!((true, "Success!"))
                             } |
                             
                             // All done
@@ -80,12 +82,12 @@ in {
                           }
                         } else {
                           doneStore!(done) |
-                          @statusOut!([false, "Public key is not the preimage of hash"])
+                          @statusOut!((false, "Public key is not the preimage of hash"))
                         }
                       }
                     } else {
                       doneStore!(done) |
-                      @statusOut!([false, "Signature verification failed"])
+                      @statusOut!((false, "Signature verification failed"))
                     }
                   }
                 }
@@ -112,8 +114,18 @@ in {
       for(@claimContractMap <- claimContractStore) {
         claimContractStore!(claimContractMap) |
         match claimContractMap.get(ethAddr) {
-          Nil           => { statusOut!([false, "Unknown Ethereum address"]) }
+          Nil           => { statusOut!((false, "Unknown Ethereum address")) }
           claimContract => { @claimContract!([pubKey, *statusOut], sig) }
+        }
+      }
+    } |
+    
+    contract WalletCheck(@"access", @pubKey, return) = {
+      for(@wallets <- walletStore) {
+        walletStore!(wallets) |
+        match wallets.get(pubKey) {
+          Nil    => { return!((false, "Unknown wallet public key")) }
+          wallet => { return!((true, wallet)) }
         }
       }
     }

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -44,6 +44,7 @@ object Genesis {
       StandardDeploys.basicWallet,
       StandardDeploys.basicWalletFaucet,
       StandardDeploys.walletCheck,
+      StandardDeploys.systemInstances,
       StandardDeploys.rev(wallets, faucetCode, posParams)
     )
 

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
@@ -17,11 +17,12 @@ object Faucet {
        |  for(@(_, BasicWalletFaucet) <- BasicWalletFaucetCh) {
        |    @BasicWalletFaucet!($mintName, *faucetCh) |
        |    for(@faucet <- faucetCh){
-       |      @"faucet"!!(faucet)
+       |      SystemInstancesRegistry!("register", "faucet", faucet)
        |    }
        |  }
        |}""".stripMargin
 
-  val noopFaucet: String => String = (mintName: String) => "Nil"
+  val noopFaucet: String => String = (mintName: String) =>
+    """SystemInstancesRegistry!("register", "faucet", Nil)"""
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
@@ -17,12 +17,12 @@ object Faucet {
        |  for(@(_, BasicWalletFaucet) <- BasicWalletFaucetCh) {
        |    @BasicWalletFaucet!($mintName, *faucetCh) |
        |    for(@faucet <- faucetCh){
-       |      SystemInstancesRegistry!("register", "faucet", faucet)
+       |      @SystemInstancesRegistry!("register", "faucet", faucet)
        |    }
        |  }
        |}""".stripMargin
 
   val noopFaucet: String => String = (mintName: String) =>
-    """SystemInstancesRegistry!("register", "faucet", Nil)"""
+    """@SystemInstancesRegistry!("register", "faucet", Nil)"""
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
@@ -41,16 +41,16 @@ class Rev[A](
     |      contract rev(@"makePurse", return) = {
     |         @revMint!("makePurse", 0, *return)
     |      } |
-    |      SystemInstancesRegistry!("register", "rev", bundle+{*rev})
+    |      @SystemInstancesRegistry!("register", "rev", bundle+{*rev}) |
     |
     |      ${faucetCode("revMint")} |
     |
     |      //PoS purse and contract creation
     |      @revMint!("makePurse", $initialTotalBond, *posPurseCh) |
     |      for(@posPurse <- posPurseCh) {
-    |        @MakePoS!(posPurse, $minimumBond, $maximumBond, $initialBondsCode, posCh) |
+    |        @MakePoS!(posPurse, $minimumBond, $maximumBond, $initialBondsCode, *posCh) |
     |        for(@pos <- posCh) {
-    |          SystemInstancesRegistry!("register", "pos", pos)
+    |          @SystemInstancesRegistry!("register", "pos", pos)
     |        }
     |      } |
     |

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
@@ -50,7 +50,7 @@ class Rev[A](
     |      for(@posPurse <- posPurseCh) {
     |        @MakePoS!(posPurse, $minimumBond, $maximumBond, $initialBondsCode, *posCh) |
     |        for(@pos <- posCh) {
-    |          @SystemInstancesRegistry!("register", "pos", pos)
+    |          @SystemInstancesRegistry!("register", "pos", bundle+{pos})
     |        }
     |      } |
     |

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
@@ -22,30 +22,36 @@ class Rev[A](
     |//requires MakeMint, BasicWallet, WalletCheck, MakePoS
     |new
     |  rl(`rho:registry:lookup`), MakeMintCh, WalletCheckCh, BasicWalletCh,
-    |  MakePoSCh, revMintCh, posPurseCh
+    |  MakePoSCh, SystemInstancesCh, revMintCh, posPurseCh, rev, posCh
     |in {
     |  rl!(`rho:id:exunyijimapk7z43g3bbr69awqdz54kyroj9q43jgu3dh567fxsftx`, *MakeMintCh) |
     |  rl!(`rho:id:oqez475nmxx9ktciscbhps18wnmnwtm6egziohc3rkdzekkmsrpuyt`, *WalletCheckCh) |
     |  rl!(`rho:id:3yicxut5xtx5tnmnneta7actof4yse3xangw4awzt8c8owqmddgyms`, *BasicWalletCh) |
     |  rl!(`rho:id:nqt875jea4rr83383ys6guzsbebg6k7o7uhrint6d7km67886c4y4s`, *MakePoSCh) |
+    |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
     |  for(
     |    @(_, MakeMint) <- MakeMintCh; @(_, WalletCheck) <- WalletCheckCh;
-    |    @(_, BasicWallet) <- BasicWalletCh; @(_, MakePoS) <- MakePoSCh
+    |    @(_, BasicWallet) <- BasicWalletCh; @(_, MakePoS) <- MakePoSCh;
+    |    @(_, SystemInstancesRegistry) <- SystemInstancesCh
     |  ) {
     |    @MakeMint!(*revMintCh) | for(@revMint <- revMintCh) {
     |      //TODO: How should the revMint unforgeable name be exposed (if at all)?
     |
     |      //public contract for making empty rev purses
-    |      contract @("Rev", "makePurse")(return) = {
+    |      contract rev(@"makePurse", return) = {
     |         @revMint!("makePurse", 0, *return)
     |      } |
+    |      SystemInstancesRegistry!("register", "rev", bundle+{*rev})
     |
     |      ${faucetCode("revMint")} |
     |
     |      //PoS purse and contract creation
     |      @revMint!("makePurse", $initialTotalBond, *posPurseCh) |
     |      for(@posPurse <- posPurseCh) {
-    |        @MakePoS!(posPurse, $minimumBond, $maximumBond, $initialBondsCode, "proofOfStake")
+    |        @MakePoS!(posPurse, $minimumBond, $maximumBond, $initialBondsCode, posCh) |
+    |        for(@pos <- posCh) {
+    |          SystemInstancesRegistry!("register", "pos", pos)
+    |        }
     |      } |
     |
     |      //basic wallets which exist from genesis

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -8,6 +8,7 @@ import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.math.NonNegativeNumber
 import coop.rchain.rholang.mint.{BasicWalletFaucet, MakeMint}
 import coop.rchain.rholang.proofofstake.MakePoS
+import coop.rchain.rholang.registry.SystemInstancesRegistry
 import coop.rchain.rholang.wallet.{BasicWallet, WalletCheck}
 
 object StandardDeploys {
@@ -75,6 +76,12 @@ object StandardDeploys {
       WalletCheck,
       "852a03854f285b36a44c7e84b1c07d30352196de60b593522653ba5e71c8e016",
       1540218618622L
+    )
+  def systemInstances: Deploy =
+    toDeploy(
+      SystemInstancesRegistry,
+      "08a0f8fccace949453dcb6a885e9f50dd96a58ed51c49fc2e346aa4d42ffb7c1",
+      1540563894858L
     )
   def rev(
       wallets: Seq[PreWallet],

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -22,10 +22,16 @@ object BondingUtil {
   def transferStatusOut(ethAddress: String): String       = s"${ethAddress}_transferOut"
 
   def bondingForwarderDeploy(bondKey: String, ethAddress: String): String =
-    s"""for(@purse <- @"${bondingForwarderAddress(ethAddress)}"; pos <- @"proofOfStake"){
-       |  pos!("bond", "$bondKey".hexToBytes(), "ed25519Verify", purse, "$ethAddress", "${bondingStatusOut(
+    s"""new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
+       |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
+       |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
+       |    SystemInstancesRegistry!("lookup", "pos", *posCh) |
+       |    for(@purse <- @"${bondingForwarderAddress(ethAddress)}"; pos <- posCh){
+       |      pos!("bond", "$bondKey".hexToBytes(), "ed25519Verify", purse, "$ethAddress", "${bondingStatusOut(
          ethAddress
        )}")
+       |    }
+       |  }
        |}""".stripMargin
 
   def unlockDeploy[F[_]: Sync](ethAddress: String, pubKey: String, secKey: String)(
@@ -115,10 +121,15 @@ object BondingUtil {
     for {
       transferSigData <- walletTransferSigData[F](nonce, amount, destination)
       transferSig     = Secp256k1.sign(transferSigData, secKey)
-    } yield s"""
-             |for(wallet <- @"$pubKey") {
-             |  wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$transferStatusOut")
-             |}""".stripMargin
+    } yield s"""new rl(`rho:registry:lookup`), WalletCheckCh, result in {
+               |  rl!(`rho:id:oqez475nmxx9ktciscbhps18wnmnwtm6egziohc3rkdzekkmsrpuyt`, *WalletCheckCh) |
+               |  for(@(_, WalletCheck) <- WalletCheckCh) {
+               |    WalletCheck!("access", $pubKey, *result) |
+               |    for(@(true, wallet) <- result) {
+               |      wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$transferStatusOut")
+               |    }
+               |  }
+               |}""".stripMargin
 
   def faucetBondDeploy[F[_]: Sync](
       amount: Long,
@@ -142,10 +153,14 @@ object BondingUtil {
       statusOut       = transferStatusOut(pubKey)
       transferSigData <- walletTransferSigData(nonce, amount, destination)
       transferSig     = sigFunc(transferSigData)
-    } yield s"""new walletCh in {
-               |  for(faucet <- @"faucet"){ faucet!($amount, "ed25519", "$pubKey", *walletCh) } |
-               |  for(@[wallet] <- walletCh) {
-               |    @wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$statusOut")
+    } yield s"""new rl(`rho:registry:lookup`), SystemInstancesCh, walletCh, faucetCh in {
+               |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
+               |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
+               |    SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
+               |    for(faucet <- faucetCh){ faucet!($amount, "ed25519", "$pubKey", *walletCh) } |
+               |    for(@[wallet] <- walletCh) {
+               |      @wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$statusOut")
+               |    }
                |  }
                |}""".stripMargin
 

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -25,7 +25,7 @@ object BondingUtil {
     s"""new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
        |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
        |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-       |    SystemInstancesRegistry!("lookup", "pos", *posCh) |
+       |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
        |    for(@purse <- @"${bondingForwarderAddress(ethAddress)}"; pos <- posCh){
        |      pos!("bond", "$bondKey".hexToBytes(), "ed25519Verify", purse, "$ethAddress", "${bondingStatusOut(
          ethAddress
@@ -124,9 +124,9 @@ object BondingUtil {
     } yield s"""new rl(`rho:registry:lookup`), WalletCheckCh, result in {
                |  rl!(`rho:id:oqez475nmxx9ktciscbhps18wnmnwtm6egziohc3rkdzekkmsrpuyt`, *WalletCheckCh) |
                |  for(@(_, WalletCheck) <- WalletCheckCh) {
-               |    WalletCheck!("access", $pubKey, *result) |
+               |    @WalletCheck!("access", "$pubKey", *result) |
                |    for(@(true, wallet) <- result) {
-               |      wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$transferStatusOut")
+               |      @wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$transferStatusOut")
                |    }
                |  }
                |}""".stripMargin
@@ -156,7 +156,7 @@ object BondingUtil {
     } yield s"""new rl(`rho:registry:lookup`), SystemInstancesCh, walletCh, faucetCh in {
                |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
                |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-               |    SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
+               |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
                |    for(faucet <- faucetCh){ faucet!($amount, "ed25519", "$pubKey", *walletCh) } |
                |    for(@[wallet] <- walletCh) {
                |      @wallet!("transfer", $amount, $nonce, "${Base16.encode(transferSig)}", "$destination", "$statusOut")

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -93,7 +93,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
       """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
         |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
         |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-        |    SystemInstancesRegistry!("lookup", "pos", *posCh) |
+        |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
         |    for(pos <- posCh){ pos!("getBonds", "__SCALA__") }
         |  }
         |}""".stripMargin

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -418,7 +418,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
       |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
       |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-      |    SystemInstancesRegistry!("lookup", "pos", *posCh) |
+      |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
       |    for(pos <- posCh){
       |      new bondsCh, getRanking in {
       |        contract getRanking(@bonds, @acc, return) = {
@@ -479,8 +479,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     //val skStr = "6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14"
     val pkStr = "16989775f3f207a717134216816d3c9d97b0bfb8d560b29485f23f6ead435f09"
-    val sigStr = "c5d019c761bcc15a928e1dab4e77df0e17c29aa541a52f0716fe74adedf654f2" +
-      "6a415abcd5171b97c9d080b341f671b56c17ae10f9d35eb812ca10440ea83408"
+    val sigStr = "51c2b091559745d51c7270189911d9d894d538f76150ed67d164705dcf0af52" +
+      "e101fa06396db2b2ac21a4bfbe3461567b5f8b3d2e666c377cb92d96bc38e2c08"
     val amount = 157L
     val createWalletCode =
       s"""new 
@@ -489,7 +489,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
          |in {
          |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
          |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-         |    SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
+         |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
          |    for(faucet <- faucetCh){ faucet!($amount, "ed25519", "$pkStr", *walletCh) } |
          |    for(@[wallet] <- walletCh){ walletCh!!(wallet) }
          |  } |

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -70,7 +70,7 @@ class RevIssuanceTest extends FlatSpec with Matchers {
         postUnlockHash,
         Par().copy(exprs = Seq(Expr(GString(statusOut))))
       )
-    assert(unlockResult.head.exprs.head.getEListBody.ps.head.exprs.head.getGBool) //assert unlock success
+    assert(unlockResult.head.exprs.head.getETupleBody.ps.head.exprs.head.getGBool) //assert unlock success
 
     val (postTransferHash, _) = runtimeManager.computeState(postUnlockHash, transferDeploy :: Nil)
     val transferSuccess = runtimeManager.getData(


### PR DESCRIPTION
## Overview
In this PR we replace the forgable names which used to hold the instances for the faucet and proof-of-stake system contracts and replace them with a contract dedicated to storing such instances. System contracts are now accessed by first looking up the `SystemInstancesRegistry` from the registry, then calling `lookup` for the relevant contract.

This PR also changes the behaviour of `WalletCheck` to no longer put the claimed wallet at a forgable name, instead it keeps them internally and they can be lookup up using the public key.

Only one major usage of forgable names remain. This is the name of the forwarders created by `BondingUtil` in order to facilitate bonding. Changing these to unforgable names is a little tricky and warrants some discussion.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-920

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
