### PR TITLE
RCHAIN-2837 linting

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -194,10 +194,6 @@ The [comm](comm) subproject contains code for network related operations for RCh
 
 The [rholang](rholang) subproject contains compiler related code for the Rholang language.
 
-### Rosette
-
-The [rosette](rosette) subproject contains code for a low level virtual machine for RChain.
-
 ### Rspace
 
 The [rspace](rspace) subproject contains code related to the key-value storage of the RChain blockchain.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -194,10 +194,6 @@ The [comm](comm) subproject contains code for network related operations for RCh
 
 The [rholang](rholang) subproject contains compiler related code for the Rholang language.
 
-### Roscala
-
-The [roscala](roscala) subproject contains a Scala translation of the Rosette VM.
-
 ### Rosette
 
 The [rosette](rosette) subproject contains code for a low level virtual machine for RChain.

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -205,7 +205,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
 object FileLMDBIndexBlockStore {
   private val checkpointPattern: Regex = "([0-9]+)-([0-9]+)".r
 
-  case class Config(
+  final case class Config(
       storagePath: Path,
       indexPath: Path,
       checkpointsDirPath: Path,
@@ -215,12 +215,12 @@ object FileLMDBIndexBlockStore {
       noTls: Boolean = true
   )
 
-  private[blockstorage] case class CheckpointIndex(
+  private[blockstorage] final case class CheckpointIndex(
       env: Env[ByteBuffer],
       index: Dbi[ByteBuffer]
   )
 
-  private[blockstorage] case class Checkpoint(
+  private[blockstorage] final case class Checkpoint(
       start: Long,
       end: Long,
       dirPath: Path,

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -123,7 +123,7 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
 
 object LMDBBlockStore {
 
-  case class Config(
+  final case class Config(
       path: Path,
       mapSize: Long,
       maxDbs: Int = 1,

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,16 @@ lazy val projectSettings = Seq(
     Resolver.sonatypeRepo("snapshots"),
     "jitpack" at "https://jitpack.io"
   ),
+  wartremoverExcluded += sourceManaged.value,
+  wartremoverErrors in (Compile, compile) ++= Warts.allBut(
+    Wart.ImplicitParameter, Wart.Recursion, Wart.DefaultArguments, Wart.ImplicitConversion,
+    Wart.LeakingSealed, Wart.Overloading, Wart.Nothing, Wart.NonUnitStatements,
+    Wart.Equals, Wart.PublicInference, Wart.Var, Wart.TraversableOps, Wart.ArrayEquals,
+    Wart.Throw, Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,
+    Wart.EitherProjectionPartial, Wart.Option2Iterable, Wart.ToString, Wart.JavaConversions,
+    Wart.MutableDataStructures, Wart.FinalVal, Wart.Null, Wart.AsInstanceOf, Wart.ExplicitImplicitTypes,
+    Wart.StringPlusAny, Wart.AnyVal
+  ),
   scalafmtOnCompile := sys.env.get("CI").isEmpty, // disable in CI environments
   scapegoatVersion in ThisBuild := "1.3.4",
   testOptions in Test += Tests.Argument("-oD"), //output test durations

--- a/build.sbt
+++ b/build.sbt
@@ -393,27 +393,6 @@ lazy val rholangProtoBuild = (project in file("rholang-proto-build"))
   )
   .dependsOn(rholang)
 
-lazy val roscalaMacros = (project in file("roscala/macros"))
-  .settings(commonSettings: _*)
-  .settings(
-    libraryDependencies ++= commonDependencies ++ Seq(
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value
-    )
-  )
-
-lazy val roscala = (project in file("roscala"))
-  .settings(commonSettings: _*)
-  .settings(
-    name := "Rosette",
-    mainClass in assembly := Some("coop.rchain.rosette.Main"),
-    assemblyJarName in assembly := "rosette.jar",
-    inThisBuild(
-      List(addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
-    ),
-    libraryDependencies ++= commonDependencies
-  )
-  .dependsOn(roscalaMacros)
-
 lazy val blockStorage = (project in file("block-storage"))
   .settings(commonSettings: _*)
   .settings(
@@ -530,7 +509,6 @@ lazy val rchain = (project in file("."))
     regex,
     rholang,
     rholangCLI,
-    roscala,
     rspace,
     rspaceBench,
     shared

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -4,10 +4,10 @@ sealed trait BlockStatus {
   val inDag: Boolean
 }
 
-case object Processing extends BlockStatus {
+final case object Processing extends BlockStatus {
   override val inDag: Boolean = false
 }
-case class BlockException(ex: Throwable) extends BlockStatus {
+final case class BlockException(ex: Throwable) extends BlockStatus {
   override val inDag: Boolean = false
 }
 
@@ -19,32 +19,32 @@ sealed trait InvalidBlock extends BlockStatus {
 }
 sealed trait Slashable
 
-case object Valid extends ValidBlock
+final case object Valid extends ValidBlock
 
 // AdmissibleEquivocation are blocks that would create an equivocation but are
 // pulled in through a justification of another block
-case object AdmissibleEquivocation extends InvalidBlock with Slashable
+final case object AdmissibleEquivocation extends InvalidBlock with Slashable
 // TODO: Make IgnorableEquivocation slashable again and remember to add an entry to the equivocation record.
 // For now we won't eagerly slash equivocations that we can just ignore,
 // as we aren't forced to add it to our view as a dependency.
 // TODO: The above will become a DOS vector if we don't fix.
-case object IgnorableEquivocation   extends InvalidBlock
-case object InvalidUnslashableBlock extends InvalidBlock
-case object MissingBlocks           extends InvalidBlock
+final case object IgnorableEquivocation   extends InvalidBlock
+final case object InvalidUnslashableBlock extends InvalidBlock
+final case object MissingBlocks           extends InvalidBlock
 
-case object InvalidBlockNumber      extends InvalidBlock with Slashable
-case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
-case object InvalidParents          extends InvalidBlock with Slashable
-case object InvalidFollows          extends InvalidBlock with Slashable
-case object InvalidSequenceNumber   extends InvalidBlock with Slashable
-case object InvalidShardId          extends InvalidBlock with Slashable
-case object JustificationRegression extends InvalidBlock with Slashable
-case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
-case object NeglectedEquivocation   extends InvalidBlock with Slashable
-case object InvalidTransaction      extends InvalidBlock with Slashable
-case object InvalidBondsCache       extends InvalidBlock with Slashable
-case object InvalidBlockHash        extends InvalidBlock with Slashable
-case object InvalidDeployCount      extends InvalidBlock with Slashable
+final case object InvalidBlockNumber      extends InvalidBlock with Slashable
+final case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
+final case object InvalidParents          extends InvalidBlock with Slashable
+final case object InvalidFollows          extends InvalidBlock with Slashable
+final case object InvalidSequenceNumber   extends InvalidBlock with Slashable
+final case object InvalidShardId          extends InvalidBlock with Slashable
+final case object JustificationRegression extends InvalidBlock with Slashable
+final case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
+final case object NeglectedEquivocation   extends InvalidBlock with Slashable
+final case object InvalidTransaction      extends InvalidBlock with Slashable
+final case object InvalidBondsCache       extends InvalidBlock with Slashable
+final case object InvalidBlockHash        extends InvalidBlock with Slashable
+final case object InvalidDeployCount      extends InvalidBlock with Slashable
 
 object BlockStatus {
   def valid: BlockStatus                    = Valid

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-case class CasperConf(
+final case class CasperConf(
     publicKeyBase16: Option[String],
     privateKey: Option[Either[String, Path]],
     sigAlgorithm: String,

--- a/casper/src/main/scala/coop/rchain/casper/CreateBlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CreateBlockStatus.scala
@@ -10,15 +10,15 @@ sealed trait CreateBlockStatus {
     Applicative[F].pure[CreateBlockStatus](this)
 }
 sealed trait NoBlock extends CreateBlockStatus
-case class Created(block: BlockMessage) extends CreateBlockStatus {
+final case class Created(block: BlockMessage) extends CreateBlockStatus {
   override def map(f: BlockMessage => BlockMessage): CreateBlockStatus = Created(f(block))
   override def mapF[F[_]: Applicative](f: BlockMessage => F[BlockMessage]): F[CreateBlockStatus] =
     f(block).map(Created.apply)
 }
-case class InternalDeployError(ex: Throwable) extends NoBlock
-case object ReadOnlyMode                      extends NoBlock
-case object LockUnavailable                   extends NoBlock
-case object NoNewDeploys                      extends NoBlock
+final case class InternalDeployError(ex: Throwable) extends NoBlock
+final case object ReadOnlyMode                      extends NoBlock
+final case object LockUnavailable                   extends NoBlock
+final case object NoNewDeploys                      extends NoBlock
 
 object CreateBlockStatus {
   def created(block: BlockMessage): CreateBlockStatus       = Created(block)

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -43,12 +43,12 @@ import coop.rchain.shared.{Cell, Log, LogSource}
   * to detect the equivocation corresponding to the "equivocation record".
   */
 sealed trait EquivocationDiscoveryStatus
-case object EquivocationNeglected extends EquivocationDiscoveryStatus
-case object EquivocationDetected  extends EquivocationDiscoveryStatus
-case object EquivocationOblivious extends EquivocationDiscoveryStatus
+final case object EquivocationNeglected extends EquivocationDiscoveryStatus
+final case object EquivocationDetected  extends EquivocationDiscoveryStatus
+final case object EquivocationOblivious extends EquivocationDiscoveryStatus
 
 // This is the sequence number of the equivocator's base block
-case class EquivocationRecord(
+final case class EquivocationRecord(
     equivocator: Validator,
     equivocationBaseBlockSeqNum: SequenceNumber,
     equivocationDetectedBlockHashes: Set[BlockHash]

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -28,7 +28,7 @@ import coop.rchain.shared._
   @param invalidBlockTracker
   @param equivocationsTracker: Used to keep track of when other validators detect the equivocation consisting of the base block at the sequence number identified by the (validator, base equivocation sequence number) pair of each EquivocationRecord.
   */
-case class CasperState(
+final case class CasperState(
     blockBuffer: Set[BlockMessage] = Set.empty[BlockMessage],
     deployHistory: Set[Deploy] = Set.empty[Deploy],
     invalidBlockTracker: Set[BlockHash] = Set.empty[BlockHash],

--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -18,7 +18,7 @@ import coop.rchain.shared.{Log, LogSource}
 
 import scala.language.higherKinds
 
-case class ValidatorIdentity(
+final case class ValidatorIdentity(
     publicKey: Array[Byte],
     privateKey: Array[Byte],
     sigAlgorithm: String

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -14,7 +14,7 @@ import cats.mtl.implicits._
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.ski._
 
-case class ValidatorBlock(
+final case class ValidatorBlock(
     blockHash: String,
     parentsHashes: List[String],
     justifications: List[String]
@@ -32,13 +32,13 @@ object ValidatorBlock {
   }
 }
 
-case class GraphConfig(showJustificationLines: Boolean = false)
+final case class GraphConfig(showJustificationLines: Boolean = false)
 
 object GraphzGenerator {
 
   type ValidatorsBlocks = Map[Long, ValidatorBlock]
 
-  case class DagInfo[G[_]](
+  final case class DagInfo[G[_]](
       validators: Map[String, ValidatorsBlocks] = Map.empty,
       timeseries: List[Long] = List.empty
   )

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/PreWallet.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/PreWallet.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.genesis.contracts
 
 import scala.util.{Failure, Success, Try}
 
-case class PreWallet(ethAddress: String, initRevBalance: BigInt)
+final case class PreWallet(ethAddress: String, initRevBalance: BigInt)
 
 object PreWallet {
 

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -4,9 +4,9 @@ import coop.rchain.casper.util.Sorting
 import coop.rchain.crypto.codec.Base16
 
 //TODO: include other fields relevent to PoS (e.g. rewards channel)
-case class ProofOfStakeValidator(id: Array[Byte], stake: Long)
+final case class ProofOfStakeValidator(id: Array[Byte], stake: Long)
 
-case class ProofOfStakeParams(
+final case class ProofOfStakeParams(
     minimumBond: Long,
     maximumBond: Long,
     validators: Seq[ProofOfStakeValidator]

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Wallet.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Wallet.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.genesis.contracts
 
 import scala.util.{Failure, Success, Try}
 
-case class Wallet(algorithm: String, pk: String, initRevBalance: Int)
+final case class Wallet(algorithm: String, pk: String, initRevBalance: Int)
 
 object Wallet {
   def rhoPublicName(w: Wallet): String = s"@`rho:pubkey:${w.algorithm}:${w.pk}`"

--- a/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
@@ -9,7 +9,7 @@ trait DoublyLinkedDag[A] {
   val childToParentAdjacencyList: Map[A, Set[A]]
   val dependencyFree: Set[A]
 }
-case class BlockDependencyDag(
+final case class BlockDependencyDag(
     parentToChildAdjacencyList: Map[BlockHash, Set[BlockHash]],
     childToParentAdjacencyList: Map[BlockHash, Set[BlockHash]],
     dependencyFree: Set[BlockHash]

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/ProcessedDeployUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/ProcessedDeployUtil.scala
@@ -5,7 +5,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.models.PCost
 import coop.rchain.rspace.trace
 
-case class InternalProcessedDeploy(
+final case class InternalProcessedDeploy(
     deploy: Deploy,
     cost: PCost,
     log: Seq[trace.Event],

--- a/comm/src/main/scala/coop/rchain/comm/CachedConnections.scala
+++ b/comm/src/main/scala/coop/rchain/comm/CachedConnections.scala
@@ -55,7 +55,7 @@ object Transport {
   type TransportCell[F[_]] = Cell[F, TransportState]
 }
 
-case class TransportState(
+final case class TransportState(
     connections: Transport.Connections = Map.empty,
     server: Option[Cancelable] = None,
     clientQueue: Option[Cancelable] = None,

--- a/comm/src/main/scala/coop/rchain/comm/UPnP.scala
+++ b/comm/src/main/scala/coop/rchain/comm/UPnP.scala
@@ -223,7 +223,7 @@ object UPnP {
     }
 }
 
-case class UPnPDevices(
+final case class UPnPDevices(
     all: Map[InetAddress, GatewayDevice],
     gateways: Seq[GatewayDevice],
     validGateway: Option[GatewayDevice]

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -4,10 +4,10 @@ import scala.concurrent.duration._
 
 import coop.rchain.comm.PeerNode
 
-case class RPConf(
+final case class RPConf(
     local: PeerNode,
     bootstrap: Option[PeerNode],
     defaultTimeout: FiniteDuration,
     clearConnections: ClearConnetionsConf
 )
-case class ClearConnetionsConf(maxNumOfConnections: Int, numOfConnectionsPinged: Int)
+final case class ClearConnetionsConf(maxNumOfConnections: Int, numOfConnectionsPinged: Int)

--- a/comm/src/main/scala/coop/rchain/comm/transport/CommunicationResponse.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/CommunicationResponse.scala
@@ -4,9 +4,9 @@ import coop.rchain.comm.protocol.routing.Protocol
 import coop.rchain.comm.CommError
 
 sealed trait CommunicationResponse
-case class HandledWithMessage(pm: Protocol) extends CommunicationResponse
-case object HandledWitoutMessage            extends CommunicationResponse
-case class NotHandled(error: CommError)     extends CommunicationResponse
+final case class HandledWithMessage(pm: Protocol) extends CommunicationResponse
+final case object HandledWitoutMessage            extends CommunicationResponse
+final case class NotHandled(error: CommError)     extends CommunicationResponse
 
 object CommunicationResponse {
   def handledWithMessage(protocol: Protocol): CommunicationResponse = HandledWithMessage(protocol)

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -49,7 +49,7 @@ object PacketOps {
       } yield resErr
   }
 
-  case class PacketFile(file: Path, fos: FileOutputStream)
+  final case class PacketFile(file: Path, fos: FileOutputStream)
 
   def createPacketFile[F[_]: Sync](folder: Path, postfix: String): F[PacketFile] =
     for {

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -26,7 +26,7 @@ object StreamHandler {
 
   type CircuitBreaker = Long => Boolean
 
-  private case class Streamed(
+  private final case class Streamed(
       sender: Option[PeerNode] = None,
       typeId: Option[String] = None,
       contentLength: Option[Int] = None,
@@ -86,8 +86,8 @@ object StreamHandler {
     EitherT(collectStream.attempt >>= {
       case Right(stmd) if stmd.circuitBroken =>
         stmd.path.deleteSingleFile[Task].as(Left(new RuntimeException("Circuit was broken")))
-      case res @ Left(ex) => init.path.deleteSingleFile[Task].as(res)
-      case res            => res.pure[Task]
+      case res @ Left(_) => init.path.deleteSingleFile[Task].as(res)
+      case res           => res.pure[Task]
     })
 
   }

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
@@ -13,7 +13,7 @@ import java.nio.file._
 import scala.concurrent.duration._
 import coop.rchain.catscontrib.Catscontrib._
 
-case class StreamToPeers(peers: Seq[PeerNode], path: Path, sender: PeerNode)
+final case class StreamToPeers(peers: Seq[PeerNode], path: Path, sender: PeerNode)
 
 class StreamObservable(bufferSize: Int, folder: Path)(implicit log: Log[Task], scheduler: Scheduler)
     extends Observable[StreamToPeers] {

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -83,7 +83,7 @@ class TcpServerObservable(
 
         (StreamHandler.handleStream(tempFolder, observable, neverBreak) >>= {
           case Left(ex)   => logger.error(s"Could not receive stream! Details: ${ex.getMessage}", ex)
-          case Right(msg) => Task.delay(bufferBlobMessage.pushNext(msg))
+          case Right(msg) => Task.delay(bufferBlobMessage.pushNext(msg)).as(())
         }).as(ChunkResponse())
 
       }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -131,12 +131,14 @@ class TcpTransportLayer(
   def stream(peers: Seq[PeerNode], blob: Blob): Task[Unit] =
     streamObservable.stream(peers.toList, blob) *> log.info(s"stream to $peers blob")
 
+  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
   private object PeerUnavailable {
     def unapply(e: Throwable): Boolean =
       e.isInstanceOf[StatusRuntimeException] &&
         e.asInstanceOf[StatusRuntimeException].getStatus.getCode == Status.Code.UNAVAILABLE
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
   private object PeerTimeout {
     def unapply(e: Throwable): Boolean = e.isInstanceOf[TimeoutException]
   }

--- a/comm/src/main/scala/coop/rchain/comm/transport/Tls.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/Tls.scala
@@ -2,7 +2,7 @@ package coop.rchain.comm.transport
 
 import java.nio.file.Path
 
-case class Tls(
+final case class Tls(
     certificate: Path,
     key: Path,
     customCertificateLocation: Boolean,

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -8,7 +8,7 @@ import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.shared._
 import coop.rchain.comm.protocol.routing._
 
-case class Blob(sender: PeerNode, packet: Packet)
+final case class Blob(sender: PeerNode, packet: Packet)
 
 trait TransportLayer[F[_]] {
   def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]]

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
@@ -21,6 +21,7 @@ abstract class ConcurrentQueue[A] {
   def drain(buffer: mutable.Buffer[A], limit: Int): Unit
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Return"))
 object ConcurrentQueue {
   final val recommendedSize: Int = 1024
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/LimitedBuffer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/LimitedBuffer.scala
@@ -21,6 +21,7 @@ trait LimitedBuffer[A] {
   def complete(): Unit
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Return"))
 private final class DropNewBuffer[A](out: Subscriber[A], bufferSize: Int) extends LimitedBuffer[A] {
 
   require(bufferSize > 0, "bufferSize must be a strictly positive number")

--- a/crypto/src/main/scala/coop/rchain/crypto/keys.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/keys.scala
@@ -1,5 +1,5 @@
 package coop.rchain.crypto
 
-case class PublicKey(bytes: Array[Byte])
+final case class PublicKey(bytes: Array[Byte])
 
-case class PrivateKey(bytes: Array[Byte])
+final case class PrivateKey(bytes: Array[Byte])

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -22,6 +22,7 @@ object Secp256k1 {
     * @return (private key, public key) pair
     *
     */
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def newKeyPair: (PrivateKey, PublicKey) = {
     val kpg = KeyPairGenerator.getInstance("ECDSA", provider)
     kpg.initialize(new ECGenParameterSpec(curveName), SecureRandomUtil.secureRandomNonBlocking)

--- a/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
@@ -48,12 +48,14 @@ object CertificateHelper {
   def from(certFilePath: String): X509Certificate =
     fromFile(new File(certFilePath))
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def fromFile(certFile: File): X509Certificate = {
     val cf = CertificateFactory.getInstance("X.509")
     val is = new FileInputStream(certFile)
     cf.generateCertificate(is).asInstanceOf[X509Certificate]
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def readKeyPair(keyFile: File): KeyPair = {
     import coop.rchain.shared.Resources._
     val str = withResource(Source.fromFile(keyFile)) {
@@ -79,6 +81,7 @@ object CertificateHelper {
     kpg.generateKeyPair
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def generate(keyPair: KeyPair): X509Certificate = {
     import sun.security.x509._
 
@@ -117,7 +120,7 @@ object CertificateHelper {
 
 }
 
-case class ParameterSpec(
+final case class ParameterSpec(
     curve: EllipticCurve,
     generator: ECPoint,
     order: BigInt,

--- a/models/src/main/scala/coop/rchain/models/ParMap.scala
+++ b/models/src/main/scala/coop/rchain/models/ParMap.scala
@@ -7,7 +7,7 @@ import monix.eval.Coeval
 import scala.collection.immutable.BitSet
 import coop.rchain.models.rholang.implicits._
 
-case class ParMap(
+final case class ParMap(
     ps: SortedParMap,
     connectiveUsed: Boolean,
     locallyFree: Coeval[BitSet],

--- a/models/src/main/scala/coop/rchain/models/ParSet.scala
+++ b/models/src/main/scala/coop/rchain/models/ParSet.scala
@@ -7,7 +7,7 @@ import monix.eval.Coeval
 import scala.collection.immutable.BitSet
 
 //locallyFree is of type Coeval to make use of memoization
-case class ParSet(
+final case class ParSet(
     ps: SortedParHashSet,
     connectiveUsed: Boolean,
     locallyFree: Coeval[BitSet],

--- a/node/src/main/scala/coop/rchain/node/StatusInfo.scala
+++ b/node/src/main/scala/coop/rchain/node/StatusInfo.scala
@@ -10,7 +10,7 @@ import org.http4s.HttpRoutes
 
 object StatusInfo {
 
-  case class Status(
+  final case class Status(
       version: String,
       peers: Int,
       nodes: Int

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -505,4 +505,4 @@ final class Configuration(
   def printHelp(): Task[Unit] = Task.delay(options.printHelp())
 }
 
-case class Profile(name: String, dataDir: (() => Path, String))
+final case class Profile(name: String, dataDir: (() => Path, String))

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -6,7 +6,7 @@ import coop.rchain.casper.util.comm.ListenAtName.Name
 import coop.rchain.comm.PeerNode
 import coop.rchain.shared.StoreType
 
-case class Server(
+final case class Server(
     host: Option[String],
     port: Int,
     httpPort: Int,
@@ -24,13 +24,13 @@ case class Server(
     maxMessageSize: Int
 )
 
-case class GrpcServer(
+final case class GrpcServer(
     host: String,
     portExternal: Int,
     portInternal: Int
 )
 
-case class Tls(
+final case class Tls(
     certificate: Path,
     key: Path,
     customCertificateLocation: Boolean,
@@ -38,14 +38,14 @@ case class Tls(
     secureRandomNonBlocking: Boolean
 )
 
-case class Kamon(
+final case class Kamon(
     prometheus: Boolean,
     influxDb: Option[InfluxDb],
     zipkin: Boolean,
     sigar: Boolean
 )
 
-case class InfluxDb(
+final case class InfluxDb(
     hostname: String,
     port: Int,
     database: String,
@@ -53,39 +53,39 @@ case class InfluxDb(
     authentication: Option[InfluxDBAuthentication]
 )
 
-case class InfluxDBAuthentication(
+final case class InfluxDBAuthentication(
     user: String,
     password: String
 )
 
 sealed trait Command
-case class Eval(files: List[String]) extends Command
-case object Repl                     extends Command
-case object Diagnostics              extends Command
-case class Deploy(
+final case class Eval(files: List[String]) extends Command
+final case object Repl                     extends Command
+final case object Diagnostics              extends Command
+final case class Deploy(
     address: String,
     phloLimit: Long,
     phloPrice: Long,
     nonce: Int,
     location: String
 ) extends Command
-case object DeployDemo                                               extends Command
-case object Propose                                                  extends Command
-case class ShowBlock(hash: String)                                   extends Command
-case class ShowBlocks(depth: Int)                                    extends Command
-case class VisualizeDag(depth: Int, showJustificationLines: Boolean) extends Command
-case object Run                                                      extends Command
-case object Help                                                     extends Command
-case class DataAtName(name: Name)                                    extends Command
-case class ContAtName(names: List[Name])                             extends Command
-case class BondingDeployGen(
+final case object DeployDemo                                               extends Command
+final case object Propose                                                  extends Command
+final case class ShowBlock(hash: String)                                   extends Command
+final case class ShowBlocks(depth: Int)                                    extends Command
+final case class VisualizeDag(depth: Int, showJustificationLines: Boolean) extends Command
+final case object Run                                                      extends Command
+final case object Help                                                     extends Command
+final case class DataAtName(name: Name)                                    extends Command
+final case class ContAtName(names: List[Name])                             extends Command
+final case class BondingDeployGen(
     bondKey: String,
     ethAddress: String,
     amount: Long,
     secKey: String,
     pubKey: String
 ) extends Command
-case class FaucetBondingDeployGen(
+final case class FaucetBondingDeployGen(
     amount: Long,
     sigAlgorithm: String,
     secKey: String,

--- a/node/src/main/scala/coop/rchain/node/configuration/toml/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/toml/model.scala
@@ -6,7 +6,7 @@ import coop.rchain.comm.PeerNode
 
 import scala.concurrent.duration.FiniteDuration
 
-case class Configuration(
+final case class Configuration(
     server: Option[Server],
     grpcServer: Option[GrpcServer],
     tls: Option[Tls],
@@ -15,7 +15,7 @@ case class Configuration(
     influxDb: Option[InfluxDb]
 )
 
-case class Server(
+final case class Server(
     host: Option[String],
     port: Option[Int],
     httpPort: Option[Int],
@@ -35,18 +35,18 @@ case class Server(
     threadPoolSize: Option[Int]
 )
 
-case class GrpcServer(
+final case class GrpcServer(
     host: Option[String],
     port: Option[Int],
     portInternal: Option[Int]
 )
 
-case class Tls(
+final case class Tls(
     certificate: Option[Path],
     key: Option[Path]
 )
 
-case class Validators(
+final case class Validators(
     count: Option[Int],
     bondsFile: Option[String],
     known: Option[String],
@@ -65,14 +65,14 @@ case class Validators(
     deployTimestamp: Option[Long]
 )
 
-case class Kamon(
+final case class Kamon(
     prometheus: Option[Boolean],
     influxDb: Option[Boolean],
     zipkin: Option[Boolean],
     sigar: Option[Boolean]
 )
 
-case class InfluxDb(
+final case class InfluxDb(
     hostname: Option[String],
     port: Option[Int],
     database: Option[String],
@@ -80,7 +80,7 @@ case class InfluxDb(
     authentication: Option[InfluxDbAuthentication]
 )
 
-case class InfluxDbAuthentication(
+final case class InfluxDbAuthentication(
     user: String,
     password: String
 )

--- a/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
@@ -47,7 +47,7 @@ class NewPrometheusReporter extends MetricReporter {
   */
 object NewPrometheusReporter {
 
-  case class Configuration(
+  final case class Configuration(
       startEmbeddedServer: Boolean,
       embeddedServerHostname: String,
       embeddedServerPort: Int,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 addSbtPlugin("com.typesafe.sbt"       % "sbt-license-report"    % "1.2.0")
+addSbtPlugin("org.wartremover"        % "sbt-wartremover"       % "2.3.7")
 addSbtPlugin("com.geirsson"           %  "sbt-scalafmt"         % "1.6.0-RC4")
 addSbtPlugin("com.eed3si9n"           %  "sbt-assembly"         % "0.14.9")
 addSbtPlugin("org.scoverage"          %  "sbt-scoverage"        % "1.5.1")

--- a/regex/src/main/scala/coop/rchain/regex/Fsm.scala
+++ b/regex/src/main/scala/coop/rchain/regex/Fsm.scala
@@ -244,7 +244,7 @@ object Fsm {
   * closure), intersected, and simplified.
   * The majority of these methods are available using operator overloads.
   */
-case class Fsm(
+final case class Fsm(
     alphabet: Set[Char],
     states: Set[Int],
     initialState: Int,
@@ -285,6 +285,7 @@ case class Fsm(
   /**
     * A state is "live" if a final state can be reached from it.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def isLive(state: Int): Boolean = {
     val reachable = mutable.Queue(state)
     val checked   = mutable.Set(state)
@@ -319,6 +320,7 @@ case class Fsm(
     * If `Fsm.AnythingElse` is in your alphabet, then any symbol not in your
     * alphabet will be converted to `Fsm.AnythingElse`
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def accepts(input: String): Boolean = {
     var currentState = initialState
     for (currentSymbol <- input) {
@@ -346,6 +348,7 @@ case class Fsm(
     * If you fall into oblivion, then the derivative is an FSM accepting no
     * strings.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def derive(input: String): Try[Fsm] = {
     var currentState = initialState
     for (currentSymbol <- input) {
@@ -573,6 +576,7 @@ case class Fsm(
     * Consider the FSM as a set of strings and return the cardinality of thatset
     * - Some[Int], or None if there are infinitely many
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def cardinality: Option[Int] = {
     val stateToCount = mutable.Map[Int, Option[Int]]()
     //no tail recursion here

--- a/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
+++ b/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
@@ -18,7 +18,7 @@ private[regex] trait RegexOptions extends ParseOptions {
   val endsWith: List[String]
 }
 
-case class PathRegexOptions(
+final case class PathRegexOptions(
     caseSensitive: Boolean = false,
     strict: Boolean = false,
     end: Boolean = true,
@@ -37,7 +37,7 @@ object PathRegexOptions {
   val nonEnd        = PathRegexOptions(end = false)
 }
 
-private[regex] case class PathToken(
+private[regex] final case class PathToken(
     name: Option[String],
     key: Int,
     prefix: Option[Char],
@@ -123,7 +123,7 @@ private[regex] object PathToken {
     new PathToken(None, -1, None, None, false, false, false, None, Some(substring))
 }
 
-case class PathRegex(tokens: List[PathToken], options: RegexOptions) {
+final case class PathRegex(tokens: List[PathToken], options: RegexOptions) {
   def withOptions(newOptions: RegexOptions): PathRegex = new PathRegex(tokens, newOptions)
 
   /**
@@ -252,7 +252,7 @@ object PathRegex {
   private[this] val rxPath =
     """(\\.)|(?:\:(\w+)(?:\(((?:\\.|[^\\()])+)\))?|\(((?:\\.|[^\\()])+)\))([+*?])?""".r
 
-  private[this] case class ParseState(
+  private[this] final case class ParseState(
       subStr: String,
       rawPathPart: String,
       tokens: List[PathToken],

--- a/regex/src/main/scala/coop/rchain/regex/RegexPattern.scala
+++ b/regex/src/main/scala/coop/rchain/regex/RegexPattern.scala
@@ -187,6 +187,7 @@ sealed abstract class RegexPattern {
 }
 
 //we need 3 states to handle case [a-b-z], that means Set(a,b,-,z)
+@SuppressWarnings(Array("org.wartremover.warts.Enumeration"))
 private[regex] object RangeState extends Enumeration {
   val firstSymbol, notStarted, inside, justFinished = Value
 }
@@ -298,7 +299,7 @@ object CharClassPattern extends ParsedPattern {
         None
       }
 
-    case class ParseState(
+    final case class ParseState(
         collectedChars: List[Char],
         collectedUnionClasses: List[CharClassPattern],
         rangeState: RangeState.Value

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import scala.collection.immutable.Map
 
-case class Env[A] private (envMap: Map[Int, A], level: Int, shift: Int) {
+final case class Env[A] private (envMap: Map[Int, A], level: Int, shift: Int) {
   def put(a: A): Env[A] =
     Env(envMap + (level -> a), level + 1, shift)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -24,7 +24,7 @@ object PrettyPrinter {
     def cap() = Printer.OUTPUT_CAPPED.map(n => s"${str.take(n)}...").getOrElse(str)
   }
 }
-case class PrettyPrinter(
+final case class PrettyPrinter(
     freeShift: Int,
     boundShift: Int,
     newsShiftIndices: Vector[Int],

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -562,7 +562,7 @@ class RegistryImpl[F[_]](
       val Some(Expr(ETupleBody(ETuple(Seq(newNonce, _), _, _)))) = replacement.singleExpr
       val Some(Expr(GInt(oldNonceInt)))                          = oldNonce.singleExpr
       val Some(Expr(GInt(newNonceInt)))                          = newNonce.singleExpr
-      return newNonceInt > oldNonceInt
+      newNonceInt > oldNonceInt
     }
     genericInsertCallback(args, nonceCheck, fetchDataNonceInsert, sequenceNumber)
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -96,6 +96,7 @@ object RholangCLI {
     }
 
   @tailrec
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def repl(runtime: Runtime[Task])(implicit scheduler: Scheduler): Unit = {
     printPrompt()
     Option(scala.io.StdIn.readLine()) match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -199,7 +199,7 @@ object Runtime {
     }.sequence
 
   object SystemProcess {
-    case class Context[F[_]: Sync](
+    final case class Context[F[_]: Sync](
         space: RhoISpace[F],
         dispatcher: RhoDispatch[F],
         registry: Registry[F],
@@ -209,7 +209,7 @@ object Runtime {
       val systemProcesses = SystemProcesses[F](dispatcher, space)
     }
 
-    case class Definition[F[_]](
+    final case class Definition[F[_]](
         urn: String,
         fixedChannel: Name,
         arity: Arity,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccount.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccount.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter.accounting
 import cats.Monoid
 import coop.rchain.models.PCost
 
-case class CostAccount(idx: Int, cost: Cost) {
+final case class CostAccount(idx: Int, cost: Cost) {
   def +(other: Cost): CostAccount =
     copy(idx + 1, cost + other)
   def +(other: CostAccount): CostAccount =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -298,8 +298,8 @@ object SpatialMatcher extends SpatialMatcherInstances {
   )(implicit lf: HasLocallyFree[T], sm: SpatialMatcher[T, T]): F[Unit] = {
 
     sealed trait Pattern
-    case class Term(term: T)         extends Pattern
-    case class Remainder(level: Int) extends Pattern
+    final case class Term(term: T)         extends Pattern
+    final case class Remainder(level: Int) extends Pattern
 
     val remainderPatterns: Seq[Pattern] = remainder.fold(
       Seq.empty[Pattern]
@@ -397,7 +397,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
       _                   <- freeMap.modify(_ + (level -> remainderParUpdated))
     } yield Unit
 
-  case class ParCount(
+  final case class ParCount(
       sends: Int = 0,
       receives: Int = 0,
       news: Int = 0,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
@@ -27,8 +27,8 @@ final case class StreamT[F[_], A](next: F[Step[F, A]])
 object StreamT extends StreamTInstances0 {
 
   sealed trait Step[F[_], A]
-  case class SNil[F[_], A]()                              extends Step[F, A]
-  case class SCons[F[_], A](head: A, tail: StreamT[F, A]) extends Step[F, A]
+  final case class SNil[F[_], A]()                              extends Step[F, A]
+  final case class SCons[F[_], A](head: A, tail: StreamT[F, A]) extends Step[F, A]
 
   def empty[F[_]: Applicative, A]: StreamT[F, A] =
     StreamT[F, A](Applicative[F].pure(SNil()))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -1082,16 +1082,19 @@ object ProcNormalizeMatcher {
   * @param env
   * @param knownFree
   */
-case class ProcVisitInputs(
+final case class ProcVisitInputs(
     par: Par,
     env: IndexMapChain[VarSort],
     knownFree: DebruijnLevelMap[VarSort]
 )
 // Returns the update Par and an updated map of free variables.
-case class ProcVisitOutputs(par: Par, knownFree: DebruijnLevelMap[VarSort])
+final case class ProcVisitOutputs(par: Par, knownFree: DebruijnLevelMap[VarSort])
 
-case class NameVisitInputs(env: IndexMapChain[VarSort], knownFree: DebruijnLevelMap[VarSort])
-case class NameVisitOutputs(chan: Par, knownFree: DebruijnLevelMap[VarSort])
+final case class NameVisitInputs(env: IndexMapChain[VarSort], knownFree: DebruijnLevelMap[VarSort])
+final case class NameVisitOutputs(chan: Par, knownFree: DebruijnLevelMap[VarSort])
 
-case class CollectVisitInputs(env: IndexMapChain[VarSort], knownFree: DebruijnLevelMap[VarSort])
-case class CollectVisitOutputs(expr: Expr, knownFree: DebruijnLevelMap[VarSort])
+final case class CollectVisitInputs(
+    env: IndexMapChain[VarSort],
+    knownFree: DebruijnLevelMap[VarSort]
+)
+final case class CollectVisitOutputs(expr: Expr, knownFree: DebruijnLevelMap[VarSort])

--- a/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
@@ -1,3 +1,3 @@
 package coop.rchain.rspace
 
-case class Checkpoint(root: Blake2b256Hash, log: trace.Log)
+final case class Checkpoint(root: Blake2b256Hash, log: trace.Log)

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace
 import scala.concurrent.SyncVar
+import cats._, cats.data._, cats.implicits._
 
 trait InMemTransaction[S] {
   def commit(): Unit
@@ -43,7 +44,7 @@ trait InMemoryOps[S] extends CloseOps {
 
     new InMemTransaction[S] {
 
-      val name: String = "read-" + Thread.currentThread().getId
+      val name: String = "read-" + Thread.currentThread().getId.show
 
       private[this] val state = stateRef.get
 
@@ -64,7 +65,7 @@ trait InMemoryOps[S] extends CloseOps {
     failIfClosed()
 
     new InMemTransaction[S] {
-      val name: String = "write-" + Thread.currentThread().getId
+      val name: String = "write-" + Thread.currentThread().getId.show
 
       private[this] val initial = stateRef.take
       private[this] var current = initial

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -12,7 +12,7 @@ import coop.rchain.shared.SeqOps.{dropIndex, removeFirst}
 import kamon._
 import scodec.Codec
 
-case class State[C, P, A, K](
+final case class State[C, P, A, K](
     dbGNATs: Map[Blake2b256Hash, GNAT[C, P, A, K]],
     dbJoins: Map[C, Seq[Seq[C]]]
 ) {

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -19,11 +19,12 @@ import scala.collection.mutable.ListBuffer
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+@SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial"))
 object AddressBookExample {
 
   /* Here we define a type for channels */
 
-  case class Channel(name: String)
+  final case class Channel(name: String)
 
   /* Ordering for Channel */
 
@@ -32,9 +33,9 @@ object AddressBookExample {
 
   /* Here we define a type for data */
 
-  case class Name(first: String, last: String)
-  case class Address(street: String, city: String, state: String, zip: String)
-  case class Entry(name: Name, address: Address, email: String, phone: String)
+  final case class Name(first: String, last: String)
+  final case class Address(street: String, city: String, state: String, zip: String)
+  final case class Entry(name: Name, address: Address, email: String, phone: String)
 
   /* Here we define a type for patterns */
 
@@ -62,6 +63,7 @@ object AddressBookExample {
       }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
   class EntriesCaptor extends ((Seq[Entry]) => Unit) with Serializable {
 
     @transient
@@ -114,6 +116,7 @@ object AddressBookExample {
         }
       }
 
+      @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
       def decode(bytes: ByteVector): Either[Throwable, Channel] =
         try {
           val bais = new ByteArrayInputStream(bytes.toArray)

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -29,6 +29,7 @@ object StringExamples {
     *
     * It captures the data it consumes.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
   class StringsCaptor extends ((Seq[String]) => Unit) with Serializable {
 
     @transient

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/package.scala
@@ -19,6 +19,7 @@ package object examples {
           ByteVector.view(baos.toByteArray)
         }
 
+      @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
       def decode(bytes: ByteVector): Either[Throwable, T] =
         Either.catchNonFatal {
           withResource(new ByteArrayInputStream(bytes.toArray)) { bais =>

--- a/rspace/src/main/scala/coop/rchain/rspace/history/Branch.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Branch.scala
@@ -3,7 +3,7 @@ package coop.rchain.rspace.history
 import scodec.Codec
 import scodec.codecs.utf8
 
-case class Branch(name: String)
+final case class Branch(name: String)
 
 object Branch {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
@@ -6,7 +6,7 @@ import coop.rchain.rspace.{Blake2b256Hash, InMemoryOps, InMemTransaction, _}
 
 import kamon.Kamon
 
-case class State[K, V](
+final case class State[K, V](
     _dbTrie: Map[Blake2b256Hash, Trie[K, V]],
     _dbRoot: Map[Branch, Blake2b256Hash],
     _dbPastRoots: Map[Branch, Seq[Blake2b256Hash]],

--- a/rspace/src/main/scala/coop/rchain/rspace/history/Trie.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Trie.scala
@@ -12,9 +12,9 @@ sealed trait NonEmptyPointer extends Pointer {
   def hash: Blake2b256Hash
 }
 
-case class NodePointer(hash: Blake2b256Hash) extends NonEmptyPointer
-case class LeafPointer(hash: Blake2b256Hash) extends NonEmptyPointer
-case object EmptyPointer                     extends Pointer
+final case class NodePointer(hash: Blake2b256Hash) extends NonEmptyPointer
+final case class LeafPointer(hash: Blake2b256Hash) extends NonEmptyPointer
+case object EmptyPointer                           extends Pointer
 
 sealed trait Trie[+K, +V]                                          extends Product with Serializable
 final case class Leaf[K, V](key: K, value: V)                      extends Trie[K, V]

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -142,7 +142,11 @@ object internal {
       }
   }
 
-  case class Install[P, E, A, R, K](patterns: Seq[P], continuation: K, _match: Match[P, E, A, R])
+  final case class Install[P, E, A, R, K](
+      patterns: Seq[P],
+      continuation: K,
+      _match: Match[P, E, A, R]
+  )
 
   type Installs[C, P, E, A, R, K] = Map[Seq[C], Install[P, E, A, R, K]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -37,7 +37,7 @@ object Event {
   implicit def codecLog: Codec[Seq[Event]] = codecSeq[Event](codecEvent)
 }
 
-case class COMM(consume: Consume, produces: Seq[Produce]) extends Event {
+final case class COMM(consume: Consume, produces: Seq[Produce]) extends Event {
   def nextSequenceNumber: Int =
     Math.max(
       consume.sequenceNumber,
@@ -51,8 +51,11 @@ object COMM {
 
 sealed trait IOEvent extends Event
 
-case class Produce private (channelsHash: Blake2b256Hash, hash: Blake2b256Hash, sequenceNumber: Int)
-    extends IOEvent {
+final case class Produce private (
+    channelsHash: Blake2b256Hash,
+    hash: Blake2b256Hash,
+    sequenceNumber: Int
+) extends IOEvent {
 
   override def equals(obj: scala.Any): Boolean = obj match {
     case produce: Produce => produce.hash == hash && produce.sequenceNumber == sequenceNumber
@@ -89,7 +92,7 @@ object Produce {
     (Codec[Blake2b256Hash] :: Codec[Blake2b256Hash] :: int32).as[Produce]
 }
 
-case class Consume private (
+final case class Consume private (
     channelsHashes: Seq[Blake2b256Hash],
     hash: Blake2b256Hash,
     sequenceNumber: Int

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -62,6 +62,7 @@ package object util {
     * Based on:
     * [[https://github.com/OpenTSDB/asynchbase/blob/f6a8ccb7e55ed9bc0aad265345da4c679e750055/src/Bytes.java#L549-L572]]
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def memcmp(a: Array[Byte], b: Array[Byte]): Int = {
     val c = a.length - b.length
     if (c != 0) {
@@ -84,6 +85,7 @@ package object util {
       data = gnat.data.sortBy(_.source.hash.bytes)(ordByteVector)
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def veccmp(a: ByteVector, b: ByteVector): Int = {
     val c = a.length - b.length
     if (c != 0) {

--- a/scripts/ci/codecov-upload
+++ b/scripts/ci/codecov-upload
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-for d in block-storage casper crypto comm rholang roscala node rspace shared; do
+for d in block-storage casper crypto comm rholang node rspace shared; do
 	codecov -X gcov -s ./$d -c -F ${d//-}
 done

--- a/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_.scala
@@ -14,8 +14,8 @@ trait ApplicativeError_[F[_], E] {
 
   def attempt[A](fa: F[A])(implicit ev: Applicative[F]): F[Either[E, A]] =
     handleErrorWith(
-      Applicative[F].map(fa)(Right(_): Either[E, A])
-    )(e => Applicative[F].pure(Left(e)))
+      Applicative[F].map(fa)(_.asRight[E])
+    )(e => Applicative[F].pure(e.asLeft[A]))
 
 }
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/BooleanOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/BooleanOps.scala
@@ -1,5 +1,7 @@
 package coop.rchain.catscontrib
 
+import cats._, cats.data._, cats.implicits._
+
 final class BooleanOps(self: Boolean) {
 
   final def either[A, B](a: => A): ConditionalEither[A] = new ConditionalEither(a)
@@ -8,7 +10,7 @@ final class BooleanOps(self: Boolean) {
 
   final class ConditionalEither[A](a: => A) {
     def or[B](b: => B): Either[B, A] =
-      if (self) Right(a) else Left(b)
+      if (self) a.asRight[B] else b.asLeft[A]
   }
 }
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Capture.scala
@@ -15,7 +15,7 @@ trait Capture[F[_]] {
   def capture[A](a: => A): F[A]
 
   /** Alias for `capture`. */
-  def apply[A] = capture[A] _
+  def apply[A]: (=> A) => F[A] = capture[A] _
 
   /** Construct a failed computation described by the given `Throwable`. */
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))

--- a/shared/src/main/scala/coop/rchain/catscontrib/OptionOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/OptionOps.scala
@@ -1,7 +1,9 @@
 package coop.rchain.catscontrib
 
+import cats._, cats.data._, cats.implicits._
+
 final class OptionOps[A](self: Option[A]) {
-  def toRight[L](left: L): Either[L, A] = self.fold[Either[L, A]](Left(left))(a => Right(a))
+  def toRight[L](left: L): Either[L, A] = self.fold[Either[L, A]](left.asLeft[A])(a => a.asRight[L])
 }
 
 trait ToOptionOps {

--- a/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/Taskable.scala
@@ -29,7 +29,7 @@ sealed trait TaskableInstances0 {
           .toTask(fa.value)
           .flatMap {
             case Right(a) => Task.now(a)
-            case Left(e)  => Task.raiseError(ToTaskException(e))
+            case Left(e)  => Task.raiseError[A](ToTaskException(e))
           }
 
     }

--- a/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
@@ -23,6 +23,7 @@ package object implicits {
           case NonFatal(e) => f(e)
         }
 
+      @SuppressWarnings(Array("org.wartremover.warts.Throw"))
       def raiseError[A](e: Throwable): cats.Id[A] = throw e
 
       def flatMap[A, B](fa: cats.Id[A])(f: A => cats.Id[B]): cats.Id[B] =
@@ -31,6 +32,7 @@ package object implicits {
       def tailRecM[A, B](a: A)(f: A => cats.Id[Either[A, B]]): cats.Id[B] =
         catsInstancesForId.tailRecM(a)(f)
 
+      @SuppressWarnings(Array("org.wartremover.warts.Throw"))
       def bracketCase[A, B](acquire: A)(use: A => B)(release: (A, ExitCase[Throwable]) => Unit): B =
         Try(use(acquire)) match {
           case Success(result) =>
@@ -66,7 +68,7 @@ package object implicits {
             })
       )
 
-    override def raiseError[A](e: Throwable): Try[A] = trySyntax.raiseError(e)
+    override def raiseError[A](e: Throwable): Try[A] = trySyntax.raiseError[A](e)
 
     override def handleErrorWith[A](fa: Try[A])(f: Throwable => Try[A]): Try[A] =
       trySyntax.handleErrorWith(fa)(f)

--- a/shared/src/main/scala/coop/rchain/catscontrib/eitherT.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/eitherT.scala
@@ -5,7 +5,7 @@ import cats._, cats.data._, cats.implicits._
 object eitherT extends EitherTInstances
 
 trait EitherTInstances {
-  implicit def eitherTMonadTrans[A] = new EitherTMonadTrans[A] {}
+  implicit def eitherTMonadTrans[A]: MonadTrans[EitherT[?[_], A, ?]] = new EitherTMonadTrans[A] {}
 }
 
 trait EitherTMonadTrans[A] extends MonadTrans[EitherT[?[_], A, ?]] {

--- a/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
@@ -1,14 +1,12 @@
 package coop.rchain.catscontrib
 
-import cats.{Monad, Monoid}
-import cats.implicits._
-
+import cats._, cats.data._, cats.implicits._
 import scala.math.Ordering
 
 object ListContrib {
   def sortBy[A, K: Monoid](list: List[A], map: collection.Map[A, K])(
       implicit ord: Ordering[K]
-  ) =
+  ): List[A] =
     list.sortBy(map.getOrElse(_, Monoid[K].empty))(ord)
 
   // From https://hygt.github.io/2018/08/05/Cats-findM-collectFirstM.html
@@ -16,9 +14,9 @@ object ListContrib {
     list.tailRecM[G, Option[A]] {
       case head :: tail =>
         p(head).map {
-          case true  => Right(Some(head))
-          case false => Left(tail)
+          case true  => Some(head).asRight[List[A]]
+          case false => tail.asLeft[Option[A]]
         }
-      case Nil => G.pure(Right(None))
+      case Nil => G.pure(None.asRight[List[A]])
     }
 }

--- a/shared/src/main/scala/coop/rchain/catscontrib/stateT.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/stateT.scala
@@ -5,7 +5,7 @@ import cats._, cats.data._, cats.implicits._
 object stateT extends StateTInstances
 
 trait StateTInstances {
-  implicit def stateTMonadTrans[A] = new StateTMonadTrans[A] {}
+  implicit def stateTMonadTrans[A]: MonadTrans[StateT[?[_], A, ?]] = new StateTMonadTrans[A] {}
 }
 
 trait StateTMonadTrans[A] extends MonadTrans[StateT[?[_], A, ?]] {

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -16,7 +16,7 @@ object TaskContrib {
     def nonCancelingTimeout(after: FiniteDuration): Task[A] =
       nonCancelingTimeoutTo(
         after,
-        Task.raiseError(new TimeoutException(s"Task timed-out after $after of inactivity"))
+        Task.raiseError[A](new TimeoutException(s"Task timed-out after $after of inactivity"))
       )
 
     def nonCancelingTimeoutTo[B >: A](after: FiniteDuration, backup: Task[B]): Task[B] =

--- a/shared/src/main/scala/coop/rchain/catscontrib/writerT.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/writerT.scala
@@ -5,7 +5,8 @@ import cats._, cats.data._, cats.implicits._
 object writerT extends WriterTInstances
 
 trait WriterTInstances {
-  implicit def writerTMonadTrans[A: Monoid] = new WriterTMonadTrans[A]() {}
+  implicit def writerTMonadTrans[L: Monoid]: MonadTrans[WriterT[?[_], L, ?]] =
+    new WriterTMonadTrans[L]() {}
 }
 
 abstract class WriterTMonadTrans[L: Monoid]() extends MonadTrans[WriterT[?[_], L, ?]] {

--- a/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
+++ b/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
@@ -37,6 +37,7 @@ object GrpcMonix {
       grpcObserverToMonixSubscriber(inputObserver, outputSubsriber.scheduler)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def monixSubscriberToGrpcObserver[T](subscriber: Subscriber[T]): StreamObserver[T] =
     new StreamObserver[T] {
       override def onError(t: Throwable): Unit = subscriber.onError(t)
@@ -44,6 +45,7 @@ object GrpcMonix {
       override def onNext(value: T): Unit      = subscriber.onNext(value)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def reactiveSubscriberToGrpcObserver[T](subscriber: SubscriberR[_ >: T]): StreamObserver[T] =
     new StreamObserver[T] {
       override def onError(t: Throwable): Unit = subscriber.onError(t)
@@ -51,6 +53,7 @@ object GrpcMonix {
       override def onNext(value: T): Unit      = subscriber.onNext(value)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def grpcObserverToMonixSubscriber[T](observer: StreamObserver[T], s: Scheduler): Subscriber[T] =
     new Subscriber[T] {
       override implicit def scheduler: Scheduler = s
@@ -87,6 +90,7 @@ object GrpcMonix {
       grpcOperatorToMonixOperator(operator)
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def unliftByTransformer[I, O](
       transformer: Transformer[I, O],
       subscriber: Subscriber[O]

--- a/shared/src/main/scala/coop/rchain/metrics/Metrics.scala
+++ b/shared/src/main/scala/coop/rchain/metrics/Metrics.scala
@@ -45,6 +45,7 @@ object Metrics extends MetricsInstances {
   import shapeless.tag.@@
   sealed trait SourceTag
   type Source = String @@ SourceTag
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   private def Source(name: String): Source         = name.asInstanceOf[Source]
   def Source(prefix: Source, name: String): Source = Source(s"$prefix.$name")
   val BaseSource: Source                           = Source("rchain")

--- a/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
+++ b/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
@@ -2,6 +2,7 @@ package coop.rchain.scodec
 
 import scodec.{Attempt, Codec, Err}
 
+import cats._, cats.data._, cats.implicits._
 import scala.collection.immutable.Seq
 
 package object codecs {
@@ -15,7 +16,7 @@ package object codecs {
       .narrow[Seq[A]](
         {
           case (cnt, xs) =>
-            if (xs.size == cnt)
+            if (xs.size === cnt)
               Attempt.successful(xs)
             else
               Attempt.failure(

--- a/shared/src/main/scala/coop/rchain/shared/AtomicMonadState.scala
+++ b/shared/src/main/scala/coop/rchain/shared/AtomicMonadState.scala
@@ -7,6 +7,7 @@ import coop.rchain.catscontrib.Capture
 
 import monix.execution.atomic.Atomic
 
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.While")) // false positive
 class AtomicMonadState[F[_]: Capture, S](state: Atomic[S])(implicit val monad: Monad[F])
     extends MonadState[F, S] {
   def get: F[S]                   = Capture[F].capture(state.get)

--- a/shared/src/main/scala/coop/rchain/shared/AttemptOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/AttemptOps.scala
@@ -7,6 +7,7 @@ object AttemptOps {
 
   implicit class RichAttempt[T](a: Attempt[T]) {
 
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     def get: T =
       a match {
         case Attempt.Successful(res) => res

--- a/shared/src/main/scala/coop/rchain/shared/Cell.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Cell.scala
@@ -34,6 +34,7 @@ object Cell extends CellInstances0 {
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def unsafe[F[_]: Applicative, S](const: S): Cell[F, S] =
     new Cell[F, S] {
       private var s: S = const
@@ -44,6 +45,7 @@ object Cell extends CellInstances0 {
       def read: F[S] = s.pure[F]
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def id[S](init: S): Cell[Id, S] = new Cell[Id, S] {
     var s: S = init
     def modify(f: S => S): Unit =

--- a/shared/src/main/scala/coop/rchain/shared/Iso.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Iso.scala
@@ -11,12 +11,12 @@ object Iso {
       implicit
       lGenA: LabelledGeneric.Aux[A, Repr],
       lGenB: LabelledGeneric.Aux[B, Repr]
-  ) = new Iso[A, B] {
+  ): Iso[A, B] = new Iso[A, B] {
     override def to(a: A): B =
       lGenB.from(lGenA.to(a))
     override def from(b: B): A =
       lGenA.from(lGenB.to(b))
   }
 
-  def apply[A, B](implicit iso: Iso[A, B]) = iso
+  def apply[A, B](implicit iso: Iso[A, B]): Iso[A, B] = iso
 }

--- a/shared/src/main/scala/coop/rchain/shared/Log.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Log.scala
@@ -20,6 +20,7 @@ object LogSource {
     val clazz: Class[_] = c
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Null")) // false-positive
   implicit def matLogSource: LogSource = macro LogSourceMacros.mkLogSource
 }
 

--- a/shared/src/main/scala/coop/rchain/shared/LongOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/LongOps.scala
@@ -1,7 +1,7 @@
 package coop.rchain.shared
 import java.lang.Long.numberOfLeadingZeros
 import java.util.Locale
-
+import cats._, cats.data._, cats.implicits._
 object LongOps {
 
   implicit class RichLong(value: Long) {
@@ -14,7 +14,7 @@ object LongOps {
       */
     def toHumanReadableSize: String =
       if (value < 1024) {
-        value + " B"
+        value.show + " B"
       } else {
         //division and then multiplication by 10 resets trailing bits
         val z: Int = (63 - numberOfLeadingZeros(value)) / 10

--- a/shared/src/main/scala/coop/rchain/shared/Printer.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Printer.scala
@@ -2,7 +2,7 @@ package coop.rchain.shared
 import scala.util.Try
 
 object Printer {
-  final val OUTPUT_CAPPED = Try(System.getenv("PRETTY_PRINTER_OUTPUT_TRIM_AFTER"))
+  val OUTPUT_CAPPED: Option[Int] = Try(System.getenv("PRETTY_PRINTER_OUTPUT_TRIM_AFTER"))
     .map(Integer.parseInt(_))
     .toOption
     .flatMap {

--- a/shared/src/main/scala/coop/rchain/shared/Resources.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Resources.scala
@@ -12,6 +12,9 @@ object Resources {
     * @param a A given resource implementing [[AutoCloseable]]
     * @param f A function that takes this resource as its argument
     */
+  @SuppressWarnings(
+    Array("org.wartremover.warts.Var", "org.wartremover.warts.Throw", "org.wartremover.warts.Null")
+  )
   def withResource[A <: AutoCloseable, B](a: => A)(f: A => B): B = {
     val resource: A = a
     require(resource != null, "resource is null")

--- a/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
@@ -6,6 +6,7 @@ object SeqOps {
 
   /** Drops the 'i'th element of a list.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def dropIndex[T](xs: Seq[T], n: Int): Seq[T] = {
     if ((n < 0) || (n >= xs.size)) {
       throw new IndexOutOfBoundsException(s"Index $n is outside the sequence bounds 0..${xs.size}")

--- a/shared/src/main/scala/coop/rchain/shared/StringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StringOps.scala
@@ -3,7 +3,7 @@ package coop.rchain.shared
 import scala.util.Try
 
 object StringOps {
-  case class ColoredString(str: String, color: String) {
+  final case class ColoredString(str: String, color: String) {
     def colorize: String = color + str + "\u001B[0m"
   }
 


### PR DESCRIPTION
## Overview
### Remove roscala and roscalaMacros as scala projects

Roscala is currently **not** being used.
Source code stays in repository but we remove it from configuration,
so it is not compiled, when the project is compiled.

### Introduce Wart.Remover

There is a lot of rules that were excluded currently. Some of them are
false-positives, but majority of them would just require a lot more
changes in this commit. They will be eventually removed from the
exclusion list.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2837

