### PR TITLE
Modify MultiParentCasperRef to return default closed over effect

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperRef.scala
@@ -21,11 +21,10 @@ object MultiParentCasperRef {
 
   def withCasper[F[_]: Monad: Log: MultiParentCasperRef, A](
       f: MultiParentCasper[F] => F[A],
-      default: A
+      default: F[A]
   ): F[A] =
     MultiParentCasperRef[F].get flatMap {
       case Some(casper) => f(casper)
-      case None =>
-        Log[F].warn(s"Casper instance was not available.").map(_ => default)
+      case None         => default
     }
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -39,7 +39,7 @@ object BlockAPI {
              }
       } yield re
 
-    val errorMessage = "Could not deploy, casper instance was not available."
+    val errorMessage = "Could not deploy, casper instance was not available yet."
 
     MultiParentCasperRef
       .withCasper[F, DeployServiceResponse](
@@ -53,7 +53,7 @@ object BlockAPI {
   def createBlock[F[_]: Sync: Concurrent: MultiParentCasperRef: Log](
       blockApiLock: Semaphore[F]
   ): F[DeployServiceResponse] = {
-    val errorMessage = "Could not create block, casper instance was not available."
+    val errorMessage = "Could not create block, casper instance was not available yet."
     MultiParentCasperRef.withCasper[F, DeployServiceResponse](
       casper => {
         Sync[F].bracket(blockApiLock.tryAcquire) {
@@ -90,7 +90,7 @@ object BlockAPI {
       listeningName: Par
   ): F[ListeningNameDataResponse] = {
 
-    val errorMessage = "Could not get listening name data, casper instance was not available."
+    val errorMessage = "Could not get listening name data, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
@@ -126,7 +126,7 @@ object BlockAPI {
       listeningNames: Seq[Par]
   ): F[ListeningNameContinuationResponse] = {
     val errorMessage =
-      "Could not get listening names confinuation, casper instance was not available."
+      "Could not get listening names continuation, casper instance was not available yet."
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         mainChain           <- getMainChainFromTip[F](depth)
@@ -243,7 +243,7 @@ object BlockAPI {
   ): F[String] = {
 
     val errorMessage =
-      "Could not visualize graph, casper instance was not available."
+      "Could not visualize graph, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]): F[String] =
       for {
@@ -267,7 +267,7 @@ object BlockAPI {
   ): F[List[BlockInfoWithoutTuplespace]] = {
 
     val errorMessage =
-      "Could not show blocks, casper instance was not available."
+      "Could not show blocks, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
@@ -306,7 +306,7 @@ object BlockAPI {
   ): F[List[BlockInfoWithoutTuplespace]] = {
 
     val errorMessage =
-      "Could not show main chain, casper instance was not available."
+      "Could not show main chain, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
@@ -330,7 +330,7 @@ object BlockAPI {
   ): F[BlockQueryResponse] = {
 
     val errorMessage =
-      "Could not find bloc with deploy, casper instance was not available."
+      "Could not find block with deploy, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]): F[BlockQueryResponse] =
       for {
@@ -374,7 +374,7 @@ object BlockAPI {
   ): F[BlockQueryResponse] = {
 
     val errorMessage =
-      "Could not show block, casper instance was not available."
+      "Could not show block, casper instance was not available yet."
 
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -39,16 +39,21 @@ object BlockAPI {
              }
       } yield re
 
+    val errorMessage = "Could not deploy, casper instance was not available."
+
     MultiParentCasperRef
       .withCasper[F, DeployServiceResponse](
         casperDeploy(_),
-        DeployServiceResponse(success = false, s"Error: Casper instance not available")
+        Log[F]
+          .warn(errorMessage)
+          .as(DeployServiceResponse(success = false, s"Error: $errorMessage"))
       )
   }
 
   def createBlock[F[_]: Sync: Concurrent: MultiParentCasperRef: Log](
       blockApiLock: Semaphore[F]
-  ): F[DeployServiceResponse] =
+  ): F[DeployServiceResponse] = {
+    val errorMessage = "Could not create block, casper instance was not available."
     MultiParentCasperRef.withCasper[F, DeployServiceResponse](
       casper => {
         Sync[F].bracket(blockApiLock.tryAcquire) {
@@ -74,13 +79,19 @@ object BlockAPI {
           blockApiLock.release
         }
       },
-      default = DeployServiceResponse(success = false, "Error: Casper instance not available")
+      default = Log[F]
+        .warn(errorMessage)
+        .as(DeployServiceResponse(success = false, s"Error: $errorMessage"))
     )
+  }
 
   def getListeningNameDataResponse[F[_]: Concurrent: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int,
       listeningName: Par
   ): F[ListeningNameDataResponse] = {
+
+    val errorMessage = "Could not get listening name data, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         mainChain           <- getMainChainFromTip[F](depth)
@@ -104,7 +115,9 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, ListeningNameDataResponse](
       casperResponse(_),
-      ListeningNameDataResponse(status = "Error: Casper instance not available")
+      Log[F]
+        .warn(errorMessage)
+        .as(ListeningNameDataResponse(status = s"Error: $errorMessage"))
     )
   }
 
@@ -112,6 +125,8 @@ object BlockAPI {
       depth: Int,
       listeningNames: Seq[Par]
   ): F[ListeningNameContinuationResponse] = {
+    val errorMessage =
+      "Could not get listening names confinuation, casper instance was not available."
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         mainChain           <- getMainChainFromTip[F](depth)
@@ -136,7 +151,9 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, ListeningNameContinuationResponse](
       casperResponse(_),
-      ListeningNameContinuationResponse(status = "Error: Casper instance not available")
+      Log[F]
+        .warn(errorMessage)
+        .as(ListeningNameContinuationResponse(status = s"Error: $errorMessage"))
     )
   }
 
@@ -225,6 +242,9 @@ object BlockAPI {
       stringify: G[Graphz[G]] => String
   ): F[String] = {
 
+    val errorMessage =
+      "Could not visualize graph, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]): F[String] =
       for {
         dag                <- MultiParentCasper[F].blockDag
@@ -238,13 +258,17 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, String](
       casperResponse(_),
-      "no casper"
+      Log[F].warn(errorMessage).as(errorMessage)
     )
   }
 
   def showBlocks[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
+
+    val errorMessage =
+      "Could not show blocks, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         dag         <- MultiParentCasper[F].blockDag
@@ -258,7 +282,7 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, List[BlockInfoWithoutTuplespace]](
       casperResponse(_),
-      List.empty[BlockInfoWithoutTuplespace]
+      Log[F].warn(errorMessage).as(List.empty[BlockInfoWithoutTuplespace])
     )
   }
 
@@ -280,6 +304,10 @@ object BlockAPI {
   def showMainChain[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
+
+    val errorMessage =
+      "Could not show main chain, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         dag        <- MultiParentCasper[F].blockDag
@@ -291,7 +319,7 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, List[BlockInfoWithoutTuplespace]](
       casperResponse(_),
-      List.empty[BlockInfoWithoutTuplespace]
+      Log[F].warn(errorMessage).as(List.empty[BlockInfoWithoutTuplespace])
     )
   }
 
@@ -300,6 +328,10 @@ object BlockAPI {
       user: ByteString,
       timestamp: Long
   ): F[BlockQueryResponse] = {
+
+    val errorMessage =
+      "Could not find bloc with deploy, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]): F[BlockQueryResponse] =
       for {
         dag                <- MultiParentCasper[F].blockDag
@@ -322,7 +354,9 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, BlockQueryResponse](
       casperResponse(_),
-      BlockQueryResponse(status = "Error: Casper instance not available")
+      Log[F]
+        .warn(errorMessage)
+        .as(BlockQueryResponse(status = s"Error: errorMessage"))
     )
   }
 
@@ -338,6 +372,10 @@ object BlockAPI {
   def showBlock[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       q: BlockQuery
   ): F[BlockQueryResponse] = {
+
+    val errorMessage =
+      "Could not show block, casper instance was not available."
+
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         dag        <- MultiParentCasper[F].blockDag
@@ -360,7 +398,7 @@ object BlockAPI {
 
     MultiParentCasperRef.withCasper[F, BlockQueryResponse](
       casperResponse(_),
-      BlockQueryResponse(status = "Error: Casper instance not available")
+      Log[F].warn(errorMessage).as(BlockQueryResponse(status = s"Error: $errorMessage"))
     )
   }
 


### PR DESCRIPTION
## Overview
Whole approach of `MultiParentCasperRef` is **at least**
bizzare... Transitions are being made in `PacketHandler`, which sets a
value of a `MultiParentCasperRef`. This does not look as a right
design and should be addressed. In particular, node should be
constantly aware in which state it's in and react accordingly.

For now, in this change, we are giving a visibility **which* method
was used, to trigger `casper not available` output.

We must rememgber that `casper not available` is **not** an
error. This is normal that node might be in transition while receving
different message and command from api. `casper not available` is just
kind remainder to the caller "i'm not ready, yet".

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2855



