### PR TITLE
 Use grpc 'deadline after' instead of a Task timeout for transport requests

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -5,11 +5,11 @@ import scala.util.Try
 
 import cats.implicits._
 
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm._
 import coop.rchain.comm.CachedConnections.ConnectionsCache
 import coop.rchain.comm.discovery.KademliaGrpcMonix.KademliaRPCServiceStub
+import coop.rchain.grpc.implicits._
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.implicits._
 import coop.rchain.shared.{Log, LogSource}
@@ -40,10 +40,9 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
       _     <- Metrics[Task].incrementCounter("ping")
       local <- peerNodeAsk.ask
       ping  = Ping().withSender(node(local))
-      pongErr <- withClient(peer)(
+      pongErr <- withClient(peer, timeout)(
                   _.sendPing(ping)
                     .timer("ping-time")
-                    .nonCancelingTimeout(timeout)
                 ).attempt
     } yield pongErr.fold(kp(false), kp(true))
 
@@ -52,10 +51,9 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
       _      <- Metrics[Task].incrementCounter("protocol-lookup-send")
       local  <- peerNodeAsk.ask
       lookup = Lookup().withId(ByteString.copyFrom(key.toArray)).withSender(node(local))
-      responseErr <- withClient(peer)(
+      responseErr <- withClient(peer, timeout)(
                       _.sendLookup(lookup)
                         .timer("lookup-time")
-                        .nonCancelingTimeout(timeout)
                     ).attempt
     } yield responseErr.fold(kp(Seq.empty[PeerNode]), _.nodes.map(toPeerNode))
 
@@ -73,12 +71,12 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
       } yield s.copy(connections = s.connections - peer)
     }
 
-  private def withClient[A](peer: PeerNode, enforce: Boolean = false)(
+  private def withClient[A](peer: PeerNode, timeout: FiniteDuration, enforce: Boolean = false)(
       f: KademliaRPCServiceStub => Task[A]
   ): Task[A] =
     for {
       channel <- cell.connection(peer, enforce)
-      stub    <- Task.delay(KademliaGrpcMonix.stub(channel))
+      stub    <- Task.delay(KademliaGrpcMonix.stub(channel).withDeadlineAfter(timeout))
       result <- f(stub).doOnFinish {
                  case Some(_) => disconnect(peer)
                  case _       => Task.unit

--- a/node/src/main/scala/coop/rchain/node/diagnostics/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/effects/package.scala
@@ -221,10 +221,9 @@ package object effects {
         m.getOrElseUpdate(source(name), Kamon.timer(source(name))) match {
           case c: metric.Timer =>
             for {
-              t  <- Sync[F].delay(c.start())
-              r0 <- Sync[F].attempt(block)
-              _  = t.stop()
-              r  <- r0.fold(Sync[F].raiseError, Sync[F].pure)
+              t <- Sync[F].delay(c.start())
+              r <- block
+              _ = t.stop()
             } yield r
         }
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
 
   val circeVersion   = "0.10.0"
   val http4sVersion  = "0.19.0"
-  val kamonVersion   = "1.1.3"
+  val kamonVersion   = "1.1.5"
   val catsVersion    = "1.5.0"
   val catsMtlVersion = "0.4.0"
 
@@ -36,7 +36,7 @@ object Dependencies {
   // see https://jitpack.io/#rchain/kalium
   val kalium              = "com.github.rchain"           % "kalium"                    % "0.8.1"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
-  val kamonSystemMetrics  = "io.kamon"                   %% "kamon-system-metrics"      % "1.0.0"
+  val kamonSystemMetrics  = "io.kamon"                   %% "kamon-system-metrics"      % "1.0.1"
   val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % "1.1.1"
   val kamonInfluxDb       = "io.kamon"                   %% "kamon-influxdb"            % "1.0.2"
   val kamonZipkin         = "io.kamon"                   %% "kamon-zipkin"              % "1.0.0"

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -1,7 +1,5 @@
 package coop.rchain.catscontrib
 
-import java.util.concurrent.TimeoutException
-
 import monix.eval.Task
 import monix.execution.Scheduler
 import cats.implicits._
@@ -12,20 +10,6 @@ object TaskContrib {
   implicit class TaskOps[A](task: Task[A]) {
     def unsafeRunSync(implicit scheduler: Scheduler): A =
       Await.result(task.runToFuture, Duration.Inf)
-
-    def nonCancelingTimeout(after: FiniteDuration): Task[A] =
-      nonCancelingTimeoutTo(
-        after,
-        Task.raiseError[A](new TimeoutException(s"Task timed-out after $after of inactivity"))
-      )
-
-    def nonCancelingTimeoutTo[B >: A](after: FiniteDuration, backup: Task[B]): Task[B] =
-      Task.racePair(task, Task.unit.delayExecution(after)).flatMap {
-        case Left((a, _)) =>
-          Task.now(a)
-        case Right(_) =>
-          backup
-      }
 
     // TODO should also push stacktrace to logs (not only console as it is doing right now)
     def attemptAndLog: Task[A] = task.attempt.flatMap {

--- a/shared/src/main/scala/coop/rchain/grpc/implicits.scala
+++ b/shared/src/main/scala/coop/rchain/grpc/implicits.scala
@@ -1,0 +1,3 @@
+package coop.rchain.grpc
+
+object implicits extends syntax.AllSyntax

--- a/shared/src/main/scala/coop/rchain/grpc/syntax/AllSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/grpc/syntax/AllSyntax.scala
@@ -1,0 +1,3 @@
+package coop.rchain.grpc.syntax
+
+trait AllSyntax extends StubSyntax

--- a/shared/src/main/scala/coop/rchain/grpc/syntax/Stub.scala
+++ b/shared/src/main/scala/coop/rchain/grpc/syntax/Stub.scala
@@ -1,0 +1,17 @@
+package coop.rchain.grpc.syntax
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import io.grpc.stub.AbstractStub
+
+trait StubSyntax {
+  implicit final def grpcSyntaxStub[S <: AbstractStub[S]](stub: S): StubOps[S] =
+    new StubOps[S](stub)
+}
+
+final class StubOps[S <: AbstractStub[S]](val stub: S) extends AnyVal {
+  def withDeadlineAfter(duration: FiniteDuration): S =
+    stub.withDeadlineAfter(duration.toNanos, TimeUnit.NANOSECONDS)
+}

--- a/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
+++ b/shared/src/main/scala/coop/rchain/grpcmonix/GrpcMonix.scala
@@ -7,6 +7,7 @@ import coop.rchain.shared.{Log, LogSource}
 
 import com.google.common.util.concurrent.ListenableFuture
 import io.grpc.stub.StreamObserver
+import io.grpc.{Status, StatusRuntimeException}
 import monix.eval.Task
 import monix.execution._
 import monix.execution.Ack.{Continue, Stop}
@@ -78,6 +79,8 @@ object GrpcMonix {
           observer.onNext(value)
           observer.onCompleted()
         } catch {
+          case sre: StatusRuntimeException if sre.getStatus.getCode == Status.Code.CANCELLED =>
+            logger.warn(s"Failed to send a response: peer request timeout")
           case NonFatal(e) => logger.warn(s"Failed to send a response: ${e.getMessage}")
         }
     }


### PR DESCRIPTION
## Overview
A Task timeout doesn't stop the underlying grpc request. A request can hang forever and block resources. Instead use deadlines, the build-in mechanism in grpc. 

Also, don't record timer metrics for failed (f.e. timeout) requests. 
Upgrade Kamon system-metrics to suppress the Sigar load Exception on JDK10+

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2862

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).