### PR TITLE
RCHAIN-2837 xfatal, var, throw

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,12 @@ lazy val graphz = (project in file("graphz"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
+    scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
+    ),
     libraryDependencies ++= commonDependencies ++ Seq(
       catsCore,
       catsEffect,

--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,12 @@ lazy val shared = (project in file("shared"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
+    scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
+    ),
     libraryDependencies ++= commonDependencies ++ Seq(
       catsCore,
       catsEffect,

--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ lazy val projectSettings = Seq(
   wartremoverExcluded += sourceManaged.value,
   wartremoverErrors in (Compile, compile) ++= Warts.allBut(
     // those we want
-    Wart.DefaultArguments,
+    Wart.DefaultArguments, Wart.ImplicitParameter, Wart.ImplicitConversion,
     // those don't want
-    Wart.ImplicitParameter, Wart.Recursion, Wart.ImplicitConversion,
+    Wart.Recursion,
     Wart.LeakingSealed, Wart.Overloading, Wart.Nothing, Wart.NonUnitStatements,
     Wart.Equals, Wart.PublicInference, Wart.TraversableOps, Wart.ArrayEquals,
     Wart.Throw, Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,

--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,12 @@ lazy val projectSettings = Seq(
   ),
   wartremoverExcluded += sourceManaged.value,
   wartremoverErrors in (Compile, compile) ++= Warts.allBut(
-    Wart.ImplicitParameter, Wart.Recursion, Wart.DefaultArguments, Wart.ImplicitConversion,
+    // those we want
+    Wart.DefaultArguments,
+    // those don't want
+    Wart.ImplicitParameter, Wart.Recursion, Wart.ImplicitConversion,
     Wart.LeakingSealed, Wart.Overloading, Wart.Nothing, Wart.NonUnitStatements,
-    Wart.Equals, Wart.PublicInference, Wart.Var, Wart.TraversableOps, Wart.ArrayEquals,
+    Wart.Equals, Wart.PublicInference, Wart.TraversableOps, Wart.ArrayEquals,
     Wart.Throw, Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,
     Wart.EitherProjectionPartial, Wart.Option2Iterable, Wart.ToString, Wart.JavaConversions,
     Wart.MutableDataStructures, Wart.FinalVal, Wart.Null, Wart.AsInstanceOf, Wart.ExplicitImplicitTypes,

--- a/build.sbt
+++ b/build.sbt
@@ -236,6 +236,12 @@ lazy val node = (project in file("node"))
   .settings(
     version := "0.8.3" + git.gitHeadCommit.value.map(".git" + _.take(8)).getOrElse(""),
     name := "rnode",
+    scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
+    ),
     maintainer := "Pyrofex, Inc. <info@pyrofex.net>",
     packageSummary := "RChain Node",
     packageDescription := "RChain Node - the RChain blockchain node server software.",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val projectSettings = Seq(
     Wart.Recursion,
     Wart.LeakingSealed, Wart.Overloading, Wart.Nothing, Wart.NonUnitStatements,
     Wart.Equals, Wart.PublicInference, Wart.TraversableOps, Wart.ArrayEquals,
-    Wart.Throw, Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,
+    Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,
     Wart.EitherProjectionPartial, Wart.Option2Iterable, Wart.ToString, Wart.JavaConversions,
     Wart.MutableDataStructures, Wart.FinalVal, Wart.Null, Wart.AsInstanceOf, Wart.ExplicitImplicitTypes,
     Wart.StringPlusAny, Wart.AnyVal

--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,12 @@ lazy val crypto = (project in file("crypto"))
   .settings(commonSettings: _*)
   .settings(
     name := "crypto",
+    scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
+    ),
     libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
       guava,
       bouncyCastle,

--- a/build.sbt
+++ b/build.sbt
@@ -154,6 +154,12 @@ lazy val comm = (project in file("comm"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
+    scalacOptions ++= Seq(
+      "-Xfatal-warnings",
+      "-unchecked",
+      "-deprecation",
+      "-feature"
+    ),
     dependencyOverrides += "org.slf4j" % "slf4j-api" % "1.7.25",
     libraryDependencies ++= commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
       grpcNetty,

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -38,6 +38,7 @@ final case class CasperConf(
 object CasperConf {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   def parseValidatorsFile[F[_]: Monad: Capture: Log](
       knownValidatorsFile: Option[String]
   ): F[Set[ByteString]] =
@@ -66,6 +67,7 @@ object CasperConf {
           }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def publicKey(
       givenPublicKey: Option[Array[Byte]],
       sigAlgorithm: String,

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -301,6 +301,7 @@ object EquivocationDetector {
     } yield equivocationDetected
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   private def maybeAddEquivocationChild[F[_]: Monad: BlockStore](
       justificationBlock: BlockMessage,
       equivocatingValidator: Validator,
@@ -347,6 +348,7 @@ object EquivocationDetector {
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   private def addEquivocationChild[F[_]: Monad: BlockStore](
       justificationBlock: BlockMessage,
       equivocationBaseBlockSeqNum: SequenceNumber,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -430,6 +430,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
       _      <- addEffects(status, b)
     } yield status
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   // TODO: Handle slashing
   private def addEffects(status: BlockStatus, block: BlockMessage): F[Unit] =
     status match {

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -12,6 +12,7 @@ import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.rholang.interpreter.{accounting, Runtime}
 import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.StoreType
+import coop.rchain.shared.Log
 import java.io.PrintWriter
 import java.nio.file.{Files, Path}
 
@@ -180,7 +181,7 @@ object BondingUtil {
       runtimeDir => Sync[F].delay { runtimeDir.recursivelyDelete() }
     )
 
-  def makeRuntimeResource[F[_]: Sync: ContextShift, M[_]](
+  def makeRuntimeResource[F[_]: Sync: ContextShift: Log, M[_]](
       runtimeDirResource: Resource[F, Path]
   )(implicit P: Parallel[F, M], scheduler: ExecutionContext): Resource[F, Runtime[F]] =
     runtimeDirResource.flatMap(
@@ -201,7 +202,7 @@ object BondingUtil {
         Resource.make(RuntimeManager.fromRuntime[F](activeRuntime))(_ => Sync[F].unit)
     )
 
-  def writeIssuanceBasedRhoFiles[F[_]: Concurrent: ContextShift, M[_]](
+  def writeIssuanceBasedRhoFiles[F[_]: Concurrent: ContextShift: Log, M[_]](
       bondKey: String,
       ethAddress: String,
       amount: Long,
@@ -224,7 +225,7 @@ object BondingUtil {
     )
   }
 
-  def writeFaucetBasedRhoFiles[F[_]: Concurrent: ContextShift, M[_]](
+  def writeFaucetBasedRhoFiles[F[_]: Concurrent: ContextShift: Log, M[_]](
       amount: Long,
       sigAlgorithm: String,
       secKey: String,

--- a/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
@@ -59,6 +59,7 @@ object DoublyLinkedDagOperations {
   }
 
   // If the element doesn't exist in the dag, the dag is returned as is
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   def remove[A](dag: DoublyLinkedDag[A], element: A): DoublyLinkedDag[A] = {
     val parentToChildAdjacencyList: Map[A, Set[A]] = dag.parentToChildAdjacencyList
     val childToParentAdjacencyList: Map[A, Set[A]] = dag.childToParentAdjacencyList

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -81,6 +81,7 @@ object ProtoUtil {
     } yield mainChain
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   def unsafeGetBlock[F[_]: Monad: BlockStore](hash: BlockHash): F[BlockMessage] =
     for {
       maybeBlock <- BlockStore[F].get(hash)

--- a/casper/src/main/scala/coop/rchain/casper/util/SignatureAlgorithms.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/SignatureAlgorithms.scala
@@ -3,6 +3,7 @@ import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 
 object SignatureAlgorithms {
   type SignatureAlgorithm = (Array[Byte], Array[Byte]) => Array[Byte]
+  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
   def lookup(algorithm: String): SignatureAlgorithm =
     algorithm match {
       case "ed25519"   => Ed25519.sign

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1742,6 +1742,7 @@ object HashSetCasperTest {
     val initial           = Genesis.withoutContracts(bonds, 1L, deployTimestamp, "rchain")
     val storageDirectory  = Files.createTempDirectory(s"hash-set-casper-test-genesis")
     val storageSize: Long = 1024L * 1024
+    implicit val log      = new Log.NOPLog[Task]
 
     val activeRuntime =
       Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -258,10 +258,10 @@ object GenesisTest {
   def withRawGenResources(
       body: (Runtime[Task], Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
   ): Task[Unit] = {
-    val storePath = storageLocation
-    val gp        = genesisPath
-    val log       = new LogStub[Task]
-    val time      = new LogicalTime[Task]
+    val storePath    = storageLocation
+    val gp           = genesisPath
+    implicit val log = new LogStub[Task]
+    val time         = new LogicalTime[Task]
 
     for {
       runtime <- Runtime.create[Task, Task.Par](storePath, storageSize, StoreType.LMDB)

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -150,6 +150,7 @@ object HashSetCasperTestNode {
   def createRuntime(storageDirectory: Path, storageSize: Long)(
       implicit scheduler: Scheduler
   ): (RuntimeManager[Effect], Close[Effect]) = {
+    implicit val log = new Log.NOPLog[Task]()
     val activeRuntime =
       Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
@@ -13,7 +13,7 @@ import coop.rchain.comm.transport
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.casper.scalatestcontrib._
-import coop.rchain.shared.StoreType
+import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
@@ -95,7 +95,8 @@ object BlockApproverProtocolTest {
   ): Effect[(BlockApproverProtocol, HashSetCasperTestNode[Effect])] = {
     import monix.execution.Scheduler.Implicits.global
 
-    val runtimeDir = BlockDagStorageTestFixture.blockStorageDir
+    val runtimeDir   = BlockDagStorageTestFixture.blockStorageDir
+    implicit val log = new Log.NOPLog[Task]()
     val activeRuntime =
       Runtime.create[Task, Task.Par](runtimeDir, 1024L * 1024, StoreType.LMDB).unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -34,7 +34,7 @@ import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.shared.{Cell, StoreType}
+import coop.rchain.shared.{Cell, Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.WordSpec
@@ -51,6 +51,7 @@ class CasperPacketHandlerSpec extends WordSpec {
         .create[Task, Task.Par](runtimeDir, 1024L * 1024, StoreType.LMDB)(
           ContextShift[Task],
           Sync[Task],
+          log,
           Parallel[Task, Task.Par],
           scheduler
         )

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -12,6 +12,7 @@ import java.nio.file.{Files, Path, Paths}
 import coop.rchain.rholang.interpreter.{PrettyPrinter, Runtime}
 import coop.rchain.rspace.Checkpoint
 import coop.rchain.shared.StoreType.InMem
+import coop.rchain.shared.Log
 import coop.rchain.models._
 import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
 import coop.rchain.catscontrib.TaskContrib._
@@ -93,7 +94,7 @@ class Interactive private (runtime: Runtime[Task])(implicit scheduler: Scheduler
 object Interactive {
   def apply(): Interactive = {
     implicit val scheduler = Scheduler.io("rhoang-interpreter")
-
+    implicit val log       = new Log.NOPLog[Task]
     new Interactive(TestSetUtil.runtime())
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -36,13 +36,13 @@ class InterpreterUtilTest
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture {
+  implicit val logEff  = new LogStub[Task]
   val storageSize      = 1024L * 1024
   val storageDirectory = Files.createTempDirectory("casper-interp-util-test")
   val activeRuntime =
     Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync
-  val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
 
-  implicit val logEff = new LogStub[Task]
+  val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
 
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in withStorage {
     implicit blockStore => implicit blockDagStorage =>

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.util.rholang
 import cats.effect.Resource
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.rholang.Resources.mkRuntime
-import coop.rchain.shared.StoreType
+import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -11,11 +11,14 @@ object Resources {
       prefix: String,
       storageSize: Int = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
-  )(implicit scheduler: Scheduler): Resource[Task, RuntimeManager[Task]] =
+  )(implicit scheduler: Scheduler): Resource[Task, RuntimeManager[Task]] = {
+    implicit val log: Log[Task] = new Log.NOPLog[Task]
+
     mkRuntime(prefix)
       .flatMap { runtime =>
         Resource.make(RuntimeManager.fromRuntime[Task](runtime))(
           _ => Task.unit /* FIXME close the manager */
         )
       }
+  }
 }

--- a/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
@@ -28,6 +28,7 @@ object ReputationOrder extends Ordering[Reputable] {
   def compare(a: Reputable, b: Reputable) = a.reputation compare b.reputation
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 final case class PeerTableEntry[A](entry: A, gkey: A => Seq[Byte]) extends Keyed {
   var pinging           = false
   val key               = gkey(entry)

--- a/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
@@ -23,6 +23,10 @@ object HostnameTrustManagerFactory {
   val Instance: HostnameTrustManagerFactory = new HostnameTrustManagerFactory()
 }
 
+/**
+  * This wart exists because that's how grpc works. They looooovveee throwing exceptions
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 private class HostnameTrustManager extends X509ExtendedTrustManager {
 
   def checkClientTrusted(

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -17,6 +17,10 @@ class SslSessionClientInterceptor() extends ClientInterceptor {
     new SslSessionClientCallInterceptor(next.newCall(method, callOptions))
 }
 
+/**
+  * This wart exists because that's how grpc works. They looooovveee throwing exceptions
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT])
     extends ClientCall[ReqT, RespT] {
   self =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -7,6 +7,10 @@ import coop.rchain.shared.{Log, LogSource}
 import io.grpc._
 import javax.net.ssl.SSLSession
 
+/**
+  * This wart exists because that's how grpc works. They looooovveee throwing exceptions
+  */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 class SslSessionServerInterceptor() extends ServerInterceptor {
 
   def interceptCall[ReqT, RespT](

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -55,6 +55,8 @@ class TcpTransportLayer(
 
   private val streamObservable = new StreamObservable(clientQueueSize, tempFolder)
 
+  // TODO FIX-ME No throwing exceptions!
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private lazy val serverSslContext: SslContext =
     try {
       GrpcSslContexts
@@ -68,6 +70,8 @@ class TcpTransportLayer(
         throw e
     }
 
+  // TODO FIX-ME No throwing exceptions!
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private lazy val clientSslContext: SslContext =
     try {
       val builder = GrpcSslContexts.forClient

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
@@ -21,7 +21,7 @@ abstract class ConcurrentQueue[A] {
   def drain(buffer: mutable.Buffer[A], limit: Int): Unit
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Return"))
+@SuppressWarnings(Array("org.wartremover.warts.Return", "org.wartremover.warts.Var"))
 object ConcurrentQueue {
   final val recommendedSize: Int = 1024
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/LimitedBuffer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/LimitedBuffer.scala
@@ -21,7 +21,7 @@ trait LimitedBuffer[A] {
   def complete(): Unit
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Return"))
+@SuppressWarnings(Array("org.wartremover.warts.Return", "org.wartremover.warts.Var"))
 private final class DropNewBuffer[A](out: Subscriber[A], bufferSize: Int) extends LimitedBuffer[A] {
 
   require(bufferSize > 0, "bufferSize must be a strictly positive number")

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -101,6 +101,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
               Chunk.Content.Header(header.content.header.get.copy(sender = None))
             val incompleteHeader = header.copy(content = newHeaderContent)
             (incompleteHeader :: data).toIterator
+          case Nil => throw new RuntimeException("")
         })
       // when
       val err: Throwable = handleStreamErr(streamWithIncompleteHeader)
@@ -113,7 +114,8 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       // given
       val streamWithoutHeader: Observable[Chunk] =
         Observable.fromIterator(createStreamIterator().map(_.toList).map {
-          case header :: data => data.toIterator
+          case _ :: data => data.toIterator
+          case _         => throw new RuntimeException("")
         })
       // when
       val err: Throwable = handleStreamErr(streamWithoutHeader)
@@ -126,7 +128,8 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       // given
       val incompleteStream: Observable[Chunk] =
         Observable.fromIterator(createStreamIterator().map(_.toList).map {
-          case header :: data1 :: data2 => (header :: data2).toIterator
+          case header :: _ :: data2 => (header :: data2).toIterator
+          case _                    => throw new RuntimeException("")
         })
       // when
       val err: Throwable = handleStreamErr(incompleteStream)
@@ -176,7 +179,6 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   private def peerNode(name: String): PeerNode =
     PeerNode(NodeIdentifier(name.getBytes), Endpoint("", 80, 80))
 
-  private val alwaysBreak: CircuitBreaker = kp(true)
-  private val neverBreak: CircuitBreaker  = kp(false)
+  private val neverBreak: CircuitBreaker = kp(false)
 
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
@@ -32,6 +32,7 @@ inner hash length to 64.
 This class is an abbreviated version of Blake2bDigest.java from BouncyCastle
 https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
   */
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 class Blake2b512Block {
   import Blake2b512Block._
   private val chainValue: Array[Long] = new Array[Long](CHAIN_VALUE_LENGTH)

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
@@ -18,6 +18,7 @@ import scala.annotation.tailrec
   * Blake2b512.merge uses online tree hashing to merge two random generator
   * states.
   */
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 class Blake2b512Random private (
     private val digest: Blake2b512Block,
     private val lastBlock: ByteBuffer

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -37,6 +37,7 @@ object Ed25519 {
     * boolean value of verification
     *
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def verify(
       data: Array[Byte],
       signature: Array[Byte],
@@ -49,7 +50,7 @@ object Ed25519 {
         if (ex.getMessage contains "signature was forged or corrupted") {
           false
         } else {
-          throw ex
+          throw ex // should we return false?
         }
     }
 

--- a/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
@@ -107,16 +107,15 @@ object CertificateHelper {
     info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithmId))
 
     // Sign the cert to identify the algorithm that's used.
-    @SuppressWarnings(Array("org.wartremover.warts.Var"))
-    var cert = new X509CertImpl(info)
+    val cert = new X509CertImpl(info)
     cert.sign(privateKey, algorythm)
 
     // Update the algorith, and resign.
     val algorithmId2 = cert.get(X509CertImpl.SIG_ALG).asInstanceOf[AlgorithmId]
     info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algorithmId2)
-    cert = new X509CertImpl(info)
-    cert.sign(privateKey, algorythm)
-    cert
+    val cert2 = new X509CertImpl(info)
+    cert2.sign(privateKey, algorythm)
+    cert2
   }
 
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
@@ -107,6 +107,7 @@ object CertificateHelper {
     info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algorithmId))
 
     // Sign the cert to identify the algorithm that's used.
+    @SuppressWarnings(Array("org.wartremover.warts.Var"))
     var cert = new X509CertImpl(info)
     cert.sign(privateKey, algorythm)
 

--- a/crypto/src/main/scala/coop/rchain/crypto/util/SecureRandomUtil.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/SecureRandomUtil.scala
@@ -12,6 +12,8 @@ object SecureRandomUtil {
     "SHA1PRNG"
   )
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // this is sad :(
   lazy val secureRandomNonBlocking: SecureRandom =
     instancesNonBlocking.iterator //use iterator to try instances lazily
       .map(name => Try(SecureRandom.getInstance(name)))

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -155,6 +155,7 @@ object HashM extends HashMDerivation {
   implicit val PrivateNamePreviewQueryHash = gen[PrivateNamePreviewQuery]
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 trait HashMDerivation {
   import magnolia._
 

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -155,7 +155,6 @@ object HashM extends HashMDerivation {
   implicit val PrivateNamePreviewQueryHash = gen[PrivateNamePreviewQuery]
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
 trait HashMDerivation {
   import magnolia._
 
@@ -176,6 +175,7 @@ trait HashMDerivation {
 
   //copied and adapted from scala.util.hashing.MurmurHash3,
   //which is used in Scala's case class hash code implementation
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private def productHash(prefix: String, elements: Seq[Int]): Int = {
     val arr = elements.size
     // Case objects have the hashCode inlined directly into the

--- a/models/src/main/scala/coop/rchain/models/Memo.scala
+++ b/models/src/main/scala/coop/rchain/models/Memo.scala
@@ -3,6 +3,7 @@ import com.typesafe.scalalogging.Logger
 import monix.eval.Coeval
 import monix.eval.Coeval.Eager
 
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 class Memo[A](f: => Coeval[A]) {
 
   private[this] val logger = Logger("Memo")

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -178,6 +178,8 @@ object PrettyUtils {
     * Convert a string to a C&P-able literal. Basically
     * copied verbatim from the uPickle source code.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  // TODO remove this var
   def literalize(s: IndexedSeq[Char], unicode: Boolean = true): String = {
     val sb = new StringBuilder
     sb.append('"')

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -106,6 +106,7 @@ object ProtoM extends DescriptorPimps {
   private def writeUInt32NoTag(out: CodedOutputStream, valueSize: Int): Coeval[Unit] =
     Sync[Coeval].delay { out.writeUInt32NoTag(valueSize) }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private def writeScalarValue(
       value: Any,
       field: FieldDescriptor,
@@ -209,6 +210,7 @@ object ProtoM extends DescriptorPimps {
       scalarValueSize(value, field)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private def scalarValueSize(value: Any, field: FieldDescriptor): Coeval[Int] =
     Sync[Coeval].catchNonFatal {
 

--- a/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
@@ -11,6 +11,7 @@ import kamon.metric._
 /**
   * Based on kamon-prometheus but without the embedded server
   */
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 class NewPrometheusReporter extends MetricReporter {
   import NewPrometheusReporter.Configuration.{environmentTags, readConfiguration}
 

--- a/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
@@ -10,6 +10,7 @@ import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{information, none, time}
 import kamon.metric.MeasurementUnit.Dimension._
 
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
 class ScrapeDataBuilder(
     prometheusConfig: NewPrometheusReporter.Configuration,
     environmentTags: Map[String, String] = Map.empty

--- a/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
@@ -74,7 +74,7 @@ class ScrapeDataBuilder(
           resolveBucketConfiguration(metric)
         )
 
-        val count = format(metric.distribution.count)
+        val count = format(metric.distribution.count.toDouble)
         val sum   = format(scale(metric.distribution.sum, metric.unit))
         appendTimeSerieValue(normalizedMetricName, metric.tags, count, "_count")
         appendTimeSerieValue(normalizedMetricName, metric.tags, sum, "_sum")
@@ -86,7 +86,7 @@ class ScrapeDataBuilder(
       name: String,
       tags: Map[String, String],
       value: String,
-      suffix: String = ""
+      suffix: String
   ): Unit = {
     append(name)
     append(suffix)
@@ -136,14 +136,19 @@ class ScrapeDataBuilder(
         }
       }
 
-      appendTimeSerieValue(name, bucketTags, format(inBucketCount), "_bucket")
+      appendTimeSerieValue(name, bucketTags, format(inBucketCount.toDouble), "_bucket")
     }
 
     while (distributionBuckets.hasNext) {
       leftOver += distributionBuckets.next().frequency
     }
 
-    appendTimeSerieValue(name, tags + ("le" -> "+Inf"), format(leftOver + inBucketCount), "_bucket")
+    appendTimeSerieValue(
+      name,
+      tags + ("le" -> "+Inf"),
+      format(leftOver + inBucketCount.toDouble),
+      "_bucket"
+    )
   }
 
   private def appendTags(tags: Map[String, String]): Unit = {
@@ -187,7 +192,7 @@ class ScrapeDataBuilder(
       MeasurementUnit.scale(value, unit, time.seconds)
     case Information if unit.magnitude != information.bytes.magnitude =>
       MeasurementUnit.scale(value, unit, information.bytes)
-    case _ => value
+    case _ => value.toDouble
   }
 
 }

--- a/regex/src/main/scala/coop/rchain/regex/Fsm.scala
+++ b/regex/src/main/scala/coop/rchain/regex/Fsm.scala
@@ -320,7 +320,7 @@ final case class Fsm(
     * If `Fsm.AnythingElse` is in your alphabet, then any symbol not in your
     * alphabet will be converted to `Fsm.AnythingElse`
     */
-  @SuppressWarnings(Array("org.wartremover.warts.Return"))
+  @SuppressWarnings(Array("org.wartremover.warts.Return", "org.wartremover.warts.Var"))
   def accepts(input: String): Boolean = {
     var currentState = initialState
     for (currentSymbol <- input) {
@@ -348,7 +348,7 @@ final case class Fsm(
     * If you fall into oblivion, then the derivative is an FSM accepting no
     * strings.
     */
-  @SuppressWarnings(Array("org.wartremover.warts.Return"))
+  @SuppressWarnings(Array("org.wartremover.warts.Return", "org.wartremover.warts.Var"))
   def derive(input: String): Try[Fsm] = {
     var currentState = initialState
     for (currentSymbol <- input) {
@@ -433,6 +433,7 @@ final case class Fsm(
     * may be more efficient ways to do this, that I haven't investigated yet.
     * You can use this in list comprehensions.
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def strings: Stream[String] = {
     // Many FSMs have "dead states". Once you reach a dead state, you can no
     // longer reach a final state. Since many strings may end up here, it's

--- a/regex/src/main/scala/coop/rchain/regex/Multiplier.scala
+++ b/regex/src/main/scala/coop/rchain/regex/Multiplier.scala
@@ -82,6 +82,7 @@ private[regex] object Multiplier {
   * also permit a max of 0 (iff min is 0 too). This allows the multiplier
   * "zero" to exist, which actually are quite useful in their own special way.
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 final case class Multiplier(min: Option[Int], max: Option[Int]) {
 
   /**

--- a/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
+++ b/regex/src/main/scala/coop/rchain/regex/PathRegex.scala
@@ -37,6 +37,7 @@ object PathRegexOptions {
   val nonEnd        = PathRegexOptions(end = false)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 private[regex] final case class PathToken(
     name: Option[String],
     key: Int,

--- a/regex/src/main/scala/coop/rchain/regex/RegexPattern.scala
+++ b/regex/src/main/scala/coop/rchain/regex/RegexPattern.scala
@@ -29,6 +29,7 @@ trait ParsedPattern {
 /**
   * A companion object for the RegexPattern class
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 object RegexPattern extends ParsedPattern {
 
   /**
@@ -57,6 +58,7 @@ object RegexPattern extends ParsedPattern {
   * All patterns have some things in common. This parent class mainly
   * hosts documentation though.
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 sealed abstract class RegexPattern {
 
   /**
@@ -690,6 +692,7 @@ object ConcPattern extends ParsedPattern {
   * e.g. abcde[{@literal ^}fg]*h{4}[a-z]+(subpattern)(subpattern2)
   * To express the empty string, use an empty ConcatenationPattern().
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 final case class ConcPattern(mults: List[MultPattern]) extends RegexPattern {
 
   override lazy val alphabet: Set[Char] = mults.flatMap(_.alphabet).toSet + Fsm.anythingElse
@@ -801,6 +804,7 @@ object AltPattern extends ParsedPattern {
   * 1, a lower bound 1, and a multiplicand which is a new subpattern, "ghi|jkl".
   * This new subpattern again consists of two ConcPatterns: "ghi" and "jkl".
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 final case class AltPattern(concs: Set[ConcPattern]) extends RegexPattern {
 
   override lazy val alphabet: Set[Char] = concs.flatMap(_.alphabet) + Fsm.anythingElse
@@ -900,6 +904,7 @@ object MultPattern extends ParsedPattern {
   * multipliers like "*" (min = 0, max = inf) and so on.
   * e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, and so on
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
 final case class MultPattern(multiplicand: RegexPattern, multiplier: Multiplier)
     extends RegexPattern {
 

--- a/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
+++ b/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
@@ -21,6 +21,7 @@ object RholangProtoBuild {
 
   def escape(s: String): String = "\"" + s.replace("\"", "\\") + "\""
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def createProtoArtifact(input: Path, output: Path): Unit =
     CompiledRholangSource.fromSourceFile(input.toFile) match {
       case Left(ex) =>
@@ -92,6 +93,7 @@ object RholangProtoBuild {
     |  <resourceManaged>     - directory to write protobuf outputs to
     |""".stripMargin
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def main(args: Array[String]): Unit =
     if (args.length != 3) {
       println(cliUsage)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ErrorLog.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ErrorLog.scala
@@ -5,6 +5,8 @@ import cats.effect._
 import cats.implicits._
 import cats.mtl.FunctorTell
 
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+// TODO remove/modify this monster!
 class ErrorLog[F[_]: Sync] extends FunctorTell[F, Throwable] {
   private var errorVector: Vector[Throwable] = Vector.empty
   val functor                                = implicitly[Functor[F]]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -47,6 +47,7 @@ final case class PrettyPrinter(
   def buildString(v: Var): String              = buildStringM(v).value.cap()
   def buildString(m: GeneratedMessage): String = buildStringM(m).value.cap()
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private def buildStringM(e: Expr): Coeval[String] = Coeval.defer {
     e.exprInstance match {
 
@@ -155,6 +156,7 @@ final case class PrettyPrinter(
 
   private def buildStringM(t: GeneratedMessage): Coeval[String] = buildStringM(t, 0)
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   private def buildStringM(t: GeneratedMessage, indent: Int): Coeval[String] = Coeval.defer {
     val content = t match {
       case v: Var => buildStringM(v)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -721,6 +721,8 @@ object Reduce {
                   ReduceError("Error: interpolation Map should only contain String keys")
                 )
             }
+          @SuppressWarnings(Array("org.wartremover.warts.Var"))
+          // TODO consider replacing while loop with tailrec recursion
           def interpolate(string: String, keyValuePairs: List[(String, String)]): String = {
             val result  = StringBuilder.newBuilder
             var current = string

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -14,6 +14,7 @@ import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import monix.eval.{Coeval, Task}
 import monix.execution.{CancelableFuture, Scheduler}
 import org.rogach.scallop.{stringListConverter, ScallopConf}
+import coop.rchain.shared.Log
 
 import scala.annotation.tailrec
 import scala.concurrent.Await
@@ -51,6 +52,8 @@ object RholangCLI {
     import monix.execution.Scheduler.Implicits.global
 
     val conf = new Conf(args)
+
+    implicit val log: Log[Task] = Log.log[Task]
 
     val runtime = (for {
       runtime <- Runtime.create[Task, Task.Par](conf.dataDir(), conf.mapSize(), StoreType.LMDB)
@@ -133,6 +136,7 @@ object RholangCLI {
   }
 
   @tailrec
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def waitForSuccess(evaluatorFuture: CancelableFuture[EvaluateResult]): Unit =
     try {
       Await.ready(evaluatorFuture, 5.seconds).value match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -24,6 +24,7 @@ import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.pure.PureRSpace
 import coop.rchain.shared.StoreType
 import coop.rchain.shared.StoreType._
+import coop.rchain.shared.Log
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
@@ -285,7 +286,7 @@ object Runtime {
     )
   )
 
-  def create[F[_]: ContextShift: Sync, M[_]](
+  def create[F[_]: ContextShift: Sync: Log, M[_]](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType,
@@ -427,7 +428,7 @@ object Runtime {
     } yield ()
   }
 
-  def setupRSpace[F[_]: Sync: ContextShift](
+  def setupRSpace[F[_]: Sync: ContextShift: Log](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -8,6 +8,7 @@ import monix.execution.Scheduler.Implicits.global
 import coop.rchain.rholang.Resources.mkRuntime
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
+import coop.rchain.shared.Log
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -16,6 +17,8 @@ class InterpreterSpec extends FlatSpec with Matchers {
   private val mapSize     = 10L * 1024L * 1024L
   private val tmpPrefix   = "rspace-store-"
   private val maxDuration = 5.seconds
+
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
   behavior of "Interpreter"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -6,6 +6,7 @@ import cats.Applicative
 import cats.effect.ExitCase.Error
 import cats.effect.{ContextShift, Resource, Sync}
 import com.typesafe.scalalogging.Logger
+import coop.rchain.shared.Log
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace}
@@ -35,7 +36,7 @@ object Resources {
         })
     )
 
-  def mkRhoISpace[F[_]: Sync: ContextShift](
+  def mkRhoISpace[F[_]: Sync: ContextShift: Log](
       prefix: String = "",
       branch: String = "test",
       mapSize: Long = 1024L * 1024L * 4
@@ -65,7 +66,7 @@ object Resources {
       prefix: String,
       storageSize: Long = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
-  )(implicit scheduler: Scheduler): Resource[Task, Runtime[Task]] =
+  )(implicit log: Log[Task], scheduler: Scheduler): Resource[Task, Runtime[Task]] =
     mkTempDir[Task](prefix)
       .flatMap { tmpDir =>
         Resource.make[Task, Runtime[Task]](Task.suspend {

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -8,6 +8,7 @@ import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.StackSafetySpec.findMaxRecursionDepth
 import coop.rchain.rholang.interpreter.{Interpreter, PrettyPrinter}
 import coop.rchain.rspace.Serialize
+import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -18,9 +19,10 @@ import scala.concurrent.duration._
 
 object StackSafetySpec extends Assertions {
 
-  val mapSize     = 10L * 1024L * 1024L
-  val tmpPrefix   = "rspace-store-"
-  val maxDuration = 20.seconds
+  val mapSize                  = 10L * 1024L * 1024L
+  val tmpPrefix                = "rspace-store-"
+  val maxDuration              = 20.seconds
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
   def findMaxRecursionDepth(): Int = {
     def count(i: Int): Int =
@@ -157,6 +159,8 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
     Seq.fill(depth)(left).mkString + middle + Seq.fill(depth)(right).mkString
 
   private def checkAll(term: String): Unit = {
+    implicit val logF: Log[Task] = Log.log[Task]
+
     val rho =
       s"""
          |  //send without reducing the term, testing serialization

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -18,6 +18,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.rholang.Resources.mkRhoISpace
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rspace.internal
+import coop.rchain.shared.Log
 
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -90,8 +91,9 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     val program =
       Par(sends = Seq(Send(channel, Seq(a)), Send(channel, Seq(b))))
 
-    implicit val rand   = Blake2b512Random(Array.empty[Byte])
-    implicit val errLog = new ErrorLog[Task]()
+    implicit val rand            = Blake2b512Random(Array.empty[Byte])
+    implicit val errLog          = new ErrorLog[Task]()
+    implicit val logF: Log[Task] = Log.log[Task]
 
     def testImplementation(pureRSpace: RhoISpace[Task]): Task[
       (

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -21,6 +21,7 @@ import coop.rchain.rholang.interpreter.Runtime.RhoIStore
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rspace.Serialize
 import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
@@ -210,9 +211,10 @@ class CryptoChannelsSpec
   }
 
   override protected def withFixture(test: OneArgTest): Outcome = {
-    val randomInt = scala.util.Random.nextInt
-    val dbDir     = Files.createTempDirectory(s"rchain-storage-test-$randomInt")
-    val size      = 1024L * 1024 * 10
+    val randomInt                = scala.util.Random.nextInt
+    val dbDir                    = Files.createTempDirectory(s"rchain-storage-test-$randomInt")
+    val size                     = 1024L * 1024 * 10
+    implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
     val runtime = (for {
       runtime <- Runtime.create[Task, Task.Par](dbDir, size, StoreType.LMDB)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -10,6 +10,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.RhoIStore
 import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.shared.Log
 import coop.rchain.shared.PathOps._
 import coop.rchain.shared.StoreType
 import monix.eval.Task
@@ -20,6 +21,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class DeployParamsSpec extends fixture.FlatSpec with Matchers {
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+
   override protected def withFixture(test: OneArgTest): Outcome = {
     val randomInt = scala.util.Random.nextInt
     val dbDir     = Files.createTempDirectory(s"rchain-storage-test-$randomInt")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -24,6 +24,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
 
 import scala.collection.immutable.BitSet
 import scala.collection.mutable.HashMap
@@ -34,8 +35,10 @@ final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Ta
 
 trait PersistentStoreTester {
   def withTestSpace[R](errorLog: ErrorLog[Task])(f: TestFixture => R): R = {
-    val dbDir               = Files.createTempDirectory("rholang-interpreter-test-")
-    val context: RhoContext = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
+    val dbDir                    = Files.createTempDirectory("rholang-interpreter-test-")
+    val context: RhoContext      = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
+    implicit val logF: Log[Task] = new Log.NOPLog[Task]
+
     val space = (RSpace
       .create[
         Task,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -5,13 +5,15 @@ import coop.rchain.rholang.Resources.mkRuntime
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
+import coop.rchain.shared.Log
 
 import scala.concurrent.duration._
 
 class RuntimeSpec extends FlatSpec with Matchers {
-  private val mapSize     = 10L * 1024L * 1024L
-  private val tmpPrefix   = "rspace-store-"
-  private val maxDuration = 5.seconds
+  private val mapSize          = 10L * 1024L * 1024L
+  private val tmpPrefix        = "rspace-store-"
+  private val maxDuration      = 5.seconds
+  implicit val logF: Log[Task] = Log.log[Task]
 
 //  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -14,6 +14,7 @@ import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Context, RSpace}
+import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen}
@@ -98,6 +99,7 @@ object CostAccountingPropertyTest {
   def costOfExecution(procs: Proc*): Task[Long] = {
     implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
     implicit val errLog: ErrorLog[Task] = new ErrorLog[Task]()
+    implicit val logF: Log[Task]        = new Log.NOPLog[Task]
 
     mkRhoISpace[Task]("cost-accounting-property-test-")
       .use { pureRSpace =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -22,6 +22,7 @@ import coop.rchain.rholang.interpreter.accounting.Chargeable._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Context, ISpace, RSpace}
+import coop.rchain.shared.Log
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.TableFor1
 
@@ -798,6 +799,8 @@ class RholangMethodsCostsSpec
   private var dbDir: Path            = null
   private var context: RhoContext    = null
   private var space: RhoISpace[Task] = null
+
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
   override protected def beforeAll(): Unit = {
     import coop.rchain.catscontrib.TaskContrib._

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -19,6 +19,7 @@ import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.ChargingRSpaceTest.{ChargingRSpace, _}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Match, _}
+import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
@@ -466,4 +467,5 @@ object ChargingRSpaceTest {
     override def clear(): Task[Unit]                                                      = ???
   }
 
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 }

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -9,14 +9,16 @@ import monix.execution.Scheduler.Implicits.global
 import coop.rchain.rholang.Resources.mkRuntime
 import monix.eval.Task
 import org.scalatest.{FunSuite, Matchers}
+import coop.rchain.shared.Log
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class CompilerTests extends FunSuite with Matchers {
-  private val mapSize     = 1024L * 1024L * 10
-  private val tmpPrefix   = "rspace-store-"
-  private val maxDuration = 5.seconds
+  private val mapSize          = 1024L * 1024L * 10
+  private val tmpPrefix        = "rspace-store-"
+  private val maxDuration      = 5.seconds
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
   private val testFiles: Iterator[Path] =
     Files.walk(Paths.get(getClass.getResource("/tests").getPath)).iterator().asScala

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 import cats.effect.{ContextShift, Sync}
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.shared.Log
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.catscontrib.TaskContrib.TaskOps
@@ -105,6 +106,7 @@ object BasicBench {
     import coop.rchain.rholang.interpreter.storage.implicits._
 
     implicit val syncF: Sync[Task]                 = Task.catsEffect
+    implicit val logF: Log[Task]                   = new Log.NOPLog[Task]
     implicit val contextShiftF: ContextShift[Task] = Task.contextShift
 
     private val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -11,12 +11,14 @@ import coop.rchain.rholang.interpreter.accounting.{CostAccount, CostAccounting}
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.StoreType
+import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 
 trait EvalBenchStateBase {
   private lazy val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")
   private val mapSize: Long    = 1024L * 1024L * 1024L
+  implicit val logF: Log[Task] = new Log.NOPLog[Task]
 
   val rhoScriptSource: String
   lazy val runtime: Runtime[Task] =

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -11,6 +11,7 @@ import coop.rchain.rspace.examples.AddressBookExample.implicits._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.util._
 import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
@@ -92,8 +93,8 @@ class LMDBBench extends RSpaceBench {
   val mapSize: Long  = 1024L * 1024L * 1024L
   val noTls: Boolean = false
 
-  var dbDir: Path = null
-
+  var dbDir: Path            = null
+  implicit val logF: Log[Id] = new Log.NOPLog[Id]
   @Setup
   def setup() = {
     dbDir = Files.createTempDirectory("rchain-rspace-lmdb-bench-")
@@ -120,6 +121,8 @@ class LMDBBench extends RSpaceBench {
 @Measurement(iterations = 10)
 class InMemBench extends RSpaceBench {
 
+  implicit val logF: Log[Id] = new Log.NOPLog[Id]
+
   @Setup
   def setup() = {
     val context = Context.createInMemory[Channel, Pattern, Entry, EntriesCaptor]()
@@ -145,10 +148,10 @@ class InMemBench extends RSpaceBench {
 @Measurement(iterations = 10)
 class MixedBench extends RSpaceBench {
 
-  val mapSize: Long  = 1024L * 1024L * 1024L
-  val noTls: Boolean = false
-
-  var dbDir: Path = null
+  val mapSize: Long          = 1024L * 1024L * 1024L
+  val noTls: Boolean         = false
+  implicit val logF: Log[Id] = Log.log[Id]
+  var dbDir: Path            = null
 
   @Setup
   def setup() = {

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -9,6 +9,7 @@ import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace.examples.AddressBookExample._
 import coop.rchain.rspace.examples.AddressBookExample.implicits._
 import coop.rchain.rspace.history.Branch
+import coop.rchain.shared.Log
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
@@ -54,11 +55,11 @@ object ReplayRSpaceBench {
     var space: IdISpace[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] = null
     var replaySpace: IReplaySpace[cats.Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] =
       null
-
-    val consumeChannel = Channel("consume")
-    val produceChannel = Channel("produce")
-    val matches        = List(CityMatch(city = "Crystal Lake"))
-    val captor         = new EntriesCaptor()
+    implicit val logF: Log[Id] = new Log.NOPLog[Id]
+    val consumeChannel         = Channel("consume")
+    val produceChannel         = Channel("produce")
+    val matches                = List(CityMatch(city = "Crystal Lake"))
+    val captor                 = new EntriesCaptor()
 
     def initSpace() = {
       val rigPoint = space.createCheckpoint()

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -11,7 +11,7 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
-import coop.rchain.shared.StoreType
+import coop.rchain.shared.{Log, StoreType}
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
 import org.openjdk.jmh.annotations._
@@ -34,7 +34,8 @@ abstract class WideBenchBaseState {
 
   var runTask: Task[Vector[Throwable]] = null
 
-  implicit def readErrors = () => runtime.readAndClearErrorVector().unsafeRunSync
+  implicit def readErrors      = () => runtime.readAndClearErrorVector().unsafeRunSync
+  implicit val logF: Log[Task] = Log.log[Task]
 
   def createRuntime(): Runtime[Task] =
     Runtime.create[Task, Task.Par](dbDir, mapSize, StoreType.LMDB).unsafeRunSync

--- a/rspace/src/main/scala/coop/rchain/rspace/CloseOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/CloseOps.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rspace
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+// TODO Why!? Why would we ever allow code like that?
 trait CloseOps {
   @volatile private[this] var isClosed = false
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -110,6 +110,8 @@ trait IStore[C, P, A, K] {
   private[rspace] def getAndClearTrieUpdates(): Seq[TrieUpdate[C, P, A, K]] =
     _trieUpdates.getAndTransform(kp((0L, Nil)))._2
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def createCheckpoint(): Blake2b256Hash = {
     val trieUpdates = getAndClearTrieUpdates()
     collapse(trieUpdates).foreach(processTrieUpdate)

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -84,12 +84,14 @@ trait IStore[C, P, A, K] {
   private val _trieUpdates: AtomicAny[(Long, List[TrieUpdate[C, P, A, K]])] =
     AtomicAny[(Long, List[TrieUpdate[C, P, A, K]])]((0L, Nil))
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def trieDelete(key: Blake2b256Hash, gnat: GNAT[C, P, A, K]): Unit =
     _trieUpdates.getAndTransform {
       case (count, list) =>
         (count + 1, TrieUpdate(count, Delete, key, gnat) :: list)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   def trieInsert(key: Blake2b256Hash, gnat: GNAT[C, P, A, K]): Unit =
     _trieUpdates.getAndTransform {
       case (count, list) =>
@@ -104,6 +106,7 @@ trait IStore[C, P, A, K] {
 
   protected def processTrieUpdate(update: TrieUpdate[C, P, A, K]): Unit
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private[rspace] def getAndClearTrieUpdates(): Seq[TrieUpdate[C, P, A, K]] =
     _trieUpdates.getAndTransform(kp((0L, Nil)))._2
 

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
@@ -61,6 +61,7 @@ trait InMemoryOps[S] extends CloseOps {
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
   private[rspace] def createTxnWrite(): InMemTransaction[S] = {
     failIfClosed()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
@@ -26,6 +26,8 @@ trait InMemoryOps[S] extends CloseOps {
     sv
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R): R =
     try {
       val ret: R = f(txn)
@@ -39,6 +41,8 @@ trait InMemoryOps[S] extends CloseOps {
       txn.close()
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[rspace] def createTxnRead(): InMemTransaction[S] = {
     failIfClosed()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -260,6 +260,8 @@ class InMemoryStore[T, C, P, A, K](
 
 object InMemoryStore {
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def roundTrip[K: Serialize](k: K): K =
     Serialize[K].decode(Serialize[K].encode(k)) match {
       case Left(ex)     => throw ex

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
@@ -40,6 +40,8 @@ trait LMDBOps extends CloseOps {
     entriesGauge.set(env.stat().entries)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[rspace] def withTxn[R](txn: Txn[ByteBuffer])(f: Txn[ByteBuffer] => R): R =
     try {
       val ret: R = f(txn)
@@ -71,6 +73,8 @@ trait LMDBOps extends CloseOps {
     *
     * a benchmark showing the difference can be found in the rspaceBench project (KeyBench)
     */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   implicit class RichDbi(val dbi: Dbi[ByteBuffer]) {
 
     def get[V](txn: Txn[ByteBuffer], key: Blake2b256Hash)(implicit codecV: Codec[V]): Option[V] =

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -22,6 +22,8 @@ import scodec.bits._
   *
   * To create an instance, use [[LMDBStore.create]].
   */
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+// TODO stop throwing exceptions
 class LMDBStore[C, P, A, K] private[rspace] (
     val env: Env[ByteBuffer],
     protected[this] val databasePath: Path,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -7,7 +7,7 @@ import scala.util.Random
 
 import cats.effect.{ContextShift, Sync}
 import cats.implicits._
-
+import coop.rchain.shared.Log
 import coop.rchain.catscontrib._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
@@ -28,6 +28,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
     serializeA: Serialize[A],
     serializeK: Serialize[K],
     val syncF: Sync[F],
+    logF: Log[F],
     contextShift: ContextShift[F],
     scheduler: ExecutionContext
 ) extends RSpaceOps[F, C, P, E, A, R, K](store, branch)
@@ -53,112 +54,111 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
-      syncF.delay {
-        Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
-          if (channels.isEmpty) {
-            val msg = "channels can't be empty"
-            logger.error(msg)
-            throw new IllegalArgumentException(msg)
-          }
-          if (channels.length =!= patterns.length) {
-            val msg = "channels.length must equal patterns.length"
-            logger.error(msg)
-            throw new IllegalArgumentException(msg)
-          }
-          val span = Kamon.currentSpan()
-          span.mark("before-consume-ref-compute")
-          val consumeRef = Consume.create(channels, patterns, continuation, persist, sequenceNumber)
 
-          span.mark("before-consume-lock")
-          consumeLock(channels) {
-            span.mark("consume-lock-acquired")
-            logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
+      if (channels.isEmpty) {
+        val msg = "channels can't be empty"
+        logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
+      } else if (channels.length =!= patterns.length) {
+        val msg = "channels.length must equal patterns.length"
+        logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
+      } else
+        syncF.delay {
+          Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
+            val span = Kamon.currentSpan()
+            span.mark("before-consume-ref-compute")
+            val consumeRef =
+              Consume.create(channels, patterns, continuation, persist, sequenceNumber)
+
+            span.mark("before-consume-lock")
+            consumeLock(channels) {
+              span.mark("consume-lock-acquired")
+              logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
                              |at <channels: $channels>""".stripMargin.replace('\n', ' '))
 
-            span.mark("before-event-log-lock-acquired")
-            eventLog.update(consumeRef +: _)
-            span.mark("event-log-updated")
-            /*
-             * Here, we create a cache of the data at each channel as `channelToIndexedData`
-             * which is used for finding matches.  When a speculative match is found, we can
-             * remove the matching datum from the remaining data candidates in the cache.
-             *
-             * Put another way, this allows us to speculatively remove matching data without
-             * affecting the actual store contents.
-             */
+              span.mark("before-event-log-lock-acquired")
+              eventLog.update(consumeRef +: _)
+              span.mark("event-log-updated")
+              /*
+               * Here, we create a cache of the data at each channel as `channelToIndexedData`
+               * which is used for finding matches.  When a speculative match is found, we can
+               * remove the matching datum from the remaining data candidates in the cache.
+               *
+               * Put another way, this allows us to speculatively remove matching data without
+               * affecting the actual store contents.
+               */
 
-            span.mark("before-channel-to-indexed-data")
-            val channelToIndexedData = store.withTxn(store.createTxnRead()) { txn =>
-              channels.map { c: C =>
-                c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-              }.toMap
-            }
+              span.mark("before-channel-to-indexed-data")
+              val channelToIndexedData = store.withTxn(store.createTxnRead()) { txn =>
+                channels.map { c: C =>
+                  c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
+                }.toMap
+              }
 
-            span.mark("before-extract-data-candidates")
-            val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
-              extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
-                .map(_.sequence)
+              span.mark("before-extract-data-candidates")
+              val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
+                extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+                  .map(_.sequence)
 
-            options match {
-              case Left(e) =>
-                Left(e)
-              case Right(None) =>
-                span.mark("acquire-write-lock")
+              options match {
+                case Left(e) =>
+                  Left(e)
+                case Right(None) =>
+                  span.mark("acquire-write-lock")
 
-                store
-                  .withTxn(store.createTxnWrite()) { txn =>
-                    span.mark("before-put-continuation")
-                    store.putWaitingContinuation(
-                      txn,
-                      channels,
-                      WaitingContinuation(patterns, continuation, persist, consumeRef)
-                    )
-                    span.mark("after-put-continuation")
-                    for (channel <- channels)
-                      store.addJoin(txn, channel, channels)
-                  }
-                logger.debug(s"""|consume: no data found,
+                  store
+                    .withTxn(store.createTxnWrite()) { txn =>
+                      span.mark("before-put-continuation")
+                      store.putWaitingContinuation(
+                        txn,
+                        channels,
+                        WaitingContinuation(patterns, continuation, persist, consumeRef)
+                      )
+                      span.mark("after-put-continuation")
+                      for (channel <- channels)
+                        store.addJoin(txn, channel, channels)
+                    }
+                  logger.debug(s"""|consume: no data found,
                                  |storing <(patterns, continuation): ($patterns, $continuation)>
                                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-                Right(None)
-              case Right(Some(dataCandidates)) =>
-                consumeCommCounter.increment()
+                  Right(None)
+                case Right(Some(dataCandidates)) =>
+                  consumeCommCounter.increment()
 
-                span.mark("before-event-log-update")
-                eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
-                span.mark("event-log-updated")
+                  span.mark("before-event-log-update")
+                  eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
+                  span.mark("event-log-updated")
 
-                dataCandidates
-                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                  .foreach {
-                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex)
-                        if !persistData =>
-                      span.mark("acquire-write-lock")
-                      store.withTxn(store.createTxnWrite()) { txn =>
-                        span.mark("before-remove-datum")
-                        store.removeDatum(txn, Seq(candidateChannel), dataIndex)
-                        span.mark("after-remove-datum")
-                      }
-                    case _ =>
-                      ()
-                  }
-                logger.debug(
-                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
-                )
-                val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
-                Right(
-                  Some(
-                    (
-                      ContResult(continuation, persist, channels, patterns, contSequenceNumber),
-                      dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+                  dataCandidates
+                    .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                    .foreach {
+                      case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex)
+                          if !persistData =>
+                        span.mark("acquire-write-lock")
+                        store.withTxn(store.createTxnWrite()) { txn =>
+                          span.mark("before-remove-datum")
+                          store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+                          span.mark("after-remove-datum")
+                        }
+                      case _ =>
+                        ()
+                    }
+                  logger.debug(
+                    s"consume: data found for <patterns: $patterns> at <channels: $channels>"
+                  )
+                  val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
+                  Right(
+                    Some(
+                      (
+                        ContResult(continuation, persist, channels, patterns, contSequenceNumber),
+                        dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+                      )
                     )
                   )
-                )
 
+              }
             }
           }
         }
-      }
     }
 
   private def nextSequenceNumber(consumeRef: Consume, dataCandidates: Seq[DataCandidate[C, R]]) =
@@ -331,6 +331,7 @@ object RSpace {
       sa: Serialize[A],
       sk: Serialize[K],
       syncF: Sync[F],
+      log: Log[F],
       contextShift: ContextShift[F],
       scheduler: ExecutionContext
   ): F[ISpace[F, C, P, E, A, R, K]] =
@@ -352,6 +353,7 @@ object RSpace {
       sa: Serialize[A],
       sk: Serialize[K],
       syncF: Sync[F],
+      logF: Log[F],
       contextShift: ContextShift[F],
       scheduler: ExecutionContext
   ): F[ISpace[F, C, P, E, A, R, K]] = {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -67,6 +67,8 @@ abstract class RSpaceOps[F[_], C, P, E, A, R, K](
         install(txn, channels, patterns, continuation)(_match)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def install(
       txn: store.Transaction,
       channels: Seq[C],

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
@@ -14,6 +14,8 @@ class DefaultMultiLock[K] extends MultiLock[K] {
 
   private[this] val locks = TrieMap.empty[K, Semaphore]
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def acquire[R](keys: Seq[K])(thunk: => R)(implicit o: Ordering[K]): R = {
     // TODO: keys should be a Set[K]
     val sortedKeys = keys.toSet.toList.sorted

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -9,6 +9,7 @@ import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.shared.Language.ignore
+import coop.rchain.shared.Log
 import coop.rchain.rspace.util._
 import scala.concurrent.ExecutionContext
 import scodec.bits.ByteVector
@@ -199,6 +200,8 @@ object AddressBookExample {
 
   def exampleOne(): Unit = {
 
+    implicit val log: Log[Id] = Log.log
+
     // Here we define a temporary place to put the store's files
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
 
@@ -237,6 +240,8 @@ object AddressBookExample {
   }
 
   def exampleTwo(): Unit = {
+
+    implicit val log: Log[Id] = Log.log
 
     // Here we define a temporary place to put the store's files
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
@@ -331,6 +336,8 @@ object AddressBookExample {
   private[this] def withSpace(
       f: IdISpace[Channel, Pattern, Nothing, Entry, Entry, Printer] => Unit
   ) = {
+
+    implicit val log: Log[Id] = Log.log
     // Here we define a temporary place to put the store's files
     val storePath = Files.createTempDirectory("rspace-address-book-example-")
     // Let's define our store

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -36,6 +36,8 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def toMap: Map[Blake2b256Hash, Trie[K, V]]
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[rspace] def getLeaves(txn: T, hash: Blake2b256Hash): Seq[Leaf[K, V]] = {
     @tailrec
     def loop(txn: T, ts: Seq[Trie[K, V]], ls: Seq[Leaf[K, V]]): Seq[Leaf[K, V]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
@@ -30,6 +30,8 @@ object State {
   def empty[K, V]: State[K, V] = State[K, V](Map.empty, Map.empty, Map.empty, None)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+// TODO stop throwing exceptions
 class InMemoryTrieStore[K, V]
     extends InMemoryOps[State[K, V]]
     with ITrieStore[InMemTransaction[State[K, V]], K, V] {

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -17,6 +17,8 @@ import org.lmdbjava.DbiFlags.MDB_CREATE
 import scodec.Codec
 import scodec.bits.{BitVector, ByteVector}
 
+@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+// TODO stop throwing exceptions
 class LMDBTrieStore[K, V] private (
     val env: Env[ByteBuffer],
     protected[this] val databasePath: Path,

--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -56,6 +56,8 @@ package object history {
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def lookup[T, K, V](
       txn: T,
       store: ITrieStore[T, K, V],
@@ -112,6 +114,8 @@ package object history {
       store.getRoot(txn, branch).flatMap(lookup(txn, store, _, key))
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def lookup[T, K, V](store: ITrieStore[T, K, V], branch: Branch, keys: immutable.Seq[K])(
       implicit codecK: Codec[K]
   ): Option[immutable.Seq[V]] =
@@ -125,6 +129,8 @@ package object history {
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def getParents[T, K, V](
       store: ITrieStore[T, K, V],
       txn: T,
@@ -187,6 +193,8 @@ package object history {
         (Trie.hash[K, V](node), node)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def insert[T, K, V](store: ITrieStore[T, K, V], branch: Branch, key: K, value: V)(
       implicit
       codecK: Codec[K],
@@ -253,6 +261,8 @@ package object history {
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def insertLeafOntoSkipNode[V, K, T](
       encodedKeyByteVector: ByteVector,
       newLeafHash: Blake2b256Hash,
@@ -323,6 +333,8 @@ package object history {
     newParents ++ rehashedNodes
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def updateLeaf[V, K, T](
       newLeafHash: Blake2b256Hash,
       parents: Parents[K, V]
@@ -339,6 +351,8 @@ package object history {
     rehashedNodes
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def collapseAndUpdatePointerBlock[T, K, V](
       ptr: NonEmptyPointer,
       incomingAffix: ByteVector,
@@ -402,6 +416,8 @@ package object history {
     }
 
   @tailrec
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   private[this] def deleteLeaf[T, K, V](store: ITrieStore[T, K, V], txn: T, parents: Parents[K, V])(
       implicit
       codecK: Codec[K],
@@ -455,6 +471,8 @@ package object history {
         }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
   def delete[T, K, V](store: ITrieStore[T, K, V], branch: Branch, key: K, value: V)(
       implicit
       codecK: Codec[K],

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -152,6 +152,7 @@ object internal {
 
   import scodec.{Attempt, Err}
 
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   implicit class RichAttempt[T](a: Attempt[T]) {
     def get: T =
       a match {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -14,6 +14,7 @@ import coop.rchain.rspace.history.{Branch, InMemoryTrieStore}
 import coop.rchain.rspace.internal.GNAT
 import coop.rchain.rspace.trace.{COMM, Consume, IOEvent, Produce}
 import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
 import org.scalatest._
 
 import scala.collection.parallel.ParSeq
@@ -25,6 +26,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait ReplayRSpaceTests
     extends ReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
     with TestImplicitHelpers {
+
+  implicit val log: Log[Id] = new Log.NOPLog[Id]
 
   def consumeMany[C, P, A, R, K](
       space: IdISpace[C, P, Nothing, A, R, K],
@@ -893,6 +896,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
     implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
+    implicit val log: Log[Id] = Log.log[Id]
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.create[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
@@ -925,6 +929,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
     implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
+    implicit val log: Log[Id] = Log.log[Id]
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
     val context     = Context.createMixed[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
@@ -954,6 +959,8 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
       oC: Ordering[C]
   ): S = {
 
+    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val log: Log[Id]    = Log.log[Id]
     val ctx: Context[C, P, A, K] = Context.createInMemory()
     val space                    = RSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
     val replaySpace              = ReplayRSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
@@ -981,6 +988,7 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
     implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
+    implicit val log: Log[Id] = Log.log[Id]
 
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
     val mainStore = InMemoryStore

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -5,6 +5,7 @@ import java.lang.{Byte => JByte}
 import cats._
 import cats.effect._
 import cats.implicits._
+import coop.rchain.shared.Log
 import coop.rchain.rspace.StableHashProvider._
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
@@ -1397,6 +1398,7 @@ trait LegacyStorageActionsTests
 
 trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, A, R, K] {
   override implicit val syncF: Sync[Id]   = coop.rchain.catscontrib.effect.implicits.syncId
+  override implicit val logF: Log[Id]     = Log.log[Id]
   override implicit val monadF: Monad[Id] = syncF
   override implicit val contextShiftF: ContextShift[Id] =
     coop.rchain.rspace.test.contextShiftId
@@ -1413,6 +1415,8 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, A, R, K] {
     monix.execution.Scheduler.Implicits.global,
     Task.defaultOptions
   )
+  implicit val logF: Log[Task] = Log.log[Task]
+
   override implicit val monadF: Monad[Task] = syncF
   override implicit val contextShiftF: ContextShift[Task] = new ContextShift[Task] {
     override def shift: Task[Unit] =

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -15,6 +15,7 @@ import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
 import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
 import org.scalatest._
 
 import scala.collection.immutable.{Seq, Set}
@@ -27,6 +28,7 @@ trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with 
   type T = ISpace[F, C, P, E, A, A, K]
 
   implicit def syncF: Sync[F]
+  implicit def logF: Log[F]
   implicit def monadF: Monad[F]
   implicit def contextShiftF: ContextShift[F]
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ApplicativeError_Ops.scala
@@ -3,8 +3,7 @@ package coop.rchain.catscontrib
 import cats._, cats.data._, cats.implicits._
 
 final class ApplicativeError_Ops[F[_], E, A](self: F[A])(
-    implicit err: ApplicativeError_[F, E],
-    ev: Applicative[F]
+    implicit err: ApplicativeError_[F, E]
 ) {
   def attempt: F[Either[E, A]] = err.attempt(self)
 }
@@ -12,6 +11,6 @@ final class ApplicativeError_Ops[F[_], E, A](self: F[A])(
 trait ToApplicativeError_Ops {
   implicit def ToApplicativeError_Ops[F[_], E, A](
       fa: F[A]
-  )(implicit err: ApplicativeError_[F, E], ev: Applicative[F]): ApplicativeError_Ops[F, E, A] =
+  )(implicit err: ApplicativeError_[F, E]): ApplicativeError_Ops[F, E, A] =
     new ApplicativeError_Ops[F, E, A](fa)
 }

--- a/shared/src/main/scala/coop/rchain/shared/StringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StringOps.scala
@@ -17,7 +17,7 @@ object StringOps {
   implicit class BracesOps(expr: String) {
     // Wrap if it's sth more than just a number
     def wrapWithBraces: String =
-      Try(new Integer(expr)).fold(
+      Try(Integer.valueOf(expr)).fold(
         _ =>
           if (expr.startsWith("(") && expr.endsWith(")")) {
             expr

--- a/shared/src/test/scala/coop/rchain/catscontrib/laws/discipline/MonadTransTests.scala
+++ b/shared/src/test/scala/coop/rchain/catscontrib/laws/discipline/MonadTransTests.scala
@@ -17,8 +17,6 @@ trait MonadTransTests[MT[_[_], _]] extends Laws {
       ArbGA: Arbitrary[G[A]],
       ArbGB: Arbitrary[G[B]],
       CogenA: Cogen[A],
-      EqGA: Eq[G[A]],
-      EqGB: Eq[G[B]],
       EqMTGA: Eq[MT[G, A]],
       EqMTGB: Eq[MT[G, B]]
   ): RuleSet =

--- a/shared/src/test/scala/coop/rchain/shared/MetricsTestImpl.scala
+++ b/shared/src/test/scala/coop/rchain/shared/MetricsTestImpl.scala
@@ -6,11 +6,12 @@ import cats.effect.Sync
 
 import coop.rchain.metrics.Metrics
 
+final case class Record(value: Long, count: Long)
+
 class MetricsTestImpl[F[_]: Sync] extends Metrics[F] {
-  val counters: MutableMap[String, Long] = MutableMap.empty
-  val samplers: MutableMap[String, Long] = MutableMap.empty
-  val gauges: MutableMap[String, Long]   = MutableMap.empty
-  final case class Record(value: Long, count: Long)
+  val counters: MutableMap[String, Long]        = MutableMap.empty
+  val samplers: MutableMap[String, Long]        = MutableMap.empty
+  val gauges: MutableMap[String, Long]          = MutableMap.empty
   val records: MutableMap[String, List[Record]] = MutableMap.empty
 
   private def incrementBy(name: String, delta: Long)(


### PR DESCRIPTION
## Overview

1. compilation warnings as errors for most modules (excluding casper)
2. Remove Wart.Var from exclusion list
3. Remove Wart.Throw
4. Some TODOs introduced - removing some var and throw warts was non-trivial and should be a matters of separate PR (thus `//TODO`)

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2837

