### PR TITLE
Backpressure for concurrent message queues

### DIFF
--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -345,8 +345,9 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { (dagDataDir, blockStore) =>
         for {
           firstStorage <- createAtDefaultLocation(dagDataDir)(blockStore)
-          _ <- blockElements.traverse_(b =>
-                blockStore.put(b.blockHash, b) *> firstStorage.insert(b))
+          _ <- blockElements.traverse_(
+                b => blockStore.put(b.blockHash, b) *> firstStorage.insert(b)
+              )
           _ <- firstStorage.close()
           _ <- Sync[Task].delay {
                 Files.move(

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -94,7 +94,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                   conf.approveGenesisInterval
                 )
                 .map(protocol => {
-                  toTask(protocol.run()).forkAndForget.runAsync
+                  toTask(protocol.run()).forkAndForget.runToFuture
                   protocol
                 })
         standalone <- Ref.of[F, CasperPacketHandlerInternal[F]](new StandaloneCasperHandler[F](abp))
@@ -108,7 +108,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                     validatorId,
                     standalone
                   )
-              ).forkAndForget.runAsync
+              ).forkAndForget.runToFuture
               ().pure[F]
             }
       } yield new CasperPacketHandlerImpl[F](standalone)
@@ -128,7 +128,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         _ <- Sync[F].delay {
               implicit val ph: PacketHandler[F] = PacketHandler.pf[F](casperPacketHandler.handle)
               val rb                            = CommUtil.requestApprovedBlock[F](delay)
-              toTask(rb).forkAndForget.runAsync
+              toTask(rb).forkAndForget.runToFuture
               ().pure[F]
             }
       } yield casperPacketHandler

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -33,7 +33,7 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
     ManagedChannelBuilder
       .forAddress(host, port)
       .maxInboundMessageSize(maxMessageSize)
-      .usePlaintext(true)
+      .usePlaintext()
       .build
   private val blockingStub = DeployServiceGrpc.blockingStub(channel)
 

--- a/casper/src/test/scala/coop/rchain/casper/MaybeCellSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MaybeCellSpec.scala
@@ -19,7 +19,7 @@ class MaybeCellSpec extends FunSpec with Matchers {
         block <- lab.get
       } yield block
 
-      val result = test.runAsync
+      val result = test.runToFuture
       testScheduler.tick()
       assert(result.value == Some(Success(Some(approvedBlock))))
     }
@@ -31,7 +31,7 @@ class MaybeCellSpec extends FunSpec with Matchers {
         block <- lab.get
       } yield block
 
-      val result = test.runAsync
+      val result = test.runToFuture
       testScheduler.tick()
       assert(result.value == Some(Success(None)))
     }

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -53,10 +53,10 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
         implicit casperRef: MultiParentCasperRef[Effect]
     ): Effect[(DeployServiceResponse, DeployServiceResponse)] = EitherT.liftF(
       for {
-        t1 <- (BlockAPI.deploy[Effect](deploys.head) *> BlockAPI.createBlock[Effect]).value.fork
+        t1 <- (BlockAPI.deploy[Effect](deploys.head) *> BlockAPI.createBlock[Effect]).value.start
         _  <- Time[Task].sleep(2.second)
         t2 <- (BlockAPI.deploy[Effect](deploys.last) *> BlockAPI
-               .createBlock[Effect]).value.fork //should fail because other not done
+               .createBlock[Effect]).value.start //should fail because other not done
         r1 <- t1.join
         r2 <- t2.join
       } yield (r1.right.get, r2.right.get)

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/ApproveBlockProtocolTest.scala
@@ -41,7 +41,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       ApproveBlockProtocolTest.createProtocol(10, 100.milliseconds, 1.millisecond, Set(validatorPk))
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     sigsF.get.unsafeRunSync.size should be(0)
     metricsTest.counters.get(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(None)
     abp.addApproval(a).unsafeRunSync
@@ -61,7 +61,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       ApproveBlockProtocolTest.createProtocol(10, 100.milliseconds, 1.millisecond, Set(validatorPk))
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     sigsF.get.unsafeRunSync.size should be(0)
     metricsTest.counters.get(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(None)
     abp.addApproval(a).unsafeRunSync
@@ -85,7 +85,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       ApproveBlockProtocolTest.createProtocol(10, 100.milliseconds, 1.millisecond, Set(validatorSk))
     val a = ApproveBlockProtocolTest.invalidApproval(candidate)
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     ctx.tick(1.millisecond)
     sigs.get.unsafeRunSync.size should be(0)
     metricsTest.counters.get(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(None)
@@ -112,7 +112,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
         sigs.map(_._2).toSet
       )
     ctx.tick(startTime.milliseconds) //align clocks
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
 
     (1 to n).foreach { i =>
       val (validatorSk, validatorPk) = sigs(i - 1)
@@ -122,8 +122,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     }
 
     ctx.tick(21.milliseconds)
-    lab.get.runAsync.value.nonEmpty should be(true)
-    lab.get.runAsync.value.get should be('success)
+    lab.get.runToFuture.value.nonEmpty should be(true)
+    lab.get.runToFuture.value.get should be('success)
     ctx.clockMonotonic(MILLISECONDS) should be(startTime + d.toMillis + 1)
     metricsTest.counters(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(n)
 
@@ -147,7 +147,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       )
     ctx.tick(startTime.milliseconds) // align clocks
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
 
     (1 to (n / 2)).foreach { i =>
       val (validatorSk, validatorPk) = sigs(i - 1)
@@ -157,7 +157,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       ctx.tick(1.millisecond)
     }
 
-    lab.get.runAsync.value.get should be(Success(None))
+    lab.get.runToFuture.value.get should be(Success(None))
     metricsTest.counters(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(n / 2)
 
     ((n / 2) to n).foreach { i =>
@@ -172,8 +172,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     // since we started at `startTime` and we advanced internal clock `n` times x 1 millisecond
     // we still have to advance internal clock with missing milliseconds
     ctx.tick((d.toMillis - timeElapsed).milliseconds)
-    lab.get.runAsync.value.nonEmpty should be(true)
-    lab.get.runAsync.value.get should be('success)
+    lab.get.runToFuture.value.nonEmpty should be(true)
+    lab.get.runToFuture.value.get should be('success)
     metricsTest.counters(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(n)
 
     cancelToken.cancel()
@@ -196,11 +196,11 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
 
     ctx.tick(startTime.milliseconds) // align clocks
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     ctx.tick()
 
-    lab.get.runAsync.value.nonEmpty should be(true)
-    lab.get.runAsync.value.get should be('success)
+    lab.get.runToFuture.value.nonEmpty should be(true)
+    lab.get.runToFuture.value.get should be('success)
     metricsTest.counters.get(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(None)
 
     cancelToken.cancel()
@@ -217,7 +217,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
       ApproveBlockProtocolTest.createProtocol(10, 100.milliseconds, 1.millisecond, Set(validatorPk))
     val a = ApproveBlockProtocolTest.approval(candidate, invalidSk, invalidPk)
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     sigsF.get.unsafeRunSync.size should be(0)
     metricsTest.counters.get(ApproveBlockProtocol.METRICS_APPROVAL_COUNTER_NAME) should be(None)
     abp.addApproval(a).unsafeRunSync
@@ -240,7 +240,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     val TestFixture(_, abp, candidate, _, sigsF) =
       ApproveBlockProtocolTest.createProtocol(10, 100.milliseconds, 5.millisecond, Set(validatorPk))
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
 
     // I know that testing the logs is not the best way but I comparing messages sent won't work
     // because we attach `System.currentMillis` to every message.
@@ -271,7 +271,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     val startTime = start
     ctx.tick(startTime.milliseconds) // align clocks
 
-    val cancelToken = abp.run().fork.runAsync
+    val cancelToken = abp.run().start.runToFuture
     ctx.tick()
 
     // I know that testing the logs is not the best way but I comparing messages sent won't work

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -204,11 +204,11 @@ class CasperPacketHandlerSpec extends WordSpec {
           standaloneCasper    = new StandaloneCasperHandler[Task](abp)
           refCasper           <- Ref.of[Task, CasperPacketHandlerInternal[Task]](standaloneCasper)
           casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper)
-          c1                  = abp.run().forkAndForget.runAsync
+          c1                  = abp.run().forkAndForget.runToFuture
           c2 = StandaloneCasperHandler
             .approveBlockInterval(interval, shardId, runtimeManager, Some(validatorId), refCasper)
             .forkAndForget
-            .runAsync
+            .runToFuture
           blockApproval = ApproveBlockProtocolTest.approval(
             ApprovedBlockCandidate(Some(genesis), requiredSigns),
             validatorSk,

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -39,7 +39,8 @@ class TcpServerObservable(
     val bufferTell        = buffer.LimitedBufferObservable.dropNew[ServerMessage](tellBufferSize)
     val bufferAsk         = buffer.LimitedBufferObservable.dropNew[ServerMessage](askBufferSize)
     val bufferBlobMessage = buffer.LimitedBufferObservable.dropNew[ServerMessage](blobBufferSize)
-    val merged            = Observable.merge(bufferTell, bufferAsk, bufferBlobMessage)(BackPressure(10))
+    val merged =
+      Observable(bufferTell, bufferAsk, bufferBlobMessage).mergeMap(identity)(BackPressure(10))
 
     val service = new RoutingGrpcMonix.TransportLayer {
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/Sequencer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/Sequencer.scala
@@ -1,0 +1,62 @@
+package coop.rchain.comm.transport.buffer
+
+import scala.concurrent.Future
+
+import cats.implicits._
+
+import monix.catnap.Semaphore
+import monix.eval.Task
+import monix.execution._
+import monix.reactive._
+import monix.reactive.observers.{BufferedSubscriber, Subscriber}
+import monix.reactive.subjects._
+import monix.reactive.OverflowStrategy._
+
+trait Sequencer[I, +O] extends Observable[O] {
+  def pushNext(elem: I): Task[Ack]
+  def complete(): Task[Unit]
+}
+
+object Sequencer {
+
+  def apply[A](): Task[Sequencer[A, A]] = create(PublishToOneSubject())
+
+  def apply[I, O](subject: Subject[I, O]): Task[Sequencer[I, O]] = create(subject)
+
+  def apply[A](bufferSize: Int)(implicit s: Scheduler): Task[Sequencer[A, A]] =
+    create(new SubjectAsBuffered(PublishToOneSubject(), BackPressure(bufferSize), s))
+
+  private def create[I, O](subject: Subject[I, O]): Task[Sequencer[I, O]] =
+    Semaphore[Task](1) >>= (create(subject, _))
+
+  private def create[I, O](
+      subject: Subject[I, O],
+      semaphore: Semaphore[Task]
+  ): Task[Sequencer[I, O]] =
+    Task.delay {
+      new Sequencer[I, O] {
+        def pushNext(elem: I): Task[Ack] =
+          semaphore.withPermit(Task.fromFuture(subject.onNext(elem)))
+        def complete(): Task[Unit] = Task.delay(subject.onComplete())
+        def unsafeSubscribeFn(subscriber: Subscriber[O]): Cancelable =
+          subject.unsafeSubscribeFn(subscriber)
+      }
+    }
+
+  private class SubjectAsBuffered[I, +O](
+      subject: Subject[I, O],
+      overflowStrategy: OverflowStrategy[I],
+      scheduler: Scheduler
+  ) extends Subject[I, O] {
+
+    private[this] val in: Subscriber[I] =
+      BufferedSubscriber(Subscriber(subject, scheduler), overflowStrategy)
+
+    def size: Int                    = subject.size
+    def onNext(elem: I): Future[Ack] = in.onNext(elem)
+    def onError(ex: Throwable): Unit = in.onError(ex)
+    def onComplete(): Unit           = in.onComplete()
+    def unsafeSubscribeFn(subscriber: Subscriber[O]): Cancelable =
+      subject.unsafeSubscribeFn(subscriber)
+  }
+}

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import coop.rchain.comm.protocol.routing.Protocol
 
-import monix.eval.Callback
+import monix.execution.Callback
 
 trait ServerMessage
 // TODO rename to AksMesage and TellMesssage
@@ -18,7 +18,7 @@ trait SenderHandle {
   def complete: Boolean
 }
 
-final class Reply(callback: Callback[CommunicationResponse]) extends SenderHandle {
+final class Reply(callback: Callback[Throwable, CommunicationResponse]) extends SenderHandle {
   // contract: the callback can be called only once
   private val called = new AtomicBoolean(false)
 
@@ -36,5 +36,5 @@ final class Reply(callback: Callback[CommunicationResponse]) extends SenderHandl
 }
 
 object Reply {
-  def apply(callback: Callback[CommunicationResponse]): Reply = new Reply(callback)
+  def apply(callback: Callback[Throwable, CommunicationResponse]): Reply = new Reply(callback)
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -3,7 +3,6 @@ package coop.rchain.node.configuration
 import java.io.File
 import java.net.InetAddress
 import java.nio.file.{Path, Paths}
-import java.util.concurrent.atomic.AtomicReference
 
 import cats.implicits._
 
@@ -18,11 +17,8 @@ import coop.rchain.shared.{Log, LogSource}
 import coop.rchain.shared.StoreType
 import coop.rchain.shared.StoreType._
 
-import monix.eval.{Callback, Task}
+import monix.eval.Task
 import scala.concurrent.duration._
-
-import com.google.common.base.Optional
-import monix.execution.Scheduler
 
 object Configuration {
   private implicit val logSource: LogSource = LogSource(this.getClass)

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
@@ -33,7 +33,7 @@ class GrpcDiagnosticsService(host: String, port: Int, maxMessageSize: Int)
     ManagedChannelBuilder
       .forAddress(host, port)
       .maxInboundMessageSize(maxMessageSize)
-      .usePlaintext(true)
+      .usePlaintext()
       .build
 
   private val stub = DiagnosticsGrpcMonix.stub(channel)

--- a/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
@@ -31,7 +31,7 @@ class GrpcReplClient(host: String, port: Int, maxMessageSize: Int)
     ManagedChannelBuilder
       .forAddress(host, port)
       .maxInboundMessageSize(maxMessageSize)
-      .usePlaintext(true)
+      .usePlaintext()
       .build
 
   private val stub = ReplGrpcMonix.stub(channel)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Dependencies {
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.0"
-  val monix               = "io.monix"                   %% "monix"                     % "3.0.0-RC2-d0feeba"
+  val monix               = "io.monix"                   %% "monix"                     % "3.0.0-RC2"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.7.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.4"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.13.5" % "test"

--- a/project/GrpcMonixGenerator.scala
+++ b/project/GrpcMonixGenerator.scala
@@ -273,7 +273,7 @@ class GrpcMonixGenerator(override val params: GeneratorParams)
           s"override def invoke(request: ${method.scalaIn}, observer: ${grpcObserver(method.scalaOut)}): Unit ="
         ).indent
           .add(
-            s"serviceImpl.${method.name}(request).runAsync(grpcObserverToMonixCallback(observer))(scheduler)"
+            s"serviceImpl.${method.name}(request).runToFuture(grpcObserverToMonixCallback(observer))(scheduler)"
           )
           .outdent
       case StreamType.ClientStreaming =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -54,7 +54,7 @@ object RholangCLI {
 
     val runtime = Runtime.create(conf.dataDir(), conf.mapSize())
     Await.result(
-      Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace).runAsync,
+      Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace).runToFuture,
       5.seconds
     )
 
@@ -174,7 +174,7 @@ object RholangCLI {
         result <- Interpreter.evaluate(runtime, par)
       } yield result
 
-    waitForSuccess(evaluatorTask.runAsync)
+    waitForSuccess(evaluatorTask.runToFuture)
     printStorageContents(runtime.space.store)
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -59,7 +59,7 @@ class CryptoChannelsSpec
       Seq(ReceiveBind(Seq(EVar(Var(Wildcard(WildcardMsg())))), ackChannel)),
       Par()
     )
-    Await.ready(reduce.eval(consume).runAsync, 3.seconds)
+    Await.ready(reduce.eval(consume).runToFuture, 3.seconds)
   }
 
   def assertStoreContains(
@@ -100,7 +100,7 @@ class CryptoChannelsSpec
       // 1. meet with the system process in the tuplespace
       // 2. hash input array
       // 3. send result on supplied ack channel
-      Await.result(reduce.eval(send).runAsync, 3.seconds)
+      Await.result(reduce.eval(send).runToFuture, 3.seconds)
       storeContainsTest(ListParWithRandom(Seq(expected), rand))
       clearStore(store, reduce, ackChannel)
     }
@@ -159,7 +159,7 @@ class CryptoChannelsSpec
           persistent = false,
           BitSet()
         )
-        Await.result(reduce.eval(send).runAsync, 3.seconds)
+        Await.result(reduce.eval(send).runToFuture, 3.seconds)
         storeContainsTest(
           ListParWithRandom(Seq(Expr(GBool(true))), rand)
         )
@@ -199,7 +199,7 @@ class CryptoChannelsSpec
           persistent = false,
           BitSet()
         )
-        Await.result(reduce.eval(send).runAsync, 3.seconds)
+        Await.result(reduce.eval(send).runToFuture, 3.seconds)
         storeContainsTest(
           ListParWithRandom(List(Expr(GBool(true))), rand)
         )

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -54,7 +54,7 @@ class DeployParamsSpec extends fixture.FlatSpec with Matchers {
       _ <- shortLeashParams.setParams(empty, phloRate, empty, timestamp)
       _ <- runtime.reducer.eval(send)
     } yield ()
-    Await.result(task.runAsync, 3.seconds)
+    Await.result(task.runToFuture, 3.seconds)
     assertStoreContains(
       runtime.space.store,
       ackChannel,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -118,7 +118,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val addExpr      = EPlus(GInt(7L), GInt(8L))
         implicit val env = Env[Par]()
         val resultTask   = reducer.evalExpr(addExpr)
-        Await.result(resultTask.runAsync, 3.seconds)
+        Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(15L)))
@@ -133,7 +133,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val addExpr      = EPlus(GInt(Int.MaxValue), GInt(Int.MaxValue))
         implicit val env = Env[Par]()
         val resultTask   = reducer.evalExpr(addExpr)
-        Await.result(resultTask.runAsync, 3.seconds)
+        Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(2 * Int.MaxValue.toLong)))
@@ -148,7 +148,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val groundExpr   = GInt(7L)
         implicit val env = Env[Par]()
         val resultTask   = reducer.evalExpr(groundExpr)
-        Await.result(resultTask.runAsync, 3.seconds)
+        Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     val expected = Seq(Expr(GInt(7L)))
@@ -163,7 +163,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val eqExpr       = EEq(GPrivateBuilder("private_name"), GPrivateBuilder("private_name"))
         implicit val env = Env[Par]()
         val resultTask   = reducer.evalExpr(eqExpr)
-        Await.result(resultTask.runAsync, 3.seconds)
+        Await.result(resultTask.runToFuture, 3.seconds)
     }
     val expected = Seq(Expr(GBool(true)))
     result.exprs should be(expected)
@@ -177,7 +177,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val emptyEnv = Env.makeEnv(Par(), Par())
         val eqExpr            = EEq(EVar(BoundVar(0)), EVar(BoundVar(1)))
         val resultTask        = reducer.evalExpr(eqExpr)
-        Await.result(resultTask.runAsync, 3.seconds)
+        Await.result(resultTask.runToFuture, 3.seconds)
     }
     val expected = Seq(Expr(GBool(true)))
     result.exprs should be(expected)
@@ -197,7 +197,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- resultTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     checkData(result)(channel, Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand)
@@ -219,7 +219,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
         val task         = reducer.eval(receive).map(_ => space.store.toMap)
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
     receiveResult should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
@@ -237,7 +237,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env[Par]()
 
         val task = reducer.eval(send).map(_ => space.store.toMap)
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
     sendResult should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
@@ -258,7 +258,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- resultTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     checkData(result)(channel, Seq(GInt(7L), GInt(8L), GInt(9L)), splitRand)
@@ -279,7 +279,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
         val task         = reducer.eval(send)(env, splitRand).map(_ => space.store.toMap)
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
 
     checkData(result)(channel, Seq(GInt(7L)), splitRand)
@@ -311,7 +311,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- resultTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val bindPattern = BindPattern(
       List(
@@ -347,7 +347,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(space, reducer) =>
         implicit val env = Env[Par]()
         val task         = reducer.eval(receive)(env, splitRand).map(_ => space.store.toMap)
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
 
     val channels = List[Par](y)
@@ -387,7 +387,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send)(env, splitRand0)
           _ <- reducer.eval(receive)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskSendFirst.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -402,7 +402,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand1)
           _ <- reducer.eval(send)(env, splitRand0)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
 
     checkData(receiveFirstResult)(channel, Seq(GString("Success")), mergeRand)
@@ -437,7 +437,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send)(env, splitRand0)
           _ <- reducer.eval(receive)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskSendFirst.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -452,7 +452,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand1)
           _ <- reducer.eval(send)(env, splitRand0)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
 
     checkData(receiveFirstResult)(channel, Seq(GString("Success")), mergeRand)
@@ -488,7 +488,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send)(env, splitRand0)
           _ <- reducer.eval(receive)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskSendFirst.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -503,7 +503,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand1)
           _ <- reducer.eval(send)(env, splitRand0)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
     checkData(receiveFirstResult)(channel, Seq(GString("Success")), mergeRand)
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -540,7 +540,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send)(env, splitRand0)
           _ <- reducer.eval(receive)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskSendFirst.runToFuture, 3.seconds)
     }
 
     val channels = List[Par](GInt(2L))
@@ -560,7 +560,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand1)
           _ <- reducer.eval(send)(env, splitRand0)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
 
     checkContinuation(receiveFirstResult)(
@@ -576,7 +576,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTaskReceiveFirst = for {
           _ <- reducer.eval(Par(receives = Seq(receive), sends = Seq(send)))(env, baseRand)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
 
     checkContinuation(bothResult)(
@@ -619,7 +619,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- matchTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -665,7 +665,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send2)(env, splitRand1)
           _ <- reducer.eval(receive)(env, splitRand2)
         } yield space.store.toMap
-        Await.result(inspectTaskSendFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskSendFirst.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -681,7 +681,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(send1)(env, splitRand0)
           _ <- reducer.eval(send2)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskReceiveFirst.runAsync, 3.seconds)
+        Await.result(inspectTaskReceiveFirst.runToFuture, 3.seconds)
     }
 
     checkData(receiveFirstResult)(channel, Seq(GString("Success")), mergeRand)
@@ -695,7 +695,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand2)
           _ <- reducer.eval(send2)(env, splitRand1)
         } yield space.store.toMap
-        Await.result(inspectTaskInterleaved.runAsync, 3.seconds)
+        Await.result(inspectTaskInterleaved.runToFuture, 3.seconds)
     }
 
     checkData(interleavedResult)(channel, Seq(GString("Success")), mergeRand)
@@ -723,7 +723,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           _ <- reducer.eval(receive)(env, splitRand1)
           _ <- reducer.eval(send)(env, splitRand0)
         } yield space.store.toMap
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -741,7 +741,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val directResult: Par = withTestSpace(errorLog) {
       case TestFixture(_, reducer) =>
         implicit val env = Env[Par]()
-        Await.result(reducer.evalExprToPar(nthCall).runAsync, 3.seconds)
+        Await.result(reducer.evalExprToPar(nthCall).runToFuture, 3.seconds)
     }
     val expectedResult: Par = GInt(9L)
     directResult should be(expectedResult)
@@ -766,7 +766,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -808,7 +808,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel0: Par = GString("result0")
@@ -862,7 +862,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -881,7 +881,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val directResult: Par = withTestSpace(errorLog) {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
-        Await.result(reducer.evalExprToPar(hexToBytesCall).runAsync, 3.seconds)
+        Await.result(reducer.evalExprToPar(hexToBytesCall).runToFuture, 3.seconds)
     }
     val expectedResult: Par = Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))
     directResult should be(expectedResult)
@@ -910,7 +910,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -937,7 +937,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env.makeEnv[Par](GPrivateBuilder("one"), GPrivateBuilder("zero"))
         val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     checkData(result)(channel, Seq(Expr(GByteArray(serializedProcess))), splitRand)
@@ -961,7 +961,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
@@ -984,7 +984,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(wrapWithSend(toByteArrayCall))(env, splitRand)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -1010,7 +1010,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(wrapWithSend(toUtf8BytesCall))(env, splitRand)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -1039,7 +1039,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(
@@ -1058,7 +1058,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = for {
           _ <- nthTask
         } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result should be(HashMap.empty)
     errorLog.readAndClearErrorVector should be(Vector(MethodNotDefined("toUtf8Bytes", "Int")))
@@ -1102,7 +1102,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(proc)(env, splitRandSrc)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -1133,7 +1133,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(proc)(env, splitRandSrc)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val channel: Par = GString("result")
 
@@ -1176,7 +1176,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val env         = Env[Par]()
         val task        = reducer.eval(proc)(env, baseRand)
         val inspectTask = for { _ <- task } yield space.store.toMap
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     val channel: Par = GString("result")
@@ -1191,7 +1191,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par]()
         val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(1L)))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
@@ -1205,7 +1205,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par]()
         val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), GInt(0L)))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(false))))
@@ -1219,7 +1219,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par]()
         val inspectTask  = reducer.evalExpr(EMatches(GInt(1L), EVar(Wildcard(Var.WildcardMsg()))))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
@@ -1233,7 +1233,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par](GInt(1L))
         val inspectTask  = reducer.evalExpr(EMatches(EVar(BoundVar(0)), GInt(1L)))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
@@ -1249,7 +1249,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
         val inspectTask = reducer.evalExpr(EMatches(GInt(1L), Connective(VarRefBody(VarRef(0, 1)))))
 
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GBool(true))))
@@ -1263,7 +1263,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       case TestFixture(_, reducer) =>
         implicit val env = Env.makeEnv[Par]()
         val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", GString("abc"))))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(3L))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1278,7 +1278,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("slice", GString("abcabac"), List(GInt(3L), GInt(6L))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("aba"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1298,7 +1298,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("Hello, Alice!"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1318,7 +1318,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("abcdef"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1338,7 +1338,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1367,7 +1367,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("1 ${b} 2 ${a}"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1388,7 +1388,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GString("false true"))))
@@ -1410,7 +1410,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(task.runAsync, 3.seconds)
+        Await.result(task.runToFuture, 3.seconds)
     }
 
     result.exprs should be(Seq(Expr(GString("testUriA testUriB"))))
@@ -1426,7 +1426,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val list         = EList(List(GInt(0L), GInt(1L), GInt(2L), GInt(3L)))
         val inspectTask  = reducer.evalExpr(EMethodBody(EMethod("length", list)))
 
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(4L))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1442,7 +1442,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("slice", list, List(GInt(3L), GInt(5L))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(EListBody(EList(List(GInt(9L), GInt(4L)))))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1464,7 +1464,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             )
           )
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultList = EList(List(GInt(3L), GInt(2L), GInt(9L), GInt(6L), GInt(1L), GInt(7L)))
     result.exprs should be(Seq(Expr(EListBody(resultList))))
@@ -1482,7 +1482,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("getOrElse", map, List(GInt(1L), GString("c"))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("a"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1499,7 +1499,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("getOrElse", map, List(GInt(3L), GString("c"))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GString("c"))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1516,7 +1516,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("set", map, List(GInt(3L), GString("c"))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultMap = EMapBody(
       ParMap(
@@ -1542,7 +1542,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("set", map, List(GInt(2L), GString("c"))))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultMap =
       EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("c")))))
@@ -1568,7 +1568,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("keys", map))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultSet = ESetBody(
       ParSet(
@@ -1597,7 +1597,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMethodBody(EMethod("size", map))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(3L))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1615,7 +1615,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           EMethodBody(EMethod("size", set))
         )
 
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     result.exprs should be(Seq(Expr(GInt(3L))))
     errorLog.readAndClearErrorVector should be(Vector.empty[InterpreterError])
@@ -1631,7 +1631,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EPlusBody(EPlus(set, GInt(3L)))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
     result.exprs should be(Seq(Expr(resultSet)))
@@ -1656,7 +1656,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMinusBody(EMinus(map, GInt(3L)))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultMap =
       EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
@@ -1674,7 +1674,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMinusBody(EMinus(set, GInt(3L)))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L))))
     result.exprs should be(Seq(Expr(resultSet)))
@@ -1692,7 +1692,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EPlusPlusBody(EPlusPlus(lhsSet, rhsSet))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultSet = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L), GInt(4L))))
     result.exprs should be(Seq(Expr(resultSet)))
@@ -1712,7 +1712,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EPlusPlusBody(EPlusPlus(lhsMap, rhsMap))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultMap = EMapBody(
       ParMap(
@@ -1739,7 +1739,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EMinusMinusBody(EMinusMinus(lhsSet, rhsSet))
         )
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     val resultSet = ESetBody(ParSet(List[Par](GInt(3L), GInt(4L))))
     result.exprs should be(Seq(Expr(resultSet)))
@@ -1754,7 +1754,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env.makeEnv[Par]()
         val set          = ESetBody(ParSet(List[Par](GInt(1L), GInt(2L), GInt(3L))))
         val inspectTask  = reducer.eval(EMethodBody(EMethod("get", set, List(GInt(1L)))))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     errorLog.readAndClearErrorVector should be(
       Vector(MethodNotDefined("get", "Set"))
@@ -1770,7 +1770,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val map =
           EMapBody(ParMap(List[(Par, Par)]((GInt(1L), GString("a")), (GInt(2L), GString("b")))))
         val inspectTask = reducer.eval(EMethodBody(EMethod("add", map, List(GInt(1L)))))
-        Await.result(inspectTask.runAsync, 3.seconds)
+        Await.result(inspectTask.runToFuture, 3.seconds)
     }
     errorLog.readAndClearErrorVector should be(
       Vector(MethodNotDefined("add", "Map"))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -226,7 +226,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     checkResult(result, "result0", GInt(7), randResult0)
@@ -339,7 +339,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     checkResult(result, "result0", GInt(8), result0Rand)
@@ -405,7 +405,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     // Compute the random states for the results
@@ -506,7 +506,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     checkResult(result, "result0", GInt(8), randResult0)
@@ -547,7 +547,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     val expectedBundle: Par =
@@ -685,7 +685,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
       val resultTask = for {
         _ <- reducer.eval(completePar)
       } yield space.store.toMap
-      Await.result(resultTask.runAsync, 3.seconds)
+      Await.result(resultTask.runToFuture, 3.seconds)
     }
 
     checkResult(result, "result0", ETuple(List(GInt(789), GString("entry"))), result0Rand)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -22,7 +22,7 @@ class CostAccountingSpec extends FlatSpec with TripleEqualsSupport {
       alg <- CostAccounting.of[Task](initState)
       res <- f(alg)
     } yield res
-    Await.result(test.runAsync, 5.seconds)
+    Await.result(test.runToFuture, 5.seconds)
   }
 
   "get" should "return current cost account" in withCostAccAlg() { alg =>

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBench.scala
@@ -48,7 +48,7 @@ class EvalBench {
   def reduceMVCEPPMT(state: MVCEPPBenchState): Unit = {
     implicit val scheduler: Scheduler = monix.execution.Scheduler.Implicits.global
     val runTask                       = createTest(state)
-    processErrors(Await.result(runTask.runAsync, Duration.Inf))
+    processErrors(Await.result(runTask.runToFuture, Duration.Inf))
   }
 }
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -73,7 +73,7 @@ trait RSpaceBench {
       persist = true
     )
 
-    val results: IndexedSeq[Future[Unit]] = tasks.map(f => f.executeOn(dupePool).runAsync(dupePool))
+    val results: IndexedSeq[Future[Unit]] = tasks.map(f => f.executeOn(dupePool).runToFuture(dupePool))
 
     implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
     bh.consume(Await.ready(Future.sequence(results), Duration.Inf))

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBench.scala
@@ -61,7 +61,7 @@ abstract class WideBenchState extends WideBenchBaseState {
     //make sure we always start from clean rspace
     runtime.replaySpace.clear()
     runtime.space.clear()
-    processErrors(Await.result(createTest(setupTerm, runtime.reducer).runAsync, Duration.Inf))
+    processErrors(Await.result(createTest(setupTerm, runtime.reducer).runToFuture, Duration.Inf))
     runTask = createTest(term, runtime.reducer)
   }
 }

--- a/rspace/src/it/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/it/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -133,12 +133,12 @@ trait ConcurrencyTests
       }
     //warm-up pass - short 10 iterations loop should be enough
     val tWarmup = createTask(0, iterationsCount)
-    val fWarmup = tWarmup.runAsync
+    val fWarmup = tWarmup.runToFuture
     Await.ready(fWarmup, Duration.Inf)
     //benchmark pass
     val tasks = (1 to tasksCount).map(idx => {
       val task = createTask(idx, iterationsCount)
-      task.runAsync
+      task.runToFuture
     })
 
     val times = tasks.map(t => Await.result(t, Duration.Inf))

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
@@ -15,7 +15,7 @@ class MultiLockTest extends FlatSpec with Matchers {
     import scala.concurrent.duration._
 
     def unsafeRunSync: A =
-      Await.result(task.runAsync, Duration.Inf)
+      Await.result(task.runToFuture, Duration.Inf)
   }
 
   val tested = new DefaultMultiLock[String]()

--- a/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
@@ -44,7 +44,7 @@ trait CaptureInstances extends CaptureInstances0 {
     import monix.execution.Scheduler.Implicits.global
 
     def capture[A](a: => A): Task[A]       = Task.delay(a)
-    def unsafeUncapture[A](fa: Task[A]): A = Await.result(fa.runAsync, Duration.Inf)
+    def unsafeUncapture[A](fa: Task[A]): A = Await.result(fa.runToFuture, Duration.Inf)
   }
 
   /** TEMP REMOVE once comm no longer imperative*/

--- a/shared/src/main/scala/coop/rchain/catscontrib/Futurable.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Futurable.scala
@@ -15,7 +15,7 @@ object Futurable extends FuturableInstances {
 
 trait FuturableInstances extends FuturableInstances0 {
   implicit def taskFuturable(implicit scheduler: Scheduler): Futurable[Task] = new Futurable[Task] {
-    def toFuture[A](fa: Task[A]): Future[A] = fa.runAsync
+    def toFuture[A](fa: Task[A]): Future[A] = fa.runToFuture
   }
 }
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 object TaskContrib {
   implicit class TaskOps[A](task: Task[A]) {
     def unsafeRunSync(implicit scheduler: Scheduler): A =
-      Await.result(task.runAsync, Duration.Inf)
+      Await.result(task.runToFuture, Duration.Inf)
 
     def nonCancelingTimeout(after: FiniteDuration): Task[A] =
       nonCancelingTimeoutTo(

--- a/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
+++ b/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
@@ -7,8 +7,8 @@ import coop.rchain.shared.{Log, LogSource}
 
 import com.google.common.util.concurrent.ListenableFuture
 import io.grpc.stub.StreamObserver
-import monix.eval.{Callback, Task}
-import monix.execution.{Ack, Scheduler}
+import monix.eval.Task
+import monix.execution._
 import monix.execution.Ack.{Continue, Stop}
 import monix.reactive.Observable
 import monix.reactive.Observable.Operator
@@ -67,8 +67,8 @@ object GrpcMonix {
         }
     }
 
-  def grpcObserverToMonixCallback[T](observer: StreamObserver[T]): Callback[T] =
-    new Callback[T] {
+  def grpcObserverToMonixCallback[T](observer: StreamObserver[T]): Callback[Throwable, T] =
+    new Callback[Throwable, T] {
       override def onError(t: Throwable): Unit = observer.onError(t)
       override def onSuccess(value: T): Unit =
         try {

--- a/shared/src/main/scala/coop/rchain/shared/MVarMonadState.scala
+++ b/shared/src/main/scala/coop/rchain/shared/MVarMonadState.scala
@@ -1,10 +1,13 @@
 package coop.rchain.shared
 
-import cats._, cats.implicits._, cats.mtl.MonadState
+import cats._
+import cats.implicits._
+import cats.mtl.MonadState
 
-import monix.eval.{MVar, Task}
+import monix.catnap.MVar
+import monix.eval.Task
 
-class MVarMonadState[S](state: Task[MVar[S]])(implicit val monad: Monad[Task])
+class MVarMonadState[S](state: Task[MVar[Task, S]])(implicit val monad: Monad[Task])
     extends MonadState[Task, S] {
   /*
     Removes a value from the state.


### PR DESCRIPTION
## Overview
Monix doesn't support concurrent (buffered) `Subjects` with a backpressure overflow strategy. This PR employs a semaphore with a maximum parallelism of 1 to implement a `Sequencer`. This `Sequencer` allows threads to push messages concurrently to a subject. However, the push operation does not complete until the subject accepts the message. Until then the pushing thread gets blocked, which is sort of backpressure.
**Caveat:** The `Sequencer` should be operated by a strictly limited number of threads (or fibers) to achieve a real backpressure. Otherwise, the system will continue to produce new messages on new threads (or fibers) without slowing down in case of backpressure.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-1415
