### PR TITLE
OPS-369: Use unique image names on Drone CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -201,7 +201,12 @@ lazy val node = (project in file("node"))
     },
     /* Dockerization */
     dockerUsername := Some(organization.value),
-    dockerUpdateLatest := true,
+    version in Docker := version.value +
+      git.gitHeadCommit.value.map("-git" + _.take(8)).getOrElse(""),
+    dockerAliases ++=
+      sys.env.get("DRONE_BUILD_NUMBER")
+        .toSeq.map(num => dockerAlias.value.withTag(Some(s"DRONE-${num}"))),
+    dockerUpdateLatest := sys.env.get("DRONE").isEmpty,
     dockerBaseImage := "openjdk:11-jre-slim",
     dockerCommands := {
       val daemon = (daemonUser in Docker).value

--- a/integration-testing/.gitignore
+++ b/integration-testing/.gitignore
@@ -1,0 +1,1 @@
+/Dockerfile.tmp

--- a/integration-testing/README.md
+++ b/integration-testing/README.md
@@ -44,8 +44,10 @@ $ pipenv sync
 
 ## Step 4: Create the rnode docker image
 
-The tests use the docker image `coop.rchain/rnode:latest` as a base image for
-the docker containers. Docker has to be able to get this image. 
+Tests use RNode Docker image. If environment variable `${DRONE_BUILD_NUMBER}` is
+defined, then `coop.rchain/rnode:DRONE-${DRONE_BUILD_NUMBER}` image is used.
+These are created on Drone CI in order to use have image per build. If the
+variable is undefined, `coop.rchain/rnode:latest` is used.
  
 When the tests are run against the current source code one should build the
 docker image and publish it locally. For details see [the developer

--- a/integration-testing/rnode_testing/rnode.py
+++ b/integration-testing/rnode_testing/rnode.py
@@ -12,7 +12,9 @@ from rnode_testing.wait import wait_for, node_started
 from multiprocessing import Queue, Process
 from queue import Empty
 
-DEFAULT_IMAGE = "rchain-integration-testing:latest"
+DEFAULT_IMAGE = os.environ.get(
+        "DEFAULT_IMAGE",
+        "rchain-integration-testing:latest")
 
 rnode_binary = '/opt/docker/bin/rnode'
 rnode_directory = "/var/lib/rnode"

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -1,4 +1,14 @@
-#!/bin/bash -ue
+#!/bin/bash -e
 
-docker build --tag rchain-integration-testing .
+tag=latest
+if [[ -n $DRONE_BUILD_NUMBER ]]; then
+	# Mind our own business on Drone CI with concurrent jobs
+	tag=DRONE-$DRONE_BUILD_NUMBER
+fi
+
+export DEFAULT_IMAGE=rchain-integration-testing:$tag
+
+sed "s/rnode:latest/rnode:$tag/" Dockerfile |\
+	docker build -t $DEFAULT_IMAGE -f - .
+
 pipenv run py.test -v "$@"


### PR DESCRIPTION
Nothing should change for local development except that instead of
coop.rchain/rnode:0.7.1, coop.rchain/rnode:0.7.1-git${SHORTREV} is
created where ${SHORTREV} is first 8 characters of top commit. If the
build is not run from Git repository, -git suffix is not appended.