### PR TITLE
OPS-391 wait for the bootstrap into ApprovedBlockRecievedHandler state

### DIFF
--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -561,6 +561,7 @@ def started_bootstrap_node(*, context: TestingContext, network, mount_dir: str =
     )
     try:
         wait_for_node_started(context, bootstrap_node)
+        wait_for_approved_block_received_handler_state(context, bootstrap_node)
         yield bootstrap_node
     finally:
         bootstrap_node.cleanup()


### PR DESCRIPTION
## Overview
wait for the bootstrap into ApprovedBlockRecievedHandler state



### JIRA ticket:
https://rchain.atlassian.net/browse/OPS-391



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
