### PR TITLE
Use GCA instead of LFB in estimator 

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -7,7 +7,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.util.BlockMessageUtil
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.casper.util.DagOperations
+import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.weightFromValidatorByDag
 
 import scala.collection.immutable.{Map, Set}
@@ -21,36 +21,52 @@ object Estimator {
 
   def tips[F[_]: Monad: BlockStore](
       blockDag: BlockDagRepresentation[F],
-      lastFinalizedBlockHash: BlockHash
+      genesis: BlockMessage
   ): F[IndexedSeq[BlockMessage]] =
     for {
       latestMessageHashes <- blockDag.latestMessageHashes
-      result              <- Estimator.tips[F](blockDag, lastFinalizedBlockHash, latestMessageHashes)
+      result              <- Estimator.tips[F](blockDag, genesis, latestMessageHashes)
     } yield result
 
   /**
     * When the BlockDag has an empty latestMessages, tips will return IndexedSeq(genesis)
     *
-    * TODO: If the base block between the main parent and a secondary parent are more than
-    * X blocks deep from the main parent, ignore. Additionally, the last finalized block must
-    * be deeper than X blocks from the tip. This allows different validators to have
-    * different last finalized blocks and still come up with the same estimator tips for a block.
+    * TODO: Remove lastFinalizedBlockHash in follow up PR
     */
   def tips[F[_]: Monad: BlockStore](
       blockDag: BlockDagRepresentation[F],
-      lastFinalizedBlockHash: BlockHash,
+      genesis: BlockMessage,
       latestMessagesHashes: Map[Validator, BlockHash]
   ): F[IndexedSeq[BlockMessage]] =
     for {
-      scoresMap <- buildScoresMap(blockDag, latestMessagesHashes, lastFinalizedBlockHash)
+      gca       <- calculateGca(blockDag, genesis, latestMessagesHashes)
+      scoresMap <- buildScoresMap(blockDag, latestMessagesHashes, gca)
       sortedChildrenHash <- sortChildren(
-                             List(lastFinalizedBlockHash),
+                             List(gca),
                              blockDag,
                              scoresMap
                            )
       maybeSortedChildren <- sortedChildrenHash.traverse(BlockStore[F].get)
       sortedChildren      = maybeSortedChildren.flatten.toVector
     } yield sortedChildren
+
+  private def calculateGca[F[_]: Monad: BlockStore](
+      blockDag: BlockDagRepresentation[F],
+      genesis: BlockMessage,
+      latestMessagesHashes: Map[Validator, BlockHash]
+  ): F[BlockHash] =
+    for {
+      latestMessages <- latestMessagesHashes.values.toList
+                         .traverse(hash => ProtoUtil.unsafeGetBlock[F](hash))
+      result <- if (latestMessages.isEmpty) {
+                 genesis.pure[F]
+               } else {
+                 latestMessages.foldM(latestMessages.head) {
+                   case (acc, latestMessage) =>
+                     DagOperations.greatestCommonAncestorF[F](acc, latestMessage, genesis, blockDag)
+                 }
+               }
+    } yield result.blockHash
 
   private def buildScoresMap[F[_]: Monad](
       blockDag: BlockDagRepresentation[F],
@@ -168,7 +184,7 @@ object Estimator {
   ): F[List[BlockHash]] =
     blockDag.children(b).map(_.getOrElse(Set.empty[BlockHash]).filter(scores.contains)).map {
       case c if c.nonEmpty => c.toList
-      case _            => List(b)
+      case _               => List(b)
     }
 
   private def stillSame(blocks: List[BlockHash], newBlocks: List[BlockHash]): Boolean =

--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -166,9 +166,10 @@ object Estimator {
       blockDag: BlockDagRepresentation[F],
       scores: Map[BlockHash, Long]
   ): F[List[BlockHash]] =
-    for {
-      c <- blockDag.children(b).map(_.getOrElse(Set.empty[BlockHash]).filter(scores.contains))
-    } yield if (c.nonEmpty) c.toList else List(b)
+    blockDag.children(b).map(_.getOrElse(Set.empty[BlockHash]).filter(scores.contains)).map {
+      case c if c.nonEmpty => c.toList
+      case _            => List(b)
+    }
 
   private def stillSame(blocks: List[BlockHash], newBlocks: List[BlockHash]): Boolean =
     newBlocks == blocks

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -177,8 +177,7 @@ object Validate {
       block: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F],
-      shardId: String,
-      lastFinalizedBlockHash: BlockHash
+      shardId: String
   ): F[Either[BlockStatus, ValidBlock]] =
     for {
       blockHashStatus   <- Validate.blockHash[F](block)
@@ -199,7 +198,7 @@ object Validate {
                         _ => Validate.justificationFollows[F](block, genesis, dag)
                       )
       parentsStatus <- followsStatus.joinRight.traverse(
-                        _ => Validate.parents[F](block, lastFinalizedBlockHash, dag)
+                        _ => Validate.parents[F](block, genesis, dag)
                       )
       sequenceNumberStatus <- parentsStatus.joinRight.traverse(
                                _ => Validate.sequenceNumber[F](block, dag)
@@ -422,18 +421,18 @@ object Validate {
     */
   def parents[F[_]: Monad: Log: BlockStore](
       b: BlockMessage,
-      lastFinalizedBlockHash: BlockHash,
+      genesis: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Either[InvalidBlock, ValidBlock]] = {
     val maybeParentHashes = ProtoUtil.parentHashes(b)
     val parentHashes = maybeParentHashes match {
-      case hashes if hashes.isEmpty => Seq(lastFinalizedBlockHash)
+      case hashes if hashes.isEmpty => Seq(genesis.blockHash)
       case hashes                   => hashes
     }
 
     for {
       latestMessagesHashes <- ProtoUtil.toLatestMessageHashes(b.justifications).pure[F]
-      estimate             <- Estimator.tips[F](dag, lastFinalizedBlockHash, latestMessagesHashes)
+      estimate             <- Estimator.tips[F](dag, genesis, latestMessagesHashes)
       computedParents      <- ProtoUtil.chooseNonConflicting[F](estimate.take(1), dag)
       computedParentHashes = computedParents.map(_.blockHash)
       status <- if (parentHashes == computedParentHashes)

--- a/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
@@ -95,9 +95,13 @@ object DagOperations {
     })
   }
 
-  //Conceptually, the GCA is the first point at which the histories of b1 and b2 diverge.
-  //Based on that, we compute by finding the first block from genesis for which there
-  //exists a child of that block which is an ancestor of b1 or b2 but not both.
+  /**
+    * Conceptually, the GCA is the first point at which the histories of b1 and b2 diverge.
+    * We compute by finding the first block from genesis for which there exists a child of that block which is an ancestor of b1 or b2 but not both.
+    *
+    * TODO: Implement a GCA that doesn't require the genesis block (see https://rchain.atlassian.net/browse/RCHAIN-3002)
+    * TODO: Remove usage of BlockStore by just using BlockDagRepresentation (see https://rchain.atlassian.net/browse/RCHAIN-3003)
+    */
   def greatestCommonAncestorF[F[_]: Monad: BlockStore](
       b1: BlockMessage,
       b2: BlockMessage,

--- a/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ForkchoiceTest.scala
@@ -72,7 +72,7 @@ class ForkchoiceTest
         dag <- blockDagStorage.getRepresentation
         forkchoice <- Estimator.tips[Task](
                        dag,
-                       genesis.blockHash,
+                       genesis,
                        Map.empty[Validator, BlockHash]
                      )
       } yield forkchoice.head should be(genesis)
@@ -137,7 +137,7 @@ class ForkchoiceTest
         )
         forkchoice <- Estimator.tips[Task](
                        dag,
-                       genesis.blockHash,
+                       genesis,
                        latestBlocks
                      )
         _      = forkchoice.head should be(b6)
@@ -207,7 +207,7 @@ class ForkchoiceTest
         )
         forkchoice <- Estimator.tips[Task](
                        dag,
-                       genesis.blockHash,
+                       genesis,
                        latestBlocks
                      )
         _      = forkchoice.head should be(b8)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -993,7 +993,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield ()
   }
 
-  it should "estimate parent properly" ignore effectTest {
+  it should "estimate parent properly" in effectTest {
     val (otherSk, otherPk)          = Ed25519.newKeyPair
     val (validatorKeys, validators) = (1 to 5).map(_ => Ed25519.newKeyPair).unzip
     val (ethPivKeys, ethPubKeys)    = (1 to 5).map(_ => Secp256k1.newKeyPair).unzip

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -70,7 +70,7 @@ class ManyValidatorsTest
                            )
       newIndexedBlockDagStorage <- IndexedBlockDagStorage.create(newBlockDagStorage)
       dag                       <- newIndexedBlockDagStorage.getRepresentation
-      tips                      <- Estimator.tips[Task](dag, genesis.blockHash)(Monad[Task], blockStore)
+      tips                      <- Estimator.tips[Task](dag, genesis)(Monad[Task], blockStore)
       casperEffect <- NoOpsCasperEffect[Task](
                        HashMap.empty[BlockHash, BlockMessage],
                        tips.toIndexedSeq

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -392,18 +392,18 @@ class ValidateTest
                        dag <- blockDagStorage.getRepresentation
 
                        // Valid
-                       _ <- Validate.parents[Task](b0, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b1, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b2, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b3, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b4, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b5, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b6, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b0, b0, dag)
+                       _ <- Validate.parents[Task](b1, b0, dag)
+                       _ <- Validate.parents[Task](b2, b0, dag)
+                       _ <- Validate.parents[Task](b3, b0, dag)
+                       _ <- Validate.parents[Task](b4, b0, dag)
+                       _ <- Validate.parents[Task](b5, b0, dag)
+                       _ <- Validate.parents[Task](b6, b0, dag)
 
                        // Not valid
-                       _ <- Validate.parents[Task](b7, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b8, b0.blockHash, dag)
-                       _ <- Validate.parents[Task](b9, b0.blockHash, dag)
+                       _ <- Validate.parents[Task](b7, b0, dag)
+                       _ <- Validate.parents[Task](b8, b0, dag)
+                       _ <- Validate.parents[Task](b9, b0, dag)
 
                        _ = log.warns.size should be(3)
                        result = log.warns.forall(
@@ -436,8 +436,7 @@ class ValidateTest
               signedBlock,
               BlockMessage.defaultInstance,
               dag,
-              "rchain",
-              BlockMessage.defaultInstance.blockHash
+              "rchain"
             ) shouldBeF Left(InvalidBlockNumber)
         result = log.warns.size should be(1)
       } yield result

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -78,7 +78,7 @@ class BlocksResponseAPITest
                HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
              )
         dag  <- blockDagStorage.getRepresentation
-        tips <- Estimator.tips[Task](dag, genesis.blockHash)
+        tips <- Estimator.tips[Task](dag, genesis)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
@@ -144,7 +144,7 @@ class BlocksResponseAPITest
                HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
              )
         dag  <- blockDagStorage.getRepresentation
-        tips <- Estimator.tips[Task](dag, genesis.blockHash)
+        tips <- Estimator.tips[Task](dag, genesis)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
@@ -210,7 +210,7 @@ class BlocksResponseAPITest
              HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
            )
       dag  <- blockDagStorage.getRepresentation
-      tips <- Estimator.tips[Task](dag, genesis.blockHash)
+      tips <- Estimator.tips[Task](dag, genesis)
       casperEffect <- NoOpsCasperEffect[Task](
                        HashMap.empty[BlockHash, BlockMessage],
                        tips


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

The issue for the invalid parents right now is that the last finalized block for each validator is different. And so it is possible that even though you know that the main chain will eventually settle on a certain block B, another validator might add a block that uses something before B as a parent.
So for the purposes of calculating GHOST, we don't need a last finalized block as much as a greatest common ancestor block of all validators. The GCA block could be either before or after the last finalized block on the main chain. The GCA block may surprisingly also not be in the main chain eventually.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-2909

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
