### PR TITLE
Return via F from replayComputeState using LiftIO

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper
 
-import cats.effect.Sync
+import cats.effect.{LiftIO, Sync}
 import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
@@ -562,7 +562,7 @@ object Validate {
         false
       }
 
-  def transactions[F[_]: Sync: Log: BlockStore](
+  def transactions[F[_]: Sync: LiftIO: Log: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       emptyStateHash: StateHash,

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/BlockApproverProtocol.scala
@@ -1,6 +1,7 @@
 package coop.rchain.casper.util.comm
 
 import cats.Monad
+import cats.effect.Sync
 import cats.implicits._
 import cats.kernel.Eq
 import com.google.protobuf.ByteString
@@ -19,6 +20,7 @@ import coop.rchain.comm.transport.{Blob, TransportLayer}
 import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.shared._
+import monix.eval.Task
 import monix.execution.Scheduler
 
 import scala.util.Try
@@ -108,7 +110,7 @@ object BlockApproverProtocol {
       minimumBond: Long,
       maximumBond: Long,
       faucet: Boolean
-  )(implicit scheduler: Scheduler): Either[String, Unit] =
+  )(implicit scheduler: Scheduler, sync: Sync[Task]): Either[String, Unit] =
     for {
       _ <- (candidate.requiredSigs == requiredSigs)
             .either(())

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.util.rholang
 
 import cats.Monad
-import cats.effect.{LiftIO, Sync}
+import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.{BlockException, PrettyPrinter}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.util.rholang
 
 import cats.Monad
-import cats.effect.Sync
+import cats.effect.{LiftIO, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.{BlockException, PrettyPrinter}
@@ -31,7 +31,7 @@ object InterpreterUtil {
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys
-  def validateBlockCheckpoint[F[_]: Monad: Log: BlockStore](
+  def validateBlockCheckpoint[F[_]: Monad: Log: BlockStore: Sync: LiftIO](
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager
@@ -62,7 +62,7 @@ object InterpreterUtil {
     } yield result
   }
 
-  private def processPossiblePreStateHash[F[_]: Monad: Log: BlockStore](
+  private def processPossiblePreStateHash[F[_]: Monad: Log: BlockStore: Sync: LiftIO](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -91,7 +91,7 @@ object InterpreterUtil {
         }
     }
 
-  private def processPreStateHash[F[_]: Monad: Log: BlockStore](
+  private def processPreStateHash[F[_]: Monad: Log: BlockStore: Sync: LiftIO](
       runtimeManager: RuntimeManager,
       preStateHash: StateHash,
       tsHash: Option[StateHash],
@@ -99,54 +99,53 @@ object InterpreterUtil {
       possiblePreStateHash: Either[Throwable, StateHash],
       time: Option[Long]
   )(
-      implicit scheduler: Scheduler,
-      sync: Sync[Task]
+      implicit scheduler: Scheduler
   ): F[Either[BlockException, Option[StateHash]]] =
     runtimeManager
       .replayComputeState(preStateHash, internalDeploys, time)
-      .runSyncUnsafe(Duration.Inf) match {
-      case Left((Some(deploy), status)) =>
-        status match {
-          case InternalErrors(exs) =>
-            Left(
-              BlockException(
-                new Exception(s"Internal errors encountered while processing ${PrettyPrinter
-                  .buildString(deploy)}: ${exs.mkString("\n")}")
-              )
-            ).rightCast[Option[StateHash]].pure[F]
-          case UserErrors(errors: Vector[Throwable]) =>
-            Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
-              none[StateHash]
-            ).leftCast[BlockException].pure[F]
-          case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
+      .flatMap {
+        case Left((Some(deploy), status)) =>
+          status match {
+            case InternalErrors(exs) =>
+              Left(
+                BlockException(
+                  new Exception(s"Internal errors encountered while processing ${PrettyPrinter
+                    .buildString(deploy)}: ${exs.mkString("\n")}")
+                )
+              ).rightCast[Option[StateHash]].pure[F]
+            case UserErrors(errors: Vector[Throwable]) =>
+              Log[F].warn(s"Found user error(s) ${errors.map(_.getMessage).mkString("\n")}") *> Right(
+                none[StateHash]
+              ).leftCast[BlockException].pure[F]
+            case ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) =>
+              Log[F].warn(
+                s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
+              ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
+            case UnknownFailure =>
+              Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
+                .leftCast[BlockException]
+                .pure[F]
+          }
+        case Left((None, status)) =>
+          status match {
+            case UnusedCommEvent(ex: ReplayException) =>
+              Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
+                .leftCast[BlockException]
+                .pure[F]
+          }
+        case Right(computedStateHash) =>
+          if (tsHash.contains(computedStateHash)) {
+            // state hash in block matches computed hash!
+            Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
+          } else {
+            // state hash in block does not match computed hash -- invalid!
+            // return no state hash, do not update the state hash set
             Log[F].warn(
-              s"Found replay status mismatch; replay failure is ${replay.isFailed} and orig failure is ${orig.isFailed}"
+              s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
             ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
-          case UnknownFailure =>
-            Log[F].warn(s"Found unknown failure") *> Right(none[StateHash])
-              .leftCast[BlockException]
-              .pure[F]
-        }
-      case Left((None, status)) =>
-        status match {
-          case UnusedCommEvent(ex: ReplayException) =>
-            Log[F].warn(s"Found unused comm event ${ex.getMessage}") *> Right(none[StateHash])
-              .leftCast[BlockException]
-              .pure[F]
-        }
-      case Right(computedStateHash) =>
-        if (tsHash.contains(computedStateHash)) {
-          // state hash in block matches computed hash!
-          Right(Option(computedStateHash)).leftCast[BlockException].pure[F]
-        } else {
-          // state hash in block does not match computed hash -- invalid!
-          // return no state hash, do not update the state hash set
-          Log[F].warn(
-            s"Tuplespace hash ${tsHash.getOrElse(ByteString.EMPTY)} does not match computed hash $computedStateHash."
-          ) *> Right(none[StateHash]).leftCast[BlockException].pure[F]
 
-        }
-    }
+          }
+      }
 
   def computeDeploysCheckpoint[F[_]: Monad: BlockStore](
       parents: Seq[BlockMessage],


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This is an alternate implementation of @lukasz-golebiewski's superb idea to have a typeclass for converting back into an abstract F. See the review comments in #2006 for context.

I think we should use LiftIO instead of a custom typeclass :)

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
