### PR TITLE
RCHAIN-993 unit test showing state not catching up with a fix.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -46,7 +46,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   private val blockBuffer: mutable.HashSet[BlockMessage] =
     new mutable.HashSet[BlockMessage]()
-  private val blockBufferDependencyDagState =
+  private val dependencyDagState =
     new AtomicMonadState[F, DoublyLinkedDag[BlockHash]](AtomicAny(BlockDependencyDag.empty))
 
   private[casper] val deployHist: mutable.HashSet[Deploy] = new mutable.HashSet[Deploy]()
@@ -107,7 +107,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
       _ <- attempt match {
             case MissingBlocks => ().pure[F]
             case _ =>
-              Capture[F].capture { blockBuffer -= b } *> blockBufferDependencyDagState.modify(
+              Capture[F].capture { blockBuffer -= b } *> dependencyDagState.modify(
                 blockBufferDependencyDag =>
                   DoublyLinkedDagOperations.remove(blockBufferDependencyDag, b.blockHash)
               )
@@ -399,11 +399,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
                                                        genesis
                                                      )
                                                )
-      blockBufferDependencyDag <- blockBufferDependencyDagState.get
+      dependencyDag <- dependencyDagState.get
       postEquivocationCheckStatus <- postNeglectedEquivocationCheckStatus.joinRight.traverse(
                                       _ =>
                                         EquivocationDetector
-                                          .checkEquivocations[F](blockBufferDependencyDag, b, dag)
+                                          .checkEquivocations[F](dependencyDag, b, dag)
                                     )
       status = postEquivocationCheckStatus.joinRight.merge
       _      <- addEffects(status, b)
@@ -500,10 +500,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   private def handleMissingDependency(hash: BlockHash, childBlock: BlockMessage): F[Unit] =
     for {
-      _ <- blockBufferDependencyDagState.modify(
-        blockBufferDependencyDag =>
+      _ <- dependencyDagState.modify(
+        dependencyDag =>
           DoublyLinkedDagOperations
-            .add[BlockHash](blockBufferDependencyDag, hash, childBlock.blockHash)
+            .add[BlockHash](dependencyDag, hash, childBlock.blockHash)
       )
     } yield ()
 
@@ -527,8 +527,8 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   private def reAttemptBuffer: F[Unit] =
     for {
-      blockBufferDependencyDag <- blockBufferDependencyDagState.get
-      dependencyFree           = blockBufferDependencyDag.dependencyFree
+      dependencyDag <- dependencyDagState.get
+      dependencyFree           = dependencyDag.dependencyFree
       dependencyFreeBlocks = blockBuffer
         .filter(block => dependencyFree.contains(block.blockHash))
         .toList
@@ -541,7 +541,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
             ().pure[F]
           } else {
             for {
-              _ <- removeAdded(blockBufferDependencyDag, attempts)
+              _ <- removeAdded(dependencyDag, attempts)
               _ <- reAttemptBuffer
             } yield ()
           }
@@ -576,7 +576,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
       blockBufferDependencyDag: DoublyLinkedDag[BlockHash],
       successfulAdds: List[(BlockMessage, BlockStatus)]
   ): F[Unit] =
-    blockBufferDependencyDagState.set(
+    dependencyDagState.set(
       successfulAdds.foldLeft(blockBufferDependencyDag) {
         case (acc, successfulAdd) =>
           DoublyLinkedDagOperations.remove(acc, successfulAdd._1.blockHash)
@@ -587,8 +587,8 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   def fetchDependencies: F[Unit] =
     for {
-      blockBufferDependencyDag <- blockBufferDependencyDagState.get
-      _ <- blockBufferDependencyDag.dependencyFree.toList.traverse { hash =>
+      dependencyDag <- dependencyDagState.get
+      _ <- dependencyDag.dependencyFree.toList.traverse { hash =>
             CommUtil.sendBlockRequest[F](BlockRequest(Base16.encode(hash.toByteArray), hash))
           }
     } yield ()

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1079,6 +1079,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
    *            \  /
    *          genesis
    *
+   * f2 has in its justifications list c2. This should be handled properly.
+   *
    */
   it should "ask peers for blocks it is missing and add them" in effectTest {
     val deployDatasFs = Vector(

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1057,7 +1057,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     } yield result
   }
 
-  it should "ask peers for blocks it is missing and add them" ignore effectTest {
+  it should "ask peers for blocks it is missing and add them" in effectTest {
     val deployDatasFs = Vector(
       "@2!(2)",
       "@1!(1)"

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1119,7 +1119,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       br <- deploy(nodes(0), deployDatasFs(0).apply())
 
-      a <- List.fill(22)(propagate(nodes)).sequence//make the network chooch
+      _ <- List.fill(22)(propagate(nodes)).sequence//make the network chooch
 
       _ <- nodes(2).casperEff.contains(br) shouldBeF true
 

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1119,32 +1119,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       br <- deploy(nodes(0), deployDatasFs(0).apply())
 
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
-      _ <- propagate(nodes)
+      a <- List.fill(22)(propagate(nodes)).sequence//make the network chooch
 
-      c <- nodes(2).casperEff.contains(br)
-      _ = c shouldBe true
+      _ <- nodes(2).casperEff.contains(br) shouldBeF true
 
       nr <- deploy(nodes(2), deployDatasFs(0).apply())
       _ = nr.header.get.parentsHashList shouldBe Seq(br.blockHash)


### PR DESCRIPTION
## Overview
Introduces a unit test that shows that a change in how the blocks are added to the 2-way graph fixes a catch up problem.

essentially the fix boils down to:
if a block is a parent of 2 block then this fact needs to make its way to `blockBufferDependencyDag`. it is not sufficient to hold only one of the dependencies (out of potentially many children).
The clash happens when a parent block is also a justification for a younger block (c2 and f2).

### JIRA ticket:
https://rchain.atlassian.net/projects/RCHAIN/issues/RCHAIN-993

### Notes
none really. it's a step in identifying a bug that's been in the project for over 4 months.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
