### PR TITLE
refactor the Runtime to allow extra system processes to be passed in Runtime.create

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -91,7 +91,9 @@ object Runtime {
   type Remainder = Option[Var]
   type BodyRef   = Long
 
-  class ShortLeashParams[F[_]] private (private val params: Ref[F, ShortLeashParameters]) {
+  class ShortLeashParams[F[_]] private (
+      private val params: Ref[F, ShortLeashParameters]
+  ) {
     def setParams(codeHash: Par, phloRate: Par, userId: Par, timestamp: Par): F[Unit] =
       params.set(ShortLeashParameters(codeHash, phloRate, userId, timestamp))
 
@@ -107,7 +109,9 @@ object Runtime {
       Ref[F].of(ShortLeashParameters.empty).map(new ShortLeashParams(_))
 
     def unsafe[F[_]]()(implicit F: Sync[F]): ShortLeashParams[F] =
-      new ShortLeashParams[F](Ref.unsafe[F, ShortLeashParameters](ShortLeashParameters.empty))
+      new ShortLeashParams[F](
+        Ref.unsafe[F, ShortLeashParams.ShortLeashParameters](ShortLeashParameters.empty)
+      )
   }
 
   class BlockTime[F[_]](val timestamp: Ref[F, Par]) {
@@ -197,8 +201,100 @@ object Runtime {
         )
     }.sequence
 
+  object SystemProcess {
+    case class Context[F[_]: Sync](
+        space: RhoISpace[F],
+        dispatcher: RhoDispatch[F],
+        registry: Registry[F],
+        shortLeashParams: ShortLeashParams[F],
+        blockTime: BlockTime[F]
+    ) {
+      val systemProcesses = SystemProcesses[F](dispatcher, space)
+    }
+
+    case class Definition[F[_]](
+        urn: String,
+        fixedChannel: Name,
+        arity: Arity,
+        bodyRef: BodyRef,
+        handler: Context[F] => (Seq[ListParWithRandomAndPhlos], Int) => F[Unit],
+        remainder: Remainder = None
+    ) {
+      def toDispatchTable(
+          context: SystemProcess.Context[F]
+      ): (BodyRef, (Seq[ListParWithRandomAndPhlos], Arity) => F[Unit]) =
+        bodyRef -> handler(context)
+
+      def toUrnMap: (String, Par) = {
+        val bundle: Par = Bundle(fixedChannel, writeFlag = true)
+        urn -> bundle
+      }
+
+      def toProcDefs: (Name, Arity, Remainder, BodyRef) =
+        (fixedChannel, arity, remainder, bodyRef)
+    }
+  }
+
+  def stdSystemProcesses[F[_]]: Seq[SystemProcess.Definition[F]] = Seq(
+    SystemProcess.Definition[F]("rho:io:stdout", FixedChannels.STDOUT, 1, BodyRefs.STDOUT, {
+      ctx: SystemProcess.Context[F] =>
+        ctx.systemProcesses.stdOut
+    }),
+    SystemProcess
+      .Definition[F]("rho:io:stdoutAck", FixedChannels.STDOUT_ACK, 2, BodyRefs.STDOUT_ACK, {
+        ctx: SystemProcess.Context[F] =>
+          ctx.systemProcesses.stdOutAck
+      }),
+    SystemProcess.Definition[F]("rho:io:stderr", FixedChannels.STDERR, 1, BodyRefs.STDERR, {
+      ctx: SystemProcess.Context[F] =>
+        ctx.systemProcesses.stdErr
+    }),
+    SystemProcess
+      .Definition[F]("rho:io:stderrAck", FixedChannels.STDERR_ACK, 2, BodyRefs.STDERR_ACK, {
+        ctx: SystemProcess.Context[F] =>
+          ctx.systemProcesses.stdErrAck
+      }),
+    SystemProcess.Definition[F](
+      "rho:registry:insertArbitrary",
+      FixedChannels.REG_INSERT_RANDOM,
+      2,
+      BodyRefs.REG_PUBLIC_REGISTER_RANDOM, { ctx =>
+        ctx.registry.publicRegisterRandom
+      }
+    ),
+    SystemProcess.Definition[F](
+      "rho:registry:insertSigned:ed25519",
+      FixedChannels.REG_INSERT_SIGNED,
+      4,
+      BodyRefs.REG_PUBLIC_REGISTER_SIGNED, { ctx =>
+        ctx.registry.publicRegisterSigned
+      }
+    ),
+    SystemProcess.Definition[F](
+      "rho:deploy:params",
+      FixedChannels.GET_DEPLOY_PARAMS,
+      1,
+      BodyRefs.GET_DEPLOY_PARAMS, { ctx =>
+        ctx.systemProcesses.getDeployParams(ctx.shortLeashParams)
+      }
+    ),
+    SystemProcess.Definition[F](
+      "rho:block:timestamp",
+      FixedChannels.GET_TIMESTAMP,
+      1,
+      BodyRefs.GET_TIMESTAMP, { ctx =>
+        ctx.systemProcesses.blockTime(ctx.blockTime)
+      }
+    )
+  )
+
   // TODO: remove default store type
-  def create(dataDir: Path, mapSize: Long, storeType: StoreType = LMDB)(
+  def create(
+      dataDir: Path,
+      mapSize: Long,
+      storeType: StoreType = LMDB,
+      extraSystemProcesses: Seq[SystemProcess.Definition[Task]] = Seq.empty
+  )(
       implicit scheduler: Scheduler
   ): Runtime = {
     val errorLog                                  = new ErrorLog()
@@ -214,10 +310,6 @@ object Runtime {
       val systemProcesses = SystemProcesses[Task](dispatcher, space)
       import BodyRefs._
       Map(
-        STDOUT                       -> systemProcesses.stdOut,
-        STDOUT_ACK                   -> systemProcesses.stdOutAck,
-        STDERR                       -> systemProcesses.stdErr,
-        STDERR_ACK                   -> systemProcesses.stdErrAck,
         ED25519_VERIFY               -> systemProcesses.ed25519Verify,
         SHA256_HASH                  -> systemProcesses.sha256Hash,
         KECCAK256_HASH               -> systemProcesses.keccak256Hash,
@@ -232,28 +324,19 @@ object Runtime {
         REG_DELETE_ROOT_CALLBACK     -> (registry.deleteRootCallback(_, _)),
         REG_DELETE_CALLBACK          -> (registry.deleteCallback(_, _)),
         REG_PUBLIC_LOOKUP            -> (registry.publicLookup(_, _)),
-        REG_PUBLIC_REGISTER_RANDOM   -> (registry.publicRegisterRandom(_, _)),
-        REG_PUBLIC_REGISTER_SIGNED   -> (registry.publicRegisterSigned(_, _)),
-        REG_NONCE_INSERT_CALLBACK    -> (registry.nonceInsertCallback(_, _)),
-        GET_DEPLOY_PARAMS            -> systemProcesses.getDeployParams(shortLeashParams),
-        GET_TIMESTAMP                -> systemProcesses.blockTime(blockTime)
-      )
+        REG_NONCE_INSERT_CALLBACK    -> (registry.nonceInsertCallback(_, _))
+      ) ++
+        (stdSystemProcesses[Task] ++ extraSystemProcesses)
+          .map(
+            _.toDispatchTable(
+              SystemProcess.Context(space, dispatcher, registry, shortLeashParams, blockTime)
+            )
+          )
     }
 
-    val urnMap: Map[String, Par] = Map(
-      "rho:io:stdout"                -> Bundle(FixedChannels.STDOUT, writeFlag = true),
-      "rho:io:stdoutAck"             -> Bundle(FixedChannels.STDOUT_ACK, writeFlag = true),
-      "rho:io:stderr"                -> Bundle(FixedChannels.STDERR, writeFlag = true),
-      "rho:io:stderrAck"             -> Bundle(FixedChannels.STDERR_ACK, writeFlag = true),
-      "rho:registry:lookup"          -> Bundle(FixedChannels.REG_LOOKUP, writeFlag = true),
-      "rho:registry:insertArbitrary" -> Bundle(FixedChannels.REG_INSERT_RANDOM, writeFlag = true),
-      "rho:registry:insertSigned:ed25519" -> Bundle(
-        FixedChannels.REG_INSERT_SIGNED,
-        writeFlag = true
-      ),
-      "rho:deploy:params"   -> Bundle(FixedChannels.GET_DEPLOY_PARAMS, writeFlag = true),
-      "rho:block:timestamp" -> Bundle(FixedChannels.GET_TIMESTAMP, writeFlag = true)
-    )
+    val urnMap: Map[String, Par] = Map[String, Par](
+      "rho:registry:lookup" -> Bundle(FixedChannels.REG_LOOKUP, writeFlag = true)
+    ) ++ (stdSystemProcesses[Task] ++ extraSystemProcesses).map(_.toUrnMap)
 
     val shortLeashParams = ShortLeashParams.unsafe[Task]()
     val blockTime        = BlockTime.unsafe[Task]()
@@ -261,21 +344,13 @@ object Runtime {
     val procDefs: List[(Name, Arity, Remainder, BodyRef)] = {
       import BodyRefs._
       List(
-        (FixedChannels.STDOUT, 1, None, STDOUT),
-        (FixedChannels.STDOUT_ACK, 2, None, STDOUT_ACK),
-        (FixedChannels.STDERR, 1, None, STDERR),
-        (FixedChannels.STDERR_ACK, 2, None, STDERR_ACK),
         (FixedChannels.ED25519_VERIFY, 4, None, ED25519_VERIFY),
         (FixedChannels.SHA256_HASH, 2, None, SHA256_HASH),
         (FixedChannels.KECCAK256_HASH, 2, None, KECCAK256_HASH),
         (FixedChannels.BLAKE2B256_HASH, 2, None, BLAKE2B256_HASH),
         (FixedChannels.SECP256K1_VERIFY, 4, None, SECP256K1_VERIFY),
-        (FixedChannels.REG_LOOKUP, 2, None, REG_PUBLIC_LOOKUP),
-        (FixedChannels.REG_INSERT_RANDOM, 2, None, REG_PUBLIC_REGISTER_RANDOM),
-        (FixedChannels.REG_INSERT_SIGNED, 4, None, REG_PUBLIC_REGISTER_SIGNED),
-        (FixedChannels.GET_DEPLOY_PARAMS, 1, None, GET_DEPLOY_PARAMS),
-        (FixedChannels.GET_TIMESTAMP, 1, None, GET_TIMESTAMP)
-      )
+        (FixedChannels.REG_LOOKUP, 2, None, REG_PUBLIC_LOOKUP)
+      ) ++ (stdSystemProcesses[Task] ++ extraSystemProcesses).map(_.toProcDefs)
     }
 
     (for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.interpreter
 
-import cats.effect.Async
+import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
@@ -42,7 +42,7 @@ object SystemProcesses {
   def apply[F[_]](
       dispatcher: Dispatch[F, ListParWithRandomAndPhlos, TaggedContinuation],
       space: RhoISpace[F]
-  )(implicit F: Async[F]): SystemProcesses[F] =
+  )(implicit F: Sync[F]): SystemProcesses[F] =
     new SystemProcesses[F] {
 
       type ContWithMetaData = ContResult[Par, BindPattern, TaggedContinuation]


### PR DESCRIPTION
## Overview
See title.

This is is the first step in a series. The next step will be to inject a TestResultCollector system process when setting up the runtime for Rholang tests and make scalatest assertions on the results collected by it.


### JIRA ticket:
RHOL-1124

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
