### PR TITLE
Add bonded validators to latest messages for in-memory DAG storage

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -352,8 +352,6 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
       _ <- lock.release
     } yield ()
 
-  def insertGenesis(genesis: BlockMessage): F[Unit] = ???
-
   def checkpoint(): F[Unit] =
     ().pure[F]
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -8,7 +8,6 @@ import coop.rchain.casper.protocol.BlockMessage
 trait BlockDagStorage[F[_]] {
   def getRepresentation: F[BlockDagRepresentation[F]]
   def insert(block: BlockMessage): F[Unit]
-  def insertGenesis(genesis: BlockMessage): F[Unit]
   def checkpoint(): F[Unit]
   def clear(): F[Unit]
   def close(): F[Unit]

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
@@ -26,7 +26,6 @@ final class IndexedBlockDagStorage[F[_]: Monad](
       _ <- underlying.insert(block)
       _ <- lock.release
     } yield ()
-  def insertGenesis(genesis: BlockMessage): F[Unit] = ???
   def insertIndexed(block: BlockMessage): F[BlockMessage] =
     for {
       _                 <- lock.acquire

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -74,7 +74,7 @@ sealed abstract class MultiParentCasperInstances {
   )(implicit scheduler: Scheduler): F[MultiParentCasper[F]] =
     for {
       // Initialize DAG storage with genesis block in case it is empty
-      _   <- BlockDagStorage[F].insertGenesis(genesis)
+      _   <- BlockDagStorage[F].insert(genesis)
       dag <- BlockDagStorage[F].getRepresentation
       maybePostGenesisStateHash <- InterpreterUtil
                                     .validateBlockCheckpoint[F](


### PR DESCRIPTION
## Overview
Title says it all.

### JIRA ticket:
RHOL-1116

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
