### PR TITLE
RHOL-1090: Fix EMapBody scores

### DIFF
--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -81,6 +81,16 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     val map4 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = true, BitSet(), Some(Var()))))
     assert(sort(map3).score != sort(map4).score)
   }
+  it should "sort so that unequal ParSet have unequal scores" in {
+    val set1 = Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), None)))
+    val set2 = Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = false, Coeval.delay(BitSet()), None)))
+    assert(sort(set1).score != sort(set2).score)
+    val set3 =
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), None)))
+    val set4 =
+      Expr(ESetBody(ParSet(Seq.empty, connectiveUsed = true, Coeval.delay(BitSet()), Some(Var()))))
+    assert(sort(set3).score != sort(set4).score)
+  }
 }
 
 class VarSortMatcherSpec extends FlatSpec with Matchers {

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -52,7 +52,7 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     unsortedTerms.sorted should be(sortedTerms)
   }
   it should "sort so that unequal terms have unequal scores and the other way around" in {
-    def checkScoreEquality[A: Sortable: Arbitrary]: Unit = {
+    def checkScoreEquality[A: Sortable: Arbitrary]: Unit =
       // ScalaCheck generates similar A-s in subsequent calls which
       // we need to hit the case where `x == y` more often
       forAll(Gen.listOfN(5, arbitrary[A])) { as: List[A] =>
@@ -63,7 +63,6 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
             assert(sort(x).score == sort(y).score)
         }
       }
-    }
     checkScoreEquality[Bundle]
     checkScoreEquality[Connective]
     checkScoreEquality[Expr]
@@ -73,6 +72,14 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     checkScoreEquality[Receive]
     checkScoreEquality[Send]
     checkScoreEquality[Var]
+  }
+  it should "sort so that unequal ParMap have unequal scores" in {
+    val map1 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = true, BitSet(), None)))
+    val map2 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = false, BitSet(), None)))
+    assert(sort(map1).score != sort(map2).score)
+    val map3 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = true, BitSet(), None)))
+    val map4 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = true, BitSet(), Some(Var()))))
+    assert(sort(map3).score != sort(map4).score)
   }
 }
 


### PR DESCRIPTION
## Overview
Generative test that failed gave the following output:
```
[info] - should sort so that unequal terms have unequal scores and the other way around *** FAILED *** (1 second, 415 milliseconds)
[info]   TestFailedException was thrown during property evaluation.
[info]     Message: Node(List(Leaf(ScoreAtom(IntAtom(9))), Leaf(ScoreAtom(IntAtom(53))))) equaled Node(List(Leaf(ScoreAtom(IntAtom(9))), Leaf(ScoreAtom(IntAtom(53)))))
[info]     Location: (SortTest.scala:61)
[info]     Occurred when passed generated values (
[info]       arg0 = List(Expr(EMapBody(ParMap(SortedParMap(),true,Coeval.Always$1157293997,Some(Var(Wildcard(WildcardMsg())))))), Expr(EMapBody(ParMap(SortedParMap(),false,Coeval.Always$1553618414,Some(Var(Wildcard(WildcardMsg()))))))) // 2 shrinks
[info]     )
```
### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
RHOL-1090

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR