### PR TITLE
Make last finalized block calculation lazier

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -1,0 +1,74 @@
+package coop.rchain.casper
+
+import cats.Monad
+import cats.effect.{Concurrent, Sync}
+import cats.implicits._
+import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.shared.{Cell, Log}
+import coop.rchain.catscontrib.ListContrib
+
+object LastFinalizedBlockCalculator {
+  // TODO: Extract hardcoded fault tolerance threshold
+  private val faultToleranceThreshold = 0f
+
+  def run[F[_]: Monad: Log: Sync: Concurrent: BlockStore: BlockDagStorage: SafetyOracle](
+      dag: BlockDagRepresentation[F],
+      lastFinalizedBlockHash: BlockHash
+  )(implicit state: Cell[F, CasperState]): F[BlockHash] =
+    for {
+      maybeChildrenHashes <- dag.children(lastFinalizedBlockHash)
+      childrenHashes      = maybeChildrenHashes.getOrElse(Set.empty[BlockHash]).toList
+      maybeFinalizedChild <- ListContrib.findM(
+                              childrenHashes,
+                              (blockHash: BlockHash) =>
+                                isGreaterThanFaultToleranceThreshold(dag, blockHash)
+                            )
+      newFinalizedBlock <- maybeFinalizedChild match {
+                            case Some(finalizedChild) =>
+                              removeDeploysInFinalizedBlock[F](finalizedChild) *> run[F](
+                                dag,
+                                finalizedChild
+                              )
+                            case None => lastFinalizedBlockHash.pure[F]
+                          }
+    } yield newFinalizedBlock
+
+  private def removeDeploysInFinalizedBlock[F[_]: Monad: Log: Sync: Concurrent: BlockStore: BlockDagStorage: SafetyOracle](
+      finalizedChildHash: BlockHash
+  )(implicit state: Cell[F, CasperState]): F[Unit] =
+    for {
+      block              <- ProtoUtil.unsafeGetBlock[F](finalizedChildHash)
+      deploys            = block.body.get.deploys.map(_.deploy.get).toList
+      stateBefore        <- state.read
+      initialHistorySize = stateBefore.deployHistory.size
+      _ <- state.modify { s =>
+            s.copy(deployHistory = s.deployHistory -- deploys)
+          }
+      stateAfter     <- state.read
+      deploysRemoved = initialHistorySize - stateAfter.deployHistory.size
+      _ <- Log[F].info(
+            s"Removed $deploysRemoved deploys from deploy history as we finalized block ${PrettyPrinter
+              .buildString(finalizedChildHash)}."
+          )
+    } yield ()
+
+  /*
+   * On the first pass, block B is finalized if B's main parent block is finalized
+   * and the safety oracle says B's normalized fault tolerance is above the threshold.
+   * On the second pass, block B is finalized if any of B's children blocks are finalized.
+   *
+   * TODO: Implement the second pass in BlockAPI
+   */
+  private def isGreaterThanFaultToleranceThreshold[F[_]: Monad: Log: Sync: Concurrent: BlockStore: BlockDagStorage: SafetyOracle](
+      dag: BlockDagRepresentation[F],
+      blockHash: BlockHash
+  ): F[Boolean] =
+    for {
+      faultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, blockHash)
+      _ <- Log[F].info(
+            s"Fault tolerance for block ${PrettyPrinter.buildString(blockHash)} is $faultTolerance."
+          )
+    } yield faultTolerance > faultToleranceThreshold
+
+}

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -57,8 +57,6 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
 
   private val emptyStateHash = runtimeManager.emptyStateHash
 
-  // TODO: Extract hardcoded fault tolerance threshold
-  private val faultToleranceThreshold         = 0f
   private val lastFinalizedBlockHashContainer = Ref.unsafe[F, BlockHash](genesis.blockHash)
 
   def addBlock(
@@ -123,72 +121,14 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Capture: ConnectionsCell: Tr
             case _ =>
               reAttemptBuffer(updatedDag) // reAttempt for any status that resulted in the adding of the block into the view
           }
-      estimates                     <- estimator(updatedDag)
-      tip                           = estimates.head
-      _                             <- Log[F].info(s"New fork-choice tip is block ${PrettyPrinter.buildString(tip.blockHash)}.")
-      lastFinalizedBlockHash        <- lastFinalizedBlockHashContainer.get
-      updatedLastFinalizedBlockHash <- updateLastFinalizedBlock(updatedDag, lastFinalizedBlockHash)
-      _                             <- lastFinalizedBlockHashContainer.set(updatedLastFinalizedBlockHash)
+      estimates              <- estimator(updatedDag)
+      tip                    = estimates.head
+      _                      <- Log[F].info(s"New fork-choice tip is block ${PrettyPrinter.buildString(tip.blockHash)}.")
+      lastFinalizedBlockHash <- lastFinalizedBlockHashContainer.get
+      updatedLastFinalizedBlockHash <- LastFinalizedBlockCalculator
+                                        .run[F](dag, lastFinalizedBlockHash)
+      _ <- lastFinalizedBlockHashContainer.set(updatedLastFinalizedBlockHash)
     } yield attempt
-
-  private def updateLastFinalizedBlock(
-      dag: BlockDagRepresentation[F],
-      lastFinalizedBlockHash: BlockHash
-  ): F[BlockHash] =
-    for {
-      childrenHashes <- dag
-                         .children(lastFinalizedBlockHash)
-                         .map(_.getOrElse(Set.empty[BlockHash]).toList)
-      maybeFinalizedChild <- ListContrib.findM(
-                              childrenHashes,
-                              (blockHash: BlockHash) =>
-                                isGreaterThanFaultToleranceThreshold(dag, blockHash)
-                            )
-      newFinalizedBlock <- maybeFinalizedChild match {
-                            case Some(finalizedChild) =>
-                              removeDeploysInFinalizedBlock(finalizedChild) *> updateLastFinalizedBlock(
-                                dag,
-                                finalizedChild
-                              )
-                            case None => lastFinalizedBlockHash.pure[F]
-                          }
-    } yield newFinalizedBlock
-
-  private def removeDeploysInFinalizedBlock(finalizedChild: BlockHash): F[Unit] =
-    for {
-      b                  <- ProtoUtil.unsafeGetBlock[F](finalizedChild)
-      deploys            = b.body.get.deploys.map(_.deploy.get).toList
-      stateBefore        <- Cell[F, CasperState].read
-      initialHistorySize = stateBefore.deployHistory.size
-      _ <- Cell[F, CasperState].modify { s =>
-            s.copy(deployHistory = s.deployHistory -- deploys)
-          }
-
-      stateAfter     <- Cell[F, CasperState].read
-      deploysRemoved = initialHistorySize - stateAfter.deployHistory.size
-      _ <- Log[F].info(
-            s"Removed $deploysRemoved deploys from deploy history as we finalized block ${PrettyPrinter
-              .buildString(finalizedChild)}."
-          )
-    } yield ()
-
-  /*
-   * On the first pass, block B is finalized if B's main parent block is finalized
-   * and the safety oracle says B's normalized fault tolerance is above the threshold.
-   * On the second pass, block B is finalized if any of B's children blocks are finalized.
-   *
-   * TODO: Implement the second pass in BlockAPI
-   */
-  private def isGreaterThanFaultToleranceThreshold(
-      dag: BlockDagRepresentation[F],
-      blockHash: BlockHash
-  ): F[Boolean] =
-    for {
-      faultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, blockHash)
-      _ <- Log[F].info(
-            s"Fault tolerance for block ${PrettyPrinter.buildString(blockHash)} is $faultTolerance."
-          )
-    } yield faultTolerance > faultToleranceThreshold
 
   def contains(
       b: BlockMessage

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -426,12 +426,13 @@ object BlockAPI {
         case Some(hash) => hash
         case None       => ByteString.EMPTY
       }
-      timestamp                = header.timestamp
-      mainParent               = header.parentsHashList.headOption.getOrElse(ByteString.EMPTY)
-      parentsHashList          = header.parentsHashList
-      normalizedFaultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, block.blockHash)
-      initialFault             <- MultiParentCasper[F].normalizedInitialFault(ProtoUtil.weightMap(block))
-      bondsValidatorList       = ProtoUtil.bonds(block)
+      timestamp       = header.timestamp
+      mainParent      = header.parentsHashList.headOption.getOrElse(ByteString.EMPTY)
+      parentsHashList = header.parentsHashList
+      normalizedFaultTolerance <- SafetyOracle[F]
+                                   .normalizedFaultTolerance(dag, block.blockHash) // TODO: Warn about parent block finalization
+      initialFault       <- MultiParentCasper[F].normalizedInitialFault(ProtoUtil.weightMap(block))
+      bondsValidatorList = ProtoUtil.bonds(block)
       blockInfo <- constructor(
                     block,
                     version,
@@ -478,7 +479,7 @@ object BlockAPI {
         tupleSpaceHash = PrettyPrinter.buildStringNoLimit(tsHash),
         tupleSpaceDump = tsDesc,
         timestamp = timestamp,
-        faultTolerance = normalizedFaultTolerance - initialFault,
+        faultTolerance = normalizedFaultTolerance - initialFault, // TODO: Fix
         mainParentHash = PrettyPrinter.buildStringNoLimit(mainParent),
         parentsHashList = parentsHashList.map(PrettyPrinter.buildStringNoLimit),
         sender = PrettyPrinter.buildStringNoLimit(block.sender),


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

We previously attempted to update the last finalized block every block but now we only do
so when we are asked what the last finalized block is. This will make the vdag command a
bit slower but make block processing a lot faster. We also move last finalized block calculation
functions to its own object.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3006

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
