### PR TITLE
Bump cats

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -177,7 +177,7 @@ class AbstractRuntimeManager[F[_]: Concurrent: ToAbstractContext] protected (
           case deploy +: rem =>
             for {
               _              <- ToAbstractContext[F].fromTask(runtime.space.reset(hash))
-              availablePhlos = Cost(deploy.raw.map(_.phloLimit).get.value)
+              availablePhlos = Cost(deploy.raw.map(_.phloLimit).get)
               _              <- ToAbstractContext[F].fromTask(runtime.reducer.setAvailablePhlos(availablePhlos))
               (codeHash, phloPrice, userId, timestamp) = ProtoUtil.getRholangDeployParams(
                 deploy.raw.get
@@ -220,7 +220,7 @@ class AbstractRuntimeManager[F[_]: Concurrent: ToAbstractContext] protected (
       Concurrent[F].defer {
         terms match {
           case InternalProcessedDeploy(deploy, _, log, status) +: rem =>
-            val availablePhlos = Cost(deploy.raw.map(_.phloLimit).get.value)
+            val availablePhlos = Cost(deploy.raw.map(_.phloLimit).get)
             for {
               _ <- ToAbstractContext[F].fromTask(
                     runtime.replayReducer.setAvailablePhlos(availablePhlos)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val circeVersion   = "0.10.0"
   val http4sVersion  = "0.19.0"
   val kamonVersion   = "1.1.3"
-  val catsVersion    = "1.4.0"
+  val catsVersion    = "1.5.0"
   val catsMtlVersion = "0.4.0"
 
   // format: off
@@ -77,6 +77,7 @@ object Dependencies {
   val overrides = Seq(
     catsCore,
     catsEffect,
+    catsLawsTest,
     shapeless,
     guava,
     scodecBits,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -818,7 +818,7 @@ object Reduce {
                        case (EListBody(lhs), EListBody(rhs)) =>
                          for {
                            _ <- costAccountingAlg.charge(
-                                 listAppendCost(rhs.value.ps.toVector)
+                                 listAppendCost(rhs.ps.toVector)
                                )
                          } yield
                            Expr(


### PR DESCRIPTION
The `.value` removals are probablye due to
https://github.com/typelevel/cats/pull/2423

## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
