### PR TITLE
Add pre-state hash to blocks

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/BlockMessageUtil.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/BlockMessageUtil.scala
@@ -8,13 +8,13 @@ object BlockMessageUtil {
   def blockNumber(b: BlockMessage): Long =
     (for {
       bd <- b.body
-      ps <- bd.postState
+      ps <- bd.state
     } yield ps.blockNumber).getOrElse(0L)
 
   def bonds(b: BlockMessage): Seq[Bond] =
     (for {
       bd <- b.body
-      ps <- bd.postState
+      ps <- bd.state
     } yield ps.bonds).getOrElse(List.empty[Bond])
 
   def parentHashes(b: BlockMessage): Seq[ByteString] =
@@ -23,7 +23,7 @@ object BlockMessageUtil {
   def weightMap(blockMessage: BlockMessage): Map[ByteString, Long] =
     blockMessage.body match {
       case Some(block) =>
-        block.postState match {
+        block.state match {
           case Some(state) => weightMap(state)
           case None        => Map.empty[ByteString, Long]
         }

--- a/casper/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
@@ -25,7 +25,7 @@ object PrettyPrinter {
       header     <- b.header
       mainParent <- header.parentsHashList.headOption
       body       <- b.body
-      postState  <- body.postState
+      postState  <- body.state
     } yield
       s"Block #${postState.blockNumber} (${buildString(b.blockHash)}) " +
         s"-- Sender ID ${buildString(b.sender)} " +
@@ -55,5 +55,5 @@ object PrettyPrinter {
     s"Deploy #${d.raw.fold(0L)(_.timestamp)} -- ${buildString(d.term)}"
 
   private def buildString(r: RChainState): String =
-    buildString(r.tuplespace)
+    buildString(r.postStateHash)
 }

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -145,7 +145,7 @@ object Validate {
       for {
         _ <- Log[F].warn(ignore(b, s"block new code hash is empty."))
       } yield false
-    } else if (b.body.get.postState.isEmpty) {
+    } else if (b.body.get.state.isEmpty) {
       for {
         _ <- Log[F].warn(ignore(b, s"block post state is missing."))
       } yield false
@@ -399,7 +399,7 @@ object Validate {
       b.extraBytes
     )
     val deployHashComputed    = ProtoUtil.protoSeqHash(b.body.get.deploys)
-    val postStateHashComputed = ProtoUtil.protoHash(b.body.get.postState.get)
+    val postStateHashComputed = ProtoUtil.protoHash(b.body.get.state.get)
     if (b.blockHash == blockHashComputed &&
         b.header.get.deploysHash == deployHashComputed &&
         b.header.get.postStateHash == postStateHashComputed) {

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -77,8 +77,8 @@ object Genesis {
 
     val stateWithContracts = for {
       bd <- initial.body
-      ps <- bd.postState
-    } yield ps.withTuplespace(stateHash)
+      ps <- bd.state
+    } yield ps.withPreStateHash(runtimeManager.emptyStateHash).withPostStateHash(stateHash)
     val version   = initial.header.get.version
     val timestamp = initial.header.get.timestamp
 
@@ -86,7 +86,7 @@ object Genesis {
       processedDeploys.filterNot(_.status.isFailed).map(ProcessedDeployUtil.fromInternal)
     val sortedDeploys = blockDeploys.map(d => d.copy(log = d.log.sortBy(_.toByteArray)))
 
-    val body = Body(postState = stateWithContracts, deploys = sortedDeploys)
+    val body = Body(state = stateWithContracts, deploys = sortedDeploys)
 
     val header = blockHeader(body, List.empty[ByteString], version, timestamp)
 
@@ -111,7 +111,7 @@ object Genesis {
       .withBlockNumber(0)
       .withBonds(bondsProto)
     val body = Body()
-      .withPostState(state)
+      .withState(state)
     val header = blockHeader(body, List.empty[ByteString], version, timestamp)
 
     unsignedBlockProto(body, header, List.empty[Justification], shardId)

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -157,7 +157,7 @@ object ProtoUtil {
   def weightMap(blockMessage: BlockMessage): Map[ByteString, Long] =
     blockMessage.body match {
       case Some(block) =>
-        block.postState match {
+        block.state match {
           case Some(state) => weightMap(state)
           case None        => Map.empty[ByteString, Long]
         }
@@ -235,19 +235,23 @@ object ProtoUtil {
   def tuplespace(b: BlockMessage): Option[ByteString] =
     for {
       bd <- b.body
-      ps <- bd.postState
-    } yield ps.tuplespace
+      ps <- bd.state
+    } yield ps.postStateHash
+
+  // TODO: Reconcile with def tuplespace above
+  def postStateHash(b: BlockMessage): ByteString =
+    b.getBody.getState.postStateHash
 
   def bonds(b: BlockMessage): Seq[Bond] =
     (for {
       bd <- b.body
-      ps <- bd.postState
+      ps <- bd.state
     } yield ps.bonds).getOrElse(List.empty[Bond])
 
   def blockNumber(b: BlockMessage): Long =
     (for {
       bd <- b.body
-      ps <- bd.postState
+      ps <- bd.state
     } yield ps.blockNumber).getOrElse(0L)
 
   /*
@@ -352,7 +356,7 @@ object ProtoUtil {
   ): Header =
     Header()
       .withParentsHashList(parentHashes)
-      .withPostStateHash(protoHash(body.postState.get))
+      .withPostStateHash(protoHash(body.state.get))
       .withDeploysHash(protoSeqHash(body.deploys))
       .withDeployCount(body.deploys.size)
       .withVersion(version)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -115,7 +115,7 @@ object BlockApproverProtocol {
             .or("Candidate didn't have required signatures number.")
       block      <- Either.fromOption(candidate.block, "Candidate block is empty.")
       body       <- Either.fromOption(block.body, "Body is empty")
-      postState  <- Either.fromOption(body.postState, "Post state is empty")
+      postState  <- Either.fromOption(body.state, "Post state is empty")
       blockBonds = postState.bonds.map { case Bond(validator, stake) => validator -> stake }.toMap
       _ <- (blockBonds == bonds)
             .either(())
@@ -144,10 +144,10 @@ object BlockApproverProtocol {
                     .replayComputeState(runtimeManager.emptyStateHash, blockDeploys)
                     .runSyncUnsafe(Duration.Inf)
                     .leftMap { case (_, status) => s"Failed status during replay: $status." }
-      _ <- (stateHash == postState.tuplespace)
+      _ <- (stateHash == postState.postStateHash)
             .either(())
             .or("Tuplespace hash mismatch.")
-      tuplespaceBonds <- Try(runtimeManager.computeBonds(postState.tuplespace)).toEither
+      tuplespaceBonds <- Try(runtimeManager.computeBonds(postState.postStateHash)).toEither
                           .leftMap(_.getMessage)
       tuplespaceBondsMap = tuplespaceBonds.map { case Bond(validator, stake) => validator -> stake }.toMap
       _ <- (tuplespaceBondsMap == bonds)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -83,7 +83,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                   )
         validatorId <- ValidatorIdentity.fromConfig[F](conf)
         bondedValidators = genesis.body
-          .flatMap(_.postState.map(_.bonds.map(_.validator).toSet))
+          .flatMap(_.state.map(_.bonds.map(_.validator).toSet))
           .getOrElse(Set.empty)
         abp <- ApproveBlockProtocol
                 .of[F](

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -107,11 +107,12 @@ object DeployRuntime {
     for {
       result <- program.attempt
       _ <- result match {
-        case Left(ex) => Capture[F].capture{
-          println(s"Error: ${processError(ex).getMessage}")
-          System.exit(1)
-        }
-            case _        => ().pure[F]
+            case Left(ex) =>
+              Capture[F].capture {
+                println(s"Error: ${processError(ex).getMessage}")
+                System.exit(1)
+              }
+            case _ => ().pure[F]
           }
     } yield ()
 

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -121,7 +121,7 @@ object InterpreterUtil {
       time: Option[Long] = None
   )(
       implicit scheduler: Scheduler
-  ): F[Either[Throwable, (StateHash, Seq[InternalProcessedDeploy])]] =
+  ): F[Either[Throwable, (StateHash, StateHash, Seq[InternalProcessedDeploy])]] =
     for {
       possiblePreStateHash <- computeParentsPostState[F](parents, dag, runtimeManager, time)
     } yield
@@ -129,7 +129,7 @@ object InterpreterUtil {
         case Right(preStateHash) =>
           val (postStateHash, processedDeploys) =
             runtimeManager.computeState(preStateHash, deploys, time).runSyncUnsafe(Duration.Inf)
-          Right(postStateHash, processedDeploys)
+          Right(preStateHash, postStateHash, processedDeploys)
         case Left(err) =>
           Left(err)
       }
@@ -195,7 +195,7 @@ object InterpreterUtil {
       runtimeManager: RuntimeManager
   )(
       implicit scheduler: Scheduler
-  ): F[Either[Throwable, (StateHash, Seq[InternalProcessedDeploy])]] =
+  ): F[Either[Throwable, (StateHash, StateHash, Seq[InternalProcessedDeploy])]] =
     for {
       parents <- ProtoUtil.unsafeGetParents[F](b)
 

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -161,7 +161,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     val blockStatus    = casperEff.addBlock(block)
 
     val id: String = casperEff
-      .storageContents(block.getBody.getPostState.tuplespace)
+      .storageContents(ProtoUtil.postStateHash(block))
       .split('|')
       .find(
         _.contains(
@@ -187,7 +187,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     blockStatus shouldBe Valid
     block2Status shouldBe Valid
     casperEff
-      .storageContents(block2.getBody.getPostState.tuplespace)
+      .storageContents(ProtoUtil.postStateHash(block2))
       .contains("Hello, World!") shouldBe true
 
     node.tearDown()
@@ -352,7 +352,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     nodes(1).casperEff.contains(multiparentBlock) shouldBe true
 
     val finalTuplespace =
-      nodes(0).casperEff.storageContents(multiparentBlock.getBody.getPostState.tuplespace)
+      nodes(0).casperEff.storageContents(ProtoUtil.postStateHash(multiparentBlock))
     finalTuplespace.contains("@{0}!(0)") shouldBe true
     finalTuplespace.contains("@{1}!(1)") shouldBe true
     finalTuplespace.contains("@{2}!(2)") shouldBe true
@@ -451,7 +451,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     )
     val validatorBondsAndRanks: Seq[(ByteString, Long, Int)] = runtimeManager
       .captureResults(
-        block1.getBody.getPostState.tuplespace,
+        ProtoUtil.postStateHash(block1),
         ProtoUtil.deployDataToDeploy(rankedValidatorQuery)
       )
       .head
@@ -482,7 +482,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       wallets.head.initRevBalance.toLong - joiningFee
     )
 
-    val newBonds = block2.getBody.getPostState.bonds
+    val newBonds = block2.getBody.getState.bonds
     newBonds.toSet shouldBe correctBonds
 
     nodes.foreach(_.tearDown())
@@ -539,7 +539,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     )
     val newWalletBalance =
       node.runtimeManager.captureResults(
-        block.getBody.getPostState.tuplespace,
+        ProtoUtil.postStateHash(block),
         ProtoUtil.deployDataToDeploy(balanceQuery)
       )
 
@@ -569,8 +569,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     val Created(block2) = casperEff.deploy(bondingDeploy) *> casperEff.createBlock
     val block2Status    = casperEff.addBlock(block2)
 
-    val oldBonds = block1.getBody.getPostState.bonds
-    val newBonds = block2.getBody.getPostState.bonds
+    val oldBonds = block1.getBody.getState.bonds
+    val newBonds = block2.getBody.getState.bonds
 
     block1Status shouldBe Valid
     block2Status shouldBe Valid
@@ -659,7 +659,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       .withUser(user)
     val sigData = node.runtimeManager
       .captureResults(
-        genesis.getBody.getPostState.tuplespace,
+        ProtoUtil.postStateHash(genesis),
         ProtoUtil.deployDataToDeploy(sigDeployData)
       )
       .head
@@ -1079,7 +1079,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       .withParentsHashList(Seq(signedInvalidBlock.blockHash))
       .withDeploysHash(ProtoUtil.protoSeqHash(deploys))
     val blockHash = Blake2b256.hash(header.toByteArray)
-    val body      = Body().withPostState(postState).withDeploys(deploys)
+    val body      = Body().withState(postState).withDeploys(deploys)
     val serializedJustifications =
       Seq(Justification(signedInvalidBlock.sender, signedInvalidBlock.blockHash))
     val serializedBlockHash = ByteString.copyFrom(blockHash)
@@ -1107,7 +1107,7 @@ object HashSetCasperTest {
   def blockTuplespaceContents(
       block: BlockMessage
   )(implicit casper: MultiParentCasper[Id]): String = {
-    val tsHash = block.body.get.postState.get.tuplespace
+    val tsHash = ProtoUtil.postStateHash(block)
     MultiParentCasper[Id].storageContents(tsHash)
   }
 
@@ -1120,7 +1120,7 @@ object HashSetCasperTest {
     val blockStatus    = node.casperEff.addBlock(block)
     val queryResult = node.runtimeManager
       .captureResults(
-        block.getBody.getPostState.tuplespace,
+        ProtoUtil.postStateHash(block),
         query
       )
 

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -100,13 +100,13 @@ class ValidateTest
   implicit class ChangeBlockNumber(b: BlockMessage) {
     def withBlockNumber(n: Long): BlockMessage = {
       val body     = b.body.getOrElse(Body())
-      val state    = body.postState.getOrElse(RChainState())
+      val state    = body.getState
       val newState = state.withBlockNumber(n)
 
       val header    = b.header.getOrElse(Header())
       val newHeader = header.withPostStateHash(ProtoUtil.protoHash(newState))
 
-      b.withBody(body.withPostState(newState)).withHeader(newHeader)
+      b.withBody(body.withState(newState)).withHeader(newHeader)
     }
   }
 
@@ -524,8 +524,8 @@ class ValidateTest
       Validate.bondsCache[Id](genesis, runtimeManager) should be(Right(Valid))
 
       val modifiedBonds     = Seq.empty[Bond]
-      val modifiedPostState = genesis.body.get.postState.get.withBonds(modifiedBonds)
-      val modifiedBody      = genesis.body.get.withPostState(modifiedPostState)
+      val modifiedPostState = genesis.getBody.getState.withBonds(modifiedBonds)
+      val modifiedBody      = genesis.getBody.withState(modifiedPostState)
       val modifiedGenesis   = genesis.withBody(modifiedBody)
       Validate.bondsCache[Id](modifiedGenesis, runtimeManager) should be(Left(InvalidBondsCache))
 
@@ -545,7 +545,7 @@ class ValidateTest
     Validate.formatOfFields[Id](genesis.withSig(ByteString.EMPTY)) should be(false)
     Validate.formatOfFields[Id](genesis.withSigAlgorithm("")) should be(false)
     Validate.formatOfFields[Id](genesis.withShardId("")) should be(false)
-    Validate.formatOfFields[Id](genesis.withBody(genesis.body.get.clearPostState)) should be(false)
+    Validate.formatOfFields[Id](genesis.withBody(genesis.getBody.clearState)) should be(false)
     Validate.formatOfFields[Id](
       genesis.withHeader(genesis.header.get.withPostStateHash(ByteString.EMPTY))
     ) should be(false)

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -33,7 +33,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
     val ps = RChainState()
       .withBlockNumber(blockNumber)
       .withBonds(Seq(Bond(ByteString.copyFromUtf8("random"), 1)))
-    val body   = Body().withPostState(ps)
+    val body   = Body().withState(ps)
     val header = ProtoUtil.blockHeader(body, Seq.empty[ByteString], version, timestamp)
     BlockMessage().withBlockHash(genesisHash).withHeader(header).withBody(body)
   }
@@ -47,7 +47,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockStoreFi
   val deployCount          = 10
   val randomDeploys =
     (0 until deployCount).map(ProtoUtil.basicProcessedDeploy[Id](_)(syncId, timeEff))
-  val body: Body                       = Body().withPostState(ps).withDeploys(randomDeploys)
+  val body: Body                       = Body().withState(ps).withDeploys(randomDeploys)
   val parentsString                    = List(genesisHashString, "0000000001")
   val parentsHashList: List[BlockHash] = parentsString.map(ProtoUtil.stringToByteString)
   val header: Header                   = ProtoUtil.blockHeader(body, parentsHashList, version, timestamp)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/DeployPaymentCostTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/DeployPaymentCostTest.scala
@@ -46,7 +46,7 @@ class DeployPaymentCostTest extends FlatSpec {
 
     val paymentDeployCost = deployCost(paymentBlock, user, timestamp)
 
-    assertSuccessfulTransfer(node, paymentBlock.getBody.getPostState.tuplespace, statusChannel)
+    assertSuccessfulTransfer(node, ProtoUtil.postStateHash(paymentBlock), statusChannel)
 
     println(s"Cost of deploying payment contract is at minimum: $paymentDeployCost")
   }
@@ -198,7 +198,7 @@ object DeployPaymentCostTest {
   def deployAndCapture(p: Par, retChannel: Par, rm: RuntimeManager)(
       implicit casper: MultiParentCasperImpl[Id]
   ): Par = {
-    val postDeployStateHash = deploy[Id](p).getBody.getPostState.tuplespace
+    val postDeployStateHash = ProtoUtil.postStateHash(deploy[Id](p))
     val data                = rm.getData(postDeployStateHash, retChannel)
     assert(data.size == 1)
     data.head

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -65,7 +65,7 @@ trait BlockGenerator {
       nextId            = chain.currentId + 1
       nextCreatorSeqNum = chain.latestMessages.get(creator).fold(-1)(_.seqNum) + 1
       postState = RChainState()
-        .withTuplespace(tsHash)
+        .withPostStateHash(tsHash)
         .withBonds(bonds)
         .withBlockNumber(nextId.toLong)
       postStateHash = Blake2b256.hash(postState.toByteArray)
@@ -75,7 +75,7 @@ trait BlockGenerator {
         .withDeploysHash(ProtoUtil.protoSeqHash(deploys))
         .withTimestamp(now)
       blockHash = Blake2b256.hash(header.toByteArray)
-      body      = Body().withPostState(postState).withDeploys(deploys)
+      body      = Body().withState(postState).withDeploys(deploys)
       serializedJustifications = justifications.toList.map {
         case (creator: Validator, latestBlockHash: BlockHash) =>
           Justification(creator, latestBlockHash)

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -86,7 +86,7 @@ class HashSetCasperTestNode[F[_]](
     dataLookup = Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
     topoSort = Vector(Vector(genesis.blockHash))
   )
-  val postGenesisStateHash = genesis.body.get.postState.get.tuplespace
+  val postGenesisStateHash = ProtoUtil.postStateHash(genesis)
   implicit val casperEff = new MultiParentCasperImpl[F](
     runtimeManager,
     Some(validatorId),

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -37,11 +37,11 @@ class InterpreterUtilTest
       dag: BlockDag,
       runtimeManager: RuntimeManager
   ): (StateHash, Seq[ProcessedDeploy]) = {
-    val Right((stateHash, processedDeploys)) =
+    val Right((preStateHash, postStateHash, processedDeploys)) =
       InterpreterUtil
         .computeBlockCheckpointFromDeploys[Id](b, genesis, dag, runtimeManager)
 
-    (stateHash, processedDeploys.map(ProcessedDeployUtil.fromInternal))
+    (postStateHash, processedDeploys.map(ProcessedDeployUtil.fromInternal))
   }
 
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in {
@@ -173,9 +173,9 @@ class InterpreterUtilTest
       postGenStateHash: StateHash,
       processedDeploys: Seq[ProcessedDeploy]
   ) = {
-    val updatedBlockPostState = b.body.get.postState.get.withTuplespace(postGenStateHash)
+    val updatedBlockPostState = b.getBody.getState.withPostStateHash(postGenStateHash)
     val updatedBlockBody =
-      b.body.get.withPostState(updatedBlockPostState).withDeploys(processedDeploys)
+      b.getBody.withState(updatedBlockPostState).withDeploys(processedDeploys)
     val updatedBlock = b.withBody(updatedBlockBody)
     BlockStore[Id].put(b.blockHash, updatedBlock)
     chain.copy(idToBlocks = chain.idToBlocks.updated(id, updatedBlock))
@@ -282,7 +282,7 @@ class InterpreterUtilTest
       runtimeManager: RuntimeManager,
       deploy: Deploy*
   ): Seq[InternalProcessedDeploy] = {
-    val Right((_, result)) =
+    val Right((_, _, result)) =
       computeDeploysCheckpoint[Id](Seq.empty, deploy, initState, runtimeManager)
     result
   }
@@ -407,7 +407,7 @@ class InterpreterUtilTest
     val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
       .use { runtimeManager =>
         Task.delay {
-          val Right((computedTsHash, processedDeploys)) =
+          val Right((_, computedTsHash, processedDeploys)) =
             computeDeploysCheckpoint[Id](Seq.empty, deploys, initState, runtimeManager)
           val chain: IndexedBlockDag =
             createBlock[StateWithChain](
@@ -465,7 +465,7 @@ class InterpreterUtilTest
     val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
       .use { runtimeManager =>
         Task.delay {
-          val Right((computedTsHash, processedDeploys)) =
+          val Right((_, computedTsHash, processedDeploys)) =
             computeDeploysCheckpoint[Id](Seq.empty, deploys, initState, runtimeManager)
           val chain: IndexedBlockDag =
             createBlock[StateWithChain](
@@ -526,7 +526,7 @@ class InterpreterUtilTest
     val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
       .use { runtimeManager =>
         Task.delay {
-          val Right((computedTsHash, processedDeploys)) =
+          val Right((_, computedTsHash, processedDeploys)) =
             computeDeploysCheckpoint[Id](Seq.empty, deploys, initState, runtimeManager)
           val chain: IndexedBlockDag =
             createBlock[StateWithChain](
@@ -584,7 +584,7 @@ class InterpreterUtilTest
     val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
       .use { runtimeManager =>
         Task.delay {
-          val Right((computedTsHash, processedDeploys)) =
+          val Right((_, computedTsHash, processedDeploys)) =
             computeDeploysCheckpoint[Id](Seq.empty, deploys, initState, runtimeManager)
           val chain: IndexedBlockDag =
             createBlock[StateWithChain](
@@ -633,7 +633,7 @@ class InterpreterUtilTest
       val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
         .use { runtimeManager =>
           Task.delay {
-            val Right((computedTsHash, processedDeploys)) =
+            val Right((_, computedTsHash, processedDeploys)) =
               computeDeploysCheckpoint[Id](
                 Seq.empty,
                 deploys,
@@ -669,7 +669,7 @@ class InterpreterUtilTest
     val tsHash = mkRuntimeManager("interpreter-util-test")
       .use { runtimeManager =>
         Task.delay {
-          val Right((computedTsHash, processedDeploys)) =
+          val Right((_, computedTsHash, processedDeploys)) =
             computeDeploysCheckpoint[Id](Seq.empty, deploys, initState, runtimeManager)
           val intProcessedDeploys = processedDeploys.map(ProcessedDeployUtil.fromInternal)
           //create single deploy with log that includes excess comm events
@@ -720,7 +720,7 @@ class InterpreterUtilTest
       val (tsHash, computedTsHash) = mkRuntimeManager("interpreter-util-test")
         .use { runtimeManager =>
           Task.delay {
-            val Right((computedTsHash, processedDeploys)) =
+            val Right((_, computedTsHash, processedDeploys)) =
               computeDeploysCheckpoint[Id](
                 Seq.empty,
                 deploys,

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -229,7 +229,7 @@ message ProcessedDeploy {
 }
 
 message Body {
-  RChainState              postState    = 1;
+  RChainState              state    = 1;
   repeated ProcessedDeploy deploys      = 2;
   bytes                    extraBytes   = 3;
 }
@@ -240,12 +240,13 @@ message Justification {
 }
 
 message RChainState {
-  bytes tuplespace = 1; //hash of the tuplespace contents
+  bytes preStateHash = 1; //hash of the tuplespace contents before new deploys
+  bytes postStateHash = 2; //hash of the tuplespace contents after new deploys
 
   //Internals of what will be the "blessed" PoS contract
   //(which will be part of the tuplespace in the real implementation).
-  repeated Bond bonds        = 2;
-  int64         blockNumber  = 3;
+  repeated Bond bonds        = 3;
+  int64         blockNumber  = 4;
 }
 
 message Deploy {


### PR DESCRIPTION
This change just adds the pre-state hash to the block. It does not validate the pre-state hash or expose it to the block API, and so essentially it changes no functionality. These will be added in subsequent PRs.

### Refactoring

Extract block.getBody.getState.postStateHash pattern
to a ProtoUtil function

Make one less call to _blockDag.get by passing in dag

Inline InterpreterUtil.computeDeploysCheckpoint call

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

First half of https://rchain.atlassian.net/browse/RHOL-1068