### PR TITLE
RCHAIN-2850 Release cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -210,7 +210,7 @@ lazy val node = (project in file("node"))
   .settings(commonSettings: _*)
   .enablePlugins(RpmPlugin, DebianPlugin, JavaAppPackaging, BuildInfoPlugin)
   .settings(
-    version := "0.8.3",
+    version := "0.8.3" + git.gitHeadCommit.value.map(".git" + _.take(8)).getOrElse(""),
     name := "rnode",
     maintainer := "Pyrofex, Inc. <info@pyrofex.net>",
     packageSummary := "RChain Node",
@@ -269,8 +269,6 @@ lazy val node = (project in file("node"))
     """,
     /* Dockerization */
     dockerUsername := Some(organization.value),
-    version in Docker := version.value +
-      git.gitHeadCommit.value.map("-git" + _.take(8)).getOrElse(""),
     dockerAliases ++=
       sys.env.get("DRONE_BUILD_NUMBER")
         .toSeq.map(num => dockerAlias.value.withTag(Some(s"DRONE-${num}"))),

--- a/scripts/ci/publish-artifacts
+++ b/scripts/ci/publish-artifacts
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+prefix=branches/
 if [[ -n $DRONE_TAG ]]; then
 	REF=$DRONE_TAG
 	TAG=1
+	prefix=release/
 elif [[ -n $DRONE_BRANCH ]]; then
 	REF=$DRONE_BRANCH
 	if [[ $DRONE_BRANCH = "staging" ]]; then
@@ -31,7 +33,7 @@ echo "$SSH_PRIVATE_KEY" | base64 -d | tr -d '\r' >~/.ssh/id_rsa
 # We don't check host keys because artifacts are public.
 rsync -avrz --delete -e "ssh -p 22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
     artifacts/*.deb artifacts/*.rpm artifacts/*.tgz \
-    inbound@build.rchain-dev.tk:/srv/inbound/$REF/
+    inbound@build.rchain-dev.tk:/srv/inbound/$prefix$REF/
 
 # Upload Docker image
 


### PR DESCRIPTION
- Separate locations for tags and releases
- Put short commit ID in artifacts by default