### PR TITLE
Dont mix channel and name

### DIFF
--- a/docs/rholang/rholangtut.md
+++ b/docs/rholang/rholangtut.md
@@ -17,7 +17,7 @@ There is not an IDE for Rholang. Get started with Rholang by selecting one of th
 Rholang has two kinds of values: processes and names.
 
 ### Names
-A name represents a communication channel. You can sent messages to a name or you can receive a message from a name. 
+A name represents a communication channel. You can send messages to a name or you can receive a message from a name. 
 
 The names are created with the construct
  
@@ -31,9 +31,9 @@ If rholang is running on the blockchain, the messages sent on this channel will 
 
 We sometimes use the term "unforgeable" to describe these names when we want to emphasize the inability to construct them from bits.
 
-Receiving messages over a channel is done using the `for` construction
+Receiving messages over a name is done using the `for` construction
 
-    for( x <- channel1, y <- channel2) {
+    for( x <- name1, y <- name2) {
     ...
     }
 


### PR DESCRIPTION
SIMPLE CHANGE TO TUTORIAL
At least in the tutorial. Keeping terminology minimal and 100% clear helps a lot.