### PR TITLE
Improve DAG storage

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -773,17 +773,17 @@ object BlockDagFileStorage {
                                        true
                                      )
       state = BlockDagFileStorageState(
-        latestMessagesMap,
-        childMap,
-        dataLookupList.toMap,
-        topoSort,
-        sortedCheckpoints.lastOption.map(_.end).getOrElse(0L),
-        sortedCheckpoints,
-        latestMessagesLogOutputStream,
-        logSize,
-        calculatedLatestMessagesCrc,
-        blockMetadataLogOutputStream,
-        calculatedDataLookupCrc
+        latestMessages = latestMessagesMap,
+        childMap = childMap,
+        dataLookup = dataLookupList.toMap,
+        topoSort = topoSort,
+        sortOffset = sortedCheckpoints.lastOption.map(_.end).getOrElse(0L),
+        checkpoints = sortedCheckpoints,
+        latestMessagesLogOutputStream = latestMessagesLogOutputStream,
+        latestMessagesLogSize = logSize,
+        latestMessagesCrc = calculatedLatestMessagesCrc,
+        blockMetadataLogOutputStream = blockMetadataLogOutputStream,
+        blockMetadataCrc = calculatedDataLookupCrc
       )
     } yield
       new BlockDagFileStorage[F](
@@ -838,17 +838,17 @@ object BlockDagFileStorage {
                                        true
                                      )
       state = BlockDagFileStorageState(
-        initialLatestMessages,
-        Map(genesis.blockHash -> Set.empty[BlockHash]),
-        Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
-        Vector(Vector(genesis.blockHash)),
-        0L,
-        List.empty,
-        latestMessagesLogOutputStream,
-        initialLatestMessages.size,
-        latestMessagesCrc,
-        blockMetadataLogOutputStream,
-        blockMetadataCrc
+        latestMessages = initialLatestMessages,
+        childMap = Map(genesis.blockHash   -> Set.empty[BlockHash]),
+        dataLookup = Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
+        topoSort = Vector(Vector(genesis.blockHash)),
+        sortOffset = 0L,
+        checkpoints = List.empty,
+        latestMessagesLogOutputStream = latestMessagesLogOutputStream,
+        latestMessagesLogSize = initialLatestMessages.size,
+        latestMessagesCrc = latestMessagesCrc,
+        blockMetadataLogOutputStream = blockMetadataLogOutputStream,
+        blockMetadataCrc = blockMetadataCrc
       )
     } yield
       new BlockDagFileStorage[F](

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -68,11 +68,11 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
                                     if (number >= sortOffset) {
                                       none[Set[BlockHash]].pure[F]
                                     } else {
-                                      for {
-                                        _          <- lock.acquire
-                                        oldDagInfo <- loadCheckpoint(number)
-                                        _          <- lock.release
-                                      } yield oldDagInfo.flatMap(_.childMap.get(blockHash))
+                                      lock.withPermit(
+                                        for {
+                                          oldDagInfo <- loadCheckpoint(number)
+                                        } yield oldDagInfo.flatMap(_.childMap.get(blockHash))
+                                      )
                                     }
                                   case None => none[Set[BlockHash]].pure[F]
                                 }
@@ -93,23 +93,23 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
         assert(offset.isValidInt)
         topoSortVector.drop(offset.toInt).pure[F]
       } else if (sortOffset - startBlockNumber + topoSortVector.length < Int.MaxValue) { // Max Vector length
-        for {
-          _                    <- lock.acquire
-          checkpoints          <- checkpointsRef.get
-          checkpointsWithIndex = checkpoints.zipWithIndex
-          checkpointsToLoad    = checkpointsWithIndex.filter(startBlockNumber < _._1.end)
-          checkpointsDagInfos <- checkpointsToLoad.traverse {
-                                  case (startingCheckpoint, index) =>
-                                    loadCheckpointDagInfo(startingCheckpoint, index)
-                                }
-          topoSortPrefix = checkpointsDagInfos.toVector.flatMap { checkpointsDagInfo =>
-            val offset = startBlockNumber - checkpointsDagInfo.sortOffset
-            // offset is always a valid Int since the method result's length was validated before
-            checkpointsDagInfo.topoSort.drop(offset.toInt) // negative drops are ignored
-          }
-          result = topoSortPrefix ++ topoSortVector
-          _      <- lock.release
-        } yield result
+        lock.withPermit(
+          for {
+            checkpoints          <- checkpointsRef.get
+            checkpointsWithIndex = checkpoints.zipWithIndex
+            checkpointsToLoad    = checkpointsWithIndex.filter(startBlockNumber < _._1.end)
+            checkpointsDagInfos <- checkpointsToLoad.traverse {
+                                    case (startingCheckpoint, index) =>
+                                      loadCheckpointDagInfo(startingCheckpoint, index)
+                                  }
+            topoSortPrefix = checkpointsDagInfos.toVector.flatMap { checkpointsDagInfo =>
+              val offset = startBlockNumber - checkpointsDagInfo.sortOffset
+              // offset is always a valid Int since the method result's length was validated before
+              checkpointsDagInfo.topoSort.drop(offset.toInt) // negative drops are ignored
+            }
+            result = topoSortPrefix ++ topoSortVector
+          } yield result
+        )
       } else {
         Sync[F].raiseError(
           TopoSortLengthIsTooBig(sortOffset - startBlockNumber + topoSortVector.length)
@@ -288,123 +288,126 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
     } yield ()
 
   def getRepresentation: F[BlockDagRepresentation[F]] =
-    for {
-      _              <- lock.acquire
-      latestMessages <- latestMessagesRef.get
-      childMap       <- childMapRef.get
-      dataLookup     <- dataLookupRef.get
-      topoSort       <- topoSortRef.get
-      sortOffset     <- sortOffsetRef.get
-      _              <- lock.release
-    } yield FileDagRepresentation(latestMessages, childMap, dataLookup, topoSort, sortOffset)
+    lock.withPermit(
+      for {
+        latestMessages <- latestMessagesRef.get
+        childMap       <- childMapRef.get
+        dataLookup     <- dataLookupRef.get
+        topoSort       <- topoSortRef.get
+        sortOffset     <- sortOffsetRef.get
+      } yield FileDagRepresentation(latestMessages, childMap, dataLookup, topoSort, sortOffset)
+    )
 
   def insert(block: BlockMessage): F[BlockDagRepresentation[F]] =
-    for {
-      _             <- lock.acquire
-      alreadyStored <- dataLookupRef.get.map(_.contains(block.blockHash))
-      _ <- if (alreadyStored) {
-            Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} is already stored")
-          } else {
-            for {
-              _             <- squashLatestMessagesDataFileIfNeeded()
-              blockMetadata = BlockMetadata.fromBlock(block)
-              _             = assert(block.blockHash.size == 32)
-              _             <- dataLookupRef.update(_.updated(block.blockHash, blockMetadata))
-              _ <- childMapRef.update(
-                    childMap =>
-                      parentHashes(block)
-                        .foldLeft(childMap) {
-                          case (acc, p) =>
-                            val currChildren = acc.getOrElse(p, Set.empty[BlockHash])
-                            acc.updated(p, currChildren + block.blockHash)
-                        }
-                        .updated(block.blockHash, Set.empty[BlockHash])
-                  )
-              _ <- topoSortRef.update(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
-              //Block which contains newly bonded validators will not
-              //have those validators in its justification
-              newValidators = bonds(block)
-                .map(_.validator)
-                .toSet
-                .diff(block.justifications.map(_.validator).toSet)
-              newValidatorsWithSender <- if (block.sender.isEmpty) {
-                                          // Ignore empty sender for special cases such as genesis block
-                                          Log[F].warn(
-                                            s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
-                                          ) *> newValidators.pure[F]
-                                        } else if (block.sender.size() == 32) {
-                                          (newValidators + block.sender).pure[F]
-                                        } else {
-                                          Sync[F].raiseError[Set[ByteString]](
-                                            BlockSenderIsMalformed(block)
-                                          )
-                                        }
-              _ <- latestMessagesRef.update { latestMessages =>
-                    newValidatorsWithSender.foldLeft(latestMessages) {
-                      //Update new validators with block in which
-                      //they were bonded (i.e. this block)
-                      case (acc, v) => acc.updated(v, block.blockHash)
+    lock.withPermit(
+      for {
+        alreadyStored <- dataLookupRef.get.map(_.contains(block.blockHash))
+        _ <- if (alreadyStored) {
+              Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} is already stored")
+            } else {
+              for {
+                _             <- squashLatestMessagesDataFileIfNeeded()
+                blockMetadata = BlockMetadata.fromBlock(block)
+                _             = assert(block.blockHash.size == 32)
+                _             <- dataLookupRef.update(_.updated(block.blockHash, blockMetadata))
+                _ <- childMapRef.update(
+                      childMap =>
+                        parentHashes(block)
+                          .foldLeft(childMap) {
+                            case (acc, p) =>
+                              val currChildren = acc.getOrElse(p, Set.empty[BlockHash])
+                              acc.updated(p, currChildren + block.blockHash)
+                          }
+                          .updated(block.blockHash, Set.empty[BlockHash])
+                    )
+                _ <- topoSortRef.update(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
+                //Block which contains newly bonded validators will not
+                //have those validators in its justification
+                newValidators = bonds(block)
+                  .map(_.validator)
+                  .toSet
+                  .diff(block.justifications.map(_.validator).toSet)
+                newValidatorsWithSender <- if (block.sender.isEmpty) {
+                                            // Ignore empty sender for special cases such as genesis block
+                                            Log[F].warn(
+                                              s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
+                                            ) *> newValidators.pure[F]
+                                          } else if (block.sender.size() == 32) {
+                                            (newValidators + block.sender).pure[F]
+                                          } else {
+                                            Sync[F].raiseError[Set[ByteString]](
+                                              BlockSenderIsMalformed(block)
+                                            )
+                                          }
+                _ <- latestMessagesRef.update { latestMessages =>
+                      newValidatorsWithSender.foldLeft(latestMessages) {
+                        //Update new validators with block in which
+                        //they were bonded (i.e. this block)
+                        case (acc, v) => acc.updated(v, block.blockHash)
+                      }
                     }
-                  }
-              _ <- updateLatestMessagesFile((newValidators + block.sender).toList, block.blockHash)
-              _ <- updateDataLookupFile(blockMetadata)
-            } yield ()
-          }
-      _   <- lock.release
-      dag <- getRepresentation
-    } yield dag
+                _ <- updateLatestMessagesFile(
+                      (newValidators + block.sender).toList,
+                      block.blockHash
+                    )
+                _ <- updateDataLookupFile(blockMetadata)
+              } yield ()
+            }
+        dag <- getRepresentation
+      } yield dag
+    )
 
   def checkpoint(): F[Unit] =
     ().pure[F]
 
   def clear(): F[Unit] =
-    for {
-      _                             <- lock.acquire
-      latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
-      _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
-      blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
-      _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
-      _ <- Sync[F].delay {
-            Files.write(latestMessagesDataFilePath, Array.emptyByteArray)
-          }
-      _ <- Sync[F].delay {
-            Files.write(blockMetadataLogPath, Array.emptyByteArray)
-          }
-      newLatestMessagesCrc      = Crc32.empty[F]()
-      newLatestMessagesCrcBytes <- newLatestMessagesCrc.bytes
-      _ <- Sync[F].delay {
-            Files.write(latestMessagesCrcFilePath, newLatestMessagesCrcBytes)
-          }
-      newBlockMetadataCrc      = Crc32.empty[F]()
-      newBlockMetadataCrcBytes <- newBlockMetadataCrc.bytes
-      _ <- Sync[F].delay {
-            Files.write(blockMetadataCrcPath, newBlockMetadataCrcBytes)
-          }
-      _ <- dataLookupRef.set(Map.empty)
-      _ <- childMapRef.set(Map.empty)
-      _ <- topoSortRef.set(Vector.empty)
-      _ <- latestMessagesRef.set(Map.empty)
-      _ <- latestMessagesLogOutputStreamRef.set(
-            new FileOutputStream(latestMessagesDataFilePath.toFile)
-          )
-      _ <- blockMetadataLogOutputStreamRef.set(
-            new FileOutputStream(blockMetadataLogPath.toFile)
-          )
-      _ <- latestMessagesLogSizeRef.set(0)
-      _ <- latestMessagesCrcRef.set(newLatestMessagesCrc)
-      _ <- blockMetadataCrcRef.set(newBlockMetadataCrc)
-      _ <- lock.release
-    } yield ()
+    lock.withPermit(
+      for {
+        latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+        _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
+        blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
+        _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
+        _ <- Sync[F].delay {
+              Files.write(latestMessagesDataFilePath, Array.emptyByteArray)
+            }
+        _ <- Sync[F].delay {
+              Files.write(blockMetadataLogPath, Array.emptyByteArray)
+            }
+        newLatestMessagesCrc      = Crc32.empty[F]()
+        newLatestMessagesCrcBytes <- newLatestMessagesCrc.bytes
+        _ <- Sync[F].delay {
+              Files.write(latestMessagesCrcFilePath, newLatestMessagesCrcBytes)
+            }
+        newBlockMetadataCrc      = Crc32.empty[F]()
+        newBlockMetadataCrcBytes <- newBlockMetadataCrc.bytes
+        _ <- Sync[F].delay {
+              Files.write(blockMetadataCrcPath, newBlockMetadataCrcBytes)
+            }
+        _ <- dataLookupRef.set(Map.empty)
+        _ <- childMapRef.set(Map.empty)
+        _ <- topoSortRef.set(Vector.empty)
+        _ <- latestMessagesRef.set(Map.empty)
+        _ <- latestMessagesLogOutputStreamRef.set(
+              new FileOutputStream(latestMessagesDataFilePath.toFile)
+            )
+        _ <- blockMetadataLogOutputStreamRef.set(
+              new FileOutputStream(blockMetadataLogPath.toFile)
+            )
+        _ <- latestMessagesLogSizeRef.set(0)
+        _ <- latestMessagesCrcRef.set(newLatestMessagesCrc)
+        _ <- blockMetadataCrcRef.set(newBlockMetadataCrc)
+      } yield ()
+    )
 
   def close(): F[Unit] =
-    for {
-      _                             <- lock.acquire
-      latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
-      _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
-      blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
-      _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
-      _                             <- lock.release
-    } yield ()
+    lock.withPermit(
+      for {
+        latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+        _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
+        blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
+        _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
+      } yield ()
+    )
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -5,10 +5,11 @@ import java.nio.{BufferUnderflowException, ByteBuffer}
 import java.nio.file.{Files, Path, StandardCopyOption}
 import java.util.stream.Collectors
 
-import cats.{Id, Monad}
+import cats.Monad
 import cats.implicits._
 import cats.effect.{Concurrent, Resource, Sync}
-import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.concurrent.Semaphore
+import cats.mtl.MonadState
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagFileStorage.{Checkpoint, CheckpointedDagInfo}
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
@@ -17,35 +18,118 @@ import coop.rchain.blockstorage.util.BlockMessageUtil.{blockNumber, bonds, paren
 import coop.rchain.blockstorage.util.{BlockMessageUtil, Crc32, TopologicalSortUtil}
 import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.catscontrib.Capture
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.BlockMetadata
-import coop.rchain.shared.{Log, LogSource}
+import coop.rchain.shared.{AtomicMonadState, Log, LogSource}
+import monix.execution.atomic.AtomicAny
 
 import scala.ref.WeakReference
 import scala.util.matching.Regex
 import collection.JavaConverters._
 
+private final case class BlockDagFileStorageState[F[_]: Sync](
+    latestMessages: Map[Validator, BlockHash],
+    childMap: Map[BlockHash, Set[BlockHash]],
+    dataLookup: Map[BlockHash, BlockMetadata],
+    topoSort: Vector[Vector[BlockHash]],
+    sortOffset: Long,
+    checkpoints: List[Checkpoint],
+    latestMessagesLogOutputStream: OutputStream,
+    latestMessagesLogSize: Int,
+    latestMessagesCrc: Crc32[F],
+    blockMetadataLogOutputStream: OutputStream,
+    blockMetadataCrc: Crc32[F]
+)
+
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove!!
 final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private (
     lock: Semaphore[F],
-    latestMessagesRef: Ref[F, Map[Validator, BlockHash]],
-    childMapRef: Ref[F, Map[BlockHash, Set[BlockHash]]],
-    dataLookupRef: Ref[F, Map[BlockHash, BlockMetadata]],
-    topoSortRef: Ref[F, Vector[Vector[BlockHash]]],
-    sortOffsetRef: Ref[F, Long],
-    checkpointsRef: Ref[F, List[Checkpoint]],
-    latestMessagesLogOutputStreamRef: Ref[F, OutputStream],
-    latestMessagesLogSizeRef: Ref[F, Int],
-    latestMessagesCrcRef: Ref[F, Crc32[F]],
     latestMessagesDataFilePath: Path,
     latestMessagesCrcFilePath: Path,
     latestMessagesLogMaxSizeFactor: Int,
-    blockMetadataLogOutputStreamRef: Ref[F, OutputStream],
-    blockMetadataCrcRef: Ref[F, Crc32[F]],
     blockMetadataLogPath: Path,
-    blockMetadataCrcPath: Path
+    blockMetadataCrcPath: Path,
+    state: MonadState[F, BlockDagFileStorageState[F]]
 ) extends BlockDagStorage[F] {
   private implicit val logSource = LogSource(BlockDagFileStorage.getClass)
+
+  private[this] def getLatestMessages: F[Map[Validator, BlockHash]] =
+    state.get.map(_.latestMessages)
+  private[this] def getChildMap: F[Map[BlockHash, Set[BlockHash]]] =
+    state.get.map(_.childMap)
+  private[this] def getDataLookup: F[Map[BlockHash, BlockMetadata]] =
+    state.get.map(_.dataLookup)
+  private[this] def getTopoSort: F[Vector[Vector[BlockHash]]] =
+    state.get.map(_.topoSort)
+  private[this] def getSortOffset: F[Long] =
+    state.get.map(_.sortOffset)
+  private[this] def getCheckpoints: F[List[Checkpoint]] =
+    state.get.map(_.checkpoints)
+  private[this] def getLatestMessagesLogOutputStream: F[OutputStream] =
+    state.get.map(_.latestMessagesLogOutputStream)
+  private[this] def getLatestMessagesLogSize: F[Int] =
+    state.get.map(_.latestMessagesLogSize)
+  private[this] def getLatestMessagesCrc: F[Crc32[F]] =
+    state.get.map(_.latestMessagesCrc)
+  private[this] def getBlockMetadataLogOutputStream: F[OutputStream] =
+    state.get.map(_.blockMetadataLogOutputStream)
+  private[this] def getBlockMetadataCrc: F[Crc32[F]] =
+    state.get.map(_.blockMetadataCrc)
+
+  private[this] def setLatestMessages(v: Map[Validator, BlockHash]): F[Unit] =
+    state.modify(s => s.copy(latestMessages = v))
+  private[this] def setChildMap(v: Map[BlockHash, Set[BlockHash]]): F[Unit] =
+    state.modify(s => s.copy(childMap = v))
+  private[this] def setDataLookup(v: Map[BlockHash, BlockMetadata]): F[Unit] =
+    state.modify(s => s.copy(dataLookup = v))
+  private[this] def setTopoSort(v: Vector[Vector[BlockHash]]): F[Unit] =
+    state.modify(s => s.copy(topoSort = v))
+  private[this] def setSortOffset(v: Long): F[Unit] =
+    state.modify(s => s.copy(sortOffset = v))
+  private[this] def setCheckpoints(v: List[Checkpoint]): F[Unit] =
+    state.modify(s => s.copy(checkpoints = v))
+  private[this] def setLatestMessagesLogOutputStream(v: OutputStream): F[Unit] =
+    state.modify(s => s.copy(latestMessagesLogOutputStream = v))
+  private[this] def setLatestMessagesLogSize(v: Int): F[Unit] =
+    state.modify(s => s.copy(latestMessagesLogSize = v))
+  private[this] def setLatestMessagesCrc(v: Crc32[F]): F[Unit] =
+    state.modify(s => s.copy(latestMessagesCrc = v))
+  private[this] def setBlockMetadataLogOutputStream(v: OutputStream): F[Unit] =
+    state.modify(s => s.copy(blockMetadataLogOutputStream = v))
+  private[this] def setBlockMetadataCrc(v: Crc32[F]): F[Unit] =
+    state.modify(s => s.copy(blockMetadataCrc = v))
+
+  private[this] def modifyLatestMessages(
+      f: Map[Validator, BlockHash] => Map[Validator, BlockHash]
+  ): F[Unit] =
+    state.modify(s => s.copy(latestMessages = f(s.latestMessages)))
+  private[this] def modifyChildMap(
+      f: Map[BlockHash, Set[BlockHash]] => Map[BlockHash, Set[BlockHash]]
+  ): F[Unit] =
+    state.modify(s => s.copy(childMap = f(s.childMap)))
+  private[this] def modifyDataLookup(
+      f: Map[BlockHash, BlockMetadata] => Map[BlockHash, BlockMetadata]
+  ): F[Unit] =
+    state.modify(s => s.copy(dataLookup = f(s.dataLookup)))
+  private[this] def modifyTopoSort(
+      f: Vector[Vector[BlockHash]] => Vector[Vector[BlockHash]]
+  ): F[Unit] =
+    state.modify(s => s.copy(topoSort = f(s.topoSort)))
+  private[this] def modifySortOffset(f: Long => Long): F[Unit] =
+    state.modify(s => s.copy(sortOffset = f(s.sortOffset)))
+  private[this] def modifyCheckpoints(f: List[Checkpoint] => List[Checkpoint]): F[Unit] =
+    state.modify(s => s.copy(checkpoints = f(s.checkpoints)))
+  private[this] def modifyLatestMessagesLogOutputStream(f: OutputStream => OutputStream): F[Unit] =
+    state.modify(s => s.copy(latestMessagesLogOutputStream = f(s.latestMessagesLogOutputStream)))
+  private[this] def modifyLatestMessagesLogSize(f: Int => Int): F[Unit] =
+    state.modify(s => s.copy(latestMessagesLogSize = f(s.latestMessagesLogSize)))
+  private[this] def modifyLatestMessagesCrc(f: Crc32[F] => Crc32[F]): F[Unit] =
+    state.modify(s => s.copy(latestMessagesCrc = f(s.latestMessagesCrc)))
+  private[this] def modifyBlockMetadataLogOutputStream(f: OutputStream => OutputStream): F[Unit] =
+    state.modify(s => s.copy(blockMetadataLogOutputStream = f(s.blockMetadataLogOutputStream)))
+  private[this] def modifyBlockMetadataCrc(f: Crc32[F] => Crc32[F]): F[Unit] =
+    state.modify(s => s.copy(blockMetadataCrc = f(s.blockMetadataCrc)))
 
   private case class FileDagRepresentation(
       latestMessagesMap: Map[Validator, BlockHash],
@@ -95,7 +179,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
       } else if (sortOffset - startBlockNumber + topoSortVector.length < Int.MaxValue) { // Max Vector length
         lock.withPermit(
           for {
-            checkpoints          <- checkpointsRef.get
+            checkpoints          <- getCheckpoints
             checkpointsWithIndex = checkpoints.zipWithIndex
             checkpointsToLoad    = checkpointsWithIndex.filter(startBlockNumber < _._1.end)
             checkpointsDagInfos <- checkpointsToLoad.traverse {
@@ -160,13 +244,13 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
         for {
           loadedDagInfo <- loadDagInfo(checkpoint)
           newCheckpoint = checkpoint.copy(dagInfo = Some(WeakReference(loadedDagInfo)))
-          _             <- checkpointsRef.update(_.patch(index, List(newCheckpoint), 1))
+          _             <- modifyCheckpoints(_.patch(index, List(newCheckpoint), 1))
         } yield loadedDagInfo
     }
 
   private def loadCheckpoint(offset: Long): F[Option[CheckpointedDagInfo]] =
     for {
-      checkpoints <- checkpointsRef.get
+      checkpoints <- getCheckpoints
       neededCheckpoint = checkpoints.zipWithIndex.find {
         case (c, _) => c.start <= offset && offset < c.end
       }
@@ -182,11 +266,11 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
 
   private def updateLatestMessagesFile(validators: List[Validator], blockHash: BlockHash): F[Unit] =
     for {
-      latestMessagesCrc <- latestMessagesCrcRef.get
+      latestMessagesCrc <- getLatestMessagesCrc
       _ <- validators.traverse_ { validator =>
             val toAppend = validator.concat(blockHash).toByteArray
             for {
-              latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+              latestMessagesLogOutputStream <- getLatestMessagesLogOutputStream
               _                             <- Sync[F].delay { latestMessagesLogOutputStream.write(toAppend) }
               _                             <- Sync[F].delay { latestMessagesLogOutputStream.flush() }
               _ <- latestMessagesCrc.update(toAppend).flatMap { _ =>
@@ -194,7 +278,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
                   }
             } yield ()
           }
-      _ <- latestMessagesLogSizeRef.update(_ + 1)
+      _ <- modifyLatestMessagesLogSize(_ + 1)
     } yield ()
 
   private def updateLatestMessagesCrcFile(newCrc: Crc32[F]): F[Unit] =
@@ -227,8 +311,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
 
   private def squashLatestMessagesDataFile(): F[Unit] =
     for {
-      latestMessages                <- latestMessagesRef.get
-      latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+      latestMessages                <- getLatestMessages
+      latestMessagesLogOutputStream <- getLatestMessagesLogOutputStream
       _                             = latestMessagesLogOutputStream.close()
       tmpSquashedData               <- createTmpFile("rchain-block-dag-store-latest-messages-", "-squashed-data")
       tmpSquashedCrc                <- createTmpFile("rchain-block-dag-store-latest-messages-", "-squashed-crc")
@@ -247,17 +331,17 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
       _                <- Sync[F].delay { Files.write(tmpSquashedCrc, squashedCrcBytes) }
       _                <- replaceFile(tmpSquashedData, latestMessagesDataFilePath)
       _                <- replaceFile(tmpSquashedCrc, latestMessagesCrcFilePath)
-      _ <- latestMessagesLogOutputStreamRef.set(
+      _ <- setLatestMessagesLogOutputStream(
             new FileOutputStream(latestMessagesDataFilePath.toFile, true)
           )
-      _ <- latestMessagesCrcRef.set(squashedCrc)
-      _ <- latestMessagesLogSizeRef.set(0)
+      _ <- setLatestMessagesCrc(squashedCrc)
+      _ <- setLatestMessagesLogSize(0)
     } yield ()
 
   private def squashLatestMessagesDataFileIfNeeded(): F[Unit] =
     for {
-      latestMessages        <- latestMessagesRef.get
-      latestMessagesLogSize <- latestMessagesLogSizeRef.get
+      latestMessages        <- getLatestMessages
+      latestMessagesLogSize <- getLatestMessagesLogSize
       result <- if (latestMessagesLogSize > latestMessages.size * latestMessagesLogMaxSizeFactor) {
                  squashLatestMessagesDataFile()
                } else {
@@ -267,10 +351,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
 
   private def updateDataLookupFile(blockMetadata: BlockMetadata): F[Unit] =
     for {
-      dataLookupCrc          <- blockMetadataCrcRef.get
+      dataLookupCrc          <- getBlockMetadataCrc
       blockBytes             = blockMetadata.toByteString
       toAppend               = blockBytes.size.toByteString.concat(blockBytes).toByteArray
-      dataLookupOutputStream <- blockMetadataLogOutputStreamRef.get
+      dataLookupOutputStream <- getBlockMetadataLogOutputStream
       _                      <- Sync[F].delay { dataLookupOutputStream.write(toAppend) }
       _                      <- Sync[F].delay { dataLookupOutputStream.flush() }
       _                      <- dataLookupCrc.update(toAppend)
@@ -290,18 +374,18 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
   def getRepresentation: F[BlockDagRepresentation[F]] =
     lock.withPermit(
       for {
-        latestMessages <- latestMessagesRef.get
-        childMap       <- childMapRef.get
-        dataLookup     <- dataLookupRef.get
-        topoSort       <- topoSortRef.get
-        sortOffset     <- sortOffsetRef.get
+        latestMessages <- getLatestMessages
+        childMap       <- getChildMap
+        dataLookup     <- getDataLookup
+        topoSort       <- getTopoSort
+        sortOffset     <- getSortOffset
       } yield FileDagRepresentation(latestMessages, childMap, dataLookup, topoSort, sortOffset)
     )
 
   def insert(block: BlockMessage): F[BlockDagRepresentation[F]] =
     lock.withPermit(
       for {
-        alreadyStored <- dataLookupRef.get.map(_.contains(block.blockHash))
+        alreadyStored <- getDataLookup.map(_.contains(block.blockHash))
         _ <- if (alreadyStored) {
               Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} is already stored")
             } else {
@@ -309,8 +393,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
                 _             <- squashLatestMessagesDataFileIfNeeded()
                 blockMetadata = BlockMetadata.fromBlock(block)
                 _             = assert(block.blockHash.size == 32)
-                _             <- dataLookupRef.update(_.updated(block.blockHash, blockMetadata))
-                _ <- childMapRef.update(
+                _             <- modifyDataLookup(_.updated(block.blockHash, blockMetadata))
+                _ <- modifyChildMap(
                       childMap =>
                         parentHashes(block)
                           .foldLeft(childMap) {
@@ -320,7 +404,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
                           }
                           .updated(block.blockHash, Set.empty[BlockHash])
                     )
-                _ <- topoSortRef.update(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
+                _ <- modifyTopoSort(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
                 //Block which contains newly bonded validators will not
                 //have those validators in its justification
                 newValidators = bonds(block)
@@ -339,7 +423,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
                                               BlockSenderIsMalformed(block)
                                             )
                                           }
-                _ <- latestMessagesRef.update { latestMessages =>
+                _ <- modifyLatestMessages { latestMessages =>
                       newValidatorsWithSender.foldLeft(latestMessages) {
                         //Update new validators with block in which
                         //they were bonded (i.e. this block)
@@ -363,9 +447,9 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
   def clear(): F[Unit] =
     lock.withPermit(
       for {
-        latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+        latestMessagesLogOutputStream <- getLatestMessagesLogOutputStream
         _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
-        blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
+        blockMetadataLogOutputStream  <- getBlockMetadataLogOutputStream
         _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
         _ <- Sync[F].delay {
               Files.write(latestMessagesDataFilePath, Array.emptyByteArray)
@@ -383,28 +467,28 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore] private
         _ <- Sync[F].delay {
               Files.write(blockMetadataCrcPath, newBlockMetadataCrcBytes)
             }
-        _ <- dataLookupRef.set(Map.empty)
-        _ <- childMapRef.set(Map.empty)
-        _ <- topoSortRef.set(Vector.empty)
-        _ <- latestMessagesRef.set(Map.empty)
-        _ <- latestMessagesLogOutputStreamRef.set(
+        _ <- setDataLookup(Map.empty)
+        _ <- setChildMap(Map.empty)
+        _ <- setTopoSort(Vector.empty)
+        _ <- setLatestMessages(Map.empty)
+        _ <- setLatestMessagesLogOutputStream(
               new FileOutputStream(latestMessagesDataFilePath.toFile)
             )
-        _ <- blockMetadataLogOutputStreamRef.set(
+        _ <- setBlockMetadataLogOutputStream(
               new FileOutputStream(blockMetadataLogPath.toFile)
             )
-        _ <- latestMessagesLogSizeRef.set(0)
-        _ <- latestMessagesCrcRef.set(newLatestMessagesCrc)
-        _ <- blockMetadataCrcRef.set(newBlockMetadataCrc)
+        _ <- setLatestMessagesLogSize(0)
+        _ <- setLatestMessagesCrc(newLatestMessagesCrc)
+        _ <- setBlockMetadataCrc(newBlockMetadataCrc)
       } yield ()
     )
 
   def close(): F[Unit] =
     lock.withPermit(
       for {
-        latestMessagesLogOutputStream <- latestMessagesLogOutputStreamRef.get
+        latestMessagesLogOutputStream <- getLatestMessagesLogOutputStream
         _                             <- Sync[F].delay { latestMessagesLogOutputStream.close() }
-        blockMetadataLogOutputStream  <- blockMetadataLogOutputStreamRef.get
+        blockMetadataLogOutputStream  <- getBlockMetadataLogOutputStream
         _                             <- Sync[F].delay { blockMetadataLogOutputStream.close() }
       } yield ()
     )
@@ -651,7 +735,7 @@ object BlockDagFileStorage {
                }
     } yield result
 
-  def create[F[_]: Concurrent: Sync: Log: BlockStore](
+  def create[F[_]: Concurrent: Sync: Capture: Log: BlockStore](
       config: Config
   ): F[BlockDagFileStorage[F]] =
     for {
@@ -676,16 +760,7 @@ object BlockDagFileStorage {
                                } yield (latestMessagesMap, calculatedLatestMessagesCrc, logSize)
                              }
       (latestMessagesMap, calculatedLatestMessagesCrc, logSize) = latestMessagesResult
-      latestMessagesRef                                         <- Ref.of[F, Map[Validator, BlockHash]](latestMessagesMap)
-      latestMessagesLogSizeRef                                  <- Ref.of[F, Int](logSize)
-      latestMessagesCrcRef                                      <- Ref.of[F, Crc32[F]](calculatedLatestMessagesCrc)
-      latestMessagesDataOutputStreamRef <- Ref.of[F, OutputStream](
-                                            new FileOutputStream(
-                                              config.latestMessagesLogPath.toFile,
-                                              true
-                                            )
-                                          )
-      readDataLookupCrc <- readCrc[F](config.blockMetadataCrcPath)
+      readDataLookupCrc                                         <- readCrc[F](config.blockMetadataCrcPath)
       dataLookupFileResource = Resource.fromAutoCloseable(
         Sync[F].delay { new RandomAccessFile(config.blockMetadataLogPath.toFile, "rw") }
       )
@@ -701,43 +776,40 @@ object BlockDagFileStorage {
                            } yield result
                          }
       (dataLookupList, calculatedDataLookupCrc) = dataLookupResult
-      dataLookupRef                             <- Ref.of[F, Map[BlockHash, BlockMetadata]](dataLookupList.toMap)
-      dataLookupDataOutputStreamRef <- Ref.of[F, OutputStream](
-                                        new FileOutputStream(
-                                          config.blockMetadataLogPath.toFile,
-                                          true
-                                        )
-                                      )
-      dataLookupCrcRef  <- Ref.of[F, Crc32[F]](calculatedDataLookupCrc)
-      childMap          = extractChildMap(dataLookupList)
-      topoSort          = extractTopoSort(dataLookupList)
-      childMapRef       <- Ref.of[F, Map[BlockHash, Set[BlockHash]]](childMap)
-      topoSortRef       <- Ref.of[F, Vector[Vector[BlockHash]]](topoSort)
-      sortedCheckpoints <- loadCheckpoints(config.checkpointsDirPath)
-      checkPointsRef    <- Ref.of[F, List[Checkpoint]](sortedCheckpoints)
-      sortOffsetRef     <- Ref.of[F, Long](sortedCheckpoints.lastOption.map(_.end).getOrElse(0L))
+      childMap                                  = extractChildMap(dataLookupList)
+      topoSort                                  = extractTopoSort(dataLookupList)
+      sortedCheckpoints                         <- loadCheckpoints(config.checkpointsDirPath)
+      state = BlockDagFileStorageState(
+        latestMessagesMap,
+        childMap,
+        dataLookupList.toMap,
+        topoSort,
+        sortedCheckpoints.lastOption.map(_.end).getOrElse(0L),
+        sortedCheckpoints,
+        new FileOutputStream(
+          config.latestMessagesLogPath.toFile,
+          true
+        ),
+        logSize,
+        calculatedLatestMessagesCrc,
+        new FileOutputStream(
+          config.blockMetadataLogPath.toFile,
+          true
+        ),
+        calculatedDataLookupCrc
+      )
     } yield
       new BlockDagFileStorage[F](
         lock,
-        latestMessagesRef,
-        childMapRef,
-        dataLookupRef,
-        topoSortRef,
-        sortOffsetRef,
-        checkPointsRef,
-        latestMessagesDataOutputStreamRef,
-        latestMessagesLogSizeRef,
-        latestMessagesCrcRef,
         config.latestMessagesLogPath,
         config.latestMessagesCrcPath,
         config.latestMessagesLogMaxSizeFactor,
-        dataLookupDataOutputStreamRef,
-        dataLookupCrcRef,
         config.blockMetadataLogPath,
-        config.blockMetadataCrcPath
+        config.blockMetadataCrcPath,
+        new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
       )
 
-  def createEmptyFromGenesis[F[_]: Monad: Concurrent: Sync: Log: BlockStore](
+  def createEmptyFromGenesis[F[_]: Concurrent: Sync: Capture: Log: BlockStore](
       config: Config,
       genesis: BlockMessage
   ): F[BlockDagFileStorage[F]] =
@@ -758,59 +830,43 @@ object BlockDagFileStorage {
             case (validator, blockHash) =>
               latestMessagesCrc.update(validator.concat(blockHash).toByteArray)
           }
-      latestMessagesCrcBytes   <- latestMessagesCrc.bytes
-      _                        <- Sync[F].delay { Files.write(config.latestMessagesLogPath, latestMessagesData) }
-      _                        <- Sync[F].delay { Files.write(config.latestMessagesCrcPath, latestMessagesCrcBytes) }
-      latestMessagesRef        <- Ref.of[F, Map[Validator, BlockHash]](initialLatestMessages)
-      latestMessagesLogSizeRef <- Ref.of[F, Int](initialLatestMessages.size)
-      latestMessagesCrcRef     <- Ref.of[F, Crc32[F]](latestMessagesCrc)
-      childMapRef <- Ref.of[F, Map[BlockHash, Set[BlockHash]]](
-                      Map(genesis.blockHash -> Set.empty[BlockHash])
-                    )
-      dataLookupRef <- Ref.of[F, Map[BlockHash, BlockMetadata]](
-                        Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis))
-                      )
-      topoSortRef <- Ref.of[F, Vector[Vector[BlockHash]]](Vector(Vector(genesis.blockHash)))
-      latestMessagesDataOutputStreamRef <- Ref.of[F, OutputStream](
-                                            new FileOutputStream(
-                                              config.latestMessagesLogPath.toFile,
-                                              true
-                                            )
-                                          )
-      blockMetadataCrc      = Crc32.empty[F]()
-      genesisByteString     = genesis.toByteString
-      genesisData           = genesisByteString.size.toByteString.concat(genesisByteString).toByteArray
-      _                     <- blockMetadataCrc.update(genesisData)
-      blockMetadataCrcBytes <- blockMetadataCrc.bytes
-      _                     <- Sync[F].delay { Files.write(config.blockMetadataLogPath, genesisData) }
-      _                     <- Sync[F].delay { Files.write(config.blockMetadataCrcPath, blockMetadataCrcBytes) }
-      blockMetadataDataOutputStreamRef <- Ref.of[F, OutputStream](
-                                           new FileOutputStream(
-                                             config.blockMetadataLogPath.toFile,
-                                             true
-                                           )
-                                         )
-      blockMetadataCrcRef <- Ref.of[F, Crc32[F]](blockMetadataCrc)
-      checkPointsRef      <- Ref.of[F, List[Checkpoint]](List.empty)
-      sortOffsetRef       <- Ref.of[F, Long](0L)
+      latestMessagesCrcBytes <- latestMessagesCrc.bytes
+      _                      <- Sync[F].delay { Files.write(config.latestMessagesLogPath, latestMessagesData) }
+      _                      <- Sync[F].delay { Files.write(config.latestMessagesCrcPath, latestMessagesCrcBytes) }
+      blockMetadataCrc       = Crc32.empty[F]()
+      genesisByteString      = genesis.toByteString
+      genesisData            = genesisByteString.size.toByteString.concat(genesisByteString).toByteArray
+      _                      <- blockMetadataCrc.update(genesisData)
+      blockMetadataCrcBytes  <- blockMetadataCrc.bytes
+      _                      <- Sync[F].delay { Files.write(config.blockMetadataLogPath, genesisData) }
+      _                      <- Sync[F].delay { Files.write(config.blockMetadataCrcPath, blockMetadataCrcBytes) }
+      state = BlockDagFileStorageState(
+        initialLatestMessages,
+        Map(genesis.blockHash -> Set.empty[BlockHash]),
+        Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis)),
+        Vector(Vector(genesis.blockHash)),
+        0L,
+        List.empty,
+        new FileOutputStream(
+          config.latestMessagesLogPath.toFile,
+          true
+        ),
+        initialLatestMessages.size,
+        latestMessagesCrc,
+        new FileOutputStream(
+          config.blockMetadataLogPath.toFile,
+          true
+        ),
+        blockMetadataCrc
+      )
     } yield
       new BlockDagFileStorage[F](
         lock,
-        latestMessagesRef,
-        childMapRef,
-        dataLookupRef,
-        topoSortRef,
-        sortOffsetRef,
-        checkPointsRef,
-        latestMessagesDataOutputStreamRef,
-        latestMessagesLogSizeRef,
-        latestMessagesCrcRef,
         config.latestMessagesLogPath,
         config.latestMessagesCrcPath,
         config.latestMessagesLogMaxSizeFactor,
-        blockMetadataDataOutputStreamRef,
-        blockMetadataCrcRef,
         config.blockMetadataLogPath,
-        config.blockMetadataCrcPath
+        config.blockMetadataCrcPath,
+        new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
       )
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -3,7 +3,6 @@ package coop.rchain.blockstorage
 import cats.Applicative
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.StorageError.StorageIOErr
 import coop.rchain.casper.protocol.BlockMessage
 
 import scala.language.higherKinds
@@ -11,17 +10,17 @@ import scala.language.higherKinds
 trait BlockStore[F[_]] {
   import BlockStore.BlockHash
 
-  def put(blockMessage: BlockMessage): F[StorageIOErr[Unit]] =
+  def put(blockMessage: BlockMessage): F[Unit] =
     put((blockMessage.blockHash, blockMessage))
 
-  def put(blockHash: BlockHash, blockMessage: BlockMessage): F[StorageIOErr[Unit]] =
+  def put(blockHash: BlockHash, blockMessage: BlockMessage): F[Unit] =
     put((blockHash, blockMessage))
 
   def get(blockHash: BlockHash): F[Option[BlockMessage]]
 
   def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]]
 
-  def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]]
+  def put(f: => (BlockHash, BlockMessage)): F[Unit]
 
   def apply(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[BlockMessage] =
     get(blockHash).map(_.get)
@@ -29,11 +28,11 @@ trait BlockStore[F[_]] {
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
     get(blockHash).map(_.isDefined)
 
-  def checkpoint(): F[StorageIOErr[Unit]]
+  def checkpoint(): F[Unit]
 
-  def clear(): F[StorageIOErr[Unit]]
+  def clear(): F[Unit]
 
-  def close(): F[StorageIOErr[Unit]]
+  def close(): F[Unit]
 }
 
 object BlockStore {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -296,13 +296,7 @@ object FileLMDBIndexBlockStore {
       storagePath: Path,
       checkpointsDirPath: Path
   ): F[StorageErr[BlockStore[F]]] = {
-    implicit val raiseIOErrorThroughSync = new FunctorRaise[F, IOError] {
-      override val functor: Functor[F] =
-        Functor[F]
-
-      override def raise[A](e: IOError): F[A] =
-        Sync[F].raiseError(IOError.ExceptionWrapper(e))
-    }
+    implicit val raiseIOError: RaiseIOError[F] = IOError.raiseIOErrorThroughSync[F]
     for {
       lock <- Semaphore[F](1)
       index <- Sync[F].delay {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -276,6 +276,11 @@ object FileLMDBIndexBlockStore {
   ): StorageIOErrT[F, A] =
     EitherT(ioError).toStorageIOErrT
 
+  private[blockstorage] def toStorageErrT[F[_]: Sync, A](
+      ioError: F[IOErr[A]]
+  ): StorageErrT[F, A] =
+    EitherT(ioError).toStorageErrT
+
   private def loadCheckpoints[F[_]: Sync: Log](
       checkpointsDirPath: Path
   ): StorageErrT[F, List[Checkpoint]] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -92,8 +92,8 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
     def readBlockMessageFromFile(storageFile: RandomAccessIO[F]): F[BlockMessage] =
       for {
         _                      <- storageFile.seek(indexEntry.offset)
-        blockMessageSize       <- storageFile.readInt
-        blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
+        blockMessageSizeOpt    <- storageFile.readInt
+        blockMessagesByteArray = Array.ofDim[Byte](blockMessageSizeOpt.get)
         _                      <- storageFile.readFully(blockMessagesByteArray)
         blockMessage           = BlockMessage.parseFrom(blockMessagesByteArray)
       } yield blockMessage

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -4,22 +4,21 @@ import java.io._
 import java.nio.ByteBuffer
 import java.nio.file._
 
-import cats.Monad
-import cats.data.EitherT
+import cats.{Functor, Monad}
 import cats.effect.{Concurrent, ExitCase, Sync}
 import cats.implicits._
 import cats.effect.concurrent.Semaphore
-import cats.mtl.MonadState
+import cats.mtl.{FunctorRaise, MonadState}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.FileLMDBIndexBlockStore.{toStorageIOErrT, Checkpoint}
-import coop.rchain.blockstorage.StorageError.{StorageErr, StorageErrT, StorageIOErr, StorageIOErrT}
+import coop.rchain.blockstorage.FileLMDBIndexBlockStore.Checkpoint
+import coop.rchain.blockstorage.StorageError.StorageErr
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.shared.Resources.withResource
 import coop.rchain.blockstorage.util.byteOps._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
-import coop.rchain.blockstorage.StorageError._
-import coop.rchain.blockstorage.util.io.IOError.IOErr
+import coop.rchain.blockstorage.util.io.IOError
 import coop.rchain.catscontrib.Capture
 import coop.rchain.shared.{AtomicMonadState, Log}
 import coop.rchain.shared.ByteStringOps._
@@ -38,7 +37,7 @@ private final case class FileLMDBIndexBlockStoreState[F[_]: Sync](
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
+class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
     lock: Semaphore[F],
     env: Env[ByteBuffer],
     index: Dbi[ByteBuffer],
@@ -89,44 +88,44 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
   private[this] def modifyCurrentIndex(f: Int => Int): F[Unit] =
     state.modify(s => s.copy(currentIndex = f(s.currentIndex)))
 
-  private def readBlockMessage(indexEntry: IndexEntry): StorageIOErrT[F, BlockMessage] = {
-    def readBlockMessageFromFile(storageFile: RandomAccessIO[F]): StorageIOErrT[F, BlockMessage] =
+  private def readBlockMessage(indexEntry: IndexEntry): F[BlockMessage] = {
+    def readBlockMessageFromFile(storageFile: RandomAccessIO[F]): F[BlockMessage] =
       for {
-        _                      <- toStorageIOErrT(storageFile.seek(indexEntry.offset))
-        blockMessageSize       <- toStorageIOErrT(storageFile.readInt)
+        _                      <- storageFile.seek(indexEntry.offset)
+        blockMessageSize       <- storageFile.readInt
         blockMessagesByteArray = Array.ofDim[Byte](blockMessageSize)
-        _                      <- toStorageIOErrT(storageFile.readFully(blockMessagesByteArray))
+        _                      <- storageFile.readFully(blockMessagesByteArray)
         blockMessage           = BlockMessage.parseFrom(blockMessagesByteArray)
       } yield blockMessage
 
     for {
-      currentIndex <- EitherT.liftF(getCurrentIndex)
+      currentIndex <- getCurrentIndex
       blockMessage <- if (currentIndex == indexEntry.checkpointIndex)
                        for {
-                         storageFile  <- EitherT.liftF(getBlockMessageRandomAccessFile)
+                         storageFile  <- getBlockMessageRandomAccessFile
                          blockMessage <- readBlockMessageFromFile(storageFile)
                        } yield blockMessage
                      else
                        for {
-                         checkpoints <- EitherT.liftF(getCheckpoints)
+                         checkpoints <- getCheckpoints
                          result <- checkpoints.get(indexEntry.checkpointIndex) match {
                                     case Some(checkpoint) =>
-                                      type StorageIOErrTF[A] = StorageIOErrT[F, A]
-                                      Sync[StorageIOErrTF].bracket {
-                                        RandomAccessIO.open[F](checkpoint.storagePath)
+                                      Sync[F].bracket {
+                                        RandomAccessIO.open[F](
+                                          checkpoint.storagePath,
+                                          RandomAccessIO.Read
+                                        )
                                       } { storageFile =>
                                         readBlockMessageFromFile(storageFile)
                                       } { storageFile =>
-                                        toStorageIOErrT(storageFile.close())
+                                        storageFile.close
                                       }
                                     case None =>
-                                      EitherT
-                                        .leftT[F, BlockMessage]
-                                        .apply[StorageIOError](
-                                          UnavailableReferencedCheckpoint(
-                                            indexEntry.checkpointIndex
-                                          )
+                                      RaiseIOError[F].raise[BlockMessage](
+                                        UnavailableReferencedCheckpoint(
+                                          indexEntry.checkpointIndex
                                         )
+                                      )
                                   }
                        } yield result
     } yield blockMessage
@@ -139,12 +138,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
                           Option(index.get(txn, blockHash.toDirectByteBuffer))
                             .map(IndexEntry.load)
                         }
-        readResult <- indexEntryOpt.traverse(readBlockMessage).value
-        result <- readResult match {
-                   case Left(storageReadError) =>
-                     Log[F].error(storageReadError.message) *> none[BlockMessage].pure[F]
-                   case Right(block) => block.pure[F]
-                 }
+        result <- indexEntryOpt.traverse(readBlockMessage)
       } yield result
     )
 
@@ -162,89 +156,76 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: Log] private (
                         }
         result <- filteredIndex.flatTraverse {
                    case (blockHash, indexEntry) =>
-                     readBlockMessage(indexEntry).value.flatMap {
-                       case Left(storageReadError) =>
-                         Log[F].error(storageReadError.message) *> List
-                           .empty[(BlockHash, BlockMessage)]
-                           .pure[F]
-                       case Right(block) =>
-                         List(blockHash -> block).pure[F]
-                     }
+                     readBlockMessage(indexEntry)
+                       .map(block => List(blockHash -> block))
                  }
       } yield result
     )
 
-  override def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]] =
+  override def put(f: => (BlockHash, BlockMessage)): F[Unit] =
     lock.withPermit(
-      (for {
-        randomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
-                             getBlockMessageRandomAccessFile
-                           )
-        currentIndex              <- EitherT.liftF(getCurrentIndex)
-        endOfFileOffset           <- toStorageIOErrT(randomAccessFile.length)
-        _                         <- toStorageIOErrT(randomAccessFile.seek(endOfFileOffset))
+      for {
+        randomAccessFile          <- getBlockMessageRandomAccessFile
+        currentIndex              <- getCurrentIndex
+        endOfFileOffset           <- randomAccessFile.length
+        _                         <- randomAccessFile.seek(endOfFileOffset)
         (blockHash, blockMessage) = f
         blockMessageByteArray     = blockMessage.toByteArray
-        _                         <- toStorageIOErrT(randomAccessFile.writeInt(blockMessageByteArray.length))
-        _                         <- toStorageIOErrT(randomAccessFile.write(blockMessageByteArray))
-        _ <- EitherT.liftF[F, StorageIOError, Unit](withWriteTxn { txn =>
+        _                         <- randomAccessFile.writeInt(blockMessageByteArray.length)
+        _                         <- randomAccessFile.write(blockMessageByteArray)
+        _ <- withWriteTxn { txn =>
               index.put(
                 txn,
                 blockHash.toDirectByteBuffer,
                 currentIndex.toByteString.concat(endOfFileOffset.toByteString).toDirectByteBuffer
               )
-            })
-      } yield ()).value
+            }
+      } yield ()
     )
 
-  override def checkpoint(): F[StorageIOErr[Unit]] =
+  override def checkpoint(): F[Unit] =
     lock.withPermit(
-      (for {
-        checkpointIndex <- EitherT.liftF[F, StorageIOError, Int](getCurrentIndex)
-        checkpointPath  = checkpointsDir.resolve(checkpointIndex.toString)
-        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
-                                         getBlockMessageRandomAccessFile
-                                       )
-        _                               <- EitherT(blockMessageRandomAccessFile.close()).toStorageIOErrT
-        _                               <- moveFile(storagePath, checkpointPath, StandardCopyOption.ATOMIC_MOVE).toStorageIOErrT
-        newBlockMessageRandomAccessFile <- RandomAccessIO.open[F](storagePath).toStorageIOErrT
-        _ <- EitherT.liftF[F, StorageIOError, Unit](
-              setBlockMessageRandomAccessFile(newBlockMessageRandomAccessFile)
+      for {
+        checkpointIndex              <- getCurrentIndex
+        checkpointPath               = checkpointsDir.resolve(checkpointIndex.toString)
+        blockMessageRandomAccessFile <- getBlockMessageRandomAccessFile
+        _                            <- blockMessageRandomAccessFile.close
+        _                            <- moveFile(storagePath, checkpointPath, StandardCopyOption.ATOMIC_MOVE)
+        newBlockMessageRandomAccessFile <- RandomAccessIO
+                                            .open[F](storagePath, RandomAccessIO.ReadWrite)
+        _ <- setBlockMessageRandomAccessFile(newBlockMessageRandomAccessFile)
+        _ <- modifyCheckpoints(
+              _.updated(checkpointIndex, Checkpoint(checkpointIndex, checkpointPath))
             )
-        _ <- EitherT.liftF[F, StorageIOError, Unit](
-              modifyCheckpoints(
-                _.updated(checkpointIndex, Checkpoint(checkpointIndex, checkpointPath))
-              )
-            )
-        _ <- EitherT.liftF[F, StorageIOError, Unit](modifyCurrentIndex(_ + 1))
-      } yield ()).value
+        _ <- modifyCurrentIndex(_ + 1)
+      } yield ()
     )
 
-  override def clear(): F[StorageIOErr[Unit]] =
+  override def clear(): F[Unit] =
     lock.withPermit(
       for {
         blockMessageRandomAccessFile <- getBlockMessageRandomAccessFile
         _ <- withWriteTxn { txn =>
               index.drop(txn)
             }
-        result <- toStorageIOErrT(blockMessageRandomAccessFile.setLength(0)).value
+        result <- blockMessageRandomAccessFile.setLength(0)
       } yield result
     )
 
-  override def close(): F[StorageIOErr[Unit]] =
+  override def close(): F[Unit] =
     lock.withPermit(
-      (for {
-        blockMessageRandomAccessFile <- EitherT.liftF[F, StorageIOError, RandomAccessIO[F]](
-                                         getBlockMessageRandomAccessFile
-                                       )
-        _ <- toStorageIOErrT(blockMessageRandomAccessFile.close())
-        _ <- EitherT(Sync[F].delay { env.close() }.attempt).leftMap[StorageIOError] {
-              case e: IOException =>
-                WrappedIOError(ClosingFailed(e))
-              case t =>
-                WrappedIOError(UnexpectedIOError(t))
+      for {
+        blockMessageRandomAccessFile <- getBlockMessageRandomAccessFile
+        _                            <- blockMessageRandomAccessFile.close
+        envCloseResult               <- Sync[F].delay[Unit] { env.close() }.attempt
+        _ <- envCloseResult match {
+              case Right(_) => ().pure[F]
+              case Left(e: IOException) =>
+                RaiseIOError[F].raise[Unit](ClosingFailed(e))
+              case Left(t) =>
+                RaiseIOError[F].raise[Unit](UnexpectedIOError(t))
             }
-      } yield ()).value
+      } yield ()
     )
 }
 
@@ -271,49 +252,37 @@ object FileLMDBIndexBlockStore {
       storagePath: Path
   )
 
-  private[blockstorage] def toStorageIOErrT[F[_]: Sync, A](
-      ioError: F[IOErr[A]]
-  ): StorageIOErrT[F, A] =
-    EitherT(ioError).toStorageIOErrT
-
-  private[blockstorage] def toStorageErrT[F[_]: Sync, A](
-      ioError: F[IOErr[A]]
-  ): StorageErrT[F, A] =
-    EitherT(ioError).toStorageErrT
-
-  private def loadCheckpoints[F[_]: Sync: Log](
+  private def loadCheckpoints[F[_]: Sync: Log: RaiseIOError](
       checkpointsDirPath: Path
-  ): StorageErrT[F, List[Checkpoint]] =
+  ): F[StorageErr[List[Checkpoint]]] =
     for {
-      _                   <- toStorageIOErrT(makeDirectory(checkpointsDirPath))
-      checkpointFilesList <- toStorageIOErrT(listRegularFiles(checkpointsDirPath))
-      checkpoints <- EitherT.liftF[F, StorageError, List[Checkpoint]](
-                      checkpointFilesList.flatTraverse { filePath =>
-                        filePath.getFileName.toString match {
-                          case checkpointPattern(index) =>
-                            List(Checkpoint(index.toInt, filePath)).pure[F]
-                          case other =>
-                            Log[F]
-                              .warn(s"Ignoring directory '$other': not a valid checkpoint name") *>
-                              List.empty[Checkpoint].pure[F]
-                        }
+      _                   <- makeDirectory(checkpointsDirPath)
+      checkpointFilesList <- listRegularFiles(checkpointsDirPath)
+      checkpoints <- checkpointFilesList.flatTraverse { filePath =>
+                      filePath.getFileName.toString match {
+                        case checkpointPattern(index) =>
+                          List(Checkpoint(index.toInt, filePath)).pure[F]
+                        case other =>
+                          Log[F]
+                            .warn(s"Ignoring directory '$other': not a valid checkpoint name") *>
+                            List.empty[Checkpoint].pure[F]
                       }
-                    )
+                    }
       sortedCheckpoints = checkpoints.sortBy(_.index)
-      result <- EitherT.fromEither[F](if (sortedCheckpoints.headOption.forall(_.index == 0)) {
-                 if (sortedCheckpoints.isEmpty ||
-                     sortedCheckpoints.zip(sortedCheckpoints.tail).forall {
-                       case (current, next) => current.index + 1 == next.index
-                     }) {
-                   sortedCheckpoints.asRight[StorageError]
-                 } else {
-                   CheckpointsAreNotConsecutive(sortedCheckpoints.map(_.storagePath))
-                     .asLeft[List[Checkpoint]]
-                 }
-               } else {
-                 CheckpointsDoNotStartFromZero(sortedCheckpoints.map(_.storagePath))
-                   .asLeft[List[Checkpoint]]
-               })
+      result = if (sortedCheckpoints.headOption.forall(_.index == 0)) {
+        if (sortedCheckpoints.isEmpty ||
+            sortedCheckpoints.zip(sortedCheckpoints.tail).forall {
+              case (current, next) => current.index + 1 == next.index
+            }) {
+          sortedCheckpoints.asRight[StorageError]
+        } else {
+          CheckpointsAreNotConsecutive(sortedCheckpoints.map(_.storagePath))
+            .asLeft[List[Checkpoint]]
+        }
+      } else {
+        CheckpointsDoNotStartFromZero(sortedCheckpoints.map(_.storagePath))
+          .asLeft[List[Checkpoint]]
+      }
     } yield result
 
   def create[F[_]: Concurrent: Capture: Log](
@@ -326,30 +295,44 @@ object FileLMDBIndexBlockStore {
       env: Env[ByteBuffer],
       storagePath: Path,
       checkpointsDirPath: Path
-  ): F[StorageErr[BlockStore[F]]] =
-    (for {
-      lock <- EitherT.liftF[F, StorageError, Semaphore[F]](Semaphore[F](1))
-      index <- EitherT.liftF[F, StorageError, Dbi[ByteBuffer]](Sync[F].delay {
+  ): F[StorageErr[BlockStore[F]]] = {
+    implicit val raiseIOErrorThroughSync = new FunctorRaise[F, IOError] {
+      override val functor: Functor[F] =
+        Functor[F]
+
+      override def raise[A](e: IOError): F[A] =
+        Sync[F].raiseError(IOError.ExceptionWrapper(e))
+    }
+    for {
+      lock <- Semaphore[F](1)
+      index <- Sync[F].delay {
                 env.openDbi(s"block_store_index", MDB_CREATE)
-              })
-      blockMessageRandomAccessFile <- RandomAccessIO.open(storagePath).toStorageIOErrT
-      sortedCheckpoints            <- loadCheckpoints(checkpointsDirPath)
-      checkpointsMap               = sortedCheckpoints.map(c => c.index -> c).toMap
-      currentIndex                 = sortedCheckpoints.lastOption.map(_.index + 1).getOrElse(0)
-      initialState = FileLMDBIndexBlockStoreState[F](
-        blockMessageRandomAccessFile,
-        checkpointsMap,
-        currentIndex
-      )
-      result = new FileLMDBIndexBlockStore[F](
-        lock,
-        env,
-        index,
-        storagePath,
-        checkpointsDirPath,
-        new AtomicMonadState[F, FileLMDBIndexBlockStoreState[F]](AtomicAny(initialState))
-      )
-    } yield result: BlockStore[F]).value
+              }
+      blockMessageRandomAccessFile <- RandomAccessIO.open(storagePath, RandomAccessIO.ReadWrite)
+      sortedCheckpointsEither      <- loadCheckpoints(checkpointsDirPath)
+      result = sortedCheckpointsEither match {
+        case Right(sortedCheckpoints) =>
+          val checkpointsMap = sortedCheckpoints.map(c => c.index -> c).toMap
+          val currentIndex   = sortedCheckpoints.lastOption.map(_.index + 1).getOrElse(0)
+          val initialState = FileLMDBIndexBlockStoreState[F](
+            blockMessageRandomAccessFile,
+            checkpointsMap,
+            currentIndex
+          )
+          (new FileLMDBIndexBlockStore[F](
+            lock,
+            env,
+            index,
+            storagePath,
+            checkpointsDirPath,
+            new AtomicMonadState[F, FileLMDBIndexBlockStoreState[F]](
+              AtomicAny(initialState)
+            )
+          ): BlockStore[F]).asRight[StorageError]
+        case Left(e) => e.asLeft[BlockStore[F]]
+      }
+    } yield result
+  }
 
   def create[F[_]: Monad: Concurrent: Capture: Log](
       config: Config

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage.BlockStore.BlockHash
+import coop.rchain.blockstorage.StorageError.StorageErr
 import coop.rchain.blockstorage.util.BlockMessageUtil.{bonds, parentHashes}
 import coop.rchain.blockstorage.util.{BlockMessageUtil, TopologicalSortUtil}
 import coop.rchain.casper.protocol.BlockMessage

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -5,7 +5,6 @@ import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.StorageError.StorageIOErr
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.metrics.Metrics
 
@@ -33,24 +32,24 @@ class InMemBlockStore[F[_]] private ()(
       state <- refF.get
     } yield state.filterKeys(p(_)).toSeq
 
-  def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]] =
+  def put(f: => (BlockHash, BlockMessage)): F[Unit] =
     for {
       _ <- metricsF.incrementCounter("put")
       _ <- refF.update { state =>
             val (hash, message) = f
             state.updated(hash, message)
           }
-    } yield Right(())
+    } yield ()
 
-  def checkpoint(): F[StorageIOErr[Unit]] =
-    ().asRight[StorageIOError].pure[F]
+  def checkpoint(): F[Unit] =
+    ().pure[F]
 
-  def clear(): F[StorageIOErr[Unit]] =
+  def clear(): F[Unit] =
     for {
       _ <- refF.update { _.empty }
-    } yield Right(())
+    } yield ()
 
-  override def close(): F[StorageIOErr[Unit]] = monadF.pure(Right(()))
+  override def close(): F[Unit] = monadF.pure(())
 }
 
 object InMemBlockStore {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -13,7 +13,6 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Resources.withResource
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.StorageError.StorageIOErr
 import org.lmdbjava._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.Txn.NotReadyException
@@ -68,7 +67,7 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
   private[this] def withReadTxn[R](f: Txn[ByteBuffer] => R): F[R] =
     withTxn(env.txnRead())(f)
 
-  def put(f: => (BlockHash, BlockMessage)): F[StorageIOErr[Unit]] =
+  def put(f: => (BlockHash, BlockMessage)): F[Unit] =
     for {
       _ <- metricsF.incrementCounter("put")
       ret <- withWriteTxn { txn =>
@@ -108,17 +107,17 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
             }
     } yield ret
 
-  def checkpoint(): F[StorageIOErr[Unit]] =
-    ().asRight[StorageIOError].pure[F]
+  def checkpoint(): F[Unit] =
+    ().pure[F]
 
-  def clear(): F[StorageIOErr[Unit]] =
+  def clear(): F[Unit] =
     for {
       ret <- withWriteTxn { txn =>
               blocks.drop(txn)
             }
-    } yield Right(())
+    } yield ()
 
-  override def close(): F[StorageIOErr[Unit]] =
+  override def close(): F[Unit] =
     syncF.delay { Right(env.close()) }
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -13,6 +13,7 @@ final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path])  ex
 final case class TopoSortLengthIsTooBig(length: Long)                         extends StorageError
 final case class BlockSenderIsMalformed(block: BlockMessage)                  extends StorageError
 final case class CheckpointDoesNotExist(offset: Long)                         extends StorageError
+final case object LatestMessagesLogIsMalformed                                extends StorageError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
@@ -30,6 +31,8 @@ object StorageError {
         s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is malformed: ${Base16.encode(block.sender.toByteArray)}"
       case CheckpointDoesNotExist(offset) =>
         s"Requested a block with block number $offset, but there is no checkpoint for it"
+      case LatestMessagesLogIsMalformed =>
+        "Latest messages log is malformed"
     }
 
   implicit class StorageErrorToMessage(storageError: StorageError) {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -2,10 +2,7 @@ package coop.rchain.blockstorage
 
 import java.nio.file.Path
 
-import cats.Functor
 import cats.data.EitherT
-import coop.rchain.blockstorage.util.io.IOError
-import coop.rchain.blockstorage.util.io.IOError.IOErrT
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
 
@@ -15,19 +12,11 @@ final case class CheckpointsDoNotStartFromZero(sortedCheckpoints: List[Path]) ex
 final case class CheckpointsAreNotConsecutive(sortedCheckpoints: List[Path])  extends StorageError
 final case class TopoSortLengthIsTooBig(length: Long)                         extends StorageError
 final case class BlockSenderIsMalformed(block: BlockMessage)                  extends StorageError
-
-sealed abstract class StorageIOError extends StorageError
-
-final case class WrappedIOError(ioError: IOError) extends StorageIOError
-
-final case class UnavailableReferencedCheckpoint(checkpointIndex: Int) extends StorageIOError
+final case class CheckpointDoesNotExist(offset: Long)                         extends StorageError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
   type StorageErrT[F[_], A] = EitherT[F, StorageError, A]
-
-  type StorageIOErr[A]        = Either[StorageIOError, A]
-  type StorageIOErrT[F[_], A] = EitherT[F, StorageIOError, A]
 
   def errorMessage(ce: StorageError): String =
     ce match {
@@ -39,17 +28,11 @@ object StorageError {
         s"Topological sorting of length $length was requested while maximal length is ${Int.MaxValue}"
       case BlockSenderIsMalformed(block) =>
         s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is malformed: ${Base16.encode(block.sender.toByteArray)}"
-      case WrappedIOError(ioError) =>
-        ioError.message
-      case UnavailableReferencedCheckpoint(checkpointIndex) =>
-        s"Unavailable checkpoint: $checkpointIndex"
+      case CheckpointDoesNotExist(offset) =>
+        s"Requested a block with block number $offset, but there is no checkpoint for it"
     }
 
   implicit class StorageErrorToMessage(storageError: StorageError) {
     val message: String = StorageError.errorMessage(storageError)
-  }
-
-  implicit class IOErrorTToStorageIOErrorT[F[_]: Functor, A](ioErrT: IOErrT[F, A]) {
-    def toStorageIOErrT: StorageIOErrT[F, A] = ioErrT.leftMap(WrappedIOError.apply)
   }
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
@@ -4,25 +4,26 @@ import java.io.{FileNotFoundException, FileOutputStream}
 import java.nio.file.Path
 
 import cats.effect.Sync
-import cats.syntax.functor._
-import coop.rchain.blockstorage.util.io.IOError.IOErr
+import cats.implicits._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 
-final case class FileOutputStreamIO[F[_]: Sync] private (private val stream: FileOutputStream)
-    extends AutoCloseable {
-  def write(bytes: Array[Byte]): F[IOErr[Unit]] =
+final case class FileOutputStreamIO[F[_]: Sync: RaiseIOError] private (
+    private val stream: FileOutputStream
+) {
+  def write(bytes: Array[Byte]): F[Unit] =
     handleIo(stream.write(bytes), ByteArrayWriteFailed.apply)
 
-  def flush: F[IOErr[Unit]] =
+  def flush: F[Unit] =
     handleIo(stream.flush(), StreamFlushFailed.apply)
 
-  def close(): F[IOErr[Unit]] =
+  def close: F[Unit] =
     handleIo(stream.close(), ClosingFailed.apply)
 }
 
 object FileOutputStreamIO {
-  def open[F[_]: Sync](path: Path, append: Boolean): F[IOErr[FileOutputStreamIO[F]]] =
+  def open[F[_]: Sync: RaiseIOError](path: Path, append: Boolean): F[FileOutputStreamIO[F]] =
     handleIo(new FileOutputStream(path.toFile, append), {
       case e: FileNotFoundException => FileNotFound(e)
       case e                        => UnexpectedIOError(e)
-    }).map(_.right.map(FileOutputStreamIO.apply[F]))
+    }).map(FileOutputStreamIO.apply[F])
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
@@ -1,0 +1,27 @@
+package coop.rchain.blockstorage.util.io
+
+import java.io.{FileNotFoundException, FileOutputStream}
+import java.nio.file.Path
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import coop.rchain.blockstorage.util.io.IOError.IOErr
+
+final case class FileOutputStreamIO[F[_]: Sync] private (private val stream: FileOutputStream) extends AutoCloseable {
+  def write(bytes: Array[Byte]): F[IOErr[Unit]] =
+    handleIo(stream.write(bytes), ByteArrayWriteFailed.apply)
+
+  def flush: F[IOErr[Unit]] =
+    handleIo(stream.flush(), StreamFlushFailed.apply)
+
+  def close(): F[IOErr[Unit]] =
+    handleIo(stream.close(), ClosingFailed.apply)
+}
+
+object FileOutputStreamIO {
+  def open[F[_]: Sync](path: Path, append: Boolean): F[IOErr[FileOutputStreamIO[F]]] =
+    handleIo(new FileOutputStream(path.toFile, append), {
+      case e: FileNotFoundException => FileNotFound(e)
+      case e                        => UnexpectedIOError(e)
+    }).map(_.right.map(FileOutputStreamIO.apply[F]))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
@@ -11,7 +11,7 @@ final case class FileOutputStreamIO[F[_]: Sync: RaiseIOError] private (
     private val stream: FileOutputStream
 ) {
   def write(bytes: Array[Byte]): F[Unit] =
-    handleIo(stream.write(bytes), ByteArrayWriteFailed.apply)
+    handleIo(stream.write(bytes), StreamWriteFailed.apply)
 
   def flush: F[Unit] =
     handleIo(stream.flush(), StreamFlushFailed.apply)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileOutputStreamIO.scala
@@ -7,7 +7,8 @@ import cats.effect.Sync
 import cats.syntax.functor._
 import coop.rchain.blockstorage.util.io.IOError.IOErr
 
-final case class FileOutputStreamIO[F[_]: Sync] private (private val stream: FileOutputStream) extends AutoCloseable {
+final case class FileOutputStreamIO[F[_]: Sync] private (private val stream: FileOutputStream)
+    extends AutoCloseable {
   def write(bytes: Array[Byte]): F[IOErr[Unit]] =
     handleIo(stream.write(bytes), ByteArrayWriteFailed.apply)
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -5,34 +5,35 @@ import java.nio.file.Path
 
 import cats.effect.Sync
 import cats.implicits._
-import IOError.IOErr
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 
 import scala.language.higherKinds
 
-final case class RandomAccessIO[F[_]: Sync] private (private val file: RandomAccessFile)
-    extends AutoCloseable {
-  def close(): F[IOErr[Unit]] =
+final case class RandomAccessIO[F[_]: Sync: RaiseIOError] private (
+    private val file: RandomAccessFile
+) {
+  def close: F[Unit] =
     handleIo(file.close(), ClosingFailed.apply)
 
-  def write(bytes: Array[Byte]): F[IOErr[Unit]] =
+  def write(bytes: Array[Byte]): F[Unit] =
     handleIo(file.write(bytes), ByteArrayWriteFailed.apply)
 
-  def writeInt(v: Int): F[IOErr[Unit]] =
+  def writeInt(v: Int): F[Unit] =
     handleIo(file.writeInt(v), IntWriteFailed.apply)
 
-  def readInt: F[IOErr[Int]] =
+  def readInt: F[Int] =
     handleIo(file.readInt(), IntReadFailed.apply)
 
-  def readFully(buffer: Array[Byte]): F[IOErr[Unit]] =
+  def readFully(buffer: Array[Byte]): F[Unit] =
     handleIo(file.readFully(buffer), ByteArrayReadFailed.apply)
 
-  def length: F[IOErr[Long]] =
+  def length: F[Long] =
     handleIo(file.length(), UnexpectedIOError.apply)
 
-  def seek(offset: Long): F[IOErr[Unit]] =
+  def seek(offset: Long): F[Unit] =
     handleIo(file.seek(offset), FileSeekFailed.apply)
 
-  def setLength(length: Long): F[IOErr[Unit]] =
+  def setLength(length: Long): F[Unit] =
     handleIo(file.setLength(length), SetLengthFailed.apply)
 }
 
@@ -42,9 +43,9 @@ object RandomAccessIO {
   case object Write     extends Mode("w")
   case object ReadWrite extends Mode("rw")
 
-  def open[F[_]: Sync](path: Path, mode: Mode): F[IOErr[RandomAccessIO[F]]] =
+  def open[F[_]: Sync: RaiseIOError](path: Path, mode: Mode): F[RandomAccessIO[F]] =
     handleIo(new RandomAccessFile(path.toFile, mode.representation), {
       case e: FileNotFoundException => FileNotFound(e)
       case e                        => UnexpectedIOError(e)
-    }).map(_.right.map(RandomAccessIO.apply[F]))
+    }).map(RandomAccessIO.apply[F])
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -19,6 +19,7 @@ final case class IntWriteFailed(exception: IOException)                     exte
 final case class ByteArrayWriteFailed(exception: IOException)               extends IOError
 final case class SetLengthFailed(exception: IOException)                    extends IOError
 final case class ClosingFailed(exception: IOException)                      extends IOError
+final case class StreamFlushFailed(e: IOException)                          extends IOError
 final case class FileNotFound(exception: FileNotFoundException)             extends IOError
 final case class FileSecurityViolation(exception: SecurityException)        extends IOError
 final case class FileIsNotDirectory(exception: NotDirectoryException)       extends IOError

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -26,6 +26,9 @@ final case class FileAlreadyExists(e: FileAlreadyExistsException)           exte
 final case class DirectoryNotEmpty(e: DirectoryNotEmptyException)           extends IOError
 final case class AtomicMoveNotSupported(e: AtomicMoveNotSupportedException) extends IOError
 final case class EndOfFile(e: EOFException)                                 extends IOError
+final case class StreamWriteFailed(e: IOException)                          extends IOError
+final case class FileReadFailed(e: IOException)                             extends IOError
+final case class FileWriteFailed(e: IOException)                            extends IOError
 final case class UnexpectedIOError(throwable: Throwable)                    extends IOError
 
 final case class UnavailableReferencedCheckpoint(checkpointIndex: Int) extends IOError
@@ -104,6 +107,15 @@ object IOError {
       case UnexpectedIOError(t) =>
         val msg = Option(t.getMessage).getOrElse("")
         s"Unexpected IO error occurred: $msg"
+      case StreamWriteFailed(t) =>
+        val msg = Option(t.getMessage).getOrElse("")
+        s"Stream write failed: $msg"
+      case FileReadFailed(t) =>
+        val msg = Option(t.getMessage).getOrElse("")
+        s"File read failed: $msg"
+      case FileWriteFailed(t) =>
+        val msg = Option(t.getMessage).getOrElse("")
+        s"File write failed: $msg"
       case UnavailableReferencedCheckpoint(checkpointIndex) =>
         s"Unavailable checkpoint: $checkpointIndex"
     }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -1,6 +1,6 @@
 package coop.rchain.blockstorage.util.io
 
-import java.io.{FileNotFoundException, IOException}
+import java.io.{EOFException, FileNotFoundException, IOException}
 import java.nio.file.{
   AtomicMoveNotSupportedException,
   DirectoryNotEmptyException,
@@ -24,9 +24,11 @@ final case class FileNotFound(exception: FileNotFoundException)             exte
 final case class FileSecurityViolation(exception: SecurityException)        extends IOError
 final case class FileIsNotDirectory(exception: NotDirectoryException)       extends IOError
 final case class UnsupportedFileOperation(e: UnsupportedOperationException) extends IOError
+final case class IllegalFileOperation(e: IllegalArgumentException)          extends IOError
 final case class FileAlreadyExists(e: FileAlreadyExistsException)           extends IOError
 final case class DirectoryNotEmpty(e: DirectoryNotEmptyException)           extends IOError
 final case class AtomicMoveNotSupported(e: AtomicMoveNotSupportedException) extends IOError
+final case class EndOfFile(e: EOFException)                                 extends IOError
 final case class UnexpectedIOError(throwable: Throwable)                    extends IOError
 
 object IOError {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/errors.scala
@@ -71,6 +71,9 @@ object IOError {
       case ClosingFailed(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"File closing failed: $msg"
+      case StreamFlushFailed(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Stream flush failed: $msg"
       case FileNotFound(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"File not found: $msg"
@@ -80,6 +83,24 @@ object IOError {
       case FileIsNotDirectory(e) =>
         val msg = Option(e.getMessage).getOrElse("")
         s"File is not a directory: $msg"
+      case UnsupportedFileOperation(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Unsupported file operation: $msg"
+      case IllegalFileOperation(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Illegal file operation: $msg"
+      case FileAlreadyExists(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"File already exists: $msg"
+      case DirectoryNotEmpty(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Directory is not empty: $msg"
+      case AtomicMoveNotSupported(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"Atomic move is not supported: $msg"
+      case EndOfFile(e) =>
+        val msg = Option(e.getMessage).getOrElse("")
+        s"End of file: $msg"
       case UnexpectedIOError(t) =>
         val msg = Option(t.getMessage).getOrElse("")
         s"Unexpected IO error occurred: $msg"

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain.blockstorage.util
 
-import java.io.{EOFException, IOException}
+import java.io.IOException
 import java.nio.file._
 import java.util.stream.Collectors
 
@@ -9,6 +9,7 @@ import cats.effect.Sync
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 package object io {
   private[io] def handleIo[F[_]: Sync: RaiseIOError, A](
@@ -27,7 +28,7 @@ package object io {
           RaiseIOError[F].raise[A](UnsupportedFileOperation(e))
         case e: IllegalArgumentException =>
           RaiseIOError[F].raise[A](IllegalFileOperation(e))
-        case e =>
+        case NonFatal(e) =>
           RaiseIOError[F].raise[A](UnexpectedIOError(e))
       }
     }.flatten
@@ -48,7 +49,7 @@ package object io {
           RaiseIOError[F].raise[A](UnsupportedFileOperation(e))
         case e: IllegalArgumentException =>
           RaiseIOError[F].raise[A](IllegalFileOperation(e))
-        case e =>
+        case NonFatal(e) =>
           RaiseIOError[F].raise[A](UnexpectedIOError(e))
       }
     }.flatten
@@ -66,7 +67,7 @@ package object io {
           DirectoryNotEmpty(e)
         case e: AtomicMoveNotSupportedException =>
           AtomicMoveNotSupported(e)
-        case e =>
+        case NonFatal(e) =>
           UnexpectedIOError(e)
       }
     )

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -109,8 +109,8 @@ package object io {
     handleIo(Files.createFile(filePath), UnexpectedIOError.apply)
 
   def writeToFile[F[_]: Sync: RaiseIOError](filePath: Path, bytes: Array[Byte]): F[Path] =
-    handleIo(Files.write(filePath, bytes), ByteArrayWriteFailed.apply)
+    handleIo(Files.write(filePath, bytes), FileWriteFailed.apply)
 
   def readAllBytesFromFile[F[_]: Sync: RaiseIOError](filePath: Path): F[Array[Byte]] =
-    handleIo(Files.readAllBytes(filePath), ByteArrayReadFailed.apply)
+    handleIo(Files.readAllBytes(filePath), FileReadFailed.apply)
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -47,7 +47,7 @@ trait BlockStoreTest
       withStore { store =>
         val items = blockStoreElements
         for {
-          _ <- items.traverse_(store.put(_))
+          _ <- items.traverse_(store.put)
           _ <- items.traverse[Task, Assertion] { block =>
                 store.get(block.blockHash).map(_ shouldBe Some(block))
               }
@@ -62,7 +62,7 @@ trait BlockStoreTest
       withStore { store =>
         val items = blockStoreElements
         for {
-          _ <- items.traverse_(store.put(_))
+          _ <- items.traverse_(store.put)
           _ <- items.traverse[Task, Assertion] { block =>
                 store.find(_ == ByteString.copyFrom(block.blockHash.toByteArray)).map { w =>
                   w should have size 1

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -14,7 +14,6 @@ import coop.rchain.models.blockImplicits.{blockBatchesGen, blockElementGen, bloc
 import cats.effect.Sync
 import coop.rchain.catscontrib.Capture.taskCapture
 import coop.rchain.blockstorage.InMemBlockStore.emptyMapRef
-import coop.rchain.blockstorage.StorageError.StorageIOErr
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.catscontrib.TaskContrib._
@@ -83,11 +82,11 @@ trait BlockStoreTest
           (block.blockHash, block, toBlockMessage(block.blockHash, 200L, 20000L))
         }
         for {
-          _ <- items.traverse_[Task, StorageIOErr[Unit]] { case (k, v1, _) => store.put(k, v1) }
+          _ <- items.traverse_[Task, Unit] { case (k, v1, _) => store.put(k, v1) }
           _ <- items.traverse_[Task, Assertion] {
                 case (k, v1, _) => store.get(k).map(_ shouldBe Some(v1))
               }
-          _ <- items.traverse_[Task, StorageIOErr[Unit]] { case (k, _, v2) => store.put(k, v2) }
+          _ <- items.traverse_[Task, Unit] { case (k, _, v2) => store.put(k, v2) }
           _ <- items.traverse_[Task, Assertion] {
                 case (k, _, v2) => store.get(k).map(_ shouldBe Some(v2))
               }
@@ -204,7 +203,7 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
       withStoreLocation { blockStoreDataDir =>
         for {
           firstStore  <- createBlockStore(blockStoreDataDir)
-          _           <- blockStoreElements.traverse_[Task, StorageIOErr[Unit]](firstStore.put)
+          _           <- blockStoreElements.traverse_[Task, Unit](firstStore.put)
           _           <- firstStore.close()
           secondStore <- createBlockStore(blockStoreDataDir)
           _ <- blockStoreElements.traverse[Task, Assertion] { block =>
@@ -223,9 +222,9 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
         val (firstHalf, secondHalf) = blockStoreElements.splitAt(blockStoreElements.size / 2)
         for {
           firstStore <- createBlockStore(blockStoreDataDir)
-          _          <- firstHalf.traverse_[Task, StorageIOErr[Unit]](firstStore.put)
+          _          <- firstHalf.traverse_[Task, Unit](firstStore.put)
           _          <- firstStore.checkpoint()
-          _          <- secondHalf.traverse_[Task, StorageIOErr[Unit]](firstStore.put)
+          _          <- secondHalf.traverse_[Task, Unit](firstStore.put)
           _ <- blockStoreElements.traverse[Task, Assertion] { block =>
                 firstStore.get(block.blockHash).map(_ shouldBe Some(block))
               }
@@ -248,10 +247,10 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
         val blocks = blockStoreBatches.flatten
         for {
           firstStore <- createBlockStore(blockStoreDataDir)
-          _ <- blockStoreBatches.traverse_[Task, StorageIOErr[Unit]](
+          _ <- blockStoreBatches.traverse_[Task, Unit](
                 blockStoreElements =>
                   blockStoreElements
-                    .traverse_[Task, StorageIOErr[Unit]](firstStore.put) *> firstStore.checkpoint()
+                    .traverse_[Task, Unit](firstStore.put) *> firstStore.checkpoint()
               )
           _ <- blocks.traverse[Task, Assertion] { block =>
                 firstStore.get(block.blockHash).map(_ shouldBe Some(block))

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -214,7 +214,7 @@ object HashSetCasperTestNode {
                             blockDagDir.resolve("checkpoints")
                           ),
                           genesis
-                        )(Monad[F], Concurrent[F], Sync[F], Log[F], blockStore)
+                        )(Concurrent[F], Sync[F], Capture[F], Log[F], blockStore)
       blockProcessingLock <- Semaphore[F](1)
       casperState         <- Cell.mvarCell[F, CasperState](CasperState())
       node = new HashSetCasperTestNode[F](
@@ -306,7 +306,7 @@ object HashSetCasperTestNode {
                                     blockDagDir.resolve("checkpoints")
                                   ),
                                   genesis
-                                )(Monad[F], Concurrent[F], Sync[F], Log[F], blockStore)
+                                )(Concurrent[F], Sync[F], Capture[F], Log[F], blockStore)
               semaphore <- Semaphore[F](1)
               casperState <- Cell.mvarCell[F, CasperState](
                               CasperState()


### PR DESCRIPTION
## Overview
Various improvements to DAG storage implementation such as migration to pure IO wrappers (instead of using Java IO directly), fixing locking issues and using MonadState instead of Ref to represent internal DAG storage state.

A duplicate of #2174 but with dev branch as a base.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-659


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
