### PR TITLE
Refactor compute parents post state

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -173,53 +173,81 @@ object InterpreterUtil {
     val parentTuplespaces = parents.flatMap(p => ProtoUtil.tuplespace(p).map(p -> _))
 
     parentTuplespaces match {
-      //no parents to base off of, so use default
+      // For genesis, use empty trie's root hash
       case Seq() =>
         Right(runtimeManager.emptyStateHash).leftCast[Throwable].pure[F]
 
-      //For a single parent we look up its checkpoint
       case Seq((_, parentStateHash)) =>
         Right(parentStateHash).leftCast[Throwable].pure[F]
 
-      //In the case of multiple parents we need
-      //to apply all of the deploys that have been
-      //made in all of the branches of the DAG being
-      //merged. This is done by computing uncommon ancestors
-      //and applying the deploys in those blocks.
       case (initParent, initStateHash) +: _ =>
-        dag.deriveOrdering(0L).flatMap { implicit ordering: Ordering[BlockMetadata] => // TODO: Replace with an actual starting number
-          for {
-            parentsMetadata    <- parents.toList.traverse(b => dag.lookup(b.blockHash).map(_.get))
-            indexedParents     = parentsMetadata.toVector
-            uncommonAncestors  <- DagOperations.uncommonAncestors[F](indexedParents, dag)
-            initParentMetadata <- dag.lookup(initParent.blockHash)
-            initIndex          = indexedParents.indexOf(initParentMetadata)
-            //filter out blocks that already included by starting from the chosen initParent
-            blocksToApply = uncommonAncestors
-              .filterNot { case (_, set) => set.contains(initIndex) }
-              .keys
-              .toVector
-              .sorted //ensure blocks to apply is topologically sorted to maintain any causal dependencies
-            maybeBlocks <- blocksToApply.traverse(b => BlockStore[F].get(b.blockHash))
-            _           = assert(maybeBlocks.forall(_.isDefined))
-            blocks      = maybeBlocks.flatten
-            deploys     = blocks.flatMap(_.getBody.deploys.flatMap(ProcessedDeployUtil.toInternal))
-          } yield
-            runtimeManager
-              .replayComputeState(initStateHash, deploys, time)
-              .runSyncUnsafe(Duration.Inf) match {
-              case result @ Right(_) => result.leftCast[Throwable]
-              case Left((_, status)) =>
-                val parentHashes = parents.map(p => Base16.encode(p.blockHash.toByteArray).take(8))
-                Left(
-                  new Exception(
-                    s"Failed status while computing post state of $parentHashes: $status"
-                  )
-                )
-            }
-        }
+        computeMultiParentsPostState[F](
+          parents,
+          dag,
+          runtimeManager,
+          time,
+          initParent,
+          initStateHash
+        )
     }
   }
+
+  // In the case of multiple parents we need to apply all of the deploys that have been
+  // made in all of the branches of the DAG being merged. This is done by computing uncommon ancestors
+  // and applying the deploys in those blocks.
+  private def computeMultiParentsPostState[F[_]: Monad: BlockStore](
+      parents: Seq[BlockMessage],
+      dag: BlockDagRepresentation[F],
+      runtimeManager: RuntimeManager,
+      time: Option[Long],
+      initParent: BlockMessage,
+      initStateHash: StateHash
+  )(implicit scheduler: Scheduler): F[Either[Throwable, StateHash]] =
+    dag.deriveOrdering(0L).flatMap { implicit ordering: Ordering[BlockMetadata] => // TODO: Replace with an actual starting number
+      for {
+        parentsMetadata         <- parents.toList.traverse(b => dag.lookup(b.blockHash).map(_.get))
+        indexedParents          = parentsMetadata.toVector
+        uncommonAncestors       <- DagOperations.uncommonAncestors[F](indexedParents, dag)
+        maybeInitParentMetadata <- dag.lookup(initParent.blockHash)
+        result <- maybeInitParentMetadata match {
+                   case Some(initParentMetadata) =>
+                     val initIndex = indexedParents.indexOf(initParentMetadata)
+                     //filter out blocks that already included by starting from the chosen initParent
+                     val blocksToApply = uncommonAncestors
+                       .filterNot { case (_, set) => set.contains(initIndex) }
+                       .keys
+                       .toVector
+                       .sorted //ensure blocks to apply is topologically sorted to maintain any causal dependencies
+                     for {
+                       maybeBlocks <- blocksToApply
+                                       .traverse(b => BlockStore[F].get(b.blockHash))
+                       _      = assert(maybeBlocks.forall(_.isDefined))
+                       blocks = maybeBlocks.flatten
+                       deploys = blocks
+                         .flatMap(_.getBody.deploys.flatMap(ProcessedDeployUtil.toInternal))
+                     } yield
+                       runtimeManager
+                         .replayComputeState(initStateHash, deploys, time)
+                         .runSyncUnsafe(Duration.Inf) match {
+                         case result @ Right(_) => result.leftCast[Throwable]
+                         case Left((_, status)) =>
+                           val parentHashes =
+                             parents.map(p => Base16.encode(p.blockHash.toByteArray).take(8))
+                           Left(
+                             new Exception(
+                               s"Failed status while computing post state of $parentHashes: $status"
+                             )
+                           )
+                       }
+                   case None =>
+                     Left(
+                       new Exception(
+                         s"Could not lookup ${PrettyPrinter.buildString(initParent.blockHash)} in blockDAG."
+                       )
+                     ).pure[F]
+                 }
+      } yield result
+    }
 
   private[casper] def computeBlockCheckpointFromDeploys[F[_]: Monad: BlockStore](
       b: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -180,13 +180,12 @@ object InterpreterUtil {
       case Seq((_, parentStateHash)) =>
         Right(parentStateHash).leftCast[Throwable].pure[F]
 
-      case (initParent, initStateHash) +: _ =>
+      case (_, initStateHash) +: _ =>
         computeMultiParentsPostState[F](
           parents,
           dag,
           runtimeManager,
           time,
-          initParent,
           initStateHash
         )
     }
@@ -194,60 +193,51 @@ object InterpreterUtil {
 
   // In the case of multiple parents we need to apply all of the deploys that have been
   // made in all of the branches of the DAG being merged. This is done by computing uncommon ancestors
-  // and applying the deploys in those blocks.
+  // and applying the deploys in those blocks on top of the initial parent.
   private def computeMultiParentsPostState[F[_]: Monad: BlockStore](
       parents: Seq[BlockMessage],
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager,
       time: Option[Long],
-      initParent: BlockMessage,
       initStateHash: StateHash
   )(implicit scheduler: Scheduler): F[Either[Throwable, StateHash]] =
-    dag.deriveOrdering(0L).flatMap { implicit ordering: Ordering[BlockMetadata] => // TODO: Replace with an actual starting number
-      for {
-        parentsMetadata         <- parents.toList.traverse(b => dag.lookup(b.blockHash).map(_.get))
-        indexedParents          = parentsMetadata.toVector
-        uncommonAncestors       <- DagOperations.uncommonAncestors[F](indexedParents, dag)
-        maybeInitParentMetadata <- dag.lookup(initParent.blockHash)
-        result <- maybeInitParentMetadata match {
-                   case Some(initParentMetadata) =>
-                     val initIndex = indexedParents.indexOf(initParentMetadata)
-                     //filter out blocks that already included by starting from the chosen initParent
-                     val blocksToApply = uncommonAncestors
-                       .filterNot { case (_, set) => set.contains(initIndex) }
-                       .keys
-                       .toVector
-                       .sorted //ensure blocks to apply is topologically sorted to maintain any causal dependencies
-                     for {
-                       maybeBlocks <- blocksToApply
-                                       .traverse(b => BlockStore[F].get(b.blockHash))
-                       _      = assert(maybeBlocks.forall(_.isDefined))
-                       blocks = maybeBlocks.flatten
-                       deploys = blocks
-                         .flatMap(_.getBody.deploys.flatMap(ProcessedDeployUtil.toInternal))
-                     } yield
-                       runtimeManager
-                         .replayComputeState(initStateHash, deploys, time)
-                         .runSyncUnsafe(Duration.Inf) match {
-                         case result @ Right(_) => result.leftCast[Throwable]
-                         case Left((_, status)) =>
-                           val parentHashes =
-                             parents.map(p => Base16.encode(p.blockHash.toByteArray).take(8))
-                           Left(
-                             new Exception(
-                               s"Failed status while computing post state of $parentHashes: $status"
-                             )
-                           )
-                       }
-                   case None =>
-                     Left(
-                       new Exception(
-                         s"Could not lookup ${PrettyPrinter.buildString(initParent.blockHash)} in blockDAG."
-                       )
-                     ).pure[F]
-                 }
-      } yield result
-    }
+    for {
+      parentsMetadata <- parents.toList.traverse(b => dag.lookup(b.blockHash).map(_.get))
+      indexedParents  = parentsMetadata.toVector
+      ordering        <- dag.deriveOrdering(0L) // TODO: Replace with an actual starting number
+      blockHashesToApply <- {
+        implicit val o: Ordering[BlockMetadata] = ordering
+        for {
+          uncommonAncestors <- DagOperations.uncommonAncestors[F](indexedParents, dag)
+          initIndex         = indexedParents.indexOf(parentsMetadata.head)
+          // Filter out blocks that already included by starting from the chosen initial parent
+          // as otherwise we will be applying the initial parent's ancestor's twice.
+          result = uncommonAncestors
+            .filterNot { case (_, set) => set.contains(initIndex) }
+            .keys
+            .toVector
+            .sorted // Ensure blocks to apply is topologically sorted to maintain any causal dependencies
+        } yield result
+      }
+      maybeBlocks <- blockHashesToApply
+                      .traverse(b => BlockStore[F].get(b.blockHash))
+      _             = assert(maybeBlocks.forall(_.isDefined))
+      blocksToApply = maybeBlocks.flatten
+      deploys       = blocksToApply.flatMap(_.getBody.deploys.flatMap(ProcessedDeployUtil.toInternal))
+    } yield
+      runtimeManager
+        .replayComputeState(initStateHash, deploys, time)
+        .runSyncUnsafe(Duration.Inf) match {
+        case result @ Right(_) => result.leftCast[Throwable]
+        case Left((_, status)) =>
+          val parentHashes =
+            parents.map(p => Base16.encode(p.blockHash.toByteArray).take(8))
+          Left(
+            new Exception(
+              s"Failed status while computing post state of $parentHashes: $status"
+            )
+          )
+      }
 
   private[casper] def computeBlockCheckpointFromDeploys[F[_]: Monad: BlockStore](
       b: BlockMessage,


### PR DESCRIPTION
Fix the fact we call indexOf on an Option[Int] instead of
the actual Int.

Group ordering with the calls that require implicit ordering.

Clean up some comments.