### PR TITLE
Let syntax 2641 (WIP: IOU tests)

### DIFF
--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -64,6 +64,7 @@ PInput.          Proc2  ::= "for" "(" Receipt ")" "{" Proc "}" ;
 PChoice.         Proc2  ::= "select" "{" [Branch] "}" ;
 PMatch.          Proc2  ::= "match" Proc4 "{" [Case] "}" ;
 PBundle.         Proc2  ::= Bundle "{" Proc "}" ;
+PLet.            Proc2  ::= "let" [Binding] "in" "{" Proc3 "}";
 PIf.             Proc1  ::= "if" "(" Proc ")" Proc2 ;
 -- Use precedence to force braces around an interior if.
 PIfElse.      Proc1 ::= "if" "(" Proc ")" Proc2 "else" Proc1 ;
@@ -119,6 +120,9 @@ separator nonempty Branch "" ;
 -- Match Cases
 CaseImpl. Case ::= Proc13 "=>" Proc3 ;
 separator nonempty Case "" ;
+
+BindingProcToPat. Binding ::= [Name] NameRemainder "<-" Proc3 ;
+separator nonempty Binding "," ;
 
 -- Name Declarations.
 -- Eventually will have IOPairs.


### PR DESCRIPTION
## Overview
Implement syntactic sugar for let declarations in rholang

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2641 

### Notes

There's one noteable KLUDGE:

```
        // KLUDGE: assume these are distinct from names used elsewhere
        val idents = 0 until p.listbinding_.length map {
          case ix => s"let_%{p.line_num}_${p.col_num}_${ix}"
        }
```

but for my own work, writing `new ch in { ch!(123) | for(x <- ch) { ... use x ...} }` over and over is so mind-numbing that I'm going to use this patch to save my sanity.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [ ] includes tests for all added features,
- [ ] has a reviewer assigned,
- [x] has [all commits signed]
