### PR TITLE
Implement RhoSpec

### DIFF
--- a/casper/src/test/rholang/FailingResultCollectorTest.rho
+++ b/casper/src/test/rholang/FailingResultCollectorTest.rho
@@ -1,0 +1,8 @@
+//scalapackage coop.rchain.rholang
+
+new assert(`rho:test:assert`), assertEquals(`rho:test:assertEquals`)  in {
+
+  assert!("false should fail", false) |
+
+  assertEquals!("0 != 1 should fail", 0, "==", 1)
+}

--- a/casper/src/test/rholang/SuccessfulResultCollectorTest.rho
+++ b/casper/src/test/rholang/SuccessfulResultCollectorTest.rho
@@ -1,0 +1,8 @@
+//scalapackage coop.rchain.rholang
+
+new assert(`rho:test:assert`), assertEquals(`rho:test:assertEquals`)  in {
+
+  assert!("true forever", true) |
+
+  assertEquals!("basic arithmetic", 1, "==", 1)
+}

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BasicWalletSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BasicWalletSpec.scala
@@ -20,7 +20,7 @@ import org.abstractj.kalium.NaCl
 import org.scalatest.{FlatSpec, Matchers}
 
 class BasicWalletSpec extends FlatSpec with Matchers {
-  val runtime = TestSetUtil.runtime
+  val runtime = TestSetUtil.runtime()
   val tests   = TestSetUtil.getTests("../casper/src/test/rholang/BasicWalletTest.rho").toList
 
   val deploys = List(

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
 class EitherSpec extends FlatSpec with Matchers {
-  val runtime = TestSetUtil.runtime
+  val runtime = TestSetUtil.runtime()
   val tests   = TestSetUtil.getTests("../casper/src/test/rholang/EitherTest.rho").toList
 
   TestSetUtil.runTestsWithDeploys(EitherTest, List(StandardDeploys.either), runtime)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -1,0 +1,20 @@
+import coop.rchain.casper.helper.{RhoAssertEquals, RhoAssertTrue, RhoSpec, RhoTestAssertion}
+import coop.rchain.rholang.FailingResultCollectorTest
+import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
+import monix.execution.Scheduler.Implicits.global
+
+class FailingResultCollectorSpec extends FlatSpec with Matchers {
+  def mkTest(assertion: RhoTestAssertion): Unit =
+    it should assertion.testName in {
+      assertion match {
+        case RhoAssertEquals(testName, expected, actual) => actual should not be (expected)
+        case RhoAssertTrue(testName, value)              => value should not be (true)
+      }
+    }
+
+  RhoSpec
+    .mkAssertions(FailingResultCollectorTest)
+    .runSyncUnsafe(3.seconds)
+    .foreach(mkTest)
+}

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -10,7 +10,7 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
 class MakeMintSpec extends FlatSpec with Matchers {
-  val runtime = TestSetUtil.runtime
+  val runtime = TestSetUtil.runtime()
   val tests   = TestSetUtil.getTests("../casper/src/test/rholang/MakeMintTest.rho").toList
 
   val deploys = List(

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakePoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakePoSSpec.scala
@@ -13,7 +13,7 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
 class MakePoSSpec extends FlatSpec with Matchers {
-  val runtime = TestSetUtil.runtime
+  val runtime = TestSetUtil.runtime()
   val tests   = TestSetUtil.getTests("../casper/src/test/rholang/MakePoSTest.rho").toList
 
   val deploys = List(

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -8,7 +8,7 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
 class NonNegativeNumberSpec extends FlatSpec with Matchers {
-  val runtime = TestSetUtil.runtime
+  val runtime = TestSetUtil.runtime()
   val tests   = TestSetUtil.getTests("../casper/src/test/rholang/NonNegativeNumberTest.rho").toList
 
   TestSetUtil.runTestsWithDeploys(

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -35,7 +35,7 @@ class RevIssuanceTest extends FlatSpec with Matchers {
   }
 
   "Rev" should "be issued and accessible based on inputs from Ethereum" in {
-    val activeRuntime  = TestSetUtil.runtime
+    val activeRuntime  = TestSetUtil.runtime()
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime)
     val emptyHash      = runtimeManager.emptyStateHash
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/SuccessfulResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/SuccessfulResultCollectorSpec.scala
@@ -1,0 +1,5 @@
+package coop.rchain.casper.genesis.contracts
+import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.rholang.SuccessfulResultCollectorTest
+
+class SuccessfulResultCollectorSpec extends RhoSpec(SuccessfulResultCollectorTest)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestSetUtil.scala
@@ -11,6 +11,7 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.collection.ListOps
 import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.unittest.TestSet
@@ -40,8 +41,10 @@ object TestSetUtil {
 
   }
 
-  def runtime(implicit scheduler: Scheduler): Runtime[Task] = {
-    val runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem)
+  def runtime(
+      extraServices: Seq[SystemProcess.Definition[Task]] = Seq.empty
+  )(implicit scheduler: Scheduler): Runtime[Task] = {
+    val runtime = Runtime.create(Paths.get("/not/a/path"), -1, InMem, extraServices)
     Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace).unsafeRunSync
     runtime
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -1,0 +1,127 @@
+package coop.rchain.casper.helper
+
+import cats.effect.Sync
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import coop.rchain.casper.genesis.contracts.TestSetUtil
+import coop.rchain.models.Expr.ExprInstance.{GBool, GString}
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.{Expr, ListParWithRandomAndPhlos, Par}
+import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.Runtime.SystemProcess
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+object IsString {
+  def unapply(p: Par): Option[String] =
+    p.singleExpr().collect {
+      case Expr(GString(bs)) => bs
+    }
+}
+
+object IsBoolean {
+  def unapply(p: Par): Option[Boolean] =
+    p.singleExpr().collect {
+      case Expr(GBool(b)) => b
+    }
+}
+
+object IsCondition {
+  def unapply(p: Seq[ListParWithRandomAndPhlos]): Option[(String, Boolean)] =
+    p match {
+      case Seq(ListParWithRandomAndPhlos(Seq(IsString(testName), IsBoolean(condition)), _, _)) =>
+        Some((testName, condition))
+      case _ => None
+    }
+}
+object IsComparison {
+  def unapply(p: Seq[ListParWithRandomAndPhlos]): Option[(String, Par, String, Par)] =
+    p match {
+      case Seq(
+          ListParWithRandomAndPhlos(
+            Seq(IsString(testName), expected, IsString(operator), actual),
+            _,
+            _
+          )
+          ) =>
+        Some((testName, expected, operator, actual))
+      case _ => None
+    }
+}
+
+sealed trait RhoTestAssertion {
+  val testName: String
+}
+case class RhoAssertTrue(testName: String, value: Boolean)               extends RhoTestAssertion
+case class RhoAssertEquals(testName: String, expected: Any, actual: Any) extends RhoTestAssertion
+
+private class TestResultCollector[F[_]: Sync](assertions: Ref[F, List[RhoTestAssertion]]) {
+  def getAssertions: F[List[RhoTestAssertion]] = assertions.get
+
+  def handleMessage(
+      ctx: SystemProcess.Context[F]
+  )(message: Seq[ListParWithRandomAndPhlos], x: Int): F[Unit] = {
+    val assertion = message match {
+      case IsComparison(testName, expected, "==", actual) =>
+        RhoAssertEquals(testName, expected, actual)
+      case IsCondition(testName, condition) => RhoAssertTrue(testName, condition)
+    }
+    assertions.update(assertion :: _)
+  }
+}
+
+private object TestResultCollector {
+  def apply[F[_]: Sync]: F[TestResultCollector[F]] =
+    Ref
+      .of(List.empty[RhoTestAssertion])
+      .map(new TestResultCollector(_))
+}
+
+object RhoSpec {
+  private def mkRuntime(testResultCollector: TestResultCollector[Task]) = {
+    val testResultCollectorService =
+      Seq((2, "assert"), (4, "assertEquals"))
+        .zip(Stream.from(24))
+        .map {
+          case ((arity, name), n) =>
+            SystemProcess.Definition[Task](
+              s"rho:test:$name",
+              Runtime.byteName(n.toByte),
+              arity,
+              n,
+              testResultCollector.handleMessage
+            )
+        }
+    TestSetUtil.runtime(testResultCollectorService)
+  }
+
+  def mkAssertions(testObject: CompiledRholangSource) =
+    for {
+      testResultCollector <- TestResultCollector[Task]
+
+      _ <- Task.delay {
+            TestSetUtil.runTests(testObject, List.empty, mkRuntime(testResultCollector))
+          }
+
+      assertions <- testResultCollector.getAssertions
+    } yield assertions
+}
+
+class RhoSpec(testObject: CompiledRholangSource) extends FlatSpec with Matchers {
+  def mkTest(assertion: RhoTestAssertion): Unit =
+    it should assertion.testName in {
+      assertion match {
+        case RhoAssertEquals(testName, expected, actual) => actual should be(expected)
+        case RhoAssertTrue(testName, value)              => value should be(true)
+      }
+    }
+
+  RhoSpec
+    .mkAssertions(testObject)
+    .runSyncUnsafe(3.seconds)
+    .foreach(mkTest)
+}

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -94,6 +94,6 @@ object Interactive {
   def apply(): Interactive = {
     implicit val scheduler = Scheduler.io("rhoang-interpreter")
 
-    new Interactive(TestSetUtil.runtime)
+    new Interactive(TestSetUtil.runtime())
   }
 }

--- a/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
+++ b/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
@@ -45,8 +45,9 @@ object RholangProtoBuild {
 
     val body =
       s"""val resource = getClass.getResourceAsStream(${escape(protoName)})
-         |  override val term: Par = InterpreterUtil.mkTerm(${escapeSourceCode(source)}).right.get
-         |  override val code: String = ${escapeSourceCode(source)}""".stripMargin
+         |  val source : String = ${escapeSourceCode(source)}
+         |  override val term: Par = InterpreterUtil.mkTerm(source).right.get
+         |  override val code: String = source""".stripMargin
 
     s"""$pkgDeclaration
      |


### PR DESCRIPTION
## Overview
Implement class RhoSpec that collects failures from Rholang tests and reports them as scalatest failures



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2292 (ex RHOL-1124)



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
