### PR TITLE
Encapsulate state in multi parent casper impl

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -99,7 +99,12 @@ sealed abstract class MultiParentCasperInstances {
                                case Right(Some(hash)) => hash.pure[F]
                              }
       blockProcessingLock <- Semaphore[F](1)
-    } yield
+      casperState <- Cell.mvarCell[F, CasperState](
+                      CasperState(Set.empty[BlockMessage], Set.empty[Deploy])
+                    )
+
+    } yield {
+      implicit val state = casperState
       new MultiParentCasperImpl[F](
         runtimeManager,
         validatorId,
@@ -108,4 +113,5 @@ sealed abstract class MultiParentCasperInstances {
         shardId,
         blockProcessingLock
       )
+    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -1,7 +1,11 @@
 package coop.rchain
 
+import com.google.protobuf.ByteString
 import coop.rchain.metrics.Metrics
 
 package object casper {
+
+  type BlockHash = ByteString
+
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
 }

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1608,7 +1608,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(2).receive()
 
       _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF genesisWithEqualBonds
-      state <- nodes(0).casperEff.casperState.get
+      state <- nodes(0).casperState.read
       _     = state.deployHistory.size should be(2)
 
       createBlock6Result <- nodes(2).casperEff
@@ -1619,7 +1619,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(1).receive()
 
       _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block1
-      state <- nodes(0).casperEff.casperState.get
+      state <- nodes(0).casperState.read
       _     = state.deployHistory.size should be(1)
 
       createBlock7Result <- nodes(0).casperEff
@@ -1639,7 +1639,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(2).receive()
 
       _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
-      state <- nodes(0).casperEff.casperState.get
+      state <- nodes(0).casperState.read
       _     = state.deployHistory.size should be(2)
 
       _ <- nodes.map(_.tearDown()).toList.sequence

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1607,8 +1607,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(0).receive()
       _               <- nodes(2).receive()
 
-      _ <- nodes(0).casperEff.lastFinalizedBlock shouldBeF genesisWithEqualBonds
-      _ = nodes(0).casperEff.deployHist.size should be(2)
+      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF genesisWithEqualBonds
+      state <- nodes(0).casperEff.casperState.get
+      _     = state.deployHistory.size should be(2)
 
       createBlock6Result <- nodes(2).casperEff
                              .deploy(deployDatas(5)) *> nodes(2).casperEff.createBlock
@@ -1617,8 +1618,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(0).receive()
       _               <- nodes(1).receive()
 
-      _ <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block1
-      _ = nodes(0).casperEff.deployHist.size should be(1)
+      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block1
+      state <- nodes(0).casperEff.casperState.get
+      _     = state.deployHistory.size should be(1)
 
       createBlock7Result <- nodes(0).casperEff
                              .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
@@ -1636,8 +1638,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(0).receive()
       _               <- nodes(2).receive()
 
-      _ <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
-      _ = nodes(0).casperEff.deployHist.size should be(2)
+      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
+      state <- nodes(0).casperEff.casperState.get
+      _     = state.deployHistory.size should be(2)
 
       _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -197,9 +197,7 @@ object HashSetCasperTestNode {
                           genesis
                         )
       blockProcessingLock <- Semaphore[F](1)
-      casperState <- Cell.mvarCell[F, CasperState](
-                      CasperState(Set.empty[BlockMessage], Set.empty[Deploy])
-                    )
+      casperState         <- Cell.mvarCell[F, CasperState](CasperState())
       node = new HashSetCasperTestNode[F](
         name,
         identity,


### PR DESCRIPTION
## Overview
Encapsulates mutable state in the MultiParentCasperImpl in MonadState 

### JIRA ticket:
Prerequisite for https://rchain.atlassian.net/browse/RCHAIN-2814

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
