### PR TITLE
Add an explicit mapping from thrown errors to possible responses

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -6,15 +6,16 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.SafetyOracle
 import coop.rchain.casper.api.BlockAPI
-import coop.rchain.casper.protocol.{DeployData, DeployServiceResponse, _}
+import coop.rchain.casper.protocol.{DeployData, DeployServiceResponse, VisualizeBlocksResponse, _}
 import coop.rchain.shared._
 import coop.rchain.graphz._
 import coop.rchain.casper.api.{GraphConfig, GraphzGenerator}
 import com.google.protobuf.empty.Empty
-
+import cats._
+import cats.data._
+import cats.implicits._
 import cats.mtl._
 import cats.mtl.implicits._
-import cats._, cats.data._, cats.implicits._
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.Taskable
 import coop.rchain.catscontrib.TaskContrib._
@@ -29,9 +30,15 @@ private[api] object DeployGrpcService {
       implicit worker: Scheduler
   ): CasperMessageGrpcMonix.DeployService =
     new CasperMessageGrpcMonix.DeployService {
-
-      private def defer[A](task: F[A]): Task[A] =
-        Task.defer(task.toTask).executeOn(worker).attemptAndLog
+      import ToErrorResponseInstances._
+      private def defer[A: ToErrorResponse](task: F[A]): Task[A] =
+        Task
+          .defer(task.toTask)
+          .executeOn(worker)
+          .attemptAndLog
+          .onErrorHandle(t => {
+            ToErrorResponse[A].fromThrowable(t)
+          })
 
       override def doDeploy(d: DeployData): Task[DeployServiceResponse] =
         defer(BlockAPI.deploy[F](d))
@@ -45,7 +52,7 @@ private[api] object DeployGrpcService {
       // TODO handle potentiall errors (at least by returning proper response)
       override def visualizeDag(q: VisualizeDagQuery): Task[VisualizeBlocksResponse] = {
         type Effect[A] = StateT[Id, StringBuffer, A]
-        implicit val ser: StringSerializer[Effect]      = new StringSerializer[Effect]
+        implicit val ser: GraphSerializer[Effect]       = new StringSerializer[Effect]
         val stringify: Effect[Graphz[Effect]] => String = _.runS(new StringBuffer).toString
 
         val depth  = if (q.depth <= 0) None else Some(q.depth)
@@ -88,5 +95,65 @@ private[api] object DeployGrpcService {
           request: PrivateNamePreviewQuery
       ): Task[PrivateNamePreviewResponse] =
         defer(BlockAPI.previewPrivateNames[F](request.user, request.timestamp, request.nameQty))
+    }
+}
+
+// this isn't a solution - it's a hack employed to allow confirming that the observed UNKNOWN responses
+// are really a side effect of exceptions not properly handled in 'attemptAndLog'
+//TODO needs to be replaced with a proper response abstraction which allows errors.
+sealed trait ToErrorResponse[A] {
+  def fromThrowable(t: Throwable): A
+}
+object ToErrorResponse {
+  def apply[A](implicit ev: ToErrorResponse[A]): ToErrorResponse[A] = ev
+}
+
+object ToErrorResponseInstances {
+  implicit def listResponseDefaultError[A: ToErrorResponse]: ToErrorResponse[List[A]] =
+    new ToErrorResponse[List[A]] {
+      override def fromThrowable(t: Throwable): List[A] =
+        ToErrorResponse[A].fromThrowable(t) :: Nil
+    }
+
+  implicit val deployServiceResponseDefaultError: ToErrorResponse[DeployServiceResponse] =
+    new ToErrorResponse[DeployServiceResponse] {
+      override def fromThrowable(t: Throwable): DeployServiceResponse =
+        DeployServiceResponse(success = false, t.getMessage)
+    }
+
+  implicit val blockQueryResponseDefaultError: ToErrorResponse[BlockQueryResponse] =
+    new ToErrorResponse[BlockQueryResponse] {
+      override def fromThrowable(t: Throwable): BlockQueryResponse =
+        BlockQueryResponse(status = t.getMessage)
+    }
+
+  implicit val visualizeBlocksResponseDefaultError: ToErrorResponse[VisualizeBlocksResponse] =
+    new ToErrorResponse[VisualizeBlocksResponse] {
+      override def fromThrowable(t: Throwable): VisualizeBlocksResponse =
+        VisualizeBlocksResponse(status = t.getMessage)
+    }
+
+  implicit val blockInfoWithoutTuplespaceDefaultError: ToErrorResponse[BlockInfoWithoutTuplespace] =
+    new ToErrorResponse[BlockInfoWithoutTuplespace] {
+      override def fromThrowable(t: Throwable): BlockInfoWithoutTuplespace =
+        BlockInfoWithoutTuplespace()
+    }
+
+  implicit val listeningNameDataResponseDefaultError: ToErrorResponse[ListeningNameDataResponse] =
+    new ToErrorResponse[ListeningNameDataResponse] {
+      override def fromThrowable(t: Throwable): ListeningNameDataResponse =
+        ListeningNameDataResponse(status = t.getMessage)
+    }
+
+  implicit val listeningNameContinuationResponseDefaultError
+    : ToErrorResponse[ListeningNameContinuationResponse] =
+    new ToErrorResponse[ListeningNameContinuationResponse] {
+      override def fromThrowable(t: Throwable): ListeningNameContinuationResponse =
+        ListeningNameContinuationResponse(status = t.getMessage)
+    }
+  implicit val privateNamePreviewResponseDefaultError: ToErrorResponse[PrivateNamePreviewResponse] =
+    new ToErrorResponse[PrivateNamePreviewResponse] {
+      override def fromThrowable(t: Throwable): PrivateNamePreviewResponse =
+        PrivateNamePreviewResponse()
     }
 }


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Due to the way grpc handles unhandled exceptions we are getting messages that don't mean much (UNKNOWN).
This is a step to make this situation better (but it uses existing responses which is not ideal)

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RHAIN-2858

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
