### PR TITLE
Use Flag instead of Boolean for command-line argument has-faucet

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -197,7 +197,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val maximumBond = opt[Long](
       descr = "Maximum bond accepted by the PoS contract in the genesis block."
     )
-    val hasFaucet = opt[Boolean](
+    val hasFaucet = opt[Flag](
       descr = "True if there should be a public access Rev faucet in the genesis block."
     )
 

--- a/node/src/test/scala/coop/rchain/node/configuration/toml/TomlConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/toml/TomlConfigurationSpec.scala
@@ -48,6 +48,7 @@ class TomlConfigurationSpec extends FunSuite with Matchers {
       |approve-genesis-duration = "30min"
       |approve-genesis-interval = "1min"
       |deploy-timestamp = 1
+      |has-faucet = true
       |""".stripMargin
 
   test("Parse TOML configuration string") {
@@ -98,6 +99,7 @@ class TomlConfigurationSpec extends FunSuite with Matchers {
     root.validators.flatMap(_.approveGenesisDuration) shouldEqual Some(30.minutes)
     root.validators.flatMap(_.approveGenesisInterval) shouldEqual Some(1.minute)
     root.validators.flatMap(_.deployTimestamp) shouldEqual Some(1)
+    root.validators.flatMap(_.hasFaucet) shouldEqual Some(true)
   }
 
 }


### PR DESCRIPTION
## Overview
Use Flag instead of Boolean for command-line argument `has-faucet`. Scallop library turns a missing flag into `Some(false)` which shadows the setting for the command line.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://rchain.atlassian.net/browse/CORE-1530

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR
