### PR TITLE
Test for non integer values in NonNegativeNumber.rho

### DIFF
--- a/casper/src/main/rholang/NonNegativeNumber.rho
+++ b/casper/src/main/rholang/NonNegativeNumber.rho
@@ -47,8 +47,13 @@ new NonNegativeNumber, rs(`rho:registry:insertSigned:ed25519`), uriOut in {
         }
       } |
       return!(bundle+{*this}) |
-      if (init >= 0) { valueStore!(init) }
-      else           { valueStore!(0)    } //Initial balance is zero if given is negative}
+      match init { //Initial balance is zero if given is negative on non-integer
+        Int => {
+          if (init >= 0) { valueStore!(init)  }
+          else           { valueStore!(0) }
+        }
+         _ => { valueStore!(0) }
+      }
     }
   } |
   


### PR DESCRIPTION
## Overview
Modify NonNegativeNumber.rho so that it returns a 0 value when initialized with a non integer value rather than simply not returning at all.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please https://rchain.atlassian.net/browse/RHOL-1049
### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Originally reported and solved by @Eknir
