### PR TITLE
CORE-1448 Fix toContent (in stream api) to handle correctly data that was not compressed

### DIFF
--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -84,7 +84,7 @@ message ChunkHeader {
   Node   sender             = 1;
   string typeId             = 2;
   bool   compressed         = 3;
-  int32  contentLength = 4;
+  int32  contentLength      = 4;
 }
 
 message ChunkData {


### PR DESCRIPTION
## Overview
The reason for bug was following: When data was received and
colledcted by the server, it then was trying to check if the received
data was compressed before sending. Instead of checking the boolean
flag `compressed`, the server checked if the `contentLength` field was
set. That field however is always set (regardless if the data is
compressed or note), thus it was ALWAYS trying to decompres received
data.

This commit fixes the problem. It correctly checks if flat `compressed
` is set to true and only then attempts the decompression process.

TODO: this bug was not caught by tests. Reason: no test for stream API
when sending small messages (that will not be compressed). This needs
to be addressed. Added CORE-1449 to address that


Provide a brief description of what this PR does, and why it's needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1448