### PR TITLE
Remove roscala from project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -393,27 +393,6 @@ lazy val rholangProtoBuild = (project in file("rholang-proto-build"))
   )
   .dependsOn(rholang)
 
-lazy val roscalaMacros = (project in file("roscala/macros"))
-  .settings(commonSettings: _*)
-  .settings(
-    libraryDependencies ++= commonDependencies ++ Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    )
-  )
-
-lazy val roscala = (project in file("roscala"))
-  .settings(commonSettings: _*)
-  .settings(
-    name := "Rosette",
-    mainClass in assembly := Some("coop.rchain.rosette.Main"),
-    assemblyJarName in assembly := "rosette.jar",
-    inThisBuild(
-      List(addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
-    ),
-    libraryDependencies ++= commonDependencies
-  )
-  .dependsOn(roscalaMacros)
-
 lazy val blockStorage = (project in file("block-storage"))
   .settings(commonSettings: _*)
   .settings(
@@ -530,7 +509,6 @@ lazy val rchain = (project in file("."))
     regex,
     rholang,
     rholangCLI,
-    roscala,
     rspace,
     rspaceBench,
     shared


### PR DESCRIPTION
## Overview
We don't want to compile and test the roscala project while there is no work being done on it.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2861

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
