### PR TITLE
Get fork tip on start

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -62,6 +62,13 @@ object MultiParentCasper extends MultiParentCasperInstances {
   def apply[F[_]](implicit instance: MultiParentCasper[F]): MultiParentCasper[F] = instance
   def ignoreDoppelgangerCheck[F[_]: Applicative]: (BlockMessage, Validator) => F[Unit] =
     kp2(().pure[F])
+
+  def forkChoiceTip[F[_]: MultiParentCasper: Monad]: F[BlockMessage] =
+    for {
+      dag  <- MultiParentCasper[F].blockDag
+      tips <- MultiParentCasper[F].estimator(dag)
+      tip  = tips.head
+    } yield tip
 }
 
 sealed abstract class MultiParentCasperInstances {

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -141,6 +141,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
 
     def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Unit]
 
+    def handleForkChoiceTipRequest(peer: PeerNode, fctr: ForkChoiceTipRequest): F[Unit]
+
     def handleApprovedBlock(ab: ApprovedBlock): F[Option[MultiParentCasper[F]]]
 
     def handleApprovedBlockRequest(peer: PeerNode, br: ApprovedBlockRequest): F[Unit]
@@ -170,6 +172,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     override def handleBlockMessage(peer: PeerNode, bm: BlockMessage): F[Unit] =
       noop
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Unit] =
+      noop
+    override def handleForkChoiceTipRequest(peer: PeerNode, fctr: ForkChoiceTipRequest): F[Unit] =
       noop
     override def handleApprovedBlock(
         ab: ApprovedBlock
@@ -219,6 +223,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     override def handleBlockMessage(peer: PeerNode, bm: BlockMessage): F[Unit] =
       noop
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Unit] =
+      noop
+    override def handleForkChoiceTipRequest(peer: PeerNode, fctr: ForkChoiceTipRequest): F[Unit] =
       noop
     override def handleApprovedBlock(
         ab: ApprovedBlock
@@ -296,6 +302,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       noop
     override def handleBlockRequest(peer: PeerNode, br: BlockRequest): F[Unit] =
       noop
+    override def handleForkChoiceTipRequest(peer: PeerNode, fctr: ForkChoiceTipRequest): F[Unit] =
+      noop
     override def handleApprovedBlockRequest(
         peer: PeerNode,
         br: ApprovedBlockRequest
@@ -370,6 +378,12 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
             }
       } yield ()
 
+    override def handleForkChoiceTipRequest(
+        peer: PeerNode,
+        fctr: ForkChoiceTipRequest
+    ): F[Unit] =
+      noop
+
     override def handleApprovedBlockRequest(
         peer: PeerNode,
         br: ApprovedBlockRequest
@@ -395,6 +409,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         .unlift(
           (p: Packet) =>
             packetToBlockRequest(p) orElse
+              packetToForkChoiceTipRequest(p) orElse
               packetToApprovedBlock(p) orElse
               packetToApprovedBlockRequest(p) orElse
               packetToBlockMessage(p) orElse
@@ -407,6 +422,12 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
             for {
               cph <- cphI.get
               res <- cph.handleBlockRequest(peer, br)
+            } yield res
+
+          case fctr: ForkChoiceTipRequest =>
+            for {
+              cph <- cphI.get
+              res <- cph.handleForkChoiceTipRequest(peer, fctr)
             } yield res
 
           case ab: ApprovedBlock =>
@@ -501,6 +522,11 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   private def packetToBlockRequest(msg: Packet): Option[BlockRequest] =
     if (msg.typeId == transport.BlockRequest.id)
       Try(BlockRequest.parseFrom(msg.content.toByteArray)).toOption
+    else None
+
+  private def packetToForkChoiceTipRequest(msg: Packet): Option[ForkChoiceTipRequest] =
+    if (msg.typeId == transport.ForkChoiceTipRequest.id)
+      Try(ForkChoiceTipRequest.parseFrom(msg.content.toByteArray)).toOption
     else None
 
   private def packetToBlockApproval(msg: Packet): Option[BlockApproval] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -280,6 +280,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                      _   <- Log[F].info("Making a transition to ApprovedBlockRecievedHandler state.")
                      abh = new ApprovedBlockReceivedHandler[F](casper, approvedBlock)
                      _   <- capserHandlerInternal.set(abh)
+                     _   <- CommUtil.sendForkChoiceTipRequest[F]
                    } yield ()
                }
       } yield cont
@@ -451,6 +452,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                             )
                         abr = new ApprovedBlockReceivedHandler(casperInstance, ab)
                         _   <- cphI.set(abr)
+                        _   <- CommUtil.sendForkChoiceTipRequest[F]
                       } yield ()
 
                   }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -49,6 +49,15 @@ object CommUtil {
     } yield ()
   }
 
+  def sendForkChoiceTipRequest[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk]
+    : F[Unit] = {
+    val serialized = ForkChoiceTipRequest().toByteString
+    for {
+      _ <- sendToPeers[F](transport.ForkChoiceTipRequest, serialized)
+      _ <- Log[F].info(s"Requested fork tip from peers")
+    } yield ()
+  }
+
   def sendToPeers[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk](
       pType: PacketType,
       serializedMessage: ByteString

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -284,6 +284,14 @@ class CasperPacketHandlerSpec extends WordSpec {
           _                   = assert(blockO.contains(genesis))
           handlerInternal     <- refCasper.get
           _                   = assert(handlerInternal.isInstanceOf[ApprovedBlockReceivedHandler[Task]])
+          _ = assert(
+            transportLayer.requests.head.msg == packet(
+              local,
+              transport.ForkChoiceTipRequest,
+              ByteString.EMPTY
+            )
+          )
+          _ = transportLayer.reset()
           // assert that we really serve last approved block
           lastApprovedBlockO <- LastApprovedBlock[Task].get
           _                  = assert(lastApprovedBlockO.isDefined)

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketType.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketType.scala
@@ -12,6 +12,10 @@ case object BlockRequest extends PacketType {
   val id = "BlockRequest"
 }
 
+case object ForkChoiceTipRequest extends PacketType {
+  val id = "ForkChoiceTipRequest"
+}
+
 case object ApprovedBlock extends PacketType {
   val id = "ApprovedBlock"
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -74,6 +74,9 @@ message BlockRequest {
   bytes  hash       = 2;
 }
 
+message ForkChoiceTipRequest {
+}
+
 message FindDeployInBlockQuery {
   bytes user = 1;
   int64 timestamp = 2;


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Please have a look at what's ready and provide any feedback you may have. Thx!

On every transistion to ApprovedBlock state, a ForkTipRequest is sent so that the node - if it was restarted, or it joins late - it can catch up before it starts proposing.

I didn't implement periodic ForkTipRequests yet - I have doubts. It may lead to huge traffic waste / self DDoS for dense (N^2 connections) networks depending on implementation.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RHOL-983


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
