### PR TITLE
add support for multiple attempts for RhoSpec tests

### DIFF
--- a/casper/src/test/rholang/FailingResultCollectorTest.rho
+++ b/casper/src/test/rholang/FailingResultCollectorTest.rho
@@ -1,20 +1,23 @@
 //scalapackage coop.rchain.rholang
 
+// All the assertions in this file are expected to fail as the FailingResultCollectorSpec 
+// will make sure that in case of failing assertions a failure is properly reported
+
 new assert(`rho:test:assertAck`),
     testCompleted(`rho:test:testSuiteCompleted`),
     ch1, ch2,
     ack1, ack2, ack3, ack4, ack5, ack6
 in {
-  assert!("false should fail", false, "clue assertTrue", *ack1) |
-  assert!("0 != 1 should fail", (0, "==", 1), "clue assertEquals", *ack2) |
-  assert!("incorrect assertion should fail", ("some", "garbage", "assertion", "content"), "bad assertion should fail", *ack3) |
+  assert!("false should fail", 1, false, "clue assertTrue", *ack1) |
+  assert!("0 != 1 should fail", 1, (0, "==", 1), "clue assertEquals", *ack2) |
+  assert!("incorrect assertion should fail", 1, ("some", "garbage", "assertion", "content"), "bad assertion should fail", *ack3) |
 
   ch1 ! (1) |
   ch2 ! (2) |
   for (x <- ch1; y <- ch2) {
-    assert!("not equal vars are not equal", (*x, "==", *y), "should not be equal", *ack4) |
-    assert!("var not equal to constant", (*x, "==", 0), "var should not equal const", *ack5) |
-    assert!("cost not equal to var", (0, "==", *x), "const should not equal var", *ack6)
+    assert!("not equal vars are not equal", 1, (*x, "==", *y), "should not be equal", *ack4) |
+    assert!("var not equal to constant", 1, (*x, "==", 0), "var should not equal const", *ack5) |
+    assert!("cost not equal to var", 1, (0, "==", *x), "const should not equal var", *ack6)
   } |
 
   for (_ <- ack1; _<- ack2; _ <- ack3; _ <- ack4; _ <- ack5) {

--- a/casper/src/test/rholang/RhoSpecContract.rho
+++ b/casper/src/test/rholang/RhoSpecContract.rho
@@ -19,26 +19,26 @@ new
   testSuiteCompleted(`rho:test:testSuiteCompleted`),
   uriOut
 in {
-  stdlog!("info", "Loading RhoSpec") |
+  stdlog!("debug", "Loading RhoSpec") |
   rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
   for(@(_, ListOps) <- ListOpsCh) {
     contract RhoSpec(@"testSuite", setup, @tests) = {
-      stdlog!("info", "Defining the testSuite") |
-      new runTest, retCh in {
-        contract runTest(@(testName, testBody), testAckCh) = {
-          stdlog!("info", "Running test: " ++ testName) |
+      stdlog!("debug", "Defining the testSuite") |
+      new runTest, runTestOnce, retCh in {
+        contract runTestOnce(@(testName, testBody), @attempt, testAckCh) = {
+          stdlog!("debug", "Running test: " ++ testName ++ " attempt " + attempt) |
           new rhoSpecImpl, privateAssert in {
             contract privateAssert(@assertion, @clue, ackCh) = {
-              stdlog!("info", "asserting: " ++ clue) |
+              stdlog!("debug", "asserting: " ++ clue) |
               match assertion {
                 (expected, "== <-", actualCh) => {
                   for (@actual <- @actualCh) {
                     stdlog!("info", {"actual": actual, "expected": expected}) |
-                    assert!(testName, (expected, "==", actual), clue, *ackCh)
+                    assert!(testName, attempt, (expected, "==", actual), clue, *ackCh)
                   }
                 }
                 assertion => {
-                  assert!(testName, assertion, clue, *ackCh)
+                  assert!(testName, attempt, assertion, clue, *ackCh)
                 }
               }
             } |
@@ -74,6 +74,26 @@ in {
               for (setupResult <- setupCh) {
                 @testBody ! (*rhoSpecImpl, *setupResult, *testAckCh)
               }
+            }
+          }
+        } |
+
+
+        contract runTest(@(testName, testBody), ackCh) = {
+          runTest!((testName, testBody, 1), *ackCh)
+        } |
+
+        contract runTest(@(testName, testBody, attempts), ackCh) = {
+          stdlog!("info", "Calling runTest") |
+
+          new retCh, runTestImpl in {
+            contract runTestImpl(@attempt, retCh) = {
+              runTestOnce!((testName, testBody), attempt, *retCh)
+            } |
+
+            @ListOps!("range", 1, attempts + 1, *retCh) |
+            for(@range <- retCh) {
+              @ListOps!("foreach", range, *runTestImpl, *ackCh)
             }
           }
         } |

--- a/casper/src/test/rholang/RhoSpecContractTest.rho
+++ b/casper/src/test/rholang/RhoSpecContractTest.rho
@@ -6,7 +6,7 @@ new rl(`rho:registry:lookup`),
     stdlog(`rho:io:stdlog`),
     testSetup, testAssertEquals, testAssertTrue, testAssertMany,
     testAssertEqualsFromChannel, testAssertManyEqualsFromChannel,
-    testAssertEqualsForVariables
+    testAssertEqualsForVariables,  testMultipleAttempts
 in {
   stdlog!("info", "starting SuccessfulResultCollector...") |
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *RhoSpecCh) |
@@ -18,7 +18,8 @@ in {
       ("assert boolean conditions", *testAssertTrue),
       ("assert many conditions", *testAssertMany),
       ("assert '== <-'", *testAssertEqualsFromChannel),
-      ("assertMany '== <-'", *testAssertManyEqualsFromChannel)
+      ("assertMany '== <-'", *testAssertManyEqualsFromChannel),
+      ("run the test function multiple times", *testMultipleAttempts, 10)
     ])
   } |
 
@@ -86,5 +87,10 @@ in {
         ],
         *ackCh)
     }
+  } |
+
+  contract testMultipleAttempts(rhoSpec, self, ackCh) = {
+    stdlog ! ("info", "Running testMultipleAttempts") |
+    rhoSpec!("assert", true, "should always be successful", *ackCh)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -6,15 +6,19 @@ import scala.concurrent.duration._
 import monix.execution.Scheduler.Implicits.global
 
 class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
-  def mkTest(test: (String, List[RhoTestAssertion])): Unit =
+  def clue(clueMsg: String, attempt: Long) = s"$clueMsg (attempt $attempt)"
+  def mkTest(test: (String, Map[Long, List[RhoTestAssertion]])): Unit =
     test match {
-      case (testName, assertions) =>
+      case (testName, attempts) =>
         it should testName in {
-          assertions.foreach {
-            case RhoAssertEquals(_, expected, actual, clue) => {
-              actual should not be (expected)
-            } withClue (clue)
-            case RhoAssertTrue(_, value, clue) => { value should not be (true) } withClue (clue)
+          attempts.foreach {
+            case (attempt, assertions) =>
+              assertions.foreach {
+                case RhoAssertEquals(_, expected, actual, clueMsg) =>
+                  actual should not be (expected) withClue (clue(clueMsg, attempt))
+                case RhoAssertTrue(_, value, clueMsg) =>
+                  value should not be (true) withClue (clue(clueMsg, attempt))
+              }
           }
         }
     }

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
@@ -3,7 +3,7 @@ import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.Expr.ExprInstance.{ETupleBody, GBool, GString}
+import coop.rchain.models.Expr.ExprInstance.{ETupleBody, GBool, GInt, GString}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{ETuple, Expr, ListParWithRandomAndPhlos, Par, _}
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
@@ -26,19 +26,26 @@ object IsBoolean {
     }
 }
 
+object IsNumber {
+  def unapply(p: Par): Option[Long] =
+    p.singleExpr().collect {
+      case Expr(GInt(v)) => v
+    }
+}
+
 object IsAssert {
   def unapply(
       p: Seq[ListParWithRandomAndPhlos]
-  ): Option[(String, Par, String, AckedActionCtx)] =
+  ): Option[(String, Long, Par, String, AckedActionCtx)] =
     p match {
       case Seq(
           ListParWithRandomAndPhlos(
-            Seq(IsString(testName), assertion, IsString(clue), ackChannel),
+            Seq(IsString(testName), IsNumber(attempt), assertion, IsString(clue), ackChannel),
             rand,
             sequenceNumber
           )
           ) =>
-        Some((testName, assertion, clue, AckedActionCtx(ackChannel, rand, sequenceNumber)))
+        Some((testName, attempt, assertion, clue, AckedActionCtx(ackChannel, rand, sequenceNumber)))
       case _ => None
     }
 }
@@ -70,17 +77,26 @@ object IsSetFinished {
 sealed trait RhoTestAssertion {
   val testName: String
   val clue: String
+  val isSuccess: Boolean
 }
 
-case class RhoAssertTrue(testName: String, value: Boolean, clue: String) extends RhoTestAssertion
-case class RhoAssertEquals(testName: String, expected: Any, actual: Any, clue: String)
+case class RhoAssertTrue(testName: String, override val isSuccess: Boolean, clue: String)
     extends RhoTestAssertion
+case class RhoAssertEquals(testName: String, expected: Any, actual: Any, clue: String)
+    extends RhoTestAssertion {
+  override val isSuccess: Boolean = actual == expected
+}
 
-case class TestResult(assertions: Map[String, List[RhoTestAssertion]], hasFinished: Boolean) {
-  def addAssertion(assertion: RhoTestAssertion): TestResult = {
+case class TestResult(
+    assertions: Map[String, Map[Long, List[RhoTestAssertion]]],
+    hasFinished: Boolean
+) {
+  def addAssertion(attempt: Long, assertion: RhoTestAssertion): TestResult = {
+    val currentAttemptAssertions = assertions.getOrElse(assertion.testName, Map.empty)
     val newAssertion =
-      (assertion.testName, assertion :: assertions.getOrElse(assertion.testName, List.empty))
-    TestResult(assertions + newAssertion, hasFinished)
+      (attempt, assertion :: currentAttemptAssertions.getOrElse(attempt, List.empty))
+    val newCurrentAttemptAssertions = currentAttemptAssertions + newAssertion
+    TestResult(assertions.updated(assertion.testName, newCurrentAttemptAssertions), hasFinished)
   }
   def setFinished(hasFinished: Boolean): TestResult =
     TestResult(assertions, hasFinished = hasFinished)
@@ -133,20 +149,22 @@ class TestResultCollector[F[_]: Sync](result: Ref[F, TestResult]) {
       ctx: SystemProcess.Context[F]
   )(message: Seq[ListParWithRandomAndPhlos], x: Int): F[Unit] =
     message match {
-      case IsAssert(testName, assertion, clue, ackedActionCtx) =>
+      case IsAssert(testName, attempt, assertion, clue, ackedActionCtx) =>
         assertion match {
-          case IsComparison(expected, "==", actual) =>
+          case IsComparison(expected, "==", actual) => {
+            val assertion = RhoAssertEquals(testName, expected, actual, clue)
             runWithAck(
               ctx,
               ackedActionCtx,
-              result.update(_.addAssertion(RhoAssertEquals(testName, expected, actual, clue))),
-              Expr(GBool(expected == actual))
+              result.update(_.addAssertion(attempt, assertion)),
+              Expr(GBool(assertion.isSuccess))
             )
+          }
           case IsBoolean(condition) =>
             runWithAck(
               ctx,
               ackedActionCtx,
-              result.update(_.addAssertion(RhoAssertTrue(testName, condition, clue))),
+              result.update(_.addAssertion(attempt, RhoAssertTrue(testName, condition, clue))),
               Expr(GBool(condition))
             )
 
@@ -156,9 +174,10 @@ class TestResultCollector[F[_]: Sync](result: Ref[F, TestResult]) {
               ackedActionCtx,
               result.update(
                 _.addAssertion(
+                  attempt,
                   RhoAssertTrue(
                     testName,
-                    value = false,
+                    isSuccess = false,
                     s"Failed to evaluate assertion $assertion"
                   )
                 )


### PR DESCRIPTION
## Overview
In order to reproduce non-deterministic issues in Rholang contracts we need to run some tests multiple times. This PR introduces this RhoSpec feature such that one can optionally configure the number of retries per test. The default is 1.

If a test fails then only the first failing attempt is reported such that the test report is not too verbose.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2959



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
