### PR TITLE
RCHAIN-2827: Make Interpreter.scala tagless finally

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -18,7 +18,7 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.Interpreter
 import coop.rchain.rspace.ReplayException
 import coop.rchain.shared.{Log, LogSource}
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
 
 import scala.concurrent.duration._
@@ -28,7 +28,7 @@ object InterpreterUtil {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def mkTerm(rho: String): Either[Throwable, Par] =
-    Interpreter.buildNormalizedTerm(rho).runAttempt
+    Interpreter[Coeval].buildNormalizedTerm(rho).runAttempt
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BasicWalletSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BasicWalletSpec.scala
@@ -14,9 +14,9 @@ import coop.rchain.rholang.math.NonNegativeNumber
 import coop.rchain.rholang.mint.MakeMint
 import coop.rchain.rholang.wallet.{BasicWallet, BasicWalletTest}
 import coop.rchain.rspace.Serialize
+import monix.eval.Coeval
 import monix.execution.Scheduler.Implicits.global
 import org.abstractj.kalium.NaCl
-
 import org.scalatest.{FlatSpec, Matchers}
 
 class BasicWalletSpec extends FlatSpec with Matchers {
@@ -60,7 +60,7 @@ object Signer {
 
   private def signWithdrawal(nonce: Int, amount: Int, sigKey: String): String = {
     def parse(rho: String): Par =
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm(rho)
         .value
 

--- a/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
@@ -21,7 +21,7 @@ import coop.rchain.node.model.repl._
 import coop.rchain.node.model.diagnostics._
 import coop.rchain.rholang.interpreter.{RholangCLI, Runtime}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
 import com.google.protobuf.ByteString
 import java.io.{Reader, StringReader}
@@ -43,7 +43,7 @@ private[api] class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler)
 
   def exec(reader: Reader): Task[ReplResponse] =
     Task
-      .coeval(buildNormalizedTerm(reader))
+      .coeval(Interpreter[Coeval].buildNormalizedTerm(reader))
       .attempt
       .flatMap {
         case Left(er) =>
@@ -80,7 +80,7 @@ private[api] class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler)
   def runEvaluate(runtime: Runtime[Task], term: Par): Task[EvaluateResult] =
     for {
       _      <- Task.now(printNormalizedTerm(term))
-      result <- evaluate(runtime, term)
+      result <- Interpreter[Task].evaluate(runtime, term)
     } yield result
 
   private def printNormalizedTerm(normalizedTerm: Par): Unit = {

--- a/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -2,8 +2,9 @@ package coop.rchain.rholang.build
 
 import coop.rchain.rholang.interpreter.Interpreter
 import coop.rchain.models.Par
-
 import java.io.{File, FileInputStream, FileReader}
+
+import monix.eval.Coeval
 
 trait CompiledRholangSource {
   val term: Par
@@ -14,7 +15,7 @@ object CompiledRholangSource {
   def fromSourceFile(file: File): Either[Throwable, Par] = {
     val reader = new FileReader(file)
 
-    Interpreter.buildNormalizedTerm(reader).runAttempt
+    Interpreter[Coeval].buildNormalizedTerm(reader).runAttempt
   }
 
   def fromProtoFile(path: String): Par = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -63,9 +63,9 @@ object Interpreter {
 
     def buildPar(proc: Proc): F[Par] =
       for {
-        outputs <- normalizeTerm(proc)
-        sorted  <- Sortable[Par].sortMatch(outputs.par)
-      } yield sorted.term
+        par       <- normalizeTerm(proc)
+        sortedPar <- Sortable[Par].sortMatch(par)
+      } yield sortedPar.term
 
     def execute(runtime: Runtime[F], reader: Reader): F[Runtime[F]] =
       for {
@@ -109,7 +109,7 @@ object Interpreter {
                }
       } yield proc
 
-    private def normalizeTerm(term: Proc): F[ProcVisitOutputs] =
+    private def normalizeTerm(term: Proc): F[Par] =
       ProcNormalizeMatcher
         .normalizeMatch[F](
           term,
@@ -146,7 +146,7 @@ object Interpreter {
                 TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", ""))
               )
             }
-          } else normalizedTerm.pure[F]
+          } else normalizedTerm.pure[F].map(_.par)
         }
 
     /**

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -22,6 +22,7 @@ object errors {
   final case class NormalizerError(message: String) extends InterpreterError(message)
   final case class SyntaxError(message: String)     extends InterpreterError(message)
   final case class LexerError(message: String)      extends InterpreterError(message)
+  final case class ParserError(message: String)     extends InterpreterError(message)
 
   final case class UnboundVariableRef(varName: String, line: Int, col: Int)
       extends InterpreterError(s"Variable reference: =$varName at $line:$col is unbound.")

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -117,6 +117,6 @@ class InterpreterSpec extends FlatSpec with Matchers {
       runtime: Runtime[Task],
       source: String
   ): Task[Either[Throwable, Runtime[Task]]] =
-    Interpreter.execute(runtime, new StringReader(source)).attempt
+    Interpreter[Task].execute(runtime, new StringReader(source)).attempt
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -4,6 +4,7 @@ import coop.rchain.models.PrettyPrinted
 import coop.rchain.rholang.interpreter.Interpreter
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
 import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
+import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters
 import org.scalatest.{FlatSpec, Matchers}
@@ -19,7 +20,7 @@ class ProcGenTest extends FlatSpec with PropertyChecks with Matchers {
   it should "generate correct procs that are normalized successfully" in {
 
     forAll { p: PrettyPrinted[Proc] =>
-      Interpreter.buildPar(p.value).apply
+      Interpreter[Coeval].buildPar(p.value).apply
     }
   }
 
@@ -30,7 +31,7 @@ class ProcGenTest extends FlatSpec with PropertyChecks with Matchers {
       ProcGen.procShrinker
         .shrink(original.value)
         .headOption
-        .map(shrinked => Interpreter.buildPar(shrinked).apply)
+        .map(shrinked => Interpreter[Coeval].buildPar(shrinked).apply)
         .getOrElse(true)
 
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -180,11 +180,11 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
          |""".stripMargin
 
     isolateStackOverflow {
-      val ast = Interpreter.buildNormalizedTerm(rho).value()
+      val ast = Interpreter[Coeval].buildNormalizedTerm(rho).value()
       PrettyPrinter().buildString(ast)
       checkSuccess(rho) {
         mkRuntime(tmpPrefix, mapSize).use { runtime =>
-          Interpreter.evaluate(runtime, ast)
+          Interpreter[Task].evaluate(runtime, ast)
         }
       }
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpolateRholang.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpolateRholang.scala
@@ -42,5 +42,5 @@ object InterpolateRholang {
     * @return term after interpolation
     */
   def interpolate(term: String, interpolateMap: Map[String, Par]): Coeval[Par] =
-    Interpreter.buildNormalizedTerm(term).map(Interpolate.interpolate(_, interpolateMap))
+    Interpreter[Coeval].buildNormalizedTerm(term).map(Interpolate.interpolate(_, interpolateMap))
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -3,13 +3,14 @@ import java.io.StringReader
 
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.errors.LexerError
+import monix.eval.Coeval
 import org.scalatest.EitherValues._
 import org.scalatest.{FlatSpec, Matchers}
 
 class LexerTest extends FlatSpec with Matchers {
 
   def attemptMkTerm(input: String): Either[Throwable, Par] =
-    Interpreter.buildNormalizedTerm(input).runAttempt()
+    Interpreter[Coeval].buildNormalizedTerm(input).runAttempt()
 
   "Lexer" should "return LexerError for unterminated string at EOF" in {
     val attempt = attemptMkTerm("""{{ @"ack!(0) }}""")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -388,45 +388,45 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PSend" should "Not compile if data contains negation" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""new x in { x!(~1) }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(~1) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains conjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""new x in { x!(1 /\ 2) }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(1 /\ 2) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains disjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""new x in { x!(1 \/ 2) }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(1 \/ 2) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains wildcard" in {
     an[TopLevelWildcardsNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""@"x"!(_)""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""@"x"!(_)""").value()
     }
   }
 
   "PSend" should "Not compile if data contains free variable" in {
     an[TopLevelFreeVariablesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""@"x"!(y)""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""@"x"!(y)""").value()
     }
   }
 
   "PSend" should "not compile if name contains connectives" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""@{Nil /\ Nil}!(1)""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""@{Nil /\ Nil}!(1)""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""@{Nil \/ Nil}!(1)""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""@{Nil \/ Nil}!(1)""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""@{~Nil}!(1)""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""@{~Nil}!(1)""").value()
     }
   }
 
@@ -746,45 +746,45 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PInput" should "not compile when connectives are used in the channel" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm("""for(x <- @{Nil \/ Nil}){ Nil }""")
         .value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm("""for(x <- @{Nil /\ Nil}){ Nil }""")
         .value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""for(x <- @{~Nil}){ Nil }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @{~Nil}){ Nil }""").value()
     }
   }
 
   "PInput" should "not compile when connectives are the top level expression in the body" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""for(x <- @Nil){ 1 /\ 2 }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 /\ 2 }""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""for(x <- @Nil){ 1 \/ 2 }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 \/ 2 }""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter.buildNormalizedTerm("""for(x <- @Nil){ ~1 }""").value()
+      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ ~1 }""").value()
     }
   }
 
   "PInput" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
     an[PatternReceiveError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm("""new x in { for(@{Nil \/ Nil} <- x) { Nil } }""")
         .value()
     }
 
     an[PatternReceiveError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm("""new x in { for(@{~Nil} <- x) { Nil } }""")
         .value()
     }
@@ -792,7 +792,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PInput" should "compile when logical AND is used in the pattern of the receive" in {
     noException should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm("""new x in { for(@{Nil /\ Nil} <- x) { Nil } }""")
         .value()
     }
@@ -800,7 +800,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PContr" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
     an[PatternReceiveError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ {Nil \/ Nil}}) = { Nil } }""")
         )
@@ -808,7 +808,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     }
 
     an[PatternReceiveError] should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ ~Nil}) = { Nil } }""")
         )
@@ -818,7 +818,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PContr" should "compile when logical AND is used in the pattern of the receive" in {
     noException should be thrownBy {
-      Interpreter
+      Interpreter[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ {Nil /\ Nil}}) = { Nil } }""")
         )
@@ -1480,7 +1480,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
            }
          }
        """
-        Interpreter.buildNormalizedTerm(rho).value()
+        Interpreter[Coeval].buildNormalizedTerm(rho).value()
         assert(true)
       } catch {
         case e: Throwable =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -823,7 +823,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     assert(parseAndPrint(prettySource) == prettySource)
 
   private def parseAndPrint(source: String): String = PrettyPrinter().buildString(
-    Interpreter.buildNormalizedTerm(new StringReader(source)).runAttempt().right.get
+    Interpreter[Coeval].buildNormalizedTerm(new StringReader(source)).runAttempt().right.get
   )
 }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -15,7 +15,7 @@ import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.ISpace
 import coop.rchain.rspace.internal.{Datum, Row}
 import coop.rchain.rspace.pure.PureRSpace
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -212,7 +212,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         r!("0897e9533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2".hexToBytes(), "result2")
       }"""
 
-    val lookupPar: Par = Interpreter.buildNormalizedTerm(lookupString).value
+    val lookupPar: Par = Interpreter[Coeval].buildNormalizedTerm(lookupString).value
 
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(1)
@@ -271,7 +271,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
             }
           }
         }"""
-    val insertPar: Par                      = Interpreter.buildNormalizedTerm(insertString).value
+    val insertPar: Par                      = Interpreter[Coeval].buildNormalizedTerm(insertString).value
     val completePar                         = insertPar.addSends(rootSend, branchSend)
     implicit val evalRand: Blake2b512Random = baseRand.splitByte(2)
 
@@ -387,7 +387,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           }
         }
       }"""
-    val deletePar: Par                  = Interpreter.buildNormalizedTerm(deleteString).value
+    val deletePar: Par                  = Interpreter[Coeval].buildNormalizedTerm(deleteString).value
     val completePar                     = deletePar.addSends(rootSend, fullBranchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(3)
 
@@ -477,7 +477,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         r!(`rho:id:bnm61w3958nhr5u6wx9yx6c4js77hcxmftc9o1yo4y9yxdu7g8bnq3`, "result0") |
         r!(`rho:id:bnmzm3i5h5hj8qyoh3ubmbu57zuqn56xrk175bw5sf6kook9bq8ny3`, "result1")
       }"""
-    val lookupPar: Par                  = Interpreter.buildNormalizedTerm(lookupString).value
+    val lookupPar: Par                  = Interpreter[Coeval].buildNormalizedTerm(lookupString).value
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(4)
     val newRand                         = rand.splitByte(2)
@@ -502,7 +502,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           rl!(uri, "result1")
         }
       }"""
-    val registerPar: Par                = Interpreter.buildNormalizedTerm(registerString).value
+    val registerPar: Par                = Interpreter[Coeval].buildNormalizedTerm(registerString).value
     val completePar                     = registerPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(5)
     val newRand                         = rand.splitByte(2)
@@ -595,7 +595,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           }
         }
       }"""
-    val registerPar: Par                = Interpreter.buildNormalizedTerm(registerString).value
+    val registerPar: Par                = Interpreter[Coeval].buildNormalizedTerm(registerString).value
     val completePar                     = registerPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(6)
     val newRand                         = rand.splitByte(2)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -53,7 +53,7 @@ class RuntimeSpec extends FlatSpec with Matchers {
   private def execute(source: String): Either[Throwable, Runtime[Task]] =
     mkRuntime(tmpPrefix, mapSize)
       .use { runtime =>
-        Interpreter
+        Interpreter[Task]
           .execute(runtime, new StringReader(source))
           .attempt
       }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -14,7 +14,7 @@ import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Context, RSpace}
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Test.Parameters
@@ -34,7 +34,7 @@ class CostAccountingPropertyTest extends FlatSpec with PropertyChecks with Match
 
   implicit val taskExecutionDuration: FiniteDuration = 5.seconds
 
-  def cost(proc: Proc): Cost = Cost(Interpreter.buildPar(proc).apply)
+  def cost(proc: Proc): Cost = Cost(Interpreter[Coeval].buildPar(proc).apply)
 
   behavior of "Cost accounting in Reducer"
 
@@ -84,7 +84,7 @@ object CostAccountingPropertyTest {
   def execute(reducer: ChargingReducer[Task], p: Proc)(
       implicit rand: Blake2b512Random
   ): Task[Long] = {
-    val program = Interpreter.buildPar(p).apply
+    val program = Interpreter[Coeval].buildPar(p).apply
 
     val initPhlos = Cost(accounting.MAX_VALUE)
 

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -44,7 +44,7 @@ class CompilerTests extends FunSuite with Matchers {
   private def execute(file: Path): Either[Throwable, Runtime[Task]] =
     mkRuntime(tmpPrefix, mapSize)
       .use { runtime =>
-        Interpreter.execute(runtime, new FileReader(file.toString)).attempt
+        Interpreter[Task].execute(runtime, new FileReader(file.toString)).attempt
       }
       .runSyncUnsafe(maxDuration)
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -11,7 +11,7 @@ import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccounting}
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.StoreType
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 
 trait EvalBenchStateBase {
@@ -30,7 +30,9 @@ trait EvalBenchStateBase {
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
 
-    term = Interpreter.buildNormalizedTerm(resourceFileReader(rhoScriptSource)).runAttempt match {
+    term = Interpreter[Coeval]
+      .buildNormalizedTerm(resourceFileReader(rhoScriptSource))
+      .runAttempt match {
       case Right(par) => Some(par)
       case Left(err)  => throw err
     }

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -12,7 +12,7 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import coop.rchain.shared.StoreType
-import monix.eval.Task
+import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -42,13 +42,16 @@ abstract class WideBenchBaseState {
   @Setup(value = Level.Iteration)
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
-    setupTerm =
-      Interpreter.buildNormalizedTerm(resourceFileReader(rhoSetupScriptPath)).runAttempt match {
-        case Right(par) => Some(par)
-        case Left(err)  => throw err
-      }
+    setupTerm = Interpreter[Coeval]
+      .buildNormalizedTerm(resourceFileReader(rhoSetupScriptPath))
+      .runAttempt match {
+      case Right(par) => Some(par)
+      case Left(err)  => throw err
+    }
 
-    term = Interpreter.buildNormalizedTerm(resourceFileReader(rhoScriptSource)).runAttempt match {
+    term = Interpreter[Coeval]
+      .buildNormalizedTerm(resourceFileReader(rhoScriptSource))
+      .runAttempt match {
       case Right(par) => Some(par)
       case Left(err)  => throw err
     }


### PR DESCRIPTION
## Overview
- make Interpreter a type-class.
- pass Coeval or Task as concrete type parameter to Interpreter[F] for backwards compatibility.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2827