### PR TITLE
Add json-report for pytest (jsonapi format!)

### DIFF
--- a/integration-testing/pytest.ini
+++ b/integration-testing/pytest.ini
@@ -6,3 +6,5 @@ log_cli_format = %(asctime)s %(message)s
 # log_file=logs/integration-testing.log
 log_file_level=info
 log_file_format = [%(filename)10s:%(lineno)3d] %(asctime)s %(message)s
+json_report=report.json
+jsonapi=anything


### PR DESCRIPTION
## Overview
There are two formats that pytest can export. We are interested only
in the "jsonapi" one
