### PR TITLE
Use cost type in the matcher monad

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
@@ -21,7 +21,7 @@ object CostAccounting {
 
   def apply[F[_]](implicit ev: CostAccounting[F]): CostAccounting[F] = ev
 
-  def unsafe[F[_]: Monad](init: Cost)(implicit F: Sync[F]): CostAccounting[F] = {
+  def unsafe[F[_]](init: Cost)(implicit F: Sync[F]): CostAccounting[F] = {
     val ref = Ref.unsafe[F, Cost](init)
     new CostAccountingImpl[F](ref)
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -54,7 +54,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
       runFirst[M, Unit](doMatch).onError {
         case OutOfPhlogistonsError =>
           // if we run out of phlos during the match we have to zero phlos available
-          cost.get.flatMap(ca => charge[M](ca))
+          cost.modify(_ => Cost(0))
       }
 
     matchAndCharge

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -51,11 +51,11 @@ object SpatialMatcher extends SpatialMatcherInstances {
     val doMatch: R[Unit] = SpatialMatcher.spatialMatch[R, Par, Par](target, pattern)
 
     val matchAndCharge: M[Option[(FreeMap, Unit)]] =
-      runFirstWithCost[M, Unit](doMatch).onError {
-                 case OutOfPhlogistonsError =>
-                   // if we run out of phlos during the match we have to zero phlos available
-                   cost.get.flatMap(ca => charge[M](ca))
-               }
+      runFirst[M, Unit](doMatch).onError {
+        case OutOfPhlogistonsError =>
+          // if we run out of phlos during the match we have to zero phlos available
+          cost.get.flatMap(ca => charge[M](ca))
+      }
 
     matchAndCharge
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -50,17 +50,12 @@ object SpatialMatcher extends SpatialMatcherInstances {
 
     val doMatch: R[Unit] = SpatialMatcher.spatialMatch[R, Par, Par](target, pattern)
 
-    val matchAndCharge: M[Option[(FreeMap, Unit)]] = for {
-      phlosAvailable <- cost.get
-      result <- runFirstWithCost[M, Unit](doMatch).onError {
+    val matchAndCharge: M[Option[(FreeMap, Unit)]] =
+      runFirstWithCost[M, Unit](doMatch).onError {
                  case OutOfPhlogistonsError =>
                    // if we run out of phlos during the match we have to zero phlos available
                    cost.get.flatMap(ca => charge[M](ca))
                }
-      (phlosLeft, matchResult) = result
-      matchCost                = phlosAvailable - phlosLeft
-      _                        <- charge[M](matchCost)
-    } yield matchResult
 
     matchAndCharge
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -52,7 +52,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
 
     val matchAndCharge: M[Option[(FreeMap, Unit)]] = for {
       phlosAvailable <- cost.get
-      result <- runFirstWithCost[M, Unit](doMatch, phlosAvailable).onError {
+      result <- runFirstWithCost[M, Unit](doMatch).onError {
                  case OutOfPhlogistonsError =>
                    // if we run out of phlos during the match we have to zero phlos available
                    cost.get.flatMap(ca => charge[M](ca))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -51,11 +51,7 @@ object SpatialMatcher extends SpatialMatcherInstances {
     val doMatch: R[Unit] = SpatialMatcher.spatialMatch[R, Par, Par](target, pattern)
 
     val matchAndCharge: M[Option[(FreeMap, Unit)]] =
-      runFirst[M, Unit](doMatch).onError {
-        case OutOfPhlogistonsError =>
-          // if we run out of phlos during the match we have to zero phlos available
-          cost.modify(_ => Cost(0))
-      }
+      runFirst[M, Unit](doMatch)
 
     matchAndCharge
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -24,8 +24,7 @@ package object matcher {
   type Err[A]                   = Either[InterpreterError, A]
 
   // MatcherMonadT[Err, A] is equivalent to NonDetFreeMapWithCost[A]. Scalac is too dumb to notice though.
-  type MatcherMonadT[F[_], A]   = StateT[StreamT[F, ?], FreeMap, A]
-  type StreamWithCostT[F[_], A] = StreamT[StateT[F, Cost, ?], A]
+  type MatcherMonadT[F[_], A] = StateT[StreamT[F, ?], FreeMap, A]
 
   // The naming convention means: this is an effect-type alias.
   // Will be used similarly to capabilities, but for more generic and probably low-level/implementation stuff.

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -23,7 +23,6 @@ package object matcher {
   type ErroredOrCost[A]         = StateT[Err, Cost, A]
   type Err[A]                   = Either[InterpreterError, A]
 
-  // MatcherMonadT[Err, A] is equivalent to NonDetFreeMapWithCost[A]. Scalac is too dumb to notice though.
   type MatcherMonadT[F[_], A] = StateT[StreamT[F, ?], FreeMap, A]
 
   // The naming convention means: this is an effect-type alias.

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -42,7 +42,7 @@ package object matcher {
   ): F[Stream[(FreeMap, A)]] =
     StreamT.run(f.run(emptyMap))
 
-  private[matcher] def runFirstWithCost[F[_]: Monad: _cost, A](
+  private[matcher] def runFirst[F[_]: Monad: _cost, A](
       f: MatcherMonadT[F, A]
   ): F[Option[(FreeMap, A)]] =
     for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -37,19 +37,17 @@ package object matcher {
   def _freeMap[F[_]](implicit ev: _freeMap[F]): _freeMap[F] = ev
   def _short[F[_]](implicit ev: _short[F]): _short[F]       = ev
 
-  private[matcher] def run[F[_]: Monad: _cost, A](
+  private[matcher] def run[F[_]: Monad, A](
       f: MatcherMonadT[F, A]
   ): F[Stream[(FreeMap, A)]] =
     StreamT.run(f.run(emptyMap))
 
-  private[matcher] def runFirst[F[_]: Monad: _cost, A](
+  private[matcher] def runFirst[F[_]: Monad, A](
       f: MatcherMonadT[F, A]
   ): F[Option[(FreeMap, A)]] =
-    for {
-      cost <- _cost[F].get
-      s <- StreamT
-            .run(StreamT.dropTail(f.run(emptyMap)))
-    } yield (s.headOption)
+    StreamT
+      .run(StreamT.dropTail(f.run(emptyMap)))
+      .map(_.headOption)
 
   private[matcher] def attemptOpt[F[_], A](
       f: F[A]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -44,12 +44,12 @@ package object matcher {
 
   private[matcher] def runFirstWithCost[F[_]: Monad: _cost, A](
       f: MatcherMonadT[F, A]
-  ): F[(Cost, Option[(FreeMap, A)])] =
+  ): F[Option[(FreeMap, A)]] =
     for {
       cost <- _cost[F].get
       s <- StreamT
             .run(StreamT.dropTail(f.run(emptyMap)))
-    } yield ((cost, s.headOption))
+    } yield (s.headOption)
 
   private[matcher] def attemptOpt[F[_], A](
       f: F[A]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -945,4 +945,18 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       Left(OutOfPhlogistonsError)
     )
   }
+
+  it should "charge for matching operations" in {
+    implicit val cost: _cost[Task] = CostAccounting.unsafe[Task](Cost(100))
+
+    val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
+    val pattern: Par =
+      EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
+
+    (for {
+      res      <- spatialMatchAndCharge[Task](target, pattern)
+      phloLeft <- cost.get
+    } yield (phloLeft.value shouldBe 90)).unsafeRunSync
+
+  }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -959,4 +959,21 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     } yield (phloLeft.value shouldBe 90)).unsafeRunSync
 
   }
+
+  it should "not finish with a negative cost" in {
+    implicit val cost: _cost[Task] = CostAccounting.unsafe[Task](Cost(8))
+
+    val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
+    val pattern: Par =
+      EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
+
+    spatialMatchAndCharge[Task](target, pattern).attempt.unsafeRunSync should be(
+      Left(OutOfPhlogistonsError)
+    )
+
+    (for {
+      phloLeft <- cost.get
+    } yield (phloLeft.value shouldBe 0)).unsafeRunSync
+
+  }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -5,6 +5,8 @@ import cats.mtl.implicits._
 import cats.{Eval => _}
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.MonadError_._
+import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
@@ -12,10 +14,11 @@ import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.PrettyPrinter
-import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, OutOfPhlogistonsError}
 import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
-import monix.eval.Coeval
+import monix.eval.{Coeval, Task}
+import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatest._
 import org.scalatest.concurrent.TimeLimits
@@ -922,12 +925,24 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     assertSpatialMatch(failTarget, pattern, None)
   }
 
-  "Spatial matcher" should "short-circuit when runs out of phlo in the middle of matching" in {
+  "spatialMatch" should "short-circuit when runs out of phlo in the middle of matching" in {
     val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
     val pattern: Par =
       EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
     val res =
       spatialMatch[NonDetFreeMapWithCost, Par, Par](target, pattern).runFirstWithCost(Cost(0))
     res should be(Left(OutOfPhlogistonsError))
+  }
+
+  "spatialMatchAndCharge" should "short-circuit when runs out of phlo in the middle of matching" in {
+    implicit val cost: _cost[Task] = CostAccounting.unsafe[Task](Cost(0))
+
+    val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
+    val pattern: Par =
+      EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
+
+    spatialMatchAndCharge[Task](target, pattern).attempt.unsafeRunSync should be(
+      Left(OutOfPhlogistonsError)
+    )
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -960,7 +960,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
 
   }
 
-  it should "not finish with a negative cost" in {
+  it should "be allowed to finish with a negative cost" in {
     implicit val cost: _cost[Task] = CostAccounting.unsafe[Task](Cost(8))
 
     val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
@@ -973,7 +973,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
 
     (for {
       phloLeft <- cost.get
-    } yield (phloLeft.value shouldBe 0)).unsafeRunSync
+    } yield (phloLeft.value shouldBe -2)).unsafeRunSync
 
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -15,12 +15,12 @@ import coop.rchain.rholang.interpreter.accounting.CostAccounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.matcher.{run => runMatcher, _}
 import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
-import org.scalatest.FlatSpec
+import org.scalatest._
 
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
-class MatcherMonadSpec extends FlatSpec {
+class MatcherMonadSpec extends FlatSpec with Matchers {
 
   type F[A] = MatcherMonadT[Task, A]
 
@@ -137,11 +137,7 @@ class MatcherMonadSpec extends FlatSpec {
     val c: F[Int] = 3.pure[F]
 
     val combined = combineK(List(a, b, c))
-    (for {
-      res <- runMatcher(combined)
-    } yield (fail("Should have ran out of phlo"))).onErrorHandleWith {
-      case OutOfPhlogistonsError => Task.now(succeed)
-    }.unsafeRunSync
+    runMatcher(combined).attempt.unsafeRunSync shouldBe (Left(OutOfPhlogistonsError))
   }
 
   it should "charge for each branch as long as `charge` is before a short-circuit" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -1,20 +1,32 @@
 package coop.rchain.rholang.interpreter.matcher
 
+import cats._
+import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import cats.mtl.implicits._
 import cats.{Alternative, Foldable, MonoidK, SemigroupK}
+import coop.rchain.catscontrib.mtl.implicits._
+import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.accounting._
+import coop.rchain.rholang.interpreter.accounting.CostAccounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rholang.interpreter.matcher.{run => runMatcher, _}
 import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
 import org.scalatest.FlatSpec
 
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
 class MatcherMonadSpec extends FlatSpec {
 
-  type F[A] = NonDetFreeMapWithCost[A]
+  type F[A] = MatcherMonadT[Task, A]
 
   val A: Alternative[F] = Alternative[F]
+
+  implicit val cost: _cost[Task] = CostAccounting.unsafe[Task](Cost(0))
 
   private def combineK[FF[_]: MonoidK, G[_]: Foldable, A](gfa: G[FF[A]]): FF[A] =
     gfa.foldLeft(MonoidK[FF].empty[A])(SemigroupK[FF].combineK[A])
@@ -26,14 +38,22 @@ class MatcherMonadSpec extends FlatSpec {
     val possibleResults = Stream((0, 1), (0, 2))
     val computation     = Alternative[F].unite(possibleResults.pure[F])
     val sum             = computation.map { case (x, y) => x + y } <* charge[F](Cost(1))
-    val (cost, _)       = sum.runWithCost(Cost(possibleResults.size)).right.get
-    assert(cost.value == 0)
+    val t1 = (for {
+      _        <- cost.set(Cost(possibleResults.size))
+      _        <- runMatcher(sum)
+      phloLeft <- cost.get
+    } yield (assert(phloLeft.value == 0)))
 
     val moreVariants    = sum.flatMap(x => Alternative[F].unite(Stream(x, 0, -x).pure[F]))
     val moreComputation = moreVariants.map(x => "Do sth with " + x) <* charge[F](Cost(1))
-    val (cost2, _) =
-      moreComputation.runWithCost(Cost(possibleResults.size * 3 + possibleResults.size)).right.get
-    assert(cost2.value == 0)
+
+    val t2 = (for {
+      _        <- cost.set(Cost(possibleResults.size * 3 + possibleResults.size))
+      _        <- runMatcher(moreComputation)
+      phloLeft <- cost.get
+    } yield (assert(phloLeft.value == 0)))
+
+    t1 >> t2 unsafeRunSync
   }
 
   val modifyStates = for {
@@ -42,10 +62,14 @@ class MatcherMonadSpec extends FlatSpec {
   } yield ()
 
   it should "retain cost and matches when attemptOpt is called on successful match" in {
-    assert(
-      attemptOpt[F, Unit](modifyStates)
-        .runFirstWithCost(Cost(0)) == Right((Cost(1), Some((Map(42 -> Par()), Some(())))))
-    )
+    (for {
+      _        <- cost.set(Cost(0))
+      a        = attemptOpt(modifyStates)
+      res      <- runFirstWithCost(a)
+      (_, r)   = res
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 1)
+    } yield (assert(r == Some((Map(42 -> Par()), Some(())))))).unsafeRunSync
   }
 
   it should "retain cost but discard matches when attemptOpt is called on a match failed using _short" in {
@@ -54,10 +78,15 @@ class MatcherMonadSpec extends FlatSpec {
       _ <- _short[F].raiseError[Int](())
     } yield ()
 
-    assert(
-      attemptOpt[F, Unit](failed)
-        .runFirstWithCost(Cost(0)) == Right((Cost(1), Some((Map.empty, None))))
-    )
+    (for {
+      _        <- cost.set(Cost(0))
+      a        = attemptOpt[F, Unit](failed)
+      res      <- runFirstWithCost(a)
+      (_, r)   = res
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 1)
+    } yield (assert(r == Some((Map.empty, None))))).unsafeRunSync
+
   }
 
   it should "retain cost but discard matches when attemptOpt is called on a match failed using `guard`" in {
@@ -66,10 +95,15 @@ class MatcherMonadSpec extends FlatSpec {
       _ <- A.guard(false)
     } yield ()
 
-    assert(
-      attemptOpt[F, Unit](failed)
-        .runFirstWithCost(Cost(0)) == Right((Cost(1), Some((Map.empty, None))))
-    )
+    (for {
+      _        <- cost.set(Cost(0))
+      a        = attemptOpt[F, Unit](failed)
+      res      <- runFirstWithCost(a)
+      (_, r)   = res
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 1)
+    } yield (assert(r == Some((Map.empty, None))))).unsafeRunSync
+
   }
 
   it should "apply `guard`-s separately to each computation branch" in {
@@ -77,8 +111,13 @@ class MatcherMonadSpec extends FlatSpec {
     val b: F[Int] = A.guard(false) >> 2.pure[F]
     val c: F[Int] = A.guard(true) >> 3.pure[F]
 
-    val result = combineK(List(a, b, c)).runWithCost(Cost(0))
-    assert(result.right.get._2 == Stream((Map.empty, 1), (Map.empty, 3)))
+    (for {
+      _        <- cost.set(Cost(0))
+      combined = combineK(List(a, b, c))
+      res      <- runMatcher(combined)
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 0)
+    } yield (assert(res == Stream((Map.empty, 1), (Map.empty, 3))))).unsafeRunSync
   }
 
   it should "apply `_short[F].raiseError` separately to each computation branch" in {
@@ -86,8 +125,13 @@ class MatcherMonadSpec extends FlatSpec {
     val b: F[Int] = 2.pure[F]
     val c: F[Int] = 3.pure[F] >> _short[F].raiseError[Int](())
 
-    val result = combineK(List(a, b, c)).runWithCost(Cost(0))
-    assert(result.right.get._2 == Stream((Map.empty, 2)))
+    (for {
+      _        <- cost.set(Cost(0))
+      combined = combineK(List(a, b, c))
+      res      <- runMatcher(combined)
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 0)
+    } yield (assert(res == Stream((Map.empty, 2))))).unsafeRunSync
   }
 
   it should "fail all branches when using `_error[F].raise`" in {
@@ -95,8 +139,12 @@ class MatcherMonadSpec extends FlatSpec {
     val b: F[Int] = 2.pure[F] >> _error[F].raise[Int](OutOfPhlogistonsError)
     val c: F[Int] = 3.pure[F]
 
-    val result = combineK(List(a, b, c)).runWithCost(Cost(0))
-    assert(result == Left(OutOfPhlogistonsError))
+    val combined = combineK(List(a, b, c))
+    (for {
+      res <- runMatcher(combined)
+    } yield (fail("Should have ran out of phlo"))).onErrorHandleWith {
+      case OutOfPhlogistonsError => Task.now(succeed)
+    }.unsafeRunSync
   }
 
   it should "charge for each branch as long as `charge` is before a short-circuit" in {
@@ -108,8 +156,14 @@ class MatcherMonadSpec extends FlatSpec {
     val d: F[Unit] = charge[F](Cost(8)) >> _short[F].raiseError[Unit](())
     val e: F[Unit] = _short[F].raiseError[Int](()) >> charge[F](Cost(16))
 
-    val result = combineK(List(a, b, c, d, e)).runWithCost(Cost(1 + 2 + 8))
-    assert(result == Right((Cost(0), Stream((Map.empty, ())))))
+    (for {
+      _        <- cost.set(Cost(1 + 2 + 8))
+      combined = combineK(List(a, b, c, d, e))
+      res      <- runMatcher(combined)
+      phloLeft <- cost.get
+      _        = assert(phloLeft.value == 0)
+    } yield (assert(res == Stream((Map.empty, ()))))).unsafeRunSync
+
   }
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -66,10 +66,9 @@ class MatcherMonadSpec extends FlatSpec {
       _        <- cost.set(Cost(0))
       a        = attemptOpt(modifyStates)
       res      <- runFirstWithCost(a)
-      (_, r)   = res
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
-    } yield (assert(r == Some((Map(42 -> Par()), Some(())))))).unsafeRunSync
+    } yield (assert(res == Some((Map(42 -> Par()), Some(())))))).unsafeRunSync
   }
 
   it should "retain cost but discard matches when attemptOpt is called on a match failed using _short" in {
@@ -82,10 +81,9 @@ class MatcherMonadSpec extends FlatSpec {
       _        <- cost.set(Cost(0))
       a        = attemptOpt[F, Unit](failed)
       res      <- runFirstWithCost(a)
-      (_, r)   = res
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
-    } yield (assert(r == Some((Map.empty, None))))).unsafeRunSync
+    } yield (assert(res == Some((Map.empty, None))))).unsafeRunSync
 
   }
 
@@ -99,10 +97,9 @@ class MatcherMonadSpec extends FlatSpec {
       _        <- cost.set(Cost(0))
       a        = attemptOpt[F, Unit](failed)
       res      <- runFirstWithCost(a)
-      (_, r)   = res
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
-    } yield (assert(r == Some((Map.empty, None))))).unsafeRunSync
+    } yield (assert(res == Some((Map.empty, None))))).unsafeRunSync
 
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -65,7 +65,7 @@ class MatcherMonadSpec extends FlatSpec {
     (for {
       _        <- cost.set(Cost(0))
       a        = attemptOpt(modifyStates)
-      res      <- runFirstWithCost(a)
+      res      <- runFirst(a)
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
     } yield (assert(res == Some((Map(42 -> Par()), Some(())))))).unsafeRunSync
@@ -80,7 +80,7 @@ class MatcherMonadSpec extends FlatSpec {
     (for {
       _        <- cost.set(Cost(0))
       a        = attemptOpt[F, Unit](failed)
-      res      <- runFirstWithCost(a)
+      res      <- runFirst(a)
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
     } yield (assert(res == Some((Map.empty, None))))).unsafeRunSync
@@ -96,7 +96,7 @@ class MatcherMonadSpec extends FlatSpec {
     (for {
       _        <- cost.set(Cost(0))
       a        = attemptOpt[F, Unit](failed)
-      res      <- runFirstWithCost(a)
+      res      <- runFirst(a)
       phloLeft <- cost.get
       _        = assert(phloLeft.value == 1)
     } yield (assert(res == Some((Map.empty, None))))).unsafeRunSync


### PR DESCRIPTION
## Overview
Removes the StateT associated with the MatcherMonad and leverages usage of _cost type alias from F

### JIRA ticket:
Part of: https://rchain.atlassian.net/browse/RCHAIN-2985

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
