### PR TITLE
CORE-1547 casper dag graphz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ lazy val casper = (project in file("casper"))
     blockStorage % "compile->compile;test->test",
     comm         % "compile->compile;test->test",
     shared       % "compile->compile;test->test",
+    graphz,
     crypto,
     models,
     rspace,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -196,7 +196,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
    *  produced (no deploys, already processing, no validator id)
    */
   def createBlock: F[CreateBlockStatus] = validatorId match {
-    case Some(vId @ ValidatorIdentity(publicKey, privateKey, sigAlgorithm)) =>
+    case Some(ValidatorIdentity(publicKey, privateKey, sigAlgorithm)) =>
       for {
         dag              <- blockDag
         orderedHeads     <- estimator(dag)

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
@@ -13,12 +13,6 @@ object MultiParentCasperRef {
 
   def apply[F[_]](implicit ev: MultiParentCasperRef[F]): MultiParentCasperRef[F] = ev
 
-  private class MultiParentCasperRefImpl[F[_]](state: Ref[F, Option[MultiParentCasper[F]]])
-      extends MultiParentCasperRef[F] {
-    override def get: F[Option[MultiParentCasper[F]]]       = state.get
-    override def set(casper: MultiParentCasper[F]): F[Unit] = state.set(Some(casper))
-  }
-
   def of[F[_]: Sync]: F[MultiParentCasperRef[F]] = MaybeCell.of[F, MultiParentCasper[F]]
 
   // For usage in tests only

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -2,7 +2,9 @@ package coop.rchain.casper.api
 
 import cats.Monad
 import cats.effect.Sync
-import cats.implicits._
+import cats._, cats.data._, cats.implicits._
+import cats.mtl._
+import cats.mtl.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.Estimator.BlockHash
@@ -15,6 +17,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.graphz._
 import coop.rchain.models.{BindPattern, Par}
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rspace.{Serialize, StableHashProvider}
@@ -224,6 +227,94 @@ object BlockAPI {
             produce => produce.channelsHash == StableHashProvider.hash(sortedListeningName)
           )
     }
+  }
+
+  // TOOD extract common code from show blocks
+  def visualizeBlocks[F[_]: Monad: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+      d: Option[Int] = None
+  ): F[String] = {
+
+    type Effect[A] = StateT[Id, StringBuffer, A]
+    implicit val ser = new StringSerializer[Effect]
+    case class Acc(timeseries: List[Long] = List.empty, graph: Effect[Graphz[Effect]])
+
+    def casperResponse(implicit casper: MultiParentCasper[F]): F[String] =
+      for {
+        dag         <- MultiParentCasper[F].blockDag
+        maxHeight   <- dag.topoSort(0L).map(_.length - 1)
+        depth       = d.getOrElse(maxHeight)
+        startHeight = math.max(0, maxHeight - depth)
+        topoSort    <- dag.topoSortTail(depth)
+        acc <- topoSort.foldM(Acc(graph = Graphz[Effect]("DAG", DiGraph, rankdir = Some(BT)))) {
+                case (acc, blockHashes) =>
+                  for {
+                    blocks    <- blockHashes.traverse(ProtoUtil.unsafeGetBlock[F])
+                    timeEntry = blocks.head.getBody.getState.blockNumber
+                    maybeLvl0 = if (timeEntry != 1) None
+                    else
+                      Some(for {
+                        g       <- Graphz.subgraph[Effect](s"lvl0", DiGraph, rank = Some(Same))
+                        _       <- g.node("0")
+                        genesis = blocks.head.getHeader.parentsHashList.head
+                        _       <- g.node(name = PrettyPrinter.buildString(genesis), shape = Msquare)
+                        _       <- g.close
+                      } yield g)
+
+                    lvlGraph = for {
+                      g <- Graphz.subgraph[Effect](s"lvl$timeEntry", DiGraph, rank = Some(Same))
+                      _ <- g.node(timeEntry.toString)
+                      _ <- blocks.traverse(
+                            b => g.node(name = PrettyPrinter.buildString(b.blockHash), shape = Box)
+                          )
+                      _ <- g.close
+                    } yield g
+                    graph = for {
+                      g <- acc.graph
+                      _ <- maybeLvl0.getOrElse(().pure[Effect])
+                      _ <- g.subgraph(lvlGraph)
+                      _ <- blocks.traverse(
+                            b =>
+                              b.getHeader.parentsHashList.toList
+                                .map(PrettyPrinter.buildString)
+                                .traverse { parentHash =>
+                                  g.edge(PrettyPrinter.buildString(b.blockHash) -> parentHash)
+                                }
+                          )
+                    } yield g
+                  } yield {
+                    val timeEntries = timeEntry :: maybeLvl0.map(kp(0L)).toList
+                    acc.copy(
+                      timeseries = timeEntries ++ acc.timeseries,
+                      graph = graph
+                    )
+                  }
+
+              }
+        result <- Sync[F].delay {
+
+                   val times = acc.timeseries.sorted.map(_.toString)
+
+                   val timeseries: Effect[Graphz[Effect]] = for {
+                     g     <- Graphz.subgraph[Effect]("timeseries", DiGraph)
+                     _     <- times.traverse(n => g.node(name = n, shape = PlainText))
+                     edges = times.zip(times.drop(1))
+                     _     <- edges.traverse(g.edge)
+                     _     <- g.close
+                   } yield g
+
+                   val finalGraph: Effect[Graphz[Effect]] = for {
+                     g <- acc.graph
+                     _ <- g.subgraph(timeseries)
+                     _ <- g.close
+                   } yield g
+                   finalGraph.runS(new StringBuffer).toString
+                 }
+      } yield result
+
+    MultiParentCasperRef.withCasper[F, String](
+      casperResponse(_),
+      "no casper"
+    )
   }
 
   def showBlocks[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -33,6 +33,9 @@ object DeployRuntime {
   def showBlocks[F[_]: Monad: Sync: DeployService](depth: Int): F[Unit] =
     gracefulExit(DeployService[F].showBlocks(BlocksQuery(depth)))
 
+  def visualizeBlocks[F[_]: Monad: Sync: DeployService](depth: Int): F[Unit] =
+    gracefulExit(DeployService[F].visualizeBlocks(BlocksQuery(depth)))
+
   def listenForDataAtName[F[_]: Sync: DeployService: Time: Capture](
       name: Id[Name]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -16,6 +16,7 @@ trait DeployService[F[_]] {
   def createBlock(): F[Either[Throwable, String]] //create block and add to Casper internal state
   def showBlock(q: BlockQuery): F[Either[Throwable, String]]
   def showBlocks(q: BlocksQuery): F[Either[Throwable, String]]
+  def visualizeBlocks(q: BlocksQuery): F[Either[Throwable, String]]
   def listenForDataAtName(request: DataAtNameQuery): F[ListeningNameDataResponse]
   def listenForContinuationAtName(
       request: ContinuationAtNameQuery
@@ -53,6 +54,12 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
 
   def showBlock(q: BlockQuery): Task[Either[Throwable, String]] =
     stub.showBlock(q).map { response =>
+      if (response.status == "Success") Right(response.toProtoString)
+      else Left(new RuntimeException(response.status))
+    }
+
+  def visualizeBlocks(q: BlocksQuery): Task[Either[Throwable, String]] =
+    stub.visualizeBlocks(q).map { response =>
       if (response.status == "Success") Right(response.toProtoString)
       else Left(new RuntimeException(response.status))
     }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -33,6 +33,8 @@ service DeployService {
   rpc createBlock(google.protobuf.Empty) returns (DeployServiceResponse) {}
   // Get details about a particular block.
   rpc showBlock(BlockQuery) returns (BlockQueryResponse) {}
+  // Get dag
+  rpc visualizeBlocks(BlocksQuery) returns (VisualizeBlocksResponse) {}
   rpc showMainChain(BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {}
   // Get a summary of blocks on the blockchain.
   rpc showBlocks(BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {}
@@ -107,6 +109,11 @@ message MaybeBlockMessage {
 message BlockQueryResponse {
   string status = 1;
   BlockInfo blockInfo = 2;
+}
+
+message VisualizeBlocksResponse {
+  string status =  1;
+  string content = 2;
 }
 
 message ListeningNameDataResponse {

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -67,13 +67,14 @@ object Main {
       case Diagnostics => diagnostics.client.Runtime.diagnosticsProgram[Task]
       case Deploy(address, phlo, phloPrice, nonce, location) =>
         DeployRuntime.deployFileProgram[Task](address, phlo, phloPrice, nonce, location)
-      case DeployDemo        => DeployRuntime.deployDemoProgram[Task]
-      case Propose           => DeployRuntime.propose[Task]()
-      case ShowBlock(hash)   => DeployRuntime.showBlock[Task](hash)
-      case ShowBlocks(depth) => DeployRuntime.showBlocks[Task](depth)
-      case DataAtName(name)  => DeployRuntime.listenForDataAtName[Task](name)
-      case ContAtName(names) => DeployRuntime.listenForContinuationAtName[Task](names)
-      case Run               => nodeProgram(conf)
+      case DeployDemo             => DeployRuntime.deployDemoProgram[Task]
+      case Propose                => DeployRuntime.propose[Task]()
+      case ShowBlock(hash)        => DeployRuntime.showBlock[Task](hash)
+      case ShowBlocks(depth)      => DeployRuntime.showBlocks[Task](depth)
+      case VisualizeBlocks(depth) => DeployRuntime.visualizeBlocks[Task](depth)
+      case DataAtName(name)       => DeployRuntime.listenForDataAtName[Task](name)
+      case ContAtName(names)      => DeployRuntime.listenForContinuationAtName[Task](names)
+      case Run                    => nodeProgram(conf)
       case BondingDeployGen(bondKey, ethAddress, amount, secKey, pubKey) =>
         BondingUtil.writeIssuanceBasedRhoFiles[Task](bondKey, ethAddress, amount, secKey, pubKey)
       case FaucetBondingDeployGen(amount, sigAlgorithm, secKey, pubKey) =>

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -34,6 +34,12 @@ private[api] object DeployGrpcService {
       override def showBlock(q: BlockQuery): Task[BlockQueryResponse] =
         defer(BlockAPI.showBlock[F](q))
 
+      // TODO handle potentiall errors (at least by returning proper response)
+      override def visualizeBlocks(q: BlocksQuery): Task[VisualizeBlocksResponse] = {
+        val depth = if (q.depth <= 0) None else Some(q.depth)
+        defer(BlockAPI.visualizeBlocks[F](depth).map(VisualizeBlocksResponse(_)))
+      }
+
       override def showBlocks(request: BlocksQuery): Observable[BlockInfoWithoutTuplespace] =
         Observable
           .fromTask(defer(BlockAPI.showBlocks[F](request.depth)))

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -423,6 +423,9 @@ object Configuration {
       case Some(options.showBlocks) =>
         import options.showBlocks._
         ShowBlocks(depth.getOrElse(1))
+      case Some(options.visualizeBlocks) =>
+        import options.visualizeBlocks._
+        VisualizeBlocks(depth.getOrElse(-1))
       case Some(options.run)        => Run
       case Some(options.dataAtName) => DataAtName(options.dataAtName.name())
       case Some(options.contAtName) => ContAtName(options.contAtName.name())

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -371,6 +371,18 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showBlocks)
 
+  val visualizeBlocks = new Subcommand("vdag") {
+    descr(
+      "DAG in DOT format"
+    )
+    val depth =
+      opt[Int](
+        name = "depth",
+        descr = "depth in terms of block height"
+      )
+  }
+  addSubcommand(visualizeBlocks)
+
   def listenAtName[R](name: String, desc: String)(
       implicit conv: ValueConverter[List[String] => R]
   ) = new Subcommand(name) {

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -53,6 +53,7 @@ case object DeployDemo                   extends Command
 case object Propose                      extends Command
 case class ShowBlock(hash: String)       extends Command
 case class ShowBlocks(depth: Int)        extends Command
+case class VisualizeBlocks(depth: Int)   extends Command
 case object Run                          extends Command
 case object Help                         extends Command
 case class DataAtName(name: Name)        extends Command


### PR DESCRIPTION
## Overview

Example usage:

```
➜  stage git:(core-1547-casper-dag-graphz) ✗ ./bin/rnode deploy --phlo-limit 34 --phlo-price 34 ~/projects/rchain/rholang/examples/dupe.rho
Response: Success!
➜  stage git:(core-1547-casper-dag-graphz) ✗ ./bin/rnode propose                                                                     
Response: Success! Block 493be30cc9... created and added.
➜  stage git:(core-1547-casper-dag-graphz) ✗ ./bin/rnode vdag                                                                              
digraph DAG {
  rankdir=BT
  subgraph lvl0 {
    rank=same
    "0" []
    "353a5d51a7..." [shape=Msquare]
  }  subgraph lvl1 {
    rank=same
    "1" []
    "493be30cc9..." [shape=box]
  }
  "493be30cc9..." -> "353a5d51a7..." []
  subgraph timeseries {
    "0" [shape=plaintext]
    "1" [shape=plaintext]
    "0" -> "1" []
  }
}
```

What is missing:
1. `VisualizeCasperTest` was stashed (not commited) and is waiting till final "view" of graph will stabilize (next PR)

### JIRA ticket:
CORE-1547