### PR TITLE
Lift Task to abstract context

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -66,7 +66,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
 
 sealed abstract class MultiParentCasperInstances {
 
-  def hashSetCasper[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ToAbstractContext](
+  def hashSetCasper[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
       runtimeManager: RuntimeManager,
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -66,7 +66,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
 
 sealed abstract class MultiParentCasperInstances {
 
-  def hashSetCasper[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
+  def hashSetCasper[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ToAbstractContext](
       runtimeManager: RuntimeManager,
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -6,7 +6,6 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
-import coop.rchain.catscontrib._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util._

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -24,7 +24,7 @@ import monix.execution.atomic.AtomicAny
 
 import scala.collection.mutable
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ToAbstractContext](
     runtimeManager: RuntimeManager,
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util._

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -24,7 +24,7 @@ import monix.execution.atomic.AtomicAny
 
 import scala.collection.mutable
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ToAbstractContext](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
     runtimeManager: RuntimeManager,
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util._
@@ -23,7 +24,7 @@ import monix.execution.atomic.AtomicAny
 
 import scala.collection.mutable
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ToAbstractContext](
     runtimeManager: RuntimeManager,
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -17,7 +17,6 @@ import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.shared._
-import monix.eval.TaskLift
 import monix.execution.Scheduler
 
 import scala.util.{Failure, Success, Try}
@@ -564,7 +563,7 @@ object Validate {
         false
       }
 
-  def transactions[F[_]: Sync: Log: BlockStore: TaskLift](
+  def transactions[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       emptyStateHash: StateHash,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -5,6 +5,7 @@ import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
@@ -562,7 +563,7 @@ object Validate {
         false
       }
 
-  def transactions[F[_]: Sync: Log: BlockStore](
+  def transactions[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       emptyStateHash: StateHash,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -17,6 +17,7 @@ import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.shared._
+import monix.eval.TaskLift
 import monix.execution.Scheduler
 
 import scala.util.{Failure, Success, Try}
@@ -563,7 +564,7 @@ object Validate {
         false
       }
 
-  def transactions[F[_]: Sync: Log: BlockStore: ToAbstractContext](
+  def transactions[F[_]: Sync: Log: BlockStore: TaskLift](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       emptyStateHash: StateHash,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -5,6 +5,7 @@ import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -5,7 +5,6 @@ import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
-import coop.rchain.catscontrib._
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -19,6 +19,7 @@ import coop.rchain.comm.transport.{Blob, TransportLayer}
 import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.shared._
+import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.util.Try
@@ -141,7 +142,7 @@ object BlockApproverProtocol {
             .either(())
             .or("Mismatch between number of candidate deploys and expected number of deploys.")
       stateHash <- runtimeManager
-                    .replayComputeState(runtimeManager.emptyStateHash, blockDeploys)
+                    .replayComputeState[Task](runtimeManager.emptyStateHash, blockDeploys)
                     .runSyncUnsafe(Duration.Inf)
                     .leftMap { case (_, status) => s"Failed status during replay: $status." }
       _ <- (stateHash == postState.postStateHash)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -19,7 +19,6 @@ import coop.rchain.comm.transport.{Blob, TransportLayer}
 import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.shared._
-import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.util.Try
@@ -142,7 +141,7 @@ object BlockApproverProtocol {
             .either(())
             .or("Mismatch between number of candidate deploys and expected number of deploys.")
       stateHash <- runtimeManager
-                    .replayComputeState[Task](runtimeManager.emptyStateHash, blockDeploys)
+                    .replayComputeState(runtimeManager.emptyStateHash, blockDeploys)
                     .runSyncUnsafe(Duration.Inf)
                     .leftMap { case (_, status) => s"Failed status during replay: $status." }
       _ <- (stateHash == postState.postStateHash)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.catscontrib.ToAbstractContext
 import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
@@ -39,7 +38,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
 
   def apply[F[_]](implicit ev: CasperPacketHandler[F]): CasperPacketHandler[F] = ev
 
-  def of[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: ToAbstractContext](
+  def of[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage](
       conf: CasperConf,
       delay: FiniteDuration,
       runtimeManager: RuntimeManager,
@@ -158,7 +157,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * When in this state node can't handle any other message type so it will return `F[None]`
     **/
-  private[comm] class GenesisValidatorHandler[F[_]: Capture: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
+  private[comm] class GenesisValidatorHandler[F[_]: Capture: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage](
       runtimeManager: RuntimeManager,
       validatorId: ValidatorIdentity,
       shardId: String,
@@ -246,7 +245,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   }
 
   object StandaloneCasperHandler {
-    def approveBlockInterval[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: ToAbstractContext](
+    def approveBlockInterval[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage](
         interval: FiniteDuration,
         shardId: String,
         runtimeManager: RuntimeManager,
@@ -288,7 +287,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
     * `F[None]` to all other message types.
     **/
-  private[comm] class BootstrapCasperHandler[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
+  private[comm] class BootstrapCasperHandler[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage](
       runtimeManager: RuntimeManager,
       shardId: String,
       validatorId: Option[ValidatorIdentity],
@@ -530,7 +529,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       Try(NoApprovedBlockAvailable.parseFrom(msg.content.toByteArray)).toOption
     else None
 
-  private def onApprovedBlockTransition[F[_]: Sync: Concurrent: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
+  private def onApprovedBlockTransition[F[_]: Sync: Concurrent: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage](
       b: ApprovedBlock,
       validators: Set[ByteString],
       runtimeManager: RuntimeManager,

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.catscontrib.ToAbstractContext
 import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
@@ -38,7 +39,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
 
   def apply[F[_]](implicit ev: CasperPacketHandler[F]): CasperPacketHandler[F] = ev
 
-  def of[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage](
+  def of[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Capture: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: ToAbstractContext](
       conf: CasperConf,
       delay: FiniteDuration,
       runtimeManager: RuntimeManager,
@@ -157,7 +158,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * When in this state node can't handle any other message type so it will return `F[None]`
     **/
-  private[comm] class GenesisValidatorHandler[F[_]: Capture: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage](
+  private[comm] class GenesisValidatorHandler[F[_]: Capture: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
       runtimeManager: RuntimeManager,
       validatorId: ValidatorIdentity,
       shardId: String,
@@ -245,7 +246,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   }
 
   object StandaloneCasperHandler {
-    def approveBlockInterval[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage](
+    def approveBlockInterval[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: ToAbstractContext](
         interval: FiniteDuration,
         shardId: String,
         runtimeManager: RuntimeManager,
@@ -287,7 +288,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
     * `F[None]` to all other message types.
     **/
-  private[comm] class BootstrapCasperHandler[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage](
+  private[comm] class BootstrapCasperHandler[F[_]: Sync: Concurrent: Capture: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
       runtimeManager: RuntimeManager,
       shardId: String,
       validatorId: Option[ValidatorIdentity],
@@ -529,7 +530,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       Try(NoApprovedBlockAvailable.parseFrom(msg.content.toByteArray)).toOption
     else None
 
-  private def onApprovedBlockTransition[F[_]: Sync: Concurrent: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage](
+  private def onApprovedBlockTransition[F[_]: Sync: Concurrent: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: Capture: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage: ToAbstractContext](
       b: ApprovedBlock,
       validators: Set[ByteString],
       runtimeManager: RuntimeManager,

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -32,7 +32,7 @@ object InterpreterUtil {
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys
-  def validateBlockCheckpoint[F[_]: Sync: TaskLift: Log: BlockStore](
+  def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: TaskLift](
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager
@@ -63,7 +63,7 @@ object InterpreterUtil {
     } yield result
   }
 
-  private def processPossiblePreStateHash[F[_]: Sync: TaskLift: Log: BlockStore](
+  private def processPossiblePreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -92,7 +92,7 @@ object InterpreterUtil {
         }
     }
 
-  private def processPreStateHash[F[_]: Sync: TaskLift: Log: BlockStore](
+  private def processPreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -1,8 +1,10 @@
 package coop.rchain.casper.util.rholang
 
 import cats.Monad
+import cats.effect._
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.{BlockException, PrettyPrinter}
 import coop.rchain.casper.PrettyPrinter.buildString
 import com.google.protobuf.ByteString
@@ -29,7 +31,7 @@ object InterpreterUtil {
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys
-  def validateBlockCheckpoint[F[_]: Monad: Log: BlockStore](
+  def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager
@@ -60,7 +62,7 @@ object InterpreterUtil {
     } yield result
   }
 
-  private def processPossiblePreStateHash[F[_]: Monad: Log: BlockStore](
+  private def processPossiblePreStateHash[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -89,7 +91,7 @@ object InterpreterUtil {
         }
     }
 
-  private def processPreStateHash[F[_]: Monad: Log: BlockStore](
+  private def processPreStateHash[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -97,51 +99,53 @@ object InterpreterUtil {
       possiblePreStateHash: Either[Throwable, StateHash],
       time: Option[Long]
   )(implicit scheduler: Scheduler): F[Either[BlockException, Option[StateHash]]] =
-    runtimeManager
-      .replayComputeState(preStateHash, internalDeploys, time)
-      .runSyncUnsafe(Duration.Inf) match {
-      case Left((Some(deploy), status)) =>
-        status match {
-          case InternalErrors(exs) =>
-            Left(
-              BlockException(
-                new Exception(s"Internal errors encountered while processing ${PrettyPrinter
-                  .buildString(deploy)}: ${exs.mkString("\n")}")
-              )
-            ).rightCast[Option[StateHash]].pure[F]
-          case UserErrors(errors: Vector[Throwable]) =>
-            Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
-              none[StateHash]
-            ).leftCast[BlockException].pure[F]
-          case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
-            Log[F].warn(
-              s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
-            ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
-          case UnknownFailure =>
-            Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
-              .leftCast[BlockException]
-              .pure[F]
-        }
-      case Left((None, status)) =>
-        status match {
-          case UnusedCommEvent(ex: ReplayException) =>
-            Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
-              .leftCast[BlockException]
-              .pure[F]
-        }
-      case Right(computedStateHash) =>
-        if (tsHash.contains(computedStateHash)) {
-          // state hash in block matches computed hash!
-          Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
-        } else {
-          // state hash in block does not match computed hash -- invalid!
-          // return no state hash, do not update the state hash set
-          Log[F].warn(
-            s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
-          ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
+    (runtimeManager
+      .replayComputeState(preStateHash, internalDeploys, time))
+      .flatMap { res =>
+        res match {
+          case Left((Some(deploy), status)) =>
+            status match {
+              case InternalErrors(exs) =>
+                Left(
+                  BlockException(
+                    new Exception(s"Internal errors encountered while processing ${PrettyPrinter
+                      .buildString(deploy)}: ${exs.mkString("\n")}")
+                  )
+                ).rightCast[Option[StateHash]].pure[F]
+              case UserErrors(errors: Vector[Throwable]) =>
+                Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
+                  none[StateHash]
+                ).leftCast[BlockException].pure[F]
+              case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
+                Log[F].warn(
+                  s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
+                ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
+              case UnknownFailure =>
+                Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
+                  .leftCast[BlockException]
+                  .pure[F]
+            }
+          case Left((None, status)) =>
+            status match {
+              case UnusedCommEvent(ex: ReplayException) =>
+                Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
+                  .leftCast[BlockException]
+                  .pure[F]
+            }
+          case Right(computedStateHash) =>
+            if (tsHash.contains(computedStateHash)) {
+              // state hash in block matches computed hash!
+              Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
+            } else {
+              // state hash in block does not match computed hash -- invalid!
+              // return no state hash, do not update the state hash set
+              Log[F].warn(
+                s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
+              ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
 
+            }
         }
-    }
+      }
 
   def computeDeploysCheckpoint[F[_]: Monad: BlockStore](
       parents: Seq[BlockMessage],

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -19,7 +19,6 @@ import coop.rchain.rholang.interpreter.Interpreter
 import coop.rchain.rspace.ReplayException
 import coop.rchain.shared.{Log, LogSource}
 import monix.eval.Task
-import monix.eval.TaskLift
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
@@ -33,7 +32,7 @@ object InterpreterUtil {
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys
-  def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: TaskLift](
+  def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager
@@ -64,7 +63,7 @@ object InterpreterUtil {
     } yield result
   }
 
-  private def processPossiblePreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
+  private def processPossiblePreStateHash[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -93,7 +92,7 @@ object InterpreterUtil {
         }
     }
 
-  private def processPreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
+  private def processPreStateHash[F[_]: Sync: Log: BlockStore: ToAbstractContext](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -32,7 +32,7 @@ object InterpreterUtil {
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys
-  def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: TaskLift](
+  def validateBlockCheckpoint[F[_]: Sync: TaskLift: Log: BlockStore](
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager
@@ -63,7 +63,7 @@ object InterpreterUtil {
     } yield result
   }
 
-  private def processPossiblePreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
+  private def processPossiblePreStateHash[F[_]: Sync: TaskLift: Log: BlockStore](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -92,7 +92,7 @@ object InterpreterUtil {
         }
     }
 
-  private def processPreStateHash[F[_]: Sync: Log: BlockStore: TaskLift](
+  private def processPreStateHash[F[_]: Sync: TaskLift: Log: BlockStore](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -102,48 +102,50 @@ object InterpreterUtil {
   ): F[Either[BlockException, Option[StateHash]]] =
     (runtimeManager
       .replayComputeState(preStateHash, internalDeploys, time))
-      .flatMap {
-        case Left((Some(deploy), status)) =>
-          status match {
-            case InternalErrors(exs) =>
-              Left(
-                BlockException(
-                  new Exception(s"Internal errors encountered while processing ${PrettyPrinter
-                    .buildString(deploy)}: ${exs.mkString("\n")}")
-                )
-              ).rightCast[Option[StateHash]].pure[F]
-            case UserErrors(errors: Vector[Throwable]) =>
-              Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
-                none[StateHash]
-              ).leftCast[BlockException].pure[F]
-            case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
+      .flatMap { res =>
+        res match {
+          case Left((Some(deploy), status)) =>
+            status match {
+              case InternalErrors(exs) =>
+                Left(
+                  BlockException(
+                    new Exception(s"Internal errors encountered while processing ${PrettyPrinter
+                      .buildString(deploy)}: ${exs.mkString("\n")}")
+                  )
+                ).rightCast[Option[StateHash]].pure[F]
+              case UserErrors(errors: Vector[Throwable]) =>
+                Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
+                  none[StateHash]
+                ).leftCast[BlockException].pure[F]
+              case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
+                Log[F].warn(
+                  s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
+                ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
+              case UnknownFailure =>
+                Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
+                  .leftCast[BlockException]
+                  .pure[F]
+            }
+          case Left((None, status)) =>
+            status match {
+              case UnusedCommEvent(ex: ReplayException) =>
+                Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
+                  .leftCast[BlockException]
+                  .pure[F]
+            }
+          case Right(computedStateHash) =>
+            if (tsHash.contains(computedStateHash)) {
+              // state hash in block matches computed hash!
+              Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
+            } else {
+              // state hash in block does not match computed hash -- invalid!
+              // return no state hash, do not update the state hash set
               Log[F].warn(
-                s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
+                s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
               ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
-            case UnknownFailure =>
-              Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
-                .leftCast[BlockException]
-                .pure[F]
-          }
-        case Left((None, status)) =>
-          status match {
-            case UnusedCommEvent(ex: ReplayException) =>
-              Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
-                .leftCast[BlockException]
-                .pure[F]
-          }
-        case Right(computedStateHash) =>
-          if (tsHash.contains(computedStateHash)) {
-            // state hash in block matches computed hash!
-            Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
-          } else {
-            // state hash in block does not match computed hash -- invalid!
-            // return no state hash, do not update the state hash set
-            Log[F].warn(
-              s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
-            ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
 
-          }
+            }
+        }
       }
 
   def computeDeploysCheckpoint[F[_]: Monad: BlockStore](

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -4,7 +4,6 @@ import cats.Monad
 import cats.effect._
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
-import coop.rchain.catscontrib._
 import coop.rchain.casper.{BlockException, PrettyPrinter}
 import coop.rchain.casper.PrettyPrinter.buildString
 import com.google.protobuf.ByteString
@@ -100,7 +99,7 @@ object InterpreterUtil {
       internalDeploys: Seq[InternalProcessedDeploy],
       possiblePreStateHash: Either[Throwable, StateHash],
       time: Option[Long]
-  )(implicit scheduler: Scheduler): F[Either[BlockException, Option[StateHash]]] =
+  ): F[Either[BlockException, Option[StateHash]]] =
     (runtimeManager
       .replayComputeState(preStateHash, internalDeploys, time))
       .flatMap { res =>

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -102,50 +102,48 @@ object InterpreterUtil {
   ): F[Either[BlockException, Option[StateHash]]] =
     (runtimeManager
       .replayComputeState(preStateHash, internalDeploys, time))
-      .flatMap { res =>
-        res match {
-          case Left((Some(deploy), status)) =>
-            status match {
-              case InternalErrors(exs) =>
-                Left(
-                  BlockException(
-                    new Exception(s"Internal errors encountered while processing ${PrettyPrinter
-                      .buildString(deploy)}: ${exs.mkString("\n")}")
-                  )
-                ).rightCast[Option[StateHash]].pure[F]
-              case UserErrors(errors: Vector[Throwable]) =>
-                Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
-                  none[StateHash]
-                ).leftCast[BlockException].pure[F]
-              case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
-                Log[F].warn(
-                  s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
-                ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
-              case UnknownFailure =>
-                Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
-                  .leftCast[BlockException]
-                  .pure[F]
-            }
-          case Left((None, status)) =>
-            status match {
-              case UnusedCommEvent(ex: ReplayException) =>
-                Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
-                  .leftCast[BlockException]
-                  .pure[F]
-            }
-          case Right(computedStateHash) =>
-            if (tsHash.contains(computedStateHash)) {
-              // state hash in block matches computed hash!
-              Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
-            } else {
-              // state hash in block does not match computed hash -- invalid!
-              // return no state hash, do not update the state hash set
+      .flatMap {
+        case Left((Some(deploy), status)) =>
+          status match {
+            case InternalErrors(exs) =>
+              Left(
+                BlockException(
+                  new Exception(s"Internal errors encountered while processing ${PrettyPrinter
+                    .buildString(deploy)}: ${exs.mkString("\n")}")
+                )
+              ).rightCast[Option[StateHash]].pure[F]
+            case UserErrors(errors: Vector[Throwable]) =>
+              Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
+                none[StateHash]
+              ).leftCast[BlockException].pure[F]
+            case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
               Log[F].warn(
-                s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
+                s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
               ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
+            case UnknownFailure =>
+              Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
+                .leftCast[BlockException]
+                .pure[F]
+          }
+        case Left((None, status)) =>
+          status match {
+            case UnusedCommEvent(ex: ReplayException) =>
+              Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
+                .leftCast[BlockException]
+                .pure[F]
+          }
+        case Right(computedStateHash) =>
+          if (tsHash.contains(computedStateHash)) {
+            // state hash in block matches computed hash!
+            Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
+          } else {
+            // state hash in block does not match computed hash -- invalid!
+            // return no state hash, do not update the state hash set
+            Log[F].warn(
+              s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
+            ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
 
-            }
-        }
+          }
       }
 
   def computeDeploysCheckpoint[F[_]: Monad: BlockStore](

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.effect._
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.catscontrib._
 import coop.rchain.casper.{BlockException, PrettyPrinter}
 import coop.rchain.casper.PrettyPrinter.buildString
 import com.google.protobuf.ByteString
@@ -99,7 +100,7 @@ object InterpreterUtil {
       internalDeploys: Seq[InternalProcessedDeploy],
       possiblePreStateHash: Either[Throwable, StateHash],
       time: Option[Long]
-  ): F[Either[BlockException, Option[StateHash]]] =
+  )(implicit scheduler: Scheduler): F[Either[BlockException, Option[StateHash]]] =
     (runtimeManager
       .replayComputeState(preStateHash, internalDeploys, time))
       .flatMap { res =>

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -52,7 +52,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     result.flatMap(_.a.pars)
   }
 
-  def replayComputeState[F[_]: Sync: TaskLift](
+  def replayComputeState[F[_]: TaskLift: Sync](
       hash: StateHash,
       terms: Seq[InternalProcessedDeploy],
       time: Option[Long] = None

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -52,7 +52,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     result.flatMap(_.a.pars)
   }
 
-  def replayComputeState[F[_]: TaskLift: Sync](
+  def replayComputeState[F[_]: Sync: TaskLift](
       hash: StateHash,
       terms: Seq[InternalProcessedDeploy],
       time: Option[Long] = None

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -19,6 +19,7 @@ import coop.rchain.rspace.internal.{Datum, WaitingContinuation}
 import coop.rchain.rspace.trace.Produce
 import coop.rchain.rspace.{Blake2b256Hash, ReplayException}
 import monix.eval.Task
+import monix.eval.TaskLift
 import monix.execution.Scheduler
 
 import coop.rchain.catscontrib.TaskContrib._
@@ -52,7 +53,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     result.flatMap(_.a.pars)
   }
 
-  def replayComputeState[F[_]: ToAbstractContext: Sync](
+  def replayComputeState[F[_]: TaskLift: Sync](
       hash: StateHash,
       terms: Seq[InternalProcessedDeploy],
       time: Option[Long] = None
@@ -60,7 +61,7 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
     for {
       runtime <- Sync[F].delay(runtimeContainer.take())
       _       <- setTimestamp(time, runtime)
-      result  <- ToAbstractContext[F].fromTask(replayEval(terms, runtime, hash))
+      result  <- TaskLift[F].taskLift(replayEval(terms, runtime, hash))
       _       <- Sync[F].delay(runtimeContainer.put(runtime))
     } yield result
 
@@ -76,14 +77,14 @@ class RuntimeManager private (val emptyStateHash: ByteString, runtimeContainer: 
       _       <- Task.delay(runtimeContainer.put(runtime))
     } yield result
 
-  private def setTimestamp[F[_]: ToAbstractContext: Sync](
+  private def setTimestamp[F[_]: TaskLift: Sync](
       time: Option[Long],
       runtime: Runtime
   ): F[Unit] =
     time match {
       case Some(t) =>
         val timestamp: Par = Par(exprs = Seq(Expr(Expr.ExprInstance.GInt(t))))
-        ToAbstractContext[F].fromTask(runtime.blockTime.setParams(timestamp))
+        TaskLift[F].taskLift(runtime.blockTime.setParams(timestamp))
       case None => ().pure[F]
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -7,7 +7,6 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.catscontrib._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Expr.ExprInstance.GString

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -7,6 +7,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.catscontrib._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Expr.ExprInstance.GString

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -295,20 +295,20 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         .toList
 
     for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
+      nodes              <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       List(node0, node1) = nodes.toList
 
       unsignedBlock <- (node0.casperEff.deploy(data0) *> node0.casperEff.createBlock)
-                         .map {
-                           case Created(block) =>
-                             block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
-                         }
+                        .map {
+                          case Created(block) =>
+                            block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
+                        }
 
       _ <- node0.casperEff.addBlock(unsignedBlock, ignoreDoppelgangerCheck[Effect])
       _ <- node1.transportLayerEff.clear(node1.local) //node1 misses this block
 
       signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
-        .map { case Created(block) => block}
+                      .map { case Created(block) => block }
 
       _ <- node0.casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
       _ <- node1.receive() //receives block1; should not ask for block0

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -295,20 +295,20 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         .toList
 
     for {
-      nodes              <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
+      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       List(node0, node1) = nodes.toList
 
       unsignedBlock <- (node0.casperEff.deploy(data0) *> node0.casperEff.createBlock)
-                        .map {
-                          case Created(block) =>
-                            block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
-                        }
+                         .map {
+                           case Created(block) =>
+                             block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
+                         }
 
       _ <- node0.casperEff.addBlock(unsignedBlock, ignoreDoppelgangerCheck[Effect])
       _ <- node1.transportLayerEff.clear(node1.local) //node1 misses this block
 
       signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
-                      .map { case Created(block) => block }
+        .map { case Created(block) => block}
 
       _ <- node0.casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
       _ <- node1.receive() //receives block1; should not ask for block0

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -63,8 +63,7 @@ class HashSetCasperTestNode[F[_]](
     concurrentF: Concurrent[F],
     val blockStore: BlockStore[F],
     val blockDagStorage: BlockDagStorage[F],
-    val metricEff: Metrics[F],
-    abF: ToAbstractContext[F]
+    val metricEff: Metrics[F]
 ) {
 
   private val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-$name")
@@ -139,10 +138,6 @@ object HashSetCasperTestNode {
 
   import coop.rchain.catscontrib._
 
-  implicit val absF = new ToAbstractContext[Effect] {
-    def fromTask[A](fa: Task[A]): Effect[A] = new MonadOps(fa).liftM[CommErrT]
-  }
-
   def standaloneF[F[_]](
       genesis: BlockMessage,
       sk: Array[Byte],
@@ -152,8 +147,7 @@ object HashSetCasperTestNode {
       errorHandler: ErrorHandler[F],
       syncF: Sync[F],
       captureF: Capture[F],
-      concurrentF: Concurrent[F],
-      absF: ToAbstractContext[F]
+      concurrentF: Concurrent[F]
   ): F[HashSetCasperTestNode[F]] = {
     val name     = "standalone"
     val identity = peerNode(name, 40400)
@@ -194,7 +188,7 @@ object HashSetCasperTestNode {
         blockStoreDir,
         semaphore,
         "rchain"
-      )(scheduler, syncF, captureF, concurrentF, blockStore, blockDagStorage, metricEff, absF)
+      )(scheduler, syncF, captureF, concurrentF, blockStore, blockDagStorage, metricEff)
       result <- node.initialize.map(_ => node)
     } yield result
   }
@@ -206,8 +200,7 @@ object HashSetCasperTestNode {
       ApplicativeError_[Effect, CommError],
       syncEffectInstance,
       Capture[Effect],
-      Concurrent[Effect],
-      ToAbstractContext[Effect]
+      Concurrent[Effect]
     ).value.unsafeRunSync.right.get
 
   def networkF[F[_]](
@@ -219,8 +212,7 @@ object HashSetCasperTestNode {
       errorHandler: ErrorHandler[F],
       syncF: Sync[F],
       captureF: Capture[F],
-      concurrentF: Concurrent[F],
-      absF: ToAbstractContext[F]
+      concurrentF: Concurrent[F]
   ): F[IndexedSeq[HashSetCasperTestNode[F]]] = {
     val n     = sks.length
     val names = (1 to n).map(i => s"node-$i")
@@ -280,8 +272,7 @@ object HashSetCasperTestNode {
                 concurrentF,
                 blockStore,
                 blockDagStorage,
-                metricEff,
-                absF
+                metricEff
               )
             } yield node
         }
@@ -316,8 +307,7 @@ object HashSetCasperTestNode {
       ApplicativeError_[Effect, CommError],
       syncEffectInstance,
       Capture[Effect],
-      Concurrent[Effect],
-      ToAbstractContext[Effect]
+      Concurrent[Effect]
     )
 
   val appErrId = new ApplicativeError[Id, CommError] {

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -8,6 +8,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, ApplicativeError, Id, Monad}
 import coop.rchain.blockstorage._
+import coop.rchain.catscontrib._
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
@@ -62,7 +63,8 @@ class HashSetCasperTestNode[F[_]](
     concurrentF: Concurrent[F],
     val blockStore: BlockStore[F],
     val blockDagStorage: BlockDagStorage[F],
-    val metricEff: Metrics[F]
+    val metricEff: Metrics[F],
+    abF: ToAbstractContext[F]
 ) {
 
   private val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-$name")
@@ -84,6 +86,7 @@ class HashSetCasperTestNode[F[_]](
 
   implicit val labF        = LastApprovedBlock.unsafe[F](Some(approvedBlock))
   val postGenesisStateHash = ProtoUtil.postStateHash(genesis)
+
   implicit val casperEff = new MultiParentCasperImpl[F](
     runtimeManager,
     Some(validatorId),
@@ -131,7 +134,14 @@ class HashSetCasperTestNode[F[_]](
 }
 
 object HashSetCasperTestNode {
-  type Effect[A] = EitherT[Task, CommError, A]
+  type CommErrT[F[_], A] = EitherT[F, CommError, A]
+  type Effect[A]         = CommErrT[Task, A]
+
+  import coop.rchain.catscontrib._
+
+  implicit val absF = new ToAbstractContext[Effect] {
+    def fromTask[A](fa: Task[A]): Effect[A] = new MonadOps(fa).liftM[CommErrT]
+  }
 
   def standaloneF[F[_]](
       genesis: BlockMessage,
@@ -142,7 +152,8 @@ object HashSetCasperTestNode {
       errorHandler: ErrorHandler[F],
       syncF: Sync[F],
       captureF: Capture[F],
-      concurrentF: Concurrent[F]
+      concurrentF: Concurrent[F],
+      absF: ToAbstractContext[F]
   ): F[HashSetCasperTestNode[F]] = {
     val name     = "standalone"
     val identity = peerNode(name, 40400)
@@ -183,7 +194,7 @@ object HashSetCasperTestNode {
         blockStoreDir,
         semaphore,
         "rchain"
-      )(scheduler, syncF, captureF, concurrentF, blockStore, blockDagStorage, metricEff)
+      )(scheduler, syncF, captureF, concurrentF, blockStore, blockDagStorage, metricEff, absF)
       result <- node.initialize.map(_ => node)
     } yield result
   }
@@ -195,7 +206,8 @@ object HashSetCasperTestNode {
       ApplicativeError_[Effect, CommError],
       syncEffectInstance,
       Capture[Effect],
-      Concurrent[Effect]
+      Concurrent[Effect],
+      ToAbstractContext[Effect]
     ).value.unsafeRunSync.right.get
 
   def networkF[F[_]](
@@ -207,7 +219,8 @@ object HashSetCasperTestNode {
       errorHandler: ErrorHandler[F],
       syncF: Sync[F],
       captureF: Capture[F],
-      concurrentF: Concurrent[F]
+      concurrentF: Concurrent[F],
+      absF: ToAbstractContext[F]
   ): F[IndexedSeq[HashSetCasperTestNode[F]]] = {
     val n     = sks.length
     val names = (1 to n).map(i => s"node-$i")
@@ -260,7 +273,16 @@ object HashSetCasperTestNode {
                 blockStoreDir,
                 semaphore,
                 "rchain"
-              )(scheduler, syncF, captureF, concurrentF, blockStore, blockDagStorage, metricEff)
+              )(
+                scheduler,
+                syncF,
+                captureF,
+                concurrentF,
+                blockStore,
+                blockDagStorage,
+                metricEff,
+                absF
+              )
             } yield node
         }
         .map(_.toVector)
@@ -294,7 +316,8 @@ object HashSetCasperTestNode {
       ApplicativeError_[Effect, CommError],
       syncEffectInstance,
       Capture[Effect],
-      Concurrent[Effect]
+      Concurrent[Effect],
+      ToAbstractContext[Effect]
     )
 
   val appErrId = new ApplicativeError[Id, CommError] {

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -8,6 +8,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, ApplicativeError, Id, Monad}
 import coop.rchain.blockstorage._
+import coop.rchain.catscontrib._
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
@@ -132,7 +133,10 @@ class HashSetCasperTestNode[F[_]](
 }
 
 object HashSetCasperTestNode {
-  type Effect[A] = EitherT[Task, CommError, A]
+  type CommErrT[F[_], A] = EitherT[F, CommError, A]
+  type Effect[A]         = CommErrT[Task, A]
+
+  import coop.rchain.catscontrib._
 
   def standaloneF[F[_]](
       genesis: BlockMessage,

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -8,7 +8,6 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, ApplicativeError, Id, Monad}
 import coop.rchain.blockstorage._
-import coop.rchain.catscontrib._
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
@@ -133,10 +132,7 @@ class HashSetCasperTestNode[F[_]](
 }
 
 object HashSetCasperTestNode {
-  type CommErrT[F[_], A] = EitherT[F, CommError, A]
-  type Effect[A]         = CommErrT[Task, A]
-
-  import coop.rchain.catscontrib._
+  type Effect[A] = EitherT[Task, CommError, A]
 
   def standaloneF[F[_]](
       genesis: BlockMessage,

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -344,9 +344,6 @@ class NodeRuntime private[node] (
           .toEffect
     casperRuntime  = Runtime.create(casperStoragePath, storageSize, storeType)(rspaceScheduler)
     runtimeManager = RuntimeManager.fromRuntime(casperRuntime)(scheduler)
-    abs = new ToAbstractContext[Effect] {
-      def fromTask[A](fa: Task[A]): Effect[A] = fa.toEffect
-    }
     casperPacketHandler <- CasperPacketHandler
                             .of[Effect](conf.casper, defaultTimeout, runtimeManager, _.value)(
                               labEff,
@@ -365,7 +362,6 @@ class NodeRuntime private[node] (
                               Log.eitherTLog(Monad[Task], log),
                               multiParentCasperRef,
                               blockDagStorage,
-                              abs,
                               scheduler
                             )
     packetHandler = PacketHandler.pf[Effect](casperPacketHandler.handle)(

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -344,6 +344,9 @@ class NodeRuntime private[node] (
           .toEffect
     casperRuntime  = Runtime.create(casperStoragePath, storageSize, storeType)(rspaceScheduler)
     runtimeManager = RuntimeManager.fromRuntime(casperRuntime)(scheduler)
+    abs = new ToAbstractContext[Effect] {
+      def fromTask[A](fa: Task[A]): Effect[A] = fa.toEffect
+    }
     casperPacketHandler <- CasperPacketHandler
                             .of[Effect](conf.casper, defaultTimeout, runtimeManager, _.value)(
                               labEff,
@@ -362,6 +365,7 @@ class NodeRuntime private[node] (
                               Log.eitherTLog(Monad[Task], log),
                               multiParentCasperRef,
                               blockDagStorage,
+                              abs,
                               scheduler
                             )
     packetHandler = PacketHandler.pf[Effect](casperPacketHandler.handle)(

--- a/scripts/ci/run-integration-tests.sh
+++ b/scripts/ci/run-integration-tests.sh
@@ -21,7 +21,7 @@ main () {
 
     ./mypy.sh
     ./pylint.sh || true
-    ./run_tests.sh --mount-dir="$TEMP_RESOURCES_DIR"
+    ./run_tests.sh --log-cli-level=ERROR --mount-dir="$TEMP_RESOURCES_DIR"
 }
 
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
@@ -34,3 +34,15 @@ sealed trait TaskableInstances0 {
 
     }
 }
+
+trait ToAbstractContext[F[_]] {
+  def fromTask[A](fa: Task[A]): F[A]
+}
+
+object ToAbstractContext {
+  def apply[F[_]](implicit ev: ToAbstractContext[F]): ToAbstractContext[F] = ev
+  implicit val taskToAbstractContext: ToAbstractContext[Task] = new ToAbstractContext[Task] {
+    def fromTask[A](fa: Task[A]): Task[A] = fa
+  }
+
+}

--- a/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
@@ -34,15 +34,3 @@ sealed trait TaskableInstances0 {
 
     }
 }
-
-trait ToAbstractContext[F[_]] {
-  def fromTask[A](fa: Task[A]): F[A]
-}
-
-object ToAbstractContext {
-  def apply[F[_]](implicit ev: ToAbstractContext[F]): ToAbstractContext[F] = ev
-  implicit val taskToAbstractContext: ToAbstractContext[Task] = new ToAbstractContext[Task] {
-    def fromTask[A](fa: Task[A]): Task[A] = fa
-  }
-
-}


### PR DESCRIPTION
## Overview
The observation that led me to opening this PR is the fact that our "abstract" context F[_] is usually a monix.Task (or a class that contains it, like node.Effect). This means that it should be trivial to implement a `ToAbstractContext` type class for those classes, containing a sort of hackish `fromTask` method which would allow to make the context abstract over F again. 

This would allow us to remove `unsafeRunSync`'s gradually instead of in one giant PR. Whenever you are touching a method which makes the unsafe call, try to bring the requirement of `ToAbstractContext`'s existence into the function's signature (if necessary bring it in from the very top - vide `NodeRuntime`). 

Hopefully, once we've pushed all Tasks to the very top of the code base, this type class could be removed.

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
