### PR TITLE
Rchain 2831/casper/complex bonding scenarios

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper
 
 import java.nio.file.Files
 
-import cats.Applicative
+import cats.{Applicative, Monad}
 import cats.data.EitherT
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
@@ -38,7 +38,9 @@ import monix.execution.Scheduler
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.casper.util.comm.TestNetwork
 import coop.rchain.catscontrib.ski.kp2
+import coop.rchain.comm.rp.Connect.Connections
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Log
 import org.scalatest
@@ -904,17 +906,10 @@ class HashSetCasperTest extends FlatSpec with Matchers {
     } yield result
   }
 
-  it should "allow bonding in an existing network" in effectTest {
-    val deployDatasFs = Vector(
-      "@2!(2)",
-      "@1!(1)",
-      "@3!(3)"
-    ).zipWithIndex
-      .map(
-        d =>
-          () =>
-            ProtoUtil.sourceDeploy(d._1, System.currentTimeMillis() + d._2, accounting.MAX_VALUE)
-      )
+  it should "allow bonding in an existing network" ignore effectTest {
+    def deployment(i: Int): DeployData =
+      ProtoUtil.sourceDeploy(s"@$i!({$i})", System.currentTimeMillis() + i, accounting.MAX_VALUE)
+
     def deploy(
         node: HashSetCasperTestNode[Effect],
         dd: DeployData
@@ -926,27 +921,23 @@ class HashSetCasperTest extends FlatSpec with Matchers {
         status <- node.casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
       } yield (signedBlock1, status)
 
-    def stepSplit(nodes: Seq[HashSetCasperTestNode[Effect]]): Effect[Unit] =
+    def stepSplit(nodes: List[HashSetCasperTestNode[Effect]]): Effect[Unit] =
       for {
-        _ <- deploy(nodes(0), deployDatasFs(0).apply())
-        _ <- deploy(nodes(1), deployDatasFs(1).apply())
-        _ <- deploy(nodes(2), deployDatasFs(2).apply())
-
-        _ <- nodes(0).receive()
-        _ <- nodes(1).receive()
-        _ <- nodes(2).receive()
+        _ <- nodes.zipWithIndex.traverse { case (n, i) => deploy(n, deployment(i)) }
+        _ <- nodes.traverse(_.receive())
       } yield ()
 
-    def propagate(nodes: Seq[HashSetCasperTestNode[Effect]]): Effect[Unit] =
+    def propagate(nodes: List[HashSetCasperTestNode[Effect]]): Effect[Unit] =
       for {
-        _ <- nodes(0).receive()
-        _ <- nodes(1).receive()
-        _ <- nodes(2).receive()
+        _ <- nodes.traverse(_.receive())
       } yield ()
 
-    def bond(node: HashSetCasperTestNode[Effect]): Effect[Unit] = {
+    def bond(
+        node: HashSetCasperTestNode[Effect],
+        keys: (Array[Byte], Array[Byte])
+    ): Effect[Unit] = {
       implicit val runtimeManager = node.runtimeManager
-      val (sk, pk)                = Ed25519.newKeyPair
+      val (sk, pk)                = keys
       val pkStr                   = Base16.encode(pk)
       val amount                  = 314L
       val forwardCode             = BondingUtil.bondingForwarderDeploy(pkStr, pkStr)
@@ -972,18 +963,23 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       } yield ()
     }
 
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      _     <- stepSplit(nodes)
-      _     <- stepSplit(nodes)
-      _     <- bond(nodes(0))
-      _     <- propagate(nodes)
-      _     <- propagate(nodes)
+    val network = TestNetwork.empty[Effect]
 
-      _ <- deploy(nodes(0), deployDatasFs(0).apply())
-      _ <- deploy(nodes(2), deployDatasFs(2).apply())
-      _ <- nodes(2).receive()
-      _ <- nodes.map(_.tearDown()).toList.sequence
+    for {
+      nodes <- HashSetCasperTestNode
+                .networkEff(validatorKeys.take(3), genesis, testNetwork = network)
+                .map(_.toList)
+      _        <- stepSplit(nodes)
+      _        <- stepSplit(nodes)
+      (sk, pk) = Ed25519.newKeyPair
+      newNode  = HashSetCasperTestNode.standaloneEff(genesis, sk, testNetwork = network)
+      _        <- bond(nodes(0), (sk, pk))
+      all      <- HashSetCasperTestNode.rigConnectionsF[Effect](newNode, nodes)
+
+      _ <- stepSplit(all)
+      _ <- stepSplit(all)
+
+      _ <- all.map(_.tearDown()).sequence
     } yield ()
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -159,6 +159,25 @@ object HashSetCasperTestNode {
     )
   }
 
+  def rigConnectionsF[F[_]: Monad](
+      n: HashSetCasperTestNode[F],
+      nodes: List[HashSetCasperTestNode[F]]
+  ): F[List[HashSetCasperTestNode[F]]] = {
+    import Connections._
+    for {
+      _ <- nodes.traverse(
+            m =>
+              n.connectionsCell
+                .flatModify(_.addConn[F](m.local)(Monad[F], n.logEff, n.metricEff))
+          )
+      _ <- nodes.traverse(
+            m =>
+              m.connectionsCell
+                .flatModify(_.addConn[F](n.local)(Monad[F], m.logEff, m.metricEff))
+          )
+    } yield nodes ++ (n :: Nil)
+  }
+
   def standaloneF[F[_]](
       genesis: BlockMessage,
       sk: Array[Byte],

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
@@ -38,7 +38,10 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
           _ = node.logEff.infos.exists(_.contains("Approval sent in response")) should be(true)
           _ = node.logEff.warns.isEmpty should be(true)
 
-          queue  <- node.transportLayerEff.msgQueues(node.local).get
+          queue <- {
+            implicit val network = node.transportLayerEff.testNetworkF
+            TestNetwork.peerQueue(node.local)
+          }
           result = queue.size should be(1)
         } yield result
     }
@@ -66,8 +69,11 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 runtimeManager
               )
 
-          _      = node.logEff.warns.count(_.contains("Received unexpected candidate")) should be(2)
-          queue  <- node.transportLayerEff.msgQueues(node.local).get
+          _ = node.logEff.warns.count(_.contains("Received unexpected candidate")) should be(2)
+          queue <- {
+            implicit val network = node.transportLayerEff.testNetworkF
+            TestNetwork.peerQueue(node.local)
+          }
           result = queue.isEmpty should be(true)
         } yield result
     }

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -1,17 +1,16 @@
 package coop.rchain.casper.util.comm
 
 import cats.Monad
-import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.mtl.MonadState
+import coop.rchain.casper.util.comm.TestNetwork.TestNetwork
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.catscontrib._
 import coop.rchain.comm.CommError.CommErr
-import coop.rchain.comm.PeerNode
+import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.comm.rp.ProtocolHelper.protocol
 
 import scala.concurrent.duration.FiniteDuration
-import scala.collection.mutable
 import coop.rchain.comm.transport._
 import coop.rchain.shared.AtomicMonadState
 import monix.execution.atomic.AtomicAny
@@ -60,23 +59,14 @@ object TestNetwork {
     new AtomicMonadState[F, NodeMessageQueues](AtomicAny(Map.empty))
 }
 
-class TransportLayerTestImpl[F[_]: Monad](
-    identity: PeerNode,
-    val msgQueues: Map[PeerNode, Ref[F, mutable.Queue[Protocol]]]
+class TransportLayerTestImpl[F[_]: Monad](identity: PeerNode)(
+    implicit val testNetworkF: TestNetwork[F]
 ) extends TransportLayer[F] {
 
   def roundTrip(peer: PeerNode, msg: Protocol, timeout: FiniteDuration): F[CommErr[Protocol]] = ???
 
   def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]] =
-    msgQueues.get(peer) match {
-      case Some(qRef) =>
-        qRef
-          .update { q =>
-            q.enqueue(msg); q
-          }
-          .map(Right(_))
-      case None => ().pure[F].map(Right(_))
-    }
+    TestNetwork.send(peer, msg).map(_.asRight[CommError])
 
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]] =
     peers.toList.traverse(send(_, msg)).map(_.toSeq)
@@ -85,7 +75,7 @@ class TransportLayerTestImpl[F[_]: Monad](
       dispatch: Protocol => F[CommunicationResponse],
       handleStreamed: Blob => F[Unit]
   ): F[Unit] =
-    TransportLayerTestImpl.handleQueue(dispatch, msgQueues(identity))
+    TestNetwork.handleQueue(dispatch, identity)
 
   def stream(peers: Seq[PeerNode], blob: Blob): F[Unit] =
     broadcast(peers, protocol(blob.sender).withPacket(blob.packet)).void
@@ -95,30 +85,5 @@ class TransportLayerTestImpl[F[_]: Monad](
   def shutdown(msg: Protocol): F[Unit] = ???
 
   def clear(peer: PeerNode): F[Unit] =
-    msgQueues.get(peer) match {
-      case Some(qRef) =>
-        qRef.update { q =>
-          q.clear(); q
-        }
-      case None => ().pure[F]
-    }
-}
-
-object TransportLayerTestImpl {
-  def handleQueue[F[_]: Monad](
-      dispatch: Protocol => F[CommunicationResponse],
-      qRef: Ref[F, mutable.Queue[Protocol]]
-  ): F[Unit] =
-    for {
-      maybeProto <- qRef.modify { q =>
-                     if (q.nonEmpty) {
-                       val proto = q.dequeue()
-                       (q, proto.some)
-                     } else (q, None)
-                   }
-      _ <- maybeProto match {
-            case Some(proto) => dispatch(proto) *> handleQueue(dispatch, qRef)
-            case None        => ().pure[F]
-          }
-    } yield ()
+    TestNetwork.clear(peer)
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -1,18 +1,64 @@
 package coop.rchain.casper.util.comm
 
-import cats.{Id, Monad}
+import cats.Monad
 import cats.effect.concurrent.Ref
 import cats.implicits._
+import cats.mtl.MonadState
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.catscontrib._
-import coop.rchain.comm.CommError.{peerNodeNotFound, CommErr}
+import coop.rchain.comm.CommError.CommErr
 import coop.rchain.comm.PeerNode
-import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.rp.ProtocolHelper.protocol
 
 import scala.concurrent.duration.FiniteDuration
 import scala.collection.mutable
 import coop.rchain.comm.transport._
+import coop.rchain.shared.AtomicMonadState
+import monix.execution.atomic.AtomicAny
+
+import scala.collection.immutable.Queue
+
+object TestNetwork {
+  type NodeMessageQueues = Map[PeerNode, Queue[Protocol]]
+  type TestNetwork[F[_]] = MonadState[F, NodeMessageQueues]
+
+  def apply[F[_]](implicit ev: TestNetwork[F]): TestNetwork[F] = ev
+
+  def addPeer[F[_]: TestNetwork](peer: PeerNode): F[Unit] =
+    TestNetwork[F].modify(t => t + (peer -> Queue.empty))
+
+  def peerQueue[F[_]: TestNetwork: Monad](peer: PeerNode): F[Queue[Protocol]] =
+    TestNetwork[F].inspect(_(peer))
+
+  def send[F[_]: TestNetwork](peer: PeerNode, msg: Protocol): F[Unit] =
+    TestNetwork[F].modify(t => {
+      t + (peer -> t(peer).enqueue(msg))
+    })
+
+  def clear[F[_]: TestNetwork](peer: PeerNode): F[Unit] =
+    TestNetwork[F].modify(t => {
+      t + (peer -> Queue.empty)
+    })
+
+  def handleQueue[F[_]: TestNetwork: Monad](
+      dispatch: Protocol => F[CommunicationResponse],
+      peer: PeerNode
+  ): F[Unit] =
+    for {
+      topology     <- TestNetwork[F].get
+      q            = topology(peer)
+      maybeMessage = q.dequeueOption
+      _ <- maybeMessage.fold(().pure[F]) {
+            case (p, nq) =>
+              TestNetwork[F].set(topology + (peer -> nq)) *>
+                dispatch(p) *>
+                handleQueue(dispatch, peer)
+          }
+    } yield ()
+
+  def empty[F[_]](implicit captureF: Capture[F], monadF: Monad[F]): TestNetwork[F] =
+    new AtomicMonadState[F, NodeMessageQueues](AtomicAny(Map.empty))
+}
 
 class TransportLayerTestImpl[F[_]: Monad](
     identity: PeerNode,


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Test showing assertion error in new SafetyOracle.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-2831


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
