### PR TITLE
Add sequence numbers to produce/consume and thus trace logs

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -213,9 +213,9 @@ object BlockAPI {
     val log =
       serializedLog.map(EventConverter.toRspaceEvent).toList
     log.exists {
-      case Produce(channelHash, _) =>
+      case Produce(channelHash, _, _) =>
         channelHash == StableHashProvider.hash(sortedListeningName)
-      case Consume(channelHash, _) =>
+      case Consume(channelHash, _, _) =>
         channelHash == StableHashProvider.hash(sortedListeningName)
       case COMM(consume, produces) =>
         consume.channelsHash == StableHashProvider.hash(sortedListeningName) ||

--- a/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
@@ -21,16 +21,29 @@ object EventConverter {
 
   def toCasperEvent(event: RspaceEvent): Event = event match {
     case produce: RspaceProduce =>
-      Event(Produce(ProduceEvent(produce.channelsHash, produce.hash)))
+      Event(Produce(ProduceEvent(produce.channelsHash, produce.hash, produce.sequenceNumber)))
     case consume: RspaceConsume =>
-      Event(Consume(ConsumeEvent(consume.channelsHash, consume.hash)))
+      Event(Consume(ConsumeEvent(consume.channelsHash, consume.hash, consume.sequenceNumber)))
     case RspaceComm(rspaceConsume, rspaceProduces) =>
       Event(
         Comm(
           CommEvent(
-            Some(ConsumeEvent(rspaceConsume.channelsHash, rspaceConsume.hash)),
+            Some(
+              ConsumeEvent(
+                rspaceConsume.channelsHash,
+                rspaceConsume.hash,
+                rspaceConsume.sequenceNumber
+              )
+            ),
             rspaceProduces
-              .map(rspaceProduce => ProduceEvent(rspaceProduce.channelsHash, rspaceProduce.hash))
+              .map(
+                rspaceProduce =>
+                  ProduceEvent(
+                    rspaceProduce.channelsHash,
+                    rspaceProduce.hash,
+                    rspaceProduce.sequenceNumber
+                  )
+              )
           )
         )
       )
@@ -38,15 +51,18 @@ object EventConverter {
 
   def toRspaceEvent(event: Event): RspaceEvent = event match {
     case Event(Produce(produce: ProduceEvent)) =>
-      RspaceProduce.fromHash(produce.channelsHash, produce.hash)
+      RspaceProduce.fromHash(produce.channelsHash, produce.hash, produce.sequenceNumber)
     case Event(Consume(consume: ConsumeEvent)) =>
-      RspaceConsume.fromHash(consume.channelsHash, consume.hash)
+      RspaceConsume.fromHash(consume.channelsHash, consume.hash, consume.sequenceNumber)
     case Event(Comm(CommEvent(Some(consume: ConsumeEvent), produces))) =>
       val rspaceProduces: Seq[RspaceProduce] = produces.map { produce =>
         val rspaceProduce: RspaceProduce =
-          RspaceProduce.fromHash(produce.channelsHash, produce.hash)
+          RspaceProduce.fromHash(produce.channelsHash, produce.hash, produce.sequenceNumber)
         rspaceProduce
       }.toList
-      RspaceComm(RspaceConsume.fromHash(consume.channelsHash, consume.hash), rspaceProduces)
+      RspaceComm(
+        RspaceConsume.fromHash(consume.channelsHash, consume.hash, consume.sequenceNumber),
+        rspaceProduces
+      )
   }
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -252,11 +252,13 @@ message Event {
 message ProduceEvent {
   bytes channelsHash = 1;
   bytes hash = 2;
+  int32 sequenceNumber = 3;
 }
 
 message ConsumeEvent {
   bytes channelsHash = 1;
   bytes hash = 2;
+  int32 sequenceNumber = 3;
 }
 
 message CommEvent {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -65,7 +65,9 @@ class ChargingReducer[M[_]](implicit R: Reduce[M], C: CostAccounting[M]) {
   def setAvailablePhlos(limit: Cost): M[Unit] =
     C.set(CostAccount(0, limit))
 
-  def eval(par: Par)(implicit env: Env[Par], rand: Blake2b512Random, sequenceNumber: Int): M[Unit] =
+  def eval(
+      par: Par
+  )(implicit env: Env[Par], rand: Blake2b512Random, sequenceNumber: Int = 0): M[Unit] =
     R.eval(par)
 
   def inj(par: Par)(implicit rand: Blake2b512Random): M[Unit] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -43,29 +43,29 @@ trait Registry[F[_]] {
 
   def testInstall(): F[Unit]
 
-  def lookup(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def lookup(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def lookupCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def lookupCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def insert(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def insert(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def insertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def insertCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def nonceInsertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def nonceInsertCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def delete(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def delete(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def deleteRootCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def deleteRootCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def deleteCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def deleteCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def publicLookup(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def publicLookup(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def publicRegisterRandom(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def publicRegisterRandom(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def publicRegisterSigned(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def publicRegisterSigned(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 
-  def registerInsertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit]
+  def registerInsertCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit]
 }
 
 class RegistryImpl[F[_]](
@@ -261,43 +261,56 @@ class RegistryImpl[F[_]](
   private def parByteArray(bs: ByteString): Par = GByteArray(bs)
 
   private def handleResult[E <: Throwable](
-      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListParWithRandomAndPhlos])]]]
+      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListParWithRandomAndPhlos], Int)]]]
   ): F[Unit] =
     resultF.flatMap({
-      case Right(Some((continuation, dataList))) => dispatcher.dispatch(continuation, dataList)
-      case Right(None)                           => F.unit
-      case Left(err)                             => F.raiseError(err)
+      case Right(Some((continuation, dataList, sequenceNumber))) =>
+        dispatcher.dispatch(continuation, dataList, sequenceNumber)
+      case Right(None) => F.unit
+      case Left(err)   => F.raiseError(err)
     })
 
-  private def singleSend(data: Par, chan: Par, rand: Blake2b512Random): F[Unit] =
-    handleResult(space.produce(chan, ListParWithRandom(Seq(data), rand), false))
+  private def singleSend(
+      data: Par,
+      chan: Par,
+      rand: Blake2b512Random,
+      sequenceNumber: Int
+  ): F[Unit] =
+    handleResult(space.produce(chan, ListParWithRandom(Seq(data), rand), false, sequenceNumber))
 
-  private def succeed(result: Par, ret: Par, rand: Blake2b512Random): F[Unit] =
-    singleSend(result, ret, rand)
+  private def succeed(result: Par, ret: Par, rand: Blake2b512Random, sequenceNumber: Int): F[Unit] =
+    singleSend(result, ret, rand, sequenceNumber)
 
-  private def fail(ret: Par, rand: Blake2b512Random): F[Unit] =
-    singleSend(Par(), ret, rand)
+  private def fail(ret: Par, rand: Blake2b512Random, sequenceNumber: Int): F[Unit] =
+    singleSend(Par(), ret, rand, sequenceNumber)
 
-  private def replace(data: Par, replaceChan: Par, dataRand: Blake2b512Random): F[Unit] =
-    singleSend(data, replaceChan, dataRand)
+  private def replace(
+      data: Par,
+      replaceChan: Par,
+      dataRand: Blake2b512Random,
+      sequenceNumber: Int
+  ): F[Unit] =
+    singleSend(data, replaceChan, dataRand, sequenceNumber)
 
   private def failAndReplace(
       data: Par,
       replaceChan: Par,
       retChan: Par,
       dataRand: Blake2b512Random,
-      failRand: Blake2b512Random
+      failRand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] =
     for {
-      _ <- replace(data, replaceChan, dataRand)
-      _ <- fail(retChan, failRand)
+      _ <- replace(data, replaceChan, dataRand, sequenceNumber)
+      _ <- fail(retChan, failRand, sequenceNumber)
     } yield ()
 
   private def fetchDataLookup(
       dataSource: Par,
       key: Par,
       ret: Par,
-      rand: Blake2b512Random
+      rand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
@@ -305,7 +318,8 @@ class RegistryImpl[F[_]](
             space.produce(
               channel,
               ListParWithRandom(Seq(key, ret, dataSource), rand),
-              false
+              false,
+              sequenceNumber
             )
           )
       _ <- handleResult(
@@ -313,7 +327,8 @@ class RegistryImpl[F[_]](
               Seq[Par](channel, dataSource),
               Seq(prefixRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(BodyRefs.REG_LOOKUP_CALLBACK)),
-              false
+              false,
+              sequenceNumber
             )
           )
     } yield ()
@@ -324,7 +339,8 @@ class RegistryImpl[F[_]](
       key: Par,
       value: Par,
       ret: Par,
-      rand: Blake2b512Random
+      rand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
@@ -332,7 +348,8 @@ class RegistryImpl[F[_]](
             space.produce(
               channel,
               ListParWithRandom(Seq(key, value, ret, dataSource), rand),
-              false
+              false,
+              sequenceNumber
             )
           )
       _ <- handleResult(
@@ -340,7 +357,8 @@ class RegistryImpl[F[_]](
               Seq[Par](channel, dataSource),
               Seq(prefixValueRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(ref)),
-              false
+              false,
+              sequenceNumber
             )
           )
     } yield ()
@@ -351,24 +369,41 @@ class RegistryImpl[F[_]](
       key: Par,
       value: Par,
       ret: Par,
-      rand: Blake2b512Random
+      rand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] =
-    fetchDataInsertGeneric(BodyRefs.REG_INSERT_CALLBACK)(dataSource, key, value, ret, rand)
+    fetchDataInsertGeneric(BodyRefs.REG_INSERT_CALLBACK)(
+      dataSource,
+      key,
+      value,
+      ret,
+      rand,
+      sequenceNumber
+    )
 
   private def fetchDataNonceInsert(
       dataSource: Par,
       key: Par,
       value: Par,
       ret: Par,
-      rand: Blake2b512Random
+      rand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] =
-    fetchDataInsertGeneric(BodyRefs.REG_NONCE_INSERT_CALLBACK)(dataSource, key, value, ret, rand)
+    fetchDataInsertGeneric(BodyRefs.REG_NONCE_INSERT_CALLBACK)(
+      dataSource,
+      key,
+      value,
+      ret,
+      rand,
+      sequenceNumber
+    )
 
   private def fetchDataRootDelete(
       dataSource: Par,
       key: Par,
       ret: Par,
-      rand: Blake2b512Random
+      rand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] = {
     val channel: Par = GPrivate(ByteString.copyFrom(rand.next()))
     for {
@@ -376,7 +411,8 @@ class RegistryImpl[F[_]](
             space.produce(
               channel,
               ListParWithRandom(Seq(key, ret, dataSource), rand),
-              false
+              false,
+              sequenceNumber
             )
           )
       _ <- handleResult(
@@ -384,7 +420,8 @@ class RegistryImpl[F[_]](
               Seq[Par](channel, dataSource),
               Seq(prefixRetReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(BodyRefs.REG_DELETE_ROOT_CALLBACK)),
-              false
+              false,
+              sequenceNumber
             )
           )
     } yield ()
@@ -398,7 +435,8 @@ class RegistryImpl[F[_]](
       parentKey: Par,
       parentData: Par,
       parentReplace: Par,
-      parentRand: Blake2b512Random
+      parentRand: Blake2b512Random,
+      sequenceNumber: Int
   ): F[Unit] = {
     val keyChannel: Par    = GPrivate(ByteString.copyFrom(rand.next()))
     val parentChannel: Par = GPrivate(ByteString.copyFrom(rand.next()))
@@ -407,14 +445,16 @@ class RegistryImpl[F[_]](
             space.produce(
               keyChannel,
               ListParWithRandom(Seq(key, ret, dataSource), rand),
-              false
+              false,
+              sequenceNumber
             )
           )
       _ <- handleResult(
             space.produce(
               parentChannel,
               ListParWithRandom(Seq(parentKey, parentData, parentReplace), parentRand),
-              false
+              false,
+              sequenceNumber
             )
           )
       _ <- handleResult(
@@ -422,20 +462,21 @@ class RegistryImpl[F[_]](
               Seq[Par](keyChannel, parentChannel, dataSource),
               Seq(prefixRetReplacePattern, parentKeyDataReplacePattern, triePattern),
               TaggedContinuation(ScalaBodyRef(BodyRefs.REG_DELETE_CALLBACK)),
-              false
+              false,
+              sequenceNumber
             )
           )
     } yield ()
   }
 
-  def lookup(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def lookup(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(key, ret), rand, _)) =>
         try {
           val Some(Expr(GByteArray(_))) = key.singleExpr
-          fetchDataLookup(registryRoot, key, ret, rand)
+          fetchDataLookup(registryRoot, key, ret, rand, sequenceNumber)
         } catch {
-          case _: MatchError => fail(ret, rand)
+          case _: MatchError => fail(ret, rand, sequenceNumber)
         }
       case _ => F.unit
     }
@@ -445,13 +486,13 @@ class RegistryImpl[F[_]](
   // Result there, return it.
   // Further lookup needed, recurse.
 
-  def lookupCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def lookupCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(
           ListParWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, _),
           ListParWithRandomAndPhlos(Seq(data), dataRand, _)
           ) =>
-        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
+        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand, sequenceNumber)
         try {
           val Some(Expr(GByteArray(bs)))               = key.singleExpr
           val (head, tail)                             = safeUncons(bs)
@@ -466,21 +507,24 @@ class RegistryImpl[F[_]](
             ps(0).singleExpr() match {
               case Some(Expr(GInt(0))) =>
                 if (tail == edgeAdditional)
-                  replace(data, replaceChan, dataRand).flatMap(_ => succeed(ps(2), ret, callRand))
+                  replace(data, replaceChan, dataRand, sequenceNumber) *> succeed(
+                    ps(2),
+                    ret,
+                    callRand,
+                    sequenceNumber
+                  )
                 else
                   localFail()
               case Some(Expr(GInt(1))) =>
                 if (tail.startsWith(edgeAdditional)) {
                   val newKey = tail.substring(edgeAdditional.size)
 
-                  replace(data, replaceChan, dataRand).flatMap(
-                    _ =>
-                      fetchDataLookup(
-                        ps(2),
-                        parByteArray(newKey),
-                        ret,
-                        callRand
-                      )
+                  replace(data, replaceChan, dataRand, sequenceNumber) *> fetchDataLookup(
+                    ps(2),
+                    parByteArray(newKey),
+                    ret,
+                    callRand,
+                    sequenceNumber
                   )
                 } else
                   localFail()
@@ -494,22 +538,25 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def insert(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def insert(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(key, value, ret), rand, _)) =>
         try {
           val Some(Expr(GByteArray(_))) = key.singleExpr
-          fetchDataInsert(registryRoot, key, value, ret, rand)
+          fetchDataInsert(registryRoot, key, value, ret, rand, sequenceNumber)
         } catch {
-          case _: MatchError => fail(ret, rand)
+          case _: MatchError => fail(ret, rand, sequenceNumber)
         }
       case _ => F.unit
     }
 
-  def insertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
-    genericInsertCallback(args, (x, y) => true, fetchDataInsert)
+  def insertCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
+    genericInsertCallback(args, (x, y) => true, fetchDataInsert, sequenceNumber)
 
-  def nonceInsertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] = {
+  def nonceInsertCallback(
+      args: RootSeq[ListParWithRandomAndPhlos],
+      sequenceNumber: Int
+  ): F[Unit] = {
     def nonceCheck(original: Par, replacement: Par): Boolean = {
       val Some(Expr(ETupleBody(ETuple(Seq(oldNonce, _), _, _)))) = original.singleExpr
       val Some(Expr(ETupleBody(ETuple(Seq(newNonce, _), _, _)))) = replacement.singleExpr
@@ -517,21 +564,22 @@ class RegistryImpl[F[_]](
       val Some(Expr(GInt(newNonceInt)))                          = newNonce.singleExpr
       return newNonceInt > oldNonceInt
     }
-    genericInsertCallback(args, nonceCheck, fetchDataNonceInsert)
+    genericInsertCallback(args, nonceCheck, fetchDataNonceInsert, sequenceNumber)
   }
 
   def genericInsertCallback(
       args: RootSeq[ListParWithRandomAndPhlos],
       check: (Par, Par) => Boolean,
       // Channel, Remaining Key, Value, Return Channel, Random State
-      recurse: (Par, Par, Par, Par, Blake2b512Random) => F[Unit]
+      recurse: (Par, Par, Par, Par, Blake2b512Random, Int) => F[Unit],
+      sequenceNumber: Int
   ): F[Unit] =
     args match {
       case Seq(
           ListParWithRandomAndPhlos(Seq(key, value, ret, replaceChan), callRand, _),
           ListParWithRandomAndPhlos(Seq(data), dataRand, _)
           ) =>
-        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
+        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand, sequenceNumber)
         try {
           val Some(Expr(GByteArray(bs)))   = key.singleExpr
           val (head, tail)                 = safeUncons(bs)
@@ -539,8 +587,8 @@ class RegistryImpl[F[_]](
           def insert() = {
             val tuple: Par  = ETuple(Seq(GInt(0), parByteArray(tail), value))
             val newMap: Par = ParMap(SortedParMap(parMap.ps + (parByteArray(head) -> tuple)))
-            replace(newMap, replaceChan, dataRand)
-              .flatMap(_ => succeed(value, ret, callRand))
+            replace(newMap, replaceChan, dataRand, sequenceNumber)
+              .flatMap(_ => succeed(value, ret, callRand, sequenceNumber))
           }
           parMap.ps.get(parByteArray(head)) match {
             case None => insert()
@@ -576,9 +624,9 @@ class RegistryImpl[F[_]](
                     SortedParMap(parMap.ps + (parByteArray(head) -> updatedTuple))
                   )
                   for {
-                    _ <- replace(updatedMap, replaceChan, dataRand)
-                    _ <- replace(newMap, newName, callRand.splitByte(0))
-                    _ <- succeed(value, ret, callRand.splitByte(1))
+                    _ <- replace(updatedMap, replaceChan, dataRand, sequenceNumber)
+                    _ <- replace(newMap, newName, callRand.splitByte(0), sequenceNumber)
+                    _ <- succeed(value, ret, callRand.splitByte(1), sequenceNumber)
                   } yield ()
                 }
                 ps(0).singleExpr() match {
@@ -598,16 +646,15 @@ class RegistryImpl[F[_]](
                     if (tail.startsWith(edgeAdditional)) {
                       val newKey = tail.substring(edgeAdditional.size)
 
-                      replace(data, replaceChan, dataRand).flatMap(
-                        _ =>
-                          recurse(
-                            ps(2),
-                            parByteArray(newKey),
-                            value,
-                            ret,
-                            callRand
-                          )
-                      )
+                      replace(data, replaceChan, dataRand, sequenceNumber) *>
+                        recurse(
+                          ps(2),
+                          parByteArray(newKey),
+                          value,
+                          ret,
+                          callRand,
+                          sequenceNumber
+                        )
                     } else {
                       split()
                     }
@@ -623,25 +670,25 @@ class RegistryImpl[F[_]](
         F.unit
     }
 
-  def delete(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def delete(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(key, ret), rand, _)) =>
         try {
           val Some(Expr(GByteArray(_))) = key.singleExpr
-          fetchDataRootDelete(registryRoot, key, ret, rand)
+          fetchDataRootDelete(registryRoot, key, ret, rand, sequenceNumber)
         } catch {
-          case _: MatchError => fail(ret, rand)
+          case _: MatchError => fail(ret, rand, sequenceNumber)
         }
       case _ => F.unit
     }
 
-  def deleteRootCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def deleteRootCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(
           ListParWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, _),
           ListParWithRandomAndPhlos(Seq(data), dataRand, _)
           ) =>
-        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand)
+        def localFail() = failAndReplace(data, replaceChan, ret, dataRand, callRand, sequenceNumber)
         try {
           val Some(Expr(GByteArray(bs)))               = key.singleExpr
           val (head, tail)                             = safeUncons(bs)
@@ -657,8 +704,12 @@ class RegistryImpl[F[_]](
               case Some(Expr(GInt(0))) =>
                 if (tail == edgeAdditional) {
                   val updatedMap: Par = ParMap(SortedParMap(parMap.ps - parByteArray(head)))
-                  replace(updatedMap, replaceChan, dataRand)
-                    .flatMap(_ => succeed(ps(2), ret, callRand))
+                  replace(updatedMap, replaceChan, dataRand, sequenceNumber) *> succeed(
+                    ps(2),
+                    ret,
+                    callRand,
+                    sequenceNumber
+                  )
                 } else {
                   localFail()
                 }
@@ -673,7 +724,8 @@ class RegistryImpl[F[_]](
                     parByteArray(head),
                     data,
                     replaceChan,
-                    dataRand
+                    dataRand,
+                    sequenceNumber
                   )
                 } else {
                   localFail()
@@ -688,7 +740,7 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def deleteCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def deleteCallback(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(
           ListParWithRandomAndPhlos(Seq(key, ret, replaceChan), callRand, _),
@@ -700,8 +752,13 @@ class RegistryImpl[F[_]](
           ListParWithRandomAndPhlos(Seq(data), dataRand, _)
           ) =>
         def localFail() =
-          replace(parentData, parentReplace, parentRand).flatMap(
-            _ => failAndReplace(data, replaceChan, ret, dataRand, callRand)
+          replace(parentData, parentReplace, parentRand, sequenceNumber) *> failAndReplace(
+            data,
+            replaceChan,
+            ret,
+            dataRand,
+            callRand,
+            sequenceNumber
           )
         try {
           val Some(Expr(GByteArray(bs))) = key.singleExpr
@@ -730,7 +787,7 @@ class RegistryImpl[F[_]](
                 val updatedMap: Par = ParMap(
                   SortedParMap(parMap.ps + (parentKey -> updatedTuple))
                 )
-                replace(updatedMap, parentReplace, parentRand)
+                replace(updatedMap, parentReplace, parentRand, sequenceNumber)
               }
             }
           }
@@ -749,9 +806,9 @@ class RegistryImpl[F[_]](
                   if (parMap.ps.size > 2) {
                     val updatedMap: Par = ParMap(SortedParMap(parMap.ps - parByteArray(head)))
                     for {
-                      _ <- replace(updatedMap, replaceChan, dataRand)
-                      _ <- replace(parentData, parentReplace, parentRand)
-                      _ <- succeed(ps(2), ret, callRand)
+                      _ <- replace(updatedMap, replaceChan, dataRand, sequenceNumber)
+                      _ <- replace(parentData, parentReplace, parentRand, sequenceNumber)
+                      _ <- succeed(ps(2), ret, callRand, sequenceNumber)
                     } yield ()
                   } else if (parMap.ps.size != 2) {
                     localFail()
@@ -759,7 +816,7 @@ class RegistryImpl[F[_]](
                     val shrunkMap = (parMap.ps - parByteArray(head))
                     for {
                       _ <- Function.tupled(mergeWithParent(_, _))(shrunkMap.head)
-                      _ <- succeed(ps(2), ret, callRand)
+                      _ <- succeed(ps(2), ret, callRand, sequenceNumber)
                     } yield ()
                   }
                 } else {
@@ -776,7 +833,8 @@ class RegistryImpl[F[_]](
                     parByteArray(head),
                     data,
                     replaceChan,
-                    dataRand
+                    dataRand,
+                    sequenceNumber
                   )
                 } else {
                   localFail()
@@ -791,10 +849,10 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicLookup(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def publicLookup(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(key, ret), rand, _)) =>
-        def localFail() = fail(ret, rand)
+        def localFail() = fail(ret, rand, sequenceNumber)
         try {
           val Some(Expr(GUri(uri))) = key.singleExpr
           if (uri.startsWith("rho:id:")) {
@@ -814,7 +872,7 @@ class RegistryImpl[F[_]](
                     rand
                   )
                 )
-                lookup(args)
+                lookup(args, sequenceNumber)
               } else {
                 localFail()
               }
@@ -829,10 +887,10 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicRegisterRandom(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def publicRegisterRandom(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(value, ret), rand, _)) =>
-        def localFail() = fail(ret, rand)
+        def localFail() = fail(ret, rand, sequenceNumber)
         try {
           if (value.serializedSize > 1024)
             localFail()
@@ -848,7 +906,8 @@ class RegistryImpl[F[_]](
                       curryChan,
                       // This re-use of rand is fine because we throw it away in the callback below.
                       ListParWithRandom(Seq(uri, value, ret), rand),
-                      false
+                      false,
+                      sequenceNumber
                     )
                   )
               _ <- handleResult(
@@ -856,10 +915,18 @@ class RegistryImpl[F[_]](
                       Seq[Par](curryChan, resultChan),
                       registerInsertCallbackPatterns,
                       TaggedContinuation(ScalaBodyRef(BodyRefs.REG_REGISTER_INSERT_CALLBACK)),
-                      false
+                      false,
+                      sequenceNumber
                     )
                   )
-              _ <- fetchDataInsert(registryRoot, partialKey, value, resultChan, rand)
+              _ <- fetchDataInsert(
+                    registryRoot,
+                    partialKey,
+                    value,
+                    resultChan,
+                    rand,
+                    sequenceNumber
+                  )
             } yield ()
           }
         } catch {
@@ -869,7 +936,7 @@ class RegistryImpl[F[_]](
       case _ => F.unit
     }
 
-  def publicRegisterSigned(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def publicRegisterSigned(args: RootSeq[ListParWithRandomAndPhlos], sequenceNumber: Int): F[Unit] =
     args match {
       case Seq(ListParWithRandomAndPhlos(Seq(pubKey, value, sig, ret), rand, _)) =>
         try {
@@ -893,7 +960,8 @@ class RegistryImpl[F[_]](
                       curryChan,
                       // This re-use of rand is fine because we throw it away in the callback below.
                       ListParWithRandom(Seq(uri, value, ret), rand),
-                      false
+                      false,
+                      sequenceNumber
                     )
                   )
               _ <- handleResult(
@@ -901,30 +969,41 @@ class RegistryImpl[F[_]](
                       Seq[Par](curryChan, resultChan),
                       registerInsertCallbackPatterns,
                       TaggedContinuation(ScalaBodyRef(BodyRefs.REG_REGISTER_INSERT_CALLBACK)),
-                      false
+                      false,
+                      sequenceNumber
                     )
                   )
-              _ <- fetchDataNonceInsert(registryRoot, hashKey, value, resultChan, rand)
+              _ <- fetchDataNonceInsert(
+                    registryRoot,
+                    hashKey,
+                    value,
+                    resultChan,
+                    rand,
+                    sequenceNumber
+                  )
             } yield ()
           } else {
-            fail(ret, rand)
+            fail(ret, rand, sequenceNumber)
           }
         } catch {
-          case _: MatchError => fail(ret, rand)
+          case _: MatchError => fail(ret, rand, sequenceNumber)
         }
       case _ => F.unit
     }
 
-  def registerInsertCallback(args: RootSeq[ListParWithRandomAndPhlos]): F[Unit] =
+  def registerInsertCallback(
+      args: RootSeq[ListParWithRandomAndPhlos],
+      sequenceNumber: Int
+  ): F[Unit] =
     args match {
       case Seq(
           ListParWithRandomAndPhlos(Seq(urn, expectedValue, ret), _, _),
           ListParWithRandomAndPhlos(Seq(value), valRand, _)
           ) =>
         if (expectedValue == value) {
-          singleSend(urn, ret, valRand)
+          singleSend(urn, ret, valRand, sequenceNumber)
         } else {
-          fail(ret, valRand)
+          fail(ret, valRand, sequenceNumber)
         }
       case _ =>
         F.unit

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -59,7 +59,7 @@ object Runtime {
   type RhoContext = CPAK[Context]
 
   type RhoDispatch[F[_]] = Dispatch[F, ListParWithRandomAndPhlos, TaggedContinuation]
-  type RhoSysFunction    = Function1[Seq[ListParWithRandomAndPhlos], Task[Unit]]
+  type RhoSysFunction    = (Seq[ListParWithRandomAndPhlos], Int) => Task[Unit]
   type RhoDispatchMap    = Map[Long, RhoSysFunction]
 
   type CPAK[F[_, _, _, _]] =
@@ -180,7 +180,7 @@ object Runtime {
       replaySpace: RhoISpace[F],
       processes: List[(Name, Arity, Remainder, BodyRef)]
   ): F[List[Option[(TaggedContinuation, immutable.Seq[ListParWithRandomAndPhlos])]]] =
-    (processes.flatMap {
+    processes.flatMap {
       case (name, arity, remainder, ref) =>
         val channels = List(name)
         val patterns = List(
@@ -195,7 +195,7 @@ object Runtime {
           space.install(channels, patterns, continuation)(MATCH_UNLIMITED_PHLOS),
           replaySpace.install(channels, patterns, continuation)(MATCH_UNLIMITED_PHLOS)
         )
-    }).sequence
+    }.sequence
 
   // TODO: remove default store type
   def create(dataDir: Path, mapSize: Long, storeType: StoreType = LMDB)(
@@ -222,18 +222,18 @@ object Runtime {
         KECCAK256_HASH               -> SystemProcesses.keccak256Hash(space, dispatcher),
         BLAKE2B256_HASH              -> SystemProcesses.blake2b256Hash(space, dispatcher),
         SECP256K1_VERIFY             -> SystemProcesses.secp256k1Verify(space, dispatcher),
-        REG_LOOKUP                   -> (registry.lookup(_)),
-        REG_LOOKUP_CALLBACK          -> (registry.lookupCallback(_)),
-        REG_INSERT                   -> (registry.insert(_)),
-        REG_INSERT_CALLBACK          -> (registry.insertCallback(_)),
-        REG_REGISTER_INSERT_CALLBACK -> (registry.registerInsertCallback(_)),
-        REG_DELETE                   -> (registry.delete(_)),
-        REG_DELETE_ROOT_CALLBACK     -> (registry.deleteRootCallback(_)),
-        REG_DELETE_CALLBACK          -> (registry.deleteCallback(_)),
-        REG_PUBLIC_LOOKUP            -> (registry.publicLookup(_)),
-        REG_PUBLIC_REGISTER_RANDOM   -> (registry.publicRegisterRandom(_)),
-        REG_PUBLIC_REGISTER_SIGNED   -> (registry.publicRegisterSigned(_)),
-        REG_NONCE_INSERT_CALLBACK    -> (registry.nonceInsertCallback(_)),
+        REG_LOOKUP                   -> (registry.lookup(_, _)),
+        REG_LOOKUP_CALLBACK          -> (registry.lookupCallback(_, _)),
+        REG_INSERT                   -> (registry.insert(_, _)),
+        REG_INSERT_CALLBACK          -> (registry.insertCallback(_, _)),
+        REG_REGISTER_INSERT_CALLBACK -> (registry.registerInsertCallback(_, _)),
+        REG_DELETE                   -> (registry.delete(_, _)),
+        REG_DELETE_ROOT_CALLBACK     -> (registry.deleteRootCallback(_, _)),
+        REG_DELETE_CALLBACK          -> (registry.deleteCallback(_, _)),
+        REG_PUBLIC_LOOKUP            -> (registry.publicLookup(_, _)),
+        REG_PUBLIC_REGISTER_RANDOM   -> (registry.publicRegisterRandom(_, _)),
+        REG_PUBLIC_REGISTER_SIGNED   -> (registry.publicRegisterSigned(_, _)),
+        REG_NONCE_INSERT_CALLBACK    -> (registry.nonceInsertCallback(_, _)),
         GET_DEPLOY_PARAMS            -> SystemProcesses.getDeployParams(space, dispatcher, shortLeashParams),
         GET_TIMESTAMP                -> SystemProcesses.blockTime(space, dispatcher, blockTime)
       )
@@ -331,12 +331,14 @@ object Runtime {
       spaceResult <- space.produce(
                       Registry.registryRoot,
                       ListParWithRandom(Seq(Registry.emptyMap), rand),
-                      false
+                      false,
+                      0
                     )
       replayResult <- replaySpace.produce(
                        Registry.registryRoot,
                        ListParWithRandom(Seq(Registry.emptyMap), rand),
-                       false
+                       false,
+                       0
                      )
       _ <- spaceResult match {
             case Right(None) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -23,7 +23,7 @@ object Dispatch {
 
 class RholangAndScalaDispatcher[M[_]] private (
     reducer: => ChargingReducer[M],
-    _dispatchTable: => Map[Long, Function2[Seq[ListParWithRandomAndPhlos], Int, M[Unit]]]
+    _dispatchTable: => Map[Long, (Seq[ListParWithRandomAndPhlos], Int) => M[Unit]]
 )(implicit s: Sync[M])
     extends Dispatch[M, ListParWithRandomAndPhlos, TaggedContinuation] {
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -11,7 +11,7 @@ import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccounting}
 import coop.rchain.rholang.interpreter.storage.{ChargingRSpace, Tuplespace}
 trait Dispatch[M[_], A, K] {
-  def dispatch(continuation: K, dataList: Seq[A]): M[Unit]
+  def dispatch(continuation: K, dataList: Seq[A], sequenceNumber: Int): M[Unit]
 }
 
 object Dispatch {
@@ -23,25 +23,27 @@ object Dispatch {
 
 class RholangAndScalaDispatcher[M[_]] private (
     reducer: => ChargingReducer[M],
-    _dispatchTable: => Map[Long, Function1[Seq[ListParWithRandomAndPhlos], M[Unit]]]
+    _dispatchTable: => Map[Long, Function2[Seq[ListParWithRandomAndPhlos], Int, M[Unit]]]
 )(implicit s: Sync[M])
     extends Dispatch[M, ListParWithRandomAndPhlos, TaggedContinuation] {
 
   def dispatch(
       continuation: TaggedContinuation,
-      dataList: Seq[ListParWithRandomAndPhlos]
+      dataList: Seq[ListParWithRandomAndPhlos],
+      sequenceNumber: Int
   ): M[Unit] =
     for {
       res <- continuation.taggedCont match {
               case ParBody(parWithRand) =>
                 val env     = Dispatch.buildEnv(dataList)
                 val randoms = parWithRand.randomState +: dataList.toVector.map(_.randomState)
-                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms))
+                reducer.eval(parWithRand.body)(env, Blake2b512Random.merge(randoms), sequenceNumber)
               case ScalaBodyRef(ref) =>
                 _dispatchTable.get(ref) match {
                   case Some(f) =>
                     f(
-                      dataList.map(dl => ListParWithRandomAndPhlos(dl.pars, dl.randomState))
+                      dataList.map(dl => ListParWithRandomAndPhlos(dl.pars, dl.randomState)),
+                      sequenceNumber
                     )
                   case None => s.raiseError(new Exception(s"dispatch: no function for $ref"))
                 }
@@ -56,7 +58,7 @@ object RholangAndScalaDispatcher {
 
   def create[M[_], F[_]](
       tuplespace: RhoISpace[M],
-      dispatchTable: => Map[Long, Function1[Seq[ListParWithRandomAndPhlos], M[Unit]]],
+      dispatchTable: => Map[Long, (Seq[ListParWithRandomAndPhlos], Int) => M[Unit]],
       urnMap: Map[String, Par]
   )(
       implicit

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
@@ -55,7 +55,7 @@ object Tuplespace {
               Parallel
                 .parProduct(
                   dispatcher.dispatch(continuation, dataList, updatedSequenceNumber),
-                  produce(channel, data, persistent, updatedSequenceNumber)
+                  produce(channel, data, persistent, sequenceNumber)
                 )
                 .as(())
             } else {
@@ -93,7 +93,7 @@ object Tuplespace {
                   Parallel
                     .parProduct(
                       dispatcher.dispatch(continuation, dataList, updatedSequenceNumber),
-                      consume(binds, body, persistent, updatedSequenceNumber)
+                      consume(binds, body, persistent, sequenceNumber)
                     )
                     .as(())
                 } else {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -52,13 +52,15 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
       override def produce(
           chan: Par,
           data: ListParWithRandom,
-          persistent: Boolean
+          persistent: Boolean,
+          sequenceNumber: Int
       ): Task[Unit] =
         Task.raiseError(OutOfPhlogistonsError)
       override def consume(
           binds: Seq[(BindPattern, Par)],
           body: ParWithRandom,
-          persistent: Boolean
+          persistent: Boolean,
+          sequenceNumber: Int
       ): Task[Unit] = Task.raiseError(OutOfPhlogistonsError)
     }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -172,21 +172,28 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       s: String,
       expected: Par,
       rand: Blake2b512Random
-  ): Unit =
-    result.get(List[Par](GString(s))) should be(
+  ): Unit = {
+    val resultRow = result.get(List[Par](GString(s)))
+    // It is safe to pull out the sequence number because it can vary depending
+    // on the registry execution of the produces/consumes and we are not
+    // testing replay
+    val sequenceNumber = resultRow.fold(0)(_.data.head.source.sequenceNumber)
+    resultRow should be(
       Some(
         Row(
           List(
             Datum.create[Par, ListParWithRandom](
               GString(s),
               ListParWithRandom(Seq(expected), rand),
-              false
+              false,
+              sequenceNumber
             )
           ),
           List()
         )
       )
     )
+  }
 
   "lookup" should "recurse" in {
     val lookupString: String =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -173,11 +173,8 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       expected: Par,
       rand: Blake2b512Random
   ): Unit = {
-    val resultRow = result.get(List[Par](GString(s)))
-    // It is safe to pull out the sequence number because it can vary depending
-    // on the registry execution of the produces/consumes and we are not
-    // testing replay
-    val sequenceNumber = resultRow.fold(0)(_.data.head.source.sequenceNumber)
+    val resultRow      = result.get(List[Par](GString(s)))
+    val sequenceNumber = resultSequenceNumber(resultRow)
     resultRow should be(
       Some(
         Row(
@@ -194,6 +191,14 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       )
     )
   }
+
+  // It is safe to pull out the sequence number because it can vary depending
+  // on the registry execution of the produces/consumes and we are not
+  // testing replay
+  private def resultSequenceNumber(
+      resultRow: Option[Row[BindPattern, ListParWithRandom, TaggedContinuation]]
+  ) =
+    resultRow.fold(0)(_.data.head.source.sequenceNumber)
 
   "lookup" should "recurse" in {
     val lookupString: String =
@@ -462,10 +467,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     checkResult(result, "result6", GInt(8), result6Rand)
     checkResult(result, "result6", GInt(8), result6Rand)
     val registryRootResult = result.get(List[Par](Registry.registryRoot))
-    // It is safe to pull out the sequence number because it can vary depending
-    // on the registry execution of the produces/consumes and we are not
-    // testing replay
-    val sequenceNumber = registryRootResult.fold(0)(_.data.head.source.sequenceNumber)
+    val sequenceNumber     = resultSequenceNumber(registryRootResult)
     registryRootResult should be(
       Some(
         Row(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -461,14 +461,20 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
     checkResult(result, "result5", GInt(8), result5Rand)
     checkResult(result, "result6", GInt(8), result6Rand)
     checkResult(result, "result6", GInt(8), result6Rand)
-    result.get(List[Par](Registry.registryRoot)) should be(
+    val registryRootResult = result.get(List[Par](Registry.registryRoot))
+    // It is safe to pull out the sequence number because it can vary depending
+    // on the registry execution of the produces/consumes and we are not
+    // testing replay
+    val sequenceNumber = registryRootResult.fold(0)(_.data.head.source.sequenceNumber)
+    registryRootResult should be(
       Some(
         Row(
           List(
             Datum.create[Par, ListParWithRandom](
               Registry.registryRoot,
               ListParWithRandom(Seq(EMapBody(ParMap(SortedParMap.empty))), rootRand),
-              false
+              false,
+              sequenceNumber
             )
           ),
           List()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -40,7 +40,8 @@ class RholangOnlyDispatcher[M[_]] private (reducer: => ChargingReducer[M])(impli
 
   def dispatch(
       continuation: TaggedContinuation,
-      dataList: Seq[ListParWithRandomAndPhlos]
+      dataList: Seq[ListParWithRandomAndPhlos],
+      sequenceNumber: Int
   ): M[Unit] =
     for {
       res <- continuation.taggedCont match {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -380,7 +380,8 @@ object ChargingRSpaceTest {
         channels: immutable.Seq[Par],
         patterns: immutable.Seq[BindPattern],
         continuation: TaggedContinuation,
-        persist: Boolean
+        persist: Boolean,
+        sequenceNumber: Int
     )(
         implicit m: Match[
           BindPattern,
@@ -403,7 +404,12 @@ object ChargingRSpaceTest {
           }
         })
 
-    override def produce(channel: Par, data: ListParWithRandom, persist: Boolean)(
+    override def produce(
+        channel: Par,
+        data: ListParWithRandom,
+        persist: Boolean,
+        sequenceNumber: Int
+    )(
         implicit m: Match[
           BindPattern,
           errors.OutOfPhlogistonsError.type,

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -53,7 +53,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
       patterns: Seq[P],
       continuation: K,
       persist: Boolean,
-      sequenceNumber: Int
+      sequenceNumber: Int = 0
   )(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
@@ -85,7 +85,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param data A piece of data
     * @param persist Whether or not to attempt to persist the data
     */
-  def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
+  def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int = 0)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -10,7 +10,8 @@ final case class ContResult[C, P, R](
     value: R,
     persistent: Boolean,
     channels: Seq[C],
-    patterns: Seq[P]
+    patterns: Seq[P],
+    sequenceNumber: Int
 )
 
 /** The interface for RSpace
@@ -47,7 +48,13 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param continuation A continuation
     * @param persist Whether or not to attempt to persist the data
     */
-  def consume(channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
+  def consume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      sequenceNumber: Int
+  )(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
@@ -78,7 +85,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param data A piece of data
     * @param persist Whether or not to attempt to persist the data
     */
-  def produce(channel: C, data: A, persist: Boolean)(
+  def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -53,7 +53,7 @@ abstract class RSpaceOps[F[_], C, P, E, A, R, K](val store: IStore[C, P, A, K], 
     logger.debug(s"""|install: searching for data matching <patterns: $patterns>
                      |at <channels: $channels>""".stripMargin.replace('\n', ' '))
 
-    val consumeRef = Consume.create(channels, patterns, continuation, true)
+    val consumeRef = Consume.create(channels, patterns, continuation, true, 0)
 
     /*
      * Here, we create a cache of the data at each channel as `channelToIndexedData`

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -36,9 +36,9 @@ trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
       .delay {
         // create a set of the "new" IOEvents
         val newStuff: Set[Event] = log.filter {
-          case Produce(_, _) => true
-          case Consume(_, _) => true
-          case _             => false
+          case Produce(_, _, _) => true
+          case Consume(_, _, _) => true
+          case _                => false
         }.toSet
         // create and prepare the ReplayData table
         replayData.clear()

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -36,8 +36,8 @@ trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
       .delay {
         // create a set of the "new" IOEvents
         val newStuff: Set[Event] = log.filter {
-          case Produce(_, _, _) => true
-          case Consume(_, _, _) => true
+          case _ : Produce => true
+          case _ : Consume => true
           case _                => false
         }.toSet
         // create and prepare the ReplayData table

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -36,9 +36,9 @@ trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
       .delay {
         // create a set of the "new" IOEvents
         val newStuff: Set[Event] = log.filter {
-          case _ : Produce => true
-          case _ : Consume => true
-          case _                => false
+          case _: Produce => true
+          case _: Consume => true
+          case _          => false
         }.toSet
         // create and prepare the ReplayData table
         replayData.clear()

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -291,7 +291,7 @@ object AddressBookExample {
     println("Rollback example: And create a checkpoint...")
     val checkpointHash = space.createCheckpoint().root
 
-    def produceAlice(): Option[(Printer, Seq[Entry])] =
+    def produceAlice(): Option[(Printer, Seq[Entry], Int)] =
       space.produce(Channel("friends"), alice, persist = false).right.get
 
     println("Rollback example: First produce result should return some data")

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -15,12 +15,12 @@ object internal {
   final case class Datum[A](a: A, persist: Boolean, source: Produce)
 
   object Datum {
-    def create[C, A](channel: C, a: A, persist: Boolean)(
+    def create[C, A](channel: C, a: A, persist: Boolean, sequenceNumber: Int)(
         implicit
         serializeC: Serialize[C],
         serializeA: Serialize[A]
     ): Datum[A] =
-      Datum(a, persist, Produce.create(channel, a, persist))
+      Datum(a, persist, Produce.create(channel, a, persist, sequenceNumber))
   }
 
   final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
@@ -33,7 +33,13 @@ object internal {
   )
 
   object WaitingContinuation {
-    def create[C, P, K](channels: Seq[C], patterns: Seq[P], continuation: K, persist: Boolean)(
+    def create[C, P, K](
+        channels: Seq[C],
+        patterns: Seq[P],
+        continuation: K,
+        persist: Boolean,
+        sequenceNumber: Int
+    )(
         implicit
         serializeC: Serialize[C],
         serializeP: Serialize[P],
@@ -43,7 +49,7 @@ object internal {
         patterns,
         continuation,
         persist,
-        Consume.create(channels, patterns, continuation, persist)
+        Consume.create(channels, patterns, continuation, persist, sequenceNumber)
       )
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -15,7 +15,7 @@ object internal {
   final case class Datum[A](a: A, persist: Boolean, source: Produce)
 
   object Datum {
-    def create[C, A](channel: C, a: A, persist: Boolean, sequenceNumber: Int)(
+    def create[C, A](channel: C, a: A, persist: Boolean, sequenceNumber: Int = 0)(
         implicit
         serializeC: Serialize[C],
         serializeA: Serialize[A]
@@ -38,7 +38,7 @@ object internal {
         patterns: Seq[P],
         continuation: K,
         persist: Boolean,
-        sequenceNumber: Int
+        sequenceNumber: Int = 0
     )(
         implicit
         serializeC: Serialize[C],

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -13,7 +13,7 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
       patterns: Seq[P],
       continuation: K,
       persist: Boolean,
-      sequenceNumber: Int
+      sequenceNumber: Int = 0
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[R])]]
@@ -22,7 +22,7 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
       channel: C,
       data: A,
       persist: Boolean,
-      sequenceNumber: Int
+      sequenceNumber: Int = 0
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def createCheckpoint(): F[Checkpoint]

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -12,7 +12,8 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
       channels: Seq[C],
       patterns: Seq[P],
       continuation: K,
-      persist: Boolean
+      persist: Boolean,
+      sequenceNumber: Int
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[R])]]
@@ -20,7 +21,8 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
   def produce(
       channel: C,
       data: A,
-      persist: Boolean
+      persist: Boolean,
+      sequenceNumber: Int
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def createCheckpoint(): F[Checkpoint]
@@ -42,9 +44,10 @@ object PureRSpace {
             channels: Seq[C],
             patterns: Seq[P],
             continuation: K,
-            persist: Boolean
+            persist: Boolean,
+            sequenceNumber: Int
         ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
-          space.consume(channels, patterns, continuation, persist)
+          space.consume(channels, patterns, continuation, persist, sequenceNumber)
 
         def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[R])]] =
           space.install(channels, patterns, continuation)
@@ -52,9 +55,10 @@ object PureRSpace {
         def produce(
             channel: C,
             data: A,
-            persist: Boolean
+            persist: Boolean,
+            sequenceNumber: Int
         ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
-          space.produce(channel, data, persist)
+          space.produce(channel, data, persist, sequenceNumber)
 
         def createCheckpoint(): F[Checkpoint] = space.createCheckpoint()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpace.scala
@@ -136,12 +136,7 @@ class FineGrainedRSpace[F[_], C, P, E, A, R, K] private[rspace] (
               logger.debug(
                 s"consume: data found for <patterns: $patterns> at <channels: $channels>"
               )
-              val contSequenceNumber = Math.max(
-                consumeRef.sequenceNumber,
-                dataCandidates.map {
-                  case DataCandidate(_, Datum(_, _, source), _) => source.sequenceNumber
-                }.max
-              ) + 1
+              val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
               Right(
                 Some(
                   (
@@ -154,6 +149,14 @@ class FineGrainedRSpace[F[_], C, P, E, A, R, K] private[rspace] (
         }
       }
     }
+
+  private def nextSequenceNumber(consumeRef: Consume, dataCandidates: Seq[DataCandidate[C, R]]) =
+    Math.max(
+      consumeRef.sequenceNumber,
+      dataCandidates.map {
+        case DataCandidate(_, Datum(_, _, source), _) => source.sequenceNumber
+      }.max
+    ) + 1
 
   override def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
@@ -264,12 +267,7 @@ class FineGrainedRSpace[F[_], C, P, E, A, R, K] private[rspace] (
                     }
                 }
               logger.debug(s"produce: matching continuation found at <channels: $channels>")
-              val contSequenceNumber = Math.max(
-                consumeRef.sequenceNumber,
-                dataCandidates.map {
-                  case DataCandidate(_, Datum(_, _, source), _) => source.sequenceNumber
-                }.max
-              ) + 1
+              val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
               Right(
                 Some(
                   (

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
@@ -84,7 +84,8 @@ abstract class FineGrainedRSpaceOps[F[_], C, P, E, A, R, K](
     logger.debug(s"""|install: searching for data matching <patterns: $patterns>
                        |at <channels: $channels>""".stripMargin.replace('\n', ' '))
 
-    val consumeRef = Consume.create(channels, patterns, continuation, true)
+    // TODO: Double check if sequence number of 0 makes sense here
+    val consumeRef = Consume.create(channels, patterns, continuation, true, 0)
 
     /*
      * Here, we create a cache of the data at each channel as `channelToIndexedData`

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedRSpaceOps.scala
@@ -84,7 +84,6 @@ abstract class FineGrainedRSpaceOps[F[_], C, P, E, A, R, K](
     logger.debug(s"""|install: searching for data matching <patterns: $patterns>
                        |at <channels: $channels>""".stripMargin.replace('\n', ' '))
 
-    // TODO: Double check if sequence number of 0 makes sense here
     val consumeRef = Consume.create(channels, patterns, continuation, true, 0)
 
     /*

--- a/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/spaces/FineGrainedReplayRSpace.scala
@@ -136,10 +136,7 @@ class FineGrainedReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K],
       logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
       removeBindingsFor(commRef)
       span.mark("handle-matches-end")
-      val contSequenceNumber = Math.max(
-        commRef.consume.sequenceNumber,
-        commRef.produces.map(_.sequenceNumber).max
-      ) + 1
+      val contSequenceNumber = commRef.nextSequenceNumber
       Some(
         (
           ContResult(continuation, persist, channels, patterns, contSequenceNumber),
@@ -305,10 +302,7 @@ class FineGrainedReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K],
           logger.debug(s"produce: matching continuation found at <channels: $channels>")
           removeBindingsFor(commRef)
           span.mark("handle-match-end")
-          val contSequenceNumber = Math.max(
-            commRef.consume.sequenceNumber,
-            commRef.produces.map(_.sequenceNumber).max
-          ) + 1
+          val contSequenceNumber = commRef.nextSequenceNumber
           Some(
             (
               ContResult(continuation, persistK, channels, patterns, contSequenceNumber),

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -34,7 +34,13 @@ object Event {
   implicit def codecLog: Codec[Seq[Event]] = codecSeq[Event](codecEvent)
 }
 
-case class COMM(consume: Consume, produces: Seq[Produce]) extends Event
+case class COMM(consume: Consume, produces: Seq[Produce]) extends Event {
+  def nextSequenceNumber: Int =
+    Math.max(
+      consume.sequenceNumber,
+      produces.map(_.sequenceNumber).max
+    ) + 1
+}
 
 object COMM {
   implicit val codecCOMM: Codec[COMM] = (Codec[Consume] :: Codec[Seq[Produce]]).as[COMM]

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -62,7 +62,7 @@ object Produce {
   def unapply(arg: Produce): Option[(Blake2b256Hash, Blake2b256Hash, Int)] =
     Some((arg.channelsHash, arg.hash, arg.sequenceNumber))
 
-  def create[C, A](channel: C, datum: A, persist: Boolean, sequenceNumber: Int)(
+  def create[C, A](channel: C, datum: A, persist: Boolean, sequenceNumber: Int = 0)(
       implicit
       serializeC: Serialize[C],
       serializeA: Serialize[A]
@@ -104,7 +104,7 @@ object Consume {
       patterns: Seq[P],
       continuation: K,
       persist: Boolean,
-      sequenceNumber: Int
+      sequenceNumber: Int = 0
   )(
       implicit
       serializeC: Serialize[C],

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -10,27 +10,28 @@ package object util {
 
   implicit def unpackSeq[C, P, K, R](
       v: Seq[Option[(ContResult[C, P, K], Seq[Result[R]])]]
-  ): Seq[Option[(K, Seq[R])]] =
+  ): Seq[Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
   implicit def unpackEither[C, P, E, K, R](
       v: Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]
-  ): Either[E, Option[(K, Seq[R])]] =
+  ): Either[E, Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
   implicit def unpackEither[F[_], C, P, E, K, R](
       v: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
-  )(implicit ev: Functor[F]): F[Either[E, Option[(K, Seq[R])]]] =
+  )(implicit ev: Functor[F]): F[Either[E, Option[(K, Seq[R], Int)]]] =
     ev.map(v)(_.map(unpackOption))
 
   implicit def unpackOption[C, P, K, R](
       v: Option[(ContResult[C, P, K], Seq[Result[R]])]
-  ): Option[(K, Seq[R])] =
+  ): Option[(K, Seq[R], Int)] =
     v.map(unpackTuple)
 
-  implicit def unpackTuple[C, P, K, R](v: (ContResult[C, P, K], Seq[Result[R]])): (K, Seq[R]) =
+  implicit def unpackTuple[C, P, K, R](v: (ContResult[C, P, K], Seq[Result[R]])): (K, Seq[R], Int) =
     v match {
-      case (ContResult(continuation, _, _, _), data) => (continuation, data.map(_.value))
+      case (ContResult(continuation, _, _, _, sequenceNumber), data) =>
+        (continuation, data.map(_.value), sequenceNumber)
     }
 
   implicit def unpack[T](v: Result[T]): T                     = v.value
@@ -47,13 +48,13 @@ package object util {
 
   /** Runs a continuation with the accompanying data
     */
-  def runK[T](e: Either[Nothing, Option[((T) => Unit, T)]]): Unit =
-    e.right.get.foreach { case (k, data) => k(data) }
+  def runK[T](e: Either[Nothing, Option[((T) => Unit, T, Int)]]): Unit =
+    e.right.get.foreach { case (k, data, _) => k(data) }
 
   /** Runs a list of continuations with the accompanying data
     */
-  def runKs[T](t: Seq[Option[((T) => Unit, T)]]): Unit =
-    t.foreach { case Some((k, data)) => k(data); case None => () }
+  def runKs[T](t: Seq[Option[((T) => Unit, T, Int)]]): Unit =
+    t.foreach { case Some((k, data, _)) => k(data); case None => () }
 
   /**
     * Compare to `memcmp` in C/C++

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -837,7 +837,7 @@ trait ReplayRSpaceTests
 
     //rig
     replaySpace.rig(empty.root, afterPlay.log)
-    
+
     //some maliciously 'random' replay order
     replaySpace.produce(channel1, data3, false, 0) shouldBe noMatch
     replaySpace.produce(channel1, data3, false, 0) shouldBe noMatch

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -812,52 +812,51 @@ trait ReplayRSpaceTests
       )
     }
 
-  "replay" should "not allow for ambiguous executions" ignore withTestSpaces {
-    (space, replaySpace) =>
-      val noMatch                 = Right(None)
-      val empty                   = space.createCheckpoint()
-      val channel1                = "ch1"
-      val channel2                = "ch2"
-      val key1                    = List(channel1, channel2)
-      val patterns: List[Pattern] = List(Wildcard, Wildcard)
-      val continuation1           = "continuation"
-      val continuation2           = "continuation"
-      val data1                   = "datum1"
-      val data2                   = "datum2"
-      val data3                   = "datum3"
+  "replay" should "not allow for ambiguous executions" in withTestSpaces { (space, replaySpace) =>
+    val noMatch                 = Right(None)
+    val empty                   = space.createCheckpoint()
+    val channel1                = "ch1"
+    val channel2                = "ch2"
+    val key1                    = List(channel1, channel2)
+    val patterns: List[Pattern] = List(Wildcard, Wildcard)
+    val continuation1           = "continuation1"
+    val continuation2           = "continuation2"
+    val data1                   = "datum1"
+    val data2                   = "datum2"
+    val data3                   = "datum3"
 
-      //some maliciously 'random' play order
-      space.produce(channel1, data3, false) shouldBe noMatch
-      space.produce(channel1, data3, false) shouldBe noMatch
-      space.produce(channel2, data1, false) shouldBe noMatch
+    //some maliciously 'random' play order
+    space.produce(channel1, data3, false, 0) shouldBe noMatch
+    space.produce(channel1, data3, false, 0) shouldBe noMatch
+    space.produce(channel2, data1, false, 0) shouldBe noMatch
 
-      space.consume(key1, patterns, continuation1, false).right.get should not be empty
-      //continuation1 produces data1 on ch2
-      space.produce(channel2, data1, false) shouldBe noMatch
-      space.consume(key1, patterns, continuation2, false).right.get should not be empty
-      //continuation2 produces data2 on ch2
-      space.produce(channel2, data2, false) shouldBe noMatch
-      val afterPlay = space.createCheckpoint()
+    space.consume(key1, patterns, continuation1, false, 0).right.get should not be empty
+    //continuation1 produces data1 on ch2
+    space.produce(channel2, data1, false, 1) shouldBe noMatch
+    space.consume(key1, patterns, continuation2, false, 0).right.get should not be empty
+    //continuation2 produces data2 on ch2
+    space.produce(channel2, data2, false, 2) shouldBe noMatch
+    val afterPlay = space.createCheckpoint()
 
-      //rig
-      replaySpace.rig(empty.root, afterPlay.log)
+    //rig
+    replaySpace.rig(empty.root, afterPlay.log)
+    
+    //some maliciously 'random' replay order
+    replaySpace.produce(channel1, data3, false, 0) shouldBe noMatch
+    replaySpace.produce(channel1, data3, false, 0) shouldBe noMatch
+    replaySpace.produce(channel2, data1, false, 0) shouldBe noMatch
+    replaySpace.consume(key1, patterns, continuation2, false, 0) shouldBe noMatch
 
-      //some maliciously 'random' replay order
-      replaySpace.produce(channel1, data3, false) shouldBe noMatch
-      replaySpace.produce(channel1, data3, false) shouldBe noMatch
-      replaySpace.produce(channel2, data2, false) shouldBe noMatch
-      replaySpace.consume(key1, patterns, continuation2, false) shouldBe noMatch
+    replaySpace.consume(key1, patterns, continuation1, false, 0).right.get should not be empty
+    //continuation1 produces data1 on ch2
+    replaySpace
+      .produce(channel2, data1, false, 1)
+      .right
+      .get should not be empty //matches continuation2
+    //continuation2 produces data2 on ch2
+    replaySpace.produce(channel2, data2, false, 1) shouldBe noMatch
 
-      replaySpace.consume(key1, patterns, continuation1, false).right.get should not be empty
-      //continuation1 produces data1 on ch2
-      replaySpace
-        .produce(channel2, data1, false)
-        .right
-        .get should not be empty //matches continuation2
-      //continuation2 produces data2 on ch2
-      replaySpace.produce(channel2, data2, false) shouldBe noMatch
-
-      replaySpace.replayData.isEmpty shouldBe true
+    replaySpace.replayData.isEmpty shouldBe true
   }
 }
 


### PR DESCRIPTION
Take the following example

`new x, y in {
  x!(1) | y!(2) | for (@1 <- x; @2 <- y) { y!(3) } | x!(1) | for (@1 <- x; @2 <- y) { y!(2) }
}`

This is what happens originally

1. `x!(1)`
2. `y!(2)`
3. `for (@1 <- x; @2 <- y) { y!(2) }`
4. `y!(2)` (The continuation of step 3)
5. `x!(1)`
6.  `for (@1 <- x; @2 <- y) { y!(3) }`

And this is what happens in replay

1. `x!(1)`
2. `y!(2)`
3. `for (@1 <- x; @2 <- y) { y!(3) }`
4. `y!(3)` (The continuation of step 3)
5. `x!(1)`

And now we have an unused `for (@1 <- x; @2 <- y) { y!(2) }`

But not quite...

`y!(2)` and the same term inside the continuation of `for (@1 <- x; @2 <- y) { y!(2) }` don't have the same deterministic rand value and thus the situation outlined above never happens. However, because the registry uses peek semantics, the deterministic rand value between the produce containing the registry map that matches with the lookup consume and the one that matches with the insert consume is not differentiable. Thus we get a situation similar what I outlined above.

The fix (thanks @guardbotmk3 for the idea!) is to insert a sequence number into produces/consumes. Every time a reduction happens, the continuation receives a sequence number of max(sequence number of produces, sequence number of consumes) + 1. Note this does not totally order all produces/consumes!