### PR TITLE
CORE-1438: Open some JDK modules in startup script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,6 +199,34 @@ lazy val node = (project in file("node"))
         val oldStrategy = (assemblyMergeStrategy in assembly).value
         oldStrategy(x)
     },
+    /*
+     * This monstrosity exists because
+     * a) we want to get rid of annoying JVM >= 9 warnings,
+     * b) we must support Java 8 for RedHat (see below) and
+     * c) sbt-native-packager puts bashScriptExtraDefines before it
+     *    initializes all useful variables (like $java_version).
+     *
+     * This won't work if someone passes -no-version-check command line
+     * argument to rnode. They most probably know what they're doing.
+     *
+     * https://unix.stackexchange.com/a/29742/124070
+     * Thanks Gilles!
+     */
+    bashScriptExtraDefines += """
+      eval "original_$(declare -f java_version_check)"
+      java_version_check() {
+        original_java_version_check
+        if [[ ${java_version%%.*} -ge 9 ]]; then
+          java_args+=(
+            --illegal-access=warn # set to deny if you feel brave
+            --add-opens=java.base/java.nio=ALL-UNNAMED
+            --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens=java.base/sun.security.util=ALL-UNNAMED
+            --add-opens=java.base/sun.security.x509=ALL-UNNAMED
+          )
+        fi
+      }
+    """,
     /* Dockerization */
     dockerUsername := Some(organization.value),
     dockerUpdateLatest := true,


### PR DESCRIPTION
Modify startup script to check if the JVM version is >= 9 and in that
case to open java.base module to unnamed modules, to get rid of illegal
access warnings like this:

  WARNING: An illegal reflective access operation has occurred
  WARNING: Illegal reflective access by com.google.protobuf.UnsafeUtil (file:/usr/share/rnode/lib/com.google.protobuf.protobuf-java-3.5.1.jar) to field java.nio.Buffer.address
  WARNING: Please consider reporting this to the maintainers of com.google.protobuf.UnsafeUtil
  WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
  WARNING: All illegal access operations will be denied in a future release

I tested validator node run with and deploy and propose of dup.rho on
dev bootstrap without getting any WARNING.

Required read: https://rchain.atlassian.net/wiki/spaces/CORE/pages/629243905/Java+9+Modularity+WARNING+An+illegal+reflective+access