### PR TITLE
Kademlia RPC cache bug and refactoring

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -1,19 +1,23 @@
 package coop.rchain.comm.discovery
 
+import scala.concurrent.duration._
+import scala.util.Try
+
 import cats.implicits._
-import com.google.protobuf.ByteString
+
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
-import coop.rchain.comm.CachedConnections.ConnectionsCache
 import coop.rchain.comm._
+import coop.rchain.comm.CachedConnections.ConnectionsCache
+import coop.rchain.comm.discovery.KademliaGrpcMonix.KademliaRPCServiceStub
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.{Log, LogSource}
+
+import com.google.protobuf.ByteString
 import io.grpc._
 import io.grpc.netty._
 import monix.eval._
 import monix.execution._
-
-import scala.concurrent.duration._
 
 class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
     implicit
@@ -28,58 +32,92 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
 
   private val connections = connectionsCache(clientChannel)
 
-  import connections.connection
+  import connections.cell
 
   def ping(peer: PeerNode): Task[Boolean] =
     for {
       _       <- Metrics[Task].incrementCounter("protocol-ping-sends")
-      channel <- connection(peer, enforce = false)
       local   <- peerNodeAsk.ask
-      pongErr <- KademliaGrpcMonix
-                  .stub(channel)
-                  .sendPing(Ping().withSender(node(local)))
-                  .nonCancelingTimeout(timeout)
-                  .attempt
-      _ <- Task.delay(channel.shutdown())
-      _ <- Task.unit.asyncBoundary // return control to caller thread
+      ping    = Ping().withSender(node(local))
+      pongErr <- withClient(peer)(_.sendPing(ping).nonCancelingTimeout(timeout)).attempt
     } yield pongErr.fold(kp(false), kp(true))
 
   def lookup(key: Seq[Byte], peer: PeerNode): Task[Seq[PeerNode]] =
     for {
-      _     <- Metrics[Task].incrementCounter("protocol-lookup-send")
-      local <- peerNodeAsk.ask
-      lookup = Lookup()
-        .withId(ByteString.copyFrom(key.toArray))
-        .withSender(node(local))
-      channel <- connection(peer, enforce = false)
-      responseErr <- KademliaGrpcMonix
-                      .stub(channel)
-                      .sendLookup(lookup)
-                      .nonCancelingTimeout(timeout)
-                      .attempt
-      _ <- Task.delay(channel.shutdown())
+      _           <- Metrics[Task].incrementCounter("protocol-lookup-send")
+      local       <- peerNodeAsk.ask
+      lookup      = Lookup().withId(ByteString.copyFrom(key.toArray)).withSender(node(local))
+      responseErr <- withClient(peer)(_.sendLookup(lookup).nonCancelingTimeout(timeout)).attempt
+    } yield responseErr.fold(kp(Seq.empty[PeerNode]), _.nodes.map(toPeerNode))
+
+  def disconnect(peer: PeerNode): Task[Unit] =
+    cell.modify { s =>
+      for {
+        _ <- s.connections.get(peer) match {
+              case Some(c) =>
+                log
+                  .debug(s"Disconnecting from peer ${peer.toAddress}")
+                  .map(kp(Try(c.shutdown())))
+                  .void
+              case _ => Task.unit // ignore if connection does not exists already
+            }
+      } yield s.copy(connections = s.connections - peer)
+    }
+
+  private def withClient[A](peer: PeerNode, enforce: Boolean = false)(
+      f: KademliaRPCServiceStub => Task[A]
+  ): Task[A] =
+    for {
+      channel <- connections.connection(peer, enforce)
+      stub    <- Task.delay(KademliaGrpcMonix.stub(channel))
+      result <- f(stub).doOnFinish {
+                 case Some(_) => disconnect(peer)
+                 case _       => Task.unit
+               }
       _ <- Task.unit.asyncBoundary // return control to caller thread
-    } yield
-      responseErr.fold(
-        kp(Seq.empty[PeerNode]),
-        lr => lr.nodes.map(toPeerNode)
-      )
+    } yield result
 
   def receive(
       pingHandler: PeerNode => Task[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => Task[Seq[PeerNode]]
   ): Task[Unit] =
-    Task.delay {
-      NettyServerBuilder
-        .forPort(port)
-        .executor(scheduler)
-        .addService(
-          KademliaGrpcMonix
-            .bindService(new SimpleKademliaRPCService(pingHandler, lookupHandler), scheduler)
-        )
-        .build
-        .start
+    cell.modify { s =>
+      Task.delay {
+        val server = NettyServerBuilder
+          .forPort(port)
+          .executor(scheduler)
+          .addService(
+            KademliaGrpcMonix
+              .bindService(new SimpleKademliaRPCService(pingHandler, lookupHandler), scheduler)
+          )
+          .build
+          .start
+
+        val c: Cancelable = () => server.shutdown().awaitTermination()
+        s.copy(server = Some(c))
+      }
     }
+
+  def shutdown(): Task[Unit] = {
+    def shutdownServer: Task[Unit] = cell.modify { s =>
+      for {
+        _ <- log.info("Shutting down Kademlia RPC server")
+        _ <- s.server.fold(Task.unit)(server => Task.delay(server.cancel()))
+      } yield s.copy(server = None, shutdown = true)
+    }
+
+    def disconnectFromPeers: Task[Unit] =
+      for {
+        peers <- cell.read.map(_.connections.keys.toSeq)
+        _     <- log.info("Disconnecting from all peers")
+        _     <- Task.gatherUnordered(peers.map(disconnect))
+      } yield ()
+
+    cell.read.flatMap { s =>
+      if (s.shutdown) Task.unit
+      else shutdownServer *> disconnectFromPeers
+    }
+  }
 
   private def clientChannel(peer: PeerNode): Task[ManagedChannel] =
     for {
@@ -118,5 +156,4 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
       pingHandler(sender).as(Pong())
     }
   }
-
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaRPC.scala
@@ -16,6 +16,7 @@ trait KademliaRPC[F[_]] {
       pingHandler: PeerNode => F[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => F[Seq[PeerNode]]
   ): F[Unit]
+  def shutdown(): F[Unit]
 }
 
 object KademliaRPC {

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -19,6 +19,8 @@ import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.shared._
 import coop.rchain.shared.Compression._
 import java.nio.file._
+import java.util.concurrent.TimeoutException
+
 import io.grpc._
 import io.grpc.netty._
 import io.netty.handler.ssl._
@@ -99,12 +101,6 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
       } yield s.copy(connections = s.connections - peer)
     }
 
-  private object PeerUnavailable {
-    def unapply(e: Throwable): Boolean =
-      e.isInstanceOf[StatusRuntimeException] &&
-        e.asInstanceOf[StatusRuntimeException].getStatus.getCode == Status.Code.UNAVAILABLE
-  }
-
   private def withClient[A](peer: PeerNode, enforce: Boolean)(
       f: TransportLayerStub => Task[A]
   ): Task[A] =
@@ -112,8 +108,8 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
       channel <- connections.connection(peer, enforce)
       stub    <- Task.delay(RoutingGrpcMonix.stub(channel))
       result <- f(stub).doOnFinish {
-                 case Some(PeerUnavailable()) => disconnect(peer)
-                 case _                       => Task.unit
+                 case Some(_) => disconnect(peer)
+                 case _       => Task.unit
                }
       _ <- Task.unit.asyncBoundary // return control to caller thread
     } yield result
@@ -151,15 +147,25 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
   def stream(peers: Seq[PeerNode], blob: Blob): Task[Unit] =
     streamObservable.stream(peers.toList, blob) *> log.info(s"stream to $peers blob")
 
+  private object PeerUnavailable {
+    def unapply(e: Throwable): Boolean =
+      e.isInstanceOf[StatusRuntimeException] &&
+        e.asInstanceOf[StatusRuntimeException].getStatus.getCode == Status.Code.UNAVAILABLE
+  }
+
+  private object PeerTimeout {
+    def unapply(e: Throwable): Boolean = e.isInstanceOf[TimeoutException]
+  }
+
   private def processResponse(
       peer: PeerNode,
       response: Either[Throwable, TLResponse]
   ): CommErr[Option[Protocol]] =
     response
       .leftMap {
-        case _: TimeoutException => CommError.timeout
-        case PeerUnavailable()   => peerUnavailable(peer)
-        case e                   => protocolException(e)
+        case PeerTimeout()     => CommError.timeout
+        case PeerUnavailable() => peerUnavailable(peer)
+        case e                 => protocolException(e)
       }
       .flatMap(
         tlr =>
@@ -279,7 +285,7 @@ class TcpTransportLayer(port: Int, cert: String, key: String, maxMessageSize: In
   def shutdown(msg: Protocol): Task[Unit] = {
     def shutdownServer: Task[Unit] = cell.modify { s =>
       for {
-        _ <- log.info("Shutting down server")
+        _ <- log.info("Shutting down transport layer server")
         _ <- s.server.fold(Task.unit)(server => Task.delay(server.cancel()))
         _ <- s.clientQueue.fold(Task.unit)(server => Task.delay(server.cancel()))
       } yield s.copy(server = None, shutdown = true)

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -28,7 +28,8 @@ class DistanceSpec extends FlatSpec with Matchers {
     def receive(
         pingHandler: PeerNode => Id[Unit],
         lookupHandler: (PeerNode, Array[Byte]) => Id[Seq[PeerNode]]
-    ): Id[Unit] = ()
+    ): Id[Unit]              = ()
+    def shutdown(): Id[Unit] = ()
   }
 
   "A PeerNode of width n bytes" should "have distance to itself equal to 8n" in {

--- a/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
@@ -1,0 +1,49 @@
+package coop.rchain.comm.discovery
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+import cats.mtl.DefaultApplicativeAsk
+import cats.Applicative
+
+import coop.rchain.comm._
+import coop.rchain.metrics.Metrics
+import coop.rchain.shared.Log
+
+import monix.eval.Task
+import monix.execution.Scheduler
+
+class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
+
+  implicit val log: Log[Task]         = new Log.NOPLog[Task]
+  implicit val scheduler: Scheduler   = Scheduler.Implicits.global
+  implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP
+
+  def createEnvironment(port: Int): Task[GrpcEnvironment] =
+    Task.delay {
+      val host  = "127.0.0.1"
+      val bytes = Array.ofDim[Byte](40)
+      Random.nextBytes(bytes)
+      val peer = PeerNode.from(NodeIdentifier(bytes), host, 0, port)
+      GrpcEnvironment(host, port, peer)
+    }
+
+  def createKademliaRPC(env: GrpcEnvironment): Task[KademliaRPC[Task]] = {
+    implicit val ask: PeerNodeAsk[Task] =
+      new DefaultApplicativeAsk[Task, PeerNode] {
+        val applicative: Applicative[Task] = Applicative[Task]
+        def ask: Task[PeerNode]            = Task.pure(env.peer)
+      }
+    CachedConnections[Task, KademliaConnTag].map { implicit cache =>
+      new GrpcKademliaRPC(env.port, 500.millis)
+    }
+  }
+
+  def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)
+}
+
+case class GrpcEnvironment(
+    host: String,
+    port: Int,
+    peer: PeerNode
+) extends Environment

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCRuntime.scala
@@ -1,0 +1,170 @@
+package coop.rchain.comm.discovery
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.util.Random
+
+import cats._
+import cats.effect.Timer
+import cats.effect.concurrent.MVar
+import cats.implicits._
+
+import coop.rchain.comm._
+
+abstract class KademliaRPCRuntime[F[_]: Monad: Timer, E <: Environment] {
+
+  def createEnvironment(port: Int): F[E]
+
+  def createKademliaRPC(env: E): F[KademliaRPC[F]]
+
+  def extract[A](fa: F[A]): A
+
+  private val nextPort = new AtomicInteger((Random.nextInt(100) + 500 + 1) * 100)
+
+  def twoNodesEnvironment[A](block: (E, E) => F[A]): F[A] =
+    for {
+      e1 <- createEnvironment(nextPort.incrementAndGet())
+      e2 <- createEnvironment(nextPort.incrementAndGet())
+      r  <- block(e1, e2)
+    } yield r
+
+  trait Runtime[A] {
+    protected def pingHandler: PingHandler[F]
+    protected def lookupHandler: LookupHandler[F]
+    def run(): Result
+    trait Result {
+      def localNode: PeerNode
+      def apply(): A
+    }
+  }
+
+  abstract class TwoNodesRuntime[A](
+      val pingHandler: PingHandler[F] = Handler.pingHandler,
+      val lookupHandler: LookupHandler[F] = Handler.lookupHandlerNil
+  ) extends Runtime[A] {
+    def execute(kademliaRPC: KademliaRPC[F], local: PeerNode, remote: PeerNode): F[A]
+
+    def run(): TwoNodesResult =
+      extract(
+        twoNodesEnvironment { (e1, e2) =>
+          for {
+            localRpc  <- createKademliaRPC(e1)
+            remoteRpc <- createKademliaRPC(e2)
+            local     = e1.peer
+            remote    = e2.peer
+            _ <- localRpc.receive(
+                  Handler.pingHandler[F].handle(local),
+                  Handler.lookupHandlerNil[F].handle(local)
+                )
+            _ <- remoteRpc.receive(
+                  pingHandler.handle(remote),
+                  lookupHandler.handle(remote)
+                )
+            r <- execute(localRpc, local, remote)
+            _ <- remoteRpc.shutdown()
+            _ <- localRpc.shutdown()
+          } yield
+            new TwoNodesResult {
+              def localNode: PeerNode  = local
+              def remoteNode: PeerNode = remote
+              def apply(): A           = r
+            }
+        }
+      )
+
+    trait TwoNodesResult extends Result {
+      def remoteNode: PeerNode
+    }
+  }
+
+  abstract class TwoNodesRemoteDeadRuntime[A](
+      val pingHandler: PingHandler[F] = Handler.pingHandler,
+      val lookupHandler: LookupHandler[F] = Handler.lookupHandlerNil
+  ) extends Runtime[A] {
+    def execute(kademliaRPC: KademliaRPC[F], local: PeerNode, remote: PeerNode): F[A]
+
+    def run(): TwoNodesResult =
+      extract(
+        twoNodesEnvironment { (e1, e2) =>
+          for {
+            localRpc <- createKademliaRPC(e1)
+            local    = e1.peer
+            remote   = e2.peer
+            _ <- localRpc.receive(
+                  Handler.pingHandler[F].handle(local),
+                  Handler.lookupHandlerNil[F].handle(local)
+                )
+            r <- execute(localRpc, local, remote)
+            _ <- localRpc.shutdown()
+          } yield
+            new TwoNodesResult {
+              def localNode: PeerNode  = local
+              def remoteNode: PeerNode = remote
+              def apply(): A           = r
+            }
+        }
+      )
+
+    trait TwoNodesResult extends Result {
+      def remoteNode: PeerNode
+    }
+  }
+
+}
+
+trait Environment {
+  def peer: PeerNode
+  def host: String
+  def port: Int
+}
+
+final class DispatcherCallback[F[_]: Functor](state: MVar[F, Unit]) {
+  def notifyThatDispatched(): F[Unit] = state.tryPut(()).void
+  def waitUntilDispatched(): F[Unit]  = state.take
+}
+
+abstract class Handler[F[_]: Monad: Timer, R] {
+  def received: Seq[(PeerNode, R)] = receivedMessages
+  protected val receivedMessages: mutable.MutableList[(PeerNode, R)] =
+    mutable.MutableList.empty[(PeerNode, R)]
+}
+
+final class PingHandler[F[_]: Monad: Timer](
+    delay: Option[FiniteDuration] = None
+) extends Handler[F, PeerNode] {
+  def handle(peer: PeerNode): PeerNode => F[Unit] =
+    p =>
+      for {
+        _ <- receivedMessages.synchronized(receivedMessages += ((peer, p))).pure[F]
+        _ <- delay.fold(().pure[F])(implicitly[Timer[F]].sleep)
+      } yield ()
+}
+
+final class LookupHandler[F[_]: Monad: Timer](
+    response: Seq[PeerNode],
+    delay: Option[FiniteDuration] = None
+) extends Handler[F, (PeerNode, Array[Byte])] {
+  def handle(peer: PeerNode): (PeerNode, Array[Byte]) => F[Seq[PeerNode]] =
+    (p, a) =>
+      for {
+        _ <- delay.fold(().pure[F])(implicitly[Timer[F]].sleep)
+        _ <- receivedMessages.synchronized(receivedMessages += ((peer, (p, a)))).pure[F]
+      } yield response
+}
+
+object Handler {
+  def pingHandler[F[_]: Monad: Timer]: PingHandler[F] = new PingHandler[F]
+
+  def pingHandlerWithDelay[F[_]: Monad: Timer](delay: FiniteDuration): PingHandler[F] =
+    new PingHandler[F](Some(delay))
+
+  def lookupHandlerNil[F[_]: Monad: Timer]: LookupHandler[F] = new LookupHandler[F](Nil)
+
+  def lookupHandlerWithDelay[F[_]: Monad: Timer](delay: FiniteDuration): LookupHandler[F] =
+    new LookupHandler[F](Nil, Some(delay))
+
+  def lookupHandler[F[_]: Monad: Timer](result: Seq[PeerNode]): LookupHandler[F] =
+    new LookupHandler[F](result)
+}

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
@@ -1,0 +1,167 @@
+package coop.rchain.comm.discovery
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+import cats._
+import cats.implicits._
+
+import coop.rchain.comm.{NodeIdentifier, PeerNode}
+
+import org.scalatest._
+
+abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
+    extends KademliaRPCRuntime[F, E]
+    with WordSpecLike
+    with Matchers {
+
+  val kademliaRpcName: String = this.getClass.getSimpleName.replace("Spec", "")
+
+  kademliaRpcName when {
+    "pinging a remote peer" when {
+      "everything is fine" should {
+        "send and receive a positive response" in
+          new TwoNodesRuntime[Boolean]() {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Boolean] = kademliaRPC.ping(remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual true
+            pingHandler.received should have length 1
+            val (receiver, sender) = pingHandler.received.head
+            receiver shouldEqual result.remoteNode
+            sender shouldEqual result.localNode
+          }
+
+        "send twice and receive positive responses" in
+          new TwoNodesRuntime[(Boolean, Boolean)]() {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[(Boolean, Boolean)] =
+              for {
+                r1 <- kademliaRPC.ping(remote)
+                r2 <- kademliaRPC.ping(remote)
+              } yield (r1, r2)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual (true, true)
+            pingHandler.received should have length 2
+            val (receiver1, sender1) = pingHandler.received.head
+            val (receiver2, sender2) = pingHandler.received.tail.head
+            receiver1 shouldEqual result.remoteNode
+            receiver2 shouldEqual result.remoteNode
+            sender1 shouldEqual result.localNode
+            sender2 shouldEqual result.localNode
+          }
+      }
+
+      "response takes to long" should {
+        "get a negative result" in
+          new TwoNodesRuntime[Boolean](
+            pingHandler = Handler.pingHandlerWithDelay(1.second)
+          ) {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Boolean] = kademliaRPC.ping(remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual false
+            pingHandler.received should have length 1
+            val (receiver, sender) = pingHandler.received.head
+            receiver shouldEqual result.remoteNode
+            sender shouldEqual result.localNode
+          }
+      }
+
+      "peer is not listening" should {
+        "get a negative result" in
+          new TwoNodesRemoteDeadRuntime[Boolean]() {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Boolean] = kademliaRPC.ping(remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual false
+          }
+      }
+    }
+
+    "doing a lookup to a remote peer" when {
+      val key = Array.ofDim[Byte](40)
+      Random.nextBytes(key)
+      val otherPeer = PeerNode.from(NodeIdentifier(key), "1.2.3.4", 0, 0)
+
+      "everything is fine" should {
+        "send and receive a list of peers" in
+          new TwoNodesRuntime[Seq[PeerNode]](
+            lookupHandler = Handler.lookupHandler(Seq(otherPeer))
+          ) {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual Seq(otherPeer)
+            lookupHandler.received should have length 1
+            val (receiver, (sender, k)) = lookupHandler.received.head
+            receiver shouldEqual result.remoteNode
+            sender shouldEqual result.localNode
+            k should be(key)
+          }
+      }
+
+      "response takes to long" should {
+        "get an empty list result" in
+          new TwoNodesRuntime[Seq[PeerNode]](
+            lookupHandler = Handler.lookupHandlerWithDelay(1.second)
+          ) {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual Seq.empty[PeerNode]
+            lookupHandler.received should have length 1
+            val (receiver, (sender, k)) = lookupHandler.received.head
+            receiver shouldEqual result.remoteNode
+            sender shouldEqual result.localNode
+            k should be(key)
+          }
+      }
+
+      "peer is not listening" should {
+        "get an empty list result" in
+          new TwoNodesRemoteDeadRuntime[Seq[PeerNode]]() {
+            def execute(
+                kademliaRPC: KademliaRPC[F],
+                local: PeerNode,
+                remote: PeerNode
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+
+            val result: TwoNodesResult = run()
+
+            result() shouldEqual Seq.empty[PeerNode]
+          }
+      }
+    }
+  }
+}

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -167,7 +167,8 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     def receive(
         pingHandler: PeerNode => Id[Unit],
         lookupHandler: (PeerNode, Array[Byte]) => Id[Seq[PeerNode]]
-    ): Id[Unit] = ()
+    ): Id[Unit]              = ()
+    def shutdown(): Id[Unit] = ()
   }
 
   private def createPeer(id: String): PeerNode =

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -135,6 +135,7 @@ class NodeRuntime private[node] (
   def clearResources(servers: Servers, runtime: Runtime, casperRuntime: Runtime)(
       implicit
       transport: TransportLayer[Task],
+      kademliaRPC: KademliaRPC[Task],
       blockStore: BlockStore[Effect],
       peerNodeAsk: PeerNodeAsk[Task]
   ): Unit =
@@ -146,6 +147,7 @@ class NodeRuntime private[node] (
       loc <- peerNodeAsk.ask
       msg = ProtocolHelper.disconnect(loc)
       _   <- transport.shutdown(msg)
+      _   <- kademliaRPC.shutdown()
       _   <- log.info("Shutting down HTTP server....")
       _   <- Task.delay(Kamon.stopAllReporters())
       _   <- servers.httpServer.cancel
@@ -171,6 +173,7 @@ class NodeRuntime private[node] (
 
   def addShutdownHook(servers: Servers, runtime: Runtime, casperRuntime: Runtime)(
       implicit transport: TransportLayer[Task],
+      kademliaRPC: KademliaRPC[Task],
       blockStore: BlockStore[Effect],
       peerNodeAsk: PeerNodeAsk[Task]
   ): Task[Unit] =
@@ -186,6 +189,7 @@ class NodeRuntime private[node] (
       peerNodeAsk: PeerNodeAsk[Task],
       metrics: Metrics[Task],
       transport: TransportLayer[Task],
+      kademliaRPC: KademliaRPC[Task],
       nodeDiscovery: NodeDiscovery[Task],
       rpConnectons: ConnectionsCell[Task],
       blockStore: BlockStore[Effect],
@@ -380,6 +384,7 @@ class NodeRuntime private[node] (
       peerNodeAsk,
       metrics,
       transport,
+      kademliaRPC,
       nodeDiscovery,
       rpConnections,
       blockStore,


### PR DESCRIPTION
## Overview
Connection to remote peers worked only at the first time and then got shut down. After that, no further connection was possible to the same peer. This PR fixes the bug, improves caching and shuts down the Kademlia RPC layer on node shutdown.

### JIRA ticket:
https://rchain.atlassian.net/browse/CORE-1546

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:
- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.