### PR TITLE
CORE-1372 store chunks to file

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
@@ -5,8 +5,7 @@ import com.google.protobuf.any.{Any => AnyProto}
 import coop.rchain.comm.CommError._
 import coop.rchain.comm._
 import coop.rchain.comm.protocol.routing._
-import com.google.protobuf.ByteString
-import coop.rchain.comm.transport.PacketType
+import coop.rchain.comm.transport.{Blob, PacketType}
 import com.google.protobuf.ByteString
 
 object ProtocolHelper {
@@ -78,5 +77,13 @@ object ProtocolHelper {
     proto.message.disconnect.fold[CommErr[Disconnect]](
       Left(UnknownProtocolError(s"Was expecting Disconnect, got ${proto.message}"))
     )(Right(_))
+
+  def blob(sender: PeerNode, typeId: String, content: Array[Byte]): Blob =
+    Blob(
+      sender,
+      Packet()
+        .withTypeId(typeId)
+        .withContent(ProtocolHelper.toProtocolBytes(content))
+    )
 
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -1,5 +1,6 @@
 package coop.rchain.comm.transport
 
+import coop.rchain.shared.GracefulClose._
 import coop.rchain.comm.{CommError, PeerNode}, CommError._
 import coop.rchain.comm.protocol.routing._
 import java.nio.file._
@@ -21,9 +22,6 @@ object PacketOps {
                  case Right(packet) => gracefullyClose(fin) *> Right(packet).pure[F]
                }
     } yield resErr
-
-  def gracefullyClose[F[_]: Sync](closable: AutoCloseable): F[Either[Throwable, Unit]] =
-    Sync[F].delay(closable.close).attempt
 
   implicit class RichPacket(packet: Packet) {
     def store[F[_]: Sync](folder: Path): F[CommErr[Path]] =

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -20,7 +20,7 @@ import coop.rchain.catscontrib.TaskContrib._
 
 object StreamHandler {
 
-  case class Streamed(
+  private case class Streamed(
       sender: Option[PeerNode] = None,
       typeId: Option[String] = None,
       contentLength: Option[Int] = None,
@@ -68,7 +68,7 @@ object StreamHandler {
 
   private def push(stmd: Streamed, buff: buffer.LimitedBuffer[ServerMessage])(
       implicit logger: Log[Task]
-  ): Task[Unit] = stmd match {
+  ): Task[Boolean] = stmd match {
     case Streamed(Some(sender), Some(packetType), Some(contentLength), compressed, path, _) =>
       Task.delay {
         // TODO what if returns false?
@@ -77,7 +77,7 @@ object StreamHandler {
     case stmd =>
       logger.warn(
         s"received not full stream message, will not process. $stmd"
-      )
+      ).as(false)
   }
 
   def restore(msg: StreamMessage)(implicit logger: Log[Task]): Task[Either[Throwable, Blob]] =

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -1,5 +1,10 @@
 package coop.rchain.comm.transport
 
+import java.util.UUID
+import coop.rchain.shared.GracefulClose._
+import coop.rchain.catscontrib.ski._
+import java.io.FileOutputStream
+import java.nio.file.{Files, Path}
 import coop.rchain.shared._, Compression._
 import coop.rchain.comm.{CommError, PeerNode}
 import monix.eval.Task
@@ -11,110 +16,95 @@ import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.protocol.routing._
 import com.google.protobuf.ByteString
 import cats.implicits._
+import coop.rchain.catscontrib.TaskContrib._
 
 object StreamHandler {
+
+  case class Streamed(
+      sender: Option[PeerNode] = None,
+      typeId: Option[String] = None,
+      contentLength: Option[Int] = None,
+      compressed: Boolean = false,
+      path: Path,
+      fos: FileOutputStream
+  )
+
   def handleStream(
+      folder: Path,
       observable: Observable[Chunk],
       buff: buffer.LimitedBuffer[ServerMessage]
-  )(implicit logger: Log[Task]): Task[ChunkResponse] = {
-
-    case class PartialBlob(
-        peerNode: Option[PeerNode] = None,
-        typeId: Option[String] = None,
-        content: Option[(Array[Byte], Int)] = None,
-        contentLength: Option[Int] = None,
-        compressed: Boolean = false
-    )
-
-    object HeaderReceived {
-      def unapply(chunk: Chunk): Option[(Option[PeerNode], String, Boolean, Int)] =
-        chunk match {
-          case Chunk(Chunk.Content.Header(ChunkHeader(sender, typeId, compressed, cl))) =>
-            Some(sender.map(ProtocolHelper.toPeerNode), typeId, compressed, cl)
-          case _ => None
-        }
-    }
-
-    object FirstDataReceived {
-      def unapply(temp: (PartialBlob, Chunk)): Option[(PartialBlob, Array[Byte], Int)] =
-        temp match {
-          case (
-              partial @ PartialBlob(_, _, None, Some(cl), _),
-              Chunk(Chunk.Content.Data(ChunkData(newData)))
-              ) =>
-            Some((partial, newData.toByteArray, cl))
-          case _ => None
-        }
-    }
-
-    object NextDataReceived {
-      def unapply(
-          temp: (PartialBlob, Chunk)
-      ): Option[(PartialBlob, Array[Byte], Array[Byte], Int)] =
-        temp match {
-          case (
-              partial @ PartialBlob(_, _, Some((content, pointer)), _, _),
-              Chunk(Chunk.Content.Data(ChunkData(newData)))
-              ) =>
-            Some(partial, content, newData.toByteArray, pointer)
-          case _ => None
-        }
-    }
-
-    /**
-      * This is temporary solution.
-      * In order to deal with arbitrary blog sizes, chunks must be stored on disk.
-      * This is not implemented, thus temporaryly we do foldLef and gather partial data
-      */
-    def collect: Task[PartialBlob] = observable.foldLeftL(PartialBlob()) {
-      case (_, HeaderReceived(sender, typeId, compressed, contentLength)) =>
-        PartialBlob(sender, Some(typeId), None, Some(contentLength), compressed)
-      case FirstDataReceived(partial, firstData, contentLength) =>
-        val data = new Array[Byte](contentLength)
-        firstData.copyToArray(data)
-        partial.copy(content = Some((data, data.length)))
-      case NextDataReceived(partial, currentData, newData, pointer) =>
-        newData.copyToArray(currentData, pointer)
-        partial.copy(content = Some((currentData, pointer + newData.length)))
-    }
-
-    (collect >>= {
-      case PartialBlob(
-          Some(peerNode),
-          Some(typeId),
-          Some((content, _)),
-          Some(contentLength),
-          compressed
-          ) =>
-        toContent(content, compressed, contentLength).attempt >>= {
-          case Left(th) => logger.error(th.getMessage)
-          case Right(content) =>
-            Task.delay {
-              val packet = Packet()
-                .withTypeId(typeId)
-                .withContent(content)
-              val blob = Blob(peerNode, packet)
-              buff.pushNext(StreamMessage(blob))
-            }
-        }
-      case incorrect => logger.error(s"Streamed incorrect blob of data. Received $incorrect")
+  )(implicit logger: Log[Task]): Task[ChunkResponse] =
+    (init(folder).attempt >>= {
+      case Left(ex) => logger.error("could not create a file to store incoming stream", ex)
+      case Right(initStmd) =>
+        (collect(initStmd, observable).attempt >>= {
+          case Left(ex)    => logger.error("could not collect incoming streamed data", ex)
+          case Right(stmd) => push(stmd, buff)
+        }) *> gracefullyClose[Task](initStmd.fos).as(())
     }).as(ChunkResponse())
 
+  private def init(folder: Path): Task[Streamed] =
+    for {
+      _        <- Task.delay(folder.toFile.mkdirs())
+      fileName <- Task.delay(UUID.randomUUID.toString + "_packet_streamed.bts")
+      file     = folder.resolve(fileName)
+      fos      <- Task.delay(new FileOutputStream(file.toFile))
+    } yield Streamed(fos = fos, path = file)
+
+  private def collect(init: Streamed, observable: Observable[Chunk]): Task[Streamed] =
+    observable.foldLeftL(init) {
+      case (stmd, Chunk(Chunk.Content.Header(ChunkHeader(sender, typeId, compressed, cl)))) =>
+        stmd.copy(
+          sender = sender.map(ProtocolHelper.toPeerNode(_)),
+          typeId = Some(typeId),
+          compressed = compressed,
+          contentLength = Some(cl)
+        )
+      case (stmd, Chunk(Chunk.Content.Data(ChunkData(newData)))) =>
+        stmd.fos.write(newData.toByteArray)
+        stmd.fos.flush()
+        stmd
+    }
+
+  private def push(stmd: Streamed, buff: buffer.LimitedBuffer[ServerMessage])(
+      implicit logger: Log[Task]
+  ): Task[Unit] = stmd match {
+    case Streamed(Some(sender), Some(packetType), Some(contentLength), compressed, path, _) =>
+      Task.delay {
+        // TODO what if returns false?
+        buff.pushNext(StreamMessage(sender, packetType, path, compressed, contentLength))
+      }
+    case stmd =>
+      logger.warn(
+        s"received not full stream message, will not process. $stmd"
+      )
   }
 
-  private def toContent(
+  def restore(msg: StreamMessage)(implicit logger: Log[Task]): Task[Either[Throwable, Blob]] =
+    (fetchContent(msg.path).attempt >>= {
+      case Left(ex) => logger.error("Could not read streamed data from file", ex).as(Left(ex))
+      case Right(content) =>
+        decompressContent(content, msg.compressed, msg.contentLength).attempt >>= {
+          case Left(ex) => logger.error("Could not decompressed data ").as(Left(ex))
+          case Right(decompressedContent) =>
+            Right(ProtocolHelper.blob(msg.sender, msg.typeId, decompressedContent)).pure[Task]
+        }
+    }) >>= (res => deleteFile(msg.path) *> res.pure[Task])
+
+  private def fetchContent(path: Path): Task[Array[Byte]] = Task.delay(Files.readAllBytes(path))
+  private def decompressContent(
       raw: Array[Byte],
       compressed: Boolean,
       contentLength: Int
-  ): Task[ByteString] = {
-    val decompressed: Task[Array[Byte]] = if (compressed) {
+  ): Task[Array[Byte]] =
+    if (compressed) {
       raw
         .decompress(contentLength)
         .fold(Task.raiseError[Array[Byte]](new RuntimeException("Could not decompress data")))(
           _.pure[Task]
         )
     } else raw.pure[Task]
-    decompressed map ProtocolHelper.toProtocolBytes
-  }
 
+  private def deleteFile(path: Path): Task[Unit] =
+    Task.delay(path.toFile.delete).attemptAndLog.as(())
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -1,5 +1,6 @@
 package coop.rchain.comm.transport
 
+import java.nio.file.Path
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
@@ -27,7 +28,8 @@ class TcpServerObservable(
     tellBufferSize: Int = 1024,
     askBufferSize: Int = 1024,
     blobBufferSize: Int = 32,
-    askTimeout: FiniteDuration = 5.second
+    askTimeout: FiniteDuration = 5.second,
+    tempFolder: Path
 )(implicit scheduler: Scheduler, logger: Log[Task])
     extends Observable[ServerMessage] {
 
@@ -75,7 +77,7 @@ class TcpServerObservable(
           }
 
       def stream(observable: Observable[Chunk]): Task[ChunkResponse] =
-        StreamHandler.handleStream(observable, bufferBlobMessage)
+        StreamHandler.handleStream(tempFolder, observable, bufferBlobMessage)
 
       private def returnProtocol(protocol: Protocol): TLResponse =
         TLResponse(TLResponse.Payload.Protocol(protocol))

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -1,16 +1,22 @@
 package coop.rchain.comm.transport
 
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
-
 import coop.rchain.comm.protocol.routing.Protocol
-
 import monix.execution.Callback
+import coop.rchain.comm.PeerNode
 
 trait ServerMessage
 // TODO rename to AksMesage and TellMesssage
 final case class Ask(msg: Protocol, handle: SenderHandle) extends ServerMessage
 final case class Tell(msg: Protocol)                      extends ServerMessage
-final case class StreamMessage(blob: Blob)                extends ServerMessage
+final case class StreamMessage(
+    sender: PeerNode,
+    typeId: String,
+    path: Path,
+    compressed: Boolean,
+    contentLength: Int
+) extends ServerMessage
 
 trait SenderHandle {
   def reply(msg: CommunicationResponse): Unit

--- a/shared/src/main/scala/coop/rchain/shared/GracefulClose.scala
+++ b/shared/src/main/scala/coop/rchain/shared/GracefulClose.scala
@@ -1,0 +1,10 @@
+package coop.rchain.shared
+
+import java.nio.file._
+import cats._, cats.data._, cats.implicits._
+import cats.effect.Sync
+
+object GracefulClose {
+  def gracefullyClose[F[_]: Sync](closable: AutoCloseable): F[Either[Throwable, Unit]] =
+    Sync[F].delay(closable.close).attempt
+}


### PR DESCRIPTION
## Overview
In this PR I'm:

1. Move gravefullyClose to shared
2. Extract blob factory method in ProtocolHelper
3. Modify stream on the server side so that it can deal with arbitrary blocks

Previously incoming blocks were aggregated into a `PartialBlob` object
and then transformed to `Blob` which was handled by Casper. This could
lead to number of problems, mainly OOME. With this new approach, we
collect incoming stream of data by saving chunk by chunk into
file. Once the file is stored, we push just a path on the queue. This
way consumer of the queue handles each blob one at a time, retrieving
it from a file. This gives as a way to provide fine-grade
measurements to deal with blobs of arbitrary size.


### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
CORE-1372