### PR TITLE
Fix invalid parent temporarily by making casper single parent

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -220,7 +220,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
     for {
       lastFinalizedBlockHash <- lastFinalizedBlockHashContainer.get
       rankedEstimates        <- Estimator.tips[F](dag, lastFinalizedBlockHash)
-    } yield rankedEstimates
+    } yield rankedEstimates.take(1)
 
   /*
    * Logic:

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -434,7 +434,7 @@ object Validate {
     for {
       latestMessagesHashes <- ProtoUtil.toLatestMessageHashes(b.justifications).pure[F]
       estimate             <- Estimator.tips[F](dag, lastFinalizedBlockHash, latestMessagesHashes)
-      computedParents      <- ProtoUtil.chooseNonConflicting[F](estimate, dag)
+      computedParents      <- ProtoUtil.chooseNonConflicting[F](estimate.take(1), dag)
       computedParentHashes = computedParents.map(_.blockHash)
       status <- if (parentHashes == computedParentHashes)
                  Applicative[F].pure(Right(Valid))

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -374,7 +374,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield result
   }
 
-  it should "handle multi-parent blocks correctly" in effectTest {
+  it should "handle multi-parent blocks correctly" ignore effectTest {
     for {
       nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       deployData0 <- ProtoUtil.basicDeployData[Effect](0)

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -357,7 +357,7 @@ class ValidateTest
           current <- Time[F].currentMillis
           deploy  <- ProtoUtil.basicProcessedDeploy[F](current.toInt)
           block <- createBlock[F](
-                    parents.map(_.blockHash),
+                    parents.map(_.blockHash).take(1),
                     creator = validators(validator),
                     bonds = bonds,
                     deploys = Seq(deploy),


### PR DESCRIPTION
This is a temporary fix until I spec out the new multi-parent estimator. Note we lose no performance from this as we don't have block merging implemented yet so everything is processed in serial as of now anyways.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-2909

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
