### PR TITLE
RHOL-1028: Clean up SortedParMap

### DIFF
--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -1,29 +1,50 @@
 package coop.rchain.models
 
-import scala.collection.MapLike
 import coop.rchain.models.rholang.sorter.ordering._
 
-class SortedParMap private (private val ps: Map[Par, Par])
-    extends Map[Par, Par]
-    with MapLike[Par, Par, SortedParMap] {
+import scala.collection.GenTraversableOnce
+import scala.collection.immutable.ListMap
 
-  lazy val sortedMap: Map[Par, Par] = ps.sort.toMap
+final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)] {
 
-  override def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
+  lazy val sortedMap: ListMap[Par, Par] = ListMap(ps.sort: _*)
 
-  override def get(key: Par): Option[Par] = sortedMap.get(key)
+  def +(kv: (Par, Par)): SortedParMap = SortedParMap(sortedMap + kv)
 
-  override def iterator: Iterator[(Par, Par)] = sortedMap.toIterator
+  def ++(kvs: GenTraversableOnce[(Par, Par)]): SortedParMap = SortedParMap(sortedMap ++ kvs)
 
-  override def +[V1 >: Par](kv: (Par, V1)): Map[Par, V1] = sortedMap + kv
+  def -(key: Par): SortedParMap = SortedParMap(sortedMap - key)
 
-  override def -(key: Par): SortedParMap = SortedParMap(sortedMap - key)
+  def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys)
+
+  def apply(par: Par): Par = sortedMap(par)
+
+  def contains(par: Par): Boolean = sortedMap.contains(par)
+
+  def empty: SortedParMap = SortedParMap(ListMap.empty[Par, Par])
+
+  def get(key: Par): Option[Par] = sortedMap.get(key)
+
+  def getOrElse(key: Par, default: Par): Par = sortedMap.getOrElse(key, default)
+
+  def iterator: Iterator[(Par, Par)] = sortedMap.toIterator
+
+  def keys: Iterable[Par] = sortedMap.keys
+
+  def values: Iterable[Par] = sortedMap.values
+
+  override def equals(that: Any): Boolean = that match {
+    case spm: SortedParMap => spm.sortedMap == this.sortedMap
+    case _                 => false
+  }
 }
 
 object SortedParMap {
   def apply(map: Map[Par, Par]): SortedParMap = new SortedParMap(map)
 
   def apply(seq: Seq[(Par, Par)]): SortedParMap = SortedParMap(seq.toMap)
+
+  def apply(sortedParMap: SortedParMap): SortedParMap = SortedParMap(sortedParMap.sortedMap)
 
   def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
 }

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -17,7 +17,10 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
 
   def -(key: Par): SortedParMap = SortedParMap(sortedMap - key.sort)
 
-  def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys.sort)
+  def --(keys: GenTraversableOnce[Par]): SortedParMap =
+    SortedParMap(keys.foldLeft(sortedMap) { (map, kv) =>
+      map - kv.sort
+    })
 
   def apply(par: Par): Par = sortedMap(par.sort)
 

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -48,7 +48,5 @@ object SortedParMap {
 
   def apply(seq: Seq[(Par, Par)]): SortedParMap = SortedParMap(seq.toMap)
 
-  def apply(sortedParMap: SortedParMap): SortedParMap = SortedParMap(sortedParMap.sortedMap)
-
   def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
 }

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -7,7 +7,9 @@ import scala.collection.immutable.ListMap
 
 final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)] {
 
-  lazy val sortedMap: ListMap[Par, Par] = ListMap(ps.sort: _*)
+  // TODO: Merge `sortedMap` and `sortedMapLookup` into one VectorMap once available
+  lazy val sortedMap: ListMap[Par, Par]   = ListMap(ps.sort: _*)
+  lazy val sortedMapLookup: Map[Par, Par] = ps.sort.toMap
 
   def +(kv: (Par, Par)): SortedParMap = SortedParMap(sortedMap + kv)
 
@@ -17,15 +19,15 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
 
   def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys)
 
-  def apply(par: Par): Par = sortedMap(par)
+  def apply(par: Par): Par = sortedMapLookup(par)
 
-  def contains(par: Par): Boolean = sortedMap.contains(par)
+  def contains(par: Par): Boolean = sortedMapLookup.contains(par)
 
-  def empty: SortedParMap = SortedParMap(ListMap.empty[Par, Par])
+  def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
 
-  def get(key: Par): Option[Par] = sortedMap.get(key)
+  def get(key: Par): Option[Par] = sortedMapLookup.get(key)
 
-  def getOrElse(key: Par, default: Par): Par = sortedMap.getOrElse(key, default)
+  def getOrElse(key: Par, default: Par): Par = sortedMapLookup.getOrElse(key, default)
 
   def iterator: Iterator[(Par, Par)] = sortedMap.toIterator
 
@@ -37,6 +39,8 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
     case spm: SortedParMap => spm.sortedMap == this.sortedMap
     case _                 => false
   }
+
+  override def hashCode(): Int = sortedMap.hashCode()
 }
 
 object SortedParMap {

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -3,13 +3,13 @@ package coop.rchain.models
 import coop.rchain.models.rholang.sorter.ordering._
 
 import scala.collection.GenTraversableOnce
-import scala.collection.immutable.ListMap
+import scala.collection.immutable.HashMap
 
 final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)] {
 
-  // TODO: Merge `sortedMap` and `sortedMapLookup` into one VectorMap once available
-  lazy val sortedMap: ListMap[Par, Par]   = ListMap(ps.sort: _*)
-  lazy val sortedMapLookup: Map[Par, Par] = ps.sort.toMap
+  // TODO: Merge `sortedList` and `sortedMap` into one VectorMap once available
+  lazy val sortedList: List[(Par, Par)] = ps.sort
+  lazy val sortedMap: HashMap[Par, Par] = HashMap(sortedList: _*)
 
   def +(kv: (Par, Par)): SortedParMap = SortedParMap(sortedMap + kv)
 
@@ -19,28 +19,28 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
 
   def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys)
 
-  def apply(par: Par): Par = sortedMapLookup(par)
+  def apply(par: Par): Par = sortedMap(par)
 
-  def contains(par: Par): Boolean = sortedMapLookup.contains(par)
+  def contains(par: Par): Boolean = sortedMap.contains(par)
 
   def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
 
-  def get(key: Par): Option[Par] = sortedMapLookup.get(key)
+  def get(key: Par): Option[Par] = sortedMap.get(key)
 
-  def getOrElse(key: Par, default: Par): Par = sortedMapLookup.getOrElse(key, default)
+  def getOrElse(key: Par, default: Par): Par = sortedMap.getOrElse(key, default)
 
-  def iterator: Iterator[(Par, Par)] = sortedMap.toIterator
+  def iterator: Iterator[(Par, Par)] = sortedList.toIterator
 
-  def keys: Iterable[Par] = sortedMap.keys
+  def keys: Iterable[Par] = sortedList.map(_._1)
 
-  def values: Iterable[Par] = sortedMap.values
+  def values: Iterable[Par] = sortedList.map(_._2)
 
   override def equals(that: Any): Boolean = that match {
-    case spm: SortedParMap => spm.sortedMap == this.sortedMap
+    case spm: SortedParMap => spm.sortedList == this.sortedList
     case _                 => false
   }
 
-  override def hashCode(): Int = sortedMap.hashCode()
+  override def hashCode(): Int = sortedList.hashCode()
 }
 
 object SortedParMap {

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -15,19 +15,19 @@ final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)
 
   def ++(kvs: GenTraversableOnce[(Par, Par)]): SortedParMap = SortedParMap(sortedMap ++ kvs)
 
-  def -(key: Par): SortedParMap = SortedParMap(sortedMap - key)
+  def -(key: Par): SortedParMap = SortedParMap(sortedMap - key.sort)
 
-  def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys)
+  def --(keys: GenTraversableOnce[Par]): SortedParMap = SortedParMap(sortedMap -- keys.sort)
 
-  def apply(par: Par): Par = sortedMap(par)
+  def apply(par: Par): Par = sortedMap(par.sort)
 
-  def contains(par: Par): Boolean = sortedMap.contains(par)
+  def contains(par: Par): Boolean = sortedMap.contains(par.sort)
 
   def empty: SortedParMap = SortedParMap(Map.empty[Par, Par])
 
-  def get(key: Par): Option[Par] = sortedMap.get(key)
+  def get(key: Par): Option[Par] = sortedMap.get(key.sort)
 
-  def getOrElse(key: Par, default: Par): Par = sortedMap.getOrElse(key, default)
+  def getOrElse(key: Par, default: Par): Par = sortedMap.getOrElse(key.sort, default)
 
   def iterator: Iterator[(Par, Par)] = sortedList.toIterator
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -6,11 +6,32 @@ import coop.rchain.models.rholang.sorter.ScoredTerm._
 import monix.eval.Coeval
 import cats.implicits._
 
-import scala.collection.immutable
+import scala.collection.{immutable, GenTraversableOnce}
 
 //FIXME the `.sort` methods in this file should return via F[_] : Sync, and the corresponding ParSet and ParMap should
 //be constructed via factory methods also returning via F. Otherwise we risk StackOverflowErrors.
 object ordering {
+
+  implicit class ParOps(par: Par) {
+    implicit val sync = implicitly[Sync[Coeval]]
+
+    def sort: Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  }
+
+  implicit class GenTraversableOnceOps(ps: GenTraversableOnce[Par]) {
+    implicit val sync = implicitly[Sync[Coeval]]
+
+    def sort: GenTraversableOnce[Par] = {
+      val psSorted: List[Coeval[ScoredTerm[Par]]] =
+        ps.toList.map(par => Sortable[Par].sortMatch[Coeval](par))
+
+      val coeval: Coeval[List[Par]] = for {
+        parsSorted <- psSorted.sequence
+      } yield parsSorted.sorted.map(_.term)
+
+      coeval.value
+    }
+  }
 
   implicit class ListSortOps(ps: List[Par]) {
     implicit val sync = implicitly[Sync[Coeval]]

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -6,8 +6,6 @@ import coop.rchain.models.rholang.sorter.ScoredTerm._
 import monix.eval.Coeval
 import cats.implicits._
 
-import scala.collection.{immutable, GenTraversableOnce}
-
 //FIXME the `.sort` methods in this file should return via F[_] : Sync, and the corresponding ParSet and ParMap should
 //be constructed via factory methods also returning via F. Otherwise we risk StackOverflowErrors.
 object ordering {
@@ -16,12 +14,6 @@ object ordering {
     implicit val sync = implicitly[Sync[Coeval]]
 
     def sort: Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
-  }
-
-  implicit class GenTraversableOnceOps(ps: GenTraversableOnce[Par]) {
-    implicit val sync = implicitly[Sync[Coeval]]
-
-    def sort: GenTraversableOnce[Par] = ps.toList.sort
   }
 
   implicit class ListSortOps(ps: List[Par]) {

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -10,12 +10,6 @@ import cats.implicits._
 //be constructed via factory methods also returning via F. Otherwise we risk StackOverflowErrors.
 object ordering {
 
-  implicit class ParOps(par: Par) {
-    implicit val sync = implicitly[Sync[Coeval]]
-
-    def sort: Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
-  }
-
   implicit class ListSortOps(ps: List[Par]) {
     implicit val sync = implicitly[Sync[Coeval]]
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ordering.scala
@@ -21,16 +21,7 @@ object ordering {
   implicit class GenTraversableOnceOps(ps: GenTraversableOnce[Par]) {
     implicit val sync = implicitly[Sync[Coeval]]
 
-    def sort: GenTraversableOnce[Par] = {
-      val psSorted: List[Coeval[ScoredTerm[Par]]] =
-        ps.toList.map(par => Sortable[Par].sortMatch[Coeval](par))
-
-      val coeval: Coeval[List[Par]] = for {
-        parsSorted <- psSorted.sequence
-      } yield parsSorted.sorted.map(_.term)
-
-      coeval.value
-    }
+    def sort: GenTraversableOnce[Par] = ps.toList.sort
   }
 
   implicit class ListSortOps(ps: List[Par]) {

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -127,7 +127,7 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
         .map(_._1)
         .foreach(
           (unsorted: Par) => {
-            val sorted = unsorted.sort
+            val sorted = sort(unsorted)
             checkSortedInput(map.-, unsorted, sorted)
             checkSortedInput(map.apply, unsorted, sorted)
             checkSortedInput(map.contains, unsorted, sorted)
@@ -172,6 +172,8 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
 
   private def checkSortedInput[A, B](f: A => B, unsorted: A, sorted: A): Assertion =
     assert(f(sorted) == f(unsorted))
+
+  private def sort(par: Par): Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
 
   def isSorted[A: Sortable](a: A): Boolean =
     a == Sortable[A].sortMatch[Coeval](a).value().term

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -113,7 +113,7 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
       Par()
     )
     val sortedParMap = SortedParMap(sortedParMapKeys.zip(Seq.fill(sortedParMapKeys.size)(Par())))
-    val keys         = sortedParMap.sortedMap.keys
+    val keys         = sortedParMap.keys
     assert(keys.toList == keys.toList.sort)
   }
 

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -135,7 +135,7 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
             checkSortedInput(map.getOrElse(_: Par, Par()), unsorted, sorted)
           }
         )
-      checkSortedInput(map.--, keys, keys.sort)
+      checkSortedInput(map.--, keys, keys.toList.sort)
     }
   }
 

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -4,14 +4,17 @@ import java.util
 
 import com.google.protobuf.ByteString
 import coop.rchain.models.Assertions.assertEqual
+import coop.rchain.models.Connective.ConnectiveInstance.ConnBool
 import coop.rchain.models.Expr.ExprInstance.{GInt, _}
 import coop.rchain.models.Var.VarInstance.BoundVar
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.rholang.sorter.Sortable
+import coop.rchain.models.rholang.sorter.ordering._
+import monix.eval.Coeval
+import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
-import scala.collection.immutable.BitSet
-
-class SortedParMapSpec extends FlatSpec with Matchers {
+class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
 
   private[this] def toKVpair(pair: (Par, Par)): KeyValuePair = KeyValuePair(pair._1, pair._2)
 
@@ -80,4 +83,73 @@ class SortedParMapSpec extends FlatSpec with Matchers {
     )
     assertEqual(SortedParMap(ps), SortedParMap(ps))
   }
+
+  it should "keep keys sorted" in {
+    val sortedParMapKeys = List(
+      Par(
+        connectiveUsed = true
+      ),
+      Par(
+        bundles = Seq(
+          Bundle(
+            writeFlag = true
+          )
+        )
+      ),
+      Par(
+        connectives = Seq(
+          Connective(
+            ConnBool(
+              false
+            )
+          )
+        )
+      ),
+      Par(
+        ids = Seq(
+          GPrivate()
+        )
+      ),
+      Par()
+    )
+    val sortedParMap = SortedParMap(sortedParMapKeys.zip(Seq.fill(sortedParMapKeys.size)(Par())))
+    val keys         = sortedParMap.sortedMap.keys
+    assert(keys.toList == keys.toList.sort)
+  }
+
+  it should "preserve sortedness of all elements and the whole map for all its operations" in {
+    import coop.rchain.models.testImplicits._
+
+    forAll { (pars1: Seq[Par], pars2: Seq[Par]) =>
+      val map1 = SortedParMap(pars1.zip(pars2))
+      val map2 = SortedParMap(pars2.zip(pars1))
+      checkSorted(map1)
+      checkSorted(map2)
+      Seq(map1.headOption, map2.headOption).flatten.foreach(kv => {
+        checkSorted(map1 + kv)
+        checkSorted(map2 - kv._1)
+        checkSorted(map2 + kv)
+        checkSorted(map1 - kv._1)
+      })
+    }
+  }
+
+  private def checkSorted(sortedParMap: SortedParMap): Unit = {
+    checkSorted(sortedParMap.keys)
+    sortedParMap.values.foreach(p => assert(isSorted(p)))
+    sortedParMap.foreach(kv => {
+      assert(isSorted(kv._1))
+      assert(isSorted(kv._2))
+      assert(isSorted(sortedParMap(kv._1)))
+    })
+  }
+
+  private def checkSorted(iterable: Iterable[Par]) = {
+    import coop.rchain.models.rholang.sorter.ordering._
+    iterable.foreach(p => assert(isSorted(p)))
+    assert(iterable.toList == iterable.toList.sort)
+  }
+
+  def isSorted[A: Sortable](a: A): Boolean =
+    a == Sortable[A].sortMatch[Coeval](a).value().term
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1291,7 +1291,7 @@ object Reduce {
       def set(baseExpr: Expr, key: Par, value: Par): M[Par] =
         baseExpr.exprInstance match {
           case EMapBody(ParMap(basePs, _, _, _)) =>
-            Applicative[M].pure[Par](ParMap(SortedParMap(basePs + (key -> value))))
+            Applicative[M].pure[Par](ParMap(basePs + (key -> value)))
           case other =>
             s.raiseError(MethodNotDefined("set", other.typ))
         }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -586,7 +586,7 @@ class RegistryImpl[F[_]](
           val Some(Expr(EMapBody(parMap))) = data.singleExpr
           def insert() = {
             val tuple: Par  = ETuple(Seq(GInt(0), parByteArray(tail), value))
-            val newMap: Par = ParMap(SortedParMap(parMap.ps + (parByteArray(head) -> tuple)))
+            val newMap: Par = ParMap(parMap.ps + (parByteArray(head) -> tuple))
             replace(newMap, replaceChan, dataRand, sequenceNumber)
               .flatMap(_ => succeed(value, ret, callRand, sequenceNumber))
           }
@@ -620,9 +620,7 @@ class RegistryImpl[F[_]](
                   )
                   val newName: Par      = GPrivate(ByteString.copyFrom(callRand.next()))
                   val updatedTuple: Par = ETuple(Seq(GInt(1), outgoingEdge, newName))
-                  val updatedMap: Par = ParMap(
-                    SortedParMap(parMap.ps + (parByteArray(head) -> updatedTuple))
-                  )
+                  val updatedMap: Par   = ParMap(parMap.ps + (parByteArray(head) -> updatedTuple))
                   for {
                     _ <- replace(updatedMap, replaceChan, dataRand, sequenceNumber)
                     _ <- replace(newMap, newName, callRand.splitByte(0), sequenceNumber)
@@ -703,7 +701,7 @@ class RegistryImpl[F[_]](
             ps(0).singleExpr() match {
               case Some(Expr(GInt(0))) =>
                 if (tail == edgeAdditional) {
-                  val updatedMap: Par = ParMap(SortedParMap(parMap.ps - parByteArray(head)))
+                  val updatedMap: Par = ParMap(parMap.ps - parByteArray(head))
                   replace(updatedMap, replaceChan, dataRand, sequenceNumber) *> succeed(
                     ps(2),
                     ret,
@@ -784,9 +782,7 @@ class RegistryImpl[F[_]](
                 edgeAdditional.writeTo(mergeStream)
                 val mergedEdge        = parByteArray(mergeStream.toByteString())
                 val updatedTuple: Par = ETuple(Seq(ps(0), mergedEdge, ps(2)))
-                val updatedMap: Par = ParMap(
-                  SortedParMap(parMap.ps + (parentKey -> updatedTuple))
-                )
+                val updatedMap: Par   = ParMap(parMap.ps + (parentKey -> updatedTuple))
                 replace(updatedMap, parentReplace, parentRand, sequenceNumber)
               }
             }
@@ -804,7 +800,7 @@ class RegistryImpl[F[_]](
               case Some(Expr(GInt(0))) =>
                 if (tail == edgeAdditional) {
                   if (parMap.ps.size > 2) {
-                    val updatedMap: Par = ParMap(SortedParMap(parMap.ps - parByteArray(head)))
+                    val updatedMap: Par = ParMap(parMap.ps - parByteArray(head))
                     for {
                       _ <- replace(updatedMap, replaceChan, dataRand, sequenceNumber)
                       _ <- replace(parentData, parentReplace, parentRand, sequenceNumber)

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -44,9 +44,11 @@ object StackSafetySpec extends Assertions {
 class StackSafetySpec extends FlatSpec with Matchers {
   import StackSafetySpec._
 
-  val mapSize: Long               = 10L * 1024L * 1024L
-  val tmpPrefix: String           = "rspace-store-"
-  val maxDuration: FiniteDuration = 10.seconds
+  val mapSize     = 10L * 1024L * 1024L
+  val tmpPrefix   = "rspace-store-"
+  val maxDuration = 20.seconds
+
+  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
   val depth: Int = findMaxRecursionDepth()
 

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -48,8 +48,6 @@ class StackSafetySpec extends FlatSpec with Matchers {
   val tmpPrefix   = "rspace-store-"
   val maxDuration = 20.seconds
 
-  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
-
   val depth: Int = findMaxRecursionDepth()
 
   //FIXME make all the test cases work with checkAll.

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -98,7 +98,7 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
       PrettyPrinter(0, 2).buildString(
         ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
       )
-    result shouldBe "{7 : \"" + "Seven" + "\", x0 : x1...free0}"
+    result shouldBe """{x0 : x1, 7 : "Seven"...free0}"""
   }
 
 }


### PR DESCRIPTION
## Overview

- In a previous PR I changed `sortedMap` to `Map[Par,Par]` which caused a bug since `Map` does not preserve insertion order. I added a test case where the non-preservation of `Map` would show. 
- I added a generative test from @ArturGajowy that checks if sortedness is preserved.

I guess I should still extend from `IterableLike` but I thought I first put this out and see what @ArturGajowy says.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/RHOL-1028

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR