### PR TITLE
OPS-392 BlockContainsString should catch the GetBlockError

### DIFF
--- a/integration-tests/test/wait.py
+++ b/integration-tests/test/wait.py
@@ -95,8 +95,11 @@ class BlockContainsString:
         return '<{}({})>'.format(self.__class__.__name__, args)
 
     def is_satisfied(self) -> bool:
-        block = self.node.get_block(self.block_hash)
-        return self.expected_string in block
+        try:
+            block = self.node.get_block(self.block_hash)
+            return self.expected_string in block
+        except GetBlockError:
+            return False
 
 
 class BlocksCountAtLeast:


### PR DESCRIPTION
## Overview
Catch the GetBlockError



### JIRA ticket:
https://rchain.atlassian.net/browse/OPS-392



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
