### PR TITLE
RHOL-1120: Fix PrettyPrinter output for maps

### DIFF
--- a/models/src/main/scala/coop/rchain/models/ParMapTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMapTypeMapper.scala
@@ -11,7 +11,7 @@ object ParMapTypeMapper {
 
   private[models] def parMapToEMap(parMap: ParMap): EMap =
     EMap(
-      parMap.ps.sortedMap.map(t => zip(t._1, t._2)).toSeq,
+      parMap.ps.sortedList.map(t => zip(t._1, t._2)),
       parMap.locallyFree.value,
       parMap.connectiveUsed,
       parMap.remainder

--- a/models/src/main/scala/coop/rchain/models/SortedParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/SortedParMap.scala
@@ -10,8 +10,8 @@ import scala.collection.immutable.HashMap
 final class SortedParMap private (ps: Map[Par, Par]) extends Iterable[(Par, Par)] {
 
   // TODO: Merge `sortedList` and `sortedMap` into one VectorMap once available
-  lazy val sortedList: List[(Par, Par)] = ps.sort
-  lazy val sortedMap: HashMap[Par, Par] = HashMap(sortedList: _*)
+  lazy val sortedList: List[(Par, Par)]         = ps.sort
+  private lazy val sortedMap: HashMap[Par, Par] = HashMap(sortedList: _*)
 
   def +(kv: (Par, Par)): SortedParMap = SortedParMap(sortedMap + kv)
 

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/GroundSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/GroundSortMatcher.scala
@@ -60,7 +60,7 @@ private[sorter] object GroundSortMatcher extends Sortable[ExprInstance] {
           } yield ScoredTerm((sortedKey.term, sortedValue.term), sortedKey.score)
 
         for {
-          pars              <- gm.ps.sortedMap.toList.traverse(kv => sortKeyValuePair(kv._1, kv._2))
+          pars              <- gm.ps.sortedList.traverse(kv => sortKeyValuePair(kv._1, kv._2))
           sortedPars        = pars.sorted
           remainderScoreOpt = gm.remainder.map(_ => Leaf(Score.REMAINDER))
         } yield

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -21,7 +21,7 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
   private[this] def toKVpair(pair: (Par, Par)): KeyValuePair = KeyValuePair(pair._1, pair._2)
 
   private[this] def serializeEMap(map: SortedParMap): Array[Byte] =
-    EMap(map.sortedMap.map(toKVpair).toSeq).toByteArray
+    EMap(map.sortedList.map(toKVpair)).toByteArray
 
   val pars: Seq[(Par, Par)] = Seq[(Par, Par)](
     (GInt(7), GString("Seven")),
@@ -32,7 +32,7 @@ class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
   )
 
   private def roundTripTest(parMap: SortedParMap): Assertion =
-    EMap.parseFrom(serializeEMap(parMap)) should ===(EMap(parMap.sortedMap.map(toKVpair).toSeq))
+    EMap.parseFrom(serializeEMap(parMap)) should ===(EMap(parMap.sortedList.map(toKVpair)))
 
   def sample = SortedParMap(pars)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -91,7 +91,7 @@ case class PrettyPrinter(
       case ESetBody(ParSet(pars, _, _, remainder)) =>
         pure("Set(") |+| buildSeq(pars.sortedPars) |+| buildRemainderString(remainder) |+| pure(")")
       case EMapBody(ParMap(ps, _, _, remainder)) =>
-        pure("{") |+| (pure("") /: ps.sortedMap.zipWithIndex) {
+        pure("{") |+| (pure("") /: ps.sortedList.zipWithIndex) {
           case (string, (kv, i)) =>
             string |+| buildStringM(kv._1) |+| pure(" : ") |+| buildStringM(kv._2) |+| pure {
               if (i != ps.sortedMap.size - 1) ", "

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -94,7 +94,7 @@ case class PrettyPrinter(
         pure("{") |+| (pure("") /: ps.sortedList.zipWithIndex) {
           case (string, (kv, i)) =>
             string |+| buildStringM(kv._1) |+| pure(" : ") |+| buildStringM(kv._2) |+| pure {
-              if (i != ps.sortedMap.size - 1) ", "
+              if (i != ps.sortedList.size - 1) ", "
               else ""
             }
         } |+| buildRemainderString(remainder) |+| pure("}")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -894,7 +894,7 @@ object Reduce {
 
         case EMapBody(map) =>
           for {
-            evaledPs <- map.ps.sortedMap.toList.traverse {
+            evaledPs <- map.ps.sortedList.traverse {
                          case (key, value) =>
                            for {
                              eKey   <- evalExpr(key).map(updateLocallyFree)
@@ -1069,7 +1069,7 @@ object Reduce {
               Applicative[M].pure[Expr](
                 EMapBody(
                   ParMap(
-                    (baseMap ++ otherMap.sortedMap).toSeq,
+                    (baseMap ++ otherMap).toSeq,
                     base.connectiveUsed || other.connectiveUsed,
                     locallyFreeUnion(base.locallyFree, other.locallyFree),
                     None

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -346,7 +346,7 @@ object Substitute {
 
           case EMapBody(ParMap(spm, connectiveUsed, locallyFree, remainder)) =>
             for {
-              kvps <- spm.sortedMap.toList.traverse {
+              kvps <- spm.sortedList.traverse {
                        case (p1, p2) =>
                          for {
                            pk1 <- s1(p1)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -98,7 +98,7 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
       PrettyPrinter(0, 2).buildString(
         ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
       )
-    result shouldBe """{x0 : x1, 7 : "Seven"...free0}"""
+    result shouldBe "{7 : \"" + "Seven" + "\", x0 : x1...free0}"
   }
 
   "Map" should "Print commas correctly" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -101,6 +101,35 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
     result shouldBe """{x0 : x1, 7 : "Seven"...free0}"""
   }
 
+  "Map" should "Print commas correctly" in {
+    val mapData = new ListKeyValuePair()
+    mapData.add(
+      new KeyValuePairImpl(
+        new PGround(new GroundString("\"c\"")),
+        new PGround(new GroundInt("3"))
+      )
+    )
+    mapData.add(
+      new KeyValuePairImpl(
+        new PGround(new GroundString("\"b\"")),
+        new PGround(new GroundInt("2"))
+      )
+    )
+    mapData.add(
+      new KeyValuePairImpl(
+        new PGround(new GroundString("\"a\"")),
+        new PGround(new GroundInt("1"))
+      )
+    )
+    val map = new PCollect(new CollectMap(mapData, new ProcRemainderEmpty()))
+
+    val result =
+      PrettyPrinter().buildString(
+        ProcNormalizeMatcher.normalizeMatch[Coeval](map, inputs).value.par
+      )
+    val target = """{"a" : 1, "b" : 2, "c" : 3}"""
+    result shouldBe target
+  }
 }
 
 class ProcPrinterSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
## Overview
Output was messed up because we `zipWithIndex`ed over a `HashMap`.

### JIRA ticket:
https://rchain.atlassian.net/browse/RHOL-1120

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).