### PR TITLE
CORE-1383

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
@@ -1,0 +1,36 @@
+package coop.rchain.comm.transport
+
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.shared.Log
+import coop.rchain.comm.PeerNode
+import monix.eval.Task
+import monix.execution.{Cancelable, Scheduler}
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+import monix.reactive.OverflowStrategy._
+import monix.reactive.subjects.ConcurrentSubject
+
+case class ToStream(peerNode: PeerNode, blob: Blob)
+
+class StreamObservable(bufferSize: Int)(implicit scheduler: Scheduler)
+    extends Observable[ToStream] {
+
+  val subject = ConcurrentSubject.publishToOne[ToStream](DropNew(bufferSize))
+
+  def stream(peers: List[PeerNode], blob: Blob): Task[Unit] =
+    peers
+      .traverse(
+        peer =>
+          Task.fromFuture {
+            subject.onNext(ToStream(peer, blob))
+          }
+      )
+      .as(())
+
+  def unsafeSubscribeFn(subscriber: Subscriber[ToStream]): Cancelable = {
+    val subscription = subject.subscribe(subscriber)
+    () => {
+      subscription.cancel()
+    }
+  }
+}

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -40,6 +40,8 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
   private def certInputStream = new ByteArrayInputStream(cert.getBytes())
   private def keyInputStream  = new ByteArrayInputStream(key.getBytes())
 
+  private def streamObservable = new StreamObservable(100)
+
   import connections.cell
 
   private lazy val serverSslContext: SslContext =

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -12,7 +12,7 @@ import monix.execution.Scheduler
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-class TcpTransportLayerSpec { //extends TransportLayerSpec[Task, TcpTlsEnvironment] {
+class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] {
 
   implicit val log: Log[Task]       = new Log.NOPLog[Task]
   implicit val scheduler: Scheduler = Scheduler.Implicits.global

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -66,13 +66,14 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             remoteTl <- createTransportLayer(e2)
             local    = e1.peer
             remote   = e2.peer
+            _        <- localTl.receive(null, null)
             _ <- remoteTl.receive(
                   protocolDispatcher.dispatch(remote),
                   streamDispatcher.dispatch(remote)
                 )
             r <- execute(localTl, local, remote)
             // arbitrary sleep value, so environment has time to handle requests
-            _ <- time.sleep(200 millisecond)
+            _ <- time.sleep(1000 millisecond)
             _ <- remoteTl.shutdown(ProtocolHelper.disconnect(remote))
             _ <- localTl.shutdown(ProtocolHelper.disconnect(local))
           } yield
@@ -105,9 +106,7 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             local   = e1.peer
             remote  = e2.peer
             r       <- execute(localTl, local, remote)
-            // arbitrary sleep value, so environment has time to handle requests
-            _ <- time.sleep(200 millisecond)
-            _ <- localTl.shutdown(ProtocolHelper.disconnect(local))
+            _       <- localTl.shutdown(ProtocolHelper.disconnect(local))
           } yield
             new TwoNodesResult {
               def localNode: PeerNode  = local
@@ -144,13 +143,14 @@ abstract class TransportLayerRuntime[F[_]: Monad, E <: Environment] {
             local     = e1.peer
             remote1   = e2.peer
             remote2   = e3.peer
+            _         <- localTl.receive(null, null)
             _ <- remoteTl1
                   .receive(protocolDispatcher.dispatch(remote1), streamDispatcher.dispatch(remote1))
             _ <- remoteTl2
                   .receive(protocolDispatcher.dispatch(remote2), streamDispatcher.dispatch(remote2))
             r <- execute(localTl, local, remote1, remote2)
             // arbitrary sleep value, so environment has time to handle requests
-            _ <- time.sleep(200 millisecond)
+            _ <- time.sleep(1000 millisecond)
             _ <- remoteTl1.shutdown(ProtocolHelper.disconnect(remote1))
             _ <- remoteTl2.shutdown(ProtocolHelper.disconnect(remote2))
             _ <- localTl.shutdown(ProtocolHelper.disconnect(local))
@@ -254,6 +254,6 @@ object Dispatcher {
 
   def devNullPacketDispatcher[F[_]: Applicative]: Dispatcher[F, Blob, Unit] =
     new Dispatcher[F, Blob, Unit](
-      kp(())
+      response = kp(())
     )
 }


### PR DESCRIPTION
## Overview
After this change, whenever you call stream with given Blob, that
message is pushed on a queue and the code finishes the
execution. There is a separate consumer of this queue that will then
pop elements from it and send it (in stream fashion) to the
destination.

This way calling `stream` API executes immediately (in matter of
seconds) even for big number of peers involved.

Next PRs should bring to it:
- back pressure (as much as it is possible)
- retries

Bring TcpTransportlayerspec back to live.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1383

