### PR TITLE
dropped blockBuffer contains check

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -145,7 +145,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
     SafetyOracle[F].normalizedFaultTolerance(dag, blockHash).map(_ > faultToleranceThreshold)
 
   def contains(b: BlockMessage): F[Boolean] =
-    BlockStore[F].contains(b.blockHash).map(_ || blockBuffer.contains(b))
+    BlockStore[F].contains(b.blockHash)
 
   def deploy(deploy: Deploy): F[Unit] =
     for {


### PR DESCRIPTION
this change results in a node being able to catch up to the current state of the chain.

note that the contains check seems to be excluded by: 
```
      case MissingBlocks =>
        Capture[F].capture { blockBuffer += block } *> fetchMissingDependencies(block)
```