### PR TITLE
Express matcher effects in terms of MTL typeclasses

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -613,7 +613,7 @@ trait SpatialMatcherInstances {
       if (!pattern.connectiveUsed) {
         val cost = equalityCheckCost(pattern, target)
         if (pattern == target)
-          NonDetFreeMapWithCost.pure(()).charge(cost)
+          ().pure[NonDetFreeMapWithCost].charge(cost)
         else {
           NonDetFreeMapWithCost.empty[Unit].charge(cost)
         }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -556,14 +556,11 @@ trait SpatialMatcherInstances {
           firstMatch(target, ps)
         }
         case ConnNotBody(p) =>
-          OptionalFreeMapWithCost[Unit]((s: FreeMap) => {
-            OptionT(StateT((c: Cost) => {
-              spatialMatch(target, p).run(s).value.run(c).map {
-                case (cost, None)         => (cost, Some((s, Unit)))
-                case (cost, Some((_, _))) => (cost, None)
-              }
-            }))
-          })
+          spatialMatch(target, p).attemptOpt.flatMap {
+            case None    => ().pure[OptionalFreeMapWithCost]
+            case Some(_) => OptionalFreeMapWithCost.empty
+          }
+
         case _: VarRefBody =>
           // this should never happen because variable references should be substituted
           OptionalFreeMapWithCost.empty[Unit]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -228,7 +228,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
       sm: SpatialMatcher[T, P]
   ): OptionalFreeMapWithCost[Seq[T]] =
     (tlist, plist) match {
-      case (Nil, Nil) => OptionalFreeMapWithCost.pure(Nil)
+      case (Nil, Nil) => Seq.empty[T].pure[OptionalFreeMapWithCost]
       case (Nil, _) =>
         OptionalFreeMapWithCost.empty[Seq[T]]
       case (trem, Nil) =>
@@ -238,7 +238,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
           case Some(Var(FreeVar(level))) => {
             def freeCheck(trem: Seq[T], level: Int, acc: Seq[T]): OptionalFreeMapWithCost[Seq[T]] =
               trem match {
-                case Nil => OptionalFreeMapWithCost.pure(acc)
+                case Nil => acc.pure[OptionalFreeMapWithCost]
                 case item +: rem =>
                   if (lft.locallyFree(item, 0).isEmpty)
                     freeCheck(rem, level, acc :+ item)
@@ -247,7 +247,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
               }
             freeCheck(trem, level, Vector.empty[T])
           }
-          case Some(Var(Wildcard(_))) => OptionalFreeMapWithCost.pure(Nil)
+          case Some(Var(Wildcard(_))) => Seq.empty[T].pure[OptionalFreeMapWithCost]
           case _                      => OptionalFreeMapWithCost.empty[Seq[T]]
         }
       case (t +: trem, p +: prem) =>
@@ -293,7 +293,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
       else if (plen > tlen)
         OptionalFreeMapWithCost.empty[Unit].charge(COMPARISON_COST)
       else if (plen == 0 && tlen == 0 && remainder.isEmpty)
-        OptionalFreeMapWithCost.pure(())
+        ().pure[OptionalFreeMapWithCost]
       else if (plen == 0 && remainder.isDefined) {
         val matchResult =
           if (tlist.forall(lf.locallyFree(_, 0).isEmpty))
@@ -360,7 +360,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
               // If there is a wildcard, we succeed.
               // We also succeed if there isn't but the remainder is empty.
               if (wildcard || remainderTargetsSorted.isEmpty)
-                OptionalFreeMapWithCost.pure(())
+                ().pure[OptionalFreeMapWithCost]
               else
                 // This should be prevented by the length checks.
                 OptionalFreeMapWithCost.empty
@@ -571,35 +571,35 @@ trait SpatialMatcherInstances {
         case _: ConnBool =>
           target.singleExpr match {
             case Some(Expr(GBool(_))) =>
-              OptionalFreeMapWithCost.pure(())
+              ().pure[OptionalFreeMapWithCost]
             case _ => OptionalFreeMapWithCost.empty[Unit]
           }
 
         case _: ConnInt =>
           target.singleExpr match {
             case Some(Expr(GInt(_))) =>
-              OptionalFreeMapWithCost.pure(())
+              ().pure[OptionalFreeMapWithCost]
             case _ => OptionalFreeMapWithCost.empty[Unit]
           }
 
         case _: ConnString =>
           target.singleExpr match {
             case Some(Expr(GString(_))) =>
-              OptionalFreeMapWithCost.pure(())
+              ().pure[OptionalFreeMapWithCost]
             case _ => OptionalFreeMapWithCost.empty[Unit]
           }
 
         case _: ConnUri =>
           target.singleExpr match {
             case Some(Expr(GUri(_))) =>
-              OptionalFreeMapWithCost.pure(())
+              ().pure[OptionalFreeMapWithCost]
             case _ => OptionalFreeMapWithCost.empty[Unit]
           }
 
         case _: ConnByteArray =>
           target.singleExpr match {
             case Some(Expr(GByteArray(_))) =>
-              OptionalFreeMapWithCost.pure(())
+              ().pure[OptionalFreeMapWithCost]
             case _ => OptionalFreeMapWithCost.empty[Unit]
           }
 
@@ -712,7 +712,7 @@ trait SpatialMatcherInstances {
     fromFunction[Bundle, Bundle] { (target, pattern) =>
       val cost = equalityCheckCost(target, pattern)
       if (pattern == target)
-        OptionalFreeMapWithCost.pure(()).charge(cost)
+        ().pure[OptionalFreeMapWithCost].charge(cost)
       else {
         OptionalFreeMapWithCost.empty[Unit].charge(cost)
       }
@@ -757,7 +757,7 @@ trait SpatialMatcherInstances {
             _ <- rem match {
                   case Some(Var(FreeVar(level))) =>
                     StateT.modify[OptionWithCost, FreeMap](m => m + (level -> EList(matchedRem)))
-                  case _ => OptionalFreeMapWithCost.pure[Unit](())
+                  case _ => ().pure[OptionalFreeMapWithCost]
                 }
           } yield Unit
         }
@@ -779,7 +779,7 @@ trait SpatialMatcherInstances {
         case (EVarBody(EVar(vp)), EVarBody(EVar(vt))) =>
           val cost = equalityCheckCost(vp, vt)
           if (vp == vt)
-            OptionalFreeMapWithCost.pure(()).charge(cost)
+            ().pure[OptionalFreeMapWithCost].charge(cost)
           else
             OptionalFreeMapWithCost.empty[Unit].charge(cost)
         case (ENotBody(ENot(t)), ENotBody(ENot(p))) => spatialMatch(t, p)
@@ -838,7 +838,7 @@ trait SpatialMatcherInstances {
     fromFunction[GPrivate, GPrivate] { (target, pattern) =>
       if (target == pattern) {
         val cost = equalityCheckCost(target, pattern)
-        OptionalFreeMapWithCost.pure(()).charge(cost)
+        ().pure[OptionalFreeMapWithCost].charge(cost)
       } else
         OptionalFreeMapWithCost.empty
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -80,11 +80,6 @@ package object matcher {
     implicit def toOptionalFreeMapWithCostOps[A](s: OptionalFreeMapWithCost[A]) =
       new OptionalFreeMapWithCostOps[A](s)
 
-    def apply[A](f: FreeMap => OptionWithCost[(FreeMap, A)]): OptionalFreeMapWithCost[A] =
-      StateT((m: FreeMap) => {
-        f(m)
-      })
-
     def empty[A]: OptionalFreeMapWithCost[A] =
       MonadTrans[StateT[?[_], FreeMap, ?]].liftM(MonoidK[OptionWithCost].empty)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -113,9 +113,6 @@ package object matcher {
     def empty[A]: NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.empty)
 
-    def pure[A](value: A): NonDetFreeMapWithCost[A] =
-      StateT.pure[StreamWithCost, FreeMap, A](value)
-
     def fromStream[A](stream: Stream[A]): NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.fromStream(StateT.pure(stream)))
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -1,11 +1,12 @@
 package coop.rchain.rholang.interpreter
 
-import cats.MonadError
+import cats.{Alternative, MonadError, Monoid, MonoidK}
 import cats.arrow.FunctionK
 import cats.data.{OptionT, StateT}
 import cats.implicits._
 import cats.mtl.implicits._
 import cats.mtl.MonadState
+import coop.rchain.catscontrib.MonadTrans
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
@@ -79,7 +80,7 @@ package object matcher {
       })
 
     def empty[A]: OptionalFreeMapWithCost[A] =
-      StateT.liftF(OptionT.fromOption(None))
+      MonadTrans[StateT[?[_], FreeMap, ?]].liftM(MonoidK[OptionWithCost].empty)
 
     def fromOption[A](option: Option[A]): OptionalFreeMapWithCost[A] =
       StateT.liftF(OptionT.fromOption(option))
@@ -108,7 +109,7 @@ package object matcher {
       new NonDetFreeMapWithCostOps[A](s)
 
     def empty[A]: NonDetFreeMapWithCost[A] =
-      StateT.liftF(StreamT.empty)
+      MonadTrans[StateT[?[_], FreeMap, ?]].liftM(MonoidK[StreamWithCost].empty)
 
     def fromStream[A](stream: Stream[A]): NonDetFreeMapWithCost[A] =
       StateT.liftF(StreamT.fromStream(StateT.pure(stream)))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -36,6 +36,12 @@ package object matcher {
   type _error[F[_]]   = MonadError[F, OutOfPhlogistonsError.type]
   type _short[F[_]]   = MonadError[F, Unit] //arises from and corresponds to the OptionT/StreamT in the stack
 
+  // Implicit summoner methods, just like `Monad.apply` on `Monad`'s companion object.
+  def _freeMap[F[_]](implicit ev: _freeMap[F]): _freeMap[F] = ev
+  def _cost[F[_]](implicit ev: _cost[F]): _cost[F]          = ev
+  def _error[F[_]](implicit ev: _error[F]): _error[F]       = ev
+  def _short[F[_]](implicit ev: _short[F]): _short[F]       = ev
+
   private[matcher] def charge[F[_]](
       amount: Cost
   )(implicit cost: _cost[F], error: _error[F]): F[Unit] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -1,8 +1,10 @@
 package coop.rchain.rholang.interpreter
 
+import cats.MonadError
 import cats.arrow.FunctionK
 import cats.data.{OptionT, StateT}
 import cats.implicits._
+import cats.mtl.MonadState
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
@@ -23,6 +25,14 @@ package object matcher {
   //FreeMap => Cost => Either[OOPE, (Cost, Stream[(FreeMap, A)])]
   type NonDetFreeMapWithCost[A] = StateT[StreamWithCost, FreeMap, A]
   type StreamWithCost[A]        = StreamT[ErroredOrCostA, A]
+
+  // The naming convention means: this is an effect-type alias.
+  // Will be used similarly to capabilities, but for more generic and probably low-level/implementation stuff.
+  // Adopted from: http://atnos-org.github.io/eff/org.atnos.site.Tutorial.html#write-an-interpreter-for-your-program
+  type _freeMap[F[_]] = MonadState[F, FreeMap]
+  type _cost[F[_]]    = MonadState[F, Cost]
+  type _error[F[_]]   = MonadError[F, OutOfPhlogistonsError.type]
+  type _short[F[_]]   = MonadError[F, Unit] //arises from and corresponds to the OptionT/StreamT in the stack
 
   object OptionalFreeMapWithCost {
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -81,9 +81,6 @@ package object matcher {
     def empty[A]: OptionalFreeMapWithCost[A] =
       StateT.liftF(OptionT.fromOption(None))
 
-    def pure[A](value: A): OptionalFreeMapWithCost[A] =
-      StateT.pure[OptionWithCost, FreeMap, A](value)
-
     def fromOption[A](option: Option[A]): OptionalFreeMapWithCost[A] =
       StateT.liftF(OptionT.fromOption(option))
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -2,28 +2,26 @@ package coop.rchain.rholang.interpreter.matcher
 
 import cats.implicits._
 import coop.rchain.rholang.interpreter.accounting.Cost
-import org.scalatest.FlatSpec
-
 import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
-import coop.rchain.rholang.interpreter.matcher.OptionalFreeMapWithCost._
+import org.scalatest.FlatSpec
 
 class MatcherMonadSpec extends FlatSpec {
 
   behavior of "MatcherMonad"
 
   it should "charge for each non-deterministic branch" in {
-    pending
 
     val possibleResults = Stream((0, 1), (0, 2))
     val computation     = NonDetFreeMapWithCost.fromStream(possibleResults)
     val sum             = computation.map { case (x, y) => x + y }.charge(Cost(1))
     val (cost, _)       = sum.runWithCost(Cost(possibleResults.size)).right.get
-    assert(cost.value == 0) //is 1, so just 1 is charged
+    assert(cost.value == 0)
 
     val moreVariants    = sum.flatMap(x => NonDetFreeMapWithCost.fromStream(Stream(x, 0, -x)))
     val moreComputation = moreVariants.map(x => "Do sth with " + x).charge(Cost(1))
-    val (cost2, _)      = moreComputation.runWithCost(Cost(possibleResults.size * 3)).right.get
-    assert(cost2.value == 0) //is 4, so only 2 is charged
+    val (cost2, _) =
+      moreComputation.runWithCost(Cost(possibleResults.size * 3 + possibleResults.size)).right.get
+    assert(cost2.value == 0)
   }
 
 }


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This is not to say that the whole rholang uses the effects via MTL. This is to say that what's left should be trivial to fix :)

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
