### PR TITLE
Use random start port in unit tests TransportLayerRuntime

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
 import scala.concurrent.duration._
+import scala.util.Random
 
 import cats._
 import cats.effect.Timer
@@ -26,7 +27,7 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
 
   def extract[A](fa: F[A]): A
 
-  private val nextPort = new AtomicInteger(41000)
+  private val nextPort = new AtomicInteger((Random.nextInt(100) + 400 + 1) * 100)
 
   def twoNodesEnvironment[A](block: (E, E) => F[A]): F[A] =
     for {


### PR DESCRIPTION
## Overview
Use in `TcpTransportLayerSpec` a random start port to avoid collisions with other builds in parallel.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-1484

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR
