### PR TITLE
Edited test plan

### DIFF
--- a/docs/whiteblock-test-plan.md
+++ b/docs/whiteblock-test-plan.md
@@ -30,6 +30,13 @@ The proposed testing initiatives will be conducted within using the Whiteblock S
 | CPU Max MHz | 4000.0000                                      |
 | RAM         | 256GB DDR4                                     |
 
+## Contracts Used
+The following contracts will be deployed within the various test cases outlined in this document:
+
+- [dupe.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/dupe.rho)
+- [shortslow.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/shortslow.rho)
+- [shortfast.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/shortfast.rho)
+
 ## Performance Metrics
 
 Time measurements are expressed in terms of the time passed on the node
@@ -64,7 +71,7 @@ which define the variable to be tested.
 | Validators       | 10          | 20          | 30          |
 | Static Nodes     | 6           | 6           | 6           |
 | Contract         | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth        | 1GB         | 1Gb         | 1Gb         |
+| Bandwidth        | 1Gb         | 1Gb         | 1Gb         |
 | Network Latency  | 0ms         | 0ms         | 0ms         |
 | Packet Loss      | 0%          | 0%          | 0%          |
 
@@ -75,7 +82,7 @@ which define the variable to be tested.
 | Validators      | 6           | 5           | 5           |
 | Static Nodes    | 10          | 20          | 30          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
+| Bandwidth       | 1Gb         | 1Gb         | 1Gb         |
 | Network Latency | 0ms         | 0ms         | 0ms         |
 | Packet Loss     | 0%          | 0%          | 0%          |
 
@@ -86,7 +93,7 @@ which define the variable to be tested.
 | Validators      | 18          | 18            | 18            |
 | Static Nodes    | 18          | 18            | 18            |
 | Contract        | dupe.rho    | shortfast.rho | shortslow.rho |
-| Bandwidth       | 1GB         | 1Gb           | 1Gb           |
+| Bandwidth       | 1Gb         | 1Gb           | 1Gb           |
 | Network Latency | 0ms         | 0ms           | 0ms           |
 | Packet Loss     | 0%          | 0%            | 0%            |
 
@@ -110,7 +117,7 @@ which define the variable to be tested.
 | Validators      | 18          | 18          | 18          |
 | Static Nodes    | 18          | 18          | 18          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
+| Bandwidth       | 1Gb         | 1Gb         | 1Gb         |
 | Network Latency | 50ms        | 110ms       | 250ms       |
 | Packet Loss     | 0%          | 0%          | 0%          |
 
@@ -121,7 +128,7 @@ which define the variable to be tested.
 | Validators      | 18          | 18          | 18          |
 | Static Nodes    | 18          | 18          | 18          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
+| Bandwidth       | 1Gb         | 1Gb         | 1Gb         |
 | Network Latency | 0ms         | 0ms         | 0ms         |
 | Packet Loss     | 0.01%       | 0.5%        | 1.0%        |
 

--- a/docs/whiteblock-test-plan.md
+++ b/docs/whiteblock-test-plan.md
@@ -18,43 +18,34 @@ Per test case:
 
 ## Test Environment
 
-The proposed testing initiatives will be conducted within the Whiteblock test
-lab on a group of 6 rack mounted chassis servers.
+The proposed testing initiatives will be conducted within using the Whiteblock SaaS platform, which is a cloud-based solution.
 
-Should testing initiatives require additional computational resources or
-demand a higher overhead than can be adequately provided within the proposed
-environment, the Whiteblock cloud-based solution can be used. However, in the
-interest of cost-effectiveness, the current on-premises lab setup can
-adequately provide the current scope of work. 
-
-## System Specifications
+## Node Specifications
 
 | Component   | Value                                          |
 |-------------|------------------------------------------------|
-| Model Name  | PowerEdge R720                                 |
-| Vendor      | Dell                                           |
-| CPUs        | (2) Intel Xeon CPU E5-2667 v2 @ 3.30GHz        |
+| Node Count  | 36                                             |
+| RAM/Node    | 32GB DDR4                                      |
+| CPU         | Intel Xeon E7 (Intel Core i7-6950X)            |
 | CPU Max MHz | 4000.0000                                      |
-| NIC         | 82599ES 10-Gigabit SFI/SFP+ Network Connection |
 | RAM         | 256GB DDR4                                     |
-
 
 ## Performance Metrics
 
 Time measurements are expressed in terms of the time passed on the node
 coordinating the tests.  Assuming the coordinating node's clock hasn't been tempered with.
 
-| Value			    | Description | 
-| ------------------------- | -------- | 
-| Discovery Time	    | The length of time from a node startup to node become aware of its first peer | 
+| Value			            | Description                                                                                                               | 
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------| 
+| Discovery Time	        | The length of time from a node startup to node become aware of its first peer                                             | 
 | Block Propagation Time    | The length of time it takes for a message, once broadcast, to be received by a majority (99%) of peers within the network |
-| Consensus Time	    | The length of time from a finish of a propose operation, to all the network nodes reporting the same tip hash | 
-| Node Join Time	    | The length of time from a node startup to adding first block to its DAG | 
-| *.comm.consume	    | Counter available at `curl -s http://localhost:40403/metrics` |
-| *.comm.produce	    | Counter available at `curl -s http://localhost:40403/metrics` |
-| *.consume		    | Timespan available at `curl -s http://localhost:40403/metrics` |
-| *.produce		    | Timespan available at `curl -s http://localhost:40403/metrics` |
-| *.install		    | Timespan available at `curl -s http://localhost:40403/metrics` |
+| Consensus Time	        | The length of time from a finish of a propose operation, to all the network nodes reporting the same tip hash             | 
+| Node Join Time	        | The length of time from a node startup to adding first block to its DAG                                                   | 
+| *.comm.consume	        | Counter available at `curl -s http://localhost:40403/metrics`                                                             |
+| *.comm.produce	        | Counter available at `curl -s http://localhost:40403/metrics`                                                             |
+| *.consume		            | Timespan available at `curl -s http://localhost:40403/metrics`                                                            |
+| *.produce		            | Timespan available at `curl -s http://localhost:40403/metrics`                                                            |
+| *.install	         	    | Timespan available at `curl -s http://localhost:40403/metrics`                                                            |
 
 NOTE: The `/metrics` above are available only once they have been reported at
 least once *AND* `prometheus = true` in `rnode.toml`!
@@ -66,49 +57,48 @@ series focuses on observing and documenting the effects of certain conditions
 on performance. Each test series is comprised of three separate test cases
 which define the variable to be tested. 
 
-### Series 1: Number of Validators
+### Series 1: Validators
 
 | Variable         | Test Case A | Test Case B | Test Case C |
 |------------------|------------:|------------:|------------:|
-| Validators       | 300         | 600         | 1000        |
-| Static Nodes     | 600         | 600         | 600         |
+| Validators       | 10          | 20          | 30          |
+| Static Nodes     | 6           | 6           | 6           |
 | Contract         | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth        | 5Mb         | 5Mb         | 5Mb         |
-| Propagation Time | 8s          | 8s          | 8s          |
-
+| Bandwidth        | 1GB         | 1Gb         | 1Gb         |
+| Network Latency  | 0ms         | 0ms         | 0ms         |
+| Packet Loss      | 0%          | 0%          | 0%          |
 
 ### Series 2: Number of Static Nodes
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 600         | 600         | 600         |
-| Static Nodes    | 300         | 600         | 1000        |
+| Validators      | 6           | 5           | 5           |
+| Static Nodes    | 10          | 20          | 30          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 5Mb         | 5Mb         | 5Mb         |
+| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
 | Network Latency | 0ms         | 0ms         | 0ms         |
 | Packet Loss     | 0%          | 0%          | 0%          |
-
 
 ### Series 3: Contract
 
 | Variable        | Test Case A | Test Case B   | Test Case C   |
 |-----------------|------------:|--------------:|--------------:|
-| Validators      | 1000        | 1000          | 1000          |
-| Static Nodes    | 1000        | 1000          | 1000          |
+| Validators      | 18          | 18            | 18            |
+| Static Nodes    | 18          | 18            | 18            |
 | Contract        | dupe.rho    | shortfast.rho | shortslow.rho |
-| Bandwidth       | 5Mb         | 5Mb           | 5Mb           |
+| Bandwidth       | 1GB         | 1Gb           | 1Gb           |
 | Network Latency | 0ms         | 0ms           | 0ms           |
-| Packet Loss     | 0.01%       | 0.5%          | 1.0%          |
+| Packet Loss     | 0%          | 0%            | 0%            |
 
 
 ### Series 4: Bandwidth
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 1000        | 1000        | 1000        |
-| Static Nodes    | 1000        | 1000        | 1000        |
+| Validators      | 18          | 18          | 18          |
+| Static Nodes    | 18          | 18          | 18          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 5Mb         | 500Mb       | 1G          |
+| Bandwidth       | 30Mb        | 100Mb       | 500Mb       |
 | Network Latency | 0ms         | 0ms         | 0ms         |
 | Packet Loss     | 0%          | 0%          | 0%          |
 
@@ -117,38 +107,39 @@ which define the variable to be tested.
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 1000        | 1000        | 1000        |
-| Static Nodes    | 1000        | 1000        | 1000        |
+| Validators      | 18          | 18          | 18          |
+| Static Nodes    | 18          | 18          | 18          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 5Mb         | 5Mb         | 5Mb         |
-| Network Latency | 25ms        | 50ms        | 100ms       |
+| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
+| Network Latency | 50ms        | 110ms       | 250ms       |
 | Packet Loss     | 0%          | 0%          | 0%          |
-
 
 ### Series 6: Packet Loss
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 1000        | 1000        | 1000        |
-| Static Nodes    | 1000        | 1000        | 1000        |
+| Validators      | 18          | 18          | 18          |
+| Static Nodes    | 18          | 18          | 18          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
-| Bandwidth       | 5Mb         | 5Mb         | 5Mb         |
+| Bandwidth       | 1GB         | 1Gb         | 1Gb         |
 | Network Latency | 0ms         | 0ms         | 0ms         |
 | Packet Loss     | 0.01%       | 0.5%        | 1.0%        |
-
 
 ### Series 7: Stress Test
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 1000        | 500         | 300         |
-| Static Nodes    | 2000        | 2000        | 2000        |
+| Validators      | 1           | 35          | 34          |
+| Static Nodes    | 35          | 1           | 2           |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
 | Bandwidth       | 5Mb         | 5Mb         | 5Mb         |
-| Network Latency | 50ms        | 50ms        | 50ms        |
+| Network Latency | 100ms       | 100ms       | 100ms       |
 | Packet Loss     | 0.01%       | 0.01%       | 0.01%       |
 
 
 ## Future plans
 
  * Test transfers (requires working conflict resolution)
+
+## Additional Notes
+- This test plan should be considered a living document and is subject to change. The results of one test series may have implications on future test series and require a change in plan. 

--- a/docs/whiteblock-test-plan.md
+++ b/docs/whiteblock-test-plan.md
@@ -28,7 +28,6 @@ The proposed testing initiatives will be conducted within using the Whiteblock S
 | RAM/Node    | 32GB DDR4                                      |
 | CPU         | Intel Xeon E7 (Intel Core i7-6950X)            |
 | CPU Max MHz | 4000.0000                                      |
-| RAM         | 256GB DDR4                                     |
 
 ## Contracts Used
 The following contracts will be deployed within the various test cases outlined in this document:

--- a/docs/whiteblock-test-plan.md
+++ b/docs/whiteblock-test-plan.md
@@ -31,7 +31,6 @@ The proposed testing initiatives will be conducted within using the Whiteblock S
 
 ## Contracts Used
 The following contracts will be deployed within the various test cases outlined in this document:
-
 - [dupe.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/dupe.rho)
 - [shortslow.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/shortslow.rho)
 - [shortfast.rho](https://github.com/rchain/rchain/blob/dev/rholang/examples/shortfast.rho)
@@ -78,7 +77,7 @@ which define the variable to be tested.
 
 | Variable        | Test Case A | Test Case B | Test Case C |
 |-----------------|------------:|------------:|------------:|
-| Validators      | 6           | 5           | 5           |
+| Validators      | 5           | 5           | 5           |
 | Static Nodes    | 10          | 20          | 30          |
 | Contract        | dupe.rho    | dupe.rho    | dupe.rho    |
 | Bandwidth       | 1Gb         | 1Gb         | 1Gb         |


### PR DESCRIPTION
Made changes to test plan. 

1. I updated the system specifications and adjusted the validator/static node count to reflect these. 

2. There is no practical way to enforce a deterministic propagation time, so I removed this row as a variable. 

3. I set 1Gb as the default bandwidth per test series (apart from the test series in which bandwidth is a variable). The idea is to only observe the effects of particular variables on performance, so if the original 5Mb value is applied by default, this could have adverse effects on overall performance since 5Mb is considerably low. 

4. I increased the range of latency between test cases within Series 5. Cross continental latency is often <150ms.

5. I increased the range of packet loss between test cases within Series 6. since average packet loss can sometimes be much greater than what was provided. Admittedly, the 1% packet loss in Test Case C is very high and may result in complete system failure, but it's good to observe these edge cases for future planning. 

Again, this is a boilerplate test plan and each test series is subject to change since the results on one can have an effect on others.

