### PR TITLE
CORE-1541 Change the default value of max message size to be 0.25 MB

### DIFF
--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -101,14 +101,12 @@ class NodeRuntime private[node] (
       grpcServerExternal <- GrpcServer
                              .acquireExternalServer[Effect](
                                conf.grpcServer.portExternal,
-                               conf.server.maxMessageSize,
                                grpcScheduler,
                                blockApiLock
                              )
       grpcServerInternal <- GrpcServer
                              .acquireInternalServer(
                                conf.grpcServer.portInternal,
-                               conf.server.maxMessageSize,
                                runtime,
                                grpcScheduler
                              )

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -49,9 +49,12 @@ object GrpcServer {
 
   def apply(server: Server): GrpcServer = new GrpcServer(server)
 
+  // 16 MB is max message size allowed by HTTP2 RFC 7540
+  // grpc and netty can however work with bigger values
+  val maxMessageSize: Int = 16 * 1024 * 1024
+
   def acquireInternalServer(
       port: Int,
-      maxMessageSize: Int,
       runtime: Runtime,
       grpcExecutor: Scheduler
   )(
@@ -77,7 +80,6 @@ object GrpcServer {
 
   def acquireExternalServer[F[_]: Sync: Concurrent: Capture: MultiParentCasperRef: Log: SafetyOracle: BlockStore: Taskable](
       port: Int,
-      maxMessageSize: Int,
       grpcExecutor: Scheduler,
       blockApiLock: Semaphore[F]
   )(implicit worker: Scheduler): F[GrpcServer] =

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -56,12 +56,10 @@ object Configuration {
   private val DefaultRequiredSigns              = 0
   private val DefaultApprovalProtocolDuration   = 5.minutes
   private val DefaultApprovalProtocolInterval   = 5.seconds
-  // TODO this temporarly makes the allowed message size to be  256 MB on startup
-  // This will be rolled back after CORE-1394 and Kents changes
-  private val DefaultMaxMessageSize: Int = 256 * 1024 * 1024
+  private val DefaultMaxMessageSize: Int        = 256 * 1024 // 0.25 MB
   // within range HTTP2 RFC 7540
-  private val MaxMessageSizeMinimumValue: Int = 10 * 1024 * 1024
-  private val MaxMessageSizeMaximumValue: Int = DefaultMaxMessageSize * 4
+  private val MaxMessageSizeMinimumValue: Int = DefaultMaxMessageSize
+  private val MaxMessageSizeMaximumValue: Int = 10 * 1024 * 1024
   private val DefaultMinimumBond: Long        = 1L
   private val DefaultMaximumBond: Long        = Long.MaxValue
   private val DefaultHasFaucet: Boolean       = false


### PR DESCRIPTION
## Overview
This way all messages (including the ones that are streamed) can not
be bigger then 0.25 MB. User can still set the value to be something
different, but that value has to be in range [0.25MB, 10MB]

### JIRA ticket:
CORE-1541

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
