### PR TITLE
RCHAIN-2837 Remove NonUnitStatements from wart exclusion list

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -25,6 +25,7 @@ import scala.ref.WeakReference
 import scala.util.matching.Regex
 import collection.JavaConverters._
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove!!
 final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private (
     lock: Semaphore[F],
     latestMessagesRef: Ref[F, Map[Validator, BlockHash]],
@@ -406,6 +407,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
     } yield ()
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove
 object BlockDagFileStorage {
   private implicit val logSource       = LogSource(BlockDagFileStorage.getClass)
   private val checkpointPattern: Regex = "([0-9]+)-([0-9]+)".r

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -35,6 +35,7 @@ private final case class FileLMDBIndexBlockStoreState(
     currentIndex: Int
 )
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
     lock: Semaphore[F],
     env: Env[ByteBuffer],
@@ -454,8 +455,9 @@ object FileLMDBIndexBlockStore {
       config: Config
   ): F[StorageErr[BlockStore[F]]] =
     for {
+      notExists <- Sync[F].delay(Files.notExists(config.indexPath))
+      _         <- if (notExists) Sync[F].delay(Files.createDirectories(config.indexPath)) else ().pure[F]
       env <- Sync[F].delay {
-              if (Files.notExists(config.indexPath)) Files.createDirectories(config.indexPath)
               val flags = if (config.noTls) List(EnvFlags.MDB_NOTLS) else List.empty
               Env
                 .create()

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -18,6 +18,7 @@ import org.lmdbjava._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.Txn.NotReadyException
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks: Dbi[ByteBuffer])(
     implicit
     syncF: Sync[F],
@@ -121,6 +122,7 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
     syncF.delay { Right(env.close()) }
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object LMDBBlockStore {
 
   final case class Config(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/Crc32.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/Crc32.scala
@@ -16,6 +16,7 @@ final class Crc32[F[_]: Monad](internal: CRC32) {
   def value: F[Long] =
     internal.getValue.pure[F]
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def bytes: F[Array[Byte]] =
     value.map { value =>
       val byteBuffer = ByteBuffer.allocate(8)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
@@ -5,6 +5,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage.BlockStore.BlockHash
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object byteOps {
   implicit class ByteBufferRich(val byteBuffer: ByteBuffer) extends AnyVal {
     def getBlockHash(): BlockHash = {

--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,9 @@ lazy val projectSettings = Seq(
   wartremoverErrors in (Compile, compile) ++= Warts.allBut(
     // those we want
     Wart.DefaultArguments, Wart.ImplicitParameter, Wart.ImplicitConversion,
+    Wart.LeakingSealed, Wart.Recursion,
     // those don't want
-    Wart.Recursion,
-    Wart.LeakingSealed, Wart.Overloading, Wart.Nothing, Wart.NonUnitStatements,
+    Wart.Overloading, Wart.Nothing,
     Wart.Equals, Wart.PublicInference, Wart.TraversableOps, Wart.ArrayEquals,
     Wart.While, Wart.Any, Wart.Product, Wart.Serializable, Wart.OptionPartial,
     Wart.EitherProjectionPartial, Wart.Option2Iterable, Wart.ToString, Wart.JavaConversions,

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -284,18 +284,19 @@ object Genesis {
     val bonds        = pubKeys.zipWithIndex.toMap.mapValues(_.toLong + 1L)
     val genBondsFile = genesisPath.resolve(s"bonds.txt").toFile
 
-    val skFiles = Capture[F].capture {
-      genesisPath.toFile.mkdir()
-      keys.foreach { //create files showing the secret key for each public key
-        case (sec, pub) =>
-          val sk      = Base16.encode(sec)
-          val pk      = Base16.encode(pub)
-          val skFile  = genesisPath.resolve(s"$pk.sk").toFile
-          val printer = new PrintWriter(skFile)
-          printer.println(sk)
-          printer.close()
-      }
-    }
+    val skFiles =
+      Capture[F].capture(genesisPath.toFile.mkdir()) >>
+        Capture[F].capture {
+          keys.foreach { //create files showing the secret key for each public key
+            case (sec, pub) =>
+              val sk      = Base16.encode(sec)
+              val pk      = Base16.encode(pub)
+              val skFile  = genesisPath.resolve(s"$pk.sk").toFile
+              val printer = new PrintWriter(skFile)
+              printer.println(sk)
+              printer.close()
+          }
+        }
 
     //create bonds file for editing/future use
     for {

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -175,6 +175,7 @@ object BondingUtil {
     file.use(pw => Sync[F].delay { pw.println(content) })
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def makeRuntimeDir[F[_]: Sync]: Resource[F, Path] =
     Resource.make[F, Path](Sync[F].delay { Files.createTempDirectory("casper-bonding-helper-") })(
       runtimeDir => Sync[F].delay { runtimeDir.recursivelyDelete() }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -97,7 +97,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                   conf.approveGenesisInterval
                 )
                 .map(protocol => {
-                  toTask(protocol.run()).forkAndForget.runToFuture
+                  // TODO FIX-ME my god!!! fix fix fix!
+                  val future = toTask(protocol.run()).forkAndForget.runToFuture
                   protocol
                 })
         standalone <- Ref.of[F, CasperPacketHandlerInternal[F]](new StandaloneCasperHandler[F](abp))
@@ -131,7 +132,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
         _ <- Sync[F].delay {
               implicit val ph: PacketHandler[F] = PacketHandler.pf[F](casperPacketHandler.handle)
               val rb                            = CommUtil.requestApprovedBlock[F](delay)
-              toTask(rb).forkAndForget.runToFuture
+              // TODO FIX-ME my god!!! fix fix fix!
+              val future = toTask(rb).forkAndForget.runToFuture
               ().pure[F]
             }
       } yield casperPacketHandler

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -92,6 +92,7 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
   ): Task[ListeningNameContinuationResponse] =
     stub.listenForContinuationAtName(request)
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   override def close(): Unit = {
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {

--- a/comm/src/main/scala/coop/rchain/comm/UPnP.scala
+++ b/comm/src/main/scala/coop/rchain/comm/UPnP.scala
@@ -19,6 +19,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object UPnP {
 
   lazy val IPv4: Regex =

--- a/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/PeerTable.scala
@@ -28,7 +28,7 @@ object ReputationOrder extends Ordering[Reputable] {
   def compare(a: Reputable, b: Reputable) = a.reputation compare b.reputation
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
 final case class PeerTableEntry[A](entry: A, gkey: A => Seq[Byte]) extends Keyed {
   var pinging           = false
   val key               = gkey(entry)
@@ -77,6 +77,7 @@ object PeerTable {
   * network discovery and routing protocol.
   *
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 final class PeerTable[A <: PeerNode](
     localKey: Seq[Byte],
     private[discovery] val k: Int,

--- a/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/HostnameTrustManagerFactory.scala
@@ -26,7 +26,7 @@ object HostnameTrustManagerFactory {
 /**
   * This wart exists because that's how grpc works. They looooovveee throwing exceptions
   */
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+@SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements"))
 private class HostnameTrustManager extends X509ExtendedTrustManager {
 
   def checkClientTrusted(

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpServerObservable.scala
@@ -52,6 +52,7 @@ class TcpServerObservable(
             }
           }
 
+      @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
       def ask(request: TLRequest): Task[TLResponse] =
         request.protocol
           .fold(internalServerError("protocol not available in request").pure[Task]) { protocol =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -70,7 +70,7 @@ class TcpTransportLayer(
     }
 
   // TODO FIX-ME No throwing exceptions!
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements"))
   private lazy val clientSslContext: SslContext =
     try {
       val builder = GrpcSslContexts.forClient
@@ -278,7 +278,7 @@ class TcpTransportLayer(
     }
 
     cell.modify { s =>
-      /** 
+      /**
         * //TODO Bring back lvl of parallelism to Math.max(Runtime.getRuntime.availableProcessors(), 2) once
         * MultiparentCasperImpl is not synchronous (uses semaphore)
         */

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
@@ -21,7 +21,13 @@ abstract class ConcurrentQueue[A] {
   def drain(buffer: mutable.Buffer[A], limit: Int): Unit
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Return", "org.wartremover.warts.Var"))
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Return",
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.NonUnitStatements"
+  )
+)
 object ConcurrentQueue {
   final val recommendedSize: Int = 1024
 

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b256.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b256.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable.Seq
 /**
   * Blake2b256 hashing algorithm
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Blake2b256 {
 
   def hash(input: Array[Byte]): Array[Byte] = {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Block.scala
@@ -157,6 +157,7 @@ class Blake2b512Block {
   }
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Blake2b512Block {
   /*
   def apply(): Blake2b512Block = {

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Blake2b512Random.scala
@@ -18,7 +18,7 @@ import scala.annotation.tailrec
   * Blake2b512.merge uses online tree hashing to merge two random generator
   * states.
   */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
 class Blake2b512Random private (
     private val digest: Blake2b512Block,
     private val lastBlock: ByteBuffer
@@ -113,6 +113,7 @@ class Blake2b512Random private (
     ((digest.hashCode * 31 + pathView.position()) * 31 + position) * 31 + lastBlock.hashCode
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Blake2b512Random {
   private[this] def apply(init: Array[Byte], offset: Int, length: Int): Blake2b512Random = {
     val result = new Blake2b512Random(Blake2b512Block(0.toByte), ByteBuffer.allocate(128))

--- a/crypto/src/main/scala/coop/rchain/crypto/hash/Keccak256.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/hash/Keccak256.scala
@@ -5,6 +5,7 @@ import org.bouncycastle.crypto.digests.KeccakDigest
 /**
   * Keccak256 hashing algorithm
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Keccak256 {
 
   def hash(input: Array[Byte]): Array[Byte] = {

--- a/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BitSetBytesMapper.scala
@@ -24,6 +24,7 @@ object BitSetBytesMapper {
     ByteString.copyFrom(usedBytes)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def byteStringToBitSet(byteString: ByteString): BitSet = {
     val bufferSize = nextMultiple(BYTES_PER_LONG, byteString.size())
     val byteBuffer = ByteBuffer.allocate(bufferSize).order(LITTLE_ENDIAN)

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -178,7 +178,7 @@ object PrettyUtils {
     * Convert a string to a C&P-able literal. Basically
     * copied verbatim from the uPickle source code.
     */
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
   // TODO remove this var
   def literalize(s: IndexedSeq[Char], unicode: Boolean = true): String = {
     val sb = new StringBuilder

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -108,13 +108,14 @@ object Main {
       case Left(CouldNotConnectToBootstrap) =>
         log.error("Node could not connect to bootstrap node.")
       case Left(InitializationError(msg)) =>
-        log.error(msg)
-        Task.delay(System.exit(-1))
+        log.error(msg) >>
+          Task.delay(System.exit(-1))
       case Left(error) =>
         log.error(s"Failed! Reason: '$error")
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   implicit private def consoleIO: ConsoleIO[Task] = {
     val console = new ConsoleReader()
     console.setHistoryEnabled(true)

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -49,6 +49,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.http4s.server.blaze._
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class NodeRuntime private[node] (
     conf: Configuration,
     id: NodeIdentifier,

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -27,6 +27,7 @@ import coop.rchain.catscontrib._
 import ski._
 
 class GrpcServer(server: Server) {
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def start: Task[Unit] = Task.delay(server.start())
 
   private def attemptShutdown: Task[Boolean] =

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -120,6 +120,7 @@ object ConfigMapper {
     final class AddToMap(map: mutable.Map[String, Any]) {
       def apply(prefix: String): AddWithPrefix = new AddWithPrefix(prefix)
 
+      @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
       final class AddWithPrefix(prefix: String) {
         def apply[A: OptionConverter](key: String, opt: ScallopOption[A]): Unit =
           opt.foreach(a => map += s"$prefix.$key" -> OptionConverter[A].toConfigValue(a))

--- a/node/src/main/scala/coop/rchain/node/diagnostics/JmxReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/JmxReporter.scala
@@ -10,6 +10,7 @@ import kamon.MetricReporter
 import kamon.metric._
 import java.time.Instant
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class JmxReporter extends MetricReporter {
 
   private val snapshotAccumulator =

--- a/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/NewPrometheusReporter.scala
@@ -11,7 +11,7 @@ import kamon.metric._
 /**
   * Based on kamon-prometheus but without the embedded server
   */
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
 class NewPrometheusReporter extends MetricReporter {
   import NewPrometheusReporter.Configuration.{environmentTags, readConfiguration}
 

--- a/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/ScrapeDataBuilder.scala
@@ -10,7 +10,7 @@ import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{information, none, time}
 import kamon.metric.MeasurementUnit.Dimension._
 
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
 class ScrapeDataBuilder(
     prometheusConfig: NewPrometheusReporter.Configuration,
     environmentTags: Map[String, String] = Map.empty

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/DiagnosticService.scala
@@ -83,6 +83,7 @@ class GrpcDiagnosticsService(host: String, port: Int, maxMessageSize: Int)
   def threads: Task[Threads] =
     stub.getThreads(Empty())
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   override def close(): Unit = {
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {

--- a/node/src/main/scala/coop/rchain/node/effects/JLineConsoleIO.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/JLineConsoleIO.scala
@@ -15,6 +15,7 @@ import coop.rchain.shared.StringOps.ColoredString
 import coop.rchain.shared.TerminalMode
 import monix.eval.Task
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class JLineConsoleIO(console: ConsoleReader) extends ConsoleIO[Task] {
   private val mode = TerminalMode.readMode
 

--- a/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ReplClient.scala
@@ -64,6 +64,7 @@ class GrpcReplClient(host: String, port: Int, maxMessageSize: Int)
   private def processError(t: Throwable): Throwable =
     Option(t.getCause).getOrElse(t)
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   override def close(): Unit = {
     val terminated = channel.shutdown().awaitTermination(10, TimeUnit.SECONDS)
     if (!terminated) {

--- a/regex/src/main/scala/coop/rchain/regex/Fsm.scala
+++ b/regex/src/main/scala/coop/rchain/regex/Fsm.scala
@@ -7,6 +7,7 @@ import scala.util.{Failure, Success, Try}
 /**
   * A companion object for the Fsm class.
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object Fsm {
 
   /**
@@ -244,6 +245,7 @@ object Fsm {
   * closure), intersected, and simplified.
   * The majority of these methods are available using operator overloads.
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 final case class Fsm(
     alphabet: Set[Char],
     states: Set[Int],

--- a/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
+++ b/rholang-proto-build/src/main/scala/coop/rchain/rholang/build/RholangProtoBuild.scala
@@ -93,7 +93,7 @@ object RholangProtoBuild {
     |  <resourceManaged>     - directory to write protobuf outputs to
     |""".stripMargin
 
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements"))
   def main(args: Array[String]): Unit =
     if (args.length != 3) {
       println(cliUsage)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -231,7 +231,7 @@ object Reduce {
           }
         }
         .parSequence
-        .as(Unit)
+        .as(())
     }
 
     override def inj(
@@ -705,7 +705,9 @@ object Reduce {
                   ReduceError("Error: interpolation Map should only contain String keys")
                 )
             }
-          @SuppressWarnings(Array("org.wartremover.warts.Var"))
+          @SuppressWarnings(
+            Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements")
+          )
           // TODO consider replacing while loop with tailrec recursion
           def interpolate(string: String, keyValuePairs: List[(String, String)]): String = {
             val result  = StringBuilder.newBuilder

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -226,7 +226,7 @@ class RegistryImpl[F[_]](
             publicRegisterSignedPatterns,
             TaggedContinuation(ScalaBodyRef(BodyRefs.REG_PUBLIC_REGISTER_SIGNED))
           )
-    } yield Unit
+    } yield ()
 
   private val prefixRetReplacePattern = BindPattern(
     Seq(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -4,6 +4,7 @@ object errors {
 
   sealed abstract class InterpreterError(message: String) extends Throwable(message) {
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     def this(message: String, cause: Throwable) {
       this(message)
       initCause(cause)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -235,7 +235,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
               handleRemainder[F, T](remainderTargetsSorted, level, merger)
             }
           }
-    } yield Unit
+    } yield ()
   }
 
   private def isolateState[H[_]: MonadState[?[_], S], S](f: H[_]): H[S] = {
@@ -284,7 +284,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
       //TODO: enforce sorted-ness of returned terms using types / by verifying the sorted-ness here
       remainderParUpdated = merger(remainderPar, remainderTargets)
       _                   <- freeMap.modify(_ + (level -> remainderParUpdated))
-    } yield Unit
+    } yield ()
 
 }
 
@@ -457,7 +457,7 @@ trait SpatialMatcherInstances {
               varLevel,
               wildcard
             )
-      } yield Unit
+      } yield ()
     }
   }
 
@@ -480,7 +480,7 @@ trait SpatialMatcherInstances {
       for {
         _ <- spatialMatch(target.chan, pattern.chan)
         _ <- foldMatch(target.data, pattern.data)
-      } yield Unit
+      } yield ()
   }
 
   implicit def receiveSpatialMatcherInstance[F[_]: Splittable: Alternative: Monad: _error: _cost: _freeMap: _short]
@@ -492,7 +492,7 @@ trait SpatialMatcherInstances {
         for {
           _ <- listMatchSingle(target.binds, pattern.binds)
           _ <- spatialMatch(target.body, pattern.body)
-        } yield Unit
+        } yield ()
     }
 
   implicit def newSpatialMatcherInstance[F[_]: Splittable: Alternative: Monad: _error: _cost: _freeMap: _short]
@@ -514,10 +514,10 @@ trait SpatialMatcherInstances {
                   _freeMap[F].modify(m => m + (level -> EList(matchedRem)))
                 case _ => ().pure[F]
               }
-        } yield Unit
+        } yield ()
       }
       case (ETupleBody(ETuple(tlist, _, _)), ETupleBody(ETuple(plist, _, _))) => {
-        foldMatch(tlist, plist).map(_ => Unit)
+        foldMatch(tlist, plist).map(_ => ())
       }
       case (ESetBody(ParSet(tlist, _, _, _)), ESetBody(ParSet(plist, _, _, rem))) =>
         val isWildcard      = rem.collect { case Var(Wildcard(_)) => true }.isDefined
@@ -543,12 +543,12 @@ trait SpatialMatcherInstances {
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case (EDivBody(EDiv(t1, t2)), EDivBody(EDiv(p1, p2))) =>
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case (
           EPercentPercentBody(EPercentPercent(t1, t2)),
           EPercentPercentBody(EPercentPercent(p1, p2))
@@ -556,22 +556,22 @@ trait SpatialMatcherInstances {
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case (EPlusBody(EPlus(t1, t2)), EPlusBody(EPlus(p1, p2))) =>
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case (EPlusPlusBody(EPlusPlus(t1, t2)), EPlusPlusBody(EPlusPlus(p1, p2))) =>
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case (EMinusMinusBody(EMinusMinus(t1, t2)), EMinusMinusBody(EMinusMinus(p1, p2))) =>
         for {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
-        } yield Unit
+        } yield ()
       case _ => MonoidK[F].empty[Unit]
     }
   }
@@ -582,7 +582,7 @@ trait SpatialMatcherInstances {
       for {
         _ <- spatialMatch(target.target, pattern.target)
         _ <- foldMatch(target.cases, pattern.cases)
-      } yield Unit
+      } yield ()
     }
 
   /**

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -32,6 +32,7 @@ object State {
   def empty[C, P, A, K]: State[C, P, A, K] = State[C, P, A, K](Map.empty, Map.empty)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class InMemoryStore[T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -22,7 +22,7 @@ import scodec.bits._
   *
   * To create an instance, use [[LMDBStore.create]].
   */
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
+@SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements"))
 // TODO stop throwing exceptions
 class LMDBStore[C, P, A, K] private[rspace] (
     val env: Env[ByteBuffer],

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -30,6 +30,7 @@ class NoopTxn[S] extends InMemTransaction[S] {
   *
   * It should be used with RSpace that solves high level locking (e.g. FineGrainedRSpace).
   */
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class LockFreeInMemoryStore[T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -44,6 +44,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
   private[this] val produceSpan   = Kamon.buildSpan(MetricsSource + ".produce")
   protected[this] val installSpan = Kamon.buildSpan(MetricsSource + ".install")
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def consume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -169,6 +170,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       }.max
     ) + 1
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -15,6 +15,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
 abstract class RSpaceOps[F[_], C, P, E, A, R, K](
     val store: IStore[C, P, A, K],
     val branch: Branch

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -43,6 +43,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
   private[this] val produceSpan   = Kamon.buildSpan(MetricsSource + ".produce")
   protected[this] val installSpan = Kamon.buildSpan(MetricsSource + ".install")
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   def consume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -69,6 +70,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
         }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedConsume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -97,6 +99,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
         .sequence
     }
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
     def storeWaitingContinuation(
         consumeRef: Consume,
         maybeCommRef: Option[COMM]
@@ -199,6 +202,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
@@ -215,6 +219,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
       }
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedProduce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]] = {
@@ -374,6 +379,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[C, P, A, K], branch: Br
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   @inline
   private def removeBindingsFor(
       commRef: COMM

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
@@ -14,8 +14,7 @@ class DefaultMultiLock[K] extends MultiLock[K] {
 
   private[this] val locks = TrieMap.empty[K, Semaphore]
 
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  // TODO stop throwing exceptions
+  @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements")) // TODO stop throwing exceptions
   def acquire[R](keys: Seq[K])(thunk: => R)(implicit o: Ordering[K]): R = {
     // TODO: keys should be a Set[K]
     val sortedKeys = keys.toSet.toList.sorted

--- a/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
@@ -30,8 +30,7 @@ object State {
   def empty[K, V]: State[K, V] = State[K, V](Map.empty, Map.empty, Map.empty, None)
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
-// TODO stop throwing exceptions
+@SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements")) // TODO stop throwing exceptions
 class InMemoryTrieStore[K, V]
     extends InMemoryOps[State[K, V]]
     with ITrieStore[InMemTransaction[State[K, V]], K, V] {

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -17,8 +17,7 @@ import org.lmdbjava.DbiFlags.MDB_CREATE
 import scodec.Codec
 import scodec.bits.{BitVector, ByteVector}
 
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
-// TODO stop throwing exceptions
+@SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements")) // TODO stop throwing exceptions
 class LMDBTrieStore[K, V] private (
     val env: Env[ByteBuffer],
     protected[this] val databasePath: Path,

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -10,6 +10,7 @@ import scodec.codecs.{bool, bytes, int32, int64, variableSizeBytesLong}
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object internal {
 
   final case class Datum[A](a: A, persist: Boolean, source: Produce)

--- a/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
@@ -8,6 +8,7 @@ object ByteStringOps {
 
   implicit class RichByteString(byteVector: ByteString) {
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     def toDirectByteBuffer: ByteBuffer = {
       val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size)
       byteVector.copyTo(buffer)

--- a/shared/src/main/scala/coop/rchain/shared/ByteVectorOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteVectorOps.scala
@@ -8,6 +8,7 @@ object ByteVectorOps {
 
   implicit class RichByteVector(byteVector: ByteVector) {
 
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
     def toDirectByteBuffer: ByteBuffer = {
       val buffer: ByteBuffer = ByteBuffer.allocateDirect(byteVector.size.toInt)
       byteVector.copyToBuffer(buffer)


### PR DESCRIPTION
## Overview
Remove NonUnitStatements from wart exclusion list. 

### From wartremover documentation:

Scala allows statements to return any type. Statements should only return Unit (this ensures that they’re really intended to be statements).
```
// Won't compile: Statements must return Unit
10
false
```
When interfacing with APIs that violate this principle, one can define a function in the project

```
@specialized def discard[A](evaluateForSideEffectOnly: A): Unit = {
  val _: A = evaluateForSideEffectOnly
  () //Return unit to prevent warning due to discarding value
}

discard{ badMutateFun(foo) } // Use like this
```

### JIRA ticket:
continued work on RCHAIN-2837
