### PR TITLE
add example for rho:block:timestamp

### DIFF
--- a/rholang/examples/time.rho
+++ b/rholang/examples/time.rho
@@ -1,0 +1,9 @@
+new timestamp(`rho:block:timestamp`), stdout(`rho:io:stdout`), tCh in {
+  timestamp!(*tCh) |
+  for(@t <- tCh) {
+    match t {
+      Nil => { stdout!("no block time; no blocks yet? Not connected to Casper network?") }
+      _ => { stdout!({"block time": t}) }
+    }
+  }
+}


### PR DESCRIPTION
### JIRA ticket:
https://rchain.atlassian.net/browse/RHOL-1089

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [ ] has all commits signed
  - I don't have git signing set up where I am just now
