### PR TITLE
Removing outdated timeline for Rholang reference README

### DIFF
--- a/rholang/reference_doc/README.md
+++ b/rholang/reference_doc/README.md
@@ -23,12 +23,3 @@ Table of contents are preliminary and subject to change.
 * Rholang's [Formal Symantics](https://github.com/rchain/rchain/tree/dev/rholang/src/main/k/rholang) in K-Framework.
 * A gentler [rholang tutorial](https://github.com/JoshOrndorff/LearnRholangByExample)
 
-## Timeline
-
-Nov 5, 2018: Deadline for brain dump.
-
-Dec 3, 2018: Deadline for polished draft.
-
-Dec 3 - 10, 2018: Public feedback
-
-Dec 17, 2018: Final draft ready for publishing.


### PR DESCRIPTION
## Overview
Removing outdated timeline for Rholang reference README



### JIRA ticket:
NA



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.