### PR TITLE
Fix parent hash empty case in parents validation

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -392,22 +392,24 @@ class ValidateTest
                        dag <- blockDagStorage.getRepresentation
 
                        // Valid
-                       _ <- Validate.parents[Task](b0, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b1, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b2, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b3, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b4, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b5, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b6, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b0, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b1, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b2, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b3, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b4, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b5, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b6, b0, b0.blockHash, dag)
 
                        // Not valid
-                       _ <- Validate.parents[Task](b7, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b8, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b9, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b7, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b8, b0, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b9, b0, b0.blockHash, dag)
 
                        _ = log.warns.size should be(3)
                        result = log.warns.forall(
-                         _.contains("block parents did not match estimate based on justification")
+                         _.matches(
+                           "Ignoring block .* because block parents .* did not match estimate .* based on justification .*"
+                         )
                        ) should be(
                          true
                        )


### PR DESCRIPTION
Note the only time that genesis validation happens is
at the beginning of the chain. Hence, this would
never really have appeared as a bug: it just makes
no logical sense to label a block with an empty parent
hash as a last finalized block that isn't genesis -
as that would have a parent.

I've also added some logging to debug the invalid parents
warning we are getting on testnet.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

Part of https://rchain.atlassian.net/browse/RCHAIN-2909

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
