### PR TITLE
RHOL-1067: Include connectiveUsed flag in the sorter

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
@@ -35,16 +35,16 @@ private[sorter] object ConnectiveSortMatcher extends Sortable[Connective] {
           )
       case v @ VarRefBody(VarRef(index, depth)) =>
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_VARREF, index, depth)).pure[F]
-      case v @ ConnBool(_) =>
-        ScoredTerm(Connective(v), Leaf(Score.CONNECTIVE_BOOL)).pure[F]
-      case v @ ConnInt(_) =>
-        ScoredTerm(Connective(v), Leaf(Score.CONNECTIVE_INT)).pure[F]
-      case v @ ConnString(_) =>
-        ScoredTerm(Connective(v), Leaf(Score.CONNECTIVE_STRING)).pure[F]
-      case v @ ConnUri(_) =>
-        ScoredTerm(Connective(v), Leaf(Score.CONNECTIVE_URI)).pure[F]
-      case v @ ConnByteArray(_) =>
-        ScoredTerm(Connective(v), Leaf(Score.CONNECTIVE_BYTEARRAY)).pure[F]
+      case v @ ConnBool(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_BOOL, if (b) 1 else 0)).pure[F]
+      case v @ ConnInt(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_INT, if (b) 1 else 0)).pure[F]
+      case v @ ConnString(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_STRING, if (b) 1 else 0)).pure[F]
+      case v @ ConnUri(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_URI, if (b) 1 else 0)).pure[F]
+      case v @ ConnByteArray(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_BYTEARRAY, if (b) 1 else 0)).pure[F]
       case Empty =>
         ScoredTerm(Connective(Empty), Leaf(Score.ABSENT)).pure[F]
     }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
@@ -17,12 +17,16 @@ private[sorter] object MatchSortMatcher extends Sortable[Match] {
           Node(Seq(sortedPattern.score) ++ Seq(sortedBody.score))
         )
     for {
-      sortedValue <- Sortable.sortMatch(m.target)
-      scoredCases <- m.cases.toList.traverse(sortCase)
+      sortedValue         <- Sortable.sortMatch(m.target)
+      scoredCases         <- m.cases.toList.traverse(sortCase)
+      connectiveUsedScore = if (m.connectiveUsed) 1 else 0
     } yield
       ScoredTerm(
         Match(sortedValue.term, scoredCases.map(_.term), m.locallyFree, m.connectiveUsed),
-        Node(Score.MATCH, Seq(sortedValue.score) ++ scoredCases.map(_.score): _*)
+        Node(
+          Score.MATCH,
+          Seq(sortedValue.score) ++ scoredCases.map(_.score) ++ Seq(Leaf(connectiveUsedScore)): _*
+        )
       )
   }
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
@@ -29,6 +29,7 @@ private[sorter] object ParSortMatcher extends Sortable[Par] {
         locallyFree = par.locallyFree,
         connectiveUsed = par.connectiveUsed
       )
+      connectiveUsedScore = if (par.connectiveUsed) 1 else 0
       parScore = Node(
         Score.PAR,
         sends.map(_.score) ++
@@ -38,7 +39,8 @@ private[sorter] object ParSortMatcher extends Sortable[Par] {
           matches.map(_.score) ++
           bundles.map(_.score) ++
           connectives.map(_.score) ++
-          ids.map(_.score): _*
+          ids.map(_.score) ++
+          Seq(Leaf(connectiveUsedScore)): _*
       )
     } yield ScoredTerm(sortedPar, parScore)
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -30,9 +30,10 @@ object ReceiveSortMatcher extends Sortable[Receive] {
   // This function will then sort the insides of the preordered binds.
   def sortMatch[F[_]: Sync](r: Receive): F[ScoredTerm[Receive]] =
     for {
-      sortedBinds     <- r.binds.toList.traverse(sortBind[F])
-      persistentScore = if (r.persistent) 1 else 0
-      sortedBody      <- Sortable.sortMatch(r.body)
+      sortedBinds         <- r.binds.toList.traverse(sortBind[F])
+      persistentScore     = if (r.persistent) 1 else 0
+      connectiveUsedScore = if (r.connectiveUsed) 1 else 0
+      sortedBody          <- Sortable.sortMatch(r.body)
     } yield
       ScoredTerm(
         Receive(
@@ -45,7 +46,9 @@ object ReceiveSortMatcher extends Sortable[Receive] {
         ),
         Node(
           Score.RECEIVE,
-          Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score): _*
+          Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score) ++ Seq(
+            Leaf(connectiveUsedScore)
+          ): _*
         )
       )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -46,9 +46,8 @@ object ReceiveSortMatcher extends Sortable[Receive] {
         ),
         Node(
           Score.RECEIVE,
-          Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score) ++ Seq(
-            Leaf(connectiveUsedScore)
-          ): _*
+          Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score)
+            ++ Seq(Leaf(r.bindCount)) ++ Seq(Leaf(connectiveUsedScore)): _*
         )
       )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
@@ -17,10 +17,13 @@ private[sorter] object SendSortMatcher extends Sortable[Send] {
         locallyFree = s.locallyFree,
         connectiveUsed = s.connectiveUsed
       )
-      persistentScore = if (s.persistent) 1 else 0
+      persistentScore     = if (s.persistent) 1 else 0
+      connectiveUsedScore = if (s.connectiveUsed) 1 else 0
       sendScore = Node(
         Score.SEND,
-        Seq(Leaf(persistentScore)) ++ Seq(sortedChan.score) ++ sortedData.map(_.score): _*
+        Seq(Leaf(persistentScore)) ++ Seq(sortedChan.score) ++ sortedData.map(_.score) ++ Seq(
+          Leaf(connectiveUsedScore)
+        ): _*
       )
     } yield ScoredTerm(sortedSend, sendScore)
 }

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -595,6 +595,39 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr)
   }
 
+  it should "sort logical connectives in \"varref\", \"bool\", \"int\", \"string\", \"uri\", \"bytearray\" order" in {
+    val parExpr =
+      Par(
+        connectives = List(
+          Connective(ConnByteArray(true)),
+          Connective(ConnUri(true)),
+          Connective(ConnString(true)),
+          Connective(ConnInt(true)),
+          Connective(ConnBool(true)),
+          Connective(
+            VarRefBody(VarRef())
+          )
+        ),
+        connectiveUsed = true
+      )
+    val sortedParExpr: Par =
+      Par(
+        connectives = List(
+          Connective(
+            VarRefBody(VarRef())
+          ),
+          Connective(ConnBool(true)),
+          Connective(ConnInt(true)),
+          Connective(ConnString(true)),
+          Connective(ConnUri(true)),
+          Connective(ConnByteArray(true))
+        ),
+        connectiveUsed = true
+      )
+    val result = sort(parExpr)
+    result.term should be(sortedParExpr)
+  }
+
   it should "sort based on the connectiveUsed flag" in {
     val expr = Expr(
       EMapBody(

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -586,4 +586,23 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     val result = sort(parExpr)
     result.term should be(sortedParExpr)
   }
+
+  it should "sort based on the connectiveUsed flag" in {
+    val expr = Expr(
+      EMapBody(
+        ParMap(
+          SortedParMap(
+            Map(
+              Par() -> Par(
+                exprs = Seq()
+              ),
+              Par(connectiveUsed = true) -> Par(exprs = Seq())
+            )
+          )
+        )
+      )
+    )
+    val result = sort(expr)
+    result.term should be(expr)
+  }
 }

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -563,12 +563,6 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
               )
             )
           ),
-          Connective(VarRefBody(VarRef(0, 2))),
-          Connective(ConnInt(true)),
-          Connective(ConnBool(true)),
-          Connective(ConnString(true)),
-          Connective(ConnByteArray(true)),
-          Connective(ConnUri(true)),
           Connective(ConnNotBody(Par()))
         ),
         connectiveUsed = true
@@ -576,11 +570,6 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     val sortedParExpr: Par =
       Par(
         connectives = List(
-          Connective(ConnBool(true)),
-          Connective(ConnInt(true)),
-          Connective(ConnString(true)),
-          Connective(ConnUri(true)),
-          Connective(ConnByteArray(true)),
           Connective(ConnNotBody(Par())),
           Connective(
             ConnAndBody(
@@ -598,8 +587,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
                 )
               )
             )
-          ),
-          Connective(VarRefBody(VarRef(0, 2)))
+          )
         ),
         connectiveUsed = true
       )


### PR DESCRIPTION
## Overview
Added leaves that indicate presence or absence of connectives since generative tests can generate connectives which are set to false. Maybe instead it is time to create a generator that only creates legal AST instances?

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR