### PR TITLE
Remove mergify configuration. Bors makes mergify obsolete.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,0 @@
-pull_request_rules:
-- name: automatic merge on CI success and review for marked PRs
-  conditions:
-  - label=merge-when-ready
-  - status-success=continuous-integration/drone/pr
-  - "#approved-reviews-by>=1"
-  actions:
-    merge:
-      method: merge


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
