### PR TITLE
RCHAIN-2941 Introduce lazy serializedSizeM

### DIFF
--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -5,7 +5,7 @@ import scalapb.Message
 
 trait StacksafeMessage[A] extends scalapb.GeneratedMessage with Message[A] {
 
-  val serializedSizeM: Memo[Int]
+  def serializedSizeM: Memo[Int]
 
   def mergeFromM[F[_]: Sync](input: CodedInputStream): F[A]
 

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -132,8 +132,6 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
     super
       .generateSerializedSize(message)(withEqualsAndHashCode)
       .newline
-      .add("import monix.eval.Coeval")
-      .newline
       .add("@transient var _serializedSizeM: coop.rchain.models.Memo[Int] = null")
       .newline
       .add("def serializedSizeM: coop.rchain.models.Memo[Int] = if(_serializedSizeM == null) {")

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -132,10 +132,18 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
     super
       .generateSerializedSize(message)(withEqualsAndHashCode)
       .newline
-      .add(
-        "@transient val serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))"
-      )
+      .add("import monix.eval.Coeval")
       .newline
+      .add("@transient var _serializedSizeM: coop.rchain.models.Memo[Int] = null")
+      .newline
+      .add("def serializedSizeM: coop.rchain.models.Memo[Int] = if(_serializedSizeM == null) {")
+      .newline
+      .add("  _serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))")
+      .newline
+      .add("  _serializedSizeM")
+      .newline
+      .add("} else _serializedSizeM")
+
   }
 
   private def generateEqualsOverride(message: Descriptor)(fp: FunctionalPrinter) = {

--- a/project/StacksafeScalapbGenerator.scala
+++ b/project/StacksafeScalapbGenerator.scala
@@ -134,14 +134,12 @@ class StacksafeProtobufGenerator(params: GeneratorParams) extends ProtobufGenera
       .newline
       .add("@transient var _serializedSizeM: coop.rchain.models.Memo[Int] = null")
       .newline
-      .add("def serializedSizeM: coop.rchain.models.Memo[Int] = if(_serializedSizeM == null) {")
-      .newline
-      .add("  _serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))")
-      .newline
-      .add("  _serializedSizeM")
-      .newline
-      .add("} else _serializedSizeM")
-
+      .add("def serializedSizeM: coop.rchain.models.Memo[Int] = synchronized {")
+      .add("  if(_serializedSizeM == null) {")
+      .add("    _serializedSizeM = new coop.rchain.models.Memo(coop.rchain.models.ProtoM.serializedSize(this))")
+      .add("    _serializedSizeM")
+      .add("  } else _serializedSizeM")
+      .add("}")
   }
 
   private def generateEqualsOverride(message: Descriptor)(fp: FunctionalPrinter) = {


### PR DESCRIPTION
## Overview
### Issue (what was):

Memo class is implements an memoization concept. It has a thunk that will be “nulled” (for GC to collect it).
The problem is, that memory is freed only when calculcation is executed (get method is called and evaluated). Which is not always the case (in memory block storage, genesis block in memory). All proto generated objects have that memo value added.
This can eat up 10% of all heap!

### Fix (what is):

We init the value when it's needed (and also evaluated thus freeing memory)

Fixes issues described in assign https://rchain.atlassian.net/browse/RCHAIN-2876?focusedCommentId=13463&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13463 

### JIRA ticket:
RCHAIN-2941
