### PR TITLE
RCHAIN-2892: Fix EMethod.connectiveUsed being ignored while sorting

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -253,13 +253,15 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
           )
       case EMethodBody(em) =>
         for {
-          args         <- em.arguments.toList.traverse(Sortable[Par].sortMatch[F])
-          sortedTarget <- Sortable.sortMatch(em.target)
+          args                <- em.arguments.toList.traverse(Sortable[Par].sortMatch[F])
+          sortedTarget        <- Sortable.sortMatch(em.target)
+          connectiveUsedScore = if (em.connectiveUsed) 1 else 0
         } yield
           constructExpr(
             EMethodBody(em.withArguments(args.map(_.term.get)).withTarget(sortedTarget.term.get)),
             Node(
-              Seq(Leaf(Score.EMETHOD), Leaf(em.methodName), sortedTarget.score) ++ args.map(_.score)
+              Seq(Leaf(Score.EMETHOD), Leaf(em.methodName), sortedTarget.score) ++ args
+                .map(_.score) ++ Seq(Leaf(connectiveUsedScore))
             )
           )
       case gb: GBool =>

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -114,6 +114,11 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     checkScoreEquality[Send]
     checkScoreEquality[Var]
   }
+  it should "sort so that unequal EMethod have unequal scores" in {
+    val method1 = Expr(EMethodBody(EMethod(connectiveUsed = true)))
+    val method2 = Expr(EMethodBody(EMethod(connectiveUsed = false)))
+    assert(sort(method1).score != sort(method2).score)
+  }
   it should "sort so that unequal ParMap have unequal scores" in {
     val map1 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = true, BitSet(), None)))
     val map2 = Expr(EMapBody(ParMap(Seq.empty, connectiveUsed = false, BitSet(), None)))


### PR DESCRIPTION
## Overview
Title says it all.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2892

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
