### PR TITLE
CORE-1547 graphz for blockchain

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,17 @@ lazy val shared = (project in file("shared"))
     )
   )
 
+lazy val graphz = (project in file("graphz"))
+  .settings(commonSettings: _*)
+  .settings(
+    version := "0.1",
+    libraryDependencies ++= commonDependencies ++ Seq(
+      catsCore,
+      catsEffect,
+      catsMtl
+    )
+  ).dependsOn(shared)
+
 lazy val casper = (project in file("casper"))
   .settings(commonSettings: _*)
   .settings(rholangSettings: _*)
@@ -496,6 +507,7 @@ lazy val rchain = (project in file("."))
     casper,
     comm,
     crypto,
+    graphz,
     models,
     node,
     regex,

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -1,0 +1,159 @@
+package coop.rchain.graphz
+
+import cats._, cats.data._, cats.implicits._
+import cats.effect.Sync
+import cats.mtl._
+
+import java.io.FileOutputStream
+
+trait GraphSerializer[F[_]] {
+  def push(str: String, suffix: String = "\n"): F[Unit]
+}
+
+class StringSerializer[F[_]: Applicative: MonadState[?[_], StringBuffer]]
+    extends GraphSerializer[F] {
+  def push(str: String, suffix: String): F[Unit] =
+    MonadState[F, StringBuffer].modify(sb => sb.append(str + suffix))
+}
+
+class FileSerializer[F[_]: Sync](fos: FileOutputStream) extends GraphSerializer[F] {
+  def push(str: String, suffix: String): F[Unit] = Sync[F].delay {
+    fos.write(str.getBytes)
+    fos.flush()
+  }
+}
+
+sealed trait GraphType
+final case object Graph   extends GraphType
+final case object DiGraph extends GraphType
+
+sealed trait GraphShape
+final case object Circle       extends GraphShape
+final case object DoubleCircle extends GraphShape
+final case object Box          extends GraphShape
+final case object PlainText    extends GraphShape
+final case object Msquare      extends GraphShape
+
+sealed trait GraphRank
+final case object Same   extends GraphRank
+final case object Min    extends GraphRank
+final case object Source extends GraphRank
+final case object Max    extends GraphRank
+final case object Sink   extends GraphRank
+
+sealed trait GraphRankDir
+final case object TB extends GraphRankDir
+final case object BT extends GraphRankDir
+final case object LR extends GraphRankDir
+final case object RL extends GraphRankDir
+
+object Graphz {
+
+  implicit val showShape: Show[GraphShape] = new Show[GraphShape] {
+    def show(shape: GraphShape): String = shape match {
+      case Circle       => "circle"
+      case DoubleCircle => "doublecircle"
+      case Box          => "box"
+      case PlainText    => "plaintext"
+      case Msquare      => "Msquare"
+    }
+  }
+
+  def smallToString[A]: Show[A] = new Show[A] {
+    def show(a: A): String = a.toString.toLowerCase
+  }
+
+  implicit val showRank: Show[GraphRank]       = smallToString[GraphRank]
+  implicit val showRankDir: Show[GraphRankDir] = Show.fromToString[GraphRankDir]
+
+  def DefaultShape = Circle
+
+  def apply[F[_]: Monad](
+      name: String,
+      gtype: GraphType,
+      subgraph: Boolean = false,
+      comment: Option[String] = None,
+      label: Option[String] = None,
+      rank: Option[GraphRank] = None,
+      rankdir: Option[GraphRankDir] = None,
+      style: Option[String] = None,
+      color: Option[String] = None
+  )(
+      implicit ser: GraphSerializer[F]
+  ): F[Graphz[F]] = {
+
+    def insert(str: Option[String], v: String => String): F[Unit] = {
+      val indent = if (subgraph) tab + tab else tab
+      str.fold(().pure[F])(s => ser.push(indent + v(s)))
+    }
+
+    for {
+      _ <- comment.fold(().pure[F])(c => ser.push(s"// $c"))
+      t = if (subgraph) s"$tab$tab" else tab
+      _ <- ser.push(head(gtype, subgraph, name))
+      _ <- insert(label, l => s"label = ${quote(l)}")
+      _ <- insert(style, s => s"style=$s")
+      _ <- insert(color, s => s"color=$s")
+      _ <- insert(rank.map(_.show), r => s"rank=$r")
+      _ <- insert(rankdir.map(_.show), r => s"rankdir=$r")
+    } yield new Graphz[F](gtype, t)
+  }
+
+  def subgraph[F[_]: Monad](
+      name: String,
+      gtype: GraphType,
+      label: Option[String] = None,
+      rank: Option[GraphRank] = None,
+      rankdir: Option[GraphRankDir] = None,
+      style: Option[String] = None,
+      color: Option[String] = None
+  )(implicit ser: GraphSerializer[F]): F[Graphz[F]] =
+    apply[F](
+      name,
+      gtype,
+      subgraph = true,
+      label = label,
+      rank = rank,
+      rankdir = rankdir,
+      style = style,
+      color = color
+    )
+
+  private def head(gtype: GraphType, subgraph: Boolean, name: String): String = {
+    val prefix = (gtype, subgraph) match {
+      case (_, true)    => s"${tab}subgraph"
+      case (Graph, _)   => s"graph"
+      case (DiGraph, _) => s"digraph"
+    }
+    if (name == "") s"$prefix {" else s"$prefix $name {"
+  }
+
+  def quote(str: String): String = str match {
+    case _ if str.startsWith("\"") => str
+    case _                         => s""""$str""""
+  }
+
+  val tab = "  "
+}
+
+class Graphz[F[_]: Monad](gtype: GraphType, t: String)(implicit ser: GraphSerializer[F]) {
+
+  def edge(edg: (String, String)): F[Unit] = edge(edg._1, edg._2)
+  def edge(src: String, dst: String): F[Unit] =
+    ser.push(edgeMkStr.format(Graphz.quote(src), Graphz.quote(dst), "[]"))
+  def node(name: String, shape: GraphShape = Circle): F[Unit] =
+    ser.push(nodeMkStr(name, shape))
+  def subgraph(sub: F[Graphz[F]]): F[Unit] = sub >>= (_ => ser.push(""))
+  def close: F[Unit]                       = ser.push(s"${t.substring(Graphz.tab.length)}}", suffix = "")
+
+  private def edgeMkStr: String = gtype match {
+    case Graph   => s"$t%s -- %s %s"
+    case DiGraph => s"$t%s -> %s %s"
+  }
+
+  private def nodeMkStr(name: String, shape: GraphShape): String = {
+    import Graphz.showShape
+    val attributes = if (shape == Graphz.DefaultShape) "" else s"shape=${shape.show}"
+    t + Graphz.quote(name) + " [" + attributes + "]"
+  }
+}

--- a/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
+++ b/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
@@ -1,0 +1,361 @@
+package coop.rchain.graphz
+
+import cats._, cats.data._, cats.implicits._
+import cats.mtl._
+import cats.mtl.implicits._
+import org.scalatest._
+
+class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+
+  type Effect[A] = StateT[Id, StringBuffer, A]
+
+  implicit val ser = new StringSerializer[Effect]
+
+  describe("Graphz") {
+    it("simple graph") {
+      val graph = for {
+        g <- Graphz[Effect]("G", Graph)
+        _ <- g.close
+      } yield g
+      graph.show shouldBe (
+        """graph G {
+          |}""".stripMargin
+      )
+    }
+
+    it("simple digraph") {
+      val graph = for {
+        g <- Graphz[Effect]("G", DiGraph)
+        _ <- g.close
+      } yield g
+      graph.show shouldBe (
+        """digraph G {
+          |}""".stripMargin
+      )
+    }
+
+    it("simple graph with comment") {
+      val graph = for {
+        g <- Graphz[Effect]("G", Graph, comment = Some("this is comment"))
+        _ <- g.close
+      } yield g
+      graph.show shouldBe (
+        """// this is comment
+          |graph G {
+          |}""".stripMargin
+      )
+    }
+
+    it("graph, two nodes one edge") {
+      // given
+      val graph = for {
+        g <- Graphz[Effect]("G", Graph)
+        _ <- g.edge("Hello", "World")
+        _ <- g.close
+      } yield g
+      // then
+      graph.show shouldBe (
+        """graph G {
+          |  "Hello" -- "World" []
+          |}""".stripMargin
+      )
+    }
+
+    it("digraph, two nodes one edge") {
+      // given
+      val graph = for {
+        g <- Graphz[Effect]("G", DiGraph)
+        _ <- g.edge("Hello", "World")
+        _ <- g.close
+      } yield g
+      // then
+      graph.show shouldBe (
+        """digraph G {
+          |  "Hello" -> "World" []
+          |}""".stripMargin
+      )
+    }
+
+    it("digraph, nodes with style") {
+      // given
+      val graph = for {
+        g <- Graphz[Effect]("G", DiGraph)
+        _ <- g.node("Hello", shape = Box)
+        _ <- g.node("World", shape = DoubleCircle)
+        _ <- g.edge("Hello", "World")
+        _ <- g.close
+      } yield g
+      // then
+      graph.show shouldBe (
+        """digraph G {
+	  |  "Hello" [shape=box]
+	  |  "World" [shape=doublecircle]
+          |  "Hello" -> "World" []
+          |}""".stripMargin
+      )
+    }
+
+    it("digraph with simple subgraphs") {
+      val process1 = for {
+        g <- Graphz.subgraph[Effect]("", DiGraph)
+        _ <- g.node("A")
+        _ <- g.node("B")
+        _ <- g.node("C")
+        _ <- g.edge("A", "B")
+        _ <- g.edge("B", "C")
+        _ <- g.close
+      } yield g
+
+      val process2 = for {
+        g <- Graphz.subgraph[Effect]("", DiGraph)
+        _ <- g.node("K")
+        _ <- g.node("L")
+        _ <- g.node("M")
+        _ <- g.edge("K", "L")
+        _ <- g.edge("L", "M")
+        _ <- g.close
+      } yield g
+
+      val graph = for {
+        g <- Graphz[Effect]("Process", DiGraph)
+        _ <- g.node("0")
+        _ <- g.subgraph(process1)
+        _ <- g.edge("0", "A")
+        _ <- g.subgraph(process2)
+        _ <- g.edge("0", "K")
+        _ <- g.node("1")
+        _ <- g.edge("M", "1")
+        _ <- g.edge("C", "1")
+        _ <- g.close
+      } yield g
+      graph.show shouldBe (
+        """digraph Process {
+          |  "0" []
+          |  subgraph {
+          |    "A" []
+          |    "B" []
+          |    "C" []
+          |    "A" -> "B" []
+          |    "B" -> "C" []
+          |  }
+          |  "0" -> "A" []
+          |  subgraph {
+          |    "K" []
+          |    "L" []
+          |    "M" []
+          |    "K" -> "L" []
+          |    "L" -> "M" []
+          |  }
+          |  "0" -> "K" []
+          |  "1" []
+          |  "M" -> "1" []
+          |  "C" -> "1" []
+          |}""".stripMargin
+      )
+    }
+
+    it("digraph with fancy subgraphs") {
+      val process1 = for {
+        g <- Graphz
+              .subgraph[Effect](
+                "cluster_p1",
+                DiGraph,
+                label = Some("process #1"),
+                color = Some("blue")
+              )
+        _ <- g.node("A")
+        _ <- g.node("B")
+        _ <- g.node("C")
+        _ <- g.edge("A", "B")
+        _ <- g.edge("B", "C")
+        _ <- g.close
+      } yield g
+
+      val process2 = for {
+        g <- Graphz
+              .subgraph[Effect](
+                "cluster_p2",
+                DiGraph,
+                label = Some("process #2"),
+                color = Some("green")
+              )
+        _ <- g.node("K")
+        _ <- g.node("L")
+        _ <- g.node("M")
+        _ <- g.edge("K", "L")
+        _ <- g.edge("L", "M")
+        _ <- g.close
+      } yield g
+
+      val graph = for {
+        g <- Graphz[Effect]("Process", DiGraph)
+        _ <- g.node("0")
+        _ <- g.subgraph(process1)
+        _ <- g.edge("0", "A")
+        _ <- g.subgraph(process2)
+        _ <- g.edge("0", "K")
+        _ <- g.node("1")
+        _ <- g.edge("M", "1")
+        _ <- g.edge("C", "1")
+        _ <- g.close
+      } yield g
+      graph.show shouldBe (
+        """digraph Process {
+          |  "0" []
+          |  subgraph cluster_p1 {
+          |    label = "process #1"
+          |    color=blue
+          |    "A" []
+          |    "B" []
+          |    "C" []
+          |    "A" -> "B" []
+          |    "B" -> "C" []
+          |  }
+          |  "0" -> "A" []
+          |  subgraph cluster_p2 {
+          |    label = "process #2"
+          |    color=green
+          |    "K" []
+          |    "L" []
+          |    "M" []
+          |    "K" -> "L" []
+          |    "L" -> "M" []
+          |  }
+          |  "0" -> "K" []
+          |  "1" []
+          |  "M" -> "1" []
+          |  "C" -> "1" []
+          |}""".stripMargin
+      )
+    }
+
+    it("blockchain, simple") {
+      // given
+      val lvl1 = for {
+        g <- Graphz.subgraph[Effect]("", DiGraph, rank = Some(Same))
+        _ <- g.node("1")
+        _ <- g.node("ddeecc", shape = Box)
+        _ <- g.node("ffeeff", shape = Box)
+        _ <- g.close
+      } yield g
+
+      val lvl0 = for {
+        g <- Graphz.subgraph[Effect]("", DiGraph, rank = Some(Same))
+        _ <- g.node("0")
+        _ <- g.node("000000", shape = Box)
+        _ <- g.close
+      } yield g
+
+      val timeline = for {
+        g <- Graphz.subgraph[Effect]("timeline", DiGraph)
+        _ <- g.node("3", shape = PlainText)
+        _ <- g.node("2", shape = PlainText)
+        _ <- g.node("1", shape = PlainText)
+        _ <- g.node("0", shape = PlainText)
+        _ <- g.edge("0" -> "1")
+        _ <- g.edge("1" -> "2")
+        _ <- g.edge("2" -> "3")
+        _ <- g.close
+      } yield g
+
+      val graph = for {
+        g <- Graphz[Effect]("Blockchain", DiGraph, rankdir = Some(BT))
+        _ <- g.subgraph(lvl1)
+        _ <- g.edge("000000" -> "ffeeff")
+        _ <- g.edge("000000" -> "ddeecc")
+        _ <- g.subgraph(lvl0)
+        _ <- g.subgraph(timeline)
+        _ <- g.close
+      } yield g
+      // then
+      graph.show shouldBe (
+        """digraph Blockchain {
+          |  rankdir=BT
+          |  subgraph {
+          |    rank=same
+          |    "1" []
+          |    "ddeecc" [shape=box]
+          |    "ffeeff" [shape=box]
+          |  }
+          |  "000000" -> "ffeeff" []
+          |  "000000" -> "ddeecc" []
+          |  subgraph {
+          |    rank=same
+          |    "0" []
+          |    "000000" [shape=box]
+          |  }
+          |  subgraph timeline {
+          |    "3" [shape=plaintext]
+          |    "2" [shape=plaintext]
+          |    "1" [shape=plaintext]
+          |    "0" [shape=plaintext]
+          |    "0" -> "1" []
+          |    "1" -> "2" []
+          |    "2" -> "3" []
+          |  }
+          |}""".stripMargin
+      )
+    }
+
+    // from https://github.com/xflr6/graphviz/blob/master/examples/process.py
+    it("Process example") {
+      (for {
+        graph <- Graphz[Effect]("G", Graph)
+        _     <- graph.edge("run", "intr")
+        _     <- graph.edge("intr", "runbl")
+        _     <- graph.edge("runbl", "run")
+        _     <- graph.edge("run", "kernel")
+        _     <- graph.edge("kernel", "zombie")
+        _     <- graph.edge("kernel", "sleep")
+        _     <- graph.edge("kernel", "runmem")
+        _     <- graph.edge("sleep", "swap")
+        _     <- graph.edge("swap", "runswap")
+        _     <- graph.edge("runswap", "new")
+        _     <- graph.edge("runswap", "runmem")
+        _     <- graph.edge("new", "runmem")
+        _     <- graph.edge("sleep", "runmem")
+        _     <- graph.close
+      } yield graph).show shouldBe (
+        """graph G {
+          |  "run" -- "intr" []
+          |  "intr" -- "runbl" []
+          |  "runbl" -- "run" []
+          |  "run" -- "kernel" []
+          |  "kernel" -- "zombie" []
+          |  "kernel" -- "sleep" []
+          |  "kernel" -- "runmem" []
+          |  "sleep" -- "swap" []
+          |  "swap" -- "runswap" []
+          |  "runswap" -- "new" []
+          |  "runswap" -- "runmem" []
+          |  "new" -- "runmem" []
+          |  "sleep" -- "runmem" []
+          |}""".stripMargin
+      )
+    }
+
+  }
+
+  implicit class GraphzOps(graph: Effect[Graphz[Effect]]) {
+    def show: String =
+      graph.runS(new StringBuffer).toString
+
+    import java.io.File
+    import java.io.PrintWriter
+
+    def view(): Unit = {
+      val sourcePath = "/Users/rabbit/temp.gv"
+      val outputPath = "/Users/rabbit/output.pdf"
+      new File(sourcePath).createNewFile()
+      val writer = new PrintWriter(sourcePath)
+      writer.println(show)
+      writer.flush()
+      writer.close
+      val dotCmd  = s"dot -Tpdf $sourcePath -o $outputPath"
+      val openCmd = s"open $outputPath"
+      import sys.process._
+      (dotCmd !)
+      (openCmd !)
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Introduces new module `graphz` that allows building grphs in DOT language with a small memory footprint (potentially big graphs).

This PR creates just the module (tests are showing the usage). Next PR will use this module to build DAG representation from Casper.

### JIRA ticket:
CORE-1547