### PR TITLE
RCHAIN-2940 Change number of consumers that handle incoming queue of blocks to 1

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TcpTransportLayer.scala
@@ -278,7 +278,11 @@ class TcpTransportLayer(
     }
 
     cell.modify { s =>
-      val parallelism = Math.max(Runtime.getRuntime.availableProcessors(), 2)
+      /** 
+        * //TODO Bring back lvl of parallelism to Math.max(Runtime.getRuntime.availableProcessors(), 2) once
+        * MultiparentCasperImpl is not synchronous (uses semaphore)
+        */
+      val parallelism = 1
       val queueScheduler =
         Scheduler.fixedPool("tl-dispatcher", parallelism, reporter = UncaughtExceptionLogger)
       for {


### PR DESCRIPTION
## Overview

An interesting observation was fact that some callback were held by
MultiparentCasperImpl semaphore.

This itself is not an issue. But when you look how TransportLayer is
propagating received blocks to casper. Each incoming message (block)
is stored on the file system. There is a server queue to which an
information is added that given block was stored. Then there is a
number of consumers that consume elements from the queue, read
messages from the filesystem and push calculation to casper.

Detail in https://rchain.atlassian.net/browse/RCHAIN-2876?focusedCommentId=13463&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13463

### JIRA ticket:
RCHAIN-2940
