### PR TITLE
Implement grpc API responses as a custom Either message

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -1,60 +1,68 @@
 package coop.rchain.casper.api
 
+import scala.collection.immutable
+
 import cats.Monad
 import cats.effect.concurrent.Semaphore
-import cats.effect.Concurrent
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import com.google.protobuf.ByteString
+
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.casper._
 import coop.rchain.casper.Estimator.BlockHash
-import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
+import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.casper.util.{EventConverter, ProtoUtil}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.graphz._
 import coop.rchain.models.Par
-import coop.rchain.rspace.StableHashProvider
-import coop.rchain.rspace.trace.{COMM, Consume, Produce}
-import coop.rchain.shared.Log
-import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.models.rholang.sorter.Sortable._
+import coop.rchain.models.serialization.implicits.mkProtobufInstance
+import coop.rchain.rspace.StableHashProvider
+import coop.rchain.rspace.trace._
+import coop.rchain.shared.Log
 
-import scala.collection.immutable
-import coop.rchain.casper.util.EventConverter
-import coop.rchain.casper._
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.casper.util.ProtoUtil
+import com.google.protobuf.ByteString
 
 object BlockAPI {
 
-  def deploy[F[_]: Monad: MultiParentCasperRef: Log](d: DeployData): F[DeployServiceResponse] = {
-    def casperDeploy(implicit casper: MultiParentCasper[F]): F[DeployServiceResponse] =
+  type Error           = String
+  type ApiErr[A]       = Either[Error, A]
+  type Effect[F[_], A] = F[ApiErr[A]]
+
+  def deploy[F[_]: Monad: MultiParentCasperRef: Log](
+      d: DeployData
+  ): Effect[F, DeployServiceResponse] = {
+    def casperDeploy(
+        implicit casper: MultiParentCasper[F]
+    ): Effect[F, DeployServiceResponse] =
       for {
         r <- MultiParentCasper[F].deploy(d)
         re <- r match {
-               case Right(_)  => DeployServiceResponse(success = true, "Success!").pure[F]
-               case Left(err) => DeployServiceResponse(success = false, err.getMessage).pure[F]
+               case Right(_)  => DeployServiceResponse("Success!").asRight.pure[F]
+               case Left(err) => err.getMessage.asLeft.pure[F]
              }
       } yield re
 
     val errorMessage = "Could not deploy, casper instance was not available yet."
 
     MultiParentCasperRef
-      .withCasper[F, DeployServiceResponse](
+      .withCasper[F, ApiErr[DeployServiceResponse]](
         casperDeploy(_),
         Log[F]
           .warn(errorMessage)
-          .as(DeployServiceResponse(success = false, s"Error: $errorMessage"))
+          .as(s"Error: $errorMessage".asLeft)
       )
   }
 
   def createBlock[F[_]: Sync: Concurrent: MultiParentCasperRef: Log](
       blockApiLock: Semaphore[F]
-  ): F[DeployServiceResponse] = {
+  ): Effect[F, DeployServiceResponse] = {
     val errorMessage = "Could not create block, casper instance was not available yet."
-    MultiParentCasperRef.withCasper[F, DeployServiceResponse](
+    MultiParentCasperRef.withCasper[F, ApiErr[DeployServiceResponse]](
       casper => {
         Sync[F].bracket(blockApiLock.tryAcquire) {
           case true =>
@@ -62,10 +70,7 @@ object BlockAPI {
               maybeBlock <- casper.createBlock
               result <- maybeBlock match {
                          case err: NoBlock =>
-                           DeployServiceResponse(
-                             success = false,
-                             s"Error while creating block: $err"
-                           ).pure[F]
+                           s"Error while creating block: $err".asLeft[DeployServiceResponse].pure[F]
                          case Created(block) =>
                            casper
                              .addBlock(block, ignoreDoppelgangerCheck[F])
@@ -73,26 +78,27 @@ object BlockAPI {
                        }
             } yield result
           case false =>
-            DeployServiceResponse(success = false, "Error: There is another propose in progress.")
-              .pure[F]
+            "Error: There is another propose in progress.".asLeft[DeployServiceResponse].pure[F]
         } { _ =>
           blockApiLock.release
         }
       },
       default = Log[F]
         .warn(errorMessage)
-        .as(DeployServiceResponse(success = false, s"Error: $errorMessage"))
+        .as(s"Error: $errorMessage".asLeft)
     )
   }
 
   def getListeningNameDataResponse[F[_]: Concurrent: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int,
       listeningName: Par
-  ): F[ListeningNameDataResponse] = {
+  ): Effect[F, ListeningNameDataResponse] = {
 
     val errorMessage = "Could not get listening name data, casper instance was not available yet."
 
-    def casperResponse(implicit casper: MultiParentCasper[F]) =
+    def casperResponse(
+        implicit casper: MultiParentCasper[F]
+    ): Effect[F, ListeningNameDataResponse] =
       for {
         mainChain           <- getMainChainFromTip[F](depth)
         maybeRuntimeManager <- casper.getRuntimeManager
@@ -108,26 +114,27 @@ object BlockAPI {
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield
         ListeningNameDataResponse(
-          status = "Success",
           blockResults = blocksWithActiveName,
           length = blocksWithActiveName.length
-        )
+        ).asRight
 
-    MultiParentCasperRef.withCasper[F, ListeningNameDataResponse](
+    MultiParentCasperRef.withCasper[F, ApiErr[ListeningNameDataResponse]](
       casperResponse(_),
       Log[F]
         .warn(errorMessage)
-        .as(ListeningNameDataResponse(status = s"Error: $errorMessage"))
+        .as(s"Error: $errorMessage".asLeft)
     )
   }
 
   def getListeningNameContinuationResponse[F[_]: Concurrent: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int,
       listeningNames: Seq[Par]
-  ): F[ListeningNameContinuationResponse] = {
+  ): Effect[F, ListeningNameContinuationResponse] = {
     val errorMessage =
       "Could not get listening names continuation, casper instance was not available yet."
-    def casperResponse(implicit casper: MultiParentCasper[F]) =
+    def casperResponse(
+        implicit casper: MultiParentCasper[F]
+    ): Effect[F, ListeningNameContinuationResponse] =
       for {
         mainChain           <- getMainChainFromTip[F](depth)
         maybeRuntimeManager <- casper.getRuntimeManager
@@ -144,16 +151,15 @@ object BlockAPI {
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield
         ListeningNameContinuationResponse(
-          status = "Success",
           blockResults = blocksWithActiveName,
           length = blocksWithActiveName.length
-        )
+        ).asRight
 
-    MultiParentCasperRef.withCasper[F, ListeningNameContinuationResponse](
+    MultiParentCasperRef.withCasper[F, ApiErr[ListeningNameContinuationResponse]](
       casperResponse(_),
       Log[F]
         .warn(errorMessage)
-        .as(ListeningNameContinuationResponse(status = s"Error: $errorMessage"))
+        .as(s"Error: $errorMessage".asLeft)
     )
   }
 
@@ -208,7 +214,7 @@ object BlockAPI {
   private def isListeningNameReduced(
       block: BlockMessage,
       sortedListeningName: immutable.Seq[Par]
-  ) = {
+  ): Boolean = {
     val serializedLog = for {
       bd    <- block.body.toSeq
       pd    <- bd.deploys
@@ -240,12 +246,12 @@ object BlockAPI {
       d: Option[Int] = None,
       visualizer: (Vector[Vector[BlockHash]], String) => F[G[Graphz[G]]],
       stringify: G[Graphz[G]] => String
-  ): F[String] = {
+  ): Effect[F, VisualizeBlocksResponse] = {
 
     val errorMessage =
       "Could not visualize graph, casper instance was not available yet."
 
-    def casperResponse(implicit casper: MultiParentCasper[F]): F[String] =
+    def casperResponse(implicit casper: MultiParentCasper[F]): Effect[F, VisualizeBlocksResponse] =
       for {
         dag                <- MultiParentCasper[F].blockDag
         maxHeight          <- dag.topoSort(0L).map(_.length - 1)
@@ -254,11 +260,11 @@ object BlockAPI {
         topoSort           <- dag.topoSortTail(depth)
         lastFinalizedBlock <- MultiParentCasper[F].lastFinalizedBlock
         graph              <- visualizer(topoSort, PrettyPrinter.buildString(lastFinalizedBlock.blockHash))
-      } yield stringify(graph)
+      } yield VisualizeBlocksResponse(stringify(graph)).asRight
 
-    MultiParentCasperRef.withCasper[F, String](
+    MultiParentCasperRef.withCasper[F, ApiErr[VisualizeBlocksResponse]](
       casperResponse(_),
-      Log[F].warn(errorMessage).as(errorMessage)
+      Log[F].warn(errorMessage).as(errorMessage.asLeft)
     )
   }
 
@@ -327,12 +333,14 @@ object BlockAPI {
   def findBlockWithDeploy[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       user: ByteString,
       timestamp: Long
-  ): F[BlockQueryResponse] = {
+  ): Effect[F, BlockQueryResponse] = {
 
     val errorMessage =
       "Could not find block with deploy, casper instance was not available yet."
 
-    def casperResponse(implicit casper: MultiParentCasper[F]): F[BlockQueryResponse] =
+    def casperResponse(
+        implicit casper: MultiParentCasper[F]
+    ): Effect[F, BlockQueryResponse] =
       for {
         dag                <- MultiParentCasper[F].blockDag
         allBlocksTopoSort  <- dag.topoSort(0L)
@@ -340,23 +348,20 @@ object BlockAPI {
         blockQueryResponse <- maybeBlock.traverse(getFullBlockInfo[F])
       } yield
         blockQueryResponse.fold(
-          BlockQueryResponse(
-            status = s"Error: Failure to find block containing deploy signed by ${PrettyPrinter
-              .buildString(user)} with timestamp ${timestamp.toString}"
-          )
+          s"Error: Failure to find block containing deploy signed by ${PrettyPrinter
+            .buildString(user)} with timestamp ${timestamp.toString}".asLeft[BlockQueryResponse]
         )(
           blockInfo =>
             BlockQueryResponse(
-              status = "Success",
               blockInfo = Some(blockInfo)
-            )
+            ).asRight
         )
 
-    MultiParentCasperRef.withCasper[F, BlockQueryResponse](
+    MultiParentCasperRef.withCasper[F, ApiErr[BlockQueryResponse]](
       casperResponse(_),
       Log[F]
         .warn(errorMessage)
-        .as(BlockQueryResponse(status = s"Error: errorMessage"))
+        .as(s"Error: errorMessage".asLeft)
     )
   }
 
@@ -366,17 +371,19 @@ object BlockAPI {
       timestamp: Long
   ): F[Option[BlockMessage]] =
     blockHashes.toStream
-      .traverse(ProtoUtil.unsafeGetBlock[F](_))
+      .traverse(ProtoUtil.unsafeGetBlock[F])
       .map(blocks => blocks.find(ProtoUtil.containsDeploy(_, user, timestamp)))
 
   def showBlock[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       q: BlockQuery
-  ): F[BlockQueryResponse] = {
+  ): Effect[F, BlockQueryResponse] = {
 
     val errorMessage =
       "Could not show block, casper instance was not available yet."
 
-    def casperResponse(implicit casper: MultiParentCasper[F]) =
+    def casperResponse(
+        implicit casper: MultiParentCasper[F]
+    ): Effect[F, BlockQueryResponse] =
       for {
         dag        <- MultiParentCasper[F].blockDag
         maybeBlock <- getBlock[F](q, dag)
@@ -384,21 +391,15 @@ object BlockAPI {
                                case Some(block) =>
                                  for {
                                    blockInfo <- getFullBlockInfo[F](block)
-                                 } yield
-                                   BlockQueryResponse(
-                                     status = "Success",
-                                     blockInfo = Some(blockInfo)
-                                   )
+                                 } yield BlockQueryResponse(blockInfo = Some(blockInfo)).asRight
                                case None =>
-                                 BlockQueryResponse(
-                                   status = s"Error: Failure to find block with hash ${q.hash}"
-                                 ).pure[F]
+                                 s"Error: Failure to find block with hash ${q.hash}".asLeft.pure[F]
                              }
       } yield blockQueryResponse
 
-    MultiParentCasperRef.withCasper[F, BlockQueryResponse](
+    MultiParentCasperRef.withCasper[F, ApiErr[BlockQueryResponse]](
       casperResponse(_),
-      Log[F].warn(errorMessage).as(BlockQueryResponse(status = s"Error: $errorMessage"))
+      Log[F].warn(errorMessage).as(s"Error: $errorMessage".asLeft)
     )
   }
 
@@ -518,42 +519,38 @@ object BlockAPI {
       dag: BlockDagRepresentation[F]
   ): F[Option[BlockMessage]] =
     for {
-      findResult <- BlockStore[F].find(h => {
-                     Base16.encode(h.toByteArray).startsWith(q.hash)
-                   })
+      findResult <- BlockStore[F].find(h => Base16.encode(h.toByteArray).startsWith(q.hash))
     } yield
       findResult.headOption match {
-        case Some((_, block)) =>
-          Some(block)
-        case None =>
-          none[BlockMessage]
+        case Some((_, block)) => Some(block)
+        case None             => none[BlockMessage]
       }
 
-  private def addResponse(status: BlockStatus, block: BlockMessage): DeployServiceResponse =
+  private def addResponse(
+      status: BlockStatus,
+      block: BlockMessage
+  ): ApiErr[DeployServiceResponse] =
     status match {
       case _: InvalidBlock =>
-        DeployServiceResponse(success = false, s"Failure! Invalid block: $status")
+        s"Failure! Invalid block: $status".asLeft
       case _: ValidBlock =>
         val hash = PrettyPrinter.buildString(block.blockHash)
-        DeployServiceResponse(success = true, s"Success! Block $hash created and added.")
+        DeployServiceResponse(s"Success! Block $hash created and added.").asRight
       case BlockException(ex) =>
-        DeployServiceResponse(success = false, s"Error during block processing: $ex")
+        s"Error during block processing: $ex".asLeft
       case Processing =>
-        DeployServiceResponse(
-          success = false,
-          "No action taken since other thread is already processing the block."
-        )
+        "No action taken since other thread is already processing the block.".asLeft
     }
 
   def previewPrivateNames[F[_]: Monad: Log](
       user: ByteString,
       timestamp: Long,
       nameQty: Int
-  ): F[PrivateNamePreviewResponse] = {
+  ): Effect[F, PrivateNamePreviewResponse] = {
     val seed    = DeployData().withUser(user).withTimestamp(timestamp)
     val rand    = Blake2b512Random(DeployData.toByteArray(seed))
     val safeQty = nameQty min 1024
     val ids     = (0 until safeQty).map(_ => ByteString.copyFrom(rand.next()))
-    PrivateNamePreviewResponse(ids).pure[F]
+    PrivateNamePreviewResponse(ids).asRight[String].pure[F]
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -6,6 +6,7 @@ import scala.language.higherKinds
 import scala.util._
 
 import cats.{Id, Monad}
+import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
 
@@ -17,6 +18,8 @@ import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.models.Par
 import coop.rchain.shared.Time
+import cats.syntax.either._
+import coop.rchain.shared.ThrowableOps._
 
 object DeployRuntime {
 
@@ -45,8 +48,8 @@ object DeployRuntime {
     gracefulExit {
       listenAtNameUntilChanges(name) { par: Par =>
         val request = DataAtNameQuery(Int.MaxValue, Some(par))
-        DeployService[F].listenForDataAtName(request) map (_.blockResults)
-      }.map(kp(Right("")))
+        EitherT(DeployService[F].listenForDataAtName(request))
+      }.map(kp("")).value
     }
 
   def listenForContinuationAtName[F[_]: Sync: Time: DeployService: Capture](
@@ -55,8 +58,8 @@ object DeployRuntime {
     gracefulExit {
       listenAtNameUntilChanges(names) { pars: List[Par] =>
         val request = ContinuationAtNameQuery(Int.MaxValue, pars)
-        DeployService[F].listenForContinuationAtName(request) map (_.blockResults)
-      }.map(kp(Right("")))
+        EitherT(DeployService[F].listenForContinuationAtName(request))
+      }.map(kp("")).value
     }
 
   //Accepts a Rholang source file and deploys it to Casper
@@ -70,7 +73,7 @@ object DeployRuntime {
     gracefulExit(
       Sync[F].delay(Try(Source.fromFile(file).mkString).toEither).flatMap {
         case Left(ex) =>
-          Sync[F].delay(Left(new RuntimeException(s"Error with given file: \n${ex.getMessage}")))
+          Sync[F].delay(Left(Seq(s"Error with given file: \n${ex.getMessage}")))
         case Right(code) =>
           for {
             timestamp <- Sync[F].delay(System.currentTimeMillis())
@@ -99,25 +102,27 @@ object DeployRuntime {
             println(s"Sending the following to Casper: ${d.term}")
           }
       response <- DeployService[F].deploy(d)
-      msg      = response.fold(processError(_).getMessage, "Response: " + _)
+      msg      = response.fold(_.mkString(System.lineSeparator()), "Response: " + _)
       _        <- Sync[F].delay(println(msg))
       _        <- Time[F].sleep(4.seconds)
     } yield ()
 
-  private def gracefulExit[F[_]: Monad: Sync, A](program: F[Either[Throwable, String]]): F[Unit] =
+  private def gracefulExit[F[_]: Monad: Sync, A](
+      program: F[Either[Seq[String], String]]
+  ): F[Unit] =
     for {
       result <- Sync[F].attempt(program)
-      _ <- result.joinRight match {
-            case Left(ex) =>
+      _ <- processError(result).joinRight match {
+            case Left(errors) =>
               Sync[F].delay {
-                println(processError(ex).getMessage)
+                errors.foreach(error => println(error))
                 System.exit(1)
               }
             case Right(msg) => Sync[F].delay(println(msg))
           }
     } yield ()
 
-  private def processError(t: Throwable): Throwable =
-    Option(t.getCause).getOrElse(t)
+  private def processError[A](error: Either[Throwable, A]): Either[Seq[String], A] =
+    error.leftMap(_.toMessageList())
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -18,9 +18,13 @@ import coop.rchain.p2p.EffectsTestInstances.{LogStub, LogicalTime}
 
 import com.google.protobuf.ByteString
 import monix.eval.Task
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
 
-class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStorageFixture {
+class BlockQueryResponseAPITest
+    extends FlatSpec
+    with Matchers
+    with Inside
+    with BlockDagStorageFixture {
   implicit val timeEff = new LogicalTime[Task]
   val secondBlockQuery = "1234"
   val badTestHashQuery = "No such a hash"
@@ -83,28 +87,28 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
         effects                                 <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
         (logEff, casperRef, cliqueOracleEffect) = effects
         q                                       = BlockQuery(hash = secondBlockQuery)
-        blockQueryResponseE <- BlockAPI.showBlock[Task](q)(
-                                Sync[Task],
-                                casperRef,
-                                logEff,
-                                cliqueOracleEffect,
-                                blockStore
-                              )
-        _                  = blockQueryResponseE.isRight shouldBe true
-        blockQueryResponse = blockQueryResponseE.right.get
-        blockInfo          = blockQueryResponse.blockInfo.get
-        _                  = blockInfo.blockHash should be(secondHashString)
-        _                  = blockInfo.blockSize should be(secondBlock.serializedSize.toString)
-        _                  = blockInfo.blockNumber should be(blockNumber)
-        _                  = blockInfo.version should be(version)
-        _                  = blockInfo.deployCount should be(deployCount)
-        _                  = blockInfo.faultTolerance should be(faultTolerance)
-        _                  = blockInfo.mainParentHash should be(genesisHashString)
-        _                  = blockInfo.parentsHashList should be(parentsString)
-        _                  = blockInfo.sender should be(secondBlockSenderString)
-        _                  = blockInfo.shardId should be(shardId)
-        result             = blockInfo.bondsValidatorList should be(bondValidatorHashList)
-      } yield result
+        blockQueryResponse <- BlockAPI.showBlock[Task](q)(
+                               Sync[Task],
+                               casperRef,
+                               logEff,
+                               cliqueOracleEffect,
+                               blockStore
+                             )
+        _ = inside(blockQueryResponse) {
+          case Right(BlockQueryResponse(Some(blockInfo))) =>
+            blockInfo.blockHash should be(secondHashString)
+            blockInfo.blockSize should be(secondBlock.serializedSize.toString)
+            blockInfo.blockNumber should be(blockNumber)
+            blockInfo.version should be(version)
+            blockInfo.deployCount should be(deployCount)
+            blockInfo.faultTolerance should be(faultTolerance)
+            blockInfo.mainParentHash should be(genesisHashString)
+            blockInfo.parentsHashList should be(parentsString)
+            blockInfo.sender should be(secondBlockSenderString)
+            blockInfo.shardId should be(shardId)
+            blockInfo.bondsValidatorList should be(bondValidatorHashList)
+        }
+      } yield ()
   }
 
   it should "return error when no block exists" in withStorage {
@@ -120,12 +124,13 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
                                cliqueOracleEffect,
                                blockStore
                              )
-      } yield {
-        blockQueryResponse.isLeft shouldBe true
-        blockQueryResponse.left.get should be(
-          s"Error: Failure to find block with hash ${badTestHashQuery}"
-        )
-      }
+        _ = inside(blockQueryResponse) {
+          case Left(msg) =>
+            msg should be(
+              s"Error: Failure to find block with hash $badTestHashQuery"
+            )
+        }
+      } yield ()
   }
 
   "findBlockWithDeploy" should "return successful block info response" in withStorage {
@@ -135,28 +140,28 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
         (logEff, casperRef, cliqueOracleEffect) = effects
         user                                    = ByteString.EMPTY
         timestamp                               = 1L
-        blockQueryResponseE <- BlockAPI.findBlockWithDeploy[Task](user, timestamp)(
-                                Sync[Task],
-                                casperRef,
-                                logEff,
-                                cliqueOracleEffect,
-                                blockStore
-                              )
-        _                  = blockQueryResponseE.isRight shouldBe true
-        blockQueryResponse = blockQueryResponseE.right.get
-        blockInfo          = blockQueryResponse.blockInfo.get
-        _                  = blockInfo.blockHash should be(secondHashString)
-        _                  = blockInfo.blockSize should be(secondBlock.serializedSize.toString)
-        _                  = blockInfo.blockNumber should be(blockNumber)
-        _                  = blockInfo.version should be(version)
-        _                  = blockInfo.deployCount should be(deployCount)
-        _                  = blockInfo.faultTolerance should be(faultTolerance)
-        _                  = blockInfo.mainParentHash should be(genesisHashString)
-        _                  = blockInfo.parentsHashList should be(parentsString)
-        _                  = blockInfo.sender should be(secondBlockSenderString)
-        _                  = blockInfo.shardId should be(shardId)
-        result             = blockInfo.bondsValidatorList should be(bondValidatorHashList)
-      } yield result
+        blockQueryResponse <- BlockAPI.findBlockWithDeploy[Task](user, timestamp)(
+                               Sync[Task],
+                               casperRef,
+                               logEff,
+                               cliqueOracleEffect,
+                               blockStore
+                             )
+        _ = inside(blockQueryResponse) {
+          case Right(BlockQueryResponse(Some(blockInfo))) =>
+            blockInfo.blockHash should be(secondHashString)
+            blockInfo.blockSize should be(secondBlock.serializedSize.toString)
+            blockInfo.blockNumber should be(blockNumber)
+            blockInfo.version should be(version)
+            blockInfo.deployCount should be(deployCount)
+            blockInfo.faultTolerance should be(faultTolerance)
+            blockInfo.mainParentHash should be(genesisHashString)
+            blockInfo.parentsHashList should be(parentsString)
+            blockInfo.sender should be(secondBlockSenderString)
+            blockInfo.shardId should be(shardId)
+            blockInfo.bondsValidatorList should be(bondValidatorHashList)
+        }
+      } yield ()
   }
 
   it should "return error when no block matching query exists" in withStorage {
@@ -173,12 +178,13 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with BlockDagStor
                                cliqueOracleEffect,
                                blockStore
                              )
-      } yield {
-        blockQueryResponse.isLeft shouldBe true
-        blockQueryResponse.left.get should be(
-          s"Error: Failure to find block containing deploy signed by  with timestamp ${timestamp.toString}"
-        )
-      }
+        _ = inside(blockQueryResponse) {
+          case Left(msg) =>
+            msg should be(
+              s"Error: Failure to find block containing deploy signed by  with timestamp $timestamp"
+            )
+        }
+      } yield ()
   }
 
   private def effectsForSimpleCasperSetup(

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -82,8 +82,8 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
       result       <- testProgram(blockApiLock)(casperRef)
     } yield result).value.unsafeRunSync.right.get
 
-    response1.isRight shouldBe true
-    response2.isRight shouldBe false
+    response1 shouldBe a[Right[String, DeployServiceResponse]]
+    response2 shouldBe a[Left[String, DeployServiceResponse]]
     response2.left.get shouldBe "Error: There is another propose in progress."
 
     node.tearDown()

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -1,10 +1,13 @@
 package coop.rchain.casper.api
 
 import scala.concurrent.duration._
+
 import cats.Monad
 import cats.data.EitherT
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
+
+import coop.rchain.blockstorage.BlockDagRepresentation
 import coop.rchain.casper._
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.protocol._
@@ -12,15 +15,15 @@ import coop.rchain.casper.util._
 import coop.rchain.casper.util.rholang._
 import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
+import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
+import coop.rchain.casper.api.BlockAPI.ApiErr
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.p2p.EffectsTestInstances._
-import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.shared.Time
+
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation
-import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
@@ -36,6 +39,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
   private val genesis                     = createGenesis(bonds)
 
   "createBlock" should "not allow simultaneous calls" in {
+    implicit val logEff    = new LogStub[Effect]
     implicit val scheduler = Scheduler.fixedPool("three-threads", 3)
     implicit val time = new Time[Task] {
       private val timer                               = Task.timer
@@ -50,20 +54,26 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
       "for(_ <- @1){ @2!(2) }"
     ).map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
 
-    implicit val logEff = new LogStub[Effect]
+    def createBlock(deploy: DeployData, blockApiLock: Semaphore[Effect])(
+        implicit casperRef: MultiParentCasperRef[Effect]
+    ): Effect[ApiErr[DeployServiceResponse]] =
+      for {
+        _ <- BlockAPI.deploy[Effect](deploy)
+        r <- BlockAPI.createBlock[Effect](blockApiLock)
+      } yield r
+
     def testProgram(blockApiLock: Semaphore[Effect])(
         implicit casperRef: MultiParentCasperRef[Effect]
-    ): Effect[(DeployServiceResponse, DeployServiceResponse)] = EitherT.liftF(
-      for {
-        t1 <- (BlockAPI.deploy[Effect](deploys.head) *> BlockAPI
-               .createBlock[Effect](blockApiLock)).value.start
-        _ <- Time[Task].sleep(2.second)
-        t2 <- (BlockAPI.deploy[Effect](deploys.last) *> BlockAPI
-               .createBlock[Effect](blockApiLock)).value.start //should fail because other not done
-        r1 <- t1.join
-        r2 <- t2.join
-      } yield (r1.right.get, r2.right.get)
-    )
+    ): Effect[(ApiErr[DeployServiceResponse], ApiErr[DeployServiceResponse])] =
+      EitherT.liftF(
+        for {
+          t1 <- createBlock(deploys.head, blockApiLock).value.start
+          _  <- Time[Task].sleep(2.second)
+          t2 <- createBlock(deploys.last, blockApiLock).value.start //should fail because other not done
+          r1 <- t1.join
+          r2 <- t2.join
+        } yield (r1.right.get, r2.right.get)
+      )
 
     val (response1, response2) = (for {
       casperRef    <- MultiParentCasperRef.of[Effect]
@@ -72,9 +82,9 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
       result       <- testProgram(blockApiLock)(casperRef)
     } yield result).value.unsafeRunSync.right.get
 
-    response1.success shouldBe true
-    response2.success shouldBe false
-    response2.message shouldBe "Error: There is another propose in progress."
+    response1.isRight shouldBe true
+    response2.isRight shouldBe false
+    response2.left.get shouldBe "Error: There is another propose in progress."
 
     node.tearDown()
   }

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -18,9 +18,9 @@ import coop.rchain.rholang.interpreter.accounting
 
 import com.google.protobuf.ByteString
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest._
 
-class ListeningNameAPITest extends FlatSpec with Matchers {
+class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
   import HashSetCasperTest._
 
@@ -50,13 +50,15 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
       resultData    = Par().copy(exprs = Seq(Expr(GInt(0))))
       listeningNameResponse1 <- BlockAPI
                                  .getListeningNameDataResponse[Effect](Int.MaxValue, listeningName)
-      _       = listeningNameResponse1.isRight shouldBe true
-      data1   = listeningNameResponse1.right.get.blockResults.map(_.postBlockData)
-      blocks1 = listeningNameResponse1.right.get.blockResults.map(_.block)
-      _       = data1 should be(List(List(resultData)))
-      _       = blocks1.length should be(1)
-      result  = listeningNameResponse1.right.get.length should be(1)
-    } yield result
+      _ = inside(listeningNameResponse1) {
+        case Right(ListeningNameDataResponse(blockResults, l)) =>
+          val data1   = blockResults.map(_.postBlockData)
+          val blocks1 = blockResults.map(_.block)
+          data1 should be(List(List(resultData)))
+          blocks1.length should be(1)
+          l should be(1)
+      }
+    } yield ()
   }
 
   it should "work across a chain" in effectTest {
@@ -84,13 +86,14 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        _       = listeningNameResponse1.isRight shouldBe true
-        data1   = listeningNameResponse1.right.get.blockResults.map(_.postBlockData)
-        blocks1 = listeningNameResponse1.right.get.blockResults.map(_.block)
-        _       = data1 should be(List(List(resultData)))
-        _       = blocks1.length should be(1)
-        _       = listeningNameResponse1.right.get.length should be(1)
-
+        _ = inside(listeningNameResponse1) {
+          case Right(ListeningNameDataResponse(blockResults, l)) =>
+            val data1   = blockResults.map(_.postBlockData)
+            val blocks1 = blockResults.map(_.block)
+            data1 should be(List(List(resultData)))
+            blocks1.length should be(1)
+            l should be(1)
+        }
         createBlock2Result <- nodes(1).casperEff
                                .deploy(deployDatas(1)) *> nodes(1).casperEff.createBlock
         Created(block2) = createBlock2Result
@@ -116,20 +119,21 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        _       = listeningNameResponse2.isRight shouldBe true
-        data2   = listeningNameResponse2.right.get.blockResults.map(_.postBlockData)
-        blocks2 = listeningNameResponse2.right.get.blockResults.map(_.block)
-        _ = data2 should be(
-          List(
-            List(resultData, resultData, resultData, resultData),
-            List(resultData, resultData, resultData),
-            List(resultData, resultData),
-            List(resultData)
-          )
-        )
-        _ = blocks2.length should be(4)
-        _ = listeningNameResponse2.right.get.length should be(4)
-
+        _ = inside(listeningNameResponse2) {
+          case Right(ListeningNameDataResponse(blockResults, l)) =>
+            val data2   = blockResults.map(_.postBlockData)
+            val blocks2 = blockResults.map(_.block)
+            data2 should be(
+              List(
+                List(resultData, resultData, resultData, resultData),
+                List(resultData, resultData, resultData),
+                List(resultData, resultData),
+                List(resultData)
+              )
+            )
+            blocks2.length should be(4)
+            l should be(4)
+        }
         createBlock5Result <- nodes(1).casperEff
                                .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
         Created(block5) = createBlock5Result
@@ -155,45 +159,46 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        _       = listeningNameResponse3.isRight shouldBe true
-        data3   = listeningNameResponse3.right.get.blockResults.map(_.postBlockData)
-        blocks3 = listeningNameResponse3.right.get.blockResults.map(_.block)
-        _ = data3 should be(
-          List(
-            List(
-              resultData,
-              resultData,
-              resultData,
-              resultData,
-              resultData,
-              resultData,
-              resultData
-            ),
-            List(resultData, resultData, resultData, resultData, resultData, resultData),
-            List(resultData, resultData, resultData, resultData, resultData),
-            List(resultData, resultData, resultData, resultData),
-            List(resultData, resultData, resultData),
-            List(resultData, resultData),
-            List(resultData)
-          )
-        )
-        _ = blocks3.length should be(7)
-        _ = listeningNameResponse3.right.get.length should be(7)
-
+        _ = inside(listeningNameResponse3) {
+          case Right(ListeningNameDataResponse(blockResults, l)) =>
+            val data3   = blockResults.map(_.postBlockData)
+            val blocks3 = blockResults.map(_.block)
+            data3 should be(
+              List(
+                List(
+                  resultData,
+                  resultData,
+                  resultData,
+                  resultData,
+                  resultData,
+                  resultData,
+                  resultData
+                ),
+                List(resultData, resultData, resultData, resultData, resultData, resultData),
+                List(resultData, resultData, resultData, resultData, resultData),
+                List(resultData, resultData, resultData, resultData),
+                List(resultData, resultData, resultData),
+                List(resultData, resultData),
+                List(resultData)
+              )
+            )
+            blocks3.length should be(7)
+            l should be(7)
+        }
         listeningNameResponse3UntilDepth <- BlockAPI
                                              .getListeningNameDataResponse[Effect](1, listeningName)
-        _ = listeningNameResponse3UntilDepth.isRight shouldBe true
-        _ = listeningNameResponse3UntilDepth.right.get.length should be(1)
-
+        _ = inside(listeningNameResponse3UntilDepth) {
+          case Right(ListeningNameDataResponse(_, l)) => l should be(1)
+        }
         listeningNameResponse3UntilDepth2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                               2,
                                               listeningName
                                             )
-        _      = listeningNameResponse3UntilDepth2.isRight shouldBe true
-        result = listeningNameResponse3UntilDepth2.right.get.length should be(2)
-
+        _ = inside(listeningNameResponse3UntilDepth2) {
+          case Right(ListeningNameDataResponse(_, l)) => l should be(2)
+        }
         _ = nodes.foreach(_.tearDown())
-      } yield result
+      } yield ()
     }
   }
 
@@ -230,13 +235,14 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                  Int.MaxValue,
                                  listeningNamesShuffled1
                                )
-      _              = listeningNameResponse1.isRight shouldBe true
-      continuations1 = listeningNameResponse1.right.get.blockResults.map(_.postBlockContinuations)
-      blocks1        = listeningNameResponse1.right.get.blockResults.map(_.block)
-      _              = continuations1 should be(List(List(desiredResult)))
-      _              = blocks1.length should be(1)
-      _              = listeningNameResponse1.right.get.length should be(1)
-
+      _ = inside(listeningNameResponse1) {
+        case Right(ListeningNameContinuationResponse(blockResults, l)) =>
+          val continuations1 = blockResults.map(_.postBlockContinuations)
+          val blocks1        = blockResults.map(_.block)
+          continuations1 should be(List(List(desiredResult)))
+          blocks1.length should be(1)
+          l should be(1)
+      }
       listeningNamesShuffled2 = List(
         Par().copy(exprs = Seq(Expr(GInt(2)), Expr(GInt(1)), Expr(GInt(3)))),
         Par().copy(exprs = Seq(Expr(GInt(1)), Expr(GInt(2))))
@@ -245,12 +251,14 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                  Int.MaxValue,
                                  listeningNamesShuffled2
                                )
-      _              = listeningNameResponse2.isRight shouldBe true
-      continuations2 = listeningNameResponse2.right.get.blockResults.map(_.postBlockContinuations)
-      blocks2        = listeningNameResponse2.right.get.blockResults.map(_.block)
-      _              = continuations2 should be(List(List(desiredResult)))
-      _              = blocks2.length should be(1)
-      result         = listeningNameResponse2.right.get.length should be(1)
-    } yield result
+      _ = inside(listeningNameResponse2) {
+        case Right(ListeningNameContinuationResponse(blockResults, l)) =>
+          val continuations2 = blockResults.map(_.postBlockContinuations)
+          val blocks2        = blockResults.map(_.block)
+          continuations2 should be(List(List(desiredResult)))
+          blocks2.length should be(1)
+          l should be(1)
+      }
+    } yield ()
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -1,22 +1,24 @@
 package coop.rchain.casper.api
 
 import cats.implicits._
-import com.google.protobuf.ByteString
+
+import coop.rchain.casper.{Created, HashSetCasperTest}
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.protocol._
-import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.casper.{Created, HashSetCasperTest}
 import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.catscontrib.Capture._
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models._
+import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.accounting
+
+import com.google.protobuf.ByteString
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
-import coop.rchain.catscontrib.Capture._
 
 class ListeningNameAPITest extends FlatSpec with Matchers {
 
@@ -48,11 +50,12 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
       resultData    = Par().copy(exprs = Seq(Expr(GInt(0))))
       listeningNameResponse1 <- BlockAPI
                                  .getListeningNameDataResponse[Effect](Int.MaxValue, listeningName)
-      data1   = listeningNameResponse1.blockResults.map(_.postBlockData)
-      blocks1 = listeningNameResponse1.blockResults.map(_.block)
+      _       = listeningNameResponse1.isRight shouldBe true
+      data1   = listeningNameResponse1.right.get.blockResults.map(_.postBlockData)
+      blocks1 = listeningNameResponse1.right.get.blockResults.map(_.block)
       _       = data1 should be(List(List(resultData)))
       _       = blocks1.length should be(1)
-      result  = listeningNameResponse1.length should be(1)
+      result  = listeningNameResponse1.right.get.length should be(1)
     } yield result
   }
 
@@ -81,11 +84,12 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        data1   = listeningNameResponse1.blockResults.map(_.postBlockData)
-        blocks1 = listeningNameResponse1.blockResults.map(_.block)
+        _       = listeningNameResponse1.isRight shouldBe true
+        data1   = listeningNameResponse1.right.get.blockResults.map(_.postBlockData)
+        blocks1 = listeningNameResponse1.right.get.blockResults.map(_.block)
         _       = data1 should be(List(List(resultData)))
         _       = blocks1.length should be(1)
-        _       = listeningNameResponse1.length should be(1)
+        _       = listeningNameResponse1.right.get.length should be(1)
 
         createBlock2Result <- nodes(1).casperEff
                                .deploy(deployDatas(1)) *> nodes(1).casperEff.createBlock
@@ -112,8 +116,9 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        data2   = listeningNameResponse2.blockResults.map(_.postBlockData)
-        blocks2 = listeningNameResponse2.blockResults.map(_.block)
+        _       = listeningNameResponse2.isRight shouldBe true
+        data2   = listeningNameResponse2.right.get.blockResults.map(_.postBlockData)
+        blocks2 = listeningNameResponse2.right.get.blockResults.map(_.block)
         _ = data2 should be(
           List(
             List(resultData, resultData, resultData, resultData),
@@ -123,7 +128,7 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
           )
         )
         _ = blocks2.length should be(4)
-        _ = listeningNameResponse2.length should be(4)
+        _ = listeningNameResponse2.right.get.length should be(4)
 
         createBlock5Result <- nodes(1).casperEff
                                .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
@@ -150,8 +155,9 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                    Int.MaxValue,
                                    listeningName
                                  )
-        data3   = listeningNameResponse3.blockResults.map(_.postBlockData)
-        blocks3 = listeningNameResponse3.blockResults.map(_.block)
+        _       = listeningNameResponse3.isRight shouldBe true
+        data3   = listeningNameResponse3.right.get.blockResults.map(_.postBlockData)
+        blocks3 = listeningNameResponse3.right.get.blockResults.map(_.block)
         _ = data3 should be(
           List(
             List(
@@ -172,17 +178,19 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
           )
         )
         _ = blocks3.length should be(7)
-        _ = listeningNameResponse3.length should be(7)
+        _ = listeningNameResponse3.right.get.length should be(7)
 
         listeningNameResponse3UntilDepth <- BlockAPI
                                              .getListeningNameDataResponse[Effect](1, listeningName)
-        _ = listeningNameResponse3UntilDepth.length should be(1)
+        _ = listeningNameResponse3UntilDepth.isRight shouldBe true
+        _ = listeningNameResponse3UntilDepth.right.get.length should be(1)
 
         listeningNameResponse3UntilDepth2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                               2,
                                               listeningName
                                             )
-        result = listeningNameResponse3UntilDepth2.length should be(2)
+        _      = listeningNameResponse3UntilDepth2.isRight shouldBe true
+        result = listeningNameResponse3UntilDepth2.right.get.length should be(2)
 
         _ = nodes.foreach(_.tearDown())
       } yield result
@@ -222,11 +230,12 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                  Int.MaxValue,
                                  listeningNamesShuffled1
                                )
-      continuations1 = listeningNameResponse1.blockResults.map(_.postBlockContinuations)
-      blocks1        = listeningNameResponse1.blockResults.map(_.block)
+      _              = listeningNameResponse1.isRight shouldBe true
+      continuations1 = listeningNameResponse1.right.get.blockResults.map(_.postBlockContinuations)
+      blocks1        = listeningNameResponse1.right.get.blockResults.map(_.block)
       _              = continuations1 should be(List(List(desiredResult)))
       _              = blocks1.length should be(1)
-      _              = listeningNameResponse1.length should be(1)
+      _              = listeningNameResponse1.right.get.length should be(1)
 
       listeningNamesShuffled2 = List(
         Par().copy(exprs = Seq(Expr(GInt(2)), Expr(GInt(1)), Expr(GInt(3)))),
@@ -236,11 +245,12 @@ class ListeningNameAPITest extends FlatSpec with Matchers {
                                  Int.MaxValue,
                                  listeningNamesShuffled2
                                )
-      continuations2 = listeningNameResponse2.blockResults.map(_.postBlockContinuations)
-      blocks2        = listeningNameResponse2.blockResults.map(_.block)
+      _              = listeningNameResponse2.isRight shouldBe true
+      continuations2 = listeningNameResponse2.right.get.blockResults.map(_.postBlockContinuations)
+      blocks2        = listeningNameResponse2.right.get.blockResults.map(_.block)
       _              = continuations2 should be(List(List(desiredResult)))
       _              = blocks2.length should be(1)
-      result         = listeningNameResponse2.length should be(1)
+      result         = listeningNameResponse2.right.get.length should be(1)
     } yield result
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/PreviewPrivateNameTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/PreviewPrivateNameTest.scala
@@ -1,12 +1,9 @@
 package coop.rchain.casper.api
 
 import cats.Id
-import com.google.protobuf.{ByteString, Int64Value}
-import coop.rchain.casper.protocol.DeployData
+
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.{GPrivate}
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 
 import org.scalatest.{FlatSpec, Matchers}
@@ -21,7 +18,7 @@ class PreviewPrivateNameTest extends FlatSpec with Matchers {
       nth + 1
     )
 
-    Base16.encode(preview.ids(nth).toByteArray)
+    Base16.encode(preview.right.get.ids(nth).toByteArray)
   }
 
   val myNodePk = "464f6780d71b724525be14348b59c53dc8795346dfd7576c9f01c397ee7523e6"

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -61,11 +61,11 @@ class DagOperationsTest
 
         dag <- blockDagStorage.getRepresentation
 
-        _ <- DagOperations.lowestCommonAncestorF[Task](b1, b5, dag) shouldBeF b1
-        _ <- DagOperations.lowestCommonAncestorF[Task](b3, b2, dag) shouldBeF b1
-        _ <- DagOperations.lowestCommonAncestorF[Task](b6, b7, dag) shouldBeF b1
-        _ <- DagOperations.lowestCommonAncestorF[Task](b2, b2, dag) shouldBeF b2
-        _ <- DagOperations.lowestCommonAncestorF[Task](b10, b9, dag) shouldBeF b8
+        _      <- DagOperations.lowestCommonAncestorF[Task](b1, b5, dag) shouldBeF b1
+        _      <- DagOperations.lowestCommonAncestorF[Task](b3, b2, dag) shouldBeF b1
+        _      <- DagOperations.lowestCommonAncestorF[Task](b6, b7, dag) shouldBeF b1
+        _      <- DagOperations.lowestCommonAncestorF[Task](b2, b2, dag) shouldBeF b2
+        _      <- DagOperations.lowestCommonAncestorF[Task](b10, b9, dag) shouldBeF b8
         result <- DagOperations.lowestCommonAncestorF[Task](b3, b7, dag) shouldBeF b3
       } yield result
   }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -13,6 +13,7 @@ import "google/protobuf/empty.proto";
 
 import "scalapb/scalapb.proto";
 import "RhoTypes.proto";
+import "Either.proto";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"
@@ -28,24 +29,34 @@ option (scalapb.options) = {
 // To get results back, use `listenForDataAtName`.
 service DeployService {
   // Queue deployment of Rholang code (or fail to parse).
-  rpc DoDeploy(DeployData) returns (DeployServiceResponse) {}
+  // Returns on success DeployServiceResponse
+  rpc DoDeploy(DeployData) returns (Either) {}
   // Add a block including all pending deploys.
-  rpc createBlock(google.protobuf.Empty) returns (DeployServiceResponse) {}
+  // Returns on success DeployServiceResponse
+  rpc createBlock(google.protobuf.Empty) returns (Either) {}
   // Get details about a particular block.
-  rpc showBlock(BlockQuery) returns (BlockQueryResponse) {}
+  // Returns on success BlockQueryResponse
+  rpc showBlock(BlockQuery) returns (Either) {}
   // Get dag
-  rpc visualizeDag(VisualizeDagQuery) returns (VisualizeBlocksResponse) {}
-  rpc showMainChain(BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {}
+  // Returns on success VisualizeBlocksResponse
+  rpc visualizeDag(VisualizeDagQuery) returns (Either) {}
+  // Returns on success BlockInfoWithoutTuplespace
+  rpc showMainChain(BlocksQuery) returns (stream Either) {}
   // Get a summary of blocks on the blockchain.
-  rpc showBlocks(BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {}
+  // Returns on success BlockInfoWithoutTuplespace
+  rpc showBlocks(BlocksQuery) returns (stream Either) {}
   // Find data sent to a name.
-  rpc listenForDataAtName(DataAtNameQuery) returns (ListeningNameDataResponse) {}
+  // Returns on success ListeningNameDataResponse
+  rpc listenForDataAtName(DataAtNameQuery) returns (Either) {}
   // Find processes receiving on a name.
-  rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ListeningNameContinuationResponse) {}
+  // Returns on success ListeningNameContinuationResponse
+  rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (Either) {}
   // Find block from a deploy.
-  rpc findBlockWithDeploy(FindDeployInBlockQuery) returns (BlockQueryResponse) {}
+  // Returns on success BlockQueryResponse
+  rpc findBlockWithDeploy(FindDeployInBlockQuery) returns (Either) {}
   // Preview new top-level unforgeable names (for example, to compute signatures over them).
-  rpc previewPrivateNames(PrivateNamePreviewQuery) returns (PrivateNamePreviewResponse) {}
+  // Returns on success PrivateNamePreviewResponse
+  rpc previewPrivateNames(PrivateNamePreviewQuery) returns (Either) {}
 }
 
 
@@ -101,8 +112,7 @@ message ContinuationAtNameQuery {
 }
 
 message DeployServiceResponse {
-  bool   success = 1;
-  string message = 2;
+  string message = 1;
 }
 
 message MaybeBlockMessage {
@@ -110,8 +120,7 @@ message MaybeBlockMessage {
 }
 
 message BlockQueryResponse {
-  string status = 1;
-  BlockInfo blockInfo = 2;
+  BlockInfo blockInfo = 1;
 }
 
 message VisualizeDagQuery {
@@ -120,20 +129,17 @@ message VisualizeDagQuery {
 }
 
 message VisualizeBlocksResponse {
-  string status =  1;
-  string content = 2;
+  string content = 1;
 }
 
 message ListeningNameDataResponse {
-  string status = 1;
-  repeated DataWithBlockInfo blockResults = 2;
-  int32 length = 3;
+  repeated DataWithBlockInfo blockResults = 1;
+  int32 length = 2;
 }
 
 message ListeningNameContinuationResponse {
-  string status = 1;
-  repeated ContinuationsWithBlockInfo blockResults = 2;
-  int32 length = 3;
+  repeated ContinuationsWithBlockInfo blockResults = 1;
+  int32 length = 2;
 }
 
 message DataWithBlockInfo {

--- a/models/src/main/protobuf/Either.proto
+++ b/models/src/main/protobuf/Either.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+import "scalapb/scalapb.proto";
+import "google/protobuf/any.proto";
+
+option java_package = "coop.rchain.either";
+
+message EitherAny {
+  string type_url = 1;
+  bytes value = 2;
+}
+
+message EitherError {
+  repeated string messages = 1;
+}
+
+message EitherSuccess {
+  EitherAny response = 1;
+}
+
+message Either {
+  oneof content {
+    EitherError error =     1;
+    EitherSuccess success = 2;
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/either/EitherAnyHelper.scala
+++ b/models/src/main/scala/coop/rchain/models/either/EitherAnyHelper.scala
@@ -1,0 +1,39 @@
+package coop.rchain.models.either
+
+import coop.rchain.either.EitherAny
+import coop.rchain.models.StacksafeMessage
+
+import scalapb._
+
+object EitherAnyHelper {
+  def pack[A <: StacksafeMessage[A]](generatedMessage: A): EitherAny =
+    pack(generatedMessage, "type.rchain.coop/")
+
+  def pack[A <: StacksafeMessage[A]](
+      generatedMessage: A,
+      urlPrefix: String
+  ): EitherAny =
+    EitherAny(
+      typeUrl =
+        if (urlPrefix.endsWith("/"))
+          urlPrefix + generatedMessage.companion.scalaDescriptor.fullName
+        else
+          urlPrefix + "/" + generatedMessage.companion.scalaDescriptor.fullName,
+      value = generatedMessage.toByteString
+    )
+
+  private def typeNameFromTypeUrl(typeUrl: String): String =
+    typeUrl.split("/").lastOption.getOrElse(typeUrl)
+
+  def is[A <: StacksafeMessage[A]](
+      eitherAny: EitherAny
+  )(implicit cmp: GeneratedMessageCompanion[A]): Boolean =
+    typeNameFromTypeUrl(eitherAny.typeUrl) == cmp.scalaDescriptor.fullName
+
+  def unpack[A <: StacksafeMessage[A]](
+      eitherAny: EitherAny
+  )(implicit cmp: GeneratedMessageCompanion[A]): A = {
+    require(is[A](eitherAny), s"Type of the EitherAny message does not match the given class.")
+    cmp.parseFrom(eitherAny.value.newCodedInput())
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/either/EitherHelper.scala
+++ b/models/src/main/scala/coop/rchain/models/either/EitherHelper.scala
@@ -1,0 +1,48 @@
+package coop.rchain.models.either
+
+import coop.rchain.either.{EitherError, EitherSuccess}
+import coop.rchain.either.Either.Content
+import coop.rchain.models.StacksafeMessage
+import coop.rchain.shared.ThrowableOps._
+
+import scalapb.GeneratedMessageCompanion
+
+object EitherHelper {
+  def toEither[A <: StacksafeMessage[A]](
+      msg: coop.rchain.either.Either
+  )(implicit cmp: GeneratedMessageCompanion[A]): Either[Seq[String], A] = {
+    require(msg.content.isDefined, "Either message has no content")
+    if (msg.content.isError) {
+      require(msg.content.error.isDefined, "Either message is an undefined Error")
+      Left(msg.content.error.get.messages)
+    } else {
+      require(msg.content.success.isDefined, "Either message is an undefined Success")
+      require(
+        msg.content.success.get.response.isDefined,
+        "Either message is a Success with an undefined response"
+      )
+      Right(EitherAnyHelper.unpack[A](msg.content.success.get.response.get))
+    }
+  }
+
+  def fromEitherString[A <: StacksafeMessage[A]](
+      response: Either[String, A]
+  ): coop.rchain.either.Either =
+    response match {
+      case Right(a) =>
+        coop.rchain.either.Either(Content.Success(EitherSuccess(Some(EitherAnyHelper.pack(a)))))
+      case Left(e) =>
+        coop.rchain.either.Either(Content.Error(EitherError(Seq(e))))
+    }
+
+  def fromEitherThrowable[A <: StacksafeMessage[A]](
+      response: Either[Throwable, A]
+  ): coop.rchain.either.Either =
+    response match {
+      case Right(a) =>
+        coop.rchain.either.Either(Content.Success(EitherSuccess(Some(EitherAnyHelper.pack(a)))))
+      case Left(t) =>
+        coop.rchain.either.Either(Content.Error(EitherError(t.toMessageList())))
+    }
+
+}

--- a/models/src/main/scala/coop/rchain/models/either/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/either/implicits.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models.either
+
+object implicits extends syntax.AllSyntax

--- a/models/src/main/scala/coop/rchain/models/either/syntax/AllSyntax.scala
+++ b/models/src/main/scala/coop/rchain/models/either/syntax/AllSyntax.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models.either.syntax
+
+trait AllSyntax extends EitherSyntax

--- a/models/src/main/scala/coop/rchain/models/either/syntax/Either.scala
+++ b/models/src/main/scala/coop/rchain/models/either/syntax/Either.scala
@@ -1,0 +1,36 @@
+package coop.rchain.models.either.syntax
+
+import coop.rchain.models.StacksafeMessage
+import coop.rchain.models.either.EitherHelper
+import cats.syntax.either._
+
+import scalapb.GeneratedMessageCompanion
+
+trait EitherSyntax {
+  implicit final def modelEitherSyntaxGrpcEither(msg: coop.rchain.either.Either): GrpcEitherOps =
+    new GrpcEitherOps(msg)
+
+  implicit final def modelEitherSyntaxScalaEitheString[A <: StacksafeMessage[A]](
+      response: Either[String, A]
+  ): ScalaEitherStringOps[A] =
+    new ScalaEitherStringOps(response)
+
+  implicit final def modelEitherSyntaxScalaEitherThrowable[A <: StacksafeMessage[A]](
+      response: Either[Throwable, A]
+  ): ScalaEitherThrowableOps[A] =
+    new ScalaEitherThrowableOps(response)
+}
+
+final class GrpcEitherOps(msg: coop.rchain.either.Either) {
+  def toEither[A <: StacksafeMessage[A]](
+      implicit cmp: GeneratedMessageCompanion[A]
+  ): Either[Seq[String], A] = EitherHelper.toEither(msg)
+}
+
+final class ScalaEitherStringOps[A <: StacksafeMessage[A]](response: Either[String, A]) {
+  def toGrpcEither: coop.rchain.either.Either = EitherHelper.fromEitherString[A](response)
+}
+
+final class ScalaEitherThrowableOps[A <: StacksafeMessage[A]](response: Either[Throwable, A]) {
+  def toGrpcEither: coop.rchain.either.Either = EitherHelper.fromEitherThrowable[A](response)
+}

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -1,24 +1,27 @@
 package coop.rchain.node.api
 
+import cats._
+import cats.data._
 import cats.effect.concurrent.Semaphore
 import cats.effect.Concurrent
+import cats.implicits._
+import cats.mtl.implicits._
+
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.SafetyOracle
-import coop.rchain.casper.api.BlockAPI
-import coop.rchain.casper.protocol.{DeployData, DeployServiceResponse, VisualizeBlocksResponse, _}
-import coop.rchain.shared._
-import coop.rchain.graphz._
-import coop.rchain.casper.api.{GraphConfig, GraphzGenerator}
-import com.google.protobuf.empty.Empty
-import cats._
-import cats.data._
-import cats.implicits._
-import cats.mtl._
-import cats.mtl.implicits._
+import coop.rchain.casper.api._
+import coop.rchain.casper.protocol.{DeployData, _}
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.Taskable
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.either.{Either => GrpcEither}
+import coop.rchain.graphz._
+import coop.rchain.models.StacksafeMessage
+import coop.rchain.models.either.implicits._
+import coop.rchain.shared._
+
+import com.google.protobuf.empty.Empty
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -30,27 +33,35 @@ private[api] object DeployGrpcService {
       implicit worker: Scheduler
   ): CasperMessageGrpcMonix.DeployService =
     new CasperMessageGrpcMonix.DeployService {
-      import ToErrorResponseInstances._
-      private def defer[A: ToErrorResponse](task: F[A]): Task[A] =
+
+      private def defer[A <: StacksafeMessage[A]](
+          task: F[Either[String, A]]
+      ): Task[GrpcEither] =
         Task
           .defer(task.toTask)
           .executeOn(worker)
           .attemptAndLog
-          .onErrorHandle(t => {
-            ToErrorResponse[A].fromThrowable(t)
-          })
+          .attempt
+          .map(_.fold(_.asLeft[A].toGrpcEither, _.toGrpcEither))
 
-      override def doDeploy(d: DeployData): Task[DeployServiceResponse] =
+      private def deferList[A <: StacksafeMessage[A]](task: F[List[A]]): Task[List[GrpcEither]] =
+        Task
+          .defer(task.toTask)
+          .executeOn(worker)
+          .attemptAndLog
+          .attempt
+          .map(_.fold(t => List(t.asLeft[A].toGrpcEither), _.map(_.asRight[String].toGrpcEither)))
+
+      override def doDeploy(d: DeployData): Task[GrpcEither] =
         defer(BlockAPI.deploy[F](d))
 
-      override def createBlock(e: Empty): Task[DeployServiceResponse] =
+      override def createBlock(e: Empty): Task[GrpcEither] =
         defer(BlockAPI.createBlock[F](blockApiLock))
 
-      override def showBlock(q: BlockQuery): Task[BlockQueryResponse] =
+      override def showBlock(q: BlockQuery): Task[GrpcEither] =
         defer(BlockAPI.showBlock[F](q))
 
-      // TODO handle potentiall errors (at least by returning proper response)
-      override def visualizeDag(q: VisualizeDagQuery): Task[VisualizeBlocksResponse] = {
+      override def visualizeDag(q: VisualizeDagQuery): Task[GrpcEither] = {
         type Effect[A] = StateT[Id, StringBuffer, A]
         implicit val ser: GraphSerializer[Effect]       = new StringSerializer[Effect]
         val stringify: Effect[Graphz[Effect]] => String = _.runS(new StringBuffer).toString
@@ -65,95 +76,33 @@ private[api] object DeployGrpcService {
               (ts, lfb) => GraphzGenerator.dagAsCluster[F, Effect](ts, lfb, config),
               stringify
             )
-            .map(graph => VisualizeBlocksResponse(status = "Success", content = graph))
         )
       }
 
-      override def showBlocks(request: BlocksQuery): Observable[BlockInfoWithoutTuplespace] =
+      override def showBlocks(request: BlocksQuery): Observable[GrpcEither] =
         Observable
-          .fromTask(defer(BlockAPI.showBlocks[F](request.depth)))
+          .fromTask(deferList(BlockAPI.showBlocks[F](request.depth)))
           .flatMap(Observable.fromIterable)
 
-      // TODO: Handle error case
-      override def listenForDataAtName(request: DataAtNameQuery): Task[ListeningNameDataResponse] =
+      override def listenForDataAtName(request: DataAtNameQuery): Task[GrpcEither] =
         defer(BlockAPI.getListeningNameDataResponse[F](request.depth, request.name.get))
 
       override def listenForContinuationAtName(
           request: ContinuationAtNameQuery
-      ): Task[ListeningNameContinuationResponse] =
+      ): Task[GrpcEither] =
         defer(BlockAPI.getListeningNameContinuationResponse[F](request.depth, request.names))
 
-      override def showMainChain(request: BlocksQuery): Observable[BlockInfoWithoutTuplespace] =
+      override def showMainChain(request: BlocksQuery): Observable[GrpcEither] =
         Observable
-          .fromTask(defer(BlockAPI.showMainChain[F](request.depth)))
+          .fromTask(deferList(BlockAPI.showMainChain[F](request.depth)))
           .flatMap(Observable.fromIterable)
 
-      override def findBlockWithDeploy(request: FindDeployInBlockQuery): Task[BlockQueryResponse] =
+      override def findBlockWithDeploy(request: FindDeployInBlockQuery): Task[GrpcEither] =
         defer(BlockAPI.findBlockWithDeploy[F](request.user, request.timestamp))
 
       override def previewPrivateNames(
           request: PrivateNamePreviewQuery
-      ): Task[PrivateNamePreviewResponse] =
+      ): Task[GrpcEither] =
         defer(BlockAPI.previewPrivateNames[F](request.user, request.timestamp, request.nameQty))
-    }
-}
-
-// this isn't a solution - it's a hack employed to allow confirming that the observed UNKNOWN responses
-// are really a side effect of exceptions not properly handled in 'attemptAndLog'
-//TODO needs to be replaced with a proper response abstraction which allows errors.
-sealed trait ToErrorResponse[A] {
-  def fromThrowable(t: Throwable): A
-}
-object ToErrorResponse {
-  def apply[A](implicit ev: ToErrorResponse[A]): ToErrorResponse[A] = ev
-}
-
-object ToErrorResponseInstances {
-  implicit def listResponseDefaultError[A: ToErrorResponse]: ToErrorResponse[List[A]] =
-    new ToErrorResponse[List[A]] {
-      override def fromThrowable(t: Throwable): List[A] =
-        ToErrorResponse[A].fromThrowable(t) :: Nil
-    }
-
-  implicit val deployServiceResponseDefaultError: ToErrorResponse[DeployServiceResponse] =
-    new ToErrorResponse[DeployServiceResponse] {
-      override def fromThrowable(t: Throwable): DeployServiceResponse =
-        DeployServiceResponse(success = false, t.getMessage)
-    }
-
-  implicit val blockQueryResponseDefaultError: ToErrorResponse[BlockQueryResponse] =
-    new ToErrorResponse[BlockQueryResponse] {
-      override def fromThrowable(t: Throwable): BlockQueryResponse =
-        BlockQueryResponse(status = t.getMessage)
-    }
-
-  implicit val visualizeBlocksResponseDefaultError: ToErrorResponse[VisualizeBlocksResponse] =
-    new ToErrorResponse[VisualizeBlocksResponse] {
-      override def fromThrowable(t: Throwable): VisualizeBlocksResponse =
-        VisualizeBlocksResponse(status = t.getMessage)
-    }
-
-  implicit val blockInfoWithoutTuplespaceDefaultError: ToErrorResponse[BlockInfoWithoutTuplespace] =
-    new ToErrorResponse[BlockInfoWithoutTuplespace] {
-      override def fromThrowable(t: Throwable): BlockInfoWithoutTuplespace =
-        BlockInfoWithoutTuplespace()
-    }
-
-  implicit val listeningNameDataResponseDefaultError: ToErrorResponse[ListeningNameDataResponse] =
-    new ToErrorResponse[ListeningNameDataResponse] {
-      override def fromThrowable(t: Throwable): ListeningNameDataResponse =
-        ListeningNameDataResponse(status = t.getMessage)
-    }
-
-  implicit val listeningNameContinuationResponseDefaultError
-    : ToErrorResponse[ListeningNameContinuationResponse] =
-    new ToErrorResponse[ListeningNameContinuationResponse] {
-      override def fromThrowable(t: Throwable): ListeningNameContinuationResponse =
-        ListeningNameContinuationResponse(status = t.getMessage)
-    }
-  implicit val privateNamePreviewResponseDefaultError: ToErrorResponse[PrivateNamePreviewResponse] =
-    new ToErrorResponse[PrivateNamePreviewResponse] {
-      override def fromThrowable(t: Throwable): PrivateNamePreviewResponse =
-        PrivateNamePreviewResponse()
     }
 }

--- a/shared/src/main/scala/coop/rchain/shared/ThrowableOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ThrowableOps.scala
@@ -1,5 +1,7 @@
 package coop.rchain.shared
 
+import scala.annotation.tailrec
+
 object ThrowableOps {
   implicit class RichThrowable(th: Throwable) {
     def containsMessageWith(str: String): Boolean =
@@ -8,5 +10,24 @@ object ThrowableOps {
         case (Some(cause), _)                    => cause.containsMessageWith(str)
         case _                                   => false
       }
+
+    def fold[B](z: B)(f: (B, Throwable) => B): B = {
+      @tailrec
+      def loop(t0: Throwable, acc: B): B =
+        Option(t0) match {
+          case None     => acc
+          case Some(t1) => loop(t1.getCause, f(acc, t1))
+        }
+
+      loop(th, z)
+    }
+
+    def toMessageList(prefix: String = "Caused by: "): Seq[String] =
+      fold(Seq.empty[String]) { (ms, t) =>
+        Option(t.getMessage)
+          .filter(_.trim.length > 0)
+          .fold(ms)(msg => s"${if (ms.isEmpty) "" else prefix}$msg" +: ms)
+      }.reverse
+
   }
 }


### PR DESCRIPTION
## Overview
Instead of signalling errors inside of response messages use the Either type. Use the grpc Either message in DeployGrpcService to send the API Either over the wire to the client. Use grpc Either helpers to reassemble the API Either response. Change DeployRuntime accordingly.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2928

### Notes
These changes are **not** backward compatible. Older rnode clients will be not able to communicate with the new API.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
