### PR TITLE
Introduce pure file system wrappers

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -282,7 +282,7 @@ object FileLMDBIndexBlockStore {
       checkpointsDirPath: Path
   ): StorageErrT[F, List[Checkpoint]] =
     for {
-      checkpointFilesList <- toStorageIOErrT(listFiles(checkpointsDirPath))
+      checkpointFilesList <- toStorageIOErrT(listRegularFiles(checkpointsDirPath))
       checkpoints <- EitherT.liftF[F, StorageError, List[Checkpoint]](
                       checkpointFilesList.flatTraverse { filePath =>
                         filePath.getFileName.toString match {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -91,10 +91,10 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
   private def readBlockMessage(indexEntry: IndexEntry): StorageIOErrT[F, BlockMessage] = {
     def readBlockMessageFromFile(storageFile: RandomAccessIO[F]): StorageIOErrT[F, BlockMessage] =
       for {
-        _                      <- storageFile.seek(indexEntry.offset).toStorageIOErrT
-        blockMessageSize       <- storageFile.readInt.toStorageIOErrT
+        _                      <- EitherT(storageFile.seek(indexEntry.offset)).toStorageIOErrT
+        blockMessageSize       <- EitherT(storageFile.readInt).toStorageIOErrT
         blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
-        _                      <- storageFile.readFully(blockMessagesByteArray).toStorageIOErrT
+        _                      <- EitherT(storageFile.readFully(blockMessagesByteArray)).toStorageIOErrT
         blockMessage           = BlockMessage.parseFrom(blockMessagesByteArray)
       } yield blockMessage
 
@@ -116,7 +116,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
                                       } { storageFile =>
                                         readBlockMessageFromFile(storageFile)
                                       } { storageFile =>
-                                        storageFile.close()
+                                        EitherT(storageFile.close()).toStorageIOErrT
                                       }
                                     case None =>
                                       EitherT
@@ -180,12 +180,12 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
                              getBlockMessageRandomAccessFile
                            )
         currentIndex              <- EitherT.liftF(getCurrentIndex)
-        endOfFileOffset           <- randomAccessFile.length.toStorageIOErrT
-        _                         <- randomAccessFile.seek(endOfFileOffset).toStorageIOErrT
+        endOfFileOffset           <- EitherT(randomAccessFile.length).toStorageIOErrT
+        _                         <- EitherT(randomAccessFile.seek(endOfFileOffset)).toStorageIOErrT
         (blockHash, blockMessage) = f
         blockMessageByteArray     = blockMessage.toByteArray
-        _                         <- randomAccessFile.writeInt(blockMessageByteArray.length).toStorageIOErrT
-        _                         <- randomAccessFile.write(blockMessageByteArray).toStorageIOErrT
+        _                         <- EitherT(randomAccessFile.writeInt(blockMessageByteArray.length)).toStorageIOErrT
+        _                         <- EitherT(randomAccessFile.write(blockMessageByteArray)).toStorageIOErrT
         _ <- EitherT.liftF[F, StorageIOError, Unit](withWriteTxn { txn =>
               index.put(
                 txn,
@@ -204,7 +204,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
         blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
                                          getBlockMessageRandomAccessFile
                                        )
-        _                               <- blockMessageRandomAccessFile.close().toStorageIOErrT
+        _                               <- EitherT(blockMessageRandomAccessFile.close()).toStorageIOErrT
         _                               <- moveFile(storagePath, checkpointPath, StandardCopyOption.ATOMIC_MOVE).toStorageIOErrT
         newBlockMessageRandomAccessFile <- RandomAccessIO.open[F](storagePath).toStorageIOErrT
         _ <- EitherT.liftF[F, StorageIOError, Unit](
@@ -226,7 +226,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
         _ <- withWriteTxn { txn =>
               index.drop(txn)
             }
-        result <- blockMessageRandomAccessFile.setLength(0).toStorageIOErrT.value
+        result <- EitherT(blockMessageRandomAccessFile.setLength(0)).toStorageIOErrT.value
       } yield result
     )
 
@@ -236,7 +236,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
         blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
                                          getBlockMessageRandomAccessFile
                                        )
-        _ <- blockMessageRandomAccessFile.close().toStorageIOErrT
+        _ <- EitherT(blockMessageRandomAccessFile.close()).toStorageIOErrT
         _ <- EitherT(Sync[F].delay { env.close() }.attempt).leftMap[StorageIOError] {
               case e: IOException =>
                 WrappedIOError(ClosingFailed(e))

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -3,7 +3,6 @@ package coop.rchain.blockstorage
 import java.io._
 import java.nio.ByteBuffer
 import java.nio.file._
-import java.util.stream.Collectors
 
 import cats.Monad
 import cats.data.EitherT
@@ -18,6 +17,8 @@ import coop.rchain.blockstorage.StorageError.{StorageErr, StorageErrT, StorageIO
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.shared.Resources.withResource
 import coop.rchain.blockstorage.util.byteOps._
+import coop.rchain.blockstorage.util.io._
+import coop.rchain.blockstorage.StorageError._
 import coop.rchain.catscontrib.Capture
 import coop.rchain.shared.{AtomicMonadState, Log}
 import coop.rchain.shared.ByteStringOps._
@@ -29,8 +30,8 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
-private final case class FileLMDBIndexBlockStoreState(
-    blockMessageRandomAccessFile: RandomAccessFile,
+private final case class FileLMDBIndexBlockStoreState[F[_]: Sync](
+    blockMessageRandomAccessFile: RandomAccessIO[F],
     checkpoints: Map[Int, Checkpoint],
     currentIndex: Int
 )
@@ -42,7 +43,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
     index: Dbi[ByteBuffer],
     storagePath: Path,
     checkpointsDir: Path,
-    state: MonadState[F, FileLMDBIndexBlockStoreState]
+    state: MonadState[F, FileLMDBIndexBlockStoreState[F]]
 ) extends BlockStore[F] {
   private case class IndexEntry(checkpointIndex: Int, offset: Long)
   private object IndexEntry {
@@ -74,9 +75,9 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
   private[this] def withReadTxn[R](f: Txn[ByteBuffer] => R): F[R] =
     withTxn(env.txnRead())(f)
 
-  private[this] def getBlockMessageRandomAccessFile: F[RandomAccessFile] =
+  private[this] def getBlockMessageRandomAccessFile: F[RandomAccessIO[F]] =
     state.get.map(_.blockMessageRandomAccessFile)
-  private[this] def setBlockMessageRandomAccessFile(file: RandomAccessFile): F[Unit] =
+  private[this] def setBlockMessageRandomAccessFile(file: RandomAccessIO[F]): F[Unit] =
     state.modify(_.copy(blockMessageRandomAccessFile = file))
   private[this] def getCheckpoints: F[Map[Int, Checkpoint]] =
     state.get.map(_.checkpoints)
@@ -88,25 +89,13 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
     state.modify(s => s.copy(currentIndex = f(s.currentIndex)))
 
   private def readBlockMessage(indexEntry: IndexEntry): StorageIOErrT[F, BlockMessage] = {
-    def readBlockMessageFromFile(storageFile: RandomAccessFile): StorageIOErrT[F, BlockMessage] =
+    def readBlockMessageFromFile(storageFile: RandomAccessIO[F]): StorageIOErrT[F, BlockMessage] =
       for {
-        _ <- EitherT(Sync[F].delay { storageFile.seek(indexEntry.offset) }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException => FileSeekFailed(e)
-                case e              => UnexpectedIOStorageError(e)
-              }
-        blockMessageSize <- EitherT(Sync[F].delay { storageFile.readInt() }.attempt)
-                             .leftMap[StorageIOError] {
-                               case e: IOException => IntReadFailed(e)
-                               case e              => UnexpectedIOStorageError(e)
-                             }
+        _                      <- storageFile.seek(indexEntry.offset).toStorageIOErrT
+        blockMessageSize       <- storageFile.readInt.toStorageIOErrT
         blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
-        _ <- EitherT(Sync[F].delay { storageFile.readFully(blockMessagesByteArray) }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException => ByteArrayReadFailed(e)
-                case e              => UnexpectedIOStorageError(e)
-              }
-        blockMessage = BlockMessage.parseFrom(blockMessagesByteArray)
+        _                      <- storageFile.readFully(blockMessagesByteArray).toStorageIOErrT
+        blockMessage           = BlockMessage.parseFrom(blockMessagesByteArray)
       } yield blockMessage
 
     for {
@@ -123,13 +112,11 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
                                     case Some(checkpoint) =>
                                       type StorageIOErrTF[A] = StorageIOErrT[F, A]
                                       Sync[StorageIOErrTF].bracket {
-                                        Sync[StorageIOErrTF].delay {
-                                          new RandomAccessFile(checkpoint.storagePath.toFile, "rw")
-                                        }
+                                        RandomAccessIO.open[F](checkpoint.storagePath)
                                       } { storageFile =>
                                         readBlockMessageFromFile(storageFile)
                                       } { storageFile =>
-                                        Sync[StorageIOErrTF].delay { storageFile.close() }
+                                        storageFile.close()
                                       }
                                     case None =>
                                       EitherT
@@ -189,30 +176,16 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
   override def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]] =
     lock.withPermit(
       (for {
-        randomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessFile](
+        randomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
                              getBlockMessageRandomAccessFile
                            )
-        currentIndex <- EitherT.liftF(getCurrentIndex)
-        endOfFileOffset <- EitherT(Sync[F].delay { randomAccessFile.length() }.attempt)
-                            .leftMap[StorageIOError](UnexpectedIOStorageError.apply)
-        _ <- EitherT(Sync[F].delay { randomAccessFile.seek(endOfFileOffset) }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException => FileSeekFailed(e)
-                case e              => UnexpectedIOStorageError(e)
-              }
+        currentIndex              <- EitherT.liftF(getCurrentIndex)
+        endOfFileOffset           <- randomAccessFile.length.toStorageIOErrT
+        _                         <- randomAccessFile.seek(endOfFileOffset).toStorageIOErrT
         (blockHash, blockMessage) = f
         blockMessageByteArray     = blockMessage.toByteArray
-        _ <- EitherT(
-              Sync[F].delay { randomAccessFile.writeInt(blockMessageByteArray.length) }.attempt
-            ).leftMap[StorageIOError] {
-              case e: IOException => IntWriteFailed(e)
-              case e              => UnexpectedIOStorageError(e)
-            }
-        _ <- EitherT(Sync[F].delay { randomAccessFile.write(blockMessageByteArray) }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException => ByteArrayWriteFailed(e)
-                case e              => UnexpectedIOStorageError(e)
-              }
+        _                         <- randomAccessFile.writeInt(blockMessageByteArray.length).toStorageIOErrT
+        _                         <- randomAccessFile.write(blockMessageByteArray).toStorageIOErrT
         _ <- EitherT.liftF[F, StorageIOError, Unit](withWriteTxn { txn =>
               index.put(
                 txn,
@@ -228,19 +201,12 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
       (for {
         checkpointIndex <- EitherT.liftF[F, StorageIOError, Int](getCurrentIndex)
         checkpointPath  = checkpointsDir.resolve(checkpointIndex.toString)
-        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessFile](
+        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
                                          getBlockMessageRandomAccessFile
                                        )
-        _ <- EitherT(Sync[F].delay { blockMessageRandomAccessFile.close() }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException =>
-                  ClosingFailed(e)
-                case t =>
-                  UnexpectedIOStorageError(t)
-              }
-        _ <- FileLMDBIndexBlockStore
-              .moveFile(storagePath, checkpointPath, StandardCopyOption.ATOMIC_MOVE)
-        newBlockMessageRandomAccessFile <- FileLMDBIndexBlockStore.openRandomAccessFile(storagePath)
+        _                               <- blockMessageRandomAccessFile.close().toStorageIOErrT
+        _                               <- moveFile(storagePath, checkpointPath, StandardCopyOption.ATOMIC_MOVE).toStorageIOErrT
+        newBlockMessageRandomAccessFile <- RandomAccessIO.open[F](storagePath).toStorageIOErrT
         _ <- EitherT.liftF[F, StorageIOError, Unit](
               setBlockMessageRandomAccessFile(newBlockMessageRandomAccessFile)
             )
@@ -260,36 +226,22 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
         _ <- withWriteTxn { txn =>
               index.drop(txn)
             }
-        storageFileClearAttempt <- Sync[F].delay { blockMessageRandomAccessFile.setLength(0) }.attempt
-        result = storageFileClearAttempt match {
-          case Left(e: IOException) =>
-            Left(ClearFileFailed(e))
-          case Left(t) =>
-            Left(UnexpectedIOStorageError(t))
-          case Right(_) =>
-            Right(())
-        }
+        result <- blockMessageRandomAccessFile.setLength(0).toStorageIOErrT.value
       } yield result
     )
 
   override def close(): F[StorageIOErr[Unit]] =
     lock.withPermit(
       (for {
-        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessFile](
+        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
                                          getBlockMessageRandomAccessFile
                                        )
-        _ <- EitherT(Sync[F].delay { blockMessageRandomAccessFile.close() }.attempt)
-              .leftMap[StorageIOError] {
-                case e: IOException =>
-                  ClosingFailed(e)
-                case t =>
-                  UnexpectedIOStorageError(t)
-              }
+        _ <- blockMessageRandomAccessFile.close().toStorageIOErrT
         _ <- EitherT(Sync[F].delay { env.close() }.attempt).leftMap[StorageIOError] {
               case e: IOException =>
-                ClosingFailed(e)
+                WrappedIOError(ClosingFailed(e))
               case t =>
-                UnexpectedIOStorageError(t)
+                WrappedIOError(UnexpectedIOError(t))
             }
       } yield ()).value
     )
@@ -318,75 +270,11 @@ object FileLMDBIndexBlockStore {
       storagePath: Path
   )
 
-  private def openRandomAccessFile[F[_]: Sync](path: Path): StorageIOErrT[F, RandomAccessFile] =
-    EitherT(Sync[F].delay { new RandomAccessFile(path.toFile, "rw") }.attempt).leftMap {
-      case e: FileNotFoundException => FileNotFound(e)
-      case e: SecurityException     => FileSecurityViolation(e)
-      case t                        => UnexpectedIOStorageError(t)
-    }
-
-  private def moveFile[F[_]: Sync](
-      from: Path,
-      to: Path,
-      options: CopyOption*
-  ): StorageIOErrT[F, Path] =
-    EitherT(Sync[F].delay { Files.move(from, to, options: _*) }.attempt).leftMap[StorageIOError] {
-      case e: UnsupportedOperationException =>
-        UnsupportedFileOperation(e)
-      case e: FileAlreadyExistsException =>
-        FileAlreadyExists(e)
-      case e: DirectoryNotEmptyException =>
-        DirectoryNotEmpty(e)
-      case e: AtomicMoveNotSupportedException =>
-        AtomicMoveNotSupported(e)
-      case e: SecurityException =>
-        FileSecurityViolation(e)
-      case t =>
-        UnexpectedIOStorageError(t)
-    }
-
-  private def isDirectory[F[_]: Sync](path: Path): StorageErrT[F, Boolean] =
-    EitherT(Sync[F].delay { Files.isDirectory(path) }.attempt).leftMap[StorageError] {
-      case e: SecurityException => FileSecurityViolation(e)
-      case t                    => UnexpectedIOStorageError(t)
-    }
-
-  private def isRegularFile[F[_]: Sync](path: Path): StorageErrT[F, Boolean] =
-    EitherT(Sync[F].delay { Files.isRegularFile(path) }.attempt).leftMap[StorageError] {
-      case e: SecurityException => FileSecurityViolation(e)
-      case t                    => UnexpectedIOStorageError(t)
-    }
-
-  private def listInDirectory[F[_]: Sync](dirPath: Path): StorageErrT[F, List[Path]] =
-    for {
-      _ <- EitherT(Sync[F].delay { dirPath.toFile.mkdir() }.attempt).leftMap[StorageError] {
-            case e: SecurityException => FileSecurityViolation(e)
-            case t                    => UnexpectedIOStorageError(t)
-          }
-      files <- EitherT(Sync[F].delay { Files.list(dirPath) }.attempt).leftMap[StorageError] {
-                case e: NotDirectoryException => FileIsNotDirectory(e)
-                case e: SecurityException     => FileSecurityViolation(e)
-                case t                        => UnexpectedIOStorageError(t)
-              }
-      filesList = files
-        .collect(Collectors.toList[Path])
-        .asScala
-        .toList
-    } yield filesList
-
-  private def listFiles[F[_]: Sync](dirPath: Path): StorageErrT[F, List[Path]] = {
-    type StorageErrTF[A] = StorageErrT[F, A]
-    for {
-      inDirectoryList <- listInDirectory(dirPath)
-      directoryList   <- inDirectoryList.filterA[StorageErrTF](isRegularFile)
-    } yield directoryList
-  }
-
   private def loadCheckpoints[F[_]: Sync: Log](
       checkpointsDirPath: Path
   ): StorageErrT[F, List[Checkpoint]] =
     for {
-      checkpointFilesList <- listFiles(checkpointsDirPath)
+      checkpointFilesList <- listFiles(checkpointsDirPath).toStorageIOErrT
       checkpoints <- EitherT.liftF[F, StorageError, List[Checkpoint]](
                       checkpointFilesList.flatTraverse { filePath =>
                         filePath.getFileName.toString match {
@@ -432,11 +320,11 @@ object FileLMDBIndexBlockStore {
       index <- EitherT.liftF[F, StorageError, Dbi[ByteBuffer]](Sync[F].delay {
                 env.openDbi(s"block_store_index", MDB_CREATE)
               })
-      blockMessageRandomAccessFile <- openRandomAccessFile[F](storagePath)
+      blockMessageRandomAccessFile <- RandomAccessIO.open(storagePath).toStorageIOErrT
       sortedCheckpoints            <- loadCheckpoints(checkpointsDirPath)
       checkpointsMap               = sortedCheckpoints.map(c => c.index -> c).toMap
       currentIndex                 = sortedCheckpoints.lastOption.map(_.index + 1).getOrElse(0)
-      initialState = FileLMDBIndexBlockStoreState(
+      initialState = FileLMDBIndexBlockStoreState[F](
         blockMessageRandomAccessFile,
         checkpointsMap,
         currentIndex
@@ -447,7 +335,7 @@ object FileLMDBIndexBlockStore {
         index,
         storagePath,
         checkpointsDirPath,
-        new AtomicMonadState[F, FileLMDBIndexBlockStoreState](AtomicAny(initialState))
+        new AtomicMonadState[F, FileLMDBIndexBlockStoreState[F]](AtomicAny(initialState))
       )
     } yield result: BlockStore[F]).value
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -282,6 +282,7 @@ object FileLMDBIndexBlockStore {
       checkpointsDirPath: Path
   ): StorageErrT[F, List[Checkpoint]] =
     for {
+      _                   <- toStorageIOErrT(makeDirectory(checkpointsDirPath))
       checkpointFilesList <- toStorageIOErrT(listRegularFiles(checkpointsDirPath))
       checkpoints <- EitherT.liftF[F, StorageError, List[Checkpoint]](
                       checkpointFilesList.flatTraverse { filePath =>

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -52,9 +52,4 @@ object StorageError {
   implicit class IOErrorTToStorageIOErrorT[F[_]: Functor, A](ioErrT: IOErrT[F, A]) {
     def toStorageIOErrT: StorageIOErrT[F, A] = ioErrT.leftMap(WrappedIOError.apply)
   }
-
-  implicit def ioErrorTToStorageIoError[F[_]: Functor, A](
-      ioError: IOErrT[F, A]
-  ): StorageIOErrT[F, A] =
-    ioError.leftMap(WrappedIOError.apply)
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -1,0 +1,71 @@
+package coop.rchain.blockstorage.util.io
+
+import java.io.{FileNotFoundException, IOException, RandomAccessFile}
+import java.nio.file.Path
+
+import cats.data.EitherT
+import cats.effect.Sync
+import cats.implicits._
+import IOError.IOErrT
+
+import scala.language.higherKinds
+
+final case class RandomAccessIO[F[_]: Sync](file: RandomAccessFile) {
+  def close(): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.close() }.attempt).leftMap[IOError] {
+      case e: IOException =>
+        ClosingFailed(e)
+      case t =>
+        UnexpectedIOError(t)
+    }
+
+  def write(bytes: Array[Byte]): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.write(bytes) }.attempt).leftMap[IOError] {
+      case e: IOException => ByteArrayWriteFailed(e)
+      case e              => UnexpectedIOError(e)
+    }
+
+  def writeInt(v: Int): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.writeInt(v) }.attempt).leftMap[IOError] {
+      case e: IOException => IntWriteFailed(e)
+      case e              => UnexpectedIOError(e)
+    }
+
+  def readInt: IOErrT[F, Int] =
+    EitherT(Sync[F].delay { file.readInt() }.attempt).leftMap[IOError] {
+      case e: IOException => IntReadFailed(e)
+      case e              => UnexpectedIOError(e)
+    }
+
+  def readFully(buffer: Array[Byte]): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.readFully(buffer) }.attempt).leftMap[IOError] {
+      case e: IOException => ByteArrayReadFailed(e)
+      case e              => UnexpectedIOError(e)
+    }
+
+  def length: IOErrT[F, Long] =
+    EitherT(Sync[F].delay { file.length() }.attempt).leftMap(UnexpectedIOError.apply)
+
+  def seek(offset: Long): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.seek(offset) }.attempt).leftMap[IOError] {
+      case e: IOException => FileSeekFailed(e)
+      case e              => UnexpectedIOError(e)
+    }
+
+  def setLength(length: Long): IOErrT[F, Unit] =
+    EitherT(Sync[F].delay { file.setLength(length) }.attempt).leftMap[IOError] {
+      case e: IOException => ClearFileFailed(e)
+      case t              => UnexpectedIOError(t)
+    }
+}
+
+object RandomAccessIO {
+  def open[F[_]: Sync](path: Path): IOErrT[F, RandomAccessIO[F]] =
+    EitherT(Sync[F].delay { new RandomAccessFile(path.toFile, "rw") }.attempt)
+      .leftMap[IOError] {
+        case e: FileNotFoundException => FileNotFound(e)
+        case e: SecurityException     => FileSecurityViolation(e)
+        case t                        => UnexpectedIOError(t)
+      }
+      .map(file => RandomAccessIO[F](file))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -9,7 +9,7 @@ import IOError.IOErr
 
 import scala.language.higherKinds
 
-final case class RandomAccessIO[F[_]: Sync](file: RandomAccessFile) {
+final case class RandomAccessIO[F[_]: Sync] private (private val file: RandomAccessFile) {
   private def handleIo[A](io: => A, handleIoException: IOException => IOError): F[IOErr[A]] =
     Sync[F].delay { io }.attempt.map[IOErr[A]] {
       case Left(e: IOException) => Left(handleIoException(e))

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -3,69 +3,54 @@ package coop.rchain.blockstorage.util.io
 import java.io.{FileNotFoundException, IOException, RandomAccessFile}
 import java.nio.file.Path
 
-import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
-import IOError.IOErrT
+import IOError.IOErr
 
 import scala.language.higherKinds
 
 final case class RandomAccessIO[F[_]: Sync](file: RandomAccessFile) {
-  def close(): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.close() }.attempt).leftMap[IOError] {
-      case e: IOException =>
-        ClosingFailed(e)
-      case t =>
-        UnexpectedIOError(t)
+  private def handleIo[A](io: => A, handleIoException: IOException => IOError): F[IOErr[A]] =
+    Sync[F].delay { io }.attempt.map[IOErr[A]] {
+      case Left(e: IOException) => Left(handleIoException(e))
+      case Left(e)              => Left(UnexpectedIOError(e))
+      case Right(v)             => Right(v)
     }
 
-  def write(bytes: Array[Byte]): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.write(bytes) }.attempt).leftMap[IOError] {
-      case e: IOException => ByteArrayWriteFailed(e)
-      case e              => UnexpectedIOError(e)
-    }
+  def close(): F[IOErr[Unit]] =
+    handleIo(file.close(), ClosingFailed.apply)
 
-  def writeInt(v: Int): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.writeInt(v) }.attempt).leftMap[IOError] {
-      case e: IOException => IntWriteFailed(e)
-      case e              => UnexpectedIOError(e)
-    }
+  def write(bytes: Array[Byte]): F[IOErr[Unit]] =
+    handleIo(file.write(bytes), ByteArrayWriteFailed.apply)
 
-  def readInt: IOErrT[F, Int] =
-    EitherT(Sync[F].delay { file.readInt() }.attempt).leftMap[IOError] {
-      case e: IOException => IntReadFailed(e)
-      case e              => UnexpectedIOError(e)
-    }
+  def writeInt(v: Int): F[IOErr[Unit]] =
+    handleIo(file.writeInt(v), IntWriteFailed.apply)
 
-  def readFully(buffer: Array[Byte]): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.readFully(buffer) }.attempt).leftMap[IOError] {
-      case e: IOException => ByteArrayReadFailed(e)
-      case e              => UnexpectedIOError(e)
-    }
+  def readInt: F[IOErr[Int]] =
+    handleIo(file.readInt(), IntReadFailed.apply)
 
-  def length: IOErrT[F, Long] =
-    EitherT(Sync[F].delay { file.length() }.attempt).leftMap(UnexpectedIOError.apply)
+  def readFully(buffer: Array[Byte]): F[IOErr[Unit]] =
+    handleIo(file.readFully(buffer), ByteArrayReadFailed.apply)
 
-  def seek(offset: Long): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.seek(offset) }.attempt).leftMap[IOError] {
-      case e: IOException => FileSeekFailed(e)
-      case e              => UnexpectedIOError(e)
-    }
+  def length: F[IOErr[Long]] =
+    handleIo(file.length(), UnexpectedIOError.apply)
 
-  def setLength(length: Long): IOErrT[F, Unit] =
-    EitherT(Sync[F].delay { file.setLength(length) }.attempt).leftMap[IOError] {
-      case e: IOException => ClearFileFailed(e)
-      case t              => UnexpectedIOError(t)
-    }
+  def seek(offset: Long): F[IOErr[Unit]] =
+    handleIo(file.seek(offset), FileSeekFailed.apply)
+
+  def setLength(length: Long): F[IOErr[Unit]] =
+    handleIo(file.setLength(length), ClearFileFailed.apply)
 }
 
 object RandomAccessIO {
-  def open[F[_]: Sync](path: Path): IOErrT[F, RandomAccessIO[F]] =
-    EitherT(Sync[F].delay { new RandomAccessFile(path.toFile, "rw") }.attempt)
-      .leftMap[IOError] {
-        case e: FileNotFoundException => FileNotFound(e)
-        case e: SecurityException     => FileSecurityViolation(e)
-        case t                        => UnexpectedIOError(t)
+  def open[F[_]: Sync](path: Path): F[IOErr[RandomAccessIO[F]]] =
+    Sync[F]
+      .delay { new RandomAccessFile(path.toFile, "rw") }
+      .attempt
+      .map[IOErr[RandomAccessIO[F]]] {
+        case Left(e: FileNotFoundException) => Left(FileNotFound(e))
+        case Left(e: SecurityException)     => Left(FileSecurityViolation(e))
+        case Left(t)                        => Left(UnexpectedIOError(t))
+        case Right(file)                    => Right(RandomAccessIO[F](file))
       }
-      .map(file => RandomAccessIO[F](file))
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -39,7 +39,7 @@ final case class RandomAccessIO[F[_]: Sync](file: RandomAccessFile) {
     handleIo(file.seek(offset), FileSeekFailed.apply)
 
   def setLength(length: Long): F[IOErr[Unit]] =
-    handleIo(file.setLength(length), ClearFileFailed.apply)
+    handleIo(file.setLength(length), SetLengthFailed.apply)
 }
 
 object RandomAccessIO {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -1,0 +1,75 @@
+package coop.rchain.blockstorage.util.io
+
+import java.io.{FileNotFoundException, IOException}
+import java.nio.file.{
+  AtomicMoveNotSupportedException,
+  DirectoryNotEmptyException,
+  FileAlreadyExistsException,
+  NotDirectoryException
+}
+
+import cats.data.EitherT
+
+sealed trait IOError
+
+final case class FileSeekFailed(exception: IOException)                     extends IOError
+final case class IntReadFailed(exception: IOException)                      extends IOError
+final case class ByteArrayReadFailed(exception: IOException)                extends IOError
+final case class IntWriteFailed(exception: IOException)                     extends IOError
+final case class ByteArrayWriteFailed(exception: IOException)               extends IOError
+final case class ClearFileFailed(exception: IOException)                    extends IOError
+final case class ClosingFailed(exception: IOException)                      extends IOError
+final case class FileNotFound(exception: FileNotFoundException)             extends IOError
+final case class FileSecurityViolation(exception: SecurityException)        extends IOError
+final case class FileIsNotDirectory(exception: NotDirectoryException)       extends IOError
+final case class UnsupportedFileOperation(e: UnsupportedOperationException) extends IOError
+final case class FileAlreadyExists(e: FileAlreadyExistsException)           extends IOError
+final case class DirectoryNotEmpty(e: DirectoryNotEmptyException)           extends IOError
+final case class AtomicMoveNotSupported(e: AtomicMoveNotSupportedException) extends IOError
+final case class UnexpectedIOError(throwable: Throwable)                    extends IOError
+
+object IOError {
+  type IOErr[A]        = Either[IOError, A]
+  type IOErrT[F[_], A] = EitherT[F, IOError, A]
+
+  def errorMessage(error: IOError): String =
+    error match {
+      case FileSeekFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File seek failed: $msg"
+      case IntReadFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Int read failed: $msg"
+      case ByteArrayReadFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Byte array read failed: $msg"
+      case IntWriteFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Int write failed: $msg"
+      case ByteArrayWriteFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Byte array write failed: $msg"
+      case ClearFileFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File clearing failed: $msg"
+      case ClosingFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File closing failed: $msg"
+      case FileNotFound(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File not found: $msg"
+      case FileSecurityViolation(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Security manager denied access to file: $msg"
+      case FileIsNotDirectory(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File is not a directory: $msg"
+      case UnexpectedIOError(t) =>
+        val msg = Option(t.getMessage).getOrElse("")
+        s"Unexpected IO error occurred: $msg"
+    }
+
+  implicit class IOErrorToMessage(ioError: IOError) {
+    val message: String = errorMessage(ioError)
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -17,7 +17,7 @@ final case class IntReadFailed(exception: IOException)                      exte
 final case class ByteArrayReadFailed(exception: IOException)                extends IOError
 final case class IntWriteFailed(exception: IOException)                     extends IOError
 final case class ByteArrayWriteFailed(exception: IOException)               extends IOError
-final case class ClearFileFailed(exception: IOException)                    extends IOError
+final case class SetLengthFailed(exception: IOException)                    extends IOError
 final case class ClosingFailed(exception: IOException)                      extends IOError
 final case class FileNotFound(exception: FileNotFoundException)             extends IOError
 final case class FileSecurityViolation(exception: SecurityException)        extends IOError
@@ -49,9 +49,9 @@ object IOError {
       case ByteArrayWriteFailed(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"Byte array write failed: $msg"
-      case ClearFileFailed(e) =>
+      case SetLengthFailed(e) =>
         val msg = Option(e.getMessage).getOrElse("")
-        s"File clearing failed: $msg"
+        s"Set file length failed: $msg"
       case ClosingFailed(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"File closing failed: $msg"

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -1,0 +1,70 @@
+package coop.rchain.blockstorage.util
+
+import java.nio.file._
+import java.util.stream.Collectors
+
+import cats.data.EitherT
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.blockstorage.util.io.IOError.IOErrT
+
+import scala.collection.JavaConverters._
+
+package object io {
+  def moveFile[F[_]: Sync](
+      from: Path,
+      to: Path,
+      options: CopyOption*
+  ): IOErrT[F, Path] =
+    EitherT(Sync[F].delay { Files.move(from, to, options: _*) }.attempt).leftMap[IOError] {
+      case e: UnsupportedOperationException =>
+        UnsupportedFileOperation(e)
+      case e: FileAlreadyExistsException =>
+        FileAlreadyExists(e)
+      case e: DirectoryNotEmptyException =>
+        DirectoryNotEmpty(e)
+      case e: AtomicMoveNotSupportedException =>
+        AtomicMoveNotSupported(e)
+      case e: SecurityException =>
+        FileSecurityViolation(e)
+      case t =>
+        UnexpectedIOError(t)
+    }
+
+  def isDirectory[F[_]: Sync](path: Path): IOErrT[F, Boolean] =
+    EitherT(Sync[F].delay { Files.isDirectory(path) }.attempt).leftMap[IOError] {
+      case e: SecurityException => FileSecurityViolation(e)
+      case t                    => UnexpectedIOError(t)
+    }
+
+  def isRegularFile[F[_]: Sync](path: Path): IOErrT[F, Boolean] =
+    EitherT(Sync[F].delay { Files.isRegularFile(path) }.attempt).leftMap[IOError] {
+      case e: SecurityException => FileSecurityViolation(e)
+      case t                    => UnexpectedIOError(t)
+    }
+
+  def listInDirectory[F[_]: Sync](dirPath: Path): IOErrT[F, List[Path]] =
+    for {
+      _ <- EitherT(Sync[F].delay { dirPath.toFile.mkdir() }.attempt).leftMap[IOError] {
+            case e: SecurityException => FileSecurityViolation(e)
+            case t                    => UnexpectedIOError(t)
+          }
+      files <- EitherT(Sync[F].delay { Files.list(dirPath) }.attempt).leftMap[IOError] {
+                case e: NotDirectoryException => FileIsNotDirectory(e)
+                case e: SecurityException     => FileSecurityViolation(e)
+                case t                        => UnexpectedIOError(t)
+              }
+      filesList = files
+        .collect(Collectors.toList[Path])
+        .asScala
+        .toList
+    } yield filesList
+
+  def listFiles[F[_]: Sync](dirPath: Path): IOErrT[F, List[Path]] = {
+    type IOErrTF[A] = IOErrT[F, A]
+    for {
+      inDirectoryList <- listInDirectory(dirPath)
+      directoryList   <- inDirectoryList.filterA[IOErrTF](isRegularFile)
+    } yield directoryList
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -56,7 +56,6 @@ package object io {
 
   def listInDirectory[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] =
     (for {
-      _ <- EitherT(makeDirectory(dirPath))
       files <- EitherT(handleIo(Files.list(dirPath), {
                 case e: NotDirectoryException => FileIsNotDirectory(e)
                 case e                        => UnexpectedIOError(e)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -1,70 +1,74 @@
 package coop.rchain.blockstorage.util
 
+import java.io.IOException
 import java.nio.file._
 import java.util.stream.Collectors
 
 import cats.data.EitherT
 import cats.implicits._
 import cats.effect.Sync
-import coop.rchain.blockstorage.util.io.IOError.IOErrT
+import coop.rchain.blockstorage.util.io.IOError.{IOErr, IOErrT}
 
 import scala.collection.JavaConverters._
 
 package object io {
+  private[io] def handleIo[F[_]: Sync, A](
+      io: => A,
+      handleIoException: IOException => IOError
+  ): F[IOErr[A]] =
+    Sync[F].delay { io }.attempt.map[IOErr[A]] {
+      case Left(e: IOException)                   => Left(handleIoException(e))
+      case Left(e: SecurityException)             => Left(FileSecurityViolation(e))
+      case Left(e: UnsupportedOperationException) => Left(UnsupportedFileOperation(e))
+      case Left(e)                                => Left(UnexpectedIOError(e))
+      case Right(v)                               => Right(v)
+    }
+
   def moveFile[F[_]: Sync](
       from: Path,
       to: Path,
       options: CopyOption*
-  ): IOErrT[F, Path] =
-    EitherT(Sync[F].delay { Files.move(from, to, options: _*) }.attempt).leftMap[IOError] {
-      case e: UnsupportedOperationException =>
-        UnsupportedFileOperation(e)
-      case e: FileAlreadyExistsException =>
-        FileAlreadyExists(e)
-      case e: DirectoryNotEmptyException =>
-        DirectoryNotEmpty(e)
-      case e: AtomicMoveNotSupportedException =>
-        AtomicMoveNotSupported(e)
-      case e: SecurityException =>
-        FileSecurityViolation(e)
-      case t =>
-        UnexpectedIOError(t)
-    }
+  ): F[IOErr[Path]] =
+    handleIo(
+      Files.move(from, to, options: _*), {
+        case e: FileAlreadyExistsException =>
+          FileAlreadyExists(e)
+        case e: DirectoryNotEmptyException =>
+          DirectoryNotEmpty(e)
+        case e: AtomicMoveNotSupportedException =>
+          AtomicMoveNotSupported(e)
+        case e =>
+          UnexpectedIOError(e)
+      }
+    )
 
-  def isDirectory[F[_]: Sync](path: Path): IOErrT[F, Boolean] =
-    EitherT(Sync[F].delay { Files.isDirectory(path) }.attempt).leftMap[IOError] {
-      case e: SecurityException => FileSecurityViolation(e)
-      case t                    => UnexpectedIOError(t)
-    }
+  def isDirectory[F[_]: Sync](path: Path): F[IOErr[Boolean]] =
+    handleIo(Files.isDirectory(path), UnexpectedIOError.apply)
 
-  def isRegularFile[F[_]: Sync](path: Path): IOErrT[F, Boolean] =
-    EitherT(Sync[F].delay { Files.isRegularFile(path) }.attempt).leftMap[IOError] {
-      case e: SecurityException => FileSecurityViolation(e)
-      case t                    => UnexpectedIOError(t)
-    }
+  def isRegularFile[F[_]: Sync](path: Path): F[IOErr[Boolean]] =
+    handleIo(Files.isRegularFile(path), UnexpectedIOError.apply)
 
-  def listInDirectory[F[_]: Sync](dirPath: Path): IOErrT[F, List[Path]] =
-    for {
-      _ <- EitherT(Sync[F].delay { dirPath.toFile.mkdir() }.attempt).leftMap[IOError] {
-            case e: SecurityException => FileSecurityViolation(e)
-            case t                    => UnexpectedIOError(t)
-          }
-      files <- EitherT(Sync[F].delay { Files.list(dirPath) }.attempt).leftMap[IOError] {
+  def makeDirectory[F[_]: Sync](dirPath: Path): F[IOErr[Unit]] =
+    handleIo(dirPath.toFile.mkdir(), UnexpectedIOError.apply)
+
+  def listInDirectory[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] =
+    (for {
+      _ <- EitherT(makeDirectory(dirPath))
+      files <- EitherT(handleIo(Files.list(dirPath), {
                 case e: NotDirectoryException => FileIsNotDirectory(e)
-                case e: SecurityException     => FileSecurityViolation(e)
-                case t                        => UnexpectedIOError(t)
-              }
+                case e                        => UnexpectedIOError(e)
+              }))
       filesList = files
         .collect(Collectors.toList[Path])
         .asScala
         .toList
-    } yield filesList
+    } yield filesList).value
 
-  def listFiles[F[_]: Sync](dirPath: Path): IOErrT[F, List[Path]] = {
+  def listFiles[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] = {
     type IOErrTF[A] = IOErrT[F, A]
-    for {
-      inDirectoryList <- listInDirectory(dirPath)
-      directoryList   <- inDirectoryList.filterA[IOErrTF](isRegularFile)
-    } yield directoryList
+    (for {
+      inDirectoryList <- EitherT(listInDirectory(dirPath))
+      directoryList   <- inDirectoryList.filterA[IOErrTF](f => EitherT(isRegularFile(f)))
+    } yield directoryList).value
   }
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -67,11 +67,11 @@ package object io {
         .toList
     } yield filesList).value
 
-  def listFiles[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] = {
+  def listRegularFiles[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] = {
     type IOErrTF[A] = IOErrT[F, A]
     (for {
-      inDirectoryList <- EitherT(listInDirectory(dirPath))
-      directoryList   <- inDirectoryList.filterA[IOErrTF](f => EitherT(isRegularFile(f)))
-    } yield directoryList).value
+      files        <- EitherT(listInDirectory(dirPath))
+      regularFiles <- files.filterA[IOErrTF](f => EitherT(isRegularFile(f)))
+    } yield regularFiles).value
   }
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -51,7 +51,7 @@ package object io {
   def isRegularFile[F[_]: Sync](path: Path): F[IOErr[Boolean]] =
     handleIo(Files.isRegularFile(path), UnexpectedIOError.apply)
 
-  def makeDirectory[F[_]: Sync](dirPath: Path): F[IOErr[Unit]] =
+  def makeDirectory[F[_]: Sync](dirPath: Path): F[IOErr[Boolean]] =
     handleIo(dirPath.toFile.mkdir(), UnexpectedIOError.apply)
 
   def listInDirectory[F[_]: Sync](dirPath: Path): F[IOErr[List[Path]]] =


### PR DESCRIPTION
## Overview
Introduces some pure abstractions over filesystem operations used in blockstorage module.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-652


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
