### PR TITLE
Revert to use coarser grained locking for addBlock

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -26,6 +26,7 @@ import coop.rchain.catscontrib.TaskContrib._
 
 import scala.collection.immutable.HashSet
 import scala.collection.mutable
+import scala.concurrent.SyncVar
 
 class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk](
     runtimeManager: RuntimeManager,
@@ -68,43 +69,15 @@ class MultiParentCasperImpl[F[_]: Sync: Capture: ConnectionsCell: TransportLayer
   private val faultToleranceThreshold         = 0f
   private val lastFinalizedBlockHashContainer = Ref.unsafe[F, BlockHash](genesis.blockHash)
 
-  private val processingBlocks = new AtomicSyncVar(Set.empty[BlockHash])
+  private val processingBlock          = new SyncVar[Unit]()
+  private val PROCESSING_BLOCK_TIMEOUT = 5 * 60 * 1000L
+  processingBlock.put(())
 
   def addBlock(b: BlockMessage): F[BlockStatus] =
     for {
-      acquire <- Capture[F].capture {
-                  processingBlocks.mapAndUpdate[(Set[BlockHash], Boolean)](
-                    blocks => {
-                      if (blocks.contains(b.blockHash)) blocks -> false
-                      else blocks                              -> true
-                    }, {
-                      case (blocks, false) => blocks
-                      case (blocks, true)  => blocks + b.blockHash
-                    }
-                  )
-                }
-      result <- acquire match {
-                 case Right((_, false)) =>
-                   Log[F]
-                     .info(
-                       s"Block ${PrettyPrinter.buildString(b.blockHash)} is already being processed by another thread."
-                     )
-                     .map(_ => BlockStatus.processing)
-                 case Right((_, true)) =>
-                   Log[F]
-                     .info(
-                       s"Block ${PrettyPrinter.buildString(b.blockHash)} is now processing."
-                     ) *> internalAddBlock(b).flatMap(
-                     status =>
-                       Capture[F].capture { processingBlocks.update(_ - b.blockHash); status }
-                   )
-                 case Left(ex) =>
-                   Log[F]
-                     .warn(
-                       s"Block ${PrettyPrinter.buildString(b.blockHash)} encountered an exception during processing: ${ex.getMessage}"
-                     )
-                     .map(_ => BlockStatus.exception(ex))
-               }
+      _      <- Sync[F].delay(processingBlock.take(PROCESSING_BLOCK_TIMEOUT))
+      result <- internalAddBlock(b)
+      _      <- Sync[F].delay(processingBlock.put(()))
     } yield result
 
   def internalAddBlock(b: BlockMessage): F[BlockStatus] =

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -67,7 +67,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     node.tearDown()
   }
 
-  it should "not allow multiple threads to process the same block" in {
+  it should "not allow multiple threads to process the same block" ignore {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
     val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler)
     val casper    = node.casperEff
@@ -127,7 +127,6 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     val logMessages = List(
       "Received Deploy",
-      "Block",
       "Attempting to add Block",
       "Sent Block #1",
       "Added",

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -67,7 +67,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     node.tearDown()
   }
 
-  it should "not allow multiple threads to process the same block" ignore {
+  it should "not allow multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
     val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler)
     val casper    = node.casperEff


### PR DESCRIPTION
In theory, addBlock can be called with multiple threads
if they are processing different blocks but there seems
to be some evidence that this locking algorithm isn't working.

See https://rchain.atlassian.net/projects/CORE/issues/CORE-1454