### PR TITLE
RCHAIN-1052: Fix pretty printing referenced variables

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -221,7 +221,7 @@ final case class PrettyPrinter(
           (pure("") /: m.cases.zipWithIndex) {
             case (string, (matchCase, i)) =>
               string |+| pure(indentStr * (indent + 1)) |+| buildMatchCase(matchCase, indent + 1) |+| pure {
-                if (i != m.cases.length - 1) " ;\n"
+                if (i != m.cases.length - 1) "\n"
                 else ""
               }
           } |+| pure("\n" + (indentStr * indent) + "}")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -235,13 +235,12 @@ final case class PrettyPrinter(
           case ConnOrBody(value) =>
             pure("{") |+| value.ps.map(buildStringM).toList.intercalate(pure(" \\/ ")) |+| pure("}")
           case ConnNotBody(value) => pure("~{") |+| buildStringM(value) |+| pure("}")
-          case VarRefBody(value) =>
-            pure("=") |+| buildStringM(Var(FreeVar(value.index)))
-          case _: ConnBool      => pure("Bool")
-          case _: ConnInt       => pure("Int")
-          case _: ConnString    => pure("String")
-          case _: ConnUri       => pure("Uri")
-          case _: ConnByteArray => pure("ByteArray")
+          case VarRefBody(value)  => pure(s"=$freeId${freeShift - value.index - 1}")
+          case _: ConnBool        => pure("Bool")
+          case _: ConnInt         => pure("Int")
+          case _: ConnString      => pure("String")
+          case _: ConnUri         => pure("Uri")
+          case _: ConnByteArray   => pure("ByteArray")
         }
 
       case par: Par =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -436,6 +436,17 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     result shouldBe "x0"
   }
 
+  "PVarRef" should "Print with referenced identifier" in {
+    checkRoundTrip(
+      """for( @{x0}, @{x1} <- @{0} ) {
+        |  match x0 {
+        |    =x0 => Nil
+        |    =x1 => Nil
+        |  }
+        |}""".stripMargin
+    )
+  }
+
   "PEval" should "Print eval with fresh identifier" in {
     val pEval       = new PEval(new NameVar("x"))
     val boundInputs = inputs.copy(env = inputs.env.newBinding(("x", NameSort, 0, 0)))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -595,7 +595,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   }
 
   "PInput" should "Print a more complicated receive" in {
-    // new x, y in { for ( z, @a <- y ; b, @c <- x ) { z!(c) | b!(a) | for( d <- b ){ *d | match d { case 42 => Nil ; case e => c } }
+    // new x, y in { for ( z, @a <- y ; b, @c <- x ) { z!(c) | b!(a) | for( d <- b ){ *d | match d { case 42 => Nil case e => c } }
 
     val listBindings1 = new ListName()
     listBindings1.add(new NameVar("x1"))
@@ -653,7 +653,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
         |    for( @{x6} <- @{x4} ) {
         |      x6 |
         |      match x6 {
-        |        42 => Nil ;
+        |        42 => Nil
         |        x7 => x3
         |      }
         |    }
@@ -700,7 +700,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   }
 
   "PMatch" should "Print recognize pattern bindings" in {
-    // for (@x <- @Nil) { match x { 42 => Nil ; y => Nil } } | @Nil!(47)
+    // for (@x <- @Nil) { match x { 42 => Nil y => Nil } } | @Nil!(47)
 
     val listBindings = new ListName()
     listBindings.add(new NameQuote(new PVar(new ProcVarVar("x"))))
@@ -728,7 +728,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       """@{Nil}!(47) |
         |for( @{x0} <- @{Nil} ) {
         |  match x0 {
-        |    42 => Nil ;
+        |    42 => Nil
         |    x1 => Nil
         |  }
         |}""".stripMargin
@@ -746,7 +746,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     result shouldBe
       """match true {
-        |  true => @{Nil}!(47) ;
+        |  true => @{Nil}!(47)
         |  false => Nil
         |}""".stripMargin
   }
@@ -779,7 +779,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       """match (47 == 47) {
         |  true => new x0 in {
         |    x0!(47)
-        |  } ;
+        |  }
         |  false => new x0 in {
         |    x0!(47)
         |  }


### PR DESCRIPTION
## Overview
Pretty printing `VarRef`s was not working.
Also added the possibility to separate match cases with semicolons which comes in handy for the added test case.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-1052

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
