### PR TITLE
CORE-1564 - Document usage of ski package, refactor the code to be consistent

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -1,10 +1,9 @@
 package coop.rchain.rspace
 
+import coop.rchain.catscontrib.ski._
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import monix.execution.atomic.AtomicAny
-
-import scala.Function.const
 import scala.collection.immutable.Seq
 
 /** The interface for the underlying store
@@ -106,7 +105,7 @@ trait IStore[C, P, A, K] {
   protected def processTrieUpdate(update: TrieUpdate[C, P, A, K]): Unit
 
   private[rspace] def getAndClearTrieUpdates(): Seq[TrieUpdate[C, P, A, K]] =
-    _trieUpdates.getAndTransform(const((0L, Nil)))._2
+    _trieUpdates.getAndTransform(kp((0L, Nil)))._2
 
   def createCheckpoint(): Blake2b256Hash = {
     val trieUpdates = getAndClearTrieUpdates()

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -3,7 +3,7 @@ package coop.rchain.rspace
 import cats.effect.Sync
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
-import coop.rchain.catscontrib._
+import coop.rchain.catscontrib._, ski._
 import coop.rchain.rspace.concurrent.{DefaultTwoStepLock, TwoStepLock}
 import coop.rchain.rspace.history.{Branch, Leaf}
 import coop.rchain.rspace.internal._
@@ -11,8 +11,6 @@ import coop.rchain.rspace.trace.Consume
 import coop.rchain.shared.SyncVarOps._
 import kamon._
 import kamon.trace.Tracer.SpanBuilder
-
-import scala.Function.const
 import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
@@ -147,7 +145,7 @@ abstract class RSpaceOps[F[_], C, P, E, A, R, K](
         store.withTrieTxn(txn) { trieTxn =>
           store.trieStore.validateAndPutRoot(trieTxn, store.trieBranch, root)
           val leaves = store.trieStore.getLeaves(trieTxn, root)
-          eventLog.update(const(Seq.empty))
+          eventLog.update(kp(Seq.empty))
           store.getAndClearTrieUpdates()
           store.clear(txn)
           restoreInstalls(txn)

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -2,6 +2,7 @@ package coop.rchain.rspace
 
 import java.nio.file.Files
 
+import coop.rchain.catscontrib.ski._
 import cats.Id
 import cats.effect._
 import com.google.common.collect.Multiset
@@ -15,7 +16,6 @@ import coop.rchain.rspace.trace.{COMM, Consume, IOEvent, Produce}
 import coop.rchain.shared.PathOps._
 import org.scalatest._
 
-import scala.Function.const
 import scala.collection.parallel.ParSeq
 import scala.collection.{immutable, mutable}
 import scala.util.{Random, Right}
@@ -115,7 +115,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -133,7 +133,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -160,7 +160,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -168,7 +168,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -181,7 +181,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -189,7 +189,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -211,7 +211,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = true
       )
@@ -219,7 +219,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -232,7 +232,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = true
       )
@@ -240,7 +240,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -262,7 +262,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -280,7 +280,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -307,7 +307,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -316,7 +316,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -328,7 +328,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -337,7 +337,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -358,7 +358,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = true
@@ -367,7 +367,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -379,7 +379,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = true
@@ -388,7 +388,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -409,7 +409,7 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelsCreator = const(List("ch1", "ch2")),
+        channelsCreator = kp(List("ch1", "ch2")),
         patterns = List(Wildcard, Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -418,16 +418,16 @@ trait ReplayRSpaceTests
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch1"),
-        datumCreator = const("datum1"),
+        channelCreator = kp("ch1"),
+        datumCreator = kp("datum1"),
         persist = false
       )
       val results = produceMany(
         space,
         range,
         shuffle = false,
-        channelCreator = const("ch2"),
-        datumCreator = const("datum2"),
+        channelCreator = kp("ch2"),
+        datumCreator = kp("datum2"),
         persist = false
       )
       val rigPoint = space.createCheckpoint()
@@ -438,7 +438,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelsCreator = const(List("ch1", "ch2")),
+        channelsCreator = kp(List("ch1", "ch2")),
         patterns = List(Wildcard, Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -447,16 +447,16 @@ trait ReplayRSpaceTests
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch1"),
-        datumCreator = const("datum1"),
+        channelCreator = kp("ch1"),
+        datumCreator = kp("datum1"),
         persist = false
       )
       val replayResults = produceMany(
         replaySpace,
         range,
         shuffle = true,
-        channelCreator = const("ch2"),
-        datumCreator = const("datum2"),
+        channelCreator = kp("ch2"),
+        datumCreator = kp("datum2"),
         persist = false
       )
       val finalPoint = replaySpace.createCheckpoint()
@@ -474,7 +474,7 @@ trait ReplayRSpaceTests
         space,
         range = 0 until 100,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -499,7 +499,7 @@ trait ReplayRSpaceTests
         space,
         range = 0 until 100,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -512,7 +512,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range = 0 until 100,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -537,7 +537,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range = 0 until 100,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -566,7 +566,7 @@ trait ReplayRSpaceTests
         space,
         range = 100 until 200,
         shuffle = false,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -574,7 +574,7 @@ trait ReplayRSpaceTests
         space,
         range = 200 until 300,
         shuffle = false,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -604,7 +604,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range = 100 until 200,
         shuffle = true,
-        channelCreator = const("ch1"),
+        channelCreator = kp("ch1"),
         datumCreator = i => s"datum$i",
         persist = false
       )
@@ -612,7 +612,7 @@ trait ReplayRSpaceTests
         replaySpace,
         range = 200 until 300,
         shuffle = true,
-        channelsCreator = const(List("ch1")),
+        channelsCreator = kp(List("ch1")),
         patterns = List(Wildcard),
         continuationCreator = i => s"continuation$i",
         persist = false
@@ -647,17 +647,17 @@ trait ReplayRSpaceTests
         space,
         range = 0 to 1,
         shuffle = false,
-        channelsCreator = const(channels),
+        channelsCreator = kp(channels),
         patterns = patterns,
-        continuationCreator = const(k),
+        continuationCreator = kp(k),
         persist = false
       )
       produceMany(
         space,
         range = 0 to 1,
         shuffle = false,
-        channelCreator = const(channels(0)),
-        datumCreator = const(datum),
+        channelCreator = kp(channels(0)),
+        datumCreator = kp(datum),
         persist = false
       )
       val rigPoint = space.createCheckpoint()

--- a/shared/src/main/scala/coop/rchain/catscontrib/ski/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ski/package.scala
@@ -1,9 +1,25 @@
 package coop.rchain.catscontrib
 
+/**
+  * Name ski comes from SKI combinator calculus (https://en.wikipedia.org/wiki/SKI_combinator_calculus)
+  * It represents three functions, from which we are using two: constant function (kp) and identity function (id)
+  *
+  * Const and identity function are being used frequantly in this code base (in any FP code base to be precise).
+  * Thus we provide an alias for const and indentity.
+  * Inspiried by ski package in slamdata/quasar codebase: κ and ι funcitons.
+  */
 package object ski {
+
+  /**
+    * Returns a function that takes number of arguments and always returns the last argument as a result
+    */
   def kp[A, B](x: => B): A => B                               = _ => x
   def kp2[A, B, C](x: => C): (A, B) => C                      = (_, _) => x
   def kp3[A, B, C, D](x: => D): (A, B, C) => D                = (_, _, _) => x
   def kp6[A, B, C, D, E, F, G](x: G): (A, B, C, D, E, F) => G = (_, _, _, _, _, _) => x
-  def id[A]: A => A                                           = x => x
+
+  /**
+    * Returns a functiont that always returns its argument
+    */
+  def id[A]: A => A = x => x
 }


### PR DESCRIPTION
## Overview

refactor means: All usages of const should be replaced with kp.




### JIRA ticket:
CORE-1564

