### PR TITLE
Replace turan oracle with clique oracle

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -168,6 +168,13 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
           )
     } yield ()
 
+  /*
+   * On the first pass, block B is finalized if B's main parent block is finalized
+   * and the safety oracle says B's normalized fault tolerance is above the threshold.
+   * On the second pass, block B is finalized if any of B's children blocks are finalized.
+   *
+   * TODO: Implement the second pass in BlockAPI
+   */
   private def isGreaterThanFaultToleranceThreshold(
       dag: BlockDagRepresentation[F],
       blockHash: BlockHash

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -48,7 +48,7 @@ object SafetyOracle extends SafetyOracleInstances {
 }
 
 sealed abstract class SafetyOracleInstances {
-  def turanOracle[F[_]: Monad: Log]: SafetyOracle[F] =
+  def cliqueOracle[F[_]: Monad: Log]: SafetyOracle[F] =
     new SafetyOracle[F] {
       def normalizedFaultTolerance(
           blockDag: BlockDagRepresentation[F],

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -257,21 +257,8 @@ sealed abstract class SafetyOracleInstances {
               )
           }
 
-        def findMaximumClique(
-            edges: List[(Validator, Validator)],
-            agreeingValidatorToWeight: Map[Validator, Long],
-            largestCandidate: Long
-        ): Long =
-          Clique
-            .findCliquesRecursive(edges)
-            .foldLeft(largestCandidate) {
-              case (largestWeight, clique: Seq[Validator]) =>
-                val weight = clique.map(agreeingValidatorToWeight.getOrElse(_, 0L)).sum
-                Math.max(weight, largestWeight)
-            }
-
         computeAgreementGraphEdges.map { edges =>
-          findMaximumClique(edges, agreeingValidatorToWeight, agreeingValidatorToWeight.values.max)
+          Clique.findMaximumCliqueByWeight[Validator](edges, agreeingValidatorToWeight)
         }
       }
 

--- a/casper/src/main/scala/coop/rchain/casper/util/Clique.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/Clique.scala
@@ -1,6 +1,17 @@
 package coop.rchain.casper.util
 
 object Clique {
+  def findMaximumCliqueByWeight[A](edges: List[(A, A)], weights: Map[A, Long]): Long = {
+    val maxWeight = weights.values.max
+    Clique
+      .findCliquesRecursive(edges)
+      .foldLeft(maxWeight) {
+        case (largestWeight, clique: Seq[A]) =>
+          val weight = clique.map(weights.getOrElse(_, 0L)).sum
+          Math.max(weight, largestWeight)
+      }
+  }
+
   // e is a list of undirected edges
   def findCliquesRecursive[A](e: List[(A, A)]): Stream[List[A]] = {
     val adj = getAdj(e)

--- a/casper/src/main/scala/coop/rchain/casper/util/Clique.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/Clique.scala
@@ -3,13 +3,11 @@ package coop.rchain.casper.util
 object Clique {
   def findMaximumCliqueByWeight[A](edges: List[(A, A)], weights: Map[A, Long]): Long = {
     val maxWeight = weights.values.max
-    Clique
-      .findCliquesRecursive(edges)
-      .foldLeft(maxWeight) {
-        case (largestWeight, clique: Seq[A]) =>
-          val weight = clique.map(weights.getOrElse(_, 0L)).sum
-          Math.max(weight, largestWeight)
-      }
+    findCliquesRecursive(edges).foldLeft(maxWeight) {
+      case (largestWeight, clique: Seq[A]) =>
+        val weight = clique.map(weights.getOrElse(_, 0L)).sum
+        Math.max(weight, largestWeight)
+    }
   }
 
   // e is a list of undirected edges

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -81,7 +81,7 @@ class CliqueOracleTest
         b3FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b3.blockHash)
         _                     = assert(b3FaultTolerance == -1)
         b4FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b4.blockHash)
-        result                = assert(b4FaultTolerance == -0.2f) // Clique oracle would be 0.2f
+        result                = assert(b4FaultTolerance == 0.2f)
       } yield result
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -8,6 +8,8 @@ import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import monix.eval.Task
+import org.scalatest._
+import org.scalatest.Matchers._
 
 import scala.collection.immutable.{HashMap, HashSet}
 
@@ -78,13 +80,13 @@ class CliqueOracleTest
              )
         dag                   <- blockDagStorage.getRepresentation
         genesisFaultTolerance <- SafetyOracle[Task].normalizedFaultTolerance(dag, genesis.blockHash)
-        _                     = assert(genesisFaultTolerance == 1)
+        _                     = assert(genesisFaultTolerance === 1f +- 0.01f)
         b2FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b2.blockHash)
-        _                     = assert(b2FaultTolerance == 1)
+        _                     = assert(b2FaultTolerance === 1f +- 0.01f)
         b3FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b3.blockHash)
-        _                     = assert(b3FaultTolerance == -1)
+        _                     = assert(b3FaultTolerance === -1f +- 0.01f)
         b4FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b4.blockHash)
-        result                = assert(b4FaultTolerance == 0.2f)
+        result                = assert(b4FaultTolerance === 0.2f +- 0.01f)
       } yield result
   }
 
@@ -148,13 +150,13 @@ class CliqueOracleTest
         dag <- blockDagStorage.getRepresentation
 
         genesisFaultTolerance <- SafetyOracle[Task].normalizedFaultTolerance(dag, genesis.blockHash)
-        _                     = assert(genesisFaultTolerance == 1)
+        _                     = assert(genesisFaultTolerance === 1f +- 0.01f)
         b2FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b2.blockHash)
-        _                     = assert(b2FaultTolerance == -1f / 6)
+        _                     = assert(b2FaultTolerance === -1f / 6 +- 0.01f)
         b3FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b3.blockHash)
-        _                     = assert(b3FaultTolerance == -1f)
+        _                     = assert(b3FaultTolerance === -1f +- 0.01f)
         b4FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b4.blockHash)
-        result                = assert(b4FaultTolerance == -1f / 6)
+        result                = assert(b4FaultTolerance === -1f / 6 +- 0.01f)
       } yield result
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -17,7 +17,7 @@ class CliqueOracleTest
     with BlockGenerator
     with BlockDagStorageFixture {
 
-  behavior of "Turan Oracle"
+  behavior of "Clique Oracle"
 
   implicit val logEff = new LogStub[Task]
 
@@ -30,7 +30,7 @@ class CliqueOracleTest
       val v2Bond = Bond(v2, 3)
       val bonds  = Seq(v1Bond, v2Bond)
 
-      implicit val turanOracleEffect = SafetyOracle.turanOracle[Task]
+      implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
 
       for {
         genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
@@ -99,7 +99,7 @@ class CliqueOracleTest
       val v3Bond = Bond(v3, 15)
       val bonds  = Seq(v1Bond, v2Bond, v3Bond)
 
-      implicit val turanOracleEffect = SafetyOracle.turanOracle[Task]
+      implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       for {
         genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
         b2 <- createBlock[Task](

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -147,11 +147,11 @@ class CliqueOracleTest
         genesisFaultTolerance <- SafetyOracle[Task].normalizedFaultTolerance(dag, genesis.blockHash)
         _                     = assert(genesisFaultTolerance == 1)
         b2FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b2.blockHash)
-        _                     = assert(b2FaultTolerance == -0.5f)
+        _                     = assert(b2FaultTolerance == -1f / 6)
         b3FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b3.blockHash)
         _                     = assert(b3FaultTolerance == -1f)
         b4FaultTolerance      <- SafetyOracle[Task].normalizedFaultTolerance(dag, b4.blockHash)
-        result                = assert(b4FaultTolerance == -0.5f)
+        result                = assert(b4FaultTolerance == -1f / 6)
       } yield result
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -67,15 +67,15 @@ class ManyValidatorsTest
                        HashMap.empty[BlockHash, BlockMessage],
                        tips.toIndexedSeq
                      )(Sync[Task], blockStore, newIndexedBlockDagStorage)
-      logEff            = new LogStub[Task]
-      casperRef         <- MultiParentCasperRef.of[Task]
-      _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task]
+      logEff             = new LogStub[Task]
+      casperRef          <- MultiParentCasperRef.of[Task]
+      _                  <- casperRef.set(casperEffect)
+      cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       result <- BlockAPI.showBlocks[Task](Int.MaxValue)(
                  Monad[Task],
                  casperRef,
                  logEff,
-                 turanOracleEffect,
+                 cliqueOracleEffect,
                  blockStore
                )
     } yield result

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -75,14 +75,14 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
   "showBlock" should "return successful block info response" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        effects                                <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
-        (logEff, casperRef, turanOracleEffect) = effects
-        q                                      = BlockQuery(hash = secondBlockQuery)
+        effects                                 <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
+        (logEff, casperRef, cliqueOracleEffect) = effects
+        q                                       = BlockQuery(hash = secondBlockQuery)
         blockQueryResponse <- BlockAPI.showBlock[Task](q)(
                                Sync[Task],
                                casperRef,
                                logEff,
-                               turanOracleEffect,
+                               cliqueOracleEffect,
                                blockStore
                              )
         blockInfo = blockQueryResponse.blockInfo.get
@@ -103,14 +103,14 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
   it should "return error when no block exists" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        effects                                <- emptyEffects(blockStore, blockDagStorage)
-        (logEff, casperRef, turanOracleEffect) = effects
-        q                                      = BlockQuery(hash = badTestHashQuery)
+        effects                                 <- emptyEffects(blockStore, blockDagStorage)
+        (logEff, casperRef, cliqueOracleEffect) = effects
+        q                                       = BlockQuery(hash = badTestHashQuery)
         blockQueryResponse <- BlockAPI.showBlock[Task](q)(
                                Sync[Task],
                                casperRef,
                                logEff,
-                               turanOracleEffect,
+                               cliqueOracleEffect,
                                blockStore
                              )
       } yield
@@ -122,15 +122,15 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
   "findBlockWithDeploy" should "return successful block info response" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        effects                                <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
-        (logEff, casperRef, turanOracleEffect) = effects
-        user                                   = ByteString.EMPTY
-        timestamp                              = 1L
+        effects                                 <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
+        (logEff, casperRef, cliqueOracleEffect) = effects
+        user                                    = ByteString.EMPTY
+        timestamp                               = 1L
         blockQueryResponse <- BlockAPI.findBlockWithDeploy[Task](user, timestamp)(
                                Sync[Task],
                                casperRef,
                                logEff,
-                               turanOracleEffect,
+                               cliqueOracleEffect,
                                blockStore
                              )
         blockInfo = blockQueryResponse.blockInfo.get
@@ -151,15 +151,15 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
   it should "return error when no block matching query exists" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        effects                                <- emptyEffects(blockStore, blockDagStorage)
-        (logEff, casperRef, turanOracleEffect) = effects
-        user                                   = ByteString.EMPTY
-        timestamp                              = 0L
+        effects                                 <- emptyEffects(blockStore, blockDagStorage)
+        (logEff, casperRef, cliqueOracleEffect) = effects
+        user                                    = ByteString.EMPTY
+        timestamp                               = 0L
         blockQueryResponse <- BlockAPI.findBlockWithDeploy[Task](user, timestamp)(
                                Sync[Task],
                                casperRef,
                                logEff,
-                               turanOracleEffect,
+                               cliqueOracleEffect,
                                blockStore
                              )
       } yield
@@ -181,11 +181,11 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
                          (ProtoUtil.stringToByteString(secondHashString), secondBlock)
                        )
                      )(Sync[Task], blockStore, blockDagStorage)
-      logEff            = new LogStub[Task]()
-      casperRef         <- MultiParentCasperRef.of[Task]
-      _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
-    } yield (logEff, casperRef, turanOracleEffect)
+      logEff             = new LogStub[Task]()
+      casperRef          <- MultiParentCasperRef.of[Task]
+      _                  <- casperRef.set(casperEffect)
+      cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
+    } yield (logEff, casperRef, cliqueOracleEffect)
 
   private def emptyEffects(
       blockStore: BlockStore[Task],
@@ -198,9 +198,9 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
                          (ProtoUtil.stringToByteString(secondHashString), secondBlock)
                        )
                      )(Sync[Task], blockStore, blockDagStorage)
-      logEff            = new LogStub[Task]()
-      casperRef         <- MultiParentCasperRef.of[Task]
-      _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
-    } yield (logEff, casperRef, turanOracleEffect)
+      logEff             = new LogStub[Task]()
+      casperRef          <- MultiParentCasperRef.of[Task]
+      _                  <- casperRef.set(casperEffect)
+      cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
+    } yield (logEff, casperRef, cliqueOracleEffect)
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -83,15 +83,15 @@ class BlocksResponseAPITest
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
                        )
-        logEff            = new LogStub[Task]
-        casperRef         <- MultiParentCasperRef.of[Task]
-        _                 <- casperRef.set(casperEffect)
-        turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
+        logEff             = new LogStub[Task]
+        casperRef          <- MultiParentCasperRef.of[Task]
+        _                  <- casperRef.set(casperEffect)
+        cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
         blocksResponse <- BlockAPI.showMainChain[Task](Int.MaxValue)(
                            Sync[Task],
                            casperRef,
                            logEff,
-                           turanOracleEffect,
+                           cliqueOracleEffect,
                            blockStore
                          )
       } yield blocksResponse.length should be(5)
@@ -149,15 +149,15 @@ class BlocksResponseAPITest
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
                        )
-        logEff            = new LogStub[Task]
-        casperRef         <- MultiParentCasperRef.of[Task]
-        _                 <- casperRef.set(casperEffect)
-        turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
+        logEff             = new LogStub[Task]
+        casperRef          <- MultiParentCasperRef.of[Task]
+        _                  <- casperRef.set(casperEffect)
+        cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
         blocksResponse <- BlockAPI.showBlocks[Task](Int.MaxValue)(
                            Sync[Task],
                            casperRef,
                            logEff,
-                           turanOracleEffect,
+                           cliqueOracleEffect,
                            blockStore
                          )
       } yield
@@ -215,15 +215,15 @@ class BlocksResponseAPITest
                        HashMap.empty[BlockHash, BlockMessage],
                        tips
                      )
-      logEff            = new LogStub[Task]
-      casperRef         <- MultiParentCasperRef.of[Task]
-      _                 <- casperRef.set(casperEffect)
-      turanOracleEffect = SafetyOracle.turanOracle[Task](Sync[Task], logEff)
+      logEff             = new LogStub[Task]
+      casperRef          <- MultiParentCasperRef.of[Task]
+      _                  <- casperRef.set(casperEffect)
+      cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
       blocksResponse <- BlockAPI.showBlocks[Task](2)(
                          Sync[Task],
                          casperRef,
                          logEff,
-                         turanOracleEffect,
+                         cliqueOracleEffect,
                          blockStore
                        )
     } yield

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -59,7 +59,7 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
   it should "work across a chain" in effectTest {
     HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).flatMap { nodes =>
       implicit val nodeZeroCasperRef          = nodes(0).multiparentCasperRef
-      implicit val nodeZeroSafetyOracleEffect = nodes(0).turanOracleEffect
+      implicit val nodeZeroSafetyOracleEffect = nodes(0).cliqueOracleEffect
       implicit val nodeZeroLogEffect          = nodes(0).logEff
       implicit val nodeZeroBlockStoreEffect   = nodes(0).blockStore
       implicit val abstractCtx                = nodes(0).abF

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -69,12 +69,12 @@ class HashSetCasperTestNode[F[_]](
 
   private val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-$name")
 
-  implicit val logEff            = new LogStub[F]
-  implicit val timeEff           = logicalTime
-  implicit val connectionsCell   = Cell.unsafe[F, Connections](Connect.Connections.empty)
-  implicit val transportLayerEff = tle
-  implicit val turanOracleEffect = SafetyOracle.turanOracle[F]
-  implicit val rpConfAsk         = createRPConfAsk[F](local)
+  implicit val logEff             = new LogStub[F]
+  implicit val timeEff            = logicalTime
+  implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
+  implicit val transportLayerEff  = tle
+  implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
+  implicit val rpConfAsk          = createRPConfAsk[F](local)
 
   val activeRuntime =
     Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/CliqueTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CliqueTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{Assertion, FlatSpec, Matchers}
 import scala.annotation.tailrec
 
 class CliqueTest extends FlatSpec with Matchers with BlockGenerator {
-  val e = List(
+  val g1 = List(
     (1, 6),
     (1, 2),
     (1, 3),
@@ -22,6 +22,8 @@ class CliqueTest extends FlatSpec with Matchers with BlockGenerator {
     (10, 11)
   )
 
+  val g2 = List((1, 2), (1, 4), (1, 5), (1, 6), (2, 3), (3, 4), (3, 6), (4, 5), (4, 6), (5, 6))
+
   private def compare(l: List[Int], r: List[Int]): Boolean = {
     @tailrec
     def compareHelper(l: List[Int], r: List[Int]): Boolean = (l, r) match {
@@ -36,34 +38,44 @@ class CliqueTest extends FlatSpec with Matchers with BlockGenerator {
   private def assertCliquesEqual(src: List[List[Int]], expected: List[List[Int]]): Assertion =
     src.map(_.sorted).sortWith(compare) should equal(expected.map(_.sorted).sortWith(compare))
 
-  "findCliquesRecursive" should "yield all cliques" in {
-    val c        = Clique.findCliquesRecursive(e)
-    val expected = List(List(2, 6, 1, 3), List(2, 6, 4), List(5, 4, 7), List(8, 9), List(10, 11))
-    assertCliquesEqual(c.toList, expected)
-  }
-
-  "findCliquesRecursive" should "work well in self loops" in {
-    val g        = (1, 1) :: e
-    val c        = Clique.findCliquesRecursive(g)
-    val expected = List(List(2, 6, 1, 3), List(2, 6, 4), List(5, 4, 7), List(8, 9), List(10, 11))
-    assertCliquesEqual(c.toList, expected)
-  }
-
-  "findCliquesRecursive" should "work well in another case" in {
-    val H = List((1, 2), (1, 4), (1, 5), (1, 6), (2, 3), (3, 4), (3, 6), (4, 5), (4, 6), (5, 6))
-
-    val c        = Clique.findCliquesRecursive(H)
-    val expected = List(List(1, 2), List(1, 4, 5, 6), List(2, 3), List(3, 4, 6))
-
-    assertCliquesEqual(c.toList, expected)
-  }
-
-  "findCliquesRecursive" should "work well when there is no cliques" in {
+  "findCliquesRecursive" should "work when there is no cliques" in {
     val H = List()
 
     val c        = Clique.findCliquesRecursive(H)
     val expected = List()
 
     assertCliquesEqual(c.toList, expected)
+  }
+
+  "findCliquesRecursive" should "yield all cliques" in {
+    val c        = Clique.findCliquesRecursive(g1)
+    val expected = List(List(2, 6, 1, 3), List(2, 6, 4), List(5, 4, 7), List(8, 9), List(10, 11))
+    assertCliquesEqual(c.toList, expected)
+  }
+
+  "findCliquesRecursive" should "work well in self loops" in {
+    val g3       = (1, 1) :: g1
+    val c        = Clique.findCliquesRecursive(g3)
+    val expected = List(List(2, 6, 1, 3), List(2, 6, 4), List(5, 4, 7), List(8, 9), List(10, 11))
+    assertCliquesEqual(c.toList, expected)
+  }
+
+  "findCliquesRecursive" should "work well in another case" in {
+    val c        = Clique.findCliquesRecursive(g2)
+    val expected = List(List(1, 2), List(1, 4, 5, 6), List(2, 3), List(3, 4, 6))
+
+    assertCliquesEqual(c.toList, expected)
+  }
+
+  "findMaximumCliqueByWeight" should "work with same weights" in {
+    val weights = Map[Int, Long](1 -> 1, 2 -> 1, 3 -> 1, 4 -> 1, 5 -> 1, 6 -> 1)
+
+    Clique.findMaximumCliqueByWeight[Int](g2, weights) should be(4L)
+  }
+
+  "findMaximumCliqueByWeight" should "pick max weight over weight of max size" in {
+    val weights = Map[Int, Long](1 -> 10, 2 -> 10, 3 -> 1, 4 -> 1, 5 -> 1, 6 -> 1)
+
+    Clique.findMaximumCliqueByWeight[Int](g2, weights) should be(20L)
   }
 }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -396,7 +396,7 @@ class NodeRuntime private[node] (
                         blockStore
                       )
     _      <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
-    oracle = SafetyOracle.turanOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
+    oracle = SafetyOracle.cliqueOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
     runtime <- {
       implicit val s = rspaceScheduler
       Runtime.create[Task, Task.Par](storagePath, storageSize, storeType, Seq.empty).toEffect


### PR DESCRIPTION
This should help us debug any issues with the safety oracle
as now we aren't using a lower bound on the maximum clique size.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-2835

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
