### PR TITLE
Lawful StreamT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,12 @@ lazy val rholang = (project in file("rholang"))
     //constrain the resource usage so that we hit SOE-s and OOME-s more quickly should they happen
     javaOptions in Test ++= Seq("-Xss240k", "-XX:MaxJavaStackTraceDepth=10000", "-Xmx128m")
   )
-  .dependsOn(models % "compile->compile;test->test", rspace % "compile->compile;test->test", crypto)
+  .dependsOn(
+    models % "compile->compile;test->test",
+    rspace % "compile->compile;test->test",
+    shared % "compile->compile;test->test",
+    crypto
+  )
 
 lazy val rholangCLI = (project in file("rholang-cli"))
   .settings(commonSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,9 @@ lazy val shared = (project in file("shared"))
       monix,
       scodecCore,
       scodecBits,
-      scalapbRuntimegGrpc
+      scalapbRuntimegGrpc,
+      catsLawsTest,
+      catsLawsTestkitTest
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -315,7 +315,9 @@ lazy val rholang = (project in file("rholang"))
       catsEffect,
       monix,
       scallop,
-      lightningj
+      lightningj,
+      catsLawsTest,
+      catsLawsTestkitTest
     ),
     mainClass in assembly := Some("coop.rchain.rho2rose.Rholang2RosetteCompiler"),
     coverageExcludedFiles := Seq(

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -52,7 +52,7 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     unsortedTerms.sorted should be(sortedTerms)
   }
   it should "sort so that unequal terms have unequal scores and the other way around" in {
-    def checkScoreEquality[A: Sortable: Arbitrary]: Unit = {
+    def checkScoreEquality[A: Sortable: Arbitrary]: Unit =
       // ScalaCheck generates similar A-s in subsequent calls which
       // we need to hit the case where `x == y` more often
       forAll(Gen.listOfN(5, arbitrary[A])) { as: List[A] =>
@@ -63,7 +63,6 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
             assert(sort(x).score == sort(y).score)
         }
       }
-    }
     checkScoreEquality[Bundle]
     checkScoreEquality[Connective]
     checkScoreEquality[Expr]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,11 +7,14 @@ object Dependencies {
   val circeVersion  = "0.10.0"
   val http4sVersion = "0.19.0"
   val kamonVersion  = "1.1.0"
+  val catsVersion   = "1.4.0" 
 
   // format: off
   val bitcoinjCore        = "org.bitcoinj"                % "bitcoinj-core"             % "0.14.6"
   val bouncyCastle        = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.60"
-  val catsCore            = "org.typelevel"              %% "cats-core"                 % "1.4.0"
+  val catsCore            = "org.typelevel"              %% "cats-core"                 % catsVersion
+  val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
+  val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"
   val catsEffect          = "org.typelevel"              %% "cats-effect"               % "1.0.0"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % "0.4.0"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -347,7 +347,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
 
     for {
       matchesOpt             <- maximumBipartiteMatch.findMatches(allPatterns, targets)
-      matches                <- OptionalFreeMapWithCost.liftF(matchesOpt)
+      matches                <- OptionalFreeMapWithCost.fromOption(matchesOpt)
       freeMaps               = matches.map(_._3)
       updatedFreeMap         <- aggregateUpdates(freeMaps)
       _                      <- StateT.set[OptionWithCost, FreeMap](updatedFreeMap)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -646,7 +646,7 @@ trait SpatialMatcherInstances {
         ): NonDetFreeMapWithCost[Par] = {
           val (con, bounds, remainders) = labeledConnective
           for {
-            sp <- NonDetFreeMapWithCost.liftF(
+            sp <- NonDetFreeMapWithCost.fromStream(
                    subPars(target, bounds._1, bounds._2, remainders._1, remainders._2)
                  )
             _ <- nonDetMatch(sp._1, con)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -339,7 +339,8 @@ object SpatialMatcher extends SpatialMatcherInstances {
           case Remainder(_) =>
             //Remainders can't match non-concrete terms, because they can't be captured.
             //They match everything that's concrete though.
-            guardMatch[StateT[?[_], FreeMap, ?], OptionWithCost](lf.locallyFree(t, 0).isEmpty).charge(COMPARISON_COST)
+            guardMatch[StateT[?[_], FreeMap, ?], OptionWithCost](lf.locallyFree(t, 0).isEmpty)
+              .charge(COMPARISON_COST)
         }
         isolateState[OptionalFreeMapWithCost, FreeMap](matchEffect).attemptOpt
       }
@@ -371,7 +372,9 @@ object SpatialMatcher extends SpatialMatcherInstances {
     } yield Unit
   }
 
-  private def guardMatch[F[_[_], _]: MonadTrans, G[_]: Monad: FunctorFilter](predicate: => Boolean): F[G, Unit] =
+  private def guardMatch[F[_[_], _]: MonadTrans, G[_]: Monad: FunctorFilter](
+      predicate: => Boolean
+  ): F[G, Unit] =
     MonadTrans[F].liftM(guard[G](predicate))
 
   private def guard[F[_]: FunctorFilter: Applicative](predicate: => Boolean): F[Unit] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
@@ -1,39 +1,106 @@
 package coop.rchain.rholang.interpreter.matcher
-import cats.{Applicative, Functor, Monad}
+import cats.implicits._
+import cats.{Monad, MonoidK}
+import coop.rchain.catscontrib.MonadTrans
+import coop.rchain.rholang.interpreter.matcher.StreamT.{SCons, SNil, Step}
 
 import scala.collection.immutable.Stream
-import cats.implicits._
+import scala.util.{Left, Right}
 
-final case class StreamT[F[_], A](value: F[Stream[A]]) {
-  def ap[B](f: F[A => B])(implicit F: Monad[F]): StreamT[F, B] =
-    StreamT(F.flatMap(f)(ff => F.map(value)((stream: Stream[A]) => stream.map(ff))))
-
-  def map[B](f: A => B)(implicit F: Functor[F]): StreamT[F, B] =
-    StreamT(F.map(value)(_.map(f)))
-
-  def flatMap[B](f: A => StreamT[F, B])(implicit F: Monad[F]): StreamT[F, B] =
-    flatMapF(a => f(a).value)
-
-  def flatMapF[B](f: A => F[Stream[B]])(implicit F: Monad[F]): StreamT[F, B] =
-    StreamT(Monad[F].flatMap(value)(astream => astream.flatTraverse(a => f(a))))
-}
+/**
+  * Shamelessly transcribed minimal version of Gabriel Gonzalez's beginner-friendly ListT
+  * https://github.com/Gabriel439/Haskell-List-Transformer-Library/blob/e9a1d19/src/List/Transformer.hs
+  *
+  * See also: http://www.haskellforall.com/2016/07/list-transformer-beginner-friendly-listt.html
+  *
+  * The monads resulting from applying this transformer are as lazy and stacksafe as the underlying F monad you pass.
+  * Don't pass a strict monad and expect stacksafety. This, somewhat unlawfully, includes the behavior of tailRecM (!).
+  * All is good if F is stacksafe though.
+  *
+  * @param next effectful computation of the next Step in the represented stream
+  * @tparam F
+  * @tparam A
+  */
+final case class StreamT[F[_], A](next: F[Step[F, A]])
 
 object StreamT extends StreamTInstances0 {
-  def pure[F[_], A](single: A)(implicit F: Applicative[F]): StreamT[F, A] =
-    StreamT(F.pure(Stream(single)))
+
+  sealed trait Step[F[_], A]
+  case class SNil[F[_], A]()                              extends Step[F, A]
+  case class SCons[F[_], A](head: A, tail: StreamT[F, A]) extends Step[F, A]
+
+  def empty[F[_]: Monad, A]: StreamT[F, A] =
+    StreamT[F, A](Monad[F].pure(SNil()))
+
+  def pure[F[_]: Monad, A](a: A): StreamT[F, A] =
+    StreamT(Monad[F].pure(SCons(a, empty)))
+
+  def liftF[F[_]: Monad, A](fa: F[A]): StreamT[F, A] =
+    StreamT(fa.map(value => SCons(value, empty)))
+
+  def fromStream[F[_]: Monad, A](fs: F[Stream[A]]): StreamT[F, A] = {
+
+    def next(curr: Stream[A]): Step[F, A] =
+      curr match {
+        case Stream.Empty => SNil()
+        case h #:: t      => SCons(h, StreamT[F, A](Monad[F].pure(next(t))))
+      }
+
+    StreamT[F, A](fs.map(next))
+  }
+
+  def run[F[_]: Monad, A](s: StreamT[F, A]): F[Stream[A]] =
+    s.next.flatMap {
+      case SNil()            => Monad[F].pure(Stream.Empty)
+      case SCons(head, tail) => run(tail).map(t => head +: t)
+    }
 }
 
 trait StreamTInstances0 {
-  implicit def streamTMonad[F[_]: Monad]: Monad[StreamT[F, ?]] = new Monad[StreamT[F, ?]] {
-    override def pure[A](x: A): StreamT[F, A] = StreamT(Monad[F].pure(Stream(x)))
 
-    override def flatMap[A, B](fa: StreamT[F, A])(f: A => StreamT[F, B]): StreamT[F, B] =
-      fa.flatMap(f)
+  implicit val streamTMonadTrans = new MonadTrans[StreamT] {
+    override def liftM[G[_]: Monad, A](a: G[A]): StreamT[G, A] =
+      StreamT.liftF(a)
+
+    override implicit def apply[G[_]: Monad]: Monad[StreamT[G, ?]] =
+      streamTMonad[G]
+  }
+
+  implicit def streamTMonoidK[F[_]: Monad]: MonoidK[StreamT[F, ?]] = new MonoidK[StreamT[F, ?]] {
+
+    override def empty[A]: StreamT[F, A] = StreamT.empty
+
+    override def combineK[A](x: StreamT[F, A], y: StreamT[F, A]): StreamT[F, A] = {
+      val next: F[Step[F, A]] = x.next.flatMap {
+        case SNil()            => y.next
+        case SCons(head, tail) => Monad[F].pure(SCons(head, combineK(tail, y)))
+      }
+      StreamT(next)
+    }
+
+  }
+
+  implicit def streamTMonad[F[_]: Monad]: Monad[StreamT[F, ?]] = new Monad[StreamT[F, ?]] {
+
+    override def pure[A](x: A): StreamT[F, A] =
+      StreamT.pure(x)
+
+    override def flatMap[A, B](fa: StreamT[F, A])(f: A => StreamT[F, B]): StreamT[F, B] = {
+      val next: F[Step[F, B]] = fa.next.flatMap {
+        case SNil() => Monad[F].pure[Step[F, B]](SNil())
+        case SCons(head, tail) =>
+          val effectMonoid          = MonoidK[StreamT[F, ?]]
+          val result: StreamT[F, B] = effectMonoid.combineK(f(head), tail.flatMap(f))
+          result.next
+      }
+      StreamT(next)
+    }
 
     override def tailRecM[A, B](a: A)(f: A => StreamT[F, Either[A, B]]): StreamT[F, B] =
-      f(a).flatMap {
-        case Right(b) => StreamT.pure(b)
-        case Left(e)  => tailRecM(e)(f)
+      flatMap(f(a)) {
+        case Left(a)  => tailRecM(a)(f)
+        case Right(b) => pure(b)
       }
+
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -117,9 +117,6 @@ package object matcher {
     implicit def toNonDetFreeMapWithCostOps[A](s: NonDetFreeMapWithCost[A]) =
       new NonDetFreeMapWithCostOps[A](s)
 
-    def apply[A](f: FreeMap => StreamWithCost[(FreeMap, A)]): NonDetFreeMapWithCost[A] =
-      StateT((m: FreeMap) => f(m))
-
     def empty[A]: NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.empty)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -77,29 +77,13 @@ package object matcher {
       })
 
     def empty[A]: OptionalFreeMapWithCost[A] =
-      StateT((m: FreeMap) => {
-        OptionT(
-          StateT((c: Cost) => {
-            Right((c, None))
-          })
-        )
-      })
+      StateT.liftF(OptionT.fromOption(None))
 
     def pure[A](value: A): OptionalFreeMapWithCost[A] =
-      StateT((m: FreeMap) => {
-        OptionT(
-          StateT((c: Cost) => {
-            Right((c, Some((m, value))))
-          })
-        )
-      })
+      StateT.liftF(OptionT.liftF(StateT.liftF(Right(value))))
 
     def liftF[A](option: Option[A]): OptionalFreeMapWithCost[A] =
-      StateT((m: FreeMap) => {
-        OptionT(StateT((c: Cost) => {
-          Right((c, option.map(m -> _)))
-        }))
-      })
+      StateT.liftF(OptionT.fromOption(option))
   }
 
   object NonDetFreeMapWithCost {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -126,7 +126,7 @@ package object matcher {
     def pure[A](value: A): NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.liftF(StateT.liftF(Right(value))))
 
-    def liftF[A](stream: Stream[A]): NonDetFreeMapWithCost[A] =
+    def fromStream[A](stream: Stream[A]): NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.fromStream(StateT.pure(stream)))
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -82,7 +82,7 @@ package object matcher {
     def pure[A](value: A): OptionalFreeMapWithCost[A] =
       StateT.liftF(OptionT.liftF(StateT.liftF(Right(value))))
 
-    def liftF[A](option: Option[A]): OptionalFreeMapWithCost[A] =
+    def fromOption[A](option: Option[A]): OptionalFreeMapWithCost[A] =
       StateT.liftF(OptionT.fromOption(option))
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -17,7 +17,7 @@ package object matcher {
   type OptionalFreeMapWithCost[A] = StateT[OptionWithCost, FreeMap, A]
   type OptionWithCost[A]          = OptionT[ErroredOrCostA, A]
 
-  type OOPE[A] = Either[OutOfPhlogistonsError.type, A]
+  type OOPE[A]           = Either[OutOfPhlogistonsError.type, A]
   type ErroredOrCostA[A] = StateT[OOPE, Cost, A]
 
   //FreeMap => Cost => Either[OOPE, (Cost, Stream[(FreeMap, A)])]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -1,0 +1,30 @@
+package coop.rchain.rholang.interpreter.matcher
+
+import cats.implicits._
+import coop.rchain.rholang.interpreter.accounting.Cost
+import org.scalatest.FlatSpec
+
+import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
+import coop.rchain.rholang.interpreter.matcher.OptionalFreeMapWithCost._
+
+class MatcherMonadSpec extends FlatSpec {
+
+  behavior of "MatcherMonad"
+
+  it should "charge for each non-deterministic branch" in {
+    pending
+
+    val possibleResults = Stream((0, 1), (0, 2))
+    val computation = NonDetFreeMapWithCost.fromStream(possibleResults)
+    val sum = computation.map { case (x, y) => x + y }.charge(Cost(1))
+    val (cost, _) = sum.runWithCost(Cost(possibleResults.size)).right.get
+    assert(cost.value == 0) //is 1, so just 1 is charged
+
+    val moreVariants = sum.flatMap(x => NonDetFreeMapWithCost.fromStream(Stream(x, 0, -x)))
+    val moreComputation = moreVariants.map(x => "Do sth with " + x).charge(Cost(1))
+    val (cost2, _) = moreComputation.runWithCost(Cost(possibleResults.size * 3)).right.get
+    assert(cost2.value == 0) //is 4, so only 2 is charged
+  }
+
+
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -15,16 +15,15 @@ class MatcherMonadSpec extends FlatSpec {
     pending
 
     val possibleResults = Stream((0, 1), (0, 2))
-    val computation = NonDetFreeMapWithCost.fromStream(possibleResults)
-    val sum = computation.map { case (x, y) => x + y }.charge(Cost(1))
-    val (cost, _) = sum.runWithCost(Cost(possibleResults.size)).right.get
+    val computation     = NonDetFreeMapWithCost.fromStream(possibleResults)
+    val sum             = computation.map { case (x, y) => x + y }.charge(Cost(1))
+    val (cost, _)       = sum.runWithCost(Cost(possibleResults.size)).right.get
     assert(cost.value == 0) //is 1, so just 1 is charged
 
-    val moreVariants = sum.flatMap(x => NonDetFreeMapWithCost.fromStream(Stream(x, 0, -x)))
+    val moreVariants    = sum.flatMap(x => NonDetFreeMapWithCost.fromStream(Stream(x, 0, -x)))
     val moreComputation = moreVariants.map(x => "Do sth with " + x).charge(Cost(1))
-    val (cost2, _) = moreComputation.runWithCost(Cost(possibleResults.size * 3)).right.get
+    val (cost2, _)      = moreComputation.runWithCost(Cost(possibleResults.size * 3)).right.get
     assert(cost2.value == 0) //is 4, so only 2 is charged
   }
-
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -21,7 +21,7 @@ class StreamTSpec extends FlatSpec with Matchers {
     noException shouldBe thrownBy {
       stream.head
       val wrappedStep1 = StreamT.fromStream(Coeval.now(stream))
-      val step1 = wrappedStep1.next.value().asInstanceOf[SCons[Coeval, Int]]
+      val step1        = wrappedStep1.next.value().asInstanceOf[SCons[Coeval, Int]]
       assert(step1.head == 1)
       val wrappedStep2 = step1.tail
       step2 = wrappedStep2.next
@@ -36,27 +36,31 @@ class StreamTSpec extends FlatSpec with Matchers {
 
 class StreamTLawsSpec extends CatsSuite {
 
-  type Safe[A] = Coeval[A]
-  type Effect[A] = WriterT[Safe, String, A]
+  type Safe[A]          = Coeval[A]
+  type Effect[A]        = WriterT[Safe, String, A]
   type StreamTEffect[A] = StreamT[Effect, A]
 
-  implicit val stringArb = Arbitrary(Gen.oneOf("","a", "b", "c"))
+  implicit val stringArb = Arbitrary(Gen.oneOf("", "a", "b", "c"))
 
-  implicit def arbEff[A : Arbitrary]: Arbitrary[Effect[A]] = Arbitrary(for {
-    s <- Arbitrary.arbitrary[String]
-    a <- Arbitrary.arbitrary[A]
-  } yield WriterT[Safe, String, A](Coeval.now(s -> a)))
+  implicit def arbEff[A: Arbitrary]: Arbitrary[Effect[A]] =
+    Arbitrary(for {
+      s <- Arbitrary.arbitrary[String]
+      a <- Arbitrary.arbitrary[A]
+    } yield WriterT[Safe, String, A](Coeval.now(s -> a)))
 
-  implicit def arbStreamEff[A : Arbitrary]: Arbitrary[StreamTEffect[A]] = Arbitrary(Gen.oneOf(
-    for {
-      s <- Arbitrary.arbitrary[Effect[A]]
-    } yield StreamT.liftF(s),
-    for {
-      s <- Arbitrary.arbitrary[Effect[Stream[A]]]
-    } yield StreamT.fromStream(s)
-  ))
+  implicit def arbStreamEff[A: Arbitrary]: Arbitrary[StreamTEffect[A]] =
+    Arbitrary(
+      Gen.oneOf(
+        for {
+          s <- Arbitrary.arbitrary[Effect[A]]
+        } yield StreamT.liftF(s),
+        for {
+          s <- Arbitrary.arbitrary[Effect[Stream[A]]]
+        } yield StreamT.fromStream(s)
+      )
+    )
 
-  implicit def eqEff[A: Eq]: Eq[Effect[A]] = Eq.by(x => (x.value.value))
+  implicit def eqEff[A: Eq]: Eq[Effect[A]]       = Eq.by(x => (x.value.value))
   implicit def eqFA[A: Eq]: Eq[StreamTEffect[A]] = Eq.by(StreamT.run[Effect, A])
 
   checkAll("StreamT.MonadLaws", MonadTests[StreamTEffect].monad[Int, Int, String])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import cats.laws.discipline.{MonadTests, MonoidKTests}
 import cats.tests.CatsSuite
 import cats.{Eq, Monad}
+import coop.rchain.catscontrib.laws.discipline.MonadTransTests
 import coop.rchain.rholang.StackSafetySpec
 import coop.rchain.rholang.interpreter.matcher.StreamT.{SCons, Step}
 import monix.eval.Coeval
@@ -110,5 +111,6 @@ class StreamTLawsSpec extends CatsSuite {
 
   checkAll("StreamT.MonadLaws", MonadTests[StreamTEffect].monad[Int, Int, String])
   checkAll("StreamT.MonoidKLaws", MonoidKTests[StreamTEffect].monoidK[Int])
+  checkAll("StreamT.MonadTransLaws", MonadTransTests[StreamT].monadTrans[Effect, Int, String])
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -1,0 +1,63 @@
+package coop.rchain.rholang.interpreter.matcher
+
+import cats.{Eq, Id}
+import cats.data.WriterT
+import cats.laws.discipline.{MonadTests, MonoidKTests}
+import cats.tests.CatsSuite
+import monix.eval.Coeval
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.{FlatSpec, Matchers}
+
+class StreamTSpec extends FlatSpec with Matchers {
+
+  behavior of "StreamT"
+
+  it must "not trigger spurious evaluation of underlying stream for a lazy monad" in {
+    val stream: Stream[Int] = Stream.cons(1, ???)
+    var wrapped: StreamT[Coeval, Int] = null
+
+    noException shouldBe thrownBy {
+      stream.head
+      wrapped = StreamT.fromStream[Coeval, Int](Coeval.now(stream))
+    }
+
+    val next = wrapped.next
+
+    assertThrows[NotImplementedError] {
+      next.value() //would be equal to SCons(1, StreamT(Monad[F].pure(SCons(???, empty))))
+      //FIXME make the stream not evaluate the next element until absolutely needed
+      // by requiring [F: Defer]
+    }
+  }
+
+}
+
+class StreamTLawsSpec extends CatsSuite {
+
+  type Safe[A] = Coeval[A]
+  type Effect[A] = WriterT[Safe, String, A]
+  type StreamTEffect[A] = StreamT[Effect, A]
+
+  implicit val stringArb = Arbitrary(Gen.oneOf("","a", "b", "c"))
+
+  implicit def arbEff[A : Arbitrary]: Arbitrary[Effect[A]] = Arbitrary(for {
+    s <- Arbitrary.arbitrary[String]
+    a <- Arbitrary.arbitrary[A]
+  } yield WriterT[Safe, String, A](Coeval.now(s -> a)))
+
+  implicit def arbStreamEff[A : Arbitrary]: Arbitrary[StreamTEffect[A]] = Arbitrary(Gen.oneOf(
+    for {
+      s <- Arbitrary.arbitrary[Effect[A]]
+    } yield StreamT.liftF(s),
+    for {
+      s <- Arbitrary.arbitrary[Effect[Stream[A]]]
+    } yield StreamT.fromStream(s)
+  ))
+
+  implicit def eqEff[A: Eq]: Eq[Effect[A]] = Eq.by(x => (x.value.value))
+  implicit def eqFA[A: Eq]: Eq[StreamTEffect[A]] = Eq.by(StreamT.run[Effect, A])
+
+  checkAll("StreamT.MonadLaws", MonadTests[StreamTEffect].monad[Int, Int, String])
+  checkAll("StreamT.MonoidKLaws", MonoidKTests[StreamTEffect].monoidK[Int])
+
+}

--- a/shared/src/test/scala/coop/rchain/catscontrib/laws/MonadTransLaws.scala
+++ b/shared/src/test/scala/coop/rchain/catscontrib/laws/MonadTransLaws.scala
@@ -1,0 +1,23 @@
+package coop.rchain.catscontrib.laws
+import cats.Monad
+import cats.kernel.laws.IsEq
+import coop.rchain.catscontrib.MonadTrans
+import cats.laws._
+
+trait MonadTransLaws[MT[_[_], _]] {
+  implicit def MT: MonadTrans[MT]
+
+  def identity[G[_], A](a: A)(implicit G: Monad[G], MTM: Monad[MT[G, ?]]): IsEq[MT[G, A]] =
+    MT.liftM(G.pure(a)) <-> MTM.pure(a)
+
+  def composition[G[_], A, B](
+      ga: G[A],
+      f: A => G[B]
+  )(implicit G: Monad[G], MTM: Monad[MT[G, ?]]): IsEq[MT[G, B]] =
+    MT.liftM(G.flatMap(ga)(f)) <-> MTM.flatMap(MT.liftM(ga))(a => MT.liftM(f(a)))
+}
+
+object MonadTransLaws {
+  def apply[MT[_[_], _]](implicit ev: MonadTrans[MT]): MonadTransLaws[MT] =
+    new MonadTransLaws[MT] { def MT: MonadTrans[MT] = ev }
+}

--- a/shared/src/test/scala/coop/rchain/catscontrib/laws/discipline/MonadTransTests.scala
+++ b/shared/src/test/scala/coop/rchain/catscontrib/laws/discipline/MonadTransTests.scala
@@ -1,0 +1,38 @@
+package coop.rchain.catscontrib.laws.discipline
+
+import org.scalacheck.{Arbitrary, Cogen, Prop}
+import org.typelevel.discipline.Laws
+import Prop._
+import cats.{Eq, Monad}
+import coop.rchain.catscontrib.MonadTrans
+import coop.rchain.catscontrib.laws.MonadTransLaws
+import cats.laws.discipline._
+
+trait MonadTransTests[MT[_[_], _]] extends Laws {
+  def laws: MonadTransLaws[MT]
+
+  def monadTrans[G[_]: Monad, A: Arbitrary: Eq, B: Eq](
+      implicit
+      MonadMTG: Monad[MT[G, ?]],
+      ArbGA: Arbitrary[G[A]],
+      ArbGB: Arbitrary[G[B]],
+      CogenA: Cogen[A],
+      EqGA: Eq[G[A]],
+      EqGB: Eq[G[B]],
+      EqMTGA: Eq[MT[G, A]],
+      EqMTGB: Eq[MT[G, B]]
+  ): RuleSet =
+    new DefaultRuleSet(
+      name = "monadTrans",
+      parent = None,
+      "monadTrans identity"    -> forAll(laws.identity[G, A] _),
+      "monadTrans composition" -> forAll(laws.composition[G, A, B] _)
+    )
+}
+
+object MonadTransTests {
+  def apply[MT[_[_], _]: MonadTrans]: MonadTransTests[MT] =
+    new MonadTransTests[MT] {
+      def laws: MonadTransLaws[MT] = MonadTransLaws[MT]
+    }
+}


### PR DESCRIPTION
## Overview

Previous version of `matcher.StreamT` was unlawful in it not being associative. The new implementation is lawful, has the laws tested, and delegates stacksafety and laziness to the underlying F Monad while maintaining a minimal interface.

I've first tried to adapt and test the `StreamT` we have in `shared`, but gave up after seeing the amount of work needed to have the cats-law tests passing for it (even if it is associative - it's not stacksafe), and for it having an interface similar enough to what we need in rholang.

This is needed, because the effect stack in the matcher needs remodeling (see RHOL-1091), and the target effect stack will actually need associativity of the StreamT transformer.

### JIRA issue:
RHOL-1092

### Checklist
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] You have someone in mind to assign for review. Make this assignment after submitting the PR.