### PR TITLE
Fix safety oracle disagreement assert 

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
+import coop.rchain.p2p.EffectsTestInstances.LogStub
 import monix.eval.Task
 
 import scala.collection.immutable.{HashMap, HashSet}
@@ -17,6 +18,8 @@ class CliqueOracleTest
     with BlockDagStorageFixture {
 
   behavior of "Turan Oracle"
+
+  implicit val logEff = new LogStub[Task]
 
   // See https://docs.google.com/presentation/d/1znz01SF1ljriPzbMoFV0J127ryPglUYLFyhvsb-ftQk/edit?usp=sharing slide 29 for diagram
   it should "detect finality as appropriate" in withStorage {

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -16,6 +16,7 @@ import coop.rchain.p2p.EffectsTestInstances.{LogStub, LogicalTime}
 import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.Capture._
+import coop.rchain.shared.Log
 import monix.eval.Task
 
 import scala.collection.immutable.HashMap
@@ -183,7 +184,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
       logEff            = new LogStub[Task]()
       casperRef         <- MultiParentCasperRef.of[Task]
       _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task]
+      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
     } yield (logEff, casperRef, turanOracleEffect)
 
   private def emptyEffects(
@@ -200,6 +201,6 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
       logEff            = new LogStub[Task]()
       casperRef         <- MultiParentCasperRef.of[Task]
       _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task]
+      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
     } yield (logEff, casperRef, turanOracleEffect)
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -86,7 +86,7 @@ class BlocksResponseAPITest
         logEff            = new LogStub[Task]
         casperRef         <- MultiParentCasperRef.of[Task]
         _                 <- casperRef.set(casperEffect)
-        turanOracleEffect = SafetyOracle.turanOracle[Task]
+        turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
         blocksResponse <- BlockAPI.showMainChain[Task](Int.MaxValue)(
                            Sync[Task],
                            casperRef,
@@ -152,7 +152,7 @@ class BlocksResponseAPITest
         logEff            = new LogStub[Task]
         casperRef         <- MultiParentCasperRef.of[Task]
         _                 <- casperRef.set(casperEffect)
-        turanOracleEffect = SafetyOracle.turanOracle[Task]
+        turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
         blocksResponse <- BlockAPI.showBlocks[Task](Int.MaxValue)(
                            Sync[Task],
                            casperRef,
@@ -218,7 +218,7 @@ class BlocksResponseAPITest
       logEff            = new LogStub[Task]
       casperRef         <- MultiParentCasperRef.of[Task]
       _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task]
+      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
       blocksResponse <- BlockAPI.showBlocks[Task](2)(
                          Sync[Task],
                          casperRef,

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -148,6 +148,9 @@ class Node:
     def show_blocks_with_depth(self, depth: int) -> str:
         return self.rnode_command('show-blocks', '--depth', str(depth))
 
+    def show_block(self, hash: str) -> str:
+        return self.rnode_command('show-block', hash)
+
     def get_blocks_count(self, depth: int) -> int:
         show_blocks_output = self.show_blocks_with_depth(depth)
         return extract_block_count_from_show_blocks(show_blocks_output)

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -395,7 +395,7 @@ class NodeRuntime private[node] (
                         blockStore
                       )
     _      <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
-    oracle = SafetyOracle.turanOracle[Effect](Monad[Effect])
+    oracle = SafetyOracle.turanOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
     runtime <- {
       implicit val s = rspaceScheduler
       Runtime.create[Task, Task.Par](storagePath, storageSize, storeType, Seq.empty).toEffect


### PR DESCRIPTION
## Overview
When a new validator bonds, their latest message is
set to the validator that included their bonding deploy.
For the genesis block this works out fine because
the genesis block has no sender.

The fix is by @KentShikama. I took over the PR to clean up the tests and logging changes.


### JIRA ticket:
https://rchain.atlassian.net/projects/RCHAIN/issues/RCHAIN-2805
https://rchain.atlassian.net/browse/RCHAIN-2815

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
