### PR TITLE
RCHAIN-2891: Make CostAccounting[M] a global implicit in DebruijnInterpreter[M,F]

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -36,22 +36,21 @@ trait Reduce[M[_]] {
   def eval(par: Par)(
       implicit env: Env[Par],
       rand: Blake2b512Random,
-      sequenceNumber: Int,
-      costAccountingAlg: CostAccounting[M]
+      sequenceNumber: Int
   ): M[Unit]
 
   def inj(
       par: Par
-  )(implicit rand: Blake2b512Random, costAccountingAlg: CostAccounting[M]): M[Unit]
+  )(implicit rand: Blake2b512Random): M[Unit]
 
   /**
     * Evaluate any top level expressions in @param Par .
     */
-  def evalExpr(par: Par)(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par]
+  def evalExpr(par: Par)(implicit env: Env[Par]): M[Par]
 
   def evalExprToPar(
       expr: Expr
-  )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par]
+  )(implicit env: Env[Par]): M[Par]
 }
 
 object Reduce {
@@ -61,6 +60,7 @@ object Reduce {
       private val urnMap: Map[String, Par]
   )(
       implicit
+      costAccountingAlg: CostAccounting[M],
       parallel: cats.Parallel[M, F],
       s: Sync[M],
       fTell: FunctorTell[M, Throwable]
@@ -107,8 +107,7 @@ object Reduce {
     private trait EvalJob {
       def run(mkRand: Int => Blake2b512Random)(
           env: Env[Par],
-          sequenceNumber: Int,
-          costAccountingAlg: CostAccounting[M]
+          sequenceNumber: Int
       ): M[List[Unit]]
       def size: Int
     }
@@ -117,17 +116,16 @@ object Reduce {
 
       private def mkJob[A](
           input: Seq[A],
-          handler: A => (Env[Par], Blake2b512Random, Int, CostAccounting[M]) => M[Unit]
+          handler: A => (Env[Par], Blake2b512Random, Int) => M[Unit]
       ): EvalJob =
         new EvalJob {
           override def run(mkRand: Int => Blake2b512Random)(
               env: Env[Par],
-              sequenceNumber: Int,
-              costAccountingAlg: CostAccounting[M]
+              sequenceNumber: Int
           ): M[List[Unit]] =
             Parallel.parTraverse(input.zipWithIndex.toList) {
               case (term, idx) =>
-                handler(term)(env, mkRand(idx), sequenceNumber, costAccountingAlg)
+                handler(term)(env, mkRand(idx), sequenceNumber)
             }
 
           override def size = input.size
@@ -139,19 +137,18 @@ object Reduce {
         )(
             env: Env[Par],
             rand: Blake2b512Random,
-            sequenceNumber: Int,
-            costAccountingAlg: CostAccounting[M]
+            sequenceNumber: Int
         ) =
           expr.exprInstance match {
             case EVarBody(EVar(v)) =>
               (for {
-                varref <- eval(v)(env, costAccountingAlg)
-                _      <- eval(varref)(env, rand, sequenceNumber, costAccountingAlg)
+                varref <- eval(v)(env)
+                _      <- eval(varref)(env, rand, sequenceNumber)
               } yield ()).handleErrorWith(fTell.tell)
             case e: EMethodBody =>
               (for {
-                p <- evalExprToPar(Expr(e))(env, costAccountingAlg)
-                _ <- eval(p)(env, rand, sequenceNumber, costAccountingAlg)
+                p <- evalExprToPar(Expr(e))(env)
+                _ <- eval(p)(env, rand, sequenceNumber)
               } yield ()).handleErrorWith(fTell.tell)
             case _ => s.unit
           }
@@ -161,17 +158,16 @@ object Reduce {
 
       def apply[A](
           terms: Seq[A],
-          handlerImpl: A => (Env[Par], Blake2b512Random, Int, CostAccounting[M]) => M[Unit]
-      ) = {
+          handlerImpl: A => (Env[Par], Blake2b512Random, Int) => M[Unit]
+      ): EvalJob = {
         def handler(
             term: A
         )(
             env: Env[Par],
             rand: Blake2b512Random,
-            sequenceNumber: Int,
-            costAccountingAlg: CostAccounting[M]
+            sequenceNumber: Int
         ) =
-          handlerImpl(term)(env, rand, sequenceNumber, costAccountingAlg)
+          handlerImpl(term)(env, rand, sequenceNumber)
             .handleErrorWith {
               case e: OutOfPhlogistonsError.type =>
                 s.raiseError(e)
@@ -198,8 +194,7 @@ object Reduce {
     override def eval(par: Par)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] = {
       def split(totalSize: Int, termSize: Int, rand: Blake2b512Random)(idx: Int): Blake2b512Random =
         if (totalSize == 1)
@@ -232,7 +227,7 @@ object Reduce {
         .map {
           case (job, jobIdx) => {
             def mkRand(termIdx: Int) = split(starts.last, starts(jobIdx), rand)(termIdx)
-            job.run(mkRand)(env, sequenceNumber, costAccountingAlg)
+            job.run(mkRand)(env, sequenceNumber)
           }
         }
         .parSequence
@@ -241,9 +236,9 @@ object Reduce {
 
     override def inj(
         par: Par
-    )(implicit rand: Blake2b512Random, costAccountingAlg: CostAccounting[M]): M[Unit] =
+    )(implicit rand: Blake2b512Random): M[Unit] =
       for {
-        _ <- eval(par)(Env[Par](), rand, 0, costAccountingAlg)
+        _ <- eval(par)(Env[Par](), rand, 0)
       } yield ()
 
     private def evalExplicit(
@@ -251,10 +246,9 @@ object Reduce {
     )(
         env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
-      eval(send)(env, rand, sequenceNumber, costAccountingAlg)
+      eval(send)(env, rand, sequenceNumber)
 
     /** Algorithm as follows:
       *
@@ -271,8 +265,7 @@ object Reduce {
     private def eval(send: Send)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
       for {
         evalChan <- evalExpr(send.chan)
@@ -300,16 +293,14 @@ object Reduce {
     )(
         env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
-      eval(receive)(env, rand, sequenceNumber, costAccountingAlg)
+      eval(receive)(env, rand, sequenceNumber)
 
     private def eval(receive: Receive)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
       for {
         binds <- receive.binds.toList
@@ -331,8 +322,7 @@ object Reduce {
         substBody <- substituteNoSortAndCharge[Par, M](
                       receive.body,
                       0,
-                      env.shift(receive.bindCount),
-                      costAccountingAlg
+                      env.shift(receive.bindCount)
                     )
         _ <- consume(binds, substBody, receive.persistent, rand, sequenceNumber)
         _ <- costAccountingAlg.charge(RECEIVE_EVAL_COST)
@@ -351,7 +341,7 @@ object Reduce {
       */
     private def eval(
         valproc: Var
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+    )(implicit env: Env[Par]): M[Par] =
       costAccountingAlg.charge(VAR_EVAL_COST) *> {
         valproc.varInstance match {
           case BoundVar(level) =>
@@ -375,15 +365,13 @@ object Reduce {
     )(
         env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
-      eval(mat)(env, rand, sequenceNumber, costAccountingAlg)
+      eval(mat)(env, rand, sequenceNumber)
     private def eval(mat: Match)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] = {
       def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
         Range(0, freeCount).foldLeft(env)(
@@ -419,8 +407,7 @@ object Reduce {
                           eval(singleCase.source)(
                             newEnv,
                             implicitly,
-                            sequenceNumber,
-                            costAccountingAlg
+                            sequenceNumber
                           ).map(Right(_))
                       }
               } yield res
@@ -450,15 +437,13 @@ object Reduce {
     )(
         env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
-      eval(neu)(env, rand, sequenceNumber, costAccountingAlg)
+      eval(neu)(env, rand, sequenceNumber)
     private def eval(neu: New)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] = {
       def alloc(count: Int, urns: Seq[String]): M[Env[Par]] = {
         val simpleNews = (0 until (count - urns.size)).toList.foldLeft(env) { (_env, _) =>
@@ -476,6 +461,7 @@ object Reduce {
             cata: (B, A) => Either[E, B]
         ): Either[E, B] =
           Foldable[List].foldM(as.toList, init)(cata)
+
         foldLeftEarly(simpleNews, urns, addUrn) match {
           case Right(env) => Applicative[M].pure(env)
           case Left(e)    => s.raiseError(e)
@@ -484,13 +470,13 @@ object Reduce {
 
       costAccountingAlg.charge(newBindingsCost(neu.bindCount)) *>
         alloc(neu.bindCount, neu.uri).flatMap { newEnv =>
-          eval(neu.p)(newEnv, rand, sequenceNumber, costAccountingAlg)
+          eval(neu.p)(newEnv, rand, sequenceNumber)
         }
     }
 
     private[this] def unbundleReceive(
         rb: ReceiveBind
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+    )(implicit env: Env[Par]): M[Par] =
       for {
         evalSrc <- evalExpr(rb.source)
         subst   <- substituteAndCharge[Par, M](evalSrc, 0, env)
@@ -512,21 +498,19 @@ object Reduce {
     )(
         env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
-      eval(bundle)(env, rand, sequenceNumber, costAccountingAlg)
+      eval(bundle)(env, rand, sequenceNumber)
     private def eval(bundle: Bundle)(
         implicit env: Env[Par],
         rand: Blake2b512Random,
-        sequenceNumber: Int,
-        costAccountingAlg: CostAccounting[M]
+        sequenceNumber: Int
     ): M[Unit] =
       eval(bundle.body)
 
     def evalExprToPar(
         expr: Expr
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+    )(implicit env: Env[Par]): M[Par] =
       expr.exprInstance match {
         case EVarBody(EVar(v)) =>
           for {
@@ -551,7 +535,7 @@ object Reduce {
 
     private def evalExprToExpr(
         expr: Expr
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Expr] = Sync[M].defer {
+    )(implicit env: Env[Par]): M[Expr] = Sync[M].defer {
       def relop(
           p1: Par,
           p2: Par,
@@ -897,8 +881,7 @@ object Reduce {
 
     private abstract class Method() {
       def apply(p: Par, args: Seq[Par])(
-          implicit env: Env[Par],
-          costAccountingAlg: CostAccounting[M]
+          implicit env: Env[Par]
       ): M[Par]
     }
 
@@ -913,7 +896,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         if (args.length != 1) {
           s.raiseError(errors.MethodArgumentNumberMismatch("nth", 1, args.length))
         } else {
@@ -957,7 +940,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         if (args.nonEmpty) {
           s.raiseError(MethodArgumentNumberMismatch("toByteArray", 0, args.length))
         } else {
@@ -975,7 +958,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         if (args.nonEmpty) {
           s.raiseError(MethodArgumentNumberMismatch("hexToBytes", 0, args.length))
         } else {
@@ -1006,7 +989,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         if (args.nonEmpty) {
           s.raiseError(MethodArgumentNumberMismatch("toUtf8Bytes", 0, args.length))
         } else {
@@ -1027,7 +1010,7 @@ object Reduce {
       def locallyFreeUnion(base: Coeval[BitSet], other: Coeval[BitSet]): Coeval[BitSet] =
         base.flatMap(b => other.map(o => b | o))
 
-      def union(baseExpr: Expr, otherExpr: Expr)(implicit costAccountingAlg: CostAccounting[M]) =
+      def union(baseExpr: Expr, otherExpr: Expr) =
         (baseExpr.exprInstance, otherExpr.exprInstance) match {
           case (
               ESetBody(base @ ParSet(basePs, _, _, _)),
@@ -1065,7 +1048,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("union", 1, args.length))
@@ -1077,7 +1060,7 @@ object Reduce {
     }
 
     private[this] val diff: Method = new Method() {
-      def diff(baseExpr: Expr, otherExpr: Expr)(implicit costAccountingAlg: CostAccounting[M]) =
+      def diff(baseExpr: Expr, otherExpr: Expr) =
         (baseExpr.exprInstance, otherExpr.exprInstance) match {
           case (
               ESetBody(ParSet(basePs, _, _, _)),
@@ -1104,7 +1087,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("diff", 1, args.length))
@@ -1138,7 +1121,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("add", 1, args.length))
@@ -1182,7 +1165,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("delete", 1, args.length))
@@ -1205,10 +1188,7 @@ object Reduce {
             s.raiseError(MethodNotDefined("contains", other.typ))
         }
 
-      override def apply(
-          p: Par,
-          args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("contains", 1, args.length))
@@ -1232,7 +1212,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 1)
                 s.raiseError(MethodArgumentNumberMismatch("get", 1, args.length))
@@ -1256,7 +1236,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("getOrElse", 2, args.length))
@@ -1281,7 +1261,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("set", 2, args.length))
@@ -1306,7 +1286,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("keys", 0, args.length))
@@ -1333,7 +1313,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("size", 0, args.length))
@@ -1359,7 +1339,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 0)
                 s.raiseError(MethodArgumentNumberMismatch("length", 0, args.length))
@@ -1395,7 +1375,7 @@ object Reduce {
       override def apply(
           p: Par,
           args: Seq[Par]
-      )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+      )(implicit env: Env[Par]): M[Par] =
         for {
           _ <- if (args.length != 2)
                 s.raiseError(MethodArgumentNumberMismatch("slice", 2, args.length))
@@ -1432,7 +1412,7 @@ object Reduce {
 
     def evalSingleExpr(
         p: Par
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Expr] =
+    )(implicit env: Env[Par]): M[Expr] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
           ReduceError("Error: parallel or non expression found where expression expected.")
@@ -1446,7 +1426,7 @@ object Reduce {
 
     def evalToLong(
         p: Par
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Long] =
+    )(implicit env: Env[Par]): M[Long] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
           ReduceError("Error: parallel or non expression found where expression expected.")
@@ -1477,7 +1457,7 @@ object Reduce {
 
     def evalToBool(
         p: Par
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Boolean] =
+    )(implicit env: Env[Par]): M[Boolean] =
       if (!p.sends.isEmpty || !p.receives.isEmpty || !p.news.isEmpty || !p.matches.isEmpty || !p.ids.isEmpty || !p.bundles.isEmpty)
         s.raiseError(
           ReduceError("Error: parallel or non expression found where expression expected.")
@@ -1537,7 +1517,7 @@ object Reduce {
       */
     def evalExpr(
         par: Par
-    )(implicit env: Env[Par], costAccountingAlg: CostAccounting[M]): M[Par] =
+    )(implicit env: Env[Par]): M[Par] =
       for {
         evaledExprs <- par.exprs.toList.traverse(expr => evalExprToPar(expr))
         // Note: the locallyFree cache in par could now be invalid, but given

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -43,8 +43,7 @@ object Substitute {
   def substituteNoSortAndCharge[A: Chargeable, M[_]: CostAccounting: Substitute[?[_], A]: Sync](
       term: A,
       depth: Int,
-      env: Env[Par],
-      costAccountingAlg: CostAccounting[M]
+      env: Env[Par]
   ): M[A] =
     charge(Substitute[M, A].substituteNoSort(term)(depth, env), Cost(term))
 


### PR DESCRIPTION
# Overview
This is needed to give a more MTL-friendly structure to Reduce[M].

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2891
