### PR TITLE
CORE-1566 new graph

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -17,14 +17,12 @@ case class Acc[G[_]](timeseries: List[Long] = List.empty, graph: G[Graphz[G]])
 
 object GraphzGenerator {
 
-  private def init[G[_]: Monad: GraphSerializer](name: String): Acc[G] =
-    Acc[G](
-      graph = Graphz[G](
-        name,
-        DiGraph,
-        rankdir = Some(BT),
-        node = Map("width" -> "0", "height" -> "0", "margin" -> "0.03", "fontsize" -> "8")
-      )
+  private def initGraph[G[_]: Monad: GraphSerializer](name: String): G[Graphz[G]] =
+    Graphz[G](
+      name,
+      DiGraph,
+      rankdir = Some(BT),
+      node = Map("width" -> "0", "height" -> "0", "margin" -> "0.03", "fontsize" -> "8")
     )
 
   def generate[
@@ -36,7 +34,7 @@ object GraphzGenerator {
       if (blockHash == lastFinalizedBlockHash) Some(Filled) else None
 
     for {
-      acc <- topoSort.foldM(init[G]("dag")) {
+      acc <- topoSort.foldM(Acc[G](graph = initGraph[G]("dag"))) {
               case (acc, blockHashes) =>
                 for {
                   blocks    <- blockHashes.traverse(ProtoUtil.unsafeGetBlock[F])

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -17,6 +17,13 @@ case class Acc[G[_]](timeseries: List[Long] = List.empty, graph: G[Graphz[G]])
 
 object GraphzGenerator {
 
+  type ValidatorsBlocks = Map[Long, (String, List[String])]
+  case class Acc2[G[_]](
+      validators: Map[String, ValidatorsBlocks] = Map.empty,
+      timeseries: List[Long] = List.empty,
+      graph: G[Graphz[G]]
+  )
+
   private def initGraph[G[_]: Monad: GraphSerializer](name: String): G[Graphz[G]] =
     Graphz[G](
       name,
@@ -24,6 +31,76 @@ object GraphzGenerator {
       rankdir = Some(BT),
       node = Map("width" -> "0", "height" -> "0", "margin" -> "0.03", "fontsize" -> "8")
     )
+
+  def dagAsCluster[
+      F[_]: Monad: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore,
+      G[_]: Monad: GraphSerializer
+  ](topoSort: Vector[Vector[BlockHash]], lastFinalizedBlockHash: String): F[G[Graphz[G]]] =
+    for {
+      acc <- topoSort.foldM(Acc2[G](graph = initGraph[G]("dag"))) {
+              case (acc, blockHashes) =>
+                for {
+                  blocks    <- blockHashes.traverse(ProtoUtil.unsafeGetBlock[F])
+                  timeEntry = blocks.head.getBody.getState.blockNumber
+                  validators = blocks.toList.map {
+                    case b =>
+                      val blockHash       = PrettyPrinter.buildString(b.blockHash)
+                      val blockSenderHash = PrettyPrinter.buildString(b.sender)
+                      val parents = b.getHeader.parentsHashList.toList
+                        .map(PrettyPrinter.buildString)
+                      val validatorBlocks = Map(timeEntry -> (blockHash, parents))
+                      Map(blockSenderHash -> validatorBlocks)
+                  }
+                } yield
+                  acc.copy(
+                    timeseries = timeEntry :: acc.timeseries,
+                    validators = acc.validators |+| Foldable[List].fold(validators)
+                  )
+            }
+      result <- Sync[F].delay {
+
+                 val timeseries = acc.timeseries.reverse
+                 val validators = acc.validators
+                 for {
+                   g <- acc.graph
+                   _ <- validators.toList.traverse {
+                         case (id, blocks) =>
+                           g.subgraph(validatorCluster(id, blocks, timeseries))
+                       }
+                   _ <- validators.values.toList.flatMap(_.values.toList).traverse {
+                         case (blockHash, parentsHashes) =>
+                           parentsHashes
+                             .traverse(p => g.edge(blockHash, p, constraint = Some(false)))
+
+                       }
+                   _ <- g.close
+                 } yield g
+
+               }
+    } yield result
+
+  private def validatorCluster[G[_]: Monad: GraphSerializer](
+      id: String,
+      blocks: ValidatorsBlocks,
+      timeseries: List[Long]
+  ): G[Graphz[G]] =
+    for {
+      g <- Graphz.subgraph[G](s"cluster_$id", DiGraph, label = Some(id))
+      nodes = timeseries.map(
+        ts =>
+          blocks.get(ts) match {
+            case Some((blockHash, _)) => (Solid: GraphStyle, blockHash)
+            case None                 => (Invis: GraphStyle, s"${ts.show}_$id")
+          }
+      )
+      _ <- nodes.traverse {
+            case (style, name) => g.node(name, style = Some(style), shape = Box)
+          }
+      _ <- nodes.zip(nodes.drop(1)).traverse {
+            case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Invis))
+          }
+      _ <- g.close
+    } yield g
 
   def generate[
       F[_]: Monad: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore,

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -155,8 +155,26 @@ object Graphz {
 class Graphz[F[_]: Monad](gtype: GraphType, t: String)(implicit ser: GraphSerializer[F]) {
 
   def edge(edg: (String, String)): F[Unit] = edge(edg._1, edg._2)
-  def edge(src: String, dst: String): F[Unit] =
-    ser.push(edgeMkStr.format(Graphz.quote(src), Graphz.quote(dst), "[]"))
+  def edge(
+      src: String,
+      dst: String,
+      style: Option[GraphStyle] = None,
+      constraint: Option[Boolean] = None
+  ): F[Unit] = {
+    import Graphz.{showShape, showStyle}
+    val attrStyle: Map[String, String] = style.map(s => Map("style" -> s.show)).getOrElse(Map.empty)
+    val attrConstraint: Map[String, String] =
+      constraint.map(s => Map("constraint" -> s.show)).getOrElse(Map.empty)
+    val attrs: Map[String, String] = attrStyle |+| attrConstraint
+    ser.push(
+      edgeMkStr.format(
+        Graphz.quote(src),
+        Graphz.quote(dst),
+        Graphz.attrMkStr(attrs).map(a => " " + a).getOrElse("")
+      )
+    )
+  }
+
   def node(
       name: String,
       shape: GraphShape = Circle,

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -197,7 +197,7 @@ class Graphz[F[_]: Monad](gtype: GraphType, t: String)(implicit ser: GraphSerial
   def close: F[Unit]                       = ser.push(s"${t.substring(Graphz.tab.length)}}", suffix = "")
 
   private def edgeMkStr: String = gtype match {
-    case Graph   => s"$t%s -- %s %s"
-    case DiGraph => s"$t%s -> %s %s"
+    case Graph   => s"$t%s -- %s%s"
+    case DiGraph => s"$t%s -> %s%s"
   }
 }

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -136,7 +136,7 @@ object Graphz {
       case (Graph, _)   => s"graph"
       case (DiGraph, _) => s"digraph"
     }
-    if (name == "") s"$prefix {" else s"$prefix $name {"
+    if (name == "") s"$prefix {" else s"""$prefix "$name" {"""
   }
 
   def quote(str: String): String = str match {

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -52,6 +52,7 @@ sealed trait GraphStyle
 final case object Solid  extends GraphStyle
 final case object Bold   extends GraphStyle
 final case object Filled extends GraphStyle
+final case object Invis  extends GraphStyle
 
 object Graphz {
 

--- a/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
+++ b/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
@@ -18,7 +18,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _ <- g.close
       } yield g
       graph.show shouldBe (
-        """graph G {
+        """graph "G" {
           |}""".stripMargin
       )
     }
@@ -29,7 +29,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _ <- g.close
       } yield g
       graph.show shouldBe (
-        """digraph G {
+        """digraph "G" {
           |}""".stripMargin
       )
     }
@@ -41,7 +41,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
       } yield g
       graph.show shouldBe (
         """// this is comment
-          |graph G {
+          |graph "G" {
           |}""".stripMargin
       )
     }
@@ -55,8 +55,8 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
       } yield g
       // then
       graph.show shouldBe (
-        """graph G {
-          |  "Hello" -- "World" []
+        """graph "G" {
+          |  "Hello" -- "World"
           |}""".stripMargin
       )
     }
@@ -70,8 +70,8 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
       } yield g
       // then
       graph.show shouldBe (
-        """digraph G {
-          |  "Hello" -> "World" []
+        """digraph "G" {
+          |  "Hello" -> "World"
           |}""".stripMargin
       )
     }
@@ -87,10 +87,10 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
       } yield g
       // then
       graph.show shouldBe (
-        """digraph G {
+        """digraph "G" {
 	  |  "Hello" [shape=box]
 	  |  "World" [shape=doublecircle]
-          |  "Hello" -> "World" []
+          |  "Hello" -> "World"
           |}""".stripMargin
       )
     }
@@ -129,27 +129,27 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _ <- g.close
       } yield g
       graph.show shouldBe (
-        """digraph Process {
+        """digraph "Process" {
           |  "0"
           |  subgraph {
           |    "A"
           |    "B"
           |    "C"
-          |    "A" -> "B" []
-          |    "B" -> "C" []
+          |    "A" -> "B"
+          |    "B" -> "C"
           |  }
-          |  "0" -> "A" []
+          |  "0" -> "A"
           |  subgraph {
           |    "K"
           |    "L"
           |    "M"
-          |    "K" -> "L" []
-          |    "L" -> "M" []
+          |    "K" -> "L"
+          |    "L" -> "M"
           |  }
-          |  "0" -> "K" []
+          |  "0" -> "K"
           |  "1"
-          |  "M" -> "1" []
-          |  "C" -> "1" []
+          |  "M" -> "1"
+          |  "C" -> "1"
           |}""".stripMargin
       )
     }
@@ -200,31 +200,31 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _ <- g.close
       } yield g
       graph.show shouldBe (
-        """digraph Process {
+        """digraph "Process" {
           |  "0"
-          |  subgraph cluster_p1 {
+          |  subgraph "cluster_p1" {
           |    label = "process #1"
           |    color=blue
           |    "A"
           |    "B"
           |    "C"
-          |    "A" -> "B" []
-          |    "B" -> "C" []
+          |    "A" -> "B"
+          |    "B" -> "C"
           |  }
-          |  "0" -> "A" []
-          |  subgraph cluster_p2 {
+          |  "0" -> "A"
+          |  subgraph "cluster_p2" {
           |    label = "process #2"
           |    color=green
           |    "K"
           |    "L"
           |    "M"
-          |    "K" -> "L" []
-          |    "L" -> "M" []
+          |    "K" -> "L"
+          |    "L" -> "M"
           |  }
-          |  "0" -> "K" []
+          |  "0" -> "K"
           |  "1"
-          |  "M" -> "1" []
-          |  "C" -> "1" []
+          |  "M" -> "1"
+          |  "C" -> "1"
           |}""".stripMargin
       )
     }
@@ -269,7 +269,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
       } yield g
       // then
       graph.show shouldBe (
-        """digraph Blockchain {
+        """digraph "Blockchain" {
           |  rankdir=BT
           |  subgraph {
           |    rank=same
@@ -277,21 +277,21 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
           |    "ddeecc" [shape=box]
           |    "ffeeff" [shape=box]
           |  }
-          |  "000000" -> "ffeeff" []
-          |  "000000" -> "ddeecc" []
+          |  "000000" -> "ffeeff"
+          |  "000000" -> "ddeecc"
           |  subgraph {
           |    rank=same
           |    "0"
           |    "000000" [shape=box]
           |  }
-          |  subgraph timeline {
+          |  subgraph "timeline" {
           |    "3" [shape=plaintext]
           |    "2" [shape=plaintext]
           |    "1" [shape=plaintext]
           |    "0" [shape=plaintext]
-          |    "0" -> "1" []
-          |    "1" -> "2" []
-          |    "2" -> "3" []
+          |    "0" -> "1"
+          |    "1" -> "2"
+          |    "2" -> "3"
           |  }
           |}""".stripMargin
       )
@@ -316,20 +316,20 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _     <- graph.edge("sleep", "runmem")
         _     <- graph.close
       } yield graph).show shouldBe (
-        """graph G {
-          |  "run" -- "intr" []
-          |  "intr" -- "runbl" []
-          |  "runbl" -- "run" []
-          |  "run" -- "kernel" []
-          |  "kernel" -- "zombie" []
-          |  "kernel" -- "sleep" []
-          |  "kernel" -- "runmem" []
-          |  "sleep" -- "swap" []
-          |  "swap" -- "runswap" []
-          |  "runswap" -- "new" []
-          |  "runswap" -- "runmem" []
-          |  "new" -- "runmem" []
-          |  "sleep" -- "runmem" []
+        """graph "G" {
+          |  "run" -- "intr"
+          |  "intr" -- "runbl"
+          |  "runbl" -- "run"
+          |  "run" -- "kernel"
+          |  "kernel" -- "zombie"
+          |  "kernel" -- "sleep"
+          |  "kernel" -- "runmem"
+          |  "sleep" -- "swap"
+          |  "swap" -- "runswap"
+          |  "runswap" -- "new"
+          |  "runswap" -- "runmem"
+          |  "new" -- "runmem"
+          |  "sleep" -- "runmem"
           |}""".stripMargin
       )
     }

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -2,17 +2,22 @@ package coop.rchain.node.api
 
 import cats.effect.concurrent.Semaphore
 import cats.effect.Concurrent
-import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.SafetyOracle
 import coop.rchain.casper.api.BlockAPI
-import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.casper.protocol.{DeployData, DeployServiceResponse, _}
-import coop.rchain.catscontrib.{Taskable, ToAbstractContext}
 import coop.rchain.shared._
-import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.graphz._
+import coop.rchain.casper.api.GraphzGenerator
 import com.google.protobuf.empty.Empty
+
+import cats.mtl._
+import cats.mtl.implicits._
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.catscontrib.Catscontrib._
+import coop.rchain.catscontrib.{Taskable, ToAbstractContext}
+import coop.rchain.catscontrib.TaskContrib._
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -39,8 +44,21 @@ private[api] object DeployGrpcService {
 
       // TODO handle potentiall errors (at least by returning proper response)
       override def visualizeBlocks(q: BlocksQuery): Task[VisualizeBlocksResponse] = {
+        type Effect[A] = StateT[Id, StringBuffer, A]
+        implicit val ser: StringSerializer[Effect]      = new StringSerializer[Effect]
+        val stringify: Effect[Graphz[Effect]] => String = _.runS(new StringBuffer).toString
+
         val depth = if (q.depth <= 0) None else Some(q.depth)
-        defer(BlockAPI.visualizeBlocks[F](depth).map(VisualizeBlocksResponse(_)))
+
+        defer(
+          BlockAPI
+            .visualizeDag[F, Effect](
+              depth,
+              (ts, lfb) => GraphzGenerator.dagAsCluster[F, Effect](ts, lfb),
+              stringify
+            )
+            .map(graph => VisualizeBlocksResponse(graph))
+        )
       }
 
       override def showBlocks(request: BlocksQuery): Observable[BlockInfoWithoutTuplespace] =


### PR DESCRIPTION
## Overview
As requested by @KentShikama trying to provide a new graph visualization layout that has following properties:

1. layouts all blocks of each validator in a single group / cluster
2. layouts all blocks that happened at given "tick" in the same line

It seemed that turning on clusters in graphviz and setting `rank` to same for both vertical and horizontal alignment would do the trick. Well, it did not. Graphiz has powerful ranking mechanism that I quite don't yet fully comprehend, but alining both vertically (per validator) and horizontally (per tick) was quite a challange. Some modifications were needed in the Graphz module.

In this PR I did following:
1. Refactor, init should just initialized graph, not accumulator
2. Add invisible style to edges
3. Change graph names to always be prefixed
4. Add style and contraint to edges definition
5. Extend GraphzGenerator to visualize DAG as cluster of validators
6. Modify BlockAPI to extract visualizer


![image](https://user-images.githubusercontent.com/6287558/50487043-f34f9b80-09fc-11e9-92ad-bbd52767e340.png)
 
--

### JIRA ticket:
https://rchain.atlassian.net/browse/CORE-1566

