### PR TITLE
RCHAIN-2307 Exposed Task in Runtime.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -490,11 +490,14 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
         .toSet
       allDependencies = (missingParents union missingJustifications).toList
       missingDependencies <- allDependencies.filterA(
-        blockHash =>
-          dag
-            .lookup(blockHash)
-            .map(_.isEmpty))
-      missingUnseenDependencies = missingDependencies.filter(blockHash => !blockBuffer.exists(_.blockHash == blockHash))
+                              blockHash =>
+                                dag
+                                  .lookup(blockHash)
+                                  .map(_.isEmpty)
+                            )
+      missingUnseenDependencies = missingDependencies.filter(
+        blockHash => !blockBuffer.exists(_.blockHash == blockHash)
+      )
       _ <- missingDependencies.traverse(hash => handleMissingDependency(hash, b))
       _ <- missingUnseenDependencies.traverse(hash => requestMissingDependency(hash))
     } yield ()
@@ -502,10 +505,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
   private def handleMissingDependency(hash: BlockHash, childBlock: BlockMessage): F[Unit] =
     for {
       _ <- dependencyDagState.modify(
-        dependencyDag =>
-          DoublyLinkedDagOperations
-            .add[BlockHash](dependencyDag, hash, childBlock.blockHash)
-      )
+            dependencyDag =>
+              DoublyLinkedDagOperations
+                .add[BlockHash](dependencyDag, hash, childBlock.blockHash)
+          )
     } yield ()
 
   private def requestMissingDependency(hash: BlockHash) =
@@ -528,8 +531,8 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   private def reAttemptBuffer: F[Unit] =
     for {
-      dependencyDag <- dependencyDagState.get
-      dependencyFree           = dependencyDag.dependencyFree
+      dependencyDag  <- dependencyDagState.get
+      dependencyFree = dependencyDag.dependencyFree
       dependencyFreeBlocks = blockBuffer
         .filter(block => dependencyFree.contains(block.blockHash))
         .toList

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -184,7 +184,7 @@ object BondingUtil {
 
   def makeRuntimeResource[F[_]: Sync](
       runtimeDirResource: Resource[F, Path]
-  )(implicit scheduler: Scheduler): Resource[F, Runtime] =
+  )(implicit scheduler: Scheduler): Resource[F, Runtime[Task]] =
     runtimeDirResource.flatMap(
       runtimeDir =>
         Resource
@@ -194,7 +194,7 @@ object BondingUtil {
     )
 
   def makeRuntimeManagerResource[F[_]: Sync](
-      runtimeResource: Resource[F, Runtime]
+      runtimeResource: Resource[F, Runtime[Task]]
   )(implicit scheduler: Scheduler): Resource[F, RuntimeManager[Task]] =
     runtimeResource.flatMap(
       activeRuntime =>

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1171,7 +1171,6 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     } yield result
   }
 
-
   /*
    *  DAG Looks like this:
    *
@@ -1214,7 +1213,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         _ <- node.casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
       } yield signedBlock1
 
-    def stepSplit(nodes: Seq[HashSetCasperTestNode[Effect]]) = {
+    def stepSplit(nodes: Seq[HashSetCasperTestNode[Effect]]) =
       for {
         _ <- deploy(nodes(0), deployDatasFs(0).apply())
         _ <- deploy(nodes(1), deployDatasFs(1).apply())
@@ -1223,9 +1222,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         _ <- nodes(1).receive()
         _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
       } yield ()
-    }
 
-    def stepSingle(nodes: Seq[HashSetCasperTestNode[Effect]]) = {
+    def stepSingle(nodes: Seq[HashSetCasperTestNode[Effect]]) =
       for {
         _ <- deploy(nodes(0), deployDatasFs(0).apply())
 
@@ -1233,15 +1231,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         _ <- nodes(1).receive()
         _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
       } yield ()
-    }
 
-    def propagate(nodes: Seq[HashSetCasperTestNode[Effect]]) = {
+    def propagate(nodes: Seq[HashSetCasperTestNode[Effect]]) =
       for {
         _ <- nodes(0).receive()
         _ <- nodes(1).receive()
         _ <- nodes(2).receive()
       } yield ()
-    }
 
     for {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
@@ -1264,8 +1260,8 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _ <- nodes(2).casperEff.contains(br) shouldBeF true
 
       nr <- deploy(nodes(2), deployDatasFs(0).apply())
-      _ = nr.header.get.parentsHashList shouldBe Seq(br.blockHash)
-      _ = nodes.foreach(_.tearDownNode())
+      _  = nr.header.get.parentsHashList shouldBe Seq(br.blockHash)
+      _  = nodes.foreach(_.tearDownNode())
     } yield ()
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -205,7 +205,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
   }
 
   it should "parse the wallets file and include it in the genesis state" in withRawGenResources {
-    (runtime: Runtime, genesisPath: Path, log: LogStub[Task], time: LogicalTime[Task]) =>
+    (runtime: Runtime[Task], genesisPath: Path, log: LogStub[Task], time: LogicalTime[Task]) =>
       val walletsFile = genesisPath.resolve("wallets.txt").toString
       printWallets(walletsFile)
 
@@ -255,7 +255,7 @@ object GenesisTest {
       )
 
   def withRawGenResources(
-      body: (Runtime, Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
+      body: (Runtime[Task], Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
   ): Task[Unit] = {
     val storePath = storageLocation
     val runtime   = Runtime.create(storePath, storageSize)
@@ -275,7 +275,7 @@ object GenesisTest {
       body: (RuntimeManager[Task], Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
   ): Task[Unit] =
     withRawGenResources {
-      (runtime: Runtime, genesisPath: Path, log: LogStub[Task], time: LogicalTime[Task]) =>
+      (runtime: Runtime[Task], genesisPath: Path, log: LogStub[Task], time: LogicalTime[Task]) =>
         val runtimeManager = RuntimeManager.fromRuntime(runtime)
         body(runtimeManager, genesisPath, log, time)
     }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -40,13 +40,13 @@ object TestSetUtil {
 
   }
 
-  def runtime(implicit scheduler: Scheduler): Runtime = {
+  def runtime(implicit scheduler: Scheduler): Runtime[Task] = {
     val runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
     Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace).unsafeRunSync
     runtime
   }
 
-  def evalDeploy(deploy: Deploy, runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
+  def evalDeploy(deploy: Deploy, runtime: Runtime[Task])(implicit scheduler: Scheduler): Unit = {
     runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runSyncUnsafe(1.second)
     implicit val rand: Blake2b512Random = Blake2b512Random(
       DeployData.toByteArray(ProtoUtil.stripDeployData(deploy.getRaw))
@@ -56,7 +56,7 @@ object TestSetUtil {
 
   def evalTerm(
       term: Par,
-      runtime: Runtime
+      runtime: Runtime[Task]
   )(implicit scheduler: Scheduler, rand: Blake2b512Random): Unit = {
     runtime.reducer.setAvailablePhlos(Cost(Integer.MAX_VALUE)).runSyncUnsafe(1.second)
     runtime.reducer.inj(term).unsafeRunSync
@@ -64,14 +64,18 @@ object TestSetUtil {
 
   def eval(
       code: String,
-      runtime: Runtime
+      runtime: Runtime[Task]
   )(implicit scheduler: Scheduler, rand: Blake2b512Random): Unit =
     mkTerm(code) match {
       case Right(term) => evalTerm(term, runtime)
       case Left(ex)    => throw ex
     }
 
-  def runTestsWithDeploys(tests: CompiledRholangSource, otherLibs: Seq[Deploy], runtime: Runtime)(
+  def runTestsWithDeploys(
+      tests: CompiledRholangSource,
+      otherLibs: Seq[Deploy],
+      runtime: Runtime[Task]
+  )(
       implicit scheduler: Scheduler
   ): Unit = {
     val rand = Blake2b512Random(128)
@@ -84,7 +88,7 @@ object TestSetUtil {
   def runTests(
       tests: CompiledRholangSource,
       otherLibs: Seq[CompiledRholangSource],
-      runtime: Runtime
+      runtime: Runtime[Task]
   )(implicit scheduler: Scheduler): Unit = {
     //load "libraries" required for all tests
     val rand = Blake2b512Random(128)

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -39,7 +39,7 @@ import scala.collection.mutable
   * >>> itp.cleanUp()
   * }}}
   */
-class Interactive private (runtime: Runtime)(implicit scheduler: Scheduler) {
+class Interactive private (runtime: Runtime[Task])(implicit scheduler: Scheduler) {
   private implicit val rand = Blake2b512Random(128)
 
   private val prettyPrinter = PrettyPrinter()

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -90,7 +90,7 @@ class NodeRuntime private[node] (
       httpServer: Fiber[Task, Unit]
   )
 
-  def acquireServers(runtime: Runtime, blockApiLock: Semaphore[Effect])(
+  def acquireServers(runtime: Runtime[Task], blockApiLock: Semaphore[Effect])(
       implicit
       nodeDiscovery: NodeDiscovery[Task],
       blockStore: BlockStore[Effect],
@@ -172,7 +172,7 @@ class NodeRuntime private[node] (
     } yield Servers(grpcServerExternal, grpcServerInternal, httpServerFiber)
   }
 
-  def clearResources(servers: Servers, runtime: Runtime, casperRuntime: Runtime)(
+  def clearResources(servers: Servers, runtime: Runtime[Task], casperRuntime: Runtime[Task])(
       implicit
       transport: TransportLayer[Task],
       kademliaRPC: KademliaRPC[Task],
@@ -200,7 +200,7 @@ class NodeRuntime private[node] (
       _   <- log.info("Goodbye.")
     } yield ()).unsafeRunSync(scheduler)
 
-  def addShutdownHook(servers: Servers, runtime: Runtime, casperRuntime: Runtime)(
+  def addShutdownHook(servers: Servers, runtime: Runtime[Task], casperRuntime: Runtime[Task])(
       implicit transport: TransportLayer[Task],
       kademliaRPC: KademliaRPC[Task],
       blockStore: BlockStore[Effect],
@@ -210,7 +210,7 @@ class NodeRuntime private[node] (
 
   private def exit0: Task[Unit] = Task.delay(System.exit(0))
 
-  private def nodeProgram(runtime: Runtime, casperRuntime: Runtime)(
+  private def nodeProgram(runtime: Runtime[Task], casperRuntime: Runtime[Task])(
       implicit
       time: Time[Task],
       rpConfState: RPConfState[Task],

--- a/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
@@ -38,7 +38,8 @@ import Interpreter._
 import coop.rchain.rholang.interpreter.accounting.CostAccount
 import storage.StoragePrinter
 
-private[api] class ReplGrpcService(runtime: Runtime, worker: Scheduler) extends ReplGrpcMonix.Repl {
+private[api] class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler)
+    extends ReplGrpcMonix.Repl {
 
   def exec(reader: Reader): Task[ReplResponse] =
     Task
@@ -76,7 +77,7 @@ private[api] class ReplGrpcService(runtime: Runtime, worker: Scheduler) extends 
   def eval(request: EvalRequest): Task[ReplResponse] =
     defer(exec(new StringReader(request.program)))
 
-  def runEvaluate(runtime: Runtime, term: Par): Task[EvaluateResult] =
+  def runEvaluate(runtime: Runtime[Task], term: Par): Task[EvaluateResult] =
     for {
       _      <- Task.now(printNormalizedTerm(term))
       result <- evaluate(runtime, term)

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -55,7 +55,7 @@ object GrpcServer {
 
   def acquireInternalServer(
       port: Int,
-      runtime: Runtime,
+      runtime: Runtime[Task],
       grpcExecutor: Scheduler
   )(
       implicit worker: Scheduler,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -114,7 +114,7 @@ object Interpreter {
       } else normalizedTerm.pure[M]
     }
 
-  def execute(runtime: Runtime, reader: Reader): Task[Runtime] =
+  def execute(runtime: Runtime[Task], reader: Reader): Task[Runtime[Task]] =
     for {
       term   <- Task.coeval(buildNormalizedTerm(reader)).attempt.raiseOnLeft
       errors <- evaluate(runtime, term).map(_.errors).attempt.raiseOnLeft
@@ -124,7 +124,7 @@ object Interpreter {
                  Task.raiseError(new RuntimeException(mkErrorMsg(errors)))
     } yield result
 
-  def evaluate(runtime: Runtime, normalizedTerm: Par): Task[EvaluateResult] = {
+  def evaluate(runtime: Runtime[Task], normalizedTerm: Par): Task[EvaluateResult] = {
     implicit val rand      = Blake2b512Random(128)
     val evaluatePhlosLimit = Cost(Integer.MAX_VALUE) //This is OK because evaluate is not called on deploy
     for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -97,7 +97,7 @@ object RholangCLI {
     }
 
   @tailrec
-  def repl(runtime: Runtime)(implicit scheduler: Scheduler): Unit = {
+  def repl(runtime: Runtime[Task])(implicit scheduler: Scheduler): Unit = {
     printPrompt()
     Option(scala.io.StdIn.readLine()) match {
       case Some(line) =>
@@ -116,7 +116,7 @@ object RholangCLI {
     repl(runtime)
   }
 
-  def processFile(conf: Conf, runtime: Runtime, fileName: String)(
+  def processFile(conf: Conf, runtime: Runtime[Task], fileName: String)(
       implicit scheduler: Scheduler
   ): Unit = {
     val processTerm: Par => Unit =
@@ -167,7 +167,7 @@ object RholangCLI {
     println(s"Compiled $fileName to $binaryFileName")
   }
 
-  def evaluatePar(runtime: Runtime)(par: Par)(implicit scheduler: Scheduler): Unit = {
+  def evaluatePar(runtime: Runtime[Task])(par: Par)(implicit scheduler: Scheduler): Unit = {
     val evaluatorTask =
       for {
         _      <- Task.now(printNormalizedTerm(par))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -17,7 +17,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.ShortLeashParams.ShortLeashParameters
 import coop.rchain.rholang.interpreter.Runtime._
-import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
 import coop.rchain.rholang.interpreter.errors.{OutOfPhlogistonsError, SetupError}
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace._
@@ -31,18 +31,18 @@ import monix.execution.Scheduler
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 
-class Runtime private (
-    val reducer: ChargingReducer[Task],
-    val replayReducer: ChargingReducer[Task],
-    val space: RhoISpace[Task],
-    val replaySpace: RhoReplayISpace[Task],
-    val errorLog: ErrorLog[Task],
+class Runtime[F[_]: Sync] private (
+    val reducer: ChargingReducer[F],
+    val replayReducer: ChargingReducer[F],
+    val space: RhoISpace[F],
+    val replaySpace: RhoReplayISpace[F],
+    val errorLog: ErrorLog[F],
     val context: RhoContext,
-    val shortLeashParams: Runtime.ShortLeashParams[Task],
-    val blockTime: Runtime.BlockTime[Task]
+    val shortLeashParams: Runtime.ShortLeashParams[F],
+    val blockTime: Runtime.BlockTime[F]
 ) {
-  def readAndClearErrorVector(): Task[Vector[Throwable]] = errorLog.readAndClearErrorVector()
-  def close(): Task[Unit] =
+  def readAndClearErrorVector(): F[Vector[Throwable]] = errorLog.readAndClearErrorVector()
+  def close(): F[Unit] =
     for {
       _ <- space.close()
       _ <- replaySpace.close()
@@ -296,7 +296,7 @@ object Runtime {
       extraSystemProcesses: Seq[SystemProcess.Definition[Task]] = Seq.empty
   )(
       implicit scheduler: Scheduler
-  ): Runtime = {
+  ): Runtime[Task] = {
     val errorLog                                  = new ErrorLog[Task]()
     implicit val ft: FunctorTell[Task, Throwable] = errorLog
 
@@ -379,7 +379,7 @@ object Runtime {
       res <- introduceSystemProcesses(space, replaySpace, procDefs)
     } yield {
       assert(res.forall(_.isEmpty))
-      new Runtime(
+      new Runtime[Task](
         reducer,
         replayReducer,
         space,

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -102,18 +102,21 @@ class InterpreterSpec extends FlatSpec with Matchers {
     )
   }
 
-  private def storageContents(runtime: Runtime): String =
+  private def storageContents(runtime: Runtime[Task]): String =
     StoragePrinter.prettyPrint(runtime.space.store)
 
-  private def success(runtime: Runtime, rho: String): Task[Unit] =
+  private def success(runtime: Runtime[Task], rho: String): Task[Unit] =
     execute(runtime, rho).map(_.swap.foreach(error => fail(s"""Execution failed for: $rho
                                                |Cause:
                                                |$error""".stripMargin)))
 
-  private def failure(runtime: Runtime, rho: String): Task[Throwable] =
+  private def failure(runtime: Runtime[Task], rho: String): Task[Throwable] =
     execute(runtime, rho).map(_.swap.getOrElse(fail(s"Expected $rho to fail - it didn't.")))
 
-  private def execute(runtime: Runtime, source: String): Task[Either[Throwable, Runtime]] =
+  private def execute(
+      runtime: Runtime[Task],
+      source: String
+  ): Task[Either[Throwable, Runtime[Task]]] =
     Interpreter.execute(runtime, new StringReader(source)).attempt
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -65,10 +65,12 @@ object Resources {
       prefix: String,
       storageSize: Long = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
-  )(implicit scheduler: Scheduler): Resource[Task, Runtime] =
+  )(implicit scheduler: Scheduler): Resource[Task, Runtime[Task]] =
     mkTempDir[Task](prefix)
       .flatMap { tmpDir =>
-        Resource.make[Task, Runtime](Task.delay { Runtime.create(tmpDir, storageSize, storeType) })(
+        Resource.make[Task, Runtime[Task]](Task.delay {
+          Runtime.create(tmpDir, storageSize, storeType)
+        })(
           rt => rt.close()
         )
       }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -11,8 +11,10 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoIStore
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.shared.PathOps._
+import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{fixture, Assertion, Matchers, Outcome}
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -39,7 +41,7 @@ class DeployParamsSpec extends fixture.FlatSpec with Matchers {
     assert(!datum.persist)
   }
 
-  override type FixtureParam = Runtime
+  override type FixtureParam = Runtime[Task]
 
   "rho:deploy:params" should "return the parameters that are set." in { runtime =>
     implicit val rand     = Blake2b512Random(Array.empty[Byte])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -50,7 +50,7 @@ class RuntimeSpec extends FlatSpec with Matchers {
   private def failure(rho: String): Throwable =
     execute(rho).swap.getOrElse(fail(s"Expected $rho to fail - it didn't."))
 
-  private def execute(source: String): Either[Throwable, Runtime] =
+  private def execute(source: String): Either[Throwable, Runtime[Task]] =
     mkRuntime(tmpPrefix, mapSize)
       .use { runtime =>
         Interpreter

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -41,7 +41,7 @@ class CompilerTests extends FunSuite with Matchers {
     }
   }
 
-  private def execute(file: Path): Either[Throwable, Runtime] =
+  private def execute(file: Path): Either[Throwable, Runtime[Task]] =
     mkRuntime(tmpPrefix, mapSize)
       .use { runtime =>
         Interpreter.execute(runtime, new FileReader(file.toString)).attempt

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -18,8 +18,8 @@ trait EvalBenchStateBase {
   private val mapSize: Long    = 1024L * 1024L * 1024L
 
   val rhoScriptSource: String
-  lazy val runtime: Runtime  = Runtime.create(dbDir, mapSize)
-  val rand: Blake2b512Random = Blake2b512Random(128)
+  lazy val runtime: Runtime[Task] = Runtime.create(dbDir, mapSize)
+  val rand: Blake2b512Random      = Blake2b512Random(128)
   val costAccountAlg: CostAccounting[Task] =
     CostAccounting.unsafe[Task](CostAccount(Integer.MAX_VALUE))
   var term: Option[Par] = None

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/ReplayWideBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/ReplayWideBench.scala
@@ -40,7 +40,7 @@ class ReplayWideBench {
 
 @State(Scope.Benchmark)
 class ReplayFineBenchState extends ReplayWideBenchState {
-  override def createRuntime(): Runtime = Runtime.create(dbDir, mapSize, StoreType.LMDB)
+  override def createRuntime(): Runtime[Task] = Runtime.create(dbDir, mapSize, StoreType.LMDB)
 }
 
 abstract class ReplayWideBenchState extends WideBenchBaseState {

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -28,7 +28,7 @@ abstract class WideBenchBaseState {
   lazy val dbDir: Path              = Files.createTempDirectory(BenchStorageDirPrefix)
   val mapSize: Long                 = 1024L * 1024L * 1024L * 10L
 
-  var runtime: Runtime       = null
+  var runtime: Runtime[Task] = null
   var setupTerm: Option[Par] = None
   var term: Option[Par]      = None
 
@@ -36,7 +36,7 @@ abstract class WideBenchBaseState {
 
   implicit def readErrors = () => runtime.readAndClearErrorVector().unsafeRunSync
 
-  def createRuntime(): Runtime = Runtime.create(dbDir, mapSize)
+  def createRuntime(): Runtime[Task] = Runtime.create(dbDir, mapSize)
 
   @Setup(value = Level.Iteration)
   def doSetup(): Unit = {


### PR DESCRIPTION
## Overview
Another step on the long road of the `F`. This time `Runtime` get a parameter and all the call sites explicitly use `Task`.

### JIRA ticket:
RCHAIN-2307



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
