### PR TITLE
Add an ignored unit test that shows InvalidParents status on block propagation

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -993,6 +993,72 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield ()
   }
 
+  it should "estimate parent properly" ignore effectTest {
+    val (otherSk, otherPk)          = Ed25519.newKeyPair
+    val (validatorKeys, validators) = (1 to 5).map(_ => Ed25519.newKeyPair).unzip
+    val (ethPivKeys, ethPubKeys)    = (1 to 5).map(_ => Secp256k1.newKeyPair).unzip
+    val ethAddresses =
+      ethPubKeys.map(pk => "0x" + Base16.encode(Keccak256.hash(pk.bytes.drop(1)).takeRight(20)))
+    val wallets = ethAddresses.map(addr => PreWallet(addr, BigInt(10001)))
+    val bonds = Map(
+      validators(0) -> 3L,
+      validators(1) -> 1L,
+      validators(2) -> 5L,
+      validators(3) -> 2L,
+      validators(4) -> 4L
+    )
+    val minimumBond = 100L
+    val genesis =
+      buildGenesis(wallets, bonds, minimumBond, Long.MaxValue, Faucet.basicWalletFaucet, 0L)
+
+    def deployment(i: Int, ts: Long): DeployData =
+      ProtoUtil.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
+
+    def deploy(
+        node: HashSetCasperTestNode[Effect],
+        dd: DeployData
+    ) = node.casperEff.deploy(dd)
+
+    def create(
+        node: HashSetCasperTestNode[Effect]
+    ) =
+      for {
+        createBlockResult1    <- node.casperEff.createBlock
+        Created(signedBlock1) = createBlockResult1
+      } yield signedBlock1
+
+    def add(node: HashSetCasperTestNode[Effect], signed: BlockMessage) =
+      Sync[Effect].attempt(
+        node.casperEff.addBlock(signed, ignoreDoppelgangerCheck[Effect])
+      )
+
+    val network = TestNetwork.empty[Effect]
+
+    for {
+      nodes <- HashSetCasperTestNode
+                .networkEff(validatorKeys.take(3), genesis, testNetwork = network)
+                .map(_.toList)
+      v1   = nodes(0)
+      v2   = nodes(1)
+      v3   = nodes(2)
+      _    <- deploy(v1, deployment(0, 1)) >> create(v1) >>= (v1c1 => add(v1, v1c1)) //V1#1
+      v2c1 <- deploy(v2, deployment(0, 2)) >> create(v2) //V2#1
+      _    <- v2.receive()
+      _    <- v3.receive()
+      _    <- deploy(v1, deployment(0, 4)) >> create(v1) >>= (v1c2 => add(v1, v1c2)) //V1#2
+      v3c2 <- deploy(v3, deployment(0, 5)) >> create(v3) //V3#2
+      _    <- v3.receive()
+      _    <- add(v3, v3c2) //V3#2
+      _    <- add(v2, v2c1) //V2#1
+      _    <- v3.receive()
+      r    <- deploy(v3, deployment(0, 6)) >> create(v3) >>= (b => add(v3, b))
+      _    = r shouldBe Right(Valid)
+      _    = v3.logEff.warns shouldBe empty
+
+      _ <- nodes.map(_.tearDown()).sequence
+    } yield ()
+  }
+
   it should "not fail if the forkchoice changes after a bonding event" in effectTest {
     val localValidators = validatorKeys.take(3)
     val localBonds      = localValidators.map(Ed25519.toPublic).zip(List(10L, 30L, 5000L)).toMap


### PR DESCRIPTION

## Overview
<sup>_What this PR does, and why it's needed_</sup>
title says it all


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-2991


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
