### PR TITLE
Add bors integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,11 @@
+# See https://bors.tech/documentation/getting-started/ for why we have trying and staging here:
 branches:
   - dev
   - master
   - release-*
   - testing*
+  - trying
+  - staging
 
 # Common parts
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,13 @@
+# require the below checks before bors merges anything
+status = [
+  "continuous-integration/drone/push"
+]
+
+# Ensure that reviewers (all maintainers!) can't merge their own PRs without review.
+# This works because Github doesn't allow self-review.
+required_approvals = 1
+
+# Number of seconds from when a merge commit is created to when its statuses must pass.
+timeout_sec = 7200
+
+delete_merged_branches = true

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,3 +19,10 @@
 - [x] includes tests for all added features,
 - [x] has a reviewer assigned,
 - [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
+
+### [Bors](https://bors.tech/) cheat-sheet:
+
+- `bors delegate+` enables author to request a merge from Bors.
+  Please **add it in your PR :heavy_check_mark: message** or in a comment later!
+- `bors r+` runs integration tests and merges the PR
+- `bors try` in a comment triggers integration tests for the PR

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,18 +1,21 @@
 ## Overview
-Provide a brief description of what this PR does, and why it's needed.
+<sup>_What this PR does, and why it's needed_</sup>
 
-### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
-Add link to corresponding JIRA issue.
 
-### Complete this checklist before you submit the PR
-- [ ] This PR contains no more than 200 lines of code, excluding test code.
-- [ ] This PR meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards).
-- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
-- [ ] You assigned one person to review this PR
 
-### If you are not a member of the core development team, please confirm:
-- [ ] You signed the commit. Merging requires a signature. Please see the [developer wiki](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain) for instructions.
-- [ ] Your GitHub account is also an account with [Travis CI](https://travis-ci.org). Unit tests will not run on your PR unless you have an account with Travis. Merge requires passed unit tests.
+### JIRA ticket:
+<sup>_Create it if there isn't one already._</sup>
+
+
 
 ### Notes
-Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
+<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>
+
+
+
+### Please make sure that this PR:
+- [x] is at most 200 lines of code (excluding tests),
+- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
+- [x] includes tests for all added features,
+- [x] has a reviewer assigned,
+- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This integrates `bors`, the merge bot.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/CORE-1535

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>

I've used the PR template proposed in this PR.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors delegate+` enables author to request a merge from Bors.
  Please **add it in your PR :heavy_check_mark: message** or in a comment later!
- `bors r+` runs integration tests and merges the PR
- `bors try` in a comment triggers integration tests for the PR