### PR TITLE
boot-p2p: clarify control flow, esp. re bonds (OPS-331)

### DIFF
--- a/scripts/boot-p2p.py
+++ b/scripts/boot-p2p.py
@@ -1,177 +1,205 @@
 #!/usr/bin/env python3.6
-# This is a simple script to boot a rchain p2p network using bootstrap/peer/bond named containers
-# It deletes bootstrap/peer named containers before it creates them leaving other named containers
+"""
+This is a simple script to boot a rchain p2p network using bootstrap/peer/bond named containers
+It deletes bootstrap/peer named containers before it creates them leaving other named containers
+
+Usage:
+ boot-p2p.py [options] [--help]
+
+Options:
+ -c --cpuset-cpus=C   set docker cpuset-cpus for all nodes. Allows limiting execution in specific CPUs
+                      [default: 0]
+ -i --image=I         source repo for docker image
+                      [default: coop.rchain/rnode:latest]
+ -m --memory=M        set docker memory limit for all nodes
+                      [default: 2048m]
+ -n --network=N       set docker network name
+                      [default: rchain.coop]
+ -p --peers-amount=N  set total amount of peers for network
+                      [default: 2]
+ -r --remove          forcibly remove containers that start with bootstrap and peer associated to network name
+ --bonds=FILE         set the bond file of the genesis process
+ --wallet=FILE        set the wallet file of the genesis process
+ --genesis            set if start with the genesis process
+                      ISSUE: not used???
+ --sigs=N             set the required signatures , this equals the number of nodes bonded at genesis
+                      [default: 0]
+ --has-faucet         set if the chain support has-faucet
+ --debug              verbose logging
+ -h --help            Show this help.
+
+Return code of 0 is success on test and 1 is fail.
+
+Example below shows how to boot network with 3 nodes, including bootstrap, and run specific test
+
+sudo ./boot-p2p.py -m 34360m -c 1 -p 3  --genesis --sigs 2 --bonds <bond_file_path> --wallet <wallet_file_path> --has-faucet  -i rchain-integration-testing:latest --remove
+
+"""
 # This requires Python 3.6 to be installed for f-string. Install dependencies via pip
-# python3.6 -m pip install docker ed25519
-# Return code of 0 is success on test and 1 is fail.
-# Example below shows how to boot network with 3 nodes, including bootstrap, and run specific test
-# sudo ./boot-p2p.py -m 34360m -c 1 -p 3  --genesis --sigs 2 --bonds <bond_file_path> --wallet <wallet_file_path> --has-faucet  -i rchain-integration-testing:latest --remove
+# python3.6 -m pip install docker ed25519 docopt
 
-import argparse
-import docker
-import os
-import time
-import sys
-import random
-import collections
+from collections import namedtuple
+import logging
 
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+from docopt import docopt
 
-parser.add_argument("-c", "--cpuset-cpus",
-                    dest='cpuset_cpus',
-                    type=str,
-                    default="0",
-                    help="set docker cpuset-cpus for all nodes. Allows limiting execution in specific CPUs")
-
-parser.add_argument("-i", "--image",
-                    dest='image',
-                    type=str,
-                    default="coop.rchain/rnode:latest",
-                    help="source repo for docker image")
-
-parser.add_argument("-m", "--memory",
-                    dest='memory',
-                    type=str,
-                    default="2048m",
-                    help="set docker memory limit for all nodes")
-
-parser.add_argument("-n", "--network",
-                    dest='network',
-                    type=str,
-                    default="rchain.coop",
-                    help="set docker network name")
-
-parser.add_argument("-p", "--peers-amount",
-                    dest='peer_amount',
-                    type=int,
-                    default="2",
-                    help="set total amount of peers for network")
-
-parser.add_argument("-r", "--remove",
-                    action='store_true',
-                    help="forcibly remove containers that start with bootstrap and peer associated to network name")
-
-parser.add_argument("--bonds",
-                    dest="bonds_file",
-                    type=str,
-                    help="set the bond file of the genesis process")
-
-parser.add_argument("--wallet",
-                    dest="wallet_file",
-                    type=str,
-                    help="set the wallet file of the genesis process")
-
-parser.add_argument("--genesis",
-                    dest="genesis",
-                    action='store_true',
-                    help="set if start with the genesis process")
-
-parser.add_argument("--sigs",
-                    dest="sigs",
-                    type=int,
-                    default=0,
-                    help="set the required signatures , this equals the number of nodes bonded at genesis")
-
-parser.add_argument("--has-faucet",
-                    dest="has_faucet",
-                    action="store_true",
-                    default=False,
-                    help="set if the chain support has-faucet")
-
-# Print -h/help if no args
-if len(sys.argv) == 1:
-    parser.print_help(sys.stderr)
-    sys.exit(1)
-
-# Define globals
-args = parser.parse_args()
-
-if args.sigs > args.peer_amount:
-    raise Exception('Sigs should be lower than peer amount')
-
-read_only_peer_count = args.peer_amount - args.sigs
-
-KeyPair = collections.namedtuple("KeyPair", ["private_key", "public_key"])
-
-bonds_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'demo-bonds.txt')
-keys_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "demo-validator-private-public-key-pairs.txt")
-client = docker.from_env()
-RNODE_CMD = '/opt/docker/bin/rnode'
-# bonds_file = f'/tmp/bonds.{args.network}' alternate when dynamic bonds.txt creation/manpiulation file works
-rnode_directory = "/var/lib/rnode"
-container_bonds_file = f'{rnode_directory}/genesis/bonds.txt'
-container_wallets_file = f'{rnode_directory}/genesis/wallets.txt'
-peer_prefix_command = ['run', '--bootstrap',
-                       f'rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.{args.network}?protocol=40400&discovery=40404']
-
-temp_bonds_file = f'/tmp/bonds_{random.randint(10000,99999)}'
-
-bond_key_pairs = []
-peer_key_pairs = []
+log = logging.getLogger(__name__)
 
 
-def main():
+def main(argv, cwd,
+         here, temp,
+         randint, create_keypair,
+         sleep, time,
+         docker_from_env):
     """Main program"""
-    # Check is the docket network exist and create one if not.
+    args = Flags(docopt(__doc__, argv=argv[1:]),
+                 {'--peers-amount': int, '--sigs': int})
+
+    if args.sigs > args.peers_amount:
+        raise Exception('Sigs should be lower than peer amount')
+
+    client = docker_from_env()
+
+    # Check is the docker network exist and create one if not.
     networks = [network.name for network in client.networks.list()]
     if args.network not in networks:
         client.networks.create(args.network)
     if args.remove:
         # only removes boostrap/peer.rchain.coop or .network nodes
-        remove_resources_by_network(args.network)
-    boot_p2p_network()
+        remove_resources_by_network(client.containers, args.network)
+
+    image = DockerImage(client.containers,
+                        args.image, args.cpuset_cpus, args.memory, args.network)
+
+    bond_keys = [KeyPair.encode(create_keypair())
+                 for _ in range(args.sigs)]
+    peer_keys = [KeyPair.encode(create_keypair())
+                 for _ in range(args.peers_amount - args.sigs)]
+    network = P2PNetwork(args.network, time, sleep)
+    network.boot(image, temp, args.has_faucet, bond_keys, peer_keys,
+                 wallets=cwd / args.wallet if args.wallet else None,
+                 other_bonds=cwd / args.bonds if args.bonds else None)
 
 
-def remove_resources_by_network(args_network):
+class Flags(object):
+    def __init__(self, opts,
+                 typed={}):
+        self.opts = opts
+        self.typed = typed
+
+    def __getattr__(self, name):
+        opts = self.opts
+        for k in [name, '--' + name.replace('_', '-')]:
+            if k in opts:
+                parser = self.typed.get(k, lambda x: x)
+                return parser(self.opts[k])
+        else:
+            raise AttributeError((name, opts))
+
+
+class KeyPair(namedtuple("KeyPair", ["private_key", "public_key"])):
+    @classmethod
+    def encode(cls, key_pair):
+        signing_key, verifying_key = key_pair
+        encoded_private_key = signing_key.to_ascii(encoding="base16").decode('utf-8')
+        encoded_public_key = verifying_key.to_ascii(encoding="base16").decode('utf-8')
+        return cls(private_key=encoded_private_key, public_key=encoded_public_key)
+
+
+def remove_resources_by_network(containers, args_network):
     """Remove bootstrap/peer resources in network name."""
-    print(f"Removing bootstrap/peer named containers for docker network {args_network}")
-    for container in client.containers.list(all=True, filters={"name": f"peer\d.{args.network}"}):
+    log.info(f"Removing bootstrap/peer named containers for docker network {args_network}")
+    for container in containers.list(all=True, filters={"name": f"peer\\d.{args_network}"}):
+        log.info('removing %s', container)
         container.remove(force=True, v=True)
-    for container in client.containers.list(all=True, filters={"name": f"bootstrap.{args.network}"}):
+    for container in containers.list(all=True, filters={"name": f"bootstrap.{args_network}"}):
+        log.info('removing %s', container)
         container.remove(force=True, v=True)
-    for container in client.containers.list(all=True, filters={"name": f"bond\d.{args.network}"}):
+    for container in containers.list(all=True, filters={"name": f"bond\\d.{args_network}"}):
+        log.info('removing %s', container)
         container.remove(force=True, v=True)
     # client.volumes.prune() # Removes unused volumes
-    return 0
 
 
-def boot_p2p_network():
-    create_bootstrap_node()
-    time.sleep(30)  # Give bootstrap node an early start
-    print("Starting bonded nodes")
-    create_bonded_nodes()
-    print("Starting peer nodes.")
-    create_peer_nodes()
+class P2PNetwork(object):
+    def __init__(self, network, time, sleep):
+        self.network = network
+        self.__time = time
+        self.__sleep = sleep
+
+    def boot(self, image, temp, has_faucet, bond_keys, peer_keys,
+             wallets, other_bonds=None):
+        bootstrap = BootstrapNode(self.network, other_bonds, wallets, has_faucet,
+                                  timestamp=int(self.__time() * 1000))
+        bootstrap.run(image, temp)
+
+        log.info('sleep 30: Give bootstrap node an early start')
+        self.__sleep(30)
+
+        log.info("Starting bonded nodes")
+        log.info("Create and run bonded nodes to connect via bootstrap.")
+        for i, key_pair in enumerate(bond_keys):
+            peer = PeerNode("bond", self.network, i, key_pair)
+            peer.run(image, bootstrap)
+
+        log.info("Starting peer nodes.")
+        for i, key_pair in enumerate(peer_keys):
+            peer = PeerNode("peer", self.network, i, key_pair)
+            peer.run(image, bootstrap)
+
+    def bonds_file(self, temp, bond_key_pairs, randint,
+                   other_bonds=None):
+        log.info('Make bonds file including {other_bonds} and {len(bond_key_pairs)} generated keys.')
+        if other_bonds:
+            with other_bonds.open() as bond_f:
+                init = [line.split() for line in bond_f.readlines()]
+        else:
+            init = []
+
+        bonds = init + [(key_pair.public_key, randint(50, 1000))
+                        for key_pair in bond_key_pairs]
+
+        temp_bonds_file = temp / f'bonds_{randint(10000, 99999)}'
+
+        with temp_bonds_file.open('w') as f:
+            for public_key, bond in bonds:
+                f.write(f'{public_key} {bond}\n')
+
+        return temp_bonds_file
 
 
-def generate_validator_private_key():
-    import ed25519
-    signing_key, verifying_key = ed25519.create_keypair()
-    encoded_private_key = signing_key.to_ascii(encoding="base16").decode('utf-8')
-    encoded_public_key = verifying_key.to_ascii(encoding="base16").decode('utf-8')
-    return KeyPair(private_key=encoded_private_key, public_key=encoded_public_key)
+class DockerImage(object):
+    """Access to create containers based on an image.
+    """
+    def __init__(self, containers,
+                 image, cpuset, memory, network):
+        self.__containers = containers
+        self.image = image
+        self.cpuset = cpuset
+        self.memory = memory
+        self.network = network
+
+    def run(self, name, volumes={}, command_args=[]):
+        detail = dict(
+            image=self.image,
+            name=name,
+            user='root',
+            detach=True,
+            cpuset_cpus=self.cpuset,
+            mem_limit=self.memory,
+            network=self.network,
+            volumes=volumes,
+            command=command_args,
+            hostname=name)
+        log.debug('starting: %s', detail)
+        return self.__containers.run(**detail)
 
 
-def modify_bonds_file():
-    # In order to produce a bonds.txt which contains the key pair of the bonded node which is going to start,
-    # the bonded nodes key pair should be put into the bonds file
-    # So I have to add the key pairs to the bonds file.
-    print('Modify bonds file and add bonds key pair to the bond file')
-    if args.bonds_file:
-        with open(args.bonds_file) as bond_f:
-            content = bond_f.read()
-    with open(temp_bonds_file, 'w') as f:
-        if args.bonds_file:
-            f.write(content)
-        for i in range(args.sigs):
-            key_pair = generate_validator_private_key()
-            bond_key_pairs.append(key_pair)
-            f.write(f'{key_pair.public_key} {random.randint(50,1000)}\n')
+class RNode(object):
+    directory = '/var/lib/rnode'
 
 
-def create_bootstrap_node():
-    """Create bootstrap node."""
-
+class BootstrapNode(RNode):
     # Create key/cert pem files to be loaded into rnode volume
     bootstrap_node_demo_key = (
         "-----BEGIN PRIVATE KEY-----\n"
@@ -193,92 +221,115 @@ def create_bootstrap_node():
         "VkEqI2rycmgp03DXsStJ7IGdBQ==\n"
         "-----END CERTIFICATE-----\n"
     )
-    tmp_file_key = '/tmp/node.key.pem'
-    tmp_file_cert = '/tmp/node.certificate.pem'
-    with open(tmp_file_key, 'w') as f:
-        f.write(bootstrap_node_demo_key)
-    with open(tmp_file_cert, 'w') as f:
-        f.write(bootstrap_node_demo_cert)
+
+    def __init__(self, network, bonds, wallets, has_faucet, timestamp):
+        self.network = network
+        self.name = name = f"bootstrap.{self.network}"
+
+        command, volumes = self.genesis(bonds, wallets)
+
+        if has_faucet:
+            command = command + ["--has-faucet"]
+
+        self.command = [
+            'run', "--standalone",
+            "--host", name,
+            "--deploy-timestamp", f"{timestamp}",
+            "--map-size", "17179869184",
+        ] + command
+
+        self.genesis_volumes = volumes
+
+    @property
+    def address(self):
+        return f'rnode://cb74ba04085574e9f0102cc13d39f0c72219c5bb@bootstrap.{self.network}?protocol=40400&discovery=40404'
+
+    def key_volumes(self, temp):
+        tmp_file_key = temp / 'node.key.pem'
+        tmp_file_cert = temp / 'node.certificate.pem'
+        with tmp_file_key.open('w') as f:
+            f.write(self.bootstrap_node_demo_key)
+        with tmp_file_cert.open('w') as f:
+            f.write(self.bootstrap_node_demo_cert)
+
+        volumes = {
+            str(tmp_file_cert): {
+                "bind": f'{RNode.directory}/node.certificate.pem',
+                "mode": 'rw'},
+            str(tmp_file_key): {"bind": f'{RNode.directory}/node.key.pem',
+                                "mode": 'rw'}
+        }
+
+        return volumes
+
+    def run(self, image, temp):
+        """Create bootstrap node."""
+
+        log.info("Starting bootstrap node.")
+        log.info(f"creating {self.name}")
+
+        volumes = dict(self.key_volumes(temp),
+                       **self.genesis_volumes)
+        return image.run(self.name, volumes, self.command)
+
+    @classmethod
+    def genesis(cls, sigs, bonds=None, wallets=None):
+        container_bonds_file = f'{RNode.directory}/genesis/bonds.txt'
+        container_wallets_file = f'{RNode.directory}/genesis/wallets.txt'
+
+        command = []
+        volumes = {}
+
+        if bonds or sigs:
+            command = command + ["--bonds-file", container_bonds_file]
+            volumes.update({str(bonds): {"bind": container_bonds_file, "mode": 'rw'}})
+        if wallets:
+            command = command + ["--wallets-file", container_wallets_file]
+            volumes.update({str(wallets): {"bind": container_wallets_file, "mode": 'rw'}})
+
+        return command, volumes
 
 
-    print("Starting bootstrap node.")
-    name = f"bootstrap.{args.network}"
-    print(f"creating {name}")
+class PeerNode(RNode):
+    def __init__(self, name_prefix, network, i, key_pair):
+        name = f"{name_prefix}{i}.{network}"
+        log.info(
+            f"creating {name_prefix} node {name} with private key:{key_pair.private_key} and public key:{key_pair.public_key}")
+        self.name = name
+        self._key_pair = key_pair
 
-    timestamp = int(time.time() * 1000)
+    def run(self, image, bootstrap):
+        peer_prefix_command = ['run', '--bootstrap', bootstrap.address]
 
-    command = ['run', "--standalone",
-               "--host", name,
-               "--deploy-timestamp", f"{timestamp}",
-               "--map-size", "17179869184",
-               ]
-    volume = {
-        tmp_file_cert: {
-            "bind": os.path.join(rnode_directory, 'node.certificate.pem'),
-            "mode": 'rw'},
-        tmp_file_key: {"bind": os.path.join(rnode_directory, 'node.key.pem'),
-                            "mode": 'rw'}
-    }
-
-    modify_bonds_file()
-    if args.bonds_file or args.sigs:
-        command.extend(["--bonds-file", container_bonds_file])
-        volume.update({temp_bonds_file: {"bind": container_bonds_file, "mode": 'rw'}})
-    if args.wallet_file:
-        command.extend(["--wallets-file", container_wallets_file])
-        volume.update({args.wallet_file: {"bind": container_wallets_file, "mode": 'rw'}})
-    if args.has_faucet:
-        command.append("--has-faucet")
-    container = client.containers.run(args.image,
-                                      name=name,
-                                      user='root',
-                                      detach=True,
-                                      cpuset_cpus=args.cpuset_cpus,
-                                      mem_limit=args.memory,
-                                      network=args.network,
-                                      volumes=volume,
-                                      command=command,
-                                      hostname=name)
-    return container
-
-
-def create_peer_node(i, key_pair, name_prefix):
-    name = f"{name_prefix}{i}.{args.network}"
-    print(
-        f"creating {name_prefix} node {name} with private key:{key_pair.private_key} and public key:{key_pair.public_key}")
-    command = peer_prefix_command.copy()
-    keys_command = ["--validator-private-key", key_pair.private_key,
-                    "--validator-public-key", key_pair.public_key,
-                    "--host", name]
-    command.extend(keys_command)
-    container = client.containers.run(args.image,
-                                      name=name,
-                                      user='root',
-                                      detach=True,
-                                      cpuset_cpus=args.cpuset_cpus,
-                                      mem_limit=args.memory,
-                                      network=args.network,
-                                      command=command,
-                                      hostname=name)
-    return container
-
-
-def create_bonded_nodes():
-    print("Create and run bonded nodes to connect via bootstrap.")
-
-    for i, key_pair in enumerate(bond_key_pairs):
-        create_peer_node(i, key_pair, "bond")
-
-
-def create_peer_nodes():
-    """Create peer nodes."""
-    print("Create and run peer nodes to connect via bootstrap.")
-
-    for i in range(read_only_peer_count):
-        key_pair = generate_validator_private_key()
-        create_peer_node(i, key_pair, "peer")
-    return 0
+        keys_command = ["--validator-private-key", self._key_pair.private_key,
+                        "--validator-public-key", self._key_pair.public_key,
+                        "--host", self.name]
+        return image.run(name=self.name,
+                         command_args=peer_prefix_command + keys_command)
 
 
 if __name__ == "__main__":
-    main()
+    def _script():
+        # Access ambient authority only when invoked as a script.
+        from pathlib import Path
+        from random import randint
+        from sys import argv
+        from time import sleep, time
+
+        from docker import from_env
+        from ed25519 import create_keypair
+
+        logging.basicConfig(
+            format='%(asctime)s: %(message)s',
+            datefmt='%H:%M:%S',
+            level=logging.DEBUG if '--debug' in argv else logging.INFO)
+
+        main(argv, randint=randint,
+             sleep=sleep, time=time,
+             cwd=Path('.'),
+             here=Path(__file__).resolve().parent,
+             temp=Path('/tmp'),
+             create_keypair=create_keypair,
+             docker_from_env=from_env)
+
+    _script()


### PR DESCRIPTION
## Overview

Clarify that scripts/boot-p2p.py produces a bonds file with entries for each bonded validator.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please 

https://rchain.atlassian.net/browse/OPS-331

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
  - it's a bit over 200
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes

I wasn't quite sure what the code was doing, so I refactored it to
clarify flow of control and access.

Now that I see what's going on, I think the previous version was
correct: it did add to the bonds file one line for each bonded
validator (according to --sigs).

But perhaps others would agree this is easier to read.
