### PR TITLE
CORE-1417 - Client queue must be able to store Blobs to disk

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -1,5 +1,6 @@
 package coop.rchain.comm
 
+import java.nio.file._
 import coop.rchain.comm.protocol.routing._
 import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib._, Catscontrib._, ski._
@@ -7,29 +8,31 @@ import coop.rchain.catscontrib._, Catscontrib._, ski._
 // TODO we need lower level errors and general error, for now all in one place
 // TODO cleanup unused errors (UDP trash)
 sealed trait CommError
-final case class InitializationError(msg: String)        extends CommError
-final case class UnknownCommError(msg: String)           extends CommError
-final case class DatagramSizeError(size: Int)            extends CommError
-final case class DatagramFramingError(ex: Exception)     extends CommError
-final case class DatagramException(ex: Exception)        extends CommError
-final case object HeaderNotAvailable                     extends CommError
-final case class ProtocolException(th: Throwable)        extends CommError
-final case class UnknownProtocolError(msg: String)       extends CommError
-final case class PublicKeyNotAvailable(node: PeerNode)   extends CommError
-final case class ParseError(msg: String)                 extends CommError
-final case object EncryptionHandshakeIncorrectlySigned   extends CommError
-final case object BootstrapNotProvided                   extends CommError
-final case class PeerNodeNotFound(peer: PeerNode)        extends CommError
-final case class PeerUnavailable(peer: PeerNode)         extends CommError
-final case class MalformedMessage(pm: Protocol)          extends CommError
-final case object CouldNotConnectToBootstrap             extends CommError
-final case class InternalCommunicationError(msg: String) extends CommError
-final case object TimeOut                                extends CommError
-final case object NoResponseForRequest                   extends CommError
-final case object UpstreamNotAvailable                   extends CommError
-final case class UnexpectedMessage(msgStr: String)       extends CommError
-final case object SenderNotAvailable                     extends CommError
-final case class PongNotReceivedForPing(peer: PeerNode)  extends CommError
+final case class InitializationError(msg: String)                   extends CommError
+final case class UnknownCommError(msg: String)                      extends CommError
+final case class DatagramSizeError(size: Int)                       extends CommError
+final case class DatagramFramingError(ex: Exception)                extends CommError
+final case class DatagramException(ex: Exception)                   extends CommError
+final case object HeaderNotAvailable                                extends CommError
+final case class ProtocolException(th: Throwable)                   extends CommError
+final case class UnknownProtocolError(msg: String)                  extends CommError
+final case class PublicKeyNotAvailable(node: PeerNode)              extends CommError
+final case class ParseError(msg: String)                            extends CommError
+final case object EncryptionHandshakeIncorrectlySigned              extends CommError
+final case object BootstrapNotProvided                              extends CommError
+final case class PeerNodeNotFound(peer: PeerNode)                   extends CommError
+final case class PeerUnavailable(peer: PeerNode)                    extends CommError
+final case class MalformedMessage(pm: Protocol)                     extends CommError
+final case object CouldNotConnectToBootstrap                        extends CommError
+final case class InternalCommunicationError(msg: String)            extends CommError
+final case object TimeOut                                           extends CommError
+final case object NoResponseForRequest                              extends CommError
+final case object UpstreamNotAvailable                              extends CommError
+final case class UnexpectedMessage(msgStr: String)                  extends CommError
+final case object SenderNotAvailable                                extends CommError
+final case class PongNotReceivedForPing(peer: PeerNode)             extends CommError
+final case class UnableToStorePacket(packet: Packet, th: Throwable) extends CommError
+final case class UnabletoRestorePacket(path: Path, th: Throwable)   extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -61,6 +64,9 @@ object CommError {
   def senderNotAvailable: CommError                      = SenderNotAvailable
   def pongNotReceivedForPing(peer: PeerNode): CommError  = PongNotReceivedForPing(peer)
   def timeout: CommError                                 = TimeOut
+  def unableToStorePacket(packet: Packet, th: Throwable): CommError =
+    UnableToStorePacket(packet, th)
+  def unabletoRestorePacket(path: Path, th: Throwable) = UnabletoRestorePacket(path, th)
 
   def errorMessage(ce: CommError): String =
     ce match {

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -7,6 +7,7 @@ import com.google.protobuf.CodedOutputStream
 import java.io._
 import cats._, cats.data._, cats.implicits._
 import cats.effect.Sync
+import java.util.UUID
 
 object PacketOps {
 
@@ -18,19 +19,17 @@ object PacketOps {
   }
 
   implicit class RichPacket(packet: Packet) {
-
-    val fileName = "packet.bts"
-
     def store[F[_]: Sync](folder: Path): F[Path] =
       Sync[F].delay {
-        val file = folder.resolve(fileName)
-        val fos  = new FileOutputStream(file.toFile)
+        // FIX-ME proper exception handling
+        val fileName = UUID.randomUUID.toString + "_packet.bts"
+        val file     = folder.resolve(fileName)
+        val fos      = new FileOutputStream(file.toFile)
         fos.write(packet.toByteArray)
         fos.flush()
         fos.close()
         file
       }
-
   }
 
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -1,0 +1,36 @@
+package coop.rchain.comm.transport
+
+import coop.rchain.comm.{CommError, PeerNode}, CommError.CommErr
+import coop.rchain.comm.protocol.routing._
+import java.nio.file._
+import com.google.protobuf.CodedOutputStream
+import java.io._
+import cats._, cats.data._, cats.implicits._
+import cats.effect.Sync
+
+object PacketOps {
+
+  def restore[F[_]: Sync](file: Path): F[Packet] = Sync[F].delay {
+    val fin    = new FileInputStream(file.toFile)
+    val packet = Packet.parseFrom(fin)
+    fin.close()
+    packet
+  }
+
+  implicit class RichPacket(packet: Packet) {
+
+    val fileName = "packet.bts"
+
+    def store[F[_]: Sync](folder: Path): F[Path] =
+      Sync[F].delay {
+        val file = folder.resolve(fileName)
+        val fos  = new FileOutputStream(file.toFile)
+        fos.write(packet.toByteArray)
+        fos.flush()
+        fos.close()
+        file
+      }
+
+  }
+
+}

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -1,6 +1,6 @@
 package coop.rchain.comm.transport
 
-import coop.rchain.comm.{CommError, PeerNode}, CommError.CommErr
+import coop.rchain.comm.{CommError, PeerNode}, CommError._
 import coop.rchain.comm.protocol.routing._
 import java.nio.file._
 import com.google.protobuf.CodedOutputStream
@@ -11,25 +11,39 @@ import java.util.UUID
 
 object PacketOps {
 
-  def restore[F[_]: Sync](file: Path): F[Packet] = Sync[F].delay {
-    val fin    = new FileInputStream(file.toFile)
-    val packet = Packet.parseFrom(fin)
-    fin.close()
-    packet
-  }
+  def restore[F[_]: Sync](file: Path): F[CommErr[Packet]] =
+    for {
+      fin       <- Sync[F].delay(new FileInputStream(file.toFile))
+      packetErr <- Sync[F].delay(Packet.parseFrom(fin)).attempt
+      resErr <- packetErr match {
+                 case Left(th) =>
+                   gracefullyClose(fin) *> Left(unabletoRestorePacket(file, th)).pure[F]
+                 case Right(packet) => gracefullyClose(fin) *> Right(packet).pure[F]
+               }
+    } yield resErr
+
+  def gracefullyClose[F[_]: Sync](closable: AutoCloseable): F[Either[Throwable, Unit]] =
+    Sync[F].delay(closable.close).attempt
 
   implicit class RichPacket(packet: Packet) {
-    def store[F[_]: Sync](folder: Path): F[Path] =
-      Sync[F].delay {
-        // FIX-ME proper exception handling
-        val fileName = UUID.randomUUID.toString + "_packet.bts"
-        val file     = folder.resolve(fileName)
-        val fos      = new FileOutputStream(file.toFile)
-        fos.write(packet.toByteArray)
-        fos.flush()
-        fos.close()
-        file
-      }
+    def store[F[_]: Sync](folder: Path): F[CommErr[Path]] =
+      for {
+        fileName <- Sync[F].delay(UUID.randomUUID.toString + "_packet.bts")
+        file     = folder.resolve(fileName)
+        fos      <- Sync[F].delay(new FileOutputStream(file.toFile))
+        orErr <- Sync[F].delay {
+                  fos.write(packet.toByteArray)
+                  fos.flush()
+                }.attempt
+        resErr <- orErr match {
+                   case Left(th) =>
+                     gracefullyClose(fos) *> Left(unableToStorePacket(packet, th)).pure[F]
+                   case Right(_) =>
+                     gracefullyClose(fos) map {
+                       case Left(th) => Left(unableToStorePacket(packet, th))
+                       case Right(_) => Right(file)
+                     }
+                 }
+      } yield resErr
   }
-
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -216,12 +216,12 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
               case Left(error) => log.error(s"Error while streaming packet, error: $error")
               case Right(_)    => Task.unit
             }
-            .flatMap(kp(Task.delay {
-              if (path.toFile.exists)
-                path.toFile.delete
-            }))
         case Left(error) => log.error(s"Error while streaming packet, error: $error")
-      }
+      } >>=
+        (kp(Task.delay {
+          if (path.toFile.exists)
+            path.toFile.delete
+        }))
   }
 
   private def initQueue(

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -18,7 +18,7 @@ import coop.rchain.comm.protocol.routing.RoutingGrpcMonix.TransportLayerStub
 import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.shared._
 import coop.rchain.shared.Compression._
-
+import java.nio.file._
 import io.grpc._
 import io.grpc.netty._
 import io.netty.handler.ssl._
@@ -26,7 +26,7 @@ import monix.eval._
 import monix.execution._
 import monix.reactive._
 
-class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: Int)(
+class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: Int, tempFolder: Path)(
     implicit scheduler: Scheduler,
     log: Log[Task],
     connectionsCache: ConnectionsCache[Task, TcpConnTag]
@@ -40,7 +40,7 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
   private def certInputStream = new ByteArrayInputStream(cert.getBytes())
   private def keyInputStream  = new ByteArrayInputStream(key.getBytes())
 
-  private val streamObservable = new StreamObservable(100)
+  private val streamObservable = new StreamObservable(100, tempFolder)
 
   import connections.cell
 
@@ -205,12 +205,20 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
     innerBroadcast(peers, msg)
 
   def handleToStream: ToStream => Task[Unit] = {
-    case ToStream(peer, blob) =>
-      withClient(peer, enforce = false) { stub =>
-        stub.stream(Observable.fromIterator(chunkIt(blob)))
-      }.attempt.flatMap {
-        case Left(error) => log.debug(s"Error while streaming packet, error: $error")
-        case Right(_)    => Task.unit
+    case ToStream(peer, path, sender) =>
+      PacketOps.restore[Task](path) >>= { packet =>
+        withClient(peer, enforce = false) { stub =>
+          val blob = Blob(sender, packet)
+          stub.stream(Observable.fromIterator(chunkIt(blob)))
+        }.attempt
+          .flatMap {
+            case Left(error) => log.debug(s"Error while streaming packet, error: $error")
+            case Right(_)    => Task.unit
+          }
+          .flatMap(kp(Task.delay {
+            if (path.toFile.exists)
+              path.toFile.delete
+          }))
       }
   }
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
@@ -19,7 +19,6 @@ class PacketStoreRestoreSpec
     with BeforeAndAfterEach
     with GeneratorDrivenPropertyChecks {
 
-
   import PacketOps._
 
   var tempFolder: Path = null
@@ -36,8 +35,8 @@ class PacketStoreRestoreSpec
         // given
         val packet = Packet(BlockMessage.id, ByteString.copyFrom(content))
         // when
-        val storedIn = packet.store[Id](tempFolder)
-        val restored = PacketOps.restore[Id](storedIn)
+        val storedIn = packet.store[Id](tempFolder).right.get
+        val restored = PacketOps.restore[Id](storedIn).right.get
         // then
         storedIn.toFile.exists() shouldBe (true)
         storedIn.getParent shouldBe (tempFolder)

--- a/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
@@ -1,0 +1,54 @@
+package coop.rchain.comm.transport
+
+import org.scalatest._
+import java.io.File
+import java.nio.file._
+import coop.rchain.comm._, CommError.CommErr
+import coop.rchain.comm.rp.ProtocolHelper
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.comm.protocol.routing._
+import com.google.protobuf.ByteString
+import cats.effect.Sync
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scala.util.Random
+
+class PacketStoreRestoreSpec
+    extends FunSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with GeneratorDrivenPropertyChecks {
+
+
+  import PacketOps._
+
+  var tempFolder: Path = null
+
+  override def beforeEach(): Unit =
+    tempFolder = Files.createTempDirectory("rchain")
+
+  override def afterEach(): Unit =
+    tempFolder.toFile.delete()
+
+  describe("Packet store & restore") {
+    it("should store and restore to the original Packet") {
+      forAll(contentGen) { content: Array[Byte] =>
+        // given
+        val packet = Packet(BlockMessage.id, ByteString.copyFrom(content))
+        // when
+        val storedIn = packet.store[Id](tempFolder)
+        val restored = PacketOps.restore[Id](storedIn)
+        // then
+        storedIn.toFile.exists() shouldBe (true)
+        storedIn.getParent shouldBe (tempFolder)
+        packet shouldBe (restored)
+      }
+    }
+  }
+
+  val contentGen =
+    for (n <- Gen.choose(10, 50000))
+      yield Array.fill(n)((Random.nextInt(256) - 128).toByte)
+
+  implicit val syncId: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+}

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -6,15 +6,26 @@ import coop.rchain.comm._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.util.{CertificateHelper, CertificatePrinter}
 import coop.rchain.shared.Log
-
+import java.nio.file._
 import monix.catnap.MVar
 import monix.eval.Task
 import monix.execution.Scheduler
+import org.scalatest._
 
-class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] {
+class TcpTransportLayerSpec
+    extends TransportLayerSpec[Task, TcpTlsEnvironment]
+    with BeforeAndAfterEach {
 
   implicit val log: Log[Task]       = new Log.NOPLog[Task]
   implicit val scheduler: Scheduler = Scheduler.Implicits.global
+
+  var tempFolder: Path = null
+
+  override def beforeEach(): Unit =
+    tempFolder = Files.createTempDirectory("rchain")
+
+  override def afterEach(): Unit =
+    tempFolder.toFile.delete()
 
   def createEnvironment(port: Int): Task[TcpTlsEnvironment] =
     Task.delay {
@@ -32,7 +43,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
 
   def createTransportLayer(env: TcpTlsEnvironment): Task[TransportLayer[Task]] =
     CachedConnections[Task, TcpConnTag].map { implicit cache =>
-      new TcpTransportLayer(env.port, env.cert, env.key, 4 * 1024 * 1024)
+      new TcpTransportLayer(env.port, env.cert, env.key, 4 * 1024 * 1024, tempFolder)
     }
 
   def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -309,7 +309,7 @@ class NodeRuntime private[node] (
       conf.tls.certificate,
       conf.tls.key,
       conf.server.maxMessageSize,
-      conf.server.dataDir.resolve("comm-temporary/")
+      conf.server.dataDir.resolve("tmp").resolve("comm")
     )(grpcScheduler, log, tcpConnections)
     kademliaRPC = effects.kademliaRPC(kademliaPort, defaultTimeout)(
       grpcScheduler,

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -9,7 +9,6 @@ import cats.effect.concurrent.Ref
 import cats.syntax.applicative._
 import cats.syntax.apply._
 import cats.syntax.functor._
-
 import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.blockstorage.{BlockStore, InMemBlockStore}
 import coop.rchain.casper._
@@ -310,7 +309,7 @@ class NodeRuntime private[node] (
       conf.tls.certificate,
       conf.tls.key,
       conf.server.maxMessageSize,
-      FileSystems.getDefault().getPath(conf.storagePath, "comm-temporary")
+      conf.server.dataDir.resolve("comm-temporary/")
     )(grpcScheduler, log, tcpConnections)
     kademliaRPC = effects.kademliaRPC(kademliaPort, defaultTimeout)(
       grpcScheduler,

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -309,7 +309,8 @@ class NodeRuntime private[node] (
       port,
       conf.tls.certificate,
       conf.tls.key,
-      conf.server.maxMessageSize
+      conf.server.maxMessageSize,
+      FileSystems.getDefault().getPath(conf.storagePath, "comm-temporary")
     )(grpcScheduler, log, tcpConnections)
     kademliaRPC = effects.kademliaRPC(kademliaPort, defaultTimeout)(
       grpcScheduler,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -57,7 +57,8 @@ package object effects {
       port: Int,
       certPath: Path,
       keyPath: Path,
-      maxMessageSize: Int
+      maxMessageSize: Int,
+      folder: Path
   )(
       implicit scheduler: Scheduler,
       log: Log[Task],
@@ -65,7 +66,7 @@ package object effects {
   ): TcpTransportLayer = {
     val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
     val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
-    new TcpTransportLayer(port, cert, key, maxMessageSize)
+    new TcpTransportLayer(port, cert, key, maxMessageSize, folder)
   }
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)


### PR DESCRIPTION
## Overview
In order to not get OOME, all messages that are accepted by client queue (see CORE-1383 ) need to be stored on file system. 
In this PR we are storing every single message to disk. We can potentially store messages which are bigger then some significant size (e.g 1MB). This way we know that memory will not explode, the queue will stay not bigger thne queue_size x max_message_size (for queue of 1024 elements, and max message size 1mb the memory footprint will be ~1GB)

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1417