### PR TITLE
Ops-365 Integration tests: Ditch f-strings so that Python 3.5 can be used

### DIFF
--- a/integration-testing/rnode_testing/casper_propose_and_deploy.py
+++ b/integration-testing/rnode_testing/casper_propose_and_deploy.py
@@ -7,7 +7,7 @@ from shutil import copyfile
 
 
 def mk_expected_string(node, i, random_token):
-    return "<{node.container.name}:{i}:{random_token}>".format(name=node.container.name, i=i, random_token=random_token)
+    return "<{name}:{i}:{random_token}>".format(name=node.container.name, i=i, random_token=random_token)
 
 
 def deploy_block(i, node, expected_string, contract_name):

--- a/integration-testing/rnode_testing/casper_propose_and_deploy.py
+++ b/integration-testing/rnode_testing/casper_propose_and_deploy.py
@@ -11,7 +11,7 @@ def mk_expected_string(node, i, random_token):
 
 
 def deploy_block(i, node, expected_string, contract_name):
-    logging.info("Expected string: {expected_string}".format(expected_string=expected_string))
+    logging.info("Expected string: {}".format(expected_string))
 
     copyfile(resources.file_path(contract_name, __name__), "{local_deploy_dir}/{contract_name}".format(local_deploy_dir=node.local_deploy_dir, contract_name=contract_name))
 
@@ -30,7 +30,7 @@ def deploy_block(i, node, expected_string, contract_name):
 
 
 def check_blocks(i, node, expected_string):
-    logging.info("Check all peer logs for blocks containing {expected_string}".format(expected_string=expected_string))
+    logging.info("Check all peer logs for blocks containing {}".format(expected_string))
 
     other_nodes = [n
                     for n in network.nodes
@@ -54,7 +54,7 @@ def run(config, network):
     contract_name = 'contract.rho'
 
     for node in network.nodes:
-        with log_box(logging.info, "Run test on node '{name}'".format(name=node.name)):
+        with log_box(logging.info, "Run test on node '{}'".format(node.name)):
             random_token = random_string(token_size)
 
             for i in range(0, config.blocks):

--- a/integration-testing/rnode_testing/casper_propose_and_deploy.py
+++ b/integration-testing/rnode_testing/casper_propose_and_deploy.py
@@ -7,28 +7,30 @@ from shutil import copyfile
 
 
 def mk_expected_string(node, i, random_token):
-    return f"<{node.container.name}:{i}:{random_token}>"
+    return "<{node.container.name}:{i}:{random_token}>".format(name=node.container.name, i=i, random_token=random_token)
 
 
 def deploy_block(i, node, expected_string, contract_name):
-    logging.info(f"Expected string: {expected_string}")
+    logging.info("Expected string: {expected_string}".format(expected_string=expected_string))
 
-    copyfile(resources.file_path(contract_name, __name__), f"{node.local_deploy_dir}/{contract_name}")
+    copyfile(resources.file_path(contract_name, __name__), "{local_deploy_dir}/{contract_name}".format(local_deploy_dir=node.local_deploy_dir, contract_name=contract_name))
 
-    exit_code, output = node.exec_run(f"sed -i -e 's/@placeholder@/{expected_string}/g' {node.remote_deploy_dir}/{contract_name}")
-    logging.debug(f"Sed result: {exit_code}, output: {output}")
+    exit_code, output = node.exec_run(
+        "sed -i -e 's/@placeholder@/{expected_string}/g' {remote_deploy_dir}/{contract_name}".format(
+            expected_string=expected_string, remote_deploy_dir=node.remote_deploy_dir,contract_name=contract_name))
+    logging.debug("Sed result: {exit_code}, output: {output}".format(exit_code=exit_code, output=output))
 
     exit_code, output = node.deploy_contract(contract_name)
-    logging.debug(f"Deploy result: {exit_code}, output: {output}")
+    logging.debug("Deploy result: {exit_code}, output: {output}".format(exit_code=exit_code, output=output))
 
     logging.info("Propose to blockchain previously deployed smart contracts.")
 
     exit_code, output = node.propose_contract()
-    logging.debug(f"Propose result: {exit_code}, output: {output}")
+    logging.debug("Propose result: {exit_code}, output: {output}".format(exit_code=exit_code, output=output))
 
 
 def check_blocks(i, node, expected_string):
-    logging.info(f"Check all peer logs for blocks containing {expected_string}")
+    logging.info("Check all peer logs for blocks containing {expected_string}".format(expected_string=expected_string))
 
     other_nodes = [n
                     for n in network.nodes
@@ -37,9 +39,9 @@ def check_blocks(i, node, expected_string):
     for node in other_nodes:
         wait_for(string_contains(show_blocks(node), expected_string),
                     config.receive_timeout,
-                    f"Container: {node.container.name}: String {expected_string} NOT found in blocks added.")
+                    "Container: {name}: String {expected_string} NOT found in blocks added.".format(name=node.container.name, expected_string=expected_string))
 
-        logging.info(f"Container: {node.container.name}: block {i} : SUCCESS!")
+        logging.info("Container: {name}: block {i} : SUCCESS!".format(name=node.container.name, i=i))
 
 
 def run(config, network):
@@ -52,7 +54,7 @@ def run(config, network):
     contract_name = 'contract.rho'
 
     for node in network.nodes:
-        with log_box(logging.info, f"Run test on node '{node.name}'"):
+        with log_box(logging.info, "Run test on node '{name}'".format(name=node.name)):
             random_token = random_string(token_size)
 
             for i in range(0, config.blocks):

--- a/integration-testing/rnode_testing/docker.py
+++ b/integration-testing/rnode_testing/docker.py
@@ -13,7 +13,7 @@ def run_cmd(docker_container, cmd):
 
 
 def list_containers(docker_client, network):
-    return docker_client.containers.list(all=True, filters={"name": ".{network}".format(network=network)})
+    return docker_client.containers.list(all=True, filters={"name": ".{}".format(network)})
 
 
 @contextmanager

--- a/integration-testing/rnode_testing/docker.py
+++ b/integration-testing/rnode_testing/docker.py
@@ -4,21 +4,21 @@ import rnode_testing.random
 
 
 def run_cmd(docker_container, cmd):
-    logging.info(f"{docker_container.name}: Execute <{cmd}>")
+    logging.info("{name}: Execute <{cmd}>".format(name=docker_container.name, cmd=cmd))
     r = docker_container.exec_run(['sh', '-c', cmd])
     output = r.output.decode('utf-8')
 
-    logging.info(f"{docker_container.name}: Finish <{cmd}>. Exit Code: {r.exit_code}")
+    logging.info("{name}: Finish <{cmd}>. Exit Code: {exit_code}".format(name=docker_container.name, cmd=cmd, exit_code=r.exit_code))
     return (r.exit_code, output)
 
 
 def list_containers(docker_client, network):
-    return docker_client.containers.list(all=True, filters={"name": f".{network}"})
+    return docker_client.containers.list(all=True, filters={"name": ".{network}".format(network=network)})
 
 
 @contextmanager
 def docker_network(docker_client):
-    network_name = f"rchain-{rnode_testing.random.random_string(5).lower()}"
+    network_name = "rchain-{random_string}".format(random_string=rnode_testing.random.random_string(5).lower())
 
     docker_client.networks.create(network_name, driver="bridge")
 
@@ -27,5 +27,5 @@ def docker_network(docker_client):
     finally:
         for network in docker_client.networks.list():
             if network_name == network.name:
-                logging.info(f"Removing docker network {network.name}")
+                logging.info("Removing docker network {name}".format(name=network.name))
                 network.remove()

--- a/integration-testing/rnode_testing/docker.py
+++ b/integration-testing/rnode_testing/docker.py
@@ -18,7 +18,7 @@ def list_containers(docker_client, network):
 
 @contextmanager
 def docker_network(docker_client):
-    network_name = "rchain-{random_string}".format(random_string=rnode_testing.random.random_string(5).lower())
+    network_name = "rchain-{}".format(rnode_testing.random.random_string(5).lower())
 
     docker_client.networks.create(network_name, driver="bridge")
 
@@ -27,5 +27,5 @@ def docker_network(docker_client):
     finally:
         for network in docker_client.networks.list():
             if network_name == network.name:
-                logging.info("Removing docker network {name}".format(name=network.name))
+                logging.info("Removing docker network {}".format(network.name))
                 network.remove()

--- a/integration-testing/rnode_testing/fixture.py
+++ b/integration-testing/rnode_testing/fixture.py
@@ -5,11 +5,11 @@ import inspect
 def make_wrapper(fn, fixtures):
     parameter_names = inspect.signature(fn).parameters.keys()
     parameter_list = ",".join(p for p in parameter_names if p != 'request')
-    parameter_name_list = ",".join(f"('{p}', {p})" for p in parameter_names)
+    parameter_name_list = ",".join("('{p}', {p})".format(p=p) for p in parameter_names)
     namespace = {"fn": fn, "fixtures": fixtures}
 
-    wrapper_code = f"""
-def {fn.__name__}(request, {parameter_list}):
+    wrapper_code = """
+def {fn_name}(request, {parameter_list}):
     # import logging
     # logging.info("fixtures:" + str(fixtures))
     def get_value(p_name, p_value):
@@ -22,7 +22,7 @@ def {fn.__name__}(request, {parameter_list}):
             return p_value
     param_values = [get_value(p_name, p_value) for p_name, p_value in [{parameter_name_list}]]
     return fn(*param_values)
-"""
+""".format(fn_name=fn.__name__, parameter_list=parameter_list, parameter_name_list=parameter_name_list)
 
     exec(wrapper_code, locals(), namespace)
     return namespace[fn.__name__]

--- a/integration-testing/rnode_testing/network.py
+++ b/integration-testing/rnode_testing/network.py
@@ -15,7 +15,7 @@ class RChain:
 
 @contextmanager
 def start_network(config, docker, bootstrap, validators_data, allowed_peers=None):
-    logging.debug("Docker network = {network}".format(network=bootstrap.network))
+    logging.debug("Docker network = {}".format(bootstrap.network))
 
     peers = create_peer_nodes(docker, bootstrap, bootstrap.network, validators_data.bonds_file, validators_data.peers_keys, config.rnode_timeout, allowed_peers)
 
@@ -28,7 +28,7 @@ def start_network(config, docker, bootstrap, validators_data, allowed_peers=None
 
 def wait_for_started_network(node_startup_timeout, network):
     for peer in network.peers:
-        wait_for(node_started(peer), node_startup_timeout, "Peer {name} did not start correctly.".format(name=peer.name))
+        wait_for(node_started(peer), node_startup_timeout, "Peer {} did not start correctly.".format(peer.name))
 
 
 def wait_for_converged_network(timeout, network, peer_connections):
@@ -46,7 +46,7 @@ def wait_for_approved_block_received_handler_state(bootstrap_node, node_startup_
     wait_for(
         approved_block_received_handler_state(bootstrap_node),
         node_startup_timeout,
-        "Bootstrap node {name} did not enter ApprovedBlockRecievedHandler state".format(name=bootstrap_node.name),
+        "Bootstrap node {} did not enter ApprovedBlockRecievedHandler state".format(bootstrap_node.name),
     )
 
 

--- a/integration-testing/rnode_testing/network.py
+++ b/integration-testing/rnode_testing/network.py
@@ -15,7 +15,7 @@ class RChain:
 
 @contextmanager
 def start_network(config, docker, bootstrap, validators_data, allowed_peers=None):
-    logging.debug(f"Docker network = {bootstrap.network}")
+    logging.debug("Docker network = {network}".format(network=bootstrap.network))
 
     peers = create_peer_nodes(docker, bootstrap, bootstrap.network, validators_data.bonds_file, validators_data.peers_keys, config.rnode_timeout, allowed_peers)
 
@@ -28,7 +28,7 @@ def start_network(config, docker, bootstrap, validators_data, allowed_peers=None
 
 def wait_for_started_network(node_startup_timeout, network):
     for peer in network.peers:
-        wait_for(node_started(peer), node_startup_timeout, f"Peer {peer.name} did not start correctly.")
+        wait_for(node_started(peer), node_startup_timeout, "Peer {name} did not start correctly.".format(name=peer.name))
 
 
 def wait_for_converged_network(timeout, network, peer_connections):
@@ -46,7 +46,7 @@ def wait_for_approved_block_received_handler_state(bootstrap_node, node_startup_
     wait_for(
         approved_block_received_handler_state(bootstrap_node),
         node_startup_timeout,
-        "Bootstrap node {} did not enter ApprovedBlockRecievedHandler state".format(bootstrap_node.name),
+        "Bootstrap node {name} did not enter ApprovedBlockRecievedHandler state".format(name=bootstrap_node.name),
     )
 
 

--- a/integration-testing/rnode_testing/resources.py
+++ b/integration-testing/rnode_testing/resources.py
@@ -6,9 +6,9 @@ from pathlib import Path
 def file_path(path):
     frame = inspect.stack()[1]
     caller_module = inspect.getmodule(frame[0])
-    base_dir = os.path.realpath(__file__) + f'/../../'
+    base_dir = os.path.realpath(__file__) + '/../../'
     relative_to_base = caller_module.__file__[len(base_dir):]
-    return os.path.realpath(f"resources/{relative_to_base}/{path}")
+    return os.path.realpath("resources/{relative_to_base}/{path}".format(relative_to_base=relative_to_base, path=path))
 
 
 def get_resource_path(relative_path):

--- a/integration-testing/rnode_testing/rnode.py
+++ b/integration-testing/rnode_testing/rnode.py
@@ -15,10 +15,10 @@ DEFAULT_IMAGE = "rchain-integration-testing:latest"
 
 rnode_binary = '/opt/docker/bin/rnode'
 rnode_directory = "/var/lib/rnode"
-rnode_deploy_dir = "{rnode_directory}/deploy".format(rnode_directory=rnode_directory)
-rnode_bonds_file = '{rnode_directory}/genesis/bonds.txt'.format(rnode_directory=rnode_directory)
-rnode_certificate = '{rnode_directory}/node.certificate.pem'.format(rnode_directory=rnode_directory)
-rnode_key = '{rnode_directory}/node.key.pem'.format(rnode_directory=rnode_directory)
+rnode_deploy_dir = "{}/deploy".format(rnode_directory)
+rnode_bonds_file = '{}/genesis/bonds.txt'.format(rnode_directory)
+rnode_certificate = '{}/node.certificate.pem'.format(rnode_directory)
+rnode_key = '{}/node.key.pem'.format(rnode_directory)
 
 
 class InterruptedException(Exception):
@@ -84,7 +84,7 @@ class Node:
                       re.MULTILINE | re.DOTALL)
         address = m[1]
 
-        logging.info("Bootstrap address: `{address}`".format(address=address))
+        logging.info("Bootstrap address: `{}`".format(address))
         return address
 
     def get_metrics(self):
@@ -111,10 +111,10 @@ class Node:
         return self.exec_run(cmd)
 
     def propose_contract(self):
-        return self.exec_run('{rnode_binary} propose'.format(rnode_binary=rnode_binary))
+        return self.exec_run('{} propose'.format(rnode_binary))
 
     def show_blocks(self):
-        return self.exec_run('{rnode_binary} show-blocks'.format(rnode_binary=rnode_binary))
+        return self.exec_run('{} show-blocks'.format(rnode_binary))
 
     def get_blocks_count(self):
         show_blocks_output = self.call_rnode('show-blocks', stderr=False).strip()
@@ -222,10 +222,10 @@ def create_node_container(
     deploy_dir = make_tempdir("rchain-integration-test")
 
     hosts_allow_file_content = \
-        "ALL:ALL" if allowed_peers is None else "\n".join("ALL: {peer}".format(peer=peer) for peer in allowed_peers)
+        "ALL:ALL" if allowed_peers is None else "\n".join("ALL: {}".format(peer) for peer in allowed_peers)
 
-    hosts_allow_file = make_tempfile("hosts-allow-{name}".format(name=name), hosts_allow_file_content)
-    hosts_deny_file = make_tempfile("hosts-deny-{name}".format(name=name), "ALL: ALL")
+    hosts_allow_file = make_tempfile("hosts-allow-{}".format(name), hosts_allow_file_content)
+    hosts_deny_file = make_tempfile("hosts-deny-{}".format(name), "ALL: ALL")
 
     command = make_container_command(container_command, container_command_options)
 
@@ -236,10 +236,10 @@ def create_node_container(
     logging.info('Using _JAVA_OPTIONS: {}'.format(java_options))
 
     volumes = [
-        "{hosts_allow_file}:/etc/hosts.allow".format(hosts_allow_file=hosts_allow_file),
-        "{hosts_deny_file}:/etc/hosts.deny".format(hosts_deny_file=hosts_deny_file),
-        "{bonds_file}:{rnode_bonds_file}".format(bonds_file=bonds_file, rnode_bonds_file=rnode_bonds_file),
-        "{deploy_dir}:{rnode_deploy_dir}".format(deploy_dir=deploy_dir,rnode_deploy_dir=rnode_deploy_dir),
+        "{}:/etc/hosts.allow".format(hosts_allow_file),
+        "{}:/etc/hosts.deny".format(hosts_deny_file),
+        "{}:{}".format(bonds_file, rnode_bonds_file),
+        "{}:{}".format(deploy_dir, rnode_deploy_dir),
     ]
 
     container = docker_client.containers.run(
@@ -276,7 +276,7 @@ def create_bootstrap_node(
 
     logging.info("Using key_file={key_file} and cert_file={cert_file}".format(key_file=key_file, cert_file=cert_file))
 
-    name = "bootstrap.{network}".format(network=network)
+    name = "bootstrap.{}".format(network)
     container_command_options = {
         "--port":                   40400,
         "--standalone":             "",
@@ -286,8 +286,8 @@ def create_bootstrap_node(
     }
 
     volumes = [
-        "{cert_file}:{rnode_certificate}".format(cert_file=cert_file, rnode_certificate=rnode_certificate),
-        "{key_file}:{rnode_key}".format(key_file=key_file, rnode_key=rnode_key)
+        "{}:{}".format(cert_file, rnode_certificate),
+        "{}:{}".format(key_file, rnode_key)
     ]
 
     container = create_node_container(

--- a/integration-testing/rnode_testing/util.py
+++ b/integration-testing/rnode_testing/util.py
@@ -6,7 +6,7 @@ import collections
 
 @contextlib.contextmanager
 def log_box(log_function, title="", char="*", length=150):
-    full_title = f" {title} " if title else ""
+    full_title = " {title} ".format(title=title) if title else ""
     title_stars_len = int((length - len(full_title)) / 2)
     title_stars = char * title_stars_len
     log_function(title_stars + full_title + title_stars)

--- a/integration-testing/rnode_testing/util.py
+++ b/integration-testing/rnode_testing/util.py
@@ -6,7 +6,7 @@ import collections
 
 @contextlib.contextmanager
 def log_box(log_function, title="", char="*", length=150):
-    full_title = " {title} ".format(title=title) if title else ""
+    full_title = " {} ".format(title) if title else ""
     title_stars_len = int((length - len(full_title)) / 2)
     title_stars = char * title_stars_len
     log_function(title_stars + full_title + title_stars)

--- a/integration-testing/rnode_testing/wait.py
+++ b/integration-testing/rnode_testing/wait.py
@@ -14,8 +14,8 @@ def wait_for(condition, timeout, error_message):
     :return: true  if the condition was met in the given timeout
     """
 
-    with log_box(logging.info, "Waiting maximum timeout={timeout}. Patience please!".format(timeout=timeout), "."):
-        logging.info("Wait condition is: `{condition}`".format(condition=condition.__doc__))
+    with log_box(logging.info, "Waiting maximum timeout={}. Patience please!".format(timeout), "."):
+        logging.info("Wait condition is: `{}`".format(condition.__doc__))
         elapsed = 0
         current_ex = None
         while elapsed < timeout:
@@ -49,7 +49,7 @@ def wait_for(condition, timeout, error_message):
                 time.sleep(iteration_duration)
                 elapsed = elapsed + iteration_duration
 
-        logging.warning("Giving up after {elapsed}s.".format(elapsed=elapsed))
+        logging.warning("Giving up after {}s.".format(elapsed))
         pytest.fail(error_message)
 
 
@@ -60,7 +60,7 @@ def wait_for(condition, timeout, error_message):
 
 def node_logs(node):
     def go(): return node.logs()
-    go.__doc__ = "node_logs({name})".format(name=node.name)
+    go.__doc__ = "node_logs({})".format(node.name)
     return go
 
 
@@ -73,7 +73,7 @@ def show_blocks(node):
 
         return output
 
-    go.__doc__ = "show_blocks({name})".format(name=node.name)
+    go.__doc__ = "show_blocks({})".format(node.name)
     return go
 
 

--- a/integration-testing/rnode_testing/wait.py
+++ b/integration-testing/rnode_testing/wait.py
@@ -14,8 +14,8 @@ def wait_for(condition, timeout, error_message):
     :return: true  if the condition was met in the given timeout
     """
 
-    with log_box(logging.info, f"Waiting maximum timeout={timeout}. Patience please!", "."):
-        logging.info(f"Wait condition is: `{condition.__doc__}`")
+    with log_box(logging.info, "Waiting maximum timeout={timeout}. Patience please!".format(timeout=timeout), "."):
+        logging.info("Wait condition is: `{condition}`".format(condition=condition.__doc__))
         elapsed = 0
         current_ex = None
         while elapsed < timeout:
@@ -24,7 +24,7 @@ def wait_for(condition, timeout, error_message):
             try:
                 value = condition()
 
-                logging.info(f"Condition satisfied after {elapsed}s. Returning {value}")
+                logging.info("Condition satisfied after {elapsed}s. Returning {value}".format(elapsed=elapsed, value=value))
                 return value
 
             except Exception as ex:
@@ -42,12 +42,14 @@ def wait_for(condition, timeout, error_message):
                     details = str(ex)
                     current_ex = str(ex)
 
-                logging.info(f"Condition not satisfied yet ({details}). Time left: {time_left}s. Sleeping {iteration_duration}s...")
+                logging.info("Condition not satisfied yet ({details}). Time left: {time_left}s. Sleeping {iteration_duration}s...".format(
+                    details=details, time_left=time_left, iteration_duration=iteration_duration)
+                )
 
                 time.sleep(iteration_duration)
                 elapsed = elapsed + iteration_duration
 
-        logging.warning(f"Giving up after {elapsed}s.")
+        logging.warning("Giving up after {elapsed}s.".format(elapsed=elapsed))
         pytest.fail(error_message)
 
 
@@ -58,7 +60,7 @@ def wait_for(condition, timeout, error_message):
 
 def node_logs(node):
     def go(): return node.logs()
-    go.__doc__ = f"node_logs({node.name})"
+    go.__doc__ = "node_logs({name})".format(name=node.name)
     return go
 
 
@@ -71,7 +73,7 @@ def show_blocks(node):
 
         return output
 
-    go.__doc__ = f"show_blocks({node.name})"
+    go.__doc__ = "show_blocks({name})".format(name=node.name)
     return go
 
 
@@ -85,9 +87,11 @@ def string_contains(string_factory, regex_str, flags=0):
         if m:
             return m
         else:
-            raise Exception(f"{string_factory.__doc__} doesn't contain regex '{regex_str}'")
+            raise Exception("{string_factory} doesn't contain regex '{regex_str}'".format(
+                string_factory=string_factory.__doc__, regex_str=regex_str)
+            )
 
-    go.__doc__ = f"{string_factory.__doc__} contains regex '{regex_str}'"
+    go.__doc__ = "{string_factory} contains regex '{regex_str}'".format(string_factory=string_factory.__doc__, regex_str=regex_str)
     return go
 
 
@@ -102,9 +106,9 @@ def has_peers(bootstrap_node, expected_peers):
         peers = int(m[1]) if m else 0
 
         if peers < expected_peers:
-            raise Exception(f"Expected peers: {expected_peers}. Actual peers: {peers}")
+            raise Exception("Expected peers: {expected_peers}. Actual peers: {peers}".format(expected_peers=expected_peers, peers=peers))
 
-    go.__doc__ = f"Node {bootstrap_node.name} is connected to {expected_peers} peers."
+    go.__doc__ = "Node {name} is connected to {expected_peers} peers.".format(name=bootstrap_node.name, expected_peers=expected_peers)
 
     return go
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -58,7 +58,7 @@ def make_test_config(request):
 
     with log_box(logging.info):
         s = pprint.pformat(dict(config._asdict()), indent=4)
-        logging.info("Running with test configuration: {s}".format(s=s))
+        logging.info("Running with test configuration: {}".format(s))
 
     return config
 
@@ -70,7 +70,7 @@ def temporary_bonds_file(validator_keys):
         with os.fdopen(fd, "w") as f:
             for pair in validator_keys:
                 bond = random.randint(1, 100)
-                f.write("{public_key} {bond}\n".format(public_key=pair.public_key, bond=bond))
+                f.write("{} {}\n".format(pair.public_key, bond))
         yield file
     finally:
         os.unlink(file)

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -58,7 +58,7 @@ def make_test_config(request):
 
     with log_box(logging.info):
         s = pprint.pformat(dict(config._asdict()), indent=4)
-        logging.info(f"Running with test configuration: {s}")
+        logging.info("Running with test configuration: {s}".format(s=s))
 
     return config
 
@@ -70,7 +70,7 @@ def temporary_bonds_file(validator_keys):
         with os.fdopen(fd, "w") as f:
             for pair in validator_keys:
                 bond = random.randint(1, 100)
-                f.write(f"{pair.public_key} {bond}\n")
+                f.write("{public_key} {bond}\n".format(public_key=pair.public_key, bond=bond))
         yield file
     finally:
         os.unlink(file)

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -54,7 +54,7 @@ def complete_network(system):
 @profile
 def test_metrics_api_socket(complete_network):
     for node  in complete_network.nodes:
-        logging.info("Test metrics api socket for {name}".format(name=node.name))
+        logging.info("Test metrics api socket for {}".format(node.name))
         exit_code, output = node.get_metrics()
         expect(exit_code == 0, "Could not get the metrics for node {node.name}")
 
@@ -64,13 +64,13 @@ def test_metrics_api_socket(complete_network):
 @profile
 def test_node_logs_for_errors(complete_network):
     for node in complete_network.nodes:
-        logging.info("Testing {name} node logs for errors.".format(name=node.name))
+        logging.info("Testing {} node logs for errors.".format(node.name))
         logs = node.logs()
 
         if "ERROR" in logs:
             for line in logs.splitlines():
                 if "ERROR" in line:
-                    logging.error("Error: {line}".format(line=line))
+                    logging.error("Error: {}".format(line))
             expect(not "ERROR" in line, "Node {name} error in log line: {line}".format(name=node.name, line=line))
 
     assert_expectations()
@@ -78,14 +78,14 @@ def test_node_logs_for_errors(complete_network):
 @profile
 def test_node_logs_for_RuntimeException(complete_network):
     for node in complete_network.nodes:
-        logging.info("Testing {name} node logs for \"java RuntimeException\".".format(name=node.name))
+        logging.info("Testing {} node logs for \"java RuntimeException\".".format(node.name))
         logs = node.logs()
 
 
         if "RuntimeException" in logs:
             for line in logs.splitlines():
                 if "RuntimeException" in line:
-                    logging.error("Error: {line}".format(line=line))
+                    logging.error("Error: {}".format(line))
             expect(not "RuntimeException" in line, "Node {name} error in log line: {line}".format(name=node.name, line=line))
 
     assert_expectations()

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -54,7 +54,7 @@ def complete_network(system):
 @profile
 def test_metrics_api_socket(complete_network):
     for node  in complete_network.nodes:
-        logging.info(f"Test metrics api socket for {node.name}")
+        logging.info("Test metrics api socket for {name}".format(name=node.name))
         exit_code, output = node.get_metrics()
         expect(exit_code == 0, "Could not get the metrics for node {node.name}")
 
@@ -64,29 +64,29 @@ def test_metrics_api_socket(complete_network):
 @profile
 def test_node_logs_for_errors(complete_network):
     for node in complete_network.nodes:
-        logging.info(f"Testing {node.name} node logs for errors.")
+        logging.info("Testing {name} node logs for errors.".format(node.name))
         logs = node.logs()
 
         if "ERROR" in logs:
             for line in logs.splitlines():
                 if "ERROR" in line:
-                    logging.error(f"Error: {line}")
-            expect(not "ERROR" in line, f"Node {node.name} error in log line: {line}")
+                    logging.error("Error: {line}".format(line=line))
+            expect(not "ERROR" in line, "Node {name} error in log line: {line}".format(name=node.name, line=line))
 
     assert_expectations()
 
 @profile
 def test_node_logs_for_RuntimeException(complete_network):
     for node in complete_network.nodes:
-        logging.info(f"Testing {node.name} node logs for \"java RuntimeException\".")
+        logging.info("Testing {name} node logs for \"java RuntimeException\".".format(name=node.name))
         logs = node.logs()
 
 
         if "RuntimeException" in logs:
             for line in logs.splitlines():
                 if "RuntimeException" in line:
-                    logging.error(f"Error: {line}")
-            expect(not "RuntimeException" in line, f"Node {node.name} error in log line: {line}")
+                    logging.error("Error: {line}".format(line=line))
+            expect(not "RuntimeException" in line, "Node {name} error in log line: {line}".format(name=node.name, line=line))
 
     assert_expectations()
 

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -64,7 +64,7 @@ def test_metrics_api_socket(complete_network):
 @profile
 def test_node_logs_for_errors(complete_network):
     for node in complete_network.nodes:
-        logging.info("Testing {name} node logs for errors.".format(node.name))
+        logging.info("Testing {name} node logs for errors.".format(name=node.name))
         logs = node.logs()
 
         if "ERROR" in logs:

--- a/integration-testing/test/test_repl.py
+++ b/integration-testing/test/test_repl.py
@@ -7,7 +7,7 @@ def without_banner_and_prompt(input, output):
     banner_and_prompt = '\x1b[31m\n  ╦═╗┌─┐┬ ┬┌─┐┬┌┐┌  ╔╗╔┌─┐┌┬┐┌─┐  ╦═╗╔═╗╔═╗╦  \n  ╠╦╝│  ├─┤├─┤││││  ║║║│ │ ││├┤   ╠╦╝║╣ ╠═╝║  \n  ╩╚═└─┘┴ ┴┴ ┴┴┘└┘  ╝╚╝└─┘─┴┘└─┘  ╩╚═╚═╝╩  ╩═╝\n    \x1b[0m\n\x1b[32mrholang $ '
     assert output.startswith(banner_and_prompt)
     without_banner_and_prompt = output[len(banner_and_prompt):]
-    colored_input = '\x1b[0m{input}\n'.format(input=input)
+    colored_input = '\x1b[0m{}\n'.format(input)
     assert without_banner_and_prompt.startswith(colored_input)
     return without_banner_and_prompt[len(colored_input):]
 

--- a/integration-testing/test/test_repl.py
+++ b/integration-testing/test/test_repl.py
@@ -7,7 +7,7 @@ def without_banner_and_prompt(input, output):
     banner_and_prompt = '\x1b[31m\n  ╦═╗┌─┐┬ ┬┌─┐┬┌┐┌  ╔╗╔┌─┐┌┬┐┌─┐  ╦═╗╔═╗╔═╗╦  \n  ╠╦╝│  ├─┤├─┤││││  ║║║│ │ ││├┤   ╠╦╝║╣ ╠═╝║  \n  ╩╚═└─┘┴ ┴┴ ┴┴┘└┘  ╝╚╝└─┘─┴┘└─┘  ╩╚═╚═╝╩  ╩═╝\n    \x1b[0m\n\x1b[32mrholang $ '
     assert output.startswith(banner_and_prompt)
     without_banner_and_prompt = output[len(banner_and_prompt):]
-    colored_input = f'\x1b[0m{input}\n'
+    colored_input = '\x1b[0m{input}\n'.format(input=input)
     assert without_banner_and_prompt.startswith(colored_input)
     return without_banner_and_prompt[len(colored_input):]
 


### PR DESCRIPTION
## Overview
Ditch f-strings so that Python 3.5 can be used

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/OPS-365

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
- [x] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
