### PR TITLE
RCHAIN-2854: Sort insides of EList, ParSet and ParMap

### DIFF
--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -3,8 +3,9 @@ package coop.rchain.models
 import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.testImplicits._
+import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import monix.eval.Coeval
-import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
@@ -70,12 +71,7 @@ class EqualMSpec extends FlatSpec with PropertyChecks with Matchers {
       implicit tag: ClassTag[A]
   ): Unit =
     it must s"provide same results as equals for ${tag.runtimeClass.getSimpleName}" in {
-      val gen = implicitly[Arbitrary[A]].arbitrary
-      forAll(Gen.listOfN(5, gen)) { as: List[A] =>
-        for (x :: y :: Nil <- as.combinations(2)) {
-          sameResultAsReference(x, y)
-        }
-      }
+      forAllSimilarA[A]((x, y) => sameResultAsReference(x, y))
     }
 
   private def sameResultAsReference[A <: Any: EqualM: Pretty](x: A, y: A): Assertion = {

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -75,13 +75,10 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
       forAllSimilarA[A] { (x, y) =>
         val xSorted = sort(x)
         val ySorted = sort(y)
-        if (xSorted.score != ySorted.score || xSorted.term != ySorted.term) {
+        if (xSorted.score != ySorted.score || xSorted.term != ySorted.term)
           assert(x != y)
-        } else if (xSorted.score == ySorted.score && xSorted.term == ySorted.term) {
+        else
           assert(x == y)
-        } else {
-          assert(true)
-        }
       }
 
     import coop.rchain.models.testImplicits._

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -7,9 +7,9 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.SortTest.sort
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sorter._
+import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import monix.eval.Coeval
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 
@@ -50,12 +50,12 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     )
     unsortedTerms.sorted should be(sortedTerms)
   }
-  it should "sort so that whenever scores are unequal then result terms have to be unequal" in {
+  it should "sort so that whenever scores differ then result terms have to differ and the other way around" in {
     def check[A: Sortable: Arbitrary]: Unit =
-      forAll{ (x: A, y: A) =>
-        whenever(sort(x).score != sort(y).score) {
-          assert(sort(x).term != sort(y).term)
-        }
+      forAllSimilarA[A] { (x, y) =>
+        val xSorted = sort(x)
+        val ySorted = sort(y)
+        assert((xSorted.term == ySorted.term) == (xSorted.score == ySorted.score))
       }
 
     import coop.rchain.models.testImplicits._
@@ -69,11 +69,18 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     check[Send]
     check[Var]
   }
-  it should "sort so that whenever scores or result terms are unequal then the initial terms have to be unequal" in {
+
+  it should "sort so that whenever scores or result terms differ then the initial terms differ and the other way around" in {
     def check[A: Sortable: Arbitrary]: Unit =
-      forAll{ (x: A, y: A) =>
-        whenever(sort(x).score != sort(y).score || sort(x).term != sort(y).term) {
+      forAllSimilarA[A] { (x, y) =>
+        val xSorted = sort(x)
+        val ySorted = sort(y)
+        if (xSorted.score != ySorted.score || xSorted.term != ySorted.term) {
           assert(x != y)
+        } else if (xSorted.score == ySorted.score && xSorted.term == ySorted.term) {
+          assert(x == y)
+        } else {
+          assert(true)
         }
       }
 
@@ -90,16 +97,13 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
   }
   it should "sort so that unequal terms have unequal scores and the other way around" in {
     def checkScoreEquality[A: Sortable: Arbitrary]: Unit =
-      // ScalaCheck generates similar A-s in subsequent calls which
-      // we need to hit the case where `x == y` more often
-      forAll(Gen.listOfN(5, arbitrary[A])) { as: List[A] =>
-        for (x :: y :: Nil <- as.combinations(2)) {
+      forAllSimilarA[A](
+        (x, y) =>
           if (x != y)
             assert(sort(x).score != sort(y).score)
           else
             assert(sort(x).score == sort(y).score)
-        }
-      }
+      )
 
     import coop.rchain.models.testImplicits._
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -50,6 +50,44 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     )
     unsortedTerms.sorted should be(sortedTerms)
   }
+  it should "sort so that whenever scores are unequal then result terms have to be unequal" in {
+    def check[A: Sortable: Arbitrary]: Unit =
+      forAll{ (x: A, y: A) =>
+        whenever(sort(x).score != sort(y).score) {
+          assert(sort(x).term != sort(y).term)
+        }
+      }
+
+    import coop.rchain.models.testImplicits._
+    check[Bundle]
+    check[Connective]
+    check[Expr]
+    check[Match]
+    check[New]
+    check[Par]
+    check[Receive]
+    check[Send]
+    check[Var]
+  }
+  it should "sort so that whenever scores or result terms are unequal then the initial terms have to be unequal" in {
+    def check[A: Sortable: Arbitrary]: Unit =
+      forAll{ (x: A, y: A) =>
+        whenever(sort(x).score != sort(y).score || sort(x).term != sort(y).term) {
+          assert(x != y)
+        }
+      }
+
+    import coop.rchain.models.testImplicits._
+    check[Bundle]
+    check[Connective]
+    check[Expr]
+    check[Match]
+    check[New]
+    check[Par]
+    check[Receive]
+    check[Send]
+    check[Var]
+  }
   it should "sort so that unequal terms have unequal scores and the other way around" in {
     def checkScoreEquality[A: Sortable: Arbitrary]: Unit =
       // ScalaCheck generates similar A-s in subsequent calls which

--- a/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
+++ b/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
@@ -2,7 +2,19 @@ package coop.rchain.models.testUtils
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.sorter.Sortable
 import monix.eval.Coeval
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.Assertion
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 
 object TestUtils {
-  def sort(par: Par): Par = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()
+  def forAllSimilarA[A: Arbitrary](block: (A, A) => Assertion): Unit =
+    // ScalaCheck generates similar A-s in subsequent calls which
+    // we need to hit the case where `x == y` more often
+    forAll(Gen.listOfN(5, arbitrary[A])) { as: List[A] =>
+      for (x :: y :: Nil <- as.combinations(2)) {
+        block(x, y)
+      }
+    }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -82,10 +82,10 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree)
   }
-  "List" should "sort elements" in {
+  "List" should "sort the insides of their elements" in {
     assertEqualNormalized("@0!([{1 | 2}])", "@0!([{2 | 1}])")
   }
-  "List" should "sort elements in inner send" in {
+  "List" should "sort the insides of a send encoded as a byte array" in {
     val rho1 =
       """new x in {
         |  x!(
@@ -143,7 +143,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
       ProcNormalizeMatcher.normalizeMatch[Coeval](tuple, inputs).value
     }
   }
-  "Tuple" should "sort elements" in {
+  "Tuple" should "sort the insides of their elements" in {
     assertEqualNormalized("@0!(({1 | 2}))", "@0!(({2 | 1}))")
   }
   "Set" should "delegate" in {
@@ -175,7 +175,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree.newBindings(newBindings)._1)
   }
-  "Set" should "sort elements" in {
+  "Set" should "sort the insides of their elements" in {
     assertEqualNormalized("@0!(Set({1 | 2}))", "@0!(Set({2 | 1}))")
   }
   "Map" should "delegate" in {
@@ -210,7 +210,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree.newBindings(newBindings)._1)
   }
-  "Map" should "sort elements" in {
+  "Map" should "sort the insides of their elements" in {
     assertEqualNormalized("@0!({0 : {1 | 2}})", "@0!({0 : {2 | 1}})")
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -210,7 +210,10 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree.newBindings(newBindings)._1)
   }
-  "Map" should "sort the insides of their elements" in {
+  "Map" should "sort the insides of their keys" in {
+    assertEqualNormalized("@0!({{1 | 2} : 0})", "@0!({{2 | 1} : 0})")
+  }
+  "Map" should "sort the insides of their values" in {
     assertEqualNormalized("@0!({0 : {1 | 2}})", "@0!({0 : {2 | 1}})")
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -59,6 +59,9 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     IndexMapChain[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0))),
     DebruijnLevelMap[VarSort]()
   )
+  def getNormalizedPar(rho: String): Par = Interpreter[Coeval].buildNormalizedTerm(rho).value()
+  def assertEqualNormalized(rho1: String, rho2: String): Assertion =
+    assert(getNormalizedPar(rho1) == getNormalizedPar(rho2))
 
   "List" should "delegate" in {
     val listData = new ListProc()
@@ -79,7 +82,32 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree)
   }
-
+  "List" should "sort elements" in {
+    assertEqualNormalized("@0!([{1 | 2}])", "@0!([{2 | 1}])")
+  }
+  "List" should "sort elements in inner send" in {
+    val rho1 =
+      """new x in {
+        |  x!(
+        |    [
+        |      @"a"!(
+        |        @"x"!("abc") |
+        |        @"y"!(1)
+        |      )
+        |    ].toByteArray()
+        |  )}""".stripMargin
+    val rho2 =
+      """new x in {
+        |  x!(
+        |    [
+        |      @"a"!(
+        |        @"y"!(1) |
+        |        @"x"!("abc")
+        |      )
+        |    ].toByteArray()
+        |  )}""".stripMargin
+    assertEqualNormalized(rho1, rho2)
+  }
   "Tuple" should "delegate" in {
     val tupleData = new ListProc()
     tupleData.add(new PEval(new NameVar("y")))
@@ -115,7 +143,9 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
       ProcNormalizeMatcher.normalizeMatch[Coeval](tuple, inputs).value
     }
   }
-
+  "Tuple" should "sort elements" in {
+    assertEqualNormalized("@0!(({1 | 2}))", "@0!(({2 | 1}))")
+  }
   "Set" should "delegate" in {
     val setData = new ListProc()
     setData.add(new PAdd(new PVar(new ProcVarVar("P")), new PVar(new ProcVarVar("R"))))
@@ -145,7 +175,9 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     )
     result.knownFree should be(inputs.knownFree.newBindings(newBindings)._1)
   }
-
+  "Set" should "sort elements" in {
+    assertEqualNormalized("@0!(Set({1 | 2}))", "@0!(Set({2 | 1}))")
+  }
   "Map" should "delegate" in {
     val mapData = new ListKeyValuePair()
     mapData.add(
@@ -177,6 +209,9 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
       ("Q", NameSort, 0, 0)
     )
     result.knownFree should be(inputs.knownFree.newBindings(newBindings)._1)
+  }
+  "Map" should "sort elements" in {
+    assertEqualNormalized("@0!({0 : {1 | 2}})", "@0!({0 : {2 | 1}})")
   }
 }
 


### PR DESCRIPTION
## Overview
Title says it all.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2854

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
