### PR TITLE
CORE-1525 moved doctests to scalatests.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,8 +163,7 @@ lazy val crypto = (project in file("crypto"))
       secp256k1Java,
       scodecBits
     ),
-    fork := true,
-    doctestTestFramework := DoctestTestFramework.ScalaTest
+    fork := true
   )
   .dependsOn(shared)
 

--- a/crypto/src/main/scala/coop/rchain/crypto/encryption/Curve25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/encryption/Curve25519.scala
@@ -5,29 +5,8 @@ import org.abstractj.kalium.keys._
 import org.abstractj.kalium.NaCl.Sodium.{CRYPTO_BOX_CURVE25519XSALSA20POLY1305_NONCEBYTES}
 
 /**
-Curve25519 elliptic curve cryptography
-  * {{{
-  * >>> import coop.rchain.crypto.codec._
-  * >>> val bobSec = Base16.decode("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")
-  * >>> val bobPub = Base16.decode("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")
-  * >>> val aliceSec = Base16.decode("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
-  * >>> val alicePub = Base16.decode("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")
-  * >>> val nonce = Base16.decode("69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37")
-  * >>> val message = Base16.decode("be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffce5ecbaaf33bd751a1ac728d45e6c61296cdc3c01233561f41db66cce314adb310e3be8250c46f06dceea3a7fa1348057e2f6556ad6b1318a024a838f21af1fde048977eb48f59ffd4924ca1c60902e52f0a089bc76897040e082f937763848645e0705")
-  * >>> val cipher = Curve25519.encrypt(alicePub,bobSec,nonce,message)
-  *
-  * >>> Base16.encode(cipher)
-  * f3ffc7703f9400e52a7dfb4b3d3305d98e993b9f48681273c29650ba32fc76ce48332ea7164d96a4476fb8c531a1186ac0dfc17c98dce87b4da7f011ec48c97271d2c20f9b928fe2270d6fb863d51738b48eeee314a7cc8ab932164548e526ae90224368517acfeabd6bb3732bc0e9da99832b61ca01b6de56244a9e88d5f9b37973f622a43d14a6599b1f654cb45a74e355a5
-  *
-  * >>> Curve25519.decrypt(bobPub,aliceSec,nonce,cipher).deep == message.deep
-  * true
-  *
-  * >>> Curve25519.toPublic(aliceSec).deep == alicePub.deep
-  * true
-  *
-  * }}}
-  *
-**/
+  * Curve25519 elliptic curve cryptography
+  */
 object Curve25519 {
 
   def newKeyPair: (Array[Byte], Array[Byte]) = {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b256.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b256.scala
@@ -7,18 +7,8 @@ import scodec.bits.ByteVector
 import scala.collection.immutable.Seq
 
 /**
-Blake2b256 hashing algorithm
-
-  * {{{
-  * >>> import coop.rchain.crypto.codec._
-  *
-  * >>> Base16.encode(Blake2b256.hash("".getBytes))
-  * 0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8
-  *
-  * >>> Base16.encode(Blake2b256.hash("abc".getBytes))
-  * bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319
-  * }}}
-**/
+  * Blake2b256 hashing algorithm
+  */
 object Blake2b256 {
 
   def hash(input: Array[Byte]): Array[Byte] = {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Keccak256.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Keccak256.scala
@@ -3,18 +3,8 @@ package coop.rchain.crypto.hash
 import org.bouncycastle.crypto.digests.KeccakDigest
 
 /**
-Keccak256 hashing algorithm
-
-  * {{{
-  * >>> import coop.rchain.crypto.codec._
-  *
-  * >>> Base16.encode(Keccak256.hash("".getBytes))
-  * c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
-  *
-  * >>> Base16.encode(Keccak256.hash("abc".getBytes))
-  * 4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
-  * }}}
-**/
+  * Keccak256 hashing algorithm
+  */
 object Keccak256 {
 
   def hash(input: Array[Byte]): Array[Byte] = {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Sha256.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Sha256.scala
@@ -3,24 +3,8 @@ package coop.rchain.crypto.hash
 import java.security.MessageDigest
 
 /**
-Sha256 hashing algorithm
-
-  * {{{
-  * >>> import coop.rchain.crypto.codec._
-  *
-  * >>> Base16.encode(Sha256.hash("".getBytes))
-  * e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-  *
-  * >>> Base16.encode(Sha256.hash("abc".getBytes))
-  * ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-  *
-  * >>> Base16.encode(Sha256.hash("hello world".getBytes))
-  * b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
-  *
-  * >>> Base16.encode(Sha256.hash("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".getBytes))
-  * 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
-  * }}}
-**/
+  * Sha256 hashing algorithm
+  */
 object Sha256 {
 
   def hash(input: Array[Byte]): Array[Byte] =

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -15,13 +15,6 @@ object Ed25519 {
   /**
     * Ed25519 Compute Pubkey - computes public key from secret key
     *
-    * {{{
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
-    * >>> Base16.encode(Ed25519.toPublic(sec))
-    * 77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb
-    * }}}
-    *
     * @param seckey Ed25519 Secret key, 32 bytes
     *
     * Return values
@@ -34,15 +27,6 @@ object Ed25519 {
 
   /**
     * Verifies the given Ed25519 signature.
-    *
-    * {{{
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val data = Base16.decode("916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40")
-    * >>> val sig = Base16.decode("6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509")
-    * >>> val pub = Base16.decode("77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb")
-    * >>> Ed25519.verify(data, sig, pub)
-    * true
-    * }}}
     *
     * Input values
     * @param data The data which was signed, must be exactly 32 bytes
@@ -72,15 +56,6 @@ object Ed25519 {
   /**
     * Create an Ed25519 signature.
     *
-    * {{{
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val data = Base16.decode("916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40")
-    * >>> val sig = Base16.decode("6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509")
-    * >>> val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
-    * >>> Ed25519.sign(data, sec).deep == sig.deep
-    * true
-    * }}}
-    *
     * Input values
     * @param data Message hash, 32 bytes
     * @param sec Secret key, 32 bytes
@@ -88,7 +63,7 @@ object Ed25519 {
     * Return value
     * byte array of signature
     *
-  **/
+    */
   def sign(
       data: Array[Byte],
       sec: Array[Byte]

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -19,16 +19,6 @@ object Secp256k1 {
   /**
     * Verifies the given secp256k1 signature in native code.
     *
-    * {{{
-    * >>> import coop.rchain.crypto.hash.Sha256
-    * >>> import coop.rchain.crypto.{PrivateKey, PublicKey}
-    * >>> val (PrivateKey(sec), PublicKey(pub)) = Secp256k1.newKeyPair
-    * >>> val data = Sha256.hash("testing".getBytes)
-    * >>> val sig = Secp256k1.sign(data, sec)
-    * >>> Secp256k1.verify(data, sig, pub)
-    * true
-    * }}}
-    *
     * @return (private key, public key) pair
     *
     */
@@ -49,16 +39,6 @@ object Secp256k1 {
   /**
     * Verifies the given secp256k1 signature in native code.
     *
-    * {{{
-    * >>> import coop.rchain.crypto.hash._
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val data = Sha256.hash("testing".getBytes)
-    * >>> val sig = Base16.decode("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589")
-    * >>> val pub = Base16.decode("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40")
-    * >>> Secp256k1.verify(data, sig, pub)
-    * true
-    * }}}
-    *
     * Input values
     * @param data The data which was signed, must be exactly 32 bytes
     * @param signature The signature
@@ -78,15 +58,6 @@ object Secp256k1 {
   /**
     * libsecp256k1 Create an ECDSA signature.
     *
-    * {{{
-    * >>> import coop.rchain.crypto.hash._
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val data = Sha256.hash("testing".getBytes)
-    * >>> val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
-    * >>> Base16.encode(Secp256k1.sign(data, sec)).toUpperCase()
-    * 30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9
-    * }}}
-    *
     * Input values
     * @param data Message hash, 32 bytes
     * @param sec Secret key, 32 bytes
@@ -94,7 +65,7 @@ object Secp256k1 {
     * Return value
     * byte array of signature
     *
-  **/
+    */
   def sign(
       data: Array[Byte],
       sec: Array[Byte]
@@ -103,13 +74,6 @@ object Secp256k1 {
 
   /**
     * libsecp256k1 Seckey Verify - returns true if valid, false if invalid
-    *
-    * {{{
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
-    * >>> Secp256k1.secKeyVerify(sec)
-    * true
-    * }}}
     *
     * Input value
     * @param seckey ECDSA Secret key, 32 bytes
@@ -122,13 +86,6 @@ object Secp256k1 {
 
   /**
     * libsecp256k1 Compute Pubkey - computes public key from secret key
-    *
-    * {{{
-    * >>> import coop.rchain.crypto.codec._
-    * >>> val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
-    * >>> Base16.encode(Secp256k1.toPublic(sec)).toUpperCase()
-    * 04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6
-    * }}}
     *
     * @param seckey ECDSA Secret key, 32 bytes
     *

--- a/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
@@ -1,0 +1,34 @@
+package coop.rchain.crypto.encryption
+
+import coop.rchain.crypto.codec._
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Curve25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Curve25519 elliptic curve cryptography") {
+
+    val bobSec   = Base16.decode("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")
+    val bobPub   = Base16.decode("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")
+    val aliceSec = Base16.decode("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
+    val alicePub = Base16.decode("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")
+    val nonce    = Base16.decode("69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37")
+    val message = Base16.decode(
+      "be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffce5ecbaaf33bd751a1ac728d45e6c61296cdc3c01233561f41db66cce314adb310e3be8250c46f06dceea3a7fa1348057e2f6556ad6b1318a024a838f21af1fde048977eb48f59ffd4924ca1c60902e52f0a089bc76897040e082f937763848645e0705"
+    )
+    val cipher = Curve25519.encrypt(alicePub, bobSec, nonce, message)
+
+    it("encodes a cipher") {
+      val result = Base16.encode(cipher)
+      result shouldBe "f3ffc7703f9400e52a7dfb4b3d3305d98e993b9f48681273c29650ba32fc76ce48332ea7164d96a4476fb8c531a1186ac0dfc17c98dce87b4da7f011ec48c97271d2c20f9b928fe2270d6fb863d51738b48eeee314a7cc8ab932164548e526ae90224368517acfeabd6bb3732bc0e9da99832b61ca01b6de56244a9e88d5f9b37973f622a43d14a6599b1f654cb45a74e355a5"
+    }
+
+    it("decrypts") {
+      val result = Curve25519.decrypt(bobPub, aliceSec, nonce, cipher).deep
+      result shouldBe message.deep
+    }
+
+    it("gets public") {
+      val result = Curve25519.toPublic(aliceSec).deep
+      result shouldBe alicePub.deep
+    }
+  }
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b256Test.scala
@@ -1,0 +1,17 @@
+package coop.rchain.crypto.hash
+
+import coop.rchain.crypto.codec._
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Blake2b256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Blake2b256 hashing algorithm") {
+    it("encodes empty") {
+      val result = Base16.encode(Blake2b256.hash("".getBytes))
+      result shouldBe "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+    }
+    it("encodes data") {
+      val result = Base16.encode(Blake2b256.hash("abc".getBytes))
+      result shouldBe "bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"
+    }
+  }
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Keccak256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Keccak256Test.scala
@@ -1,0 +1,18 @@
+package coop.rchain.crypto.hash
+
+import coop.rchain.crypto.codec.Base16
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Keccak256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Keccak256 hashing algorithm") {
+    it("encodes empty") {
+      val result = Base16.encode(Keccak256.hash("".getBytes))
+      result shouldBe "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    }
+    it("encodes data") {
+      val result = Base16.encode(Keccak256.hash("abc".getBytes))
+      result shouldBe "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    }
+  }
+
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Sha256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Sha256Test.scala
@@ -1,0 +1,16 @@
+package coop.rchain.crypto.hash
+import coop.rchain.crypto.codec.Base16
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Sha256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Sha256 hashing algorithm") {
+    it("encodes") {
+      Base16.encode(Sha256.hash("".getBytes)) shouldBe "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      Base16.encode(Sha256.hash("abc".getBytes)) shouldBe "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+      Base16.encode(Sha256.hash("hello world".getBytes)) shouldBe "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+      Base16.encode(
+        Sha256.hash("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".getBytes)
+      ) shouldBe "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+    }
+  }
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
@@ -1,0 +1,34 @@
+package coop.rchain.crypto.signatures
+import coop.rchain.crypto.codec.Base16
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Ed25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Ed25519") {
+
+    it("computes public key from secret key") {
+      val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+      Base16.encode(Ed25519.toPublic(sec)) shouldBe "77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb"
+
+    }
+    it("verifies the given Ed25519 signature") {
+      val data = Base16.decode(
+        "916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40"
+      )
+      val sig = Base16.decode(
+        "6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509"
+      )
+      val pub = Base16.decode("77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb")
+      Ed25519.verify(data, sig, pub) shouldBe true
+    }
+    it("creates an Ed25519 signature.") {
+      val data = Base16.decode(
+        "916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40"
+      )
+      val sig = Base16.decode(
+        "6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509"
+      )
+      val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+      Ed25519.sign(data, sec).deep shouldBe sig.deep
+    }
+  }
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
@@ -1,0 +1,45 @@
+package coop.rchain.crypto.signatures
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.hash.Sha256
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+
+class Secp256k1Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+  describe("Secp256k1") {
+
+    it("verifies the given secp256k1 signature in native code with keypair") {
+      val (PrivateKey(sec), PublicKey(pub)) = Secp256k1.newKeyPair
+      val data                              = Sha256.hash("testing".getBytes)
+      val sig                               = Secp256k1.sign(data, sec)
+      Secp256k1.verify(data, sig, pub) shouldBe true
+    }
+    it("verifies the given secp256k1 signature in native code") {
+      val data = Sha256.hash("testing".getBytes)
+      val sig = Base16.decode(
+        "3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589"
+      )
+      val pub = Base16.decode(
+        "040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40"
+      )
+      Secp256k1.verify(data, sig, pub)
+    }
+    it("packaged in libsecp256k1 creates an ECDSA signature") {
+      val data = Sha256.hash("testing".getBytes)
+      val sec  = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      Base16
+        .encode(Secp256k1.sign(data, sec))
+        .toUpperCase() shouldBe "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9"
+    }
+    it("verify returns true if valid, false if invalid") {
+      val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      Secp256k1.secKeyVerify(sec) shouldBe true
+    }
+    it("computes public key from secret key") {
+      val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      Base16
+        .encode(Secp256k1.toPublic(sec))
+        .toUpperCase() shouldBe "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6"
+    }
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,6 @@ libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 addSbtPlugin("com.geirsson"           %  "sbt-scalafmt"         % "1.6.0-RC4")
 addSbtPlugin("com.eed3si9n"           %  "sbt-assembly"         % "0.14.9")
 addSbtPlugin("org.scoverage"          %  "sbt-scoverage"        % "1.5.1")
-addSbtPlugin("com.github.tkawachi"    %  "sbt-doctest"          % "0.7.1")
 addSbtPlugin("com.github.tkawachi"    %  "sbt-repeat"           % "0.1.0")
 addSbtPlugin("com.eed3si9n"           %  "sbt-buildinfo"        % "0.9.0")
 addSbtPlugin("com.typesafe.sbt"       %  "sbt-native-packager"  % "1.3.12")


### PR DESCRIPTION
## Overview
doctests are problematic.

a full run on the project produces these:
```
λ find . -name "*Doctest*" -exec echo {} \;
./crypto/target/test-reports/coop.rchain.crypto.signatures.Secp256k1Doctest.xml
./crypto/target/test-reports/coop.rchain.crypto.signatures.Ed25519Doctest.xml
./crypto/target/test-reports/coop.rchain.crypto.hash.Blake2b256Doctest.xml
./crypto/target/test-reports/coop.rchain.crypto.hash.Keccak256Doctest.xml
./crypto/target/test-reports/coop.rchain.crypto.encryption.Curve25519Doctest.xml
./crypto/target/test-reports/coop.rchain.crypto.hash.Sha256Doctest.xml
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/encryption/Curve25519Doctest.class
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/hash/Blake2b256Doctest.class
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/hash/Sha256Doctest.class
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/hash/Keccak256Doctest.class
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/signatures/Ed25519Doctest.class
./crypto/target/scala-2.12/test-classes/coop/rchain/crypto/signatures/Secp256k1Doctest.class
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/encryption/Curve25519Doctest.scala
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/hash/Blake2b256Doctest.scala
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/hash/Sha256Doctest.scala
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/hash/Keccak256Doctest.scala
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/signatures/Ed25519Doctest.scala
./crypto/target/scala-2.12/src_managed/test/coop/rchain/crypto/signatures/Secp256k1Doctest.scala
```

### JIRA ticket:
CORE-1525

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
