### PR TITLE
CORE-1463 When storing packet, we should create folder if does not exist

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -28,6 +28,7 @@ object PacketOps {
   implicit class RichPacket(packet: Packet) {
     def store[F[_]: Sync](folder: Path): F[CommErr[Path]] =
       for {
+        _        <- Sync[F].delay(folder.toFile.mkdirs())
         fileName <- Sync[F].delay(UUID.randomUUID.toString + "_packet.bts")
         file     = folder.resolve(fileName)
         fos      <- Sync[F].delay(new FileOutputStream(file.toFile))

--- a/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
@@ -33,13 +33,14 @@ class PacketStoreRestoreSpec
     it("should store and restore to the original Packet") {
       forAll(contentGen) { content: Array[Byte] =>
         // given
+        val parent = tempFolder.resolve("inner").resolve("folder")
         val packet = Packet(BlockMessage.id, ByteString.copyFrom(content))
         // when
-        val storedIn = packet.store[Id](tempFolder).right.get
+        val storedIn = packet.store[Id](parent).right.get
         val restored = PacketOps.restore[Id](storedIn).right.get
         // then
         storedIn.toFile.exists() shouldBe (true)
-        storedIn.getParent shouldBe (tempFolder)
+        storedIn.getParent shouldBe (parent)
         packet shouldBe (restored)
       }
     }


### PR DESCRIPTION
## Overview
When storing packet, we should create folder if does not exist

There is a separate issue that we have to deal with: this code was throwing errors which got ignored (running on a separate thread). For that I've created separate ticket CORE-1464

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1463