### PR TITLE
Publish artifacts from `staging` under the built PR's base branch name

### DIFF
--- a/scripts/ci/publish-artifacts
+++ b/scripts/ci/publish-artifacts
@@ -6,6 +6,13 @@ if [[ -n $DRONE_TAG ]]; then
 	TAG=1
 elif [[ -n $DRONE_BRANCH ]]; then
 	REF=$DRONE_BRANCH
+	if [[ $DRONE_BRANCH = "staging" ]]; then
+	  # Staging is a branch used by bors for building pull requests before merging.
+	  # All artifacts produced in those builds should be uploaded as if they were built on the PR's base/target branch.
+	  COMMIT_MSG=$( git log -1 --pretty=format:%s )
+	  PR_NUMBER=$( echo "$COMMIT_MSG" | sed -r 's/^Merge #([0-9]+).*$/\1/' )
+	  REF=$( curl -s https://api.github.com/repos/rchain/rchain/pulls/$PR_NUMBER | jq -r '.base.ref' )
+	fi
 	TAG=0
 else
 	# Like, really. It'll overwrite your SSH key.


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This restores artifact upload under dev for PRs based on dev.
It also uploads artifacts built in the `staging` branch build
under the name of the branch that's the base of the PR built in `staging`

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
