### PR TITLE
New Block Storage Implementation

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -637,10 +637,10 @@ object BlockDagFileStorage {
                      }) {
                    sortedCheckpoints.pure[F]
                  } else {
-                   Sync[F].raiseError(CheckpointsAreNotConsecutive(sortedCheckpoints))
+                   Sync[F].raiseError(CheckpointsAreNotConsecutive(sortedCheckpoints.map(_.path)))
                  }
                } else {
-                 Sync[F].raiseError(CheckpointsDoNotStartFromZero(sortedCheckpoints))
+                 Sync[F].raiseError(CheckpointsDoNotStartFromZero(sortedCheckpoints.map(_.path)))
                }
     } yield result
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -13,7 +13,6 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagFileStorage.{Checkpoint, CheckpointedDagInfo}
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.errors._
 import coop.rchain.blockstorage.util.BlockMessageUtil.{blockNumber, bonds, parentHashes}
 import coop.rchain.blockstorage.util.{BlockMessageUtil, Crc32, TopologicalSortUtil}
 import coop.rchain.blockstorage.util.byteOps._

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -25,8 +25,6 @@ trait BlockStore[F[_]] {
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
     get(blockHash).map(_.isDefined)
 
-  def asMap(): F[Map[BlockHash, BlockMessage]]
-
   def clear(): F[Unit]
 
   def close(): F[Unit]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -25,6 +25,8 @@ trait BlockStore[F[_]] {
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
     get(blockHash).map(_.isDefined)
 
+  def checkpoint(): F[Unit]
+
   def clear(): F[Unit]
 
   def close(): F[Unit]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -3,6 +3,7 @@ package coop.rchain.blockstorage
 import cats.Applicative
 import cats.implicits._
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.StorageError.StorageIOErr
 import coop.rchain.casper.protocol.BlockMessage
 
 import scala.language.higherKinds
@@ -10,14 +11,14 @@ import scala.language.higherKinds
 trait BlockStore[F[_]] {
   import BlockStore.BlockHash
 
-  def put(blockHash: BlockHash, blockMessage: BlockMessage): F[Unit] =
+  def put(blockHash: BlockHash, blockMessage: BlockMessage): F[StorageIOErr[Unit]] =
     put((blockHash, blockMessage))
 
   def get(blockHash: BlockHash): F[Option[BlockMessage]]
 
   def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]]
 
-  def put(f: => (BlockHash, BlockMessage)): F[Unit]
+  def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]]
 
   def apply(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[BlockMessage] =
     get(blockHash).map(_.get)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -28,9 +28,9 @@ trait BlockStore[F[_]] {
 
   def checkpoint(): F[Unit]
 
-  def clear(): F[Unit]
+  def clear(): F[StorageIOErr[Unit]]
 
-  def close(): F[Unit]
+  def close(): F[StorageIOErr[Unit]]
 }
 
 object BlockStore {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -3,6 +3,7 @@ package coop.rchain.blockstorage
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
+import java.util.stream.Collectors
 
 import cats.Monad
 import cats.effect.{Concurrent, ExitCase, Sync}
@@ -10,20 +11,26 @@ import cats.implicits._
 import cats.effect.concurrent.{Ref, Semaphore}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockHash
+import coop.rchain.blockstorage.FileLMDBIndexBlockStore.Checkpoint
+import coop.rchain.blockstorage.errors.{CheckpointsAreNotConsecutive, CheckpointsDoNotStartFromZero}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.shared.Resources.withResource
 import coop.rchain.blockstorage.util.byteOps._
+import coop.rchain.shared.Log
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.Txn.NotReadyException
 import org.lmdbjava._
 
 import scala.collection.JavaConverters._
+import scala.ref.WeakReference
+import scala.util.matching.Regex
 
 class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
     lock: Semaphore[F],
     env: Env[ByteBuffer],
     index: Dbi[ByteBuffer],
-    blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile]
+    blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile],
+    checkpointsRef: Ref[F, List[Checkpoint]]
 ) extends BlockStore[F] {
   implicit class RichBlockHash(byteVector: BlockHash) {
 
@@ -124,6 +131,9 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
       } yield ()
     )
 
+  override def checkpoint(): F[Unit] =
+    ().pure[F]
+
   override def clear(): F[Unit] =
     lock.withPermit(
       for {
@@ -145,16 +155,88 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
 }
 
 object FileLMDBIndexBlockStore {
+  private val checkpointPattern: Regex = "([0-9]+)-([0-9]+)".r
+
   case class Config(
       storagePath: Path,
       indexPath: Path,
+      checkpointsDirPath: Path,
       mapSize: Long,
       maxDbs: Int = 1,
       maxReaders: Int = 126,
       noTls: Boolean = true
   )
 
-  def create[F[_]: Monad: Sync: Concurrent](config: Config): F[BlockStore[F]] =
+  private[blockstorage] case class CheckpointIndex(
+      env: Env[ByteBuffer],
+      index: Dbi[ByteBuffer]
+  )
+
+  private[blockstorage] case class Checkpoint(
+      start: Long,
+      end: Long,
+      dirPath: Path,
+      storagePath: Path,
+      indexPath: Path,
+      index: Option[WeakReference[CheckpointIndex]]
+  )
+
+  private def loadCheckpoints[F[_]: Sync: Log](checkpointsDirPath: Path): F[List[Checkpoint]] =
+    for {
+      checkpointDirectories <- Sync[F].delay {
+                                checkpointsDirPath.toFile.mkdir()
+                                Files.list(checkpointsDirPath).filter(p => Files.isDirectory(p))
+                              }
+      checkpointDirectoriesList = checkpointDirectories
+        .collect(Collectors.toList[Path])
+        .asScala
+        .toList
+      checkpoints <- checkpointDirectoriesList.flatTraverse { dirPath =>
+                      dirPath.getFileName.toString match {
+                        case checkpointPattern(start, end) =>
+                          List(
+                            Checkpoint(
+                              start.toLong,
+                              end.toLong,
+                              dirPath,
+                              dirPath.resolve("storage"),
+                              dirPath.resolve("index"),
+                              None
+                            )
+                          ).pure[F]
+                        case other =>
+                          Log[F].warn(s"Ignoring directory '$other': not a valid checkpoint name") *>
+                            List.empty[Checkpoint].pure[F]
+                      }
+                    }
+      sortedCheckpoints = checkpoints.sortBy(_.start)
+      result <- if (sortedCheckpoints.headOption.forall(_.start == 0)) {
+                 if (sortedCheckpoints.isEmpty ||
+                     sortedCheckpoints.zip(sortedCheckpoints.tail).forall {
+                       case (current, next) => current.end == next.start
+                     }) {
+                   sortedCheckpoints.pure[F]
+                 } else {
+                   Sync[F].raiseError(
+                     CheckpointsAreNotConsecutive(sortedCheckpoints.map(_.dirPath))
+                   )
+                 }
+               } else {
+                 Sync[F].raiseError(CheckpointsDoNotStartFromZero(sortedCheckpoints.map(_.dirPath)))
+               }
+    } yield result
+
+  def create[F[_]: Concurrent: Log](blockStoreDataDir: Path, mapSize: Long): F[BlockStore[F]] =
+    create(
+      Config(
+        blockStoreDataDir.resolve("storage"),
+        blockStoreDataDir.resolve("index"),
+        blockStoreDataDir.resolve("checkpoints"),
+        mapSize
+      )
+    )
+
+  def create[F[_]: Monad: Concurrent: Log](config: Config): F[BlockStore[F]] =
     for {
       lock <- Semaphore[F](1)
       env <- Sync[F].delay {
@@ -172,5 +254,14 @@ object FileLMDBIndexBlockStore {
                                        new RandomAccessFile(config.storagePath.toFile, "rw")
                                      }
       blockMessageRandomAccessFileRef <- Ref.of[F, RandomAccessFile](blockMessageRandomAccessFile)
-    } yield new FileLMDBIndexBlockStore[F](lock, env, index, blockMessageRandomAccessFileRef)
+      sortedCheckpoints               <- loadCheckpoints(config.checkpointsDirPath)
+      checkPointsRef                  <- Ref.of[F, List[Checkpoint]](sortedCheckpoints)
+    } yield
+      new FileLMDBIndexBlockStore[F](
+        lock,
+        env,
+        index,
+        blockMessageRandomAccessFileRef,
+        checkPointsRef
+      )
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -17,6 +17,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.shared.Resources.withResource
 import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.shared.Log
+import coop.rchain.shared.ByteStringOps._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.Txn.NotReadyException
 import org.lmdbjava._
@@ -32,17 +33,6 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
     blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile],
     checkpointsRef: Ref[F, List[Checkpoint]]
 ) extends BlockStore[F] {
-  implicit class RichBlockHash(byteVector: BlockHash) {
-
-    def toDirectByteBuffer: ByteBuffer = {
-      val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size)
-      byteVector.copyTo(buffer)
-      // TODO: get rid of this:
-      buffer.flip()
-      buffer
-    }
-  }
-
   private[this] def withTxn[R](txnThunk: => Txn[ByteBuffer])(f: Txn[ByteBuffer] => R): F[R] =
     Sync[F].bracketCase(Sync[F].delay(txnThunk)) { txn =>
       Sync[F].delay {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -124,9 +124,6 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
       } yield ()
     )
 
-  override def asMap(): F[Map[BlockHash, BlockMessage]] =
-    find(_ => true).map(_.toMap)
-
   override def clear(): F[Unit] =
     lock.withPermit(
       for {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -1,0 +1,94 @@
+package coop.rchain.blockstorage
+
+import java.io.RandomAccessFile
+import java.nio.file.Path
+
+import cats.Monad
+import cats.effect.{Concurrent, Sync}
+import cats.implicits._
+import cats.effect.concurrent.{Ref, Semaphore}
+import coop.rchain.blockstorage.BlockStore.BlockHash
+import coop.rchain.casper.protocol.BlockMessage
+
+class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
+  lock: Semaphore[F],
+  indexRef: Ref[F, Map[BlockHash, Long]],
+  blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile]
+) extends BlockStore[F] {
+  private def readBlockMessage(offset: Long): F[BlockMessage] =
+    for {
+      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+      _ <- Sync[F].delay { blockMessageRandomAccessFile.seek(offset) }
+      blockMessageSize <- Sync[F].delay { blockMessageRandomAccessFile.readInt() }
+      blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
+      _ <- Sync[F].delay { blockMessageRandomAccessFile.readFully(blockMessagesByteArray) }
+      blockMessage = BlockMessage.parseFrom(blockMessagesByteArray)
+    } yield blockMessage
+  
+  override def get(blockHash: BlockHash): F[Option[BlockMessage]] =
+    for {
+      _ <- lock.acquire
+      index <- indexRef.get
+      result <- index.get(blockHash).traverse(readBlockMessage)
+      _ <- lock.release
+    } yield result
+
+  override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]] =
+    for {
+      _ <- lock.acquire
+      index <- indexRef.get
+      filteredIndex = index.filter { case (blockHash, _) => p(blockHash) }
+      result <- filteredIndex.toList.traverse {
+        case (blockHash, offset) => readBlockMessage(offset).map(blockHash -> _)
+      }
+      _ <- lock.release
+    } yield result
+
+  override def put(f: => (BlockHash, BlockMessage)): F[Unit] =
+    for {
+      _ <- lock.acquire
+      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+      (blockHash, blockMessage) = f
+      blockMessageByteArray = blockMessage.toByteArray
+      endOfFileOffset <- Sync[F].delay { blockMessageRandomAccessFile.length() }
+      _ <- Sync[F].delay { blockMessageRandomAccessFile.seek(endOfFileOffset) }
+      _ <- Sync[F].delay { blockMessageRandomAccessFile.writeInt(blockMessageByteArray.length) }
+      _ <- Sync[F].delay { blockMessageRandomAccessFile.write(blockMessageByteArray) }
+      _ <- indexRef.update(_.updated(blockHash, endOfFileOffset))
+      _ <- lock.release
+    } yield ()
+
+  override def asMap(): F[Map[BlockHash, BlockMessage]] =
+    find(_ => true).map(_.toMap)
+  
+  override def clear(): F[Unit] =
+    for {
+      _                            <- lock.acquire
+      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+      _                            <- Sync[F].delay { blockMessageRandomAccessFile.setLength(0) }
+      _                            <- indexRef.update(_ => Map.empty)
+      _                            <- lock.release
+    } yield ()
+
+  override def close(): F[Unit] =
+    for {
+      _                            <- lock.acquire
+      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+      _                            <- Sync[F].delay { blockMessageRandomAccessFile.close() }
+      _                            <- lock.release
+    } yield ()
+}
+
+object FileLMDBIndexBlockStore {
+  case class Config(
+    path: Path
+  )
+  
+  def create[F[_]: Monad: Sync: Concurrent](config: Config): F[FileLMDBIndexBlockStore[F]] =
+    for {
+      lock                  <- Semaphore[F](1)
+      blockMessageRandomAccessFile = new RandomAccessFile(config.path.toFile, "rw")
+      indexRef <- Ref.of[F, Map[BlockHash, Long]](Map.empty)
+      blockMessageRandomAccessFileRef <- Ref.of[F, RandomAccessFile](blockMessageRandomAccessFile)
+    } yield new FileLMDBIndexBlockStore[F](lock, indexRef, blockMessageRandomAccessFileRef)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -11,84 +11,84 @@ import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol.BlockMessage
 
 class FileLMDBIndexBlockStore[F[_]: Monad: Sync] private (
-  lock: Semaphore[F],
-  indexRef: Ref[F, Map[BlockHash, Long]],
-  blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile]
+    lock: Semaphore[F],
+    indexRef: Ref[F, Map[BlockHash, Long]],
+    blockMessageRandomAccessFileRef: Ref[F, RandomAccessFile]
 ) extends BlockStore[F] {
   private def readBlockMessage(offset: Long): F[BlockMessage] =
     for {
       blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
-      _ <- Sync[F].delay { blockMessageRandomAccessFile.seek(offset) }
-      blockMessageSize <- Sync[F].delay { blockMessageRandomAccessFile.readInt() }
-      blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
-      _ <- Sync[F].delay { blockMessageRandomAccessFile.readFully(blockMessagesByteArray) }
-      blockMessage = BlockMessage.parseFrom(blockMessagesByteArray)
+      _                            <- Sync[F].delay { blockMessageRandomAccessFile.seek(offset) }
+      blockMessageSize             <- Sync[F].delay { blockMessageRandomAccessFile.readInt() }
+      blockMessagesByteArray       = Array.ofDim[Byte](blockMessageSize)
+      _                            <- Sync[F].delay { blockMessageRandomAccessFile.readFully(blockMessagesByteArray) }
+      blockMessage                 = BlockMessage.parseFrom(blockMessagesByteArray)
     } yield blockMessage
-  
+
   override def get(blockHash: BlockHash): F[Option[BlockMessage]] =
-    for {
-      _ <- lock.acquire
-      index <- indexRef.get
-      result <- index.get(blockHash).traverse(readBlockMessage)
-      _ <- lock.release
-    } yield result
+    lock.withPermit(
+      for {
+        index  <- indexRef.get
+        result <- index.get(blockHash).traverse(readBlockMessage)
+      } yield result
+    )
 
   override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]] =
-    for {
-      _ <- lock.acquire
-      index <- indexRef.get
-      filteredIndex = index.filter { case (blockHash, _) => p(blockHash) }
-      result <- filteredIndex.toList.traverse {
-        case (blockHash, offset) => readBlockMessage(offset).map(blockHash -> _)
-      }
-      _ <- lock.release
-    } yield result
+    lock.withPermit(
+      for {
+        index         <- indexRef.get
+        filteredIndex = index.filter { case (blockHash, _) => p(blockHash) }
+        result <- filteredIndex.toList.traverse {
+                   case (blockHash, offset) => readBlockMessage(offset).map(blockHash -> _)
+                 }
+      } yield result
+    )
 
   override def put(f: => (BlockHash, BlockMessage)): F[Unit] =
-    for {
-      _ <- lock.acquire
-      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
-      (blockHash, blockMessage) = f
-      blockMessageByteArray = blockMessage.toByteArray
-      endOfFileOffset <- Sync[F].delay { blockMessageRandomAccessFile.length() }
-      _ <- Sync[F].delay { blockMessageRandomAccessFile.seek(endOfFileOffset) }
-      _ <- Sync[F].delay { blockMessageRandomAccessFile.writeInt(blockMessageByteArray.length) }
-      _ <- Sync[F].delay { blockMessageRandomAccessFile.write(blockMessageByteArray) }
-      _ <- indexRef.update(_.updated(blockHash, endOfFileOffset))
-      _ <- lock.release
-    } yield ()
+    lock.withPermit(
+      for {
+        blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+        (blockHash, blockMessage)    = f
+        blockMessageByteArray        = blockMessage.toByteArray
+        endOfFileOffset              <- Sync[F].delay { blockMessageRandomAccessFile.length() }
+        _                            <- Sync[F].delay { blockMessageRandomAccessFile.seek(endOfFileOffset) }
+        _                            <- Sync[F].delay { blockMessageRandomAccessFile.writeInt(blockMessageByteArray.length) }
+        _                            <- Sync[F].delay { blockMessageRandomAccessFile.write(blockMessageByteArray) }
+        _                            <- indexRef.update(_.updated(blockHash, endOfFileOffset))
+      } yield ()
+    )
 
   override def asMap(): F[Map[BlockHash, BlockMessage]] =
     find(_ => true).map(_.toMap)
-  
+
   override def clear(): F[Unit] =
-    for {
-      _                            <- lock.acquire
-      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
-      _                            <- Sync[F].delay { blockMessageRandomAccessFile.setLength(0) }
-      _                            <- indexRef.update(_ => Map.empty)
-      _                            <- lock.release
-    } yield ()
+    lock.withPermit(
+      for {
+        blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+        _                            <- Sync[F].delay { blockMessageRandomAccessFile.setLength(0) }
+        _                            <- indexRef.update(_ => Map.empty)
+      } yield ()
+    )
 
   override def close(): F[Unit] =
-    for {
-      _                            <- lock.acquire
-      blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
-      _                            <- Sync[F].delay { blockMessageRandomAccessFile.close() }
-      _                            <- lock.release
-    } yield ()
+    lock.withPermit(
+      for {
+        blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
+        _                            <- Sync[F].delay { blockMessageRandomAccessFile.close() }
+      } yield ()
+    )
 }
 
 object FileLMDBIndexBlockStore {
   case class Config(
-    path: Path
+      path: Path
   )
-  
+
   def create[F[_]: Monad: Sync: Concurrent](config: Config): F[FileLMDBIndexBlockStore[F]] =
     for {
-      lock                  <- Semaphore[F](1)
-      blockMessageRandomAccessFile = new RandomAccessFile(config.path.toFile, "rw")
-      indexRef <- Ref.of[F, Map[BlockHash, Long]](Map.empty)
+      lock                            <- Semaphore[F](1)
+      blockMessageRandomAccessFile    = new RandomAccessFile(config.path.toFile, "rw")
+      indexRef                        <- Ref.of[F, Map[BlockHash, Long]](Map.empty)
       blockMessageRandomAccessFileRef <- Ref.of[F, RandomAccessFile](blockMessageRandomAccessFile)
     } yield new FileLMDBIndexBlockStore[F](lock, indexRef, blockMessageRandomAccessFileRef)
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -1,6 +1,6 @@
 package coop.rchain.blockstorage
 
-import java.io.{FileNotFoundException, IOException, RandomAccessFile}
+import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, NotDirectoryException, Path}
 import java.util.stream.Collectors
@@ -43,10 +43,9 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
       }
     } {
       case (txn, ExitCase.Error(NonFatal(ex))) =>
-        Sync[F].delay {
-          ex.printStackTrace()
-          txn.close()
-        } *> Sync[F].raiseError(ex)
+        val stringWriter = new StringWriter()
+        ex.printStackTrace(new PrintWriter(stringWriter))
+        Log[F].error(stringWriter.toString) *> Sync[F].delay(txn.close()) *> Sync[F].raiseError(ex)
       case (txn, _) => Sync[F].delay(txn.close())
     }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -177,6 +177,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
       for {
         blockMessageRandomAccessFile <- blockMessageRandomAccessFileRef.get
         _                            <- Sync[F].delay { blockMessageRandomAccessFile.close() }
+        _                            <- Sync[F].delay { env.close() }
       } yield ()
     )
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -6,7 +6,6 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.errors.BlockSenderIsMalformed
 import coop.rchain.blockstorage.util.BlockMessageUtil.{bonds, parentHashes}
 import coop.rchain.blockstorage.util.TopologicalSortUtil
 import coop.rchain.casper.protocol.BlockMessage

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -26,16 +26,6 @@ class InMemBlockStore[F[_]] private ()(
       state <- refF.get
     } yield state.get(blockHash)
 
-  @deprecated(
-    message = "to be removed when casper code no longer needs the whole DB in memmory",
-    since = "0.5"
-  )
-  def asMap(): F[Map[BlockHash, BlockMessage]] =
-    for {
-      _     <- metricsF.incrementCounter("as-map")
-      state <- refF.get
-    } yield state
-
   override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]] =
     for {
       _     <- metricsF.incrementCounter("find")

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -41,6 +41,9 @@ class InMemBlockStore[F[_]] private ()(
           }
     } yield ()
 
+  def checkpoint(): F[Unit] =
+    ().pure[F]
+
   def clear(): F[Unit] =
     for {
       _ <- refF.update { _.empty }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -45,12 +45,12 @@ class InMemBlockStore[F[_]] private ()(
   def checkpoint(): F[Unit] =
     ().pure[F]
 
-  def clear(): F[Unit] =
+  def clear(): F[StorageIOErr[Unit]] =
     for {
       _ <- refF.update { _.empty }
-    } yield ()
+    } yield Right(())
 
-  override def close(): F[Unit] = monadF.pure(())
+  override def close(): F[StorageIOErr[Unit]] = monadF.pure(Right(()))
 }
 
 object InMemBlockStore {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -109,6 +109,9 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
             }
     } yield ret
 
+  def checkpoint(): F[Unit] =
+    ().pure[F]
+
   def clear(): F[Unit] =
     for {
       ret <- withWriteTxn { txn =>

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -109,23 +109,6 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
             }
     } yield ret
 
-  @deprecated(
-    message = "to be removed when casper code no longer needs the whole DB in memmory",
-    since = "0.5"
-  )
-  def asMap(): F[Map[BlockHash, BlockMessage]] =
-    for {
-      _ <- metricsF.incrementCounter("as-map")
-      ret <- withReadTxn { txn =>
-              blocks.iterate(txn).asScala.foldLeft(Map.empty[BlockHash, BlockMessage]) {
-                (acc: Map[BlockHash, BlockMessage], x: CursorIterator.KeyVal[ByteBuffer]) =>
-                  val hash = ByteString.copyFrom(x.key())
-                  val msg  = BlockMessage.parseFrom(ByteString.copyFrom(x.`val`()).newCodedInput())
-                  acc.updated(hash, msg)
-              }
-            }
-    } yield ret
-
   def clear(): F[Unit] =
     for {
       ret <- withWriteTxn { txn =>

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -110,15 +110,15 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
   def checkpoint(): F[Unit] =
     ().pure[F]
 
-  def clear(): F[Unit] =
+  def clear(): F[StorageIOErr[Unit]] =
     for {
       ret <- withWriteTxn { txn =>
               blocks.drop(txn)
             }
-    } yield ()
+    } yield Right(())
 
-  override def close(): F[Unit] =
-    syncF.delay { env.close() }
+  override def close(): F[StorageIOErr[Unit]] =
+    syncF.delay { Right(env.close()) }
 }
 
 object LMDBBlockStore {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -1,4 +1,6 @@
 package coop.rchain.blockstorage
+import java.nio.file.Path
+
 import coop.rchain.blockstorage.BlockDagFileStorage.Checkpoint
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
@@ -11,14 +13,14 @@ object errors {
     }
   }
 
-  final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Checkpoint])
+  final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Path])
       extends BlockDagStorageError(
-        s"Checkpoints do not start from block number 0: ${sortedCheckpoints.map(_.path.getFileName).mkString(",")}"
+        s"Checkpoints do not start from block number 0: ${sortedCheckpoints.mkString(",")}"
       )
 
-  final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Checkpoint])
+  final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path])
       extends BlockDagStorageError(
-        s"Checkpoints are not consecutive: ${sortedCheckpoints.map(_.path.getFileName).mkString(",")}"
+        s"Checkpoints are not consecutive: ${sortedCheckpoints.mkString(",")}"
       )
 
   final case class TopoSortLengthIsTooBig(length: Long)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -20,6 +20,8 @@ final case class IntReadFailed(exception: IOException)          extends StorageI
 final case class ByteArrayReadFailed(exception: IOException)    extends StorageIOError
 final case class IntWriteFailed(exception: IOException)         extends StorageIOError
 final case class ByteArrayWriteFailed(exception: IOException)   extends StorageIOError
+final case class ClearFileFailed(exception: IOException)        extends StorageIOError
+final case class ClosingFailed(exception: IOException)          extends StorageIOError
 final case class UnexpectedIOStorageError(throwable: Throwable) extends StorageIOError
 
 object StorageError {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -1,6 +1,6 @@
 package coop.rchain.blockstorage
-import java.io.IOException
-import java.nio.file.Path
+import java.io.{FileNotFoundException, IOException}
+import java.nio.file.{NotDirectoryException, Path}
 
 import cats.data.EitherT
 import coop.rchain.casper.protocol.BlockMessage
@@ -15,14 +15,17 @@ final case class BlockSenderIsMalformed(block: BlockMessage)                  ex
 
 sealed abstract class StorageIOError extends StorageError
 
-final case class FileSeekFailed(exception: IOException)         extends StorageIOError
-final case class IntReadFailed(exception: IOException)          extends StorageIOError
-final case class ByteArrayReadFailed(exception: IOException)    extends StorageIOError
-final case class IntWriteFailed(exception: IOException)         extends StorageIOError
-final case class ByteArrayWriteFailed(exception: IOException)   extends StorageIOError
-final case class ClearFileFailed(exception: IOException)        extends StorageIOError
-final case class ClosingFailed(exception: IOException)          extends StorageIOError
-final case class UnexpectedIOStorageError(throwable: Throwable) extends StorageIOError
+final case class FileSeekFailed(exception: IOException)               extends StorageIOError
+final case class IntReadFailed(exception: IOException)                extends StorageIOError
+final case class ByteArrayReadFailed(exception: IOException)          extends StorageIOError
+final case class IntWriteFailed(exception: IOException)               extends StorageIOError
+final case class ByteArrayWriteFailed(exception: IOException)         extends StorageIOError
+final case class ClearFileFailed(exception: IOException)              extends StorageIOError
+final case class ClosingFailed(exception: IOException)                extends StorageIOError
+final case class FileNotFound(exception: FileNotFoundException)       extends StorageIOError
+final case class FileSecurityViolation(exception: SecurityException)  extends StorageIOError
+final case class FileIsNotDirectory(exception: NotDirectoryException) extends StorageIOError
+final case class UnexpectedIOStorageError(throwable: Throwable)       extends StorageIOError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
@@ -56,6 +59,21 @@ object StorageError {
       case ByteArrayWriteFailed(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"Byte array write failed: $msg"
+      case ClearFileFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File clearing failed: $msg"
+      case ClosingFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File closing failed: $msg"
+      case FileNotFound(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File not found: $msg"
+      case FileSecurityViolation(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Security manager denied access to file: $msg"
+      case FileIsNotDirectory(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File is not a directory: $msg"
       case UnexpectedIOStorageError(t) =>
         val msg = Option(t.getMessage).getOrElse("")
         s"Unexpected error ocurred during reading: $msg"

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -1,17 +1,65 @@
 package coop.rchain.blockstorage
+import java.io.IOException
 import java.nio.file.Path
 
 import cats.data.EitherT
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.crypto.codec.Base16
 
 sealed abstract class StorageError extends Exception
 
 final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Path]) extends StorageError
-final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path]) extends StorageError
-final case class TopoSortLengthIsTooBig(length: Long) extends StorageError
-final case class BlockSenderIsMalformed(block: BlockMessage) extends StorageError
+final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path])  extends StorageError
+final case class TopoSortLengthIsTooBig(length: Long)                         extends StorageError
+final case class BlockSenderIsMalformed(block: BlockMessage)                  extends StorageError
+
+sealed abstract class StorageIOError extends StorageError
+
+final case class FileSeekFailed(exception: IOException)         extends StorageIOError
+final case class IntReadFailed(exception: IOException)          extends StorageIOError
+final case class ByteArrayReadFailed(exception: IOException)    extends StorageIOError
+final case class IntWriteFailed(exception: IOException)         extends StorageIOError
+final case class ByteArrayWriteFailed(exception: IOException)   extends StorageIOError
+final case class UnexpectedIOStorageError(throwable: Throwable) extends StorageIOError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
   type StorageErrT[F[_], A] = EitherT[F, StorageError, A]
+
+  type StorageIOErr[A]        = Either[StorageIOError, A]
+  type StorageIOErrT[F[_], A] = EitherT[F, StorageIOError, A]
+
+  def errorMessage(ce: StorageError): String =
+    ce match {
+      case CheckpointsDoNotStartFromZero(sortedCheckpoints) =>
+        s"Checkpoints do not start from block number 0: ${sortedCheckpoints.mkString(",")}"
+      case CheckpointsAreNotConsecutive(sortedCheckpoints) =>
+        s"Checkpoints are not consecutive: ${sortedCheckpoints.mkString(",")}"
+      case TopoSortLengthIsTooBig(length) =>
+        s"Topological sorting of length $length was requested while maximal length is ${Int.MaxValue}"
+      case BlockSenderIsMalformed(block) =>
+        s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is malformed: ${Base16.encode(block.sender.toByteArray)}"
+      case FileSeekFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File seek failed: $msg"
+      case IntReadFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Int read failed: $msg"
+      case ByteArrayReadFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Byte array read failed: $msg"
+      case IntWriteFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Int write failed: $msg"
+      case ByteArrayWriteFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Byte array write failed: $msg"
+      case UnexpectedIOStorageError(t) =>
+        val msg = Option(t.getMessage).getOrElse("")
+        s"Unexpected error ocurred during reading: $msg"
+    }
+
+  implicit class StorageErrorToMessage(storageError: StorageError) {
+    val message: String = StorageError.errorMessage(storageError)
+  }
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -1,36 +1,17 @@
 package coop.rchain.blockstorage
 import java.nio.file.Path
 
-import coop.rchain.blockstorage.BlockDagFileStorage.Checkpoint
+import cats.data.EitherT
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.crypto.codec.Base16
 
-object errors {
-  sealed abstract class BlockDagStorageError(message: String) extends Throwable(message) {
-    def this(message: String, cause: Throwable) {
-      this(message)
-      initCause(cause)
-    }
-  }
+sealed abstract class StorageError extends Exception
 
-  final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Path])
-      extends BlockDagStorageError(
-        s"Checkpoints do not start from block number 0: ${sortedCheckpoints.mkString(",")}"
-      )
+final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Path]) extends StorageError
+final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path]) extends StorageError
+final case class TopoSortLengthIsTooBig(length: Long) extends StorageError
+final case class BlockSenderIsMalformed(block: BlockMessage) extends StorageError
 
-  final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path])
-      extends BlockDagStorageError(
-        s"Checkpoints are not consecutive: ${sortedCheckpoints.mkString(",")}"
-      )
-
-  final case class TopoSortLengthIsTooBig(length: Long)
-      extends BlockDagStorageError(
-        s"Topological sorting of length $length was requested while maximal length is ${Int.MaxValue}"
-      )
-
-  final case class BlockSenderIsMalformed(block: BlockMessage)
-      extends BlockDagStorageError(
-        s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is malformed: ${Base16
-          .encode(block.sender.toByteArray)}"
-      )
+object StorageError {
+  type StorageErr[A]        = Either[StorageError, A]
+  type StorageErrT[F[_], A] = EitherT[F, StorageError, A]
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
@@ -23,4 +23,12 @@ object byteOps {
       ByteString.copyFrom(byteBuffer.array())
     }
   }
+
+  implicit class LongRich(val value: Long) extends AnyVal {
+    def toByteString: ByteString = {
+      val byteBuffer = ByteBuffer.allocate(8)
+      byteBuffer.putLong(value)
+      ByteString.copyFrom(byteBuffer.array())
+    }
+  }
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -117,7 +117,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
   private def createBlockStore(blockStoreDataDir: Path): Task[BlockStore[Task]] = {
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = new Log.NOPLog[Task]()
-    FileLMDBIndexBlockStore.create[Task](blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
+    val env              = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
+    FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir)
   }
 
   private def createAtDefaultLocation(

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -118,7 +118,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = new Log.NOPLog[Task]()
     val env              = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
-    FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir)
+    FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir).map(_.right.get)
   }
 
   private def createAtDefaultLocation(

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -56,7 +56,6 @@ trait BlockStoreTest
                   store.get(k).map(_ shouldBe Some(v))
               }
           result <- store.find(_ => true).map(_.size shouldEqual items.size)
-          _      <- store.clear()
         } yield result
       }
     }
@@ -76,7 +75,6 @@ trait BlockStoreTest
                   }
               }
           result <- store.find(_ => true).map(_.size shouldEqual items.size)
-          _      <- store.clear()
         } yield result
       }
     }
@@ -99,7 +97,6 @@ trait BlockStoreTest
                 case (k, _, v2) => store.get(k).map(_ shouldBe Some(v2))
               }
           result <- store.find(_ => true).map(_.size shouldEqual items.size)
-          _      <- store.clear()
         } yield result
       }
     }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -54,7 +54,7 @@ trait BlockStoreTest
                 case (k, v) =>
                   store.get(k).map(_ shouldBe Some(v))
               }
-          result <- store.asMap().map(_.size shouldEqual items.size)
+          result <- store.find(_ => true).map(_.size shouldEqual items.size)
           _      <- store.clear()
         } yield result
       }
@@ -74,7 +74,7 @@ trait BlockStoreTest
                     w.head._2 shouldBe v
                   }
               }
-          result <- store.asMap().map(_.size shouldEqual items.size)
+          result <- store.find(_ => true).map(_.size shouldEqual items.size)
           _      <- store.clear()
         } yield result
       }
@@ -97,7 +97,7 @@ trait BlockStoreTest
           _ <- items.traverse_[Task, Assertion] {
                 case (k, _, v2) => store.get(k).map(_ shouldBe Some(v2))
               }
-          result <- store.asMap().map(_.size shouldEqual items.size)
+          result <- store.find(_ => true).map(_.size shouldEqual items.size)
           _      <- store.clear()
         } yield result
       }
@@ -113,10 +113,10 @@ trait BlockStoreTest
       }
 
       for {
-        _          <- store.asMap().map(_.size shouldEqual 0)
+        _          <- store.find(_ => true).map(_.size shouldEqual 0)
         putAttempt <- store.put { elem }.attempt
         _          = putAttempt.left.value shouldBe exception
-        result     <- store.asMap().map(_.size shouldEqual 0)
+        result     <- store.find(_ => true).map(_.size shouldEqual 0)
       } yield result
     }
   }
@@ -128,7 +128,7 @@ class InMemBlockStoreTest extends BlockStoreTest {
       refTask <- emptyMapRef[Task]
       metrics = new MetricsNOP[Task]()
       store   = InMemBlockStore.create[Task](Monad[Task], refTask, metrics)
-      _       <- store.asMap().map(map => assert(map.isEmpty))
+      _       <- store.find(_ => true).map(map => assert(map.isEmpty))
       result  <- f(store)
     } yield result
     test.unsafeRunSync
@@ -148,7 +148,7 @@ class LMDBBlockStoreTest extends BlockStoreTest {
     implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
     val store                           = LMDBBlockStore.create[Task](env, dbDir)
     val test = for {
-      _      <- store.asMap().map(map => assert(map.isEmpty))
+      _      <- store.find(_ => true).map(map => assert(map.isEmpty))
       result <- f(store)
     } yield result
     try {
@@ -179,7 +179,7 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
                   mapSize
                 )
               )
-      _      <- store.asMap().map(map => assert(map.isEmpty))
+      _      <- store.find(_ => true).map(map => assert(map.isEmpty))
       result <- f(store)
     } yield result
     try {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -1,14 +1,22 @@
 package coop.rchain.blockstorage
 
-import scala.language.higherKinds
+import java.nio.file.Paths
 
+import scala.language.higherKinds
 import cats._
+import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol.{BlockMessage, Header}
 import coop.rchain.rspace.Context
 import coop.rchain.shared.PathOps._
 import BlockGen.blockHashElementsGen
+import coop.rchain.blockstorage.InMemBlockStore.emptyMapRef
+import coop.rchain.metrics.Metrics
+import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.catscontrib.TaskContrib._
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 import org.scalactic.anyvals.PosInt
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -33,78 +41,89 @@ trait BlockStoreTest
   ): (BlockHash, BlockMessage) =
     (ByteString.copyFromUtf8(s._1), s._2)
 
-  def withStore[R](f: BlockStore[Id] => R): R
+  def withStore[R](f: BlockStore[Task] => Task[R]): R
 
   "Block Store" should "return Some(message) on get for a published key" in {
-    withStore { store =>
-      forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+    forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+      withStore { store =>
         val items = blockStoreElements
-        items.foreach(store.put(_))
-        items.foreach {
-          case (k, v) =>
-            store.get(k) shouldBe Some(v)
-        }
-        store.asMap().size shouldEqual items.size
-        store.clear()
+        for {
+          _ <- items.traverse_(store.put(_))
+          _ <- items.traverse[Task, Assertion] {
+                case (k, v) =>
+                  store.get(k).map(_ shouldBe Some(v))
+              }
+          result <- store.asMap().map(_.size shouldEqual items.size)
+          _      <- store.clear()
+        } yield result
       }
     }
   }
 
   it should "discover keys by predicate" in {
-    withStore { store =>
-      forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+    forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+      withStore { store =>
         val items = blockStoreElements
-        items.foreach(store.put(_))
-        items.foreach {
-          case (k, v) =>
-            val w = store.find(_ == ByteString.copyFrom(k.getBytes()))
-            w should have size 1
-            w.head._2 shouldBe v
-        }
-        store.asMap().size shouldEqual items.size
-        store.clear()
+        for {
+          _ <- items.traverse_(store.put(_))
+          _ <- items.traverse[Task, Assertion] {
+                case (k, v) =>
+                  store.find(_ == ByteString.copyFrom(k.getBytes())).map { w =>
+                    w should have size 1
+                    w.head._2 shouldBe v
+                  }
+              }
+          result <- store.asMap().map(_.size shouldEqual items.size)
+          _      <- store.clear()
+        } yield result
       }
     }
   }
 
   it should "overwrite existing value" in
-    withStore { store =>
-      forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+    forAll(blockHashElementsGen, minSize(0), sizeRange(10)) { blockStoreElements =>
+      withStore { store =>
         val items = blockStoreElements.map {
           case (hash, elem) =>
             (hash, elem, toBlockMessage(hash, 200L, 20000L))
         }
-        items.foreach { case (k, v1, _) => store.put(k, v1) }
-        items.foreach { case (k, v1, _) => store.get(k) shouldBe Some(v1) }
-        items.foreach { case (k, _, v2) => store.put(k, v2) }
-        items.foreach { case (k, _, v2) => store.get(k) shouldBe Some(v2) }
-
-        store.asMap().size shouldEqual items.size
-        store.clear()
+        for {
+          _ <- items.traverse_[Task, Unit] { case (k, v1, _) => store.put(k, v1) }
+          _ <- items.traverse_[Task, Assertion] { case (k, v1, _) => store.get(k).map(_ shouldBe Some(v1)) }
+          _ <- items.traverse_[Task, Unit] { case (k, _, v2) => store.put(k, v2) }
+          _ <- items.traverse_[Task, Assertion] { case (k, _, v2) => store.get(k).map(_ shouldBe Some(v2)) }
+          result <- store.asMap().map(_.size shouldEqual items.size)
+          _ <- store.clear()
+        } yield result
       }
     }
 
   it should "rollback the transaction on error" in {
     withStore { store =>
-      store.asMap().size shouldEqual 0
       def elem = {
         blockHashElementsGen.sample.get
         throw new RuntimeException("msg")
       }
-
-      a[RuntimeException] shouldBe thrownBy {
-        store.put { elem }
-      }
-      store.asMap().size shouldEqual 0
+      
+      for {
+        _ <- store.asMap().map(_.size shouldEqual 0)
+        _ <- store.put { elem }
+        result <- store.asMap().map(_.size shouldEqual 0)
+      } yield result
     }
   }
 }
 
 class InMemBlockStoreTest extends BlockStoreTest {
-  override def withStore[R](f: BlockStore[Id] => R): R = {
-    val store = InMemBlockStore.createWithId
-    assert(store.asMap.isEmpty)
-    f(store)
+  override def withStore[R](f: BlockStore[Task] => Task[R]): R = {
+    val test = for {
+      refTask <- emptyMapRef[Task]
+      metrics = new MetricsNOP[Task]()
+      store = InMemBlockStore.create[Task](Monad[Task], refTask, metrics)
+      _ <- store.asMap().map(map => assert(map.isEmpty))
+      result <- f(store)
+    } yield result
+    test.unsafeRunSync
   }
 }
 
@@ -115,13 +134,42 @@ class LMDBBlockStoreTest extends BlockStoreTest {
   private[this] def mkTmpDir(): Path = Files.createTempDirectory("block-store-test-")
   private[this] val mapSize: Long    = 100L * 1024L * 1024L * 4096L
 
-  override def withStore[R](f: BlockStore[Id] => R): R = {
+  override def withStore[R](f: BlockStore[Task] => Task[R]): R = {
     val dbDir = mkTmpDir()
     val env   = Context.env(dbDir, mapSize)
-    val store = LMDBBlockStore.createWithId(env, dbDir)
+    implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
+    val store = LMDBBlockStore.create[Task](env, dbDir)
+    val test = for {
+      _ <- store.asMap().map(map => assert(map.isEmpty))
+      result <- f(store)
+    } yield result
     try {
-      assert(store.asMap.isEmpty)
-      f(store)
+      test.unsafeRunSync
+    } finally {
+      env.close()
+      dbDir.recursivelyDelete
+    }
+  }
+}
+
+class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
+
+  import java.nio.file.{Files, Path}
+
+  private[this] def mkTmpDir(): Path = Files.createTempDirectory("block-store-test-")
+  private[this] val mapSize: Long    = 100L * 1024L * 1024L * 4096L
+
+  override def withStore[R](f: BlockStore[Task] => Task[R]): R = {
+    val dbDir = mkTmpDir()
+    val env   = Context.env(dbDir, mapSize)
+    implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
+    val test = for {
+      store <- FileLMDBIndexBlockStore.create[Task](FileLMDBIndexBlockStore.Config(dbDir.resolve("block-store-data")))
+      _ <- store.asMap().map(map => assert(map.isEmpty))
+      result <- f(store)
+    } yield result
+    try {
+      test.unsafeRunSync
     } finally {
       env.close()
       dbDir.recursivelyDelete

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -151,7 +151,7 @@ class LMDBBlockStoreTest extends BlockStoreTest {
       test.unsafeRunSync
     } finally {
       env.close()
-      dbDir.recursivelyDelete
+      dbDir.recursivelyDelete()
     }
   }
 }
@@ -168,7 +168,13 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
     val env   = Context.env(dbDir, mapSize)
     implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
     val test = for {
-      store <- FileLMDBIndexBlockStore.create[Task](FileLMDBIndexBlockStore.Config(dbDir.resolve("block-store-data")))
+      store <- FileLMDBIndexBlockStore.create[Task](
+        FileLMDBIndexBlockStore.Config(
+          dbDir.resolve("block-store-data"),
+          dbDir.resolve("block-store-index"),
+          mapSize
+        )
+      )
       _ <- store.asMap().map(map => assert(map.isEmpty))
       result <- f(store)
     } yield result
@@ -176,7 +182,7 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
       test.unsafeRunSync
     } finally {
       env.close()
-      dbDir.recursivelyDelete
+      dbDir.recursivelyDelete()
     }
   }
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -172,14 +172,16 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
     val dbDir                           = mkTmpDir()
     implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
     implicit val log: Log[Task]         = new Log.NOPLog[Task]()
+    val env                             = Context.env(dbDir, mapSize)
     val test = for {
-      store  <- FileLMDBIndexBlockStore.create[Task](dbDir, mapSize)
+      store  <- FileLMDBIndexBlockStore.create[Task](env, dbDir)
       _      <- store.find(_ => true).map(map => assert(map.isEmpty))
       result <- f(store)
     } yield result
     try {
       test.unsafeRunSync
     } finally {
+      env.close()
       dbDir.recursivelyDelete()
     }
   }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -171,7 +171,7 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
     implicit val log: Log[Task]         = new Log.NOPLog[Task]()
     val env                             = Context.env(dbDir, mapSize)
     val test = for {
-      store  <- FileLMDBIndexBlockStore.create[Task](env, dbDir)
+      store  <- FileLMDBIndexBlockStore.create[Task](env, dbDir).map(_.right.get)
       _      <- store.find(_ => true).map(map => assert(map.isEmpty))
       result <- f(store)
     } yield result

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -12,6 +12,7 @@ import coop.rchain.rspace.Context
 import coop.rchain.shared.PathOps._
 import BlockGen.blockHashElementsGen
 import coop.rchain.blockstorage.InMemBlockStore.emptyMapRef
+import coop.rchain.blockstorage.StorageError.StorageIOErr
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.catscontrib.TaskContrib._
@@ -88,11 +89,11 @@ trait BlockStoreTest
             (hash, elem, toBlockMessage(hash, 200L, 20000L))
         }
         for {
-          _ <- items.traverse_[Task, Unit] { case (k, v1, _) => store.put(k, v1) }
+          _ <- items.traverse_[Task, StorageIOErr[Unit]] { case (k, v1, _) => store.put(k, v1) }
           _ <- items.traverse_[Task, Assertion] {
                 case (k, v1, _) => store.get(k).map(_ shouldBe Some(v1))
               }
-          _ <- items.traverse_[Task, Unit] { case (k, _, v2) => store.put(k, v2) }
+          _ <- items.traverse_[Task, StorageIOErr[Unit]] { case (k, _, v2) => store.put(k, v2) }
           _ <- items.traverse_[Task, Assertion] {
                 case (k, _, v2) => store.get(k).map(_ shouldBe Some(v2))
               }

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -40,6 +40,7 @@ import org.scalatest.{Assertion, FlatSpec, Matchers}
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.catscontrib.ski.kp2
 import coop.rchain.metrics.Metrics
+import coop.rchain.shared.Log
 import org.scalatest
 
 import scala.collection.immutable
@@ -347,7 +348,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
             validateBlockStore(node) { blockStore =>
               blockStore.get(signedBlock.blockHash) shouldBeF Some(signedBlock)
-            }(nodes(0).metricEff)
+            }(nodes(0).metricEff, nodes(0).logEff)
           }
     } yield result
   }
@@ -366,7 +367,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
             validateBlockStore(node) { blockStore =>
               blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(signedBlock1Prime)
-            }(nodes(0).metricEff)
+            }(nodes(0).metricEff, nodes(0).logEff)
           }
     } yield result
   }
@@ -1205,7 +1206,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
             _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
             result <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
           } yield result
-        }(nodes(0).metricEff)
+        }(nodes(0).metricEff, nodes(0).logEff)
       }
     } yield result
   }
@@ -1255,7 +1256,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
                 _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
                 result <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
               } yield result
-            }(nodes(0).metricEff)
+            }(nodes(0).metricEff, nodes(0).logEff)
           }
     } yield result
   }
@@ -1384,7 +1385,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
               _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
               result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF None
             } yield result
-          }(nodes(0).metricEff)
+          }(nodes(0).metricEff, nodes(0).logEff)
     } yield result
   }
 
@@ -1461,13 +1462,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
                          signedBlock1Prime
                        )
             } yield result
-          }(nodes(0).metricEff)
+          }(nodes(0).metricEff, nodes(0).logEff)
       _ <- validateBlockStore(nodes(1)) { blockStore =>
             for {
               _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
               result <- blockStore.get(signedBlock4.blockHash) shouldBeF Some(signedBlock4)
             } yield result
-          }(nodes(1).metricEff)
+          }(nodes(1).metricEff, nodes(1).logEff)
       result <- validateBlockStore(nodes(2)) { blockStore =>
                  for {
                    _ <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
@@ -1475,7 +1476,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
                               signedBlock1Prime
                             )
                  } yield result
-               }(nodes(2).metricEff)
+               }(nodes(2).metricEff, nodes(2).logEff)
     } yield result
   }
 
@@ -1704,7 +1705,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 object HashSetCasperTest {
   def validateBlockStore[R](
       node: HashSetCasperTestNode[Effect]
-  )(f: BlockStore[Effect] => Effect[R])(implicit metrics: Metrics[Effect]) =
+  )(f: BlockStore[Effect] => Effect[R])(implicit metrics: Metrics[Effect], log: Log[Effect]) =
     for {
       bs     <- BlockDagStorageTestFixture.createBlockStorage[Effect](node.blockStoreDir)
       result <- f(bs)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1704,14 +1704,13 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 object HashSetCasperTest {
   def validateBlockStore[R](
       node: HashSetCasperTestNode[Effect]
-  )(f: BlockStore[Effect] => Effect[R])(implicit metrics: Metrics[Effect]) = {
-    val bs = BlockDagStorageTestFixture.createBlockStorage[Effect](node.blockStoreDir)
+  )(f: BlockStore[Effect] => Effect[R])(implicit metrics: Metrics[Effect]) =
     for {
+      bs     <- BlockDagStorageTestFixture.createBlockStorage[Effect](node.blockStoreDir)
       result <- f(bs)
       _      <- bs.close()
       _      <- Sync[Effect].delay { node.blockStoreDir.recursivelyDelete() }
     } yield result
-  }
 
   def blockTuplespaceContents(
       block: BlockMessage

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -93,13 +93,10 @@ object BlockDagStorageTestFixture {
 
   val mapSize: Long = 1024L * 1024L * 100L
 
-  def createBlockStorage[F[_]: Sync: Concurrent: Metrics](
+  def createBlockStorage[F[_]: Concurrent: Metrics: Log](
       blockStorageDir: Path
   ): F[BlockStore[F]] =
-    FileLMDBIndexBlockStore.create[F](
-      FileLMDBIndexBlockStore
-        .Config(blockStorageDir.resolve("data"), blockStorageDir.resolve("index"), mapSize)
-    )
+    FileLMDBIndexBlockStore.create[F](blockStorageDir, mapSize)
 
   def createBlockDagStorage(blockDagStorageDir: Path)(
       implicit metrics: Metrics[Task],

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -13,6 +13,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.rspace.Context
 import coop.rchain.shared.Log
 import org.scalatest.{BeforeAndAfter, Suite}
 import coop.rchain.shared.PathOps.RichPath
@@ -95,8 +96,10 @@ object BlockDagStorageTestFixture {
 
   def createBlockStorage[F[_]: Concurrent: Metrics: Log](
       blockStorageDir: Path
-  ): F[BlockStore[F]] =
-    FileLMDBIndexBlockStore.create[F](blockStorageDir, mapSize)
+  ): F[BlockStore[F]] = {
+    val env = Context.env(blockStorageDir, mapSize)
+    FileLMDBIndexBlockStore.create[F](env, blockStorageDir)
+  }
 
   def createBlockDagStorage(blockDagStorageDir: Path)(
       implicit metrics: Metrics[Task],

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -6,6 +6,7 @@ import java.util.zip.CRC32
 
 import cats.Id
 import cats.effect.{Concurrent, Sync}
+import cats.syntax.functor._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage._
@@ -98,7 +99,7 @@ object BlockDagStorageTestFixture {
       blockStorageDir: Path
   ): F[BlockStore[F]] = {
     val env = Context.env(blockStorageDir, mapSize)
-    FileLMDBIndexBlockStore.create[F](env, blockStorageDir)
+    FileLMDBIndexBlockStore.create[F](env, blockStorageDir).map(_.right.get)
   }
 
   def createBlockDagStorage(blockDagStorageDir: Path)(

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -181,14 +181,7 @@ object HashSetCasperTestNode {
     val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
     val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
     for {
-      blockStore <- FileLMDBIndexBlockStore.create[F](
-                     FileLMDBIndexBlockStore
-                       .Config(
-                         blockStoreDir.resolve("data"),
-                         blockStoreDir.resolve("index"),
-                         storageSize
-                       )
-                   )
+      blockStore <- FileLMDBIndexBlockStore.create[F](blockStoreDir, storageSize)
       blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                           BlockDagFileStorage.Config(
                             blockDagDir.resolve("latest-messages-data"),
@@ -266,13 +259,7 @@ object HashSetCasperTestNode {
             val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
             val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
             for {
-              blockStore <- FileLMDBIndexBlockStore.create[F](
-                             FileLMDBIndexBlockStore.Config(
-                               blockStoreDir.resolve("data"),
-                               blockStoreDir.resolve("index"),
-                               storageSize
-                             )
-                           )
+              blockStore <- FileLMDBIndexBlockStore.create[F](blockStoreDir, storageSize)
               blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                                   BlockDagFileStorage.Config(
                                     blockDagDir.resolve("latest-messages-data"),

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -10,6 +10,7 @@ import cats.{Applicative, ApplicativeError, Id, Monad}
 import coop.rchain.blockstorage._
 import coop.rchain.catscontrib._
 import coop.rchain.casper._
+import coop.rchain.casper.helper.BlockDagStorageTestFixture.mapSize
 import coop.rchain.casper.helper.HashSetCasperTestNode.Close
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
@@ -35,6 +36,7 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.p2p.effects.PacketHandler
 import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rspace.Context
 import coop.rchain.shared.{Cell, Log, StoreType}
 import coop.rchain.shared.PathOps.RichPath
 import monix.eval.Task
@@ -180,8 +182,9 @@ object HashSetCasperTestNode {
 
     val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
     val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
+    val env           = Context.env(blockStoreDir, mapSize)
     for {
-      blockStore <- FileLMDBIndexBlockStore.create[F](blockStoreDir, storageSize)
+      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir)
       blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                           BlockDagFileStorage.Config(
                             blockDagDir.resolve("latest-messages-data"),
@@ -258,8 +261,9 @@ object HashSetCasperTestNode {
 
             val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
             val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
+            val env           = Context.env(blockStoreDir, mapSize)
             for {
-              blockStore <- FileLMDBIndexBlockStore.create[F](blockStoreDir, storageSize)
+              blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir)
               blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                                   BlockDagFileStorage.Config(
                                     blockDagDir.resolve("latest-messages-data"),

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -180,11 +180,15 @@ object HashSetCasperTestNode {
 
     val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
     val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
-    implicit val blockStore =
-      LMDBBlockStore.create[F](
-        LMDBBlockStore.Config(path = blockStoreDir, mapSize = storageSize)
-      )
     for {
+      blockStore <- FileLMDBIndexBlockStore.create[F](
+                     FileLMDBIndexBlockStore
+                       .Config(
+                         blockStoreDir.resolve("data"),
+                         blockStoreDir.resolve("index"),
+                         storageSize
+                       )
+                   )
       blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                           BlockDagFileStorage.Config(
                             blockDagDir.resolve("latest-messages-data"),
@@ -194,7 +198,7 @@ object HashSetCasperTestNode {
                             blockDagDir.resolve("checkpoints")
                           ),
                           genesis
-                        )
+                        )(Monad[F], Concurrent[F], Sync[F], Log[F], blockStore)
       blockProcessingLock <- Semaphore[F](1)
       node = new HashSetCasperTestNode[F](
         name,
@@ -261,11 +265,14 @@ object HashSetCasperTestNode {
 
             val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
             val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
-            implicit val blockStore =
-              LMDBBlockStore.create[F](
-                LMDBBlockStore.Config(path = blockStoreDir, mapSize = storageSize)
-              )
             for {
+              blockStore <- FileLMDBIndexBlockStore.create[F](
+                             FileLMDBIndexBlockStore.Config(
+                               blockStoreDir.resolve("data"),
+                               blockStoreDir.resolve("index"),
+                               storageSize
+                             )
+                           )
               blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                                   BlockDagFileStorage.Config(
                                     blockDagDir.resolve("latest-messages-data"),
@@ -275,7 +282,7 @@ object HashSetCasperTestNode {
                                     blockDagDir.resolve("checkpoints")
                                   ),
                                   genesis
-                                )
+                                )(Monad[F], Concurrent[F], Sync[F], Log[F], blockStore)
               semaphore <- Semaphore[F](1)
               node = new HashSetCasperTestNode[F](
                 n,

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -184,7 +184,7 @@ object HashSetCasperTestNode {
     val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
     val env           = Context.env(blockStoreDir, mapSize)
     for {
-      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir)
+      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
       blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                           BlockDagFileStorage.Config(
                             blockDagDir.resolve("latest-messages-data"),
@@ -263,7 +263,7 @@ object HashSetCasperTestNode {
             val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
             val env           = Context.env(blockStoreDir, mapSize)
             for {
-              blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir)
+              blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
               blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
                                   BlockDagFileStorage.Config(
                                     blockDagDir.resolve("latest-messages-data"),

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -4,8 +4,7 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 
 import cats.implicits._
-
-import coop.rchain.blockstorage.{BlockDagFileStorage, LMDBBlockStore}
+import coop.rchain.blockstorage.{BlockDagFileStorage, FileLMDBIndexBlockStore}
 import coop.rchain.casper.CasperConf
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm._
@@ -187,7 +186,12 @@ object Configuration {
             maximumBond = DefaultMaximumBond,
             hasFaucet = DefaultHasFaucet
           ),
-          LMDBBlockStore.Config(dataDir.resolve("casper-block-store"), DefaultCasperBlockStoreSize),
+          FileLMDBIndexBlockStore.Config(
+            dataDir.resolve("casper-block-store").resolve("storage"),
+            dataDir.resolve("casper-block-store").resolve("index"),
+            dataDir.resolve("casper-block-store").resolve("checkpoints"),
+            DefaultCasperBlockStoreSize
+          ),
           BlockDagFileStorage.Config(
             dataDir.resolve("casper-block-dag-file-storage-latest-messages-log"),
             dataDir.resolve("casper-block-dag-file-storage-latest-messages-crc"),
@@ -414,10 +418,11 @@ object Configuration {
         genesisAppriveDuration,
         deployTimestamp
       )
-
     val blockstorage =
-      LMDBBlockStore.Config(
-        dataDir.resolve("casper-block-store"),
+      FileLMDBIndexBlockStore.Config(
+        dataDir.resolve("casper-block-store").resolve("storage"),
+        dataDir.resolve("casper-block-store").resolve("index"),
+        dataDir.resolve("casper-block-store").resolve("checkpoints"),
         casperBlockStoreSize
       )
     val blockDagStorage = BlockDagFileStorage.Config(
@@ -492,7 +497,7 @@ final class Configuration(
     val grpcServer: GrpcServer,
     val tls: Tls,
     val casper: CasperConf,
-    val blockstorage: LMDBBlockStore.Config,
+    val blockstorage: FileLMDBIndexBlockStore.Config,
     val blockDagStorage: BlockDagFileStorage.Config,
     val kamon: Kamon,
     private val options: commandline.Options

--- a/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
@@ -1,0 +1,18 @@
+package coop.rchain.shared
+
+import java.nio.ByteBuffer
+
+import com.google.protobuf.ByteString
+
+object ByteStringOps {
+
+  implicit class RichByteString(byteVector: ByteString) {
+
+    def toDirectByteBuffer: ByteBuffer = {
+      val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size)
+      byteVector.copyTo(buffer)
+      buffer.flip()
+      buffer
+    }
+  }
+}


### PR DESCRIPTION
## Overview
First part of the new block storage implementation. Only provides basic implementation of `BlockStore` API through a file storage with LMDB index and checkpoints loading (but not looking up in them as this will likely be a part of the new `BlockStore` API). Also introduces a couple of other small changes such as removing `asMap` method from `BlockStore` API and enclosing BlockStoreTest under Task.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-652



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
