### PR TITLE
Rspace/rchain 3022/introduce f in i store

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -16,6 +16,8 @@ import coop.rchain.shared.Log
 import java.io.PrintWriter
 import java.nio.file.{Files, Path}
 
+import coop.rchain.metrics.Metrics
+
 import scala.concurrent.ExecutionContext
 
 object BondingUtil {
@@ -181,7 +183,7 @@ object BondingUtil {
       runtimeDir => Sync[F].delay { runtimeDir.recursivelyDelete() }
     )
 
-  def makeRuntimeResource[F[_]: Concurrent: ContextShift: Log, M[_]](
+  def makeRuntimeResource[F[_]: Concurrent: ContextShift: Log: Metrics, M[_]](
       runtimeDirResource: Resource[F, Path]
   )(implicit P: Parallel[F, M], scheduler: ExecutionContext): Resource[F, Runtime[F]] =
     runtimeDirResource.flatMap(
@@ -202,7 +204,7 @@ object BondingUtil {
         Resource.make(RuntimeManager.fromRuntime[F](activeRuntime))(_ => Sync[F].unit)
     )
 
-  def writeIssuanceBasedRhoFiles[F[_]: Concurrent: ContextShift: Log, M[_]](
+  def writeIssuanceBasedRhoFiles[F[_]: Concurrent: ContextShift: Log: Metrics, M[_]](
       bondKey: String,
       ethAddress: String,
       amount: Long,
@@ -225,7 +227,7 @@ object BondingUtil {
     )
   }
 
-  def writeFaucetBasedRhoFiles[F[_]: Concurrent: ContextShift: Log, M[_]](
+  def writeFaucetBasedRhoFiles[F[_]: Concurrent: ContextShift: Log: Metrics, M[_]](
       amount: Long,
       sigAlgorithm: String,
       secKey: String,

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -181,7 +181,7 @@ object BondingUtil {
       runtimeDir => Sync[F].delay { runtimeDir.recursivelyDelete() }
     )
 
-  def makeRuntimeResource[F[_]: Sync: ContextShift: Log, M[_]](
+  def makeRuntimeResource[F[_]: Concurrent: ContextShift: Log, M[_]](
       runtimeDirResource: Resource[F, Path]
   )(implicit P: Parallel[F, M], scheduler: ExecutionContext): Resource[F, Runtime[F]] =
     runtimeDirResource.flatMap(

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -41,6 +41,7 @@ import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.comm.TestNetwork
 import coop.rchain.catscontrib.ski.kp2
 import coop.rchain.comm.rp.Connect.Connections
+import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Log
 import org.scalatest
@@ -1806,10 +1807,11 @@ object HashSetCasperTest {
       faucetCode: String => String,
       deployTimestamp: Long
   ): BlockMessage = {
-    val initial           = Genesis.withoutContracts(bonds, 1L, deployTimestamp, "rchain")
-    val storageDirectory  = Files.createTempDirectory(s"hash-set-casper-test-genesis")
-    val storageSize: Long = 1024L * 1024
-    implicit val log      = new Log.NOPLog[Task]
+    val initial                            = Genesis.withoutContracts(bonds, 1L, deployTimestamp, "rchain")
+    val storageDirectory                   = Files.createTempDirectory(s"hash-set-casper-test-genesis")
+    val storageSize: Long                  = 1024L * 1024
+    implicit val log                       = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     val activeRuntime =
       Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -21,6 +21,8 @@ import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared.{StoreType, Time}
 import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Assertion, BeforeAndAfterEach, FlatSpec, Matchers}
@@ -34,8 +36,9 @@ class ValidateTest
     with BeforeAndAfterEach
     with BlockGenerator
     with BlockDagStorageFixture {
-  implicit val log = new LogStub[Task]
-  val ed25519      = "ed25519"
+  implicit val log                        = new LogStub[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+  val ed25519                             = "ed25519"
 
   override def beforeEach(): Unit = {
     log.reset()

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -23,6 +23,8 @@ import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import java.nio.file.Path
 
 import cats.effect.Sync
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import monix.eval.Task
 
 class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
@@ -258,10 +260,11 @@ object GenesisTest {
   def withRawGenResources(
       body: (Runtime[Task], Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
   ): Task[Unit] = {
-    val storePath    = storageLocation
-    val gp           = genesisPath
-    implicit val log = new LogStub[Task]
-    val time         = new LogicalTime[Task]
+    val storePath                           = storageLocation
+    val gp                                  = genesisPath
+    implicit val log                        = new LogStub[Task]
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+    val time                                = new LogicalTime[Task]
 
     for {
       runtime <- Runtime.create[Task, Task.Par](storePath, storageSize, StoreType.LMDB)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -7,6 +7,8 @@ import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.InterpreterUtil.mkTerm
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.Runtime
@@ -37,7 +39,8 @@ object TestUtil {
   def runtime(
       extraServices: Seq[SystemProcess.Definition[Task]] = Seq.empty
   )(implicit scheduler: Scheduler): Runtime[Task] = {
-    implicit val log: Log[Task] = new Log.NOPLog[Task]
+    implicit val log: Log[Task]            = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     for {
       runtime <- TestRuntime.create[Task, Task.Par](extraServices)
       _       <- Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -7,7 +7,6 @@ import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, ApplicativeError, Id, Monad}
-
 import coop.rchain.blockstorage._
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.casper._
@@ -34,6 +33,7 @@ import coop.rchain.comm.rp.Connect
 import coop.rchain.comm.rp.Connect._
 import coop.rchain.comm.rp.HandleMessages.handle
 import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.p2p.effects.PacketHandler
@@ -41,9 +41,9 @@ import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rspace.Context
 import coop.rchain.shared._
 import coop.rchain.shared.PathOps.RichPath
-
 import monix.eval.Task
 import monix.execution.Scheduler
+
 import scala.collection.mutable
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 import scala.util.Random
@@ -152,7 +152,8 @@ object HashSetCasperTestNode {
   def createRuntime(storageDirectory: Path, storageSize: Long)(
       implicit scheduler: Scheduler
   ): (RuntimeManager[Effect], Close[Effect]) = {
-    implicit val log = new Log.NOPLog[Task]()
+    implicit val log                       = new Log.NOPLog[Task]()
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     val activeRuntime =
       Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
@@ -13,6 +13,8 @@ import coop.rchain.comm.transport
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -95,8 +97,9 @@ object BlockApproverProtocolTest {
   ): Effect[(BlockApproverProtocol, HashSetCasperTestNode[Effect])] = {
     import monix.execution.Scheduler.Implicits.global
 
-    val runtimeDir   = BlockDagStorageTestFixture.blockStorageDir
-    implicit val log = new Log.NOPLog[Task]()
+    val runtimeDir                          = BlockDagStorageTestFixture.blockStorageDir
+    implicit val log                        = new Log.NOPLog[Task]()
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     val activeRuntime =
       Runtime.create[Task, Task.Par](runtimeDir, 1024L * 1024, StoreType.LMDB).unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -26,7 +26,7 @@ import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.comm.rp.ProtocolHelper
 import ProtocolHelper._
 import cats.{Applicative, ApplicativeError, Parallel}
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift, Sync}
 import coop.rchain.comm.{transport, _}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
@@ -50,7 +50,7 @@ class CasperPacketHandlerSpec extends WordSpec {
       Runtime
         .create[Task, Task.Par](runtimeDir, 1024L * 1024, StoreType.LMDB)(
           ContextShift[Task],
-          Sync[Task],
+          Concurrent[Task],
           log,
           Parallel[Task, Task.Par],
           scheduler

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -44,7 +44,7 @@ import scala.concurrent.duration._
 
 class CasperPacketHandlerSpec extends WordSpec {
   private def setup() = new {
-    implicit val log            = new LogStub[Task]
+    implicit val log     = new LogStub[Task]
     implicit val metrics = new MetricsNOP[Task]
     val scheduler        = Scheduler.io("test")
     val runtimeDir       = BlockDagStorageTestFixture.blockStorageDir

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -44,6 +44,7 @@ import scala.concurrent.duration._
 
 class CasperPacketHandlerSpec extends WordSpec {
   private def setup() = new {
+    implicit val log            = new LogStub[Task]
     val scheduler  = Scheduler.io("test")
     val runtimeDir = BlockDagStorageTestFixture.blockStorageDir
     val activeRuntime =
@@ -85,7 +86,6 @@ class CasperPacketHandlerSpec extends WordSpec {
     implicit val transportLayer = new TransportLayerStub[Task]
     implicit val rpConf         = createRPConfAsk[Task](local)
     implicit val time           = TestTime.instance
-    implicit val log            = new LogStub[Task]
     implicit val errHandler =
       ApplicativeError_.applicativeError(new ApplicativeError[Task, CommError] {
         override def raiseError[A](e: CommError): Task[A] =

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -20,6 +20,8 @@ import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.InterpreterUtil._
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.models.PCost
 import coop.rchain.p2p.EffectsTestInstances.LogStub
@@ -36,9 +38,10 @@ class InterpreterUtilTest
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture {
-  implicit val logEff  = new LogStub[Task]
-  val storageSize      = 1024L * 1024
-  val storageDirectory = Files.createTempDirectory("casper-interp-util-test")
+  implicit val logEff                    = new LogStub[Task]
+  implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+  val storageSize                        = 1024L * 1024
+  val storageDirectory                   = Files.createTempDirectory("casper-interp-util-test")
   val activeRuntime =
     Runtime.create[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB).unsafeRunSync
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -4,6 +4,8 @@ import cats.implicits._
 import cats.effect.Resource
 import cats.effect.implicits._
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.shared.{Log, StoreType}
@@ -17,7 +19,8 @@ object Resources {
       storageSize: Int = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
   )(implicit scheduler: Scheduler): Resource[Task, (Runtime[Task], RuntimeManager[Task])] = {
-    implicit val log: Log[Task] = new Log.NOPLog[Task]
+    implicit val log: Log[Task]            = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     for {
       runtime        <- mkRuntime(prefix)
       runtimeManager <- Resource.liftF(RuntimeManager.fromRuntime[Task](runtime))
@@ -29,7 +32,8 @@ object Resources {
       storageSize: Int = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
   )(implicit scheduler: Scheduler): Resource[Task, RuntimeManager[Task]] = {
-    implicit val log: Log[Task] = new Log.NOPLog[Task]
+    implicit val log: Log[Task]            = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     mkRuntime(prefix)
       .flatMap { runtime =>

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -9,6 +9,8 @@ import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.Resources._
 import coop.rchain.catscontrib.TestOutlaws._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.interpreter.{accounting, Interpreter}
@@ -51,7 +53,8 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     val correctRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!(2) }"""
     val deploy         = ProtoUtil.sourceDeployNow(correctRholang)
 
-    implicit val log: Log[Task] = new Log.NOPLog[Task]
+    implicit val log: Log[Task]            = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     (for {
       reductionCost <- mkRuntime("casper-runtime")

--- a/comm/src/main/scala/coop/rchain/comm/UPnP.scala
+++ b/comm/src/main/scala/coop/rchain/comm/UPnP.scala
@@ -126,7 +126,7 @@ object UPnP {
             Log[F].info("UPnP port forwarding was most likely successful!")
 
       _ <- Log[F].info(showPortMappingHeader)
-      _ <- getPortMappings(gateway).toList.map(showPortMapping).traverse(Log[F].info)
+      _ <- getPortMappings(gateway).toList.map(showPortMapping).traverse(v => Log[F].info(v))
     } yield Some(gateway.getExternalIPAddress)
 
   def assurePortForwarding[F[_]: Log: Sync](ports: List[Int]): F[Option[String]] =

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -115,25 +115,25 @@ object EffectsTestInstances {
       warns = List.empty[String]
       errors = List.empty[String]
     }
-    def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]
-    def trace(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
-    def debug(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def isTraceEnabled(implicit ev: LogSource): F[Boolean]     = false.pure[F]
+    def trace(msg: => String)(implicit ev: LogSource): F[Unit] = ().pure[F]
+    def debug(msg: => String)(implicit ev: LogSource): F[Unit] = {
       debugs = debugs :+ msg
       ().pure[F]
     }
-    def info(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def info(msg: => String)(implicit ev: LogSource): F[Unit] = {
       infos = infos :+ msg
       ().pure[F]
     }
-    def warn(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def warn(msg: => String)(implicit ev: LogSource): F[Unit] = {
       warns = warns :+ msg
       ().pure[F]
     }
-    def error(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def error(msg: => String)(implicit ev: LogSource): F[Unit] = {
       errors = errors :+ msg
       ().pure[F]
     }
-    def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = {
+    def error(msg: => String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = {
       errors = errors :+ msg
       ().pure[F]
     }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -9,6 +9,8 @@ import coop.rchain.catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.casper.util.BondingUtil
 import coop.rchain.comm._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.node.configuration._
 import coop.rchain.node.diagnostics.client.GrpcDiagnosticsService
 import coop.rchain.node.effects._
@@ -77,9 +79,11 @@ object Main {
       case ContAtName(names) => DeployRuntime.listenForContinuationAtName[Task](names)
       case Run               => nodeProgram(conf)
       case BondingDeployGen(bondKey, ethAddress, amount, secKey, pubKey) =>
+        implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
         BondingUtil
           .writeIssuanceBasedRhoFiles[Task, Task.Par](bondKey, ethAddress, amount, secKey, pubKey)
       case FaucetBondingDeployGen(amount, sigAlgorithm, secKey, pubKey) =>
+        implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
         BondingUtil.writeFaucetBasedRhoFiles[Task, Task.Par](amount, sigAlgorithm, secKey, pubKey)
       case _ => conf.printHelp()
     }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -370,14 +370,16 @@ class NodeRuntime private[node] (
     _      <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
     oracle = SafetyOracle.cliqueOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
     runtime <- {
-      implicit val s = rspaceScheduler
+      implicit val s                = rspaceScheduler
+      implicit val m: Metrics[Task] = metrics
       Runtime.create[Task, Task.Par](storagePath, storageSize, storeType, Seq.empty).toEffect
     }
     _ <- Runtime
           .injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)
           .toEffect
     casperRuntime <- {
-      implicit val s = rspaceScheduler
+      implicit val s                = rspaceScheduler
+      implicit val m: Metrics[Task] = metrics
       Runtime.create[Task, Task.Par](casperStoragePath, storageSize, storeType, Seq.empty).toEffect
     }
     runtimeManager <- RuntimeManager.fromRuntime[Task](casperRuntime).toEffect

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -6,6 +6,7 @@ import java.nio.file.{Files, Path}
 import java.util.concurrent.TimeoutException
 
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime.RhoIStore
 import coop.rchain.rholang.interpreter.accounting.Cost
@@ -53,7 +54,8 @@ object RholangCLI {
 
     val conf = new Conf(args)
 
-    implicit val log: Log[Task] = Log.log[Task]
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
     val runtime = (for {
       runtime <- Runtime.create[Task, Task.Par](conf.dataDir(), conf.mapSize(), StoreType.LMDB)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -82,7 +82,7 @@ object RholangCLI {
     Console.println(PrettyPrinter().buildString(normalizedTerm))
   }
 
-  private def printStorageContents(store: RhoIStore): Unit = {
+  private def printStorageContents[F[_]](store: RhoIStore[F]): Unit = {
     Console.println("\nStorage Contents:")
     Console.println(StoragePrinter.prettyPrint(store))
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Path}
 
 import cats._
 import cats.effect.concurrent.Ref
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.implicits._
 import cats.mtl.FunctorTell
 import com.google.protobuf.ByteString
@@ -275,7 +275,7 @@ object Runtime {
     )
   )
 
-  def create[F[_]: ContextShift: Sync: Log, M[_]](
+  def create[F[_]: ContextShift: Concurrent: Log, M[_]](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType,
@@ -417,7 +417,7 @@ object Runtime {
     } yield ()
   }
 
-  def setupRSpace[F[_]: Sync: ContextShift: Log](
+  def setupRSpace[F[_]: Concurrent: ContextShift: Log](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -9,6 +9,7 @@ import cats.implicits._
 import cats.mtl.FunctorTell
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.models.TaggedContinuation.TaggedCont.ScalaBodyRef
 import coop.rchain.models.Var.VarInstance.FreeVar
@@ -275,7 +276,7 @@ object Runtime {
     )
   )
 
-  def create[F[_]: ContextShift: Concurrent: Log, M[_]](
+  def create[F[_]: ContextShift: Concurrent: Log: Metrics, M[_]](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType,
@@ -417,7 +418,7 @@ object Runtime {
     } yield ()
   }
 
-  def setupRSpace[F[_]: Concurrent: ContextShift: Log](
+  def setupRSpace[F[_]: Concurrent: ContextShift: Log: Metrics](
       dataDir: Path,
       mapSize: Long,
       storeType: StoreType

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -9,13 +9,11 @@ import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
 import coop.rchain.rspace.trace.{Consume, Produce}
 
 object StoragePrinter {
-  def prettyPrint(store: RhoIStore): String = {
+  def prettyPrint[F[_]](store: RhoIStore[F]): String = {
     val pars: Seq[Par] = store.toMap.map {
       case (
-          (
           channels: Seq[Par],
           row: Row[BindPattern, ListParWithRandom, TaggedContinuation]
-          )
           ) => {
         def toSends(data: Seq[Datum[ListParWithRandom]]): Par = {
           val sends: Seq[Send] = data.flatMap {

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -2,6 +2,8 @@ package coop.rchain.rholang
 
 import java.io.StringReader
 
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import monix.execution.Scheduler.Implicits.global
@@ -18,7 +20,8 @@ class InterpreterSpec extends FlatSpec with Matchers {
   private val tmpPrefix   = "rspace-store-"
   private val maxDuration = 5.seconds
 
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   behavior of "Interpreter"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -4,7 +4,7 @@ import java.nio.file.{Files, Path}
 
 import cats.Applicative
 import cats.effect.ExitCase.Error
-import cats.effect.{ContextShift, Resource, Sync}
+import cats.effect.{Concurrent, ContextShift, Resource}
 import com.typesafe.scalalogging.Logger
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime
@@ -35,7 +35,7 @@ object Resources {
         })
     )
 
-  def mkRhoISpace[F[_]: Sync: ContextShift: Log](
+  def mkRhoISpace[F[_]: Concurrent: ContextShift: Log](
       prefix: String = "",
       branch: String = "test",
       mapSize: Long = 1024L * 1024L * 4

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -6,6 +6,7 @@ import cats.Applicative
 import cats.effect.ExitCase.Error
 import cats.effect.{Concurrent, ContextShift, Resource}
 import com.typesafe.scalalogging.Logger
+import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace}
@@ -35,7 +36,7 @@ object Resources {
         })
     )
 
-  def mkRhoISpace[F[_]: Concurrent: ContextShift: Log](
+  def mkRhoISpace[F[_]: Concurrent: ContextShift: Log: Metrics](
       prefix: String = "",
       branch: String = "test",
       mapSize: Long = 1024L * 1024L * 4
@@ -66,7 +67,11 @@ object Resources {
       prefix: String,
       storageSize: Long = 1024 * 1024,
       storeType: StoreType = StoreType.LMDB
-  )(implicit log: Log[Task], scheduler: Scheduler): Resource[Task, Runtime[Task]] =
+  )(
+      implicit log: Log[Task],
+      scheduler: Scheduler,
+      metrics: Metrics[Task]
+  ): Resource[Task, Runtime[Task]] =
     mkTempDir[Task](prefix)
       .flatMap { tmpDir =>
         Resource.make[Task, Runtime[Task]](Task.suspend {

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -45,7 +45,7 @@ object Resources {
     import scala.concurrent.ExecutionContext.Implicits.global
 
     def mkRspace(dbDir: Path): F[RhoISpace[F]] = {
-      val context: RhoContext = Context.create(dbDir, mapSize)
+      val context: RhoContext[F] = Context.create(dbDir, mapSize)
 
       RSpace.create[
         F,

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rholang
 
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Connective.ConnectiveInstance.ConnNotBody
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models._
@@ -19,10 +21,11 @@ import scala.concurrent.duration._
 
 object StackSafetySpec extends Assertions {
 
-  val mapSize                  = 10L * 1024L * 1024L
-  val tmpPrefix                = "rspace-store-"
-  val maxDuration              = 20.seconds
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  val mapSize                             = 10L * 1024L * 1024L
+  val tmpPrefix                           = "rspace-store-"
+  val maxDuration                         = 20.seconds
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   def findMaxRecursionDepth(): Int = {
     def count(i: Int): Int =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -2,6 +2,8 @@ package coop.rchain.rholang.interpreter
 
 import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.{EVarBody, GString}
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
@@ -96,9 +98,10 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     val program =
       Par(sends = Seq(Send(channel, Seq(a)), Send(channel, Seq(b))))
 
-    implicit val rand            = Blake2b512Random(Array.empty[Byte])
-    implicit val errLog          = new ErrorLog[Task]()
-    implicit val logF: Log[Task] = Log.log[Task]
+    implicit val rand                       = Blake2b512Random(Array.empty[Byte])
+    implicit val errLog                     = new ErrorLog[Task]()
+    implicit val logF: Log[Task]            = Log.log[Task]
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     def testImplementation(pureRSpace: RhoISpace[Task]): Task[
       (

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -8,6 +8,8 @@ import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.{Blake2b256, Blake2b512Random, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray, GString}
 import coop.rchain.models.Var.VarInstance.Wildcard
 import coop.rchain.models.Var.WildcardMsg
@@ -211,10 +213,11 @@ class CryptoChannelsSpec
   }
 
   override protected def withFixture(test: OneArgTest): Outcome = {
-    val randomInt                = scala.util.Random.nextInt
-    val dbDir                    = Files.createTempDirectory(s"rchain-storage-test-$randomInt")
-    val size                     = 1024L * 1024 * 10
-    implicit val logF: Log[Task] = new Log.NOPLog[Task]
+    val randomInt                           = scala.util.Random.nextInt
+    val dbDir                               = Files.createTempDirectory(s"rchain-storage-test-$randomInt")
+    val size                                = 1024L * 1024 * 10
+    implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     val runtime = (for {
       runtime <- Runtime.create[Task, Task.Par](dbDir, size, StoreType.LMDB)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -54,7 +54,7 @@ class CryptoChannelsSpec
 
   // this should consume from the `ack` channel effectively preparing tuplespace for next test
   def clearStore(
-      store: RhoIStore,
+      store: RhoIStore[Task],
       ackChannel: Par,
       timeout: Duration = 3.seconds
   )(implicit env: Env[Par], reduce: ChargingReducer[Task]): Unit = {
@@ -66,7 +66,7 @@ class CryptoChannelsSpec
   }
 
   def assertStoreContains(
-      store: RhoIStore
+      store: RhoIStore[Task]
   )(ackChannel: GString)(data: ListParWithRandom): Assertion = {
     val channel: Par = ackChannel
     val datum        = store.toMap(List(channel)).data.head
@@ -232,6 +232,6 @@ class CryptoChannelsSpec
   /** TODO(mateusz.gorski): once we refactor Rholang[AndScala]Dispatcher
     *  to push effect choice up until declaration site refactor to `Reduce[Coeval]`
     */
-  override type FixtureParam = (ChargingReducer[Task], RhoIStore)
+  override type FixtureParam = (ChargingReducer[Task], RhoIStore[Task])
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
@@ -21,7 +23,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class DeployParamsSpec extends fixture.FlatSpec with Matchers {
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   override protected def withFixture(test: OneArgTest): Outcome = {
     val randomInt = scala.util.Random.nextInt

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -39,7 +39,11 @@ class DeployParamsSpec extends fixture.FlatSpec with Matchers {
     } yield (outcome)).unsafeRunSync
   }
 
-  def assertStoreContains(store: RhoIStore, ackChannel: Par, data: ListParWithRandom): Assertion = {
+  def assertStoreContains(
+      store: RhoIStore[Task],
+      ackChannel: Par,
+      data: ListParWithRandom
+  ): Assertion = {
     val datum = store.toMap(List(ackChannel)).data.head
     assert(datum.a.pars == data.pars)
     assert(datum.a.randomState == data.randomState)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -6,6 +6,8 @@ import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
@@ -34,9 +36,10 @@ final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Ta
 
 trait PersistentStoreTester {
   def withTestSpace[R](errorLog: ErrorLog[Task])(f: TestFixture => R): R = {
-    val dbDir                     = Files.createTempDirectory("rholang-interpreter-test-")
-    val context: RhoContext[Task] = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
-    implicit val logF: Log[Task]  = new Log.NOPLog[Task]
+    val dbDir                               = Files.createTempDirectory("rholang-interpreter-test-")
+    val context: RhoContext[Task]           = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
+    implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     val space = (RSpace
       .create[

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -34,9 +34,9 @@ final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Ta
 
 trait PersistentStoreTester {
   def withTestSpace[R](errorLog: ErrorLog[Task])(f: TestFixture => R): R = {
-    val dbDir                    = Files.createTempDirectory("rholang-interpreter-test-")
-    val context: RhoContext      = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
-    implicit val logF: Log[Task] = new Log.NOPLog[Task]
+    val dbDir                     = Files.createTempDirectory("rholang-interpreter-test-")
+    val context: RhoContext[Task] = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
+    implicit val logF: Log[Task]  = new Log.NOPLog[Task]
 
     val space = (RSpace
       .create[

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -1,6 +1,8 @@
 package coop.rchain.rholang.interpreter
 import java.io.StringReader
 
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.Resources.mkRuntime
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -10,12 +12,13 @@ import coop.rchain.shared.Log
 import scala.concurrent.duration._
 
 class RuntimeSpec extends FlatSpec with Matchers {
-  private val mapSize          = 10L * 1024L * 1024L
-  private val tmpPrefix        = "rspace-store-"
-  private val maxDuration      = 5.seconds
-  implicit val logF: Log[Task] = Log.log[Task]
+  private val mapSize                     = 10L * 1024L * 1024L
+  private val tmpPrefix                   = "rspace-store-"
+  private val maxDuration                 = 5.seconds
+  implicit val logF: Log[Task]            = Log.log[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-//  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
+  //  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
 
   private val channelReadOnlyError = "ReduceError: Trying to read from non-readable channel."
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -18,8 +18,6 @@ class RuntimeSpec extends FlatSpec with Matchers {
   implicit val logF: Log[Task]            = Log.log[Task]
   implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-  //  val runtime = Runtime.create(Files.createTempDirectory(tmpPrefix), mapSize)
-
   private val channelReadOnlyError = "ReduceError: Trying to read from non-readable channel."
 
   "rho:io:stdout" should "not get intercepted" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
@@ -5,13 +5,14 @@ import java.nio.file.Paths
 import cats._
 import cats.effect.{Concurrent, ContextShift}
 import cats.implicits._
+import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Log
 import coop.rchain.shared.StoreType.InMem
 
 import scala.concurrent.ExecutionContext
 
 object TestRuntime {
-  def create[F[_]: ContextShift: Concurrent: Log, M[_]](
+  def create[F[_]: ContextShift: Concurrent: Log: Metrics, M[_]](
       extraSystemProcesses: Seq[Runtime.SystemProcess.Definition[F]] = Seq.empty
   )(implicit P: Parallel[F, M], executionContext: ExecutionContext): F[Runtime[F]] =
     Runtime.create[F, M](

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import java.nio.file.Paths
 
 import cats._
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift}
 import cats.implicits._
 import coop.rchain.shared.Log
 import coop.rchain.shared.StoreType.InMem
@@ -11,7 +11,7 @@ import coop.rchain.shared.StoreType.InMem
 import scala.concurrent.ExecutionContext
 
 object TestRuntime {
-  def create[F[_]: ContextShift: Sync: Log, M[_]](
+  def create[F[_]: ContextShift: Concurrent: Log, M[_]](
       extraSystemProcesses: Seq[Runtime.SystemProcess.Definition[F]] = Seq.empty
   )(implicit P: Parallel[F, M], executionContext: ExecutionContext): F[Runtime[F]] =
     Runtime.create[F, M](

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -6,6 +6,8 @@ import cats._
 import cats.effect._
 import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.rholang.Resources.mkRhoISpace
 import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace}
@@ -96,7 +98,8 @@ object CostAccountingPropertyTest {
   }
 
   def costOfExecution(procs: Proc*): Task[Long] = {
-    implicit val logF: Log[Task] = new Log.NOPLog[Task]
+    implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+    implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     for {
       runtime <- TestRuntime.create[Task, Task.Par]()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -3,6 +3,8 @@ package coop.rchain.rholang.interpreter.accounting
 import java.nio.file.{Files, Path}
 
 import com.google.protobuf.ByteString
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
@@ -794,7 +796,8 @@ class RholangMethodsCostsSpec
   private var context: RhoContext[Task] = null
   private var space: RhoISpace[Task]    = null
 
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   override protected def beforeAll(): Unit = {
     import coop.rchain.catscontrib.TaskContrib._

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -790,9 +790,9 @@ class RholangMethodsCostsSpec
     test.runSyncUnsafe(5.seconds)
   }
 
-  private var dbDir: Path            = null
-  private var context: RhoContext    = null
-  private var space: RhoISpace[Task] = null
+  private var dbDir: Path               = null
+  private var context: RhoContext[Task] = null
+  private var space: RhoISpace[Task]    = null
 
   implicit val logF: Log[Task] = new Log.NOPLog[Task]
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -3,6 +3,8 @@ package coop.rchain.rholang.interpreter.storage
 import cats.effect.{Resource, Sync}
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance.FreeVar
@@ -463,5 +465,6 @@ object ChargingRSpaceTest {
     override def clear(): Task[Unit]                                                      = ???
   }
 
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -434,7 +434,7 @@ object ChargingRSpaceTest {
         })
 
     override def close(): Task[Unit] = rspace.close()
-    override val store: IStore[Par, BindPattern, ListParWithRandom, TaggedContinuation] =
+    override val store: IStore[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation] =
       rspace.store
     override def install(
         channels: immutable.Seq[Par],

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -4,6 +4,8 @@ import java.io.FileReader
 import java.nio.file.{Files, Path, Paths}
 
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
 import monix.execution.Scheduler.Implicits.global
 import coop.rchain.rholang.Resources.mkRuntime
@@ -15,10 +17,11 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class CompilerTests extends FunSuite with Matchers {
-  private val mapSize          = 1024L * 1024L * 10
-  private val tmpPrefix        = "rspace-store-"
-  private val maxDuration      = 5.seconds
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  private val mapSize                     = 1024L * 1024L * 10
+  private val tmpPrefix                   = "rspace-store-"
+  private val maxDuration                 = 5.seconds
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   private val testFiles: Iterator[Path] =
     Files.walk(Paths.get(getClass.getResource("/tests").getPath)).iterator().asScala

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -6,6 +6,8 @@ import java.util.concurrent.TimeUnit
 import cats.effect.{ContextShift, Sync}
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models._
@@ -107,6 +109,7 @@ object BasicBench {
 
     implicit val syncF: Sync[Task]                 = Task.catsEffect
     implicit val logF: Log[Task]                   = new Log.NOPLog[Task]
+    implicit val noopMetrics: Metrics[Task]        = new metrics.Metrics.MetricsNOP[Task]
     implicit val contextShiftF: ContextShift[Task] = Task.contextShift
 
     private val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -111,11 +111,11 @@ object BasicBench {
 
     private val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")
 
-    val context: LMDBContext[Par, BindPattern, ListParWithRandom, TaggedContinuation] =
+    val context: LMDBContext[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation] =
       Context.create(dbDir, 1024L * 1024L * 1024L)
 
-    val testStore: LMDBStore[Par, BindPattern, ListParWithRandom, TaggedContinuation] =
-      LMDBStore.create[Par, BindPattern, ListParWithRandom, TaggedContinuation](
+    val testStore: IStore[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation] =
+      LMDBStore.create[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation](
         context,
         Branch("bench")
       )

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -6,6 +6,8 @@ import java.nio.file.{Files, Path}
 import org.openjdk.jmh.annotations.{Setup, TearDown}
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
@@ -16,9 +18,10 @@ import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 
 trait EvalBenchStateBase {
-  private lazy val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")
-  private val mapSize: Long    = 1024L * 1024L * 1024L
-  implicit val logF: Log[Task] = new Log.NOPLog[Task]
+  private lazy val dbDir: Path            = Files.createTempDirectory("rchain-storage-test-")
+  private val mapSize: Long               = 1024L * 1024L * 1024L
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   val rhoScriptSource: String
   lazy val runtime: Runtime[Task] =

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -5,6 +5,8 @@ import java.util.concurrent.TimeUnit
 
 import cats.Id
 import cats.effect._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rspace._
 import coop.rchain.rspace.examples.AddressBookExample._
 import coop.rchain.rspace.examples.AddressBookExample.implicits._
@@ -19,7 +21,6 @@ import org.openjdk.jmh.infra.Blackhole
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @org.openjdk.jmh.annotations.State(Scope.Thread)
@@ -93,8 +94,10 @@ class LMDBBench extends RSpaceBench {
   val mapSize: Long  = 1024L * 1024L * 1024L
   val noTls: Boolean = false
 
-  var dbDir: Path            = null
-  implicit val logF: Log[Id] = new Log.NOPLog[Id]
+  var dbDir: Path                       = null
+  implicit val logF: Log[Id]            = new Log.NOPLog[Id]
+  implicit val noopMetrics: Metrics[Id] = new metrics.Metrics.MetricsNOP[Id]
+
   @Setup
   def setup() = {
     dbDir = Files.createTempDirectory("rchain-rspace-lmdb-bench-")
@@ -121,7 +124,8 @@ class LMDBBench extends RSpaceBench {
 @Measurement(iterations = 10)
 class InMemBench extends RSpaceBench {
 
-  implicit val logF: Log[Id] = new Log.NOPLog[Id]
+  implicit val logF: Log[Id]            = new Log.NOPLog[Id]
+  implicit val noopMetrics: Metrics[Id] = new metrics.Metrics.MetricsNOP[Id]
 
   @Setup
   def setup() = {
@@ -149,10 +153,11 @@ class InMemBench extends RSpaceBench {
 @Measurement(iterations = 10)
 class MixedBench extends RSpaceBench {
 
-  val mapSize: Long          = 1024L * 1024L * 1024L
-  val noTls: Boolean         = false
-  implicit val logF: Log[Id] = Log.log[Id]
-  var dbDir: Path            = null
+  val mapSize: Long                     = 1024L * 1024L * 1024L
+  val noTls: Boolean                    = false
+  implicit val logF: Log[Id]            = Log.log[Id]
+  implicit val noopMetrics: Metrics[Id] = new metrics.Metrics.MetricsNOP[Id]
+  var dbDir: Path                       = null
 
   @Setup
   def setup() = {

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -98,8 +98,8 @@ class LMDBBench extends RSpaceBench {
   @Setup
   def setup() = {
     dbDir = Files.createTempDirectory("rchain-rspace-lmdb-bench-")
-    val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
-    val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
+    val context   = Context.create[Id, Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
+    val testStore = LMDBStore.create[Id, Channel, Pattern, Entry, EntriesCaptor](context)
     assert(testStore.toMap.isEmpty)
     space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
       testStore,
@@ -125,9 +125,10 @@ class InMemBench extends RSpaceBench {
 
   @Setup
   def setup() = {
-    val context = Context.createInMemory[Channel, Pattern, Entry, EntriesCaptor]()
+    val context = Context.createInMemory[Id, Channel, Pattern, Entry, EntriesCaptor]()
     assert(context.trieStore.toMap.isEmpty)
-    val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
+    val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
+      InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
     space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
       testStore,
@@ -156,9 +157,10 @@ class MixedBench extends RSpaceBench {
   @Setup
   def setup() = {
     dbDir = Files.createTempDirectory("rchain-rspace-mixed-bench-")
-    val context = Context.createMixed[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize)
+    val context = Context.createMixed[Id, Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize)
     assert(context.trieStore.toMap.isEmpty)
-    val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
+    val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
+      InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
     space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
       testStore,

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -4,6 +4,8 @@ import java.util.concurrent.TimeUnit
 
 import cats.Id
 import cats.effect._
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.rspace.{State => _, _}
 import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace.examples.AddressBookExample._
@@ -55,11 +57,12 @@ object ReplayRSpaceBench {
     var space: IdISpace[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] = null
     var replaySpace: IReplaySpace[cats.Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] =
       null
-    implicit val logF: Log[Id] = new Log.NOPLog[Id]
-    val consumeChannel         = Channel("consume")
-    val produceChannel         = Channel("produce")
-    val matches                = List(CityMatch(city = "Crystal Lake"))
-    val captor                 = new EntriesCaptor()
+    implicit val logF: Log[Id]            = new Log.NOPLog[Id]
+    implicit val noopMetrics: Metrics[Id] = new metrics.Metrics.MetricsNOP[Id]
+    val consumeChannel                    = Channel("consume")
+    val produceChannel                    = Channel("produce")
+    val matches                           = List(CityMatch(city = "Crystal Lake"))
+    val captor                            = new EntriesCaptor()
 
     def initSpace() = {
       val rigPoint = space.createCheckpoint()

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -68,9 +68,10 @@ object ReplayRSpaceBench {
 
     @Setup
     def setup() = {
-      val context = Context.createInMemory[Channel, Pattern, Entry, EntriesCaptor]()
+      val context = Context.createInMemory[Id, Channel, Pattern, Entry, EntriesCaptor]()
       assert(context.trieStore.toMap.isEmpty)
-      val testStore = InMemoryStore.create(context.trieStore, Branch.MASTER)
+      val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
+        InMemoryStore.create(context.trieStore, Branch.MASTER)
       assert(testStore.toMap.isEmpty)
       space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
         testStore,

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeUnit
 
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
@@ -34,8 +36,9 @@ abstract class WideBenchBaseState {
 
   var runTask: Task[Vector[Throwable]] = null
 
-  implicit def readErrors      = () => runtime.readAndClearErrorVector().unsafeRunSync
-  implicit val logF: Log[Task] = Log.log[Task]
+  implicit def readErrors                 = () => runtime.readAndClearErrorVector().unsafeRunSync
+  implicit val logF: Log[Task]            = Log.log[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
   def createRuntime(): Runtime[Task] =
     Runtime.create[Task, Task.Par](dbDir, mapSize, StoreType.LMDB).unsafeRunSync

--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -8,7 +8,7 @@ import coop.rchain.rspace.internal.GNAT
 import org.lmdbjava.{Env, EnvFlags, Txn}
 import scodec.Codec
 
-trait Context[C, P, A, K] {
+trait Context[F[_], C, P, A, K] {
   def close(): Unit
   def createStore(branch: Branch)(
       implicit
@@ -16,21 +16,21 @@ trait Context[C, P, A, K] {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): IStore[C, P, A, K]
+  ): IStore[F, C, P, A, K]
 }
 
-private[rspace] class LMDBContext[C, P, A, K] private[rspace] (
+private[rspace] class LMDBContext[F[_], C, P, A, K] private[rspace] (
     val env: Env[ByteBuffer],
     val path: Path,
     val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]]
-) extends Context[C, P, A, K] {
+) extends Context[F, C, P, A, K] {
   override def createStore(branch: Branch)(
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): IStore[C, P, A, K] =
-    LMDBStore.create[C, P, A, K](this, branch)
+  ): IStore[F, C, P, A, K] =
+    LMDBStore.create[F, C, P, A, K](this, branch)
 
   def close(): Unit = {
     trieStore.close()
@@ -38,36 +38,36 @@ private[rspace] class LMDBContext[C, P, A, K] private[rspace] (
   }
 }
 
-private[rspace] class InMemoryContext[C, P, A, K] private[rspace] (
+private[rspace] class InMemoryContext[F[_], C, P, A, K] private[rspace] (
     val trieStore: ITrieStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], Blake2b256Hash, GNAT[
       C,
       P,
       A,
       K
     ]]
-) extends Context[C, P, A, K] {
+) extends Context[F, C, P, A, K] {
   override def createStore(branch: Branch)(
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): IStore[C, P, A, K] =
+  ): IStore[F, C, P, A, K] =
     InMemoryStore.create(trieStore, branch)
 
   def close(): Unit = {}
 }
 
-private[rspace] class MixedContext[C, P, A, K] private[rspace] (
+private[rspace] class MixedContext[F[_], C, P, A, K] private[rspace] (
     val env: Env[ByteBuffer],
     val trieStore: ITrieStore[Txn[ByteBuffer], Blake2b256Hash, GNAT[C, P, A, K]]
-) extends Context[C, P, A, K] {
+) extends Context[F, C, P, A, K] {
 
   override def createStore(branch: Branch)(
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): IStore[C, P, A, K] =
+  ): IStore[F, C, P, A, K] =
     LockFreeInMemoryStore.create(trieStore, branch)
 
   def close(): Unit = {
@@ -90,18 +90,18 @@ object Context {
       .setMaxReaders(2048)
       .open(path.toFile, flags: _*)
 
-  def create[C, P, A, K](path: Path, mapSize: Long, noTls: Boolean)(
+  def create[F[_], C, P, A, K](path: Path, mapSize: Long, noTls: Boolean)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): LMDBContext[C, P, A, K] = {
+  ): LMDBContext[F, C, P, A, K] = {
     val flags = if (noTls) List(EnvFlags.MDB_NOTLS) else List.empty
     create(path, mapSize, flags)
   }
 
-  def create[C, P, A, K](
+  def create[F[_], C, P, A, K](
       path: Path,
       mapSize: Long,
       flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
@@ -111,7 +111,7 @@ object Context {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): LMDBContext[C, P, A, K] = {
+  ): LMDBContext[F, C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -122,15 +122,15 @@ object Context {
 
     val trieStore = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env, path)
 
-    new LMDBContext[C, P, A, K](env, path, trieStore)
+    new LMDBContext[F, C, P, A, K](env, path, trieStore)
   }
 
-  def createInMemory[C, P, A, K](): InMemoryContext[C, P, A, K] = {
+  def createInMemory[F[_], C, P, A, K](): InMemoryContext[F, C, P, A, K] = {
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
     new InMemoryContext(trieStore)
   }
 
-  def createMixed[C, P, A, K](
+  def createMixed[F[_], C, P, A, K](
       path: Path,
       mapSize: Long,
       flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
@@ -140,7 +140,7 @@ object Context {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): MixedContext[C, P, A, K] = {
+  ): MixedContext[F, C, P, A, K] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -151,7 +151,7 @@ object Context {
 
     val trieStore = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env, path)
 
-    new MixedContext[C, P, A, K](env, trieStore)
+    new MixedContext[F, C, P, A, K](env, trieStore)
   }
 
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -120,7 +120,7 @@ object Context {
 
     val env = Context.env(path, mapSize, flags)
 
-    val trieStore = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env, path)
+    val trieStore = LMDBTrieStore.create[F, Blake2b256Hash, GNAT[C, P, A, K]](env, path)
 
     new LMDBContext[F, C, P, A, K](env, path, trieStore)
   }
@@ -149,7 +149,7 @@ object Context {
 
     val env = Context.env(path, mapSize, flags)
 
-    val trieStore = LMDBTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]](env, path)
+    val trieStore = LMDBTrieStore.create[F, Blake2b256Hash, GNAT[C, P, A, K]](env, path)
 
     new MixedContext[F, C, P, A, K](env, trieStore)
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -118,7 +118,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     */
   def close(): F[Unit]
 
-  val store: IStore[C, P, A, K]
+  val store: IStore[F, C, P, A, K]
 }
 
 object ISpace {

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -28,6 +28,8 @@ trait IStore[F[_], C, P, A, K] {
 
   private[rspace] def withTxnF[R](txn: F[Transaction])(f: Transaction => R): F[R]
 
+  private[rspace] def withTxnFlatF[R](txn: F[Transaction])(f: Transaction => F[R]): F[R]
+
   private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash
 
   private[rspace] def getChannels(txn: Transaction, channelsHash: Blake2b256Hash): Seq[C]

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -26,7 +26,13 @@ trait IStore[F[_], C, P, A, K] {
 
   private[rspace] def createTxnWrite(): Transaction
 
+  private[rspace] def createTxnReadF(): F[Transaction]
+
+  private[rspace] def createTxnWriteF(): F[Transaction]
+
   private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R): R
+
+  private[rspace] def withTxnF[R](txn: F[Transaction])(f: Transaction => R): F[R]
 
   private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -22,15 +22,9 @@ trait IStore[F[_], C, P, A, K] {
 
   private[rspace] type TrieTransaction
 
-  private[rspace] def createTxnRead(): Transaction
-
-  private[rspace] def createTxnWrite(): Transaction
-
   private[rspace] def createTxnReadF(): F[Transaction]
 
   private[rspace] def createTxnWriteF(): F[Transaction]
-
-  private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R): R
 
   private[rspace] def withTxnF[R](txn: F[Transaction])(f: Transaction => R): F[R]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.Seq
   * @tparam A a type representing an arbitrary piece of data
   * @tparam K a type representing a continuation
   */
-trait IStore[C, P, A, K] {
+trait IStore[F[_], C, P, A, K] {
 
   /**
     * The type of transactions

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryOps.scala
@@ -75,10 +75,8 @@ trait InMemoryOps[S] extends CloseOps {
       private[this] val initial = stateRef.take
       private[this] var current = initial
 
-      override def commit(): Unit = {
+      override def commit(): Unit =
         stateRef.put(current)
-        updateGauges()
-      }
 
       override def abort(): Unit = stateRef.put(initial)
 

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -1,14 +1,13 @@
 package coop.rchain.rspace
 
+import cats.effect.Sync
+
 import scala.collection.immutable.Seq
-
 import cats.implicits._
-
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.canonicalize
 import coop.rchain.shared.SeqOps.{dropIndex, removeFirst}
-
 import kamon._
 import scodec.Codec
 
@@ -36,7 +35,7 @@ object State {
 class InMemoryStore[F[_], T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
-)(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K])
+)(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K], syncF: Sync[F])
     extends InMemoryOps[State[C, P, A, K]]
     with IStore[F, C, P, A, K] {
 
@@ -52,6 +51,25 @@ class InMemoryStore[F[_], T, C, P, A, K](
   private[this] val MetricsSource = RSpaceMetricsSource + ".in-mem"
   private[this] val refine        = Map("path" -> "inmem")
   private[this] val entriesGauge  = Kamon.gauge(MetricsSource + ".entries").refine(refine)
+
+  private[rspace] def createTxnReadF(): F[Transaction] = syncF.delay(createTxnRead())
+
+  private[rspace] def createTxnWriteF(): F[Transaction] = syncF.delay(createTxnWrite())
+
+  private[rspace] def withTxnF[R](txnF: F[Transaction])(f: Transaction => R): F[R] =
+    for {
+      txn <- txnF
+      retErr <- syncF.delay {
+                 val r = f(txn)
+                 txn.commit()
+                 r
+               }.attempt
+      _ <- syncF.delay {
+            updateGauges()
+            txn.close()
+          }
+      ret <- retErr.fold(syncF.raiseError, _.pure[F])
+    } yield ret
 
   private[rspace] def updateGauges() =
     withTxn(createTxnRead())(_.readState { state =>
@@ -276,7 +294,8 @@ object InMemoryStore {
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]
+      sk: Serialize[K],
+      syncF: Sync[F]
   ): IStore[F, C, P, A, K] =
-    new InMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
+    new InMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk, syncF)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -33,12 +33,12 @@ object State {
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class InMemoryStore[T, C, P, A, K](
+class InMemoryStore[F[_], T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
 )(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K])
     extends InMemoryOps[State[C, P, A, K]]
-    with IStore[C, P, A, K] {
+    with IStore[F, C, P, A, K] {
 
   type TrieTransaction = T
 
@@ -269,7 +269,7 @@ object InMemoryStore {
       case Right(value) => value
     }
 
-  def create[T, C, P, A, K](
+  def create[F[_], T, C, P, A, K](
       trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
       branch: Branch
   )(
@@ -277,6 +277,6 @@ object InMemoryStore {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): InMemoryStore[T, C, P, A, K] =
-    new InMemoryStore[T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
+  ): IStore[F, C, P, A, K] =
+    new InMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -31,7 +31,6 @@ object State {
   def empty[C, P, A, K]: State[C, P, A, K] = State[C, P, A, K](Map.empty, Map.empty)
 }
 
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class InMemoryStore[F[_], T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
@@ -237,6 +236,7 @@ class InMemoryStore[F[_], T, C, P, A, K](
   private[this] def isOrphaned(gnat: GNAT[C, P, A, K]): Boolean =
     gnat.data.isEmpty && gnat.wks.isEmpty
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   protected def processTrieUpdate(update: TrieUpdate[C, P, A, K]): Unit =
     update match {
       case TrieUpdate(_, Insert, channelsHash, gnat) =>

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
@@ -13,7 +13,7 @@ import scodec.bits.BitVector
 import kamon._
 import scala.util.control.NonFatal
 
-trait LMDBOps extends CloseOps {
+trait LMDBOps[F[_]] extends CloseOps {
 
   protected[rspace] type Transaction = Txn[ByteBuffer]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBOps.scala
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Path
 
 import cats.effect.Sync
+import coop.rchain.catscontrib.ski._
 import cats.implicits._
 import org.lmdbjava.{Dbi, Env, Txn, TxnOps}
 import scodec.Codec
@@ -67,8 +68,7 @@ trait LMDBOps[F[_]] extends CloseOps {
   private[rspace] def withTxnFlatF[R](txnF: F[Txn[ByteBuffer]])(f: Txn[ByteBuffer] => F[R]): F[R] =
     for {
       txn    <- txnF
-      retErr <- f(txn).attempt
-      _      <- syncF.delay(retErr.map(_ => txn.commit()))
+      retErr <- f(txn).flatMap(r => syncF.delay(txn.commit()).as(r)).attempt
       _      <- syncF.delay(updateGauges())
       _      <- syncF.delay(txn.close())
       ret    <- syncF.fromEither(retErr)

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -3,15 +3,15 @@ package coop.rchain.rspace
 import java.nio.ByteBuffer
 import java.nio.file.Path
 
+import cats.effect.Sync
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
-
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.canonicalize
 import coop.rchain.shared.Resources.withResource
 import coop.rchain.shared.SeqOps._
-
 import org.lmdbjava._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import scodec.Codec
@@ -36,7 +36,8 @@ class LMDBStore[F[_], C, P, A, K] private[rspace] (
     codecC: Codec[C],
     codecP: Codec[P],
     codecA: Codec[A],
-    codecK: Codec[K]
+    codecK: Codec[K],
+    val syncF: Sync[F]
 ) extends IStore[F, C, P, A, K]
     with LMDBOps[F] {
 
@@ -299,7 +300,8 @@ object LMDBStore {
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]
+      sk: Serialize[K],
+      syncF: Sync[F]
   ): IStore[F, C, P, A, K] = {
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -38,7 +38,7 @@ class LMDBStore[F[_], C, P, A, K] private[rspace] (
     codecA: Codec[A],
     codecK: Codec[K]
 ) extends IStore[F, C, P, A, K]
-    with LMDBOps {
+    with LMDBOps[F] {
 
   protected val MetricsSource: String = RSpaceMetricsSource + ".lmdb"
 

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -24,7 +24,7 @@ import scodec.bits._
   */
 @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements"))
 // TODO stop throwing exceptions
-class LMDBStore[C, P, A, K] private[rspace] (
+class LMDBStore[F[_], C, P, A, K] private[rspace] (
     val env: Env[ByteBuffer],
     protected[this] val databasePath: Path,
     private[this] val _dbGNATs: Dbi[ByteBuffer],
@@ -37,7 +37,7 @@ class LMDBStore[C, P, A, K] private[rspace] (
     codecP: Codec[P],
     codecA: Codec[A],
     codecK: Codec[K]
-) extends IStore[C, P, A, K]
+) extends IStore[F, C, P, A, K]
     with LMDBOps {
 
   protected val MetricsSource: String = RSpaceMetricsSource + ".lmdb"
@@ -294,13 +294,13 @@ class LMDBStore[C, P, A, K] private[rspace] (
 
 object LMDBStore {
 
-  def create[C, P, A, K](context: LMDBContext[C, P, A, K], branch: Branch = Branch.MASTER)(
+  def create[F[_], C, P, A, K](context: LMDBContext[F, C, P, A, K], branch: Branch = Branch.MASTER)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): LMDBStore[C, P, A, K] = {
+  ): IStore[F, C, P, A, K] = {
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
     implicit val codecA: Codec[A] = sa.toCodec
@@ -309,7 +309,7 @@ object LMDBStore {
     val dbGnats: Dbi[ByteBuffer] = context.env.openDbi(s"${branch.name}-gnats", MDB_CREATE)
     val dbJoins: Dbi[ByteBuffer] = context.env.openDbi(s"${branch.name}-joins", MDB_CREATE)
 
-    new LMDBStore[C, P, A, K](
+    new LMDBStore[F, C, P, A, K](
       context.env,
       context.path,
       dbGnats,

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -41,19 +41,15 @@ class LockFreeInMemoryStore[F[_], T, C, P, A, K](
 
   protected[rspace] type Transaction = InMemTransaction[State[C, P, A, K]]
 
-  override private[rspace] def createTxnRead(): Transaction = {
+  private[rspace] def createTxnReadF(): F[Transaction] = syncF.delay {
     failIfClosed()
     new NoopTxn[State[C, P, A, K]]
   }
-  override private[rspace] def createTxnWrite(): Transaction = {
+
+  private[rspace] def createTxnWriteF(): F[Transaction] = syncF.delay {
     failIfClosed()
     new NoopTxn[State[C, P, A, K]]
   }
-  override private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R) = f(txn)
-
-  private[rspace] def createTxnReadF(): F[Transaction] = syncF.delay(createTxnRead())
-
-  private[rspace] def createTxnWriteF(): F[Transaction] = syncF.delay(createTxnWrite())
 
   private[rspace] def withTxnF[R](txnF: F[Transaction])(f: Transaction => R): F[R] =
     for {

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -1,13 +1,14 @@
 package coop.rchain.rspace
 
+import cats.effect.Sync
+import cats.implicits._
+
 import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.Seq
-
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.canonicalize
 import coop.rchain.shared.SeqOps.{dropIndex, removeFirst}
-
 import kamon._
 import scodec.Codec
 
@@ -34,7 +35,7 @@ class NoopTxn[S] extends InMemTransaction[S] {
 class LockFreeInMemoryStore[F[_], T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
-)(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K])
+)(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K], syncF: Sync[F])
     extends IStore[F, C, P, A, K]
     with CloseOps {
 
@@ -49,7 +50,27 @@ class LockFreeInMemoryStore[F[_], T, C, P, A, K](
     new NoopTxn[State[C, P, A, K]]
   }
   override private[rspace] def withTxn[R](txn: Transaction)(f: Transaction => R) = f(txn)
-  override def close(): Unit                                                     = super.close()
+
+  private[rspace] def createTxnReadF(): F[Transaction] = syncF.delay(createTxnRead())
+
+  private[rspace] def createTxnWriteF(): F[Transaction] = syncF.delay(createTxnWrite())
+
+  private[rspace] def withTxnF[R](txnF: F[Transaction])(f: Transaction => R): F[R] =
+    for {
+      txn <- txnF
+      retErr <- syncF.delay {
+                 val r = f(txn)
+                 txn.commit()
+                 r
+               }.attempt
+      _ <- syncF.delay {
+            updateGauges()
+            txn.close()
+          }
+      ret <- retErr.fold(syncF.raiseError, _.pure[F])
+    } yield ret
+
+  override def close(): Unit = super.close()
 
   type TrieTransaction = T
 
@@ -260,7 +281,8 @@ object LockFreeInMemoryStore {
       implicit sc: Serialize[C],
       sp: Serialize[P],
       sa: Serialize[A],
-      sk: Serialize[K]
+      sk: Serialize[K],
+      syncF: Sync[F]
   ): IStore[F, C, P, A, K] =
-    new LockFreeInMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
+    new LockFreeInMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk, syncF)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -31,11 +31,11 @@ class NoopTxn[S] extends InMemTransaction[S] {
   * It should be used with RSpace that solves high level locking (e.g. FineGrainedRSpace).
   */
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-class LockFreeInMemoryStore[T, C, P, A, K](
+class LockFreeInMemoryStore[F[_], T, C, P, A, K](
     val trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
     val trieBranch: Branch
 )(implicit sc: Serialize[C], sp: Serialize[P], sa: Serialize[A], sk: Serialize[K])
-    extends IStore[C, P, A, K]
+    extends IStore[F, C, P, A, K]
     with CloseOps {
 
   protected[rspace] type Transaction = InMemTransaction[State[C, P, A, K]]
@@ -253,7 +253,7 @@ class LockFreeInMemoryStore[T, C, P, A, K](
 
 object LockFreeInMemoryStore {
 
-  def create[T, C, P, A, K](
+  def create[F[_], T, C, P, A, K](
       trieStore: ITrieStore[T, Blake2b256Hash, GNAT[C, P, A, K]],
       branch: Branch
   )(
@@ -261,6 +261,6 @@ object LockFreeInMemoryStore {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K]
-  ): LockFreeInMemoryStore[T, C, P, A, K] =
-    new LockFreeInMemoryStore[T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
+  ): IStore[F, C, P, A, K] =
+    new LockFreeInMemoryStore[F, T, C, P, A, K](trieStore, branch)(sc, sp, sa, sk)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -41,10 +41,6 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
   private[this] val consumeCommCounter = Kamon.counter(MetricsSource + ".comm.consume")
   private[this] val produceCommCounter = Kamon.counter(MetricsSource + ".comm.produce")
 
-  private[this] val consumeSpan   = Kamon.buildSpan(MetricsSource + ".consume")
-  private[this] val produceSpan   = Kamon.buildSpan(MetricsSource + ".produce")
-  protected[this] val installSpan = Kamon.buildSpan(MetricsSource + ".install")
-
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def consume(
       channels: Seq[C],
@@ -65,99 +61,80 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
         logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
       } else
         syncF.delay {
-          Kamon.withSpan(consumeSpan.start(), finishSpan = true) {
-            val span = Kamon.currentSpan()
-            span.mark("before-consume-ref-compute")
-            val consumeRef =
-              Consume.create(channels, patterns, continuation, persist, sequenceNumber)
+          val consumeRef =
+            Consume.create(channels, patterns, continuation, persist, sequenceNumber)
 
-            span.mark("before-consume-lock")
-            consumeLock(channels) {
-              span.mark("consume-lock-acquired")
-              logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
+          consumeLock(channels) {
+            logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
                              |at <channels: $channels>""".stripMargin.replace('\n', ' '))
 
-              span.mark("before-event-log-lock-acquired")
-              eventLog.update(consumeRef +: _)
-              span.mark("event-log-updated")
-              /*
-               * Here, we create a cache of the data at each channel as `channelToIndexedData`
-               * which is used for finding matches.  When a speculative match is found, we can
-               * remove the matching datum from the remaining data candidates in the cache.
-               *
-               * Put another way, this allows us to speculatively remove matching data without
-               * affecting the actual store contents.
-               */
+            eventLog.update(consumeRef +: _)
+            /*
+             * Here, we create a cache of the data at each channel as `channelToIndexedData`
+             * which is used for finding matches.  When a speculative match is found, we can
+             * remove the matching datum from the remaining data candidates in the cache.
+             *
+             * Put another way, this allows us to speculatively remove matching data without
+             * affecting the actual store contents.
+             */
 
-              span.mark("before-channel-to-indexed-data")
-              val channelToIndexedData = store.withTxn(store.createTxnRead()) { txn =>
-                channels.map { c: C =>
-                  c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-                }.toMap
-              }
+            val channelToIndexedData = store.withTxn(store.createTxnRead()) { txn =>
+              channels.map { c: C =>
+                c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
+              }.toMap
+            }
 
-              span.mark("before-extract-data-candidates")
-              val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
-                extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
-                  .map(_.sequence)
+            val options: Either[E, Option[Seq[DataCandidate[C, R]]]] =
+              extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil).sequence
+                .map(_.sequence)
 
-              options match {
-                case Left(e) =>
-                  Left(e)
-                case Right(None) =>
-                  span.mark("acquire-write-lock")
-
-                  store
-                    .withTxn(store.createTxnWrite()) { txn =>
-                      span.mark("before-put-continuation")
-                      store.putWaitingContinuation(
-                        txn,
-                        channels,
-                        WaitingContinuation(patterns, continuation, persist, consumeRef)
-                      )
-                      span.mark("after-put-continuation")
-                      for (channel <- channels)
-                        store.addJoin(txn, channel, channels)
-                    }
-                  logger.debug(s"""|consume: no data found,
+            options match {
+              case Left(e) =>
+                Left(e)
+              case Right(None) =>
+                store
+                  .withTxn(store.createTxnWrite()) { txn =>
+                    store.putWaitingContinuation(
+                      txn,
+                      channels,
+                      WaitingContinuation(patterns, continuation, persist, consumeRef)
+                    )
+                    for (channel <- channels)
+                      store.addJoin(txn, channel, channels)
+                  }
+                logger.debug(s"""|consume: no data found,
                                  |storing <(patterns, continuation): ($patterns, $continuation)>
                                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-                  Right(None)
-                case Right(Some(dataCandidates)) =>
-                  consumeCommCounter.increment()
+                Right(None)
+              case Right(Some(dataCandidates)) =>
+                consumeCommCounter.increment()
 
-                  span.mark("before-event-log-update")
-                  eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
-                  span.mark("event-log-updated")
+                eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
 
-                  dataCandidates
-                    .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                    .foreach {
-                      case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex)
-                          if !persistData =>
-                        span.mark("acquire-write-lock")
-                        store.withTxn(store.createTxnWrite()) { txn =>
-                          span.mark("before-remove-datum")
-                          store.removeDatum(txn, Seq(candidateChannel), dataIndex)
-                          span.mark("after-remove-datum")
-                        }
-                      case _ =>
-                        ()
-                    }
-                  logger.debug(
-                    s"consume: data found for <patterns: $patterns> at <channels: $channels>"
-                  )
-                  val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
-                  Right(
-                    Some(
-                      (
-                        ContResult(continuation, persist, channels, patterns, contSequenceNumber),
-                        dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
-                      )
+                dataCandidates
+                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                  .foreach {
+                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex)
+                        if !persistData =>
+                      store.withTxn(store.createTxnWrite()) { txn =>
+                        store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+                      }
+                    case _ =>
+                      ()
+                  }
+                logger.debug(
+                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
+                )
+                val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
+                Right(
+                  Some(
+                    (
+                      ContResult(continuation, persist, channels, patterns, contSequenceNumber),
+                      dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
                     )
                   )
+                )
 
-              }
             }
           }
         }
@@ -177,140 +154,117 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       syncF.delay {
-        Kamon.withSpan(produceSpan.start(), finishSpan = true) {
-          val span = Kamon.currentSpan()
-          span.mark("before-produce-ref-computed")
-          val produceRef = Produce.create(channel, data, persist, sequenceNumber)
-          span.mark("before-produce-lock")
-          produceLock(channel) {
-            span.mark("produce-lock-acquired")
-            //TODO fix double join fetch
-            val groupedChannels: Seq[Seq[C]] = store.withTxn(store.createTxnRead()) { txn =>
-              store.getJoin(txn, channel)
-            }
-            span.mark("grouped-channels")
-            logger.debug(
-              s"""|produce: searching for matching continuations
+        val produceRef = Produce.create(channel, data, persist, sequenceNumber)
+        produceLock(channel) {
+          //TODO fix double join fetch
+          val groupedChannels: Seq[Seq[C]] = store.withTxn(store.createTxnRead()) { txn =>
+            store.getJoin(txn, channel)
+          }
+          logger.debug(
+            s"""|produce: searching for matching continuations
                   |at <groupedChannels: $groupedChannels>""".stripMargin
-                .replace('\n', ' ')
-            )
-            span.mark("before-event-log-lock-acquired")
-            eventLog.update(produceRef +: _)
-            span.mark("event-log-updated")
+              .replace('\n', ' ')
+          )
+          eventLog.update(produceRef +: _)
 
-            /*
-             * Find produce candidate
-             *
-             * Could also be implemented with a lazy `foldRight`.
-             */
-            @tailrec
-            def extractProduceCandidate(
-                groupedChannels: Seq[Seq[C]],
-                batChannel: C,
-                data: Datum[A]
-            ): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
-              groupedChannels match {
-                case Nil => Right(None)
-                case channels :: remaining =>
-                  span.mark("before-match-candidates")
-                  val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
-                    store.withTxn(store.createTxnRead()) { txn =>
-                      Random.shuffle(store.getWaitingContinuation(txn, channels).zipWithIndex)
-                    }
-                  /*
-                   * Here, we create a cache of the data at each channel as `channelToIndexedData`
-                   * which is used for finding matches.  When a speculative match is found, we can
-                   * remove the matching datum from the remaining data candidates in the cache.
-                   *
-                   * Put another way, this allows us to speculatively remove matching data without
-                   * affecting the actual store contents.
-                   *
-                   * In this version, we also add the produced data directly to this cache.
-                   */
-                  span.mark("before-channel-to-indexed-data")
-                  val channelToIndexedData: Map[C, Seq[(Datum[A], Int)]] = channels.map { (c: C) =>
-                    val as = store.withTxn(store.createTxnRead()) { txn =>
-                      Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-                    }
-                    c -> {
-                      if (c == batChannel) (data, -1) +: as else as
-                    }
-                  }.toMap
-                  extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
-                    case Left(e)                 => Left(e)
-                    case Right(None)             => extractProduceCandidate(remaining, batChannel, data)
-                    case Right(produceCandidate) => Right(produceCandidate)
+          /*
+           * Find produce candidate
+           *
+           * Could also be implemented with a lazy `foldRight`.
+           */
+          @tailrec
+          def extractProduceCandidate(
+              groupedChannels: Seq[Seq[C]],
+              batChannel: C,
+              data: Datum[A]
+          ): Either[E, Option[ProduceCandidate[C, P, R, K]]] =
+            groupedChannels match {
+              case Nil => Right(None)
+              case channels :: remaining =>
+                val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
+                  store.withTxn(store.createTxnRead()) { txn =>
+                    Random.shuffle(store.getWaitingContinuation(txn, channels).zipWithIndex)
                   }
-              }
-
-            span.mark("extract-produce-candidate")
-            extractProduceCandidate(groupedChannels, channel, Datum(data, persist, produceRef)) match {
-              case Left(e) => Left(e)
-              case Right(
-                  Some(
-                    ProduceCandidate(
-                      channels,
-                      WaitingContinuation(patterns, continuation, persistK, consumeRef),
-                      continuationIndex,
-                      dataCandidates
-                    )
-                  )
-                  ) =>
-                produceCommCounter.increment()
-
-                eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
-
-                if (!persistK) {
-                  span.mark("acquire-write-lock")
-                  store.withTxn(store.createTxnWrite()) { txn =>
-                    span.mark("before-remove-continuation")
-                    store.removeWaitingContinuation(txn, channels, continuationIndex)
-                    span.mark("after-remove-continuation")
+                /*
+                 * Here, we create a cache of the data at each channel as `channelToIndexedData`
+                 * which is used for finding matches.  When a speculative match is found, we can
+                 * remove the matching datum from the remaining data candidates in the cache.
+                 *
+                 * Put another way, this allows us to speculatively remove matching data without
+                 * affecting the actual store contents.
+                 *
+                 * In this version, we also add the produced data directly to this cache.
+                 */
+                val channelToIndexedData: Map[C, Seq[(Datum[A], Int)]] = channels.map { (c: C) =>
+                  val as = store.withTxn(store.createTxnRead()) { txn =>
+                    Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
                   }
+                  c -> {
+                    if (c == batChannel) (data, -1) +: as else as
+                  }
+                }.toMap
+                extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
+                  case Left(e)                 => Left(e)
+                  case Right(None)             => extractProduceCandidate(remaining, batChannel, data)
+                  case Right(produceCandidate) => Right(produceCandidate)
                 }
-                dataCandidates
-                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                  .foreach {
-                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
-                      span.mark("acquire-write-lock")
-                      store.withTxn(store.createTxnWrite()) { txn =>
-                        if (!persistData && dataIndex >= 0) {
-                          span.mark("before-remove-datum")
-                          store.removeDatum(txn, Seq(candidateChannel), dataIndex)
-                          span.mark("after-remove-datum")
-                        }
-                        span.mark("before-remove-join")
-                        store.removeJoin(txn, candidateChannel, channels)
-                        span.mark("remove-join")
-                      }
-                  }
-                logger.debug(s"produce: matching continuation found at <channels: $channels>")
-                val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
-                Right(
-                  Some(
-                    (
-                      ContResult[C, P, K](
-                        continuation,
-                        persistK,
-                        channels,
-                        patterns,
-                        contSequenceNumber
-                      ),
-                      dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
-                    )
+            }
+
+          extractProduceCandidate(groupedChannels, channel, Datum(data, persist, produceRef)) match {
+            case Left(e) => Left(e)
+            case Right(
+                Some(
+                  ProduceCandidate(
+                    channels,
+                    WaitingContinuation(patterns, continuation, persistK, consumeRef),
+                    continuationIndex,
+                    dataCandidates
                   )
                 )
-              case Right(None) =>
-                logger.debug(s"produce: no matching continuation found")
-                span.mark("acquire-write-lock")
+                ) =>
+              produceCommCounter.increment()
+
+              eventLog.update(COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _)
+
+              if (!persistK) {
                 store.withTxn(store.createTxnWrite()) { txn =>
-                  span.mark("before-put-datum")
-                  store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
-                  span.mark("after-put-datum")
+                  store.removeWaitingContinuation(txn, channels, continuationIndex)
                 }
-                logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
-                Right(None)
-            }
+              }
+              dataCandidates
+                .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                .foreach {
+                  case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                    store.withTxn(store.createTxnWrite()) { txn =>
+                      if (!persistData && dataIndex >= 0) {
+                        store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+                      }
+                      store.removeJoin(txn, candidateChannel, channels)
+                    }
+                }
+              logger.debug(s"produce: matching continuation found at <channels: $channels>")
+              val contSequenceNumber: Int = nextSequenceNumber(consumeRef, dataCandidates)
+              Right(
+                Some(
+                  (
+                    ContResult[C, P, K](
+                      continuation,
+                      persistK,
+                      channels,
+                      patterns,
+                      contSequenceNumber
+                    ),
+                    dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+                  )
+                )
+              )
+            case Right(None) =>
+              logger.debug(s"produce: no matching continuation found")
+              store.withTxn(store.createTxnWrite()) { txn =>
+                store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
+              }
+              logger.debug(s"produce: persisted <data: $data> at <channel: $channel>")
+              Right(None)
           }
         }
       }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.util.Random
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.implicits._
 import coop.rchain.shared.Log
 import coop.rchain.catscontrib._
@@ -28,7 +28,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
     serializeP: Serialize[P],
     serializeA: Serialize[A],
     serializeK: Serialize[K],
-    val syncF: Sync[F],
+    val concurrent: Concurrent[F],
     logF: Log[F],
     contextShift: ContextShift[F],
     scheduler: ExecutionContext
@@ -333,7 +333,7 @@ object RSpace {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      syncF: Sync[F],
+      concurrent: Concurrent[F],
       log: Log[F],
       contextShift: ContextShift[F],
       scheduler: ExecutionContext
@@ -362,7 +362,7 @@ object RSpace {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      syncF: Sync[F],
+      concurrent: Concurrent[F],
       logF: Log[F],
       contextShift: ContextShift[F],
       scheduler: ExecutionContext

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -2,11 +2,10 @@ package coop.rchain.rspace
 
 import java.nio.ByteBuffer
 
-import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.util.Random
-import cats.effect.{Concurrent, ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift}
 import cats.implicits._
 import coop.rchain.shared.Log
 import coop.rchain.catscontrib._
@@ -41,6 +40,100 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
   private[this] val consumeCommCounter = Kamon.counter(MetricsSource + ".comm.consume")
   private[this] val produceCommCounter = Kamon.counter(MetricsSource + ".comm.produce")
 
+  /*
+   * Here, we create a cache of the data at each channel as `channelToIndexedData`
+   * which is used for finding matches.  When a speculative match is found, we can
+   * remove the matching datum from the remaining data candidates in the cache.
+   *
+   * Put another way, this allows us to speculatively remove matching data without
+   * affecting the actual store contents.
+   */
+  private[this] def fetchChannelToIndexData(channels: Seq[C]) =
+    store.withTxnF(store.createTxnReadF()) { txn =>
+      channels.map { c: C =>
+        c -> Random.shuffle(
+          store.getData(txn, Seq(c)).zipWithIndex
+        )
+      }.toMap
+    }
+
+  private[this] def storeWaitingContinuation(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      consumeRef: Consume
+  ): F[Either[E, MaybeDataCandidate]] =
+    for {
+      _ <- store
+            .withTxnF(store.createTxnWriteF()) { txn =>
+              store.putWaitingContinuation(
+                txn,
+                channels,
+                WaitingContinuation(
+                  patterns,
+                  continuation,
+                  persist,
+                  consumeRef
+                )
+              )
+              for (channel <- channels)
+                store.addJoin(txn, channel, channels)
+            }
+      _ <- logF.debug(s"""|consume: no data found,
+                           |storing <(patterns, continuation): ($patterns, $continuation)>
+                           |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+    } yield None.asRight[E]
+
+  private[this] def storePersistentData(dataCandidates: Seq[DataCandidate[C, R]]) =
+    dataCandidates.toList
+      .sortBy(_.datumIndex)(Ordering[Int].reverse)
+      .traverse {
+        case DataCandidate(
+            candidateChannel,
+            Datum(_, persistData, _),
+            dataIndex
+            ) if !persistData =>
+          store.withTxnF(store.createTxnWriteF()) { txn =>
+            store.removeDatum(
+              txn,
+              Seq(candidateChannel),
+              dataIndex
+            )
+          }
+        case _ =>
+          ().pure[F]
+      }
+
+  private[this] def createContinuationResult(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      consumeRef: Consume,
+      dataCandidates: Seq[DataCandidate[C, R]]
+  ) = {
+    val contSequenceNumber: Int =
+      nextSequenceNumber(consumeRef, dataCandidates)
+    Right(
+      Some(
+        (
+          ContResult(
+            continuation,
+            persist,
+            channels,
+            patterns,
+            contSequenceNumber
+          ),
+          dataCandidates
+            .map(dc => Result(dc.datum.a, dc.datum.persist))
+        )
+      )
+    )
+  }
+
+  type MaybeDataCandidate = Option[(ContResult[C, P, K], Seq[Result[R]])]
+
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def consume(
       channels: Seq[C],
@@ -50,9 +143,20 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       sequenceNumber: Int
   )(
       implicit m: Match[P, E, A, R]
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
-    contextShift.evalOn(scheduler) {
+  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
+    def storeWC(consumeRef: Consume) =
+      storeWaitingContinuation(channels, patterns, continuation, persist, consumeRef)
+    def wrapResult(consumeRef: Consume, dataCandidates: Seq[DataCandidate[C, R]]) =
+      createContinuationResult(
+        channels,
+        patterns,
+        continuation,
+        persist,
+        consumeRef,
+        dataCandidates
+      )
 
+    contextShift.evalOn(scheduler) {
       if (channels.isEmpty) {
         val msg = "channels can't be empty"
         logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
@@ -61,122 +165,54 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
         logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
       } else
         for {
-          consumeRef <- Consume
-                         .create(channels, patterns, continuation, persist, sequenceNumber)
-                         .pure[F]
+          consumeRef <- syncF.delay {
+                         Consume.create(channels, patterns, continuation, persist, sequenceNumber)
+                       }
           result <- consumeLockF(channels) {
                      for {
-                       _ <- ().pure[F]
-                       _ = logger.debug(
-                         s"""|consume: searching for data matching <patterns: $patterns>
+                       _ <- logF
+                             .debug(
+                               s"""|consume: searching for data matching <patterns: $patterns>
                              |at <channels: $channels>""".stripMargin.replace('\n', ' ')
-                       )
+                             )
                        _ = eventLog.update(consumeRef +: _)
 
-                       /*
-                        * Here, we create a cache of the data at each channel as `channelToIndexedData`
-                        * which is used for finding matches.  When a speculative match is found, we can
-                        * remove the matching datum from the remaining data candidates in the cache.
-                        *
-                        * Put another way, this allows us to speculatively remove matching data without
-                        * affecting the actual store contents.
-                        */
-
-                       channelToIndexedData <- store.withTxnF(store.createTxnReadF()) { txn =>
-                                                channels.map { c: C =>
-                                                  c -> Random.shuffle(
-                                                    store.getData(txn, Seq(c)).zipWithIndex
-                                                  )
-                                                }.toMap
-                                              }
+                       channelToIndexedData <- fetchChannelToIndexData(channels)
 
                        options = extractDataCandidates(
                          channels.zip(patterns),
                          channelToIndexedData,
                          Nil
-                       ).sequence
-                         .map(_.sequence)
+                       ).sequence.map(_.sequence)
+
                        result <- options match {
                                   case Left(e) =>
-                                    Left(e).pure[F]
-                                  case Right(None) =>
-                                    store
-                                      .withTxnF(store.createTxnWriteF()) { txn =>
-                                        store.putWaitingContinuation(
-                                          txn,
-                                          channels,
-                                          WaitingContinuation(
-                                            patterns,
-                                            continuation,
-                                            persist,
-                                            consumeRef
-                                          )
-                                        )
-                                        for (channel <- channels)
-                                          store.addJoin(txn, channel, channels)
-                                      }
-                                      .map { _ =>
-                                        logger.debug(s"""|consume: no data found,
-                                 |storing <(patterns, continuation): ($patterns, $continuation)>
-                                 |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-                                        Right(None)
-                                      }
+                                    e.asLeft[MaybeDataCandidate].pure[F]
+                                  case Right(None) => storeWC(consumeRef)
                                   case Right(Some(dataCandidates)) =>
-                                    syncF.delay {
-                                      consumeCommCounter.increment()
-
-                                      eventLog.update(
+                                    for {
+                                      _ <- syncF.delay { consumeCommCounter.increment() }
+                                      _ = eventLog.update(
                                         COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _
                                       )
-                                    } >>
-                                      dataCandidates.toList
-                                        .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                                        .traverse {
-                                          case DataCandidate(
-                                              candidateChannel,
-                                              Datum(_, persistData, _),
-                                              dataIndex
-                                              ) if !persistData =>
-                                            store.withTxnF(store.createTxnWriteF()) { txn =>
-                                              store.removeDatum(
-                                                txn,
-                                                Seq(candidateChannel),
-                                                dataIndex
-                                              )
-                                            }
-                                          case _ =>
-                                            ().pure[F]
-                                        }
-                                        .map { _ =>
-                                          logger.debug(
+                                      _ <- storePersistentData(dataCandidates)
+                                      _ <- logF.debug(
                                             s"consume: data found for <patterns: $patterns> at <channels: $channels>"
                                           )
-                                          val contSequenceNumber: Int =
-                                            nextSequenceNumber(consumeRef, dataCandidates)
-                                          Right(
-                                            Some(
-                                              (
-                                                ContResult(
-                                                  continuation,
-                                                  persist,
-                                                  channels,
-                                                  patterns,
-                                                  contSequenceNumber
-                                                ),
-                                                dataCandidates
-                                                  .map(dc => Result(dc.datum.a, dc.datum.persist))
-                                              )
-                                            )
-                                          )
-                                        }
+                                    } yield wrapResult(consumeRef, dataCandidates)
+
                                 }
                      } yield result
 
                    }
         } yield result
     }
+  }
 
-  private def nextSequenceNumber(consumeRef: Consume, dataCandidates: Seq[DataCandidate[C, R]]) =
+  private[this] def nextSequenceNumber(
+      consumeRef: Consume,
+      dataCandidates: Seq[DataCandidate[C, R]]
+  ) =
     Math.max(
       consumeRef.sequenceNumber,
       dataCandidates.map {
@@ -184,87 +220,183 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       }.max
     ) + 1
 
+  /*
+   * Find produce candidate
+   *
+   * Could also be implemented with a lazy `foldRight`.
+   */
+
+  private[this] def extractProduceCandidate(
+      groupedChannels: Seq[Seq[C]],
+      batChannel: C,
+      data: Datum[A]
+  )(implicit m: Match[P, E, A, R]): F[Either[E, Option[ProduceCandidate[C, P, R, K]]]] = {
+    type MaybeProduceCandidate = Option[ProduceCandidate[C, P, R, K]]
+    def go(
+        acc: Seq[Seq[C]]
+    ): F[Either[Seq[Seq[C]], Either[E, Option[ProduceCandidate[C, P, R, K]]]]] =
+      acc match {
+        case Nil => none[ProduceCandidate[C, P, R, K]].asRight[E].asRight[Seq[Seq[C]]].pure[F]
+        case channels :: remaining =>
+          for {
+            matchCandidates <- store.withTxnF(store.createTxnReadF()) { txn =>
+                                Random.shuffle(
+                                  store
+                                    .getWaitingContinuation(txn, channels)
+                                    .zipWithIndex
+                                )
+                              }
+            /*
+             * Here, we create a cache of the data at each channel as `channelToIndexedData`
+             * which is used for finding matches.  When a speculative match is found, we can
+             * remove the matching datum from the remaining data candidates in the cache.
+             *
+             * Put another way, this allows us to speculatively remove matching data without
+             * affecting the actual store contents.
+             *
+             * In this version, we also add the produced data directly to this cache.
+             */
+            channelToIndexedDataList <- channels.traverse { c: C =>
+                                         store
+                                           .withTxnF(store.createTxnReadF()) { txn =>
+                                             Random.shuffle(
+                                               store
+                                                 .getData(txn, Seq(c))
+                                                 .zipWithIndex
+                                             )
+                                           }
+                                           .map(
+                                             as =>
+                                               c -> {
+                                                 if (c == batChannel)
+                                                   (data, -1) +: as
+                                                 else as
+                                               }
+                                           )
+                                       }
+          } yield
+            extractFirstMatch(
+              channels,
+              matchCandidates,
+              channelToIndexedDataList.toMap
+            ) match {
+              case Left(e)                 => e.asLeft[MaybeProduceCandidate].asRight[Seq[Seq[C]]]
+              case Right(None)             => remaining.asLeft[Either[E, MaybeProduceCandidate]]
+              case Right(produceCandidate) => produceCandidate.asRight[E].asRight[Seq[Seq[C]]]
+            }
+      }
+    groupedChannels.tailRecM(go)
+  }
+
+  private[this] def processMatchFound(
+      pc: ProduceCandidate[C, P, R, K]
+  ): F[Either[E, Some[(ContResult[C, P, K], Seq[Result[R]])]]] =
+    pc match {
+      case ProduceCandidate(
+          channels,
+          WaitingContinuation(
+            patterns,
+            continuation,
+            persistK,
+            consumeRef
+          ),
+          continuationIndex,
+          dataCandidates
+          ) =>
+        def registerCOMM =
+          syncF.delay {
+            eventLog
+              .update(
+                COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _
+              )
+          }
+
+        def maybePersistWaitingContinuation =
+          if (!persistK) {
+            store.withTxnF(store.createTxnWriteF()) { txn =>
+              store.removeWaitingContinuation(
+                txn,
+                channels,
+                continuationIndex
+              )
+            }
+          } else ().pure[F]
+
+        def removeMatchedDatumAndJoin =
+          dataCandidates
+            .sortBy(_.datumIndex)(Ordering[Int].reverse)
+            .traverse {
+              case DataCandidate(
+                  candidateChannel,
+                  Datum(_, persistData, _),
+                  dataIndex
+                  ) =>
+                store.withTxnF(store.createTxnWriteF()) { txn =>
+                  if (!persistData && dataIndex >= 0) {
+                    store.removeDatum(
+                      txn,
+                      Seq(candidateChannel),
+                      dataIndex
+                    )
+                  }
+                  store.removeJoin(txn, candidateChannel, channels)
+                }
+            }
+
+        def constructResult = {
+          val contSequenceNumber = nextSequenceNumber(consumeRef, dataCandidates)
+          Some(
+            (
+              ContResult[C, P, K](
+                continuation,
+                persistK,
+                channels,
+                patterns,
+                contSequenceNumber
+              ),
+              dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+            )
+          ).asRight[E]
+        }
+
+        for {
+          _ <- syncF.delay { produceCommCounter.increment() }
+          _ <- registerCOMM
+          _ <- maybePersistWaitingContinuation
+          _ <- removeMatchedDatumAndJoin
+          _ <- logF.debug(
+                s"produce: matching continuation found at <channels: $channels>"
+              )
+        } yield constructResult
+    }
+
+  private[this] def storeData(channel: C, data: A, persist: Boolean, produceRef: Produce) =
+    for {
+      _ <- logF.debug(s"produce: no matching continuation found")
+      _ <- store
+            .withTxnF(store.createTxnWriteF()) { txn =>
+              store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
+            }
+      _ <- logF.debug(s"produce: persisted <data: $data> at <channel: $channel>")
+    } yield Right(None)
+
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       for {
-        produceRef <- Produce.create(channel, data, persist, sequenceNumber).pure[F]
+        produceRef <- syncF.delay { Produce.create(channel, data, persist, sequenceNumber) }
         result <- produceLockF(channel) {
-                   /*
-                    * Find produce candidate
-                    *
-                    * Could also be implemented with a lazy `foldRight`.
-                    */
-                   type MaybeCandidate = Option[ProduceCandidate[C, P, R, K]]
-                   //@tailrec <- fix tailrec
-                   def extractProduceCandidate(
-                       groupedChannels: Seq[Seq[C]],
-                       batChannel: C,
-                       data: Datum[A]
-                   ): F[Either[E, MaybeCandidate]] =
-                     groupedChannels match {
-                       case Nil => Right(None).asInstanceOf[Either[E, MaybeCandidate]].pure[F]
-                       case channels :: remaining =>
-                         for {
-                           matchCandidates <- store.withTxnF(store.createTxnReadF()) { txn =>
-                                               Random.shuffle(
-                                                 store
-                                                   .getWaitingContinuation(txn, channels)
-                                                   .zipWithIndex
-                                               )
-                                             }
-                           /*
-                            * Here, we create a cache of the data at each channel as `channelToIndexedData`
-                            * which is used for finding matches.  When a speculative match is found, we can
-                            * remove the matching datum from the remaining data candidates in the cache.
-                            *
-                            * Put another way, this allows us to speculatively remove matching data without
-                            * affecting the actual store contents.
-                            *
-                            * In this version, we also add the produced data directly to this cache.
-                            */
-                           channelToIndexedDataList <- channels.traverse { c: C =>
-                                                        store
-                                                          .withTxnF(store.createTxnReadF()) { txn =>
-                                                            Random.shuffle(
-                                                              store
-                                                                .getData(txn, Seq(c))
-                                                                .zipWithIndex
-                                                            )
-                                                          }
-                                                          .map(
-                                                            as =>
-                                                              c -> {
-                                                                if (c == batChannel)
-                                                                  (data, -1) +: as
-                                                                else as
-                                                              }
-                                                          )
-                                                      }
-                           result <- extractFirstMatch(
-                                      channels,
-                                      matchCandidates,
-                                      channelToIndexedDataList.toMap
-                                    ) match {
-                                      case Left(e) => e.asLeft[MaybeCandidate].pure[F]
-                                      case Right(None) =>
-                                        extractProduceCandidate(remaining, batChannel, data)
-                                      case Right(produceCandidate) =>
-                                        produceCandidate.asRight[E].pure[F]
-                                    }
-                         } yield result
-                     }
                    for {
                      //TODO fix double join fetch
-                     groupedChannels <- store.withTxnF(store.createTxnReadF()) { txn =>
-                                         store.getJoin(txn, channel)
+                     groupedChannels <- store.withTxnF(store.createTxnReadF()) {
+                                         store.getJoin(_, channel)
                                        }
-                     _ = logger.debug(
-                       s"""|produce: searching for matching continuations
+                     _ <- logF.debug(
+                           s"""|produce: searching for matching continuations
                            |at <groupedChannels: $groupedChannels>""".stripMargin.replace('\n', ' ')
-                     )
+                         )
                      _ = eventLog.update(produceRef +: _)
                      extracted <- extractProduceCandidate(
                                    groupedChannels,
@@ -272,92 +404,10 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
                                    Datum(data, persist, produceRef)
                                  )
                      r <- extracted match {
-                           case Left(e) => Left(e).pure[F]
-                           case Right(
-                               Some(
-                                 ProduceCandidate(
-                                   channels,
-                                   WaitingContinuation(
-                                     patterns,
-                                     continuation,
-                                     persistK,
-                                     consumeRef
-                                   ),
-                                   continuationIndex,
-                                   dataCandidates
-                                 )
-                               )
-                               ) =>
-                             syncF
-                               .delay {
-                                 produceCommCounter.increment()
-
-                                 eventLog.update(
-                                   COMM(consumeRef, dataCandidates.map(_.datum.source)) +: _
-                                 )
-                                 persistK
-                               }
-                               .flatMap(
-                                 pk =>
-                                   if (!pk) {
-                                     store.withTxnF(store.createTxnWriteF()) { txn =>
-                                       store.removeWaitingContinuation(
-                                         txn,
-                                         channels,
-                                         continuationIndex
-                                       )
-                                     }
-                                   } else ().pure[F]
-                               )
-                               .flatMap { _ =>
-                                 dataCandidates
-                                   .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                                   .traverse {
-                                     case DataCandidate(
-                                         candidateChannel,
-                                         Datum(_, persistData, _),
-                                         dataIndex
-                                         ) =>
-                                       store.withTxnF(store.createTxnWriteF()) { txn =>
-                                         if (!persistData && dataIndex >= 0) {
-                                           store.removeDatum(txn, Seq(candidateChannel), dataIndex)
-                                         }
-                                         store.removeJoin(txn, candidateChannel, channels)
-                                       }
-                                   }
-                               }
-                               .map { _ =>
-                                 logger.debug(
-                                   s"produce: matching continuation found at <channels: $channels>"
-                                 )
-                                 val contSequenceNumber: Int =
-                                   nextSequenceNumber(consumeRef, dataCandidates)
-                                 Some(
-                                   (
-                                     ContResult[C, P, K](
-                                       continuation,
-                                       persistK,
-                                       channels,
-                                       patterns,
-                                       contSequenceNumber
-                                     ),
-                                     dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
-                                   )
-                                 ).asRight[E]
-                               }
+                           case Left(e)         => Left(e).pure[F]
+                           case Right(Some(pc)) => processMatchFound(pc)
                            case Right(None) =>
-                             logger.debug(s"produce: no matching continuation found")
-                             store
-                               .withTxnF(store.createTxnWriteF()) { txn =>
-                                 store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
-                               }
-                               .map { _ =>
-                                 logger.debug(
-                                   s"produce: persisted <data: $data> at <channel: $channel>"
-                                 )
-                                 Right(None)
-                               }
-
+                             storeData(channel, data, persist, produceRef)
                          }
                    } yield r
                  }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -141,7 +141,6 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
 
   type MaybeDataCandidate = Option[(ContResult[C, P, K], Seq[Result[R]])]
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def consume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -400,7 +399,6 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       _ <- logF.debug(s"produce: persisted <data: $data> at <channel: $channel>")
     } yield Right(None)
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   override def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -240,8 +240,6 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
 
   /*
    * Find produce candidate
-   *
-   * Could also be implemented with a lazy `foldRight`.
    */
 
   private[this] def extractProduceCandidate(

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -82,7 +82,6 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     )(thunk)
 
   protected[this] val logger: Logger
-  protected[this] val installSpan: SpanBuilder
 
   private[this] val installs: SyncVar[Installs[C, P, E, A, R, K]] = {
     val installs = new SyncVar[Installs[C, P, E, A, R, K]]()
@@ -155,10 +154,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
       implicit m: Match[P, E, A, R]
   ): F[Option[(K, Seq[R])]] =
     syncF.delay {
-      Kamon.withSpan(installSpan.start(), finishSpan = true) {
-        store.withTxn(store.createTxnWrite()) { txn =>
-          install(txn, channels, patterns, continuation)
-        }
+      store.withTxn(store.createTxnWrite()) { txn =>
+        install(txn, channels, patterns, continuation)
       }
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -1,9 +1,11 @@
 package coop.rchain.rspace
 
+import cats.Id
 import cats.effect.Sync
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
-import coop.rchain.catscontrib._, ski._
+import coop.rchain.catscontrib._
+import ski._
 import coop.rchain.rspace.concurrent.{DefaultTwoStepLock, TwoStepLock}
 import coop.rchain.rspace.history.{Branch, Leaf}
 import coop.rchain.rspace.internal._
@@ -11,6 +13,7 @@ import coop.rchain.rspace.trace.Consume
 import coop.rchain.shared.SyncVarOps._
 import kamon._
 import kamon.trace.Tracer.SpanBuilder
+
 import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
@@ -29,7 +32,7 @@ abstract class RSpaceOps[F[_], C, P, E, A, R, K](
 
   implicit val codecC = serializeC.toCodec
 
-  private val lock: TwoStepLock[Blake2b256Hash] = new DefaultTwoStepLock()
+  private val lock: TwoStepLock[Id, Blake2b256Hash] = new DefaultTwoStepLock()
 
   protected[this] def consumeLock(
       channels: Seq[C]

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -17,7 +17,7 @@ import scala.util.Random
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
 abstract class RSpaceOps[F[_], C, P, E, A, R, K](
-    val store: IStore[C, P, A, K],
+    val store: IStore[F, C, P, A, K],
     val branch: Branch
 )(
     implicit

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -15,7 +15,6 @@ import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
 
-@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
 abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     val store: IStore[F, C, P, A, K],
     val branch: Branch

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -52,12 +52,12 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
         val msg = "channels.length must equal patterns.length"
         logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
       } else
-        syncF.delay {
-          consumeLock(channels) {
-            lockedConsume(channels, patterns, continuation, persist, sequenceNumber)
-          }
+        consumeLockF(channels) {
+          lockedConsume(channels, patterns, continuation, persist, sequenceNumber)
         }
     }
+
+  type MaybeConsumeResult = Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedConsume(
@@ -68,111 +68,120 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       sequenceNumber: Int
   )(
       implicit m: Match[P, E, A, R]
-  ): Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]] = {
-    def runMatcher(comm: COMM): Option[Seq[DataCandidate[C, R]]] = {
-
-      val channelToIndexedData = channels.map { (c: C) =>
-        c -> {
-          store.withTxn(store.createTxnRead()) { txn =>
-            store.getData(txn, Seq(c)).zipWithIndex.filter {
-              case (Datum(_, _, source), _) => comm.produces.contains(source)
-            }
-          }
-        }
-      }.toMap
-      extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil)
-        .flatMap(_.toOption)
-        .sequence
-    }
+  ): F[MaybeConsumeResult] = {
+    def runMatcher(comm: COMM): F[Option[Seq[DataCandidate[C, R]]]] =
+      for {
+        channelToIndexedDataList <- channels.toList.traverse { c: C =>
+                                     store
+                                       .withTxnF(store.createTxnReadF()) { txn =>
+                                         store.getData(txn, Seq(c)).zipWithIndex.filter {
+                                           case (Datum(_, _, source), _) =>
+                                             comm.produces.contains(source)
+                                         }
+                                       }
+                                       .map(v => c -> v) // TODO inculde map in traverse?
+                                   }
+        result = extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
+          .flatMap(_.toOption)
+          .sequence
+      } yield result
 
     @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
     def storeWaitingContinuation(
         consumeRef: Consume,
         maybeCommRef: Option[COMM]
-    ): None.type = {
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.putWaitingContinuation(
-          txn,
-          channels,
-          WaitingContinuation(patterns, continuation, persist, consumeRef)
-        )
-        for (channel <- channels) store.addJoin(txn, channel, channels)
-      }
-      logger.debug(s"""|consume: no data found,
-                       |storing <(patterns, continuation): ($patterns, $continuation)>
-                       |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-      None
-    }
+    ): F[None.type] =
+      store
+        .withTxnF(store.createTxnWriteF()) { txn =>
+          store.putWaitingContinuation(
+            txn,
+            channels,
+            WaitingContinuation(patterns, continuation, persist, consumeRef)
+          )
+          for (channel <- channels) store.addJoin(txn, channel, channels)
+        }
+        .map { _ =>
+          logger.debug(s"""|consume: no data found,
+                         |storing <(patterns, continuation): ($patterns, $continuation)>
+                         |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+          None
+        }
 
     def handleMatches(
         mats: Seq[DataCandidate[C, R]],
         consumeRef: Consume,
         comms: Multiset[COMM]
-    ): Option[(ContResult[C, P, K], Seq[Result[R]])] = {
-      consumeCommCounter.increment()
-      val commRef = COMM(consumeRef, mats.map(_.datum.source))
-      assert(comms.contains(commRef), "COMM Event was not contained in the trace")
-      mats
-        .sortBy(_.datumIndex)(Ordering[Int].reverse)
-        .foreach {
-          case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
-            if (!persistData) {
-              store.withTxn(store.createTxnWrite()) { txn =>
-                store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+    ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
+      for {
+        _       <- consumeCommCounter.increment().pure[F]
+        commRef = COMM(consumeRef, mats.map(_.datum.source))
+        _       = assert(comms.contains(commRef), "COMM Event was not contained in the trace")
+        r <- mats.toList
+              .sortBy(_.datumIndex)(Ordering[Int].reverse)
+              .traverse {
+                case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                  if (!persistData) {
+                    store.withTxnF(store.createTxnWriteF()) { txn =>
+                      store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+                    }
+                  } else ().pure[F]
               }
-            }
-        }
-      logger.debug(s"consume: data found for <patterns: $patterns> at <channels: $channels>")
-      removeBindingsFor(commRef)
-      val contSequenceNumber = commRef.nextSequenceNumber
-      Some(
-        (
-          ContResult(continuation, persist, channels, patterns, contSequenceNumber),
-          mats.map(dc => Result(dc.datum.a, dc.datum.persist))
-        )
-      )
-    }
+              .map { _ =>
+                logger.debug(
+                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
+                )
+                removeBindingsFor(commRef)
+                val contSequenceNumber = commRef.nextSequenceNumber
+                Some(
+                  (
+                    ContResult(continuation, persist, channels, patterns, contSequenceNumber),
+                    mats.map(dc => Result(dc.datum.a, dc.datum.persist))
+                  )
+                )
+              }
+      } yield r
 
-    @tailrec
+//    @tailrec <- todo fix tailrec
     @SuppressWarnings(Array("org.wartremover.warts.Throw"))
     // TODO stop throwing exceptions
-    def getCommOrDataCandidates(comms: Seq[COMM]): Either[COMM, Seq[DataCandidate[C, R]]] =
+    def getCommOrDataCandidates(comms: Seq[COMM]): F[Either[COMM, Seq[DataCandidate[C, R]]]] =
       comms match {
         case Nil =>
           val msg = "List comms must not be empty"
           logger.error(msg)
           throw new IllegalArgumentException(msg)
         case commRef :: Nil =>
-          runMatcher(commRef) match {
+          runMatcher(commRef).map {
             case Some(x) => Right(x)
             case None    => Left(commRef)
           }
         case commRef :: rem =>
-          runMatcher(commRef) match {
-            case Some(x) => Right(x)
+          runMatcher(commRef).flatMap {
+            case Some(x) => Right(x).asInstanceOf[Either[COMM, Seq[DataCandidate[C, R]]]].pure[F]
             case None    => getCommOrDataCandidates(rem)
           }
       }
 
-    logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
-                     |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+    for {
+      _          <- logger.debug(s"""|consume: searching for data matching <patterns: $patterns>
+                     |at <channels: $channels>""".stripMargin.replace('\n', ' ')).pure[F]
+      consumeRef = Consume.create(channels, patterns, continuation, persist, sequenceNumber)
+      r <- replayData.get(consumeRef) match {
+            case None =>
+              storeWaitingContinuation(consumeRef, None).map(_.asRight[E])
+            case Some(comms) =>
+              val commOrDataCandidates: F[Either[COMM, Seq[DataCandidate[C, R]]]] =
+                getCommOrDataCandidates(comms.iterator().asScala.toList)
 
-    val consumeRef = Consume.create(channels, patterns, continuation, persist, sequenceNumber)
-
-    replayData.get(consumeRef) match {
-      case None =>
-        Right(storeWaitingContinuation(consumeRef, None))
-      case Some(comms) =>
-        val commOrDataCandidates: Either[COMM, Seq[DataCandidate[C, R]]] =
-          getCommOrDataCandidates(comms.iterator().asScala.toList)
-
-        commOrDataCandidates match {
-          case Left(commRef) =>
-            Right(storeWaitingContinuation(consumeRef, Some(commRef)))
-          case Right(dataCandidates) =>
-            Right(handleMatches(dataCandidates, consumeRef, comms))
-        }
-    }
+              val x: F[MaybeConsumeResult] = commOrDataCandidates flatMap {
+                case Left(commRef) =>
+                  storeWaitingContinuation(consumeRef, Some(commRef)).map(_.asRight[E])
+                case Right(dataCandidates) =>
+                  handleMatches(dataCandidates, consumeRef, comms).map(_.asRight[E])
+              }
+              x
+          }
+    } yield r
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
@@ -180,69 +189,72 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
-      syncF.delay {
-        produceLock(channel) {
-          lockedProduce(channel, data, persist, sequenceNumber)
-        }
+      produceLockF(channel) {
+        lockedProduce(channel, data, persist, sequenceNumber)
       }
     }
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedProduce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
-  ): Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]] = {
-    @tailrec
+  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
+    //@tailrec <- todo fix tailrec
     def runMatcher(
         comm: COMM,
         produceRef: Produce,
         groupedChannels: Seq[Seq[C]]
-    ): Option[ProduceCandidate[C, P, R, K]] =
+    ): F[Option[ProduceCandidate[C, P, R, K]]] =
       groupedChannels match {
-        case Nil => None
+        case Nil => None.asInstanceOf[Option[ProduceCandidate[C, P, R, K]]].pure[F]
         case channels :: remaining =>
-          val matchCandidates: Seq[(WaitingContinuation[P, K], Int)] =
-            store.withTxn(store.createTxnRead()) { txn =>
-              store.getWaitingContinuation(txn, channels).zipWithIndex.filter {
-                case (WaitingContinuation(_, _, _, source), _) =>
-                  comm.consume == source
-              }
-            }
+          for {
+            matchCandidates <- store.withTxnF(store.createTxnReadF()) { txn =>
+                                store.getWaitingContinuation(txn, channels).zipWithIndex.filter {
+                                  case (WaitingContinuation(_, _, _, source), _) =>
+                                    comm.consume == source
+                                }
+                              }
+            channelToIndexedDataList <- store.withTxnF(store.createTxnReadF()) { txn =>
+                                         channels.map { c: C =>
+                                           val as = store.getData(txn, Seq(c)).zipWithIndex.filter {
+                                             case (Datum(_, _, source), _) =>
+                                               comm.produces.contains(source)
+                                           }
+                                           c -> {
+                                             if (c == channel)
+                                               Seq((Datum(data, persist, produceRef), -1))
+                                             else as
+                                           }
+                                         }
+                                       }
+            result <- extractFirstMatch(channels, matchCandidates, channelToIndexedDataList.toMap) match {
+                       case Right(None)             => runMatcher(comm, produceRef, remaining)
+                       case Right(produceCandidate) => produceCandidate.pure[F]
+                       case Left(_)                 => ???
+                     }
+          } yield result
 
-          val channelToIndexedData: Map[C, Seq[(Datum[A], Int)]] = store
-            .withTxn(store.createTxnRead()) { txn =>
-              channels.map { (c: C) =>
-                val as = store.getData(txn, Seq(c)).zipWithIndex.filter {
-                  case (Datum(_, _, source), _) => comm.produces.contains(source)
-                }
-                c -> {
-                  if (c == channel) Seq((Datum(data, persist, produceRef), -1)) else as
-                }
-              }.toMap
-            }
-          extractFirstMatch(channels, matchCandidates, channelToIndexedData) match {
-            case Right(None)             => runMatcher(comm, produceRef, remaining)
-            case Right(produceCandidate) => produceCandidate
-            case Left(_)                 => ???
-          }
       }
 
     def storeDatum(
         produceRef: Produce,
         maybeCommRef: Option[COMM]
-    ): None.type = {
-      store.withTxn(store.createTxnWrite()) { txn =>
-        store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
-      }
-      logger.debug(s"""|produce: no matching continuation found
-                       |storing <data: $data> at <channel: $channel>""".stripMargin)
-      None
-    }
+    ): F[None.type] =
+      store
+        .withTxnF(store.createTxnWriteF()) { txn =>
+          store.putDatum(txn, Seq(channel), Datum(data, persist, produceRef))
+        }
+        .map { _ =>
+          logger.debug(s"""|produce: no matching continuation found
+                         |storing <data: $data> at <channel: $channel>""".stripMargin)
+          None
+        }
 
     def handleMatch(
         mat: ProduceCandidate[C, P, R, K],
         produceRef: Produce,
         comms: Multiset[COMM]
-    ): Option[(ContResult[C, P, K], Seq[Result[R]])] =
+    ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
       mat match {
         case ProduceCandidate(
             channels,
@@ -250,81 +262,89 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
             continuationIndex,
             dataCandidates
             ) =>
-          produceCommCounter.increment()
-          val commRef = COMM(consumeRef, dataCandidates.map(_.datum.source))
-          assert(comms.contains(commRef), "COMM Event was not contained in the trace")
-          if (!persistK) {
-            store.withTxn(store.createTxnWrite()) { txn =>
-              store.removeWaitingContinuation(txn, channels, continuationIndex)
-            }
-          }
-          dataCandidates
-            .sortBy(_.datumIndex)(Ordering[Int].reverse)
-            .foreach {
-              case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
-                store.withTxn(store.createTxnWrite()) { txn =>
-                  if (!persistData && dataIndex >= 0) {
-                    store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+          for {
+            _       <- syncF.delay { produceCommCounter.increment() }
+            commRef = COMM(consumeRef, dataCandidates.map(_.datum.source))
+            _       = assert(comms.contains(commRef), "COMM Event was not contained in the trace")
+            _ <- if (!persistK) {
+                  store.withTxnF(store.createTxnWriteF()) { txn =>
+                    store.removeWaitingContinuation(txn, channels, continuationIndex)
                   }
-                  store.removeJoin(txn, candidateChannel, channels)
+                } else {
+                  ().pure[F]
                 }
+            _ <- dataCandidates.toList
+                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                  .traverse {
+                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                      store.withTxnF(store.createTxnWriteF()) { txn =>
+                        if (!persistData && dataIndex >= 0) {
+                          store.removeDatum(txn, Seq(candidateChannel), dataIndex)
+                        }
+                        store.removeJoin(txn, candidateChannel, channels)
+                      }
+                  }
+            r = {
+              logger.debug(s"produce: matching continuation found at <channels: $channels>")
+              removeBindingsFor(commRef)
+              val contSequenceNumber = commRef.nextSequenceNumber
+              Some(
+                (
+                  ContResult(continuation, persistK, channels, patterns, contSequenceNumber),
+                  dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+                )
+              )
             }
-          logger.debug(s"produce: matching continuation found at <channels: $channels>")
-          removeBindingsFor(commRef)
-          val contSequenceNumber = commRef.nextSequenceNumber
-          Some(
-            (
-              ContResult(continuation, persistK, channels, patterns, contSequenceNumber),
-              dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
-            )
-          )
+          } yield r
       }
 
-    store.withTxn(store.createTxnRead()) { txn =>
-      val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
+    for {
+      groupedChannels <- store.withTxnF(store.createTxnReadF()) { txn =>
+                          store.getJoin(txn, channel)
+                        }
 
-      logger.debug(s"""|produce: searching for matching continuations
+      _ = logger.debug(s"""|produce: searching for matching continuations
                        |at <groupedChannels: $groupedChannels>""".stripMargin.replace('\n', ' '))
 
-      val produceRef = Produce.create(channel, data, persist, sequenceNumber)
+      produceRef = Produce.create(channel, data, persist, sequenceNumber)
 
-      @tailrec
-      @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-      // TODO stop throwing exceptions
-      def getCommOrProduceCandidate(
-          comms: Seq[COMM]
-      ): Either[COMM, ProduceCandidate[C, P, R, K]] =
-        comms match {
-          case Nil =>
-            val msg = "comms must not be empty"
-            logger.error(msg)
-            throw new IllegalArgumentException(msg)
-          case commRef :: Nil =>
-            runMatcher(commRef, produceRef, groupedChannels) match {
-              case Some(x) => Right(x)
-              case None    => Left(commRef)
-            }
-          case commRef :: rem =>
-            runMatcher(commRef, produceRef, groupedChannels) match {
-              case Some(x) => Right(x)
-              case None    => getCommOrProduceCandidate(rem)
-            }
-        }
-
-      replayData.get(produceRef) match {
-        case None =>
-          Right(storeDatum(produceRef, None))
-        case Some(comms) =>
-          val commOrProduceCandidate: Either[COMM, ProduceCandidate[C, P, R, K]] =
-            getCommOrProduceCandidate(comms.iterator().asScala.toList)
-          commOrProduceCandidate match {
-            case Left(comm) =>
-              Right(storeDatum(produceRef, Some(comm)))
-            case Right(produceCandidate) =>
-              Right(handleMatch(produceCandidate, produceRef, comms))
-          }
-      }
-    }
+      result <- replayData.get(produceRef) match {
+                 case None =>
+                   storeDatum(produceRef, None).map(r => Right(r))
+                 case Some(comms) =>
+                   //@tailrec <-- todo fix tailrec
+                   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+                   // TODO stop throwing exceptions
+                   def getCommOrProduceCandidate(
+                       comms: Seq[COMM]
+                   ): F[Either[COMM, ProduceCandidate[C, P, R, K]]] =
+                     comms match {
+                       case Nil =>
+                         val msg = "comms must not be empty"
+                         logger.error(msg)
+                         throw new IllegalArgumentException(msg)
+                       case commRef :: Nil =>
+                         runMatcher(commRef, produceRef, groupedChannels) map {
+                           case Some(x) => Right(x)
+                           case None    => Left(commRef)
+                         }
+                       case commRef :: rem =>
+                         runMatcher(commRef, produceRef, groupedChannels) flatMap {
+                           case Some(x) => x.asRight[COMM].pure[F]
+                           case None    => getCommOrProduceCandidate(rem)
+                         }
+                     }
+                   val commOrProduceCandidate: F[Either[COMM, ProduceCandidate[C, P, R, K]]] =
+                     getCommOrProduceCandidate(comms.iterator().asScala.toList)
+                   val r: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = commOrProduceCandidate flatMap {
+                     case Left(comm) =>
+                       storeDatum(produceRef, Some(comm)).map(r => Right(r))
+                     case Right(produceCandidate) =>
+                       handleMatch(produceCandidate, produceRef, comms).map(r => Right(r))
+                   }
+                   r
+               }
+    } yield result
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -4,11 +4,10 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift}
 import cats.implicits._
 import coop.rchain.catscontrib._
 import Catscontrib._
-import cats.Id
 import coop.rchain.shared.Log
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
@@ -24,7 +23,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
     serializeP: Serialize[P],
     serializeA: Serialize[A],
     serializeK: Serialize[K],
-    val syncF: Sync[F],
+    val concurrent: Concurrent[F],
     logF: Log[F],
     contextShift: ContextShift[F],
     scheduler: ExecutionContext
@@ -417,7 +416,7 @@ object ReplayRSpace {
       sp: Serialize[P],
       sa: Serialize[A],
       sk: Serialize[K],
-      sync: Sync[F],
+      concurrent: Concurrent[F],
       log: Log[F],
       contextShift: ContextShift[F],
       scheduler: ExecutionContext

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -40,7 +40,6 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
   private[this] val consumeSpanLabel = Metrics.Source(MetricsSource, "consume")
   private[this] val produceSpanLabel = Metrics.Source(MetricsSource, "produce")
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   def consume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -67,7 +66,6 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
 
   type MaybeConsumeResult = Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedConsume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -99,7 +97,6 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
                  }
       } yield result
 
-    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
     def storeWaitingContinuation(
         consumeRef: Consume,
         maybeCommRef: Option[COMM]
@@ -206,7 +203,6 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
     } yield r
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
       implicit m: Match[P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
@@ -222,7 +218,6 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       } yield result
     }
 
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // TODO remove when Kamon replaced with Metrics API
   private[this] def lockedProduce(
       channel: C,
       data: A,

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -73,17 +73,13 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
     }
 
   def getData(channel: C): F[Seq[Datum[A]]] =
-    syncF.delay {
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, Seq(channel))
-      }
+    store.withTxnF(store.createTxnReadF()) { txn =>
+      store.getData(txn, Seq(channel))
     }
 
   def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
-    syncF.delay {
-      store.withTxn(store.createTxnRead()) { txn =>
-        store.getWaitingContinuation(txn, channels)
-      }
+    store.withTxnF(store.createTxnReadF()) { txn =>
+      store.getWaitingContinuation(txn, channels)
     }
 
   /** Iterates through (channel, pattern) pairs looking for matching data.

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -26,7 +26,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
   /**
     * A store which satisfies the [[IStore]] interface.
     */
-  val store: IStore[C, P, A, K]
+  val store: IStore[F, C, P, A, K]
 
   val branch: Branch
 

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
@@ -7,39 +7,7 @@ import scala.collection.immutable.Seq
 
 import scala.collection.concurrent.TrieMap
 
-trait MultiLock[K] {
-  def acquire[R](keys: Seq[K])(thunk: => R)(implicit o: Ordering[K]): R
-}
-
-class DefaultMultiLock[K] extends MultiLock[K] {
-
-  import java.util.concurrent.Semaphore
-
-  private[this] val locks = TrieMap.empty[K, Semaphore]
-
-  @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements")) // TODO stop throwing exceptions
-  def acquire[R](keys: Seq[K])(thunk: => R)(implicit o: Ordering[K]): R = {
-    // TODO: keys should be a Set[K]
-    val sortedKeys = keys.toSet.toList.sorted
-    for {
-      k         <- sortedKeys
-      semaphore = locks.getOrElseUpdate(k, new Semaphore(1))
-      _         = semaphore.acquire()
-    } yield ()
-    try {
-      thunk
-    } finally {
-      for {
-        k         <- sortedKeys
-        semaphore = locks.getOrElse(k, throw new Exception(s"Couldn't find lock for channel $k"))
-        _         = semaphore.release()
-      } yield ()
-    }
-  }
-
-}
-
-class FunctionalMultiLock[F[_]: Concurrent, K] {
+class MultiLock[F[_]: Concurrent, K] {
 
   private[this] val locks = TrieMap.empty[K, Semaphore[F]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
@@ -1,12 +1,31 @@
 package coop.rchain.rspace.concurrent
+import cats.Id
+import cats.implicits._
+import cats.effect.Concurrent
+import scala.collection.immutable.Seq
 
-trait TwoStepLock[K] {
-  def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => Seq[K])(thunk: => W)(
+trait TwoStepLock[F[_], K] {
+  def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => F[Seq[K]])(thunk: => F[W])(
       implicit o: Ordering[K]
-  ): W
+  ): F[W]
 }
 
-class DefaultTwoStepLock[K] extends TwoStepLock[K] {
+class ConcurrentTwoStepLockF[F[_]: Concurrent, K] extends TwoStepLock[F, K] {
+  private[this] val phaseA: FunctionalMultiLock[F, K] = new FunctionalMultiLock[F, K]
+  private[this] val phaseB: FunctionalMultiLock[F, K] = new FunctionalMultiLock[F, K]
+
+  override def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => F[Seq[K]])(thunk: => F[W])(
+      implicit o: Ordering[K]
+  ): F[W] =
+    phaseA.acquire(keysA) {
+      for {
+        keysB <- phaseTwo()
+        res   <- phaseB.acquire(keysB)(thunk)
+      } yield res
+    }
+}
+
+class DefaultTwoStepLock[K] extends TwoStepLock[Id, K] {
   private[this] val phaseA: MultiLock[K] = new DefaultMultiLock[K]
   private[this] val phaseB: MultiLock[K] = new DefaultMultiLock[K]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
@@ -1,5 +1,5 @@
 package coop.rchain.rspace.concurrent
-import cats.Id
+
 import cats.implicits._
 import cats.effect.Concurrent
 import scala.collection.immutable.Seq
@@ -11,8 +11,8 @@ trait TwoStepLock[F[_], K] {
 }
 
 class ConcurrentTwoStepLockF[F[_]: Concurrent, K] extends TwoStepLock[F, K] {
-  private[this] val phaseA: FunctionalMultiLock[F, K] = new FunctionalMultiLock[F, K]
-  private[this] val phaseB: FunctionalMultiLock[F, K] = new FunctionalMultiLock[F, K]
+  private[this] val phaseA: MultiLock[F, K] = new MultiLock[F, K]
+  private[this] val phaseB: MultiLock[F, K] = new MultiLock[F, K]
 
   override def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => F[Seq[K]])(thunk: => F[W])(
       implicit o: Ordering[K]
@@ -22,20 +22,5 @@ class ConcurrentTwoStepLockF[F[_]: Concurrent, K] extends TwoStepLock[F, K] {
         keysB <- phaseTwo()
         res   <- phaseB.acquire(keysB)(thunk)
       } yield res
-    }
-}
-
-class DefaultTwoStepLock[K] extends TwoStepLock[Id, K] {
-  private[this] val phaseA: MultiLock[K] = new DefaultMultiLock[K]
-  private[this] val phaseB: MultiLock[K] = new DefaultMultiLock[K]
-
-  override def acquire[R, S, W](
-      keysA: Seq[K]
-  )(phaseTwo: () => Seq[K])(thunk: => W)(implicit o: Ordering[K]): W =
-    phaseA.acquire(keysA) {
-      val keysB = phaseTwo
-      phaseB.acquire(keysB()) {
-        thunk
-      }
     }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -4,20 +4,20 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.nio.file.{Files, Path}
 
 import cats.Id
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift, Sync}
 import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
 import coop.rchain.shared.Language.ignore
 import coop.rchain.shared.Log
 import coop.rchain.rspace.util._
+
 import scala.concurrent.ExecutionContext
 import scodec.bits.ByteVector
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
 @SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial"))
@@ -85,7 +85,7 @@ object AddressBookExample {
 
   object implicits {
 
-    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
 
     implicit val contextShiftId: ContextShift[Id] =
       new ContextShift[Id] {

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -4,7 +4,8 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, 
 import java.nio.file.{Files, Path}
 
 import cats.Id
-import cats.effect.{Concurrent, ContextShift, Sync}
+import cats.effect.{Concurrent, ContextShift}
+import coop.rchain.metrics.Metrics
 import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace._
 import coop.rchain.rspace.history.Branch
@@ -200,7 +201,8 @@ object AddressBookExample {
 
   def exampleOne(): Unit = {
 
-    implicit val log: Log[Id] = Log.log
+    implicit val log: Log[Id]          = Log.log
+    implicit val metricsF: Metrics[Id] = new Metrics.MetricsNOP[Id]()
 
     // Here we define a temporary place to put the store's files
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
@@ -241,7 +243,8 @@ object AddressBookExample {
 
   def exampleTwo(): Unit = {
 
-    implicit val log: Log[Id] = Log.log
+    implicit val log: Log[Id]          = Log.log
+    implicit val metricsF: Metrics[Id] = new Metrics.MetricsNOP[Id]()
 
     // Here we define a temporary place to put the store's files
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
@@ -337,7 +340,9 @@ object AddressBookExample {
       f: IdISpace[Channel, Pattern, Nothing, Entry, Entry, Printer] => Unit
   ) = {
 
-    implicit val log: Log[Id] = Log.log
+    implicit val log: Log[Id]          = Log.log
+    implicit val metricsF: Metrics[Id] = new Metrics.MetricsNOP[Id]()
+
     // Here we define a temporary place to put the store's files
     val storePath = Files.createTempDirectory("rspace-address-book-example-")
     // Let's define our store

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -206,7 +206,7 @@ object AddressBookExample {
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
 
     // Let's define our store
-    val context = Context.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
+    val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
     val space =
       RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
@@ -247,7 +247,7 @@ object AddressBookExample {
     val storePath: Path = Files.createTempDirectory("rspace-address-book-example-")
 
     // Let's define our store
-    val context = Context.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
+    val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
     val space =
       RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
@@ -341,7 +341,7 @@ object AddressBookExample {
     // Here we define a temporary place to put the store's files
     val storePath = Files.createTempDirectory("rspace-address-book-example-")
     // Let's define our store
-    val context = Context.create[Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
+    val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
     val space =
       RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
     try {

--- a/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/LMDBTrieStore.scala
@@ -4,14 +4,14 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 
+import cats.effect.Sync
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
-
 import coop.rchain.rspace.{Blake2b256Hash, LMDBOps, Serialize, _}
 import coop.rchain.rspace.internal._
 import coop.rchain.shared.ByteVectorOps._
 import coop.rchain.shared.Resources.withResource
-
 import org.lmdbjava._
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import scodec.Codec
@@ -28,7 +28,8 @@ class LMDBTrieStore[F[_], K, V] private (
 )(
     implicit
     codecK: Codec[K],
-    codecV: Codec[V]
+    codecV: Codec[V],
+    val syncF: Sync[F]
 ) extends ITrieStore[Txn[ByteBuffer], K, V]
     with LMDBOps[F] {
 
@@ -146,7 +147,8 @@ object LMDBTrieStore {
   def create[F[_], K, V](env: Env[ByteBuffer], path: Path)(
       implicit
       codecK: Codec[K],
-      codecV: Codec[V]
+      codecV: Codec[V],
+      syncF: Sync[F]
   ): LMDBTrieStore[F, K, V] = {
     val dbTrie: Dbi[ByteBuffer]      = env.openDbi("Trie", MDB_CREATE)
     val dbRoots: Dbi[ByteBuffer]     = env.openDbi("Roots", MDB_CREATE)

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -43,8 +43,8 @@ trait HistoryActionsTests[F[_]]
   private[this] def getRootHash(
       store: IStore[F, String, Pattern, String, StringsCaptor],
       branch: Branch
-  ): Blake2b256Hash =
-    store.withTxn(store.createTxnRead()) { txn =>
+  ): F[Blake2b256Hash] =
+    store.withTxnF(store.createTxnReadF()) { txn =>
       store.withTrieTxn(txn) { trieTxn =>
         store.trieStore.getRoot(trieTxn, branch).get
       }
@@ -91,7 +91,8 @@ trait HistoryActionsTests[F[_]]
               gnat.wks.head.persist
             )
         _          = history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None
-        retrieved  <- space.retrieve(getRootHash(space.store, space.store.trieBranch), channelsHash)
+        root       <- getRootHash(space.store, space.store.trieBranch)
+        retrieved  <- space.retrieve(root, channelsHash)
         _          = retrieved shouldBe None
         checkpoint <- space.createCheckpoint()
         _          = checkpoint.root shouldBe nodeHash
@@ -151,20 +152,16 @@ trait HistoryActionsTests[F[_]]
         _ = history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash1) shouldBe Some(
           gnat1
         )
-        retrieved1 <- space.retrieve(
-                       getRootHash(space.store, space.store.trieBranch),
-                       channelsHash1
-                     )
+        root       <- getRootHash(space.store, space.store.trieBranch)
+        retrieved1 <- space.retrieve(root, channelsHash1)
         _ = retrieved1 shouldBe Some(
           gnat1
         )
         _ = history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash2) shouldBe Some(
           gnat2
         )
-        retrieved2 <- space.retrieve(
-                       getRootHash(space.store, space.store.trieBranch),
-                       channelsHash2
-                     )
+        root2      <- getRootHash(space.store, space.store.trieBranch)
+        retrieved2 <- space.retrieve(root2, channelsHash2)
         _ = retrieved2 shouldBe Some(
           gnat2
         )
@@ -312,26 +309,26 @@ trait HistoryActionsTests[F[_]]
         root1                                                            = checkpoint1.root
         contents1: Map[Seq[String], Row[Pattern, String, StringsCaptor]] = space.store.toMap
         _                                                                = space.store.isEmpty shouldBe false
-        _ = space.store.withTxn(space.store.createTxnRead()) { txn =>
-          space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-          space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-        }
+        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+              space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+              space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+            }
 
         // Rollback to first checkpoint
         _ <- space.reset(root0)
         _ = space.store.isEmpty shouldBe true
-        _ = space.store.withTxn(space.store.createTxnRead()) { txn =>
-          space.store.getJoin(txn, "ch1") shouldBe Nil
-          space.store.getJoin(txn, "ch2") shouldBe Nil
-        }
+        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+              space.store.getJoin(txn, "ch1") shouldBe Nil
+              space.store.getJoin(txn, "ch2") shouldBe Nil
+            }
 
         // Rollback to second checkpoint
         _ <- space.reset(root1)
         _ = space.store.isEmpty shouldBe false
-        _ = space.store.withTxn(space.store.createTxnRead()) { txn =>
-          space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-          space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-        }
+        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+              space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+              space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+            }
 
       } yield (space.store.toMap shouldBe contents1)
   }
@@ -469,7 +466,8 @@ trait HistoryActionsTests[F[_]]
       expectedProduce1   = Produce.create(channels(0), data(0), false)
       expectedProduce2   = Produce.create(channels(1), data(1), false)
       commEvent          = COMM(expectedConsume, Seq(expectedProduce1, expectedProduce2))
-      Checkpoint(_, log) = space.createCheckpoint()
+      checkpoint         <- space.createCheckpoint()
+      Checkpoint(_, log) = checkpoint
     } yield
       (log should contain theSameElementsInOrderAs Seq(
         commEvent,

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -41,7 +41,7 @@ trait HistoryActionsTests[F[_]]
     * Helper for testing purposes only.
     */
   private[this] def getRootHash(
-      store: IStore[String, Pattern, String, StringsCaptor],
+      store: IStore[F, String, Pattern, String, StringsCaptor],
       branch: Branch
   ): Blake2b256Hash =
     store.withTxn(store.createTxnRead()) { txn =>

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -29,7 +29,7 @@ trait IStoreTests
         val datum                                                     = Datum.create(channel, datumValue, false)
 
         store
-          .withTxn(store.createTxnWrite()) { txn =>
+          .withTxnF(store.createTxnWriteF()) { txn =>
             store.putDatum(txn, key, datum)
             store.getData(txn, key) should contain theSameElementsAs (Seq(datum))
             store.clear(txn)
@@ -45,7 +45,7 @@ trait IStoreTests
         val datum1 = Datum.create(channel, datumValue, false)
         val datum2 = Datum.create(channel, datumValue + "2", false)
 
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.putDatum(txn, key, datum1)
           store.putDatum(txn, key, datum2)
           store.getData(txn, key) should contain theSameElementsAs (Seq(datum1, datum2))
@@ -75,7 +75,7 @@ trait IStoreTests
             Datum.create(channel, datumValue + i, false)
           }
 
-          store.withTxn(store.createTxnWrite()) { txn =>
+          store.withTxnF(store.createTxnWriteF()) { txn =>
             data.foreach { d =>
               store.putDatum(txn, key, d)
             }
@@ -94,7 +94,7 @@ trait IStoreTests
         val store = space.store
         val key   = List(channel)
         val hash  = store.hashChannels(key)
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.putDatum(txn, key, Datum.create(channel, datum, persist = false))
           // collectGarbage is called in removeDatum:
           store.removeDatum(txn, key, 0)
@@ -114,7 +114,7 @@ trait IStoreTests
         val wc: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, patterns, continuation, false)
 
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.putWaitingContinuation(txn, key, wc)
           store.getWaitingContinuation(txn, key) shouldBe List(wc)
           store.clear(txn)
@@ -135,7 +135,7 @@ trait IStoreTests
         val wc2: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, List(StringMatch(pattern + 2)), continuation, false)
 
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.putWaitingContinuation(txn, key, wc1)
           store.putWaitingContinuation(txn, key, wc2)
           store.getWaitingContinuation(txn, key) should contain theSameElementsAs List(wc1, wc2)
@@ -156,7 +156,7 @@ trait IStoreTests
         val wc2: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, List(StringMatch(pattern + 2)), continuation, false)
 
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.putWaitingContinuation(txn, key, wc1)
           store.putWaitingContinuation(txn, key, wc2)
           store.removeWaitingContinuation(txn, key, 0)
@@ -170,7 +170,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.addJoin(txn, channel, channels)
           store.getJoin(txn, channel) shouldBe List(channels)
           store.clear(txn)
@@ -182,7 +182,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.addJoin(txn, channel, channels)
           store.removeJoin(txn, channel, channels)
           store.getJoin(txn, channel) shouldBe empty
@@ -195,7 +195,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxn(store.createTxnWrite()) { txn =>
+        store.withTxnF(store.createTxnWriteF()) { txn =>
           store.addJoin(txn, channel, channels)
           store.addJoin(txn, channel, List("otherChannel"))
           store.removeJoin(txn, channel, channels)

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -24,9 +24,9 @@ trait IStoreTests
   "putDatum" should "put datum in a new channel" in forAll("channel", "datum") {
     (channel: String, datumValue: String) =>
       withTestSpace { space =>
-        val store: IStore[String, Pattern, String, StringsCaptor] = space.store
-        val key                                                   = List(channel)
-        val datum                                                 = Datum.create(channel, datumValue, false)
+        val store: IStore[Id, String, Pattern, String, StringsCaptor] = space.store
+        val key                                                       = List(channel)
+        val datum                                                     = Datum.create(channel, datumValue, false)
 
         store
           .withTxn(store.createTxnWrite()) { txn =>

--- a/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
@@ -11,7 +11,7 @@ trait JoinOperationsTests
   "joins" should "remove joins if no PsK" in withTestSpace { space =>
     val store = space.store
 
-    store.withTxn(store.createTxnWrite()) { txn =>
+    store.withTxnF(store.createTxnWriteF()) { txn =>
       store.putDatum(txn, List("ch1"), Datum.create("ch1", "datum1", persist = false))
       store.putDatum(txn, List("ch2"), Datum.create("ch2", "datum2", persist = false))
       store.addJoin(txn, "ch1", List("ch1", "ch2"))
@@ -22,17 +22,17 @@ trait JoinOperationsTests
       store.addJoin(txn, "ch2", List("ch1", "ch2"))
     }
 
-    store.withTxn(store.createTxnRead()) { txn =>
+    store.withTxnF(store.createTxnReadF()) { txn =>
       store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
       store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
     }
 
-    store.withTxn(store.createTxnWrite()) { txn =>
+    store.withTxnF(store.createTxnWriteF()) { txn =>
       store.removeJoin(txn, "ch1", List("ch1", "ch2"))
       store.removeJoin(txn, "ch2", List("ch1", "ch2"))
     }
 
-    store.withTxn(store.createTxnRead()) { txn =>
+    store.withTxnF(store.createTxnReadF()) { txn =>
       store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
       store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
     }
@@ -41,7 +41,7 @@ trait JoinOperationsTests
 
     //now ensure that garbage-collection works and all joins
     //are removed when we remove As
-    store.withTxn(store.createTxnWrite()) { txn =>
+    store.withTxnF(store.createTxnWriteF()) { txn =>
       store.removeDatum(txn, List("ch1"), 0)
       store.removeDatum(txn, List("ch2"), 0)
     }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -862,7 +862,7 @@ trait ReplayRSpaceTests
 trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
   val logger = Logger(this.getClass.getName.stripSuffix("$"))
 
-  implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+  implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
   implicit val contextShiftF: ContextShift[Id] =
     coop.rchain.rspace.test.contextShiftId
 
@@ -893,7 +893,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
       oC: Ordering[C]
   ): S = {
 
-    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
     implicit val log: Log[Id] = Log.log[Id]
@@ -926,7 +926,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
       oC: Ordering[C]
   ): S = {
 
-    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
     implicit val log: Log[Id] = Log.log[Id]
@@ -959,11 +959,11 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
       oC: Ordering[C]
   ): S = {
 
-    implicit val syncF: Sync[Id]     = coop.rchain.catscontrib.effect.implicits.syncId
-    implicit val log: Log[Id]        = Log.log[Id]
-    val ctx: Context[Id, C, P, A, K] = Context.createInMemory()
-    val space                        = RSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
-    val replaySpace                  = ReplayRSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
+    implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
+    implicit val log: Log[Id]                = Log.log[Id]
+    val ctx: Context[Id, C, P, A, K]         = Context.createInMemory()
+    val space                                = RSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
+    val replaySpace                          = ReplayRSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
 
     try {
       f(space, replaySpace)
@@ -985,7 +985,7 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
       sk: Serialize[K],
       oC: Ordering[C]
   ): S = {
-    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val concurrentF: Concurrent[Id] = coop.rchain.catscontrib.effect.implicits.concurrentId
     implicit val contextShiftF: ContextShift[Id] =
       coop.rchain.rspace.test.contextShiftId
     implicit val log: Log[Id] = Log.log[Id]

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -24,8 +24,8 @@ import scala.collection.immutable
 import scala.util.{Random, Right}
 
 object SchedulerPools {
-  implicit val global = Scheduler.fixedPool("GlobalPool", 1000)
-  val rspacePool      = Scheduler.fixedPool("RSpacePool", 100)
+  implicit val global = Scheduler.fixedPool("GlobalPool", 20)
+  val rspacePool      = Scheduler.fixedPool("RSpacePool", 5)
 }
 
 //noinspection ZeroIndexToHead,NameBooleanParameters

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -2,7 +2,7 @@ package coop.rchain.rspace
 
 import java.nio.file.Files
 
-import cats.{Functor, Id}
+import cats.Functor
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
 import cats.effect._
@@ -20,7 +20,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
 
-import scala.collection.{immutable, mutable}
+import scala.collection.immutable
 import scala.util.{Random, Right}
 
 object SchedulerPools {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -899,7 +899,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
     implicit val log: Log[Id] = Log.log[Id]
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
-    val context     = Context.create[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
+    val context     = Context.create[Id, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
     val space       = RSpace.create[Id, C, P, E, A, A, K](context, Branch.MASTER)
     val replaySpace = ReplayRSpace.create[Id, C, P, E, A, A, K](context, Branch.REPLAY)
 
@@ -932,7 +932,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
     implicit val log: Log[Id] = Log.log[Id]
 
     val dbDir       = Files.createTempDirectory("rchain-storage-test-")
-    val context     = Context.createMixed[C, P, A, K](dbDir, 1024L * 1024L * 4096L)
+    val context     = Context.createMixed[Id, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
     val space       = RSpace.create[Id, C, P, E, A, A, K](context, Branch.MASTER)
     val replaySpace = ReplayRSpace.create[Id, C, P, E, A, A, K](context, Branch.REPLAY)
 
@@ -959,11 +959,11 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
       oC: Ordering[C]
   ): S = {
 
-    implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
-    implicit val log: Log[Id]    = Log.log[Id]
-    val ctx: Context[C, P, A, K] = Context.createInMemory()
-    val space                    = RSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
-    val replaySpace              = ReplayRSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
+    implicit val syncF: Sync[Id]     = coop.rchain.catscontrib.effect.implicits.syncId
+    implicit val log: Log[Id]        = Log.log[Id]
+    val ctx: Context[Id, C, P, A, K] = Context.createInMemory()
+    val space                        = RSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
+    val replaySpace                  = ReplayRSpace.create[Id, C, P, E, A, A, K](ctx, Branch.REPLAY)
 
     try {
       f(space, replaySpace)
@@ -992,13 +992,13 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
 
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
     val mainStore = InMemoryStore
-      .create[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
+      .create[Id, InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
         trieStore,
         Branch.REPLAY
       )
     val space = RSpace.create[Id, C, P, E, A, A, K](mainStore, Branch.REPLAY)
     val store =
-      new InMemoryStore[InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
+      new InMemoryStore[Id, InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
         trieStore,
         Branch.REPLAY
       ) {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -976,7 +976,8 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
           Concurrent[Task],
           log,
           ContextShift[Task],
-          dedicated
+          dedicated,
+          metricsF
         )
         .unsafeRunSync
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -2,18 +2,18 @@ package coop.rchain.rspace
 
 import java.nio.file.Files
 
-import cats.Functor
+import cats.{Functor, Id}
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
 import cats.effect._
 import cats.implicits._
-import com.google.common.collect.Multiset
 import com.typesafe.scalalogging.Logger
+import coop.rchain.metrics.Metrics
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.history.{Branch, InMemoryTrieStore}
 import coop.rchain.rspace.internal.GNAT
-import coop.rchain.rspace.trace.{COMM, Consume, IOEvent, Produce}
+import coop.rchain.rspace.trace.Consume
 import coop.rchain.shared.PathOps._
 import coop.rchain.shared.Log
 import monix.eval.Task
@@ -947,8 +947,9 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
       sk: Serialize[K],
       oC: Ordering[C]
   ): S = {
-    implicit val log: Log[Task] = Log.log[Task]
-    val dedicated               = SchedulerPools.rspacePool
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
+    val dedicated                        = SchedulerPools.rspacePool
 
     val dbDir   = Files.createTempDirectory("rchain-storage-test-")
     val context = Context.create[Task, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
@@ -961,7 +962,8 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
         Concurrent[Task],
         log,
         ContextShift[Task],
-        dedicated
+        dedicated,
+        metricsF
       )
       .unsafeRunSync
     val replaySpace =
@@ -1001,7 +1003,8 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
       sk: Serialize[K],
       oC: Ordering[C]
   ): S = {
-    implicit val log: Log[Task] = Log.log[Task]
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
     val dbDir   = Files.createTempDirectory("rchain-storage-test-")
     val context = Context.createMixed[Task, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
@@ -1032,7 +1035,8 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
       sk: Serialize[K],
       oC: Ordering[C]
   ): S = {
-    implicit val log: Log[Task] = Log.log[Task]
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
     val ctx: Context[Task, C, P, A, K] = Context.createInMemory()
     val space                          = RSpace.create[Task, C, P, E, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
@@ -1059,7 +1063,8 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
       sk: Serialize[K],
       oC: Ordering[C]
   ): S = {
-    implicit val log: Log[Task] = Log.log[Task]
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
     val trieStore = InMemoryTrieStore.create[Blake2b256Hash, GNAT[C, P, A, K]]()
     val mainStore = InMemoryStore

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -51,12 +51,12 @@ trait StorageActionsTests[F[_]]
     for {
       r <- space.produce(key.head, "datum", persist = false)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", persist = false))
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", persist = false))
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
 
       _ = r shouldBe Right(None)
       //store is not empty - we have 'A' stored
@@ -71,23 +71,23 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(key.head, "datum1", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
       _  = r1 shouldBe Right(None)
       r2 <- space.produce(key.head, "datum2", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) should contain theSameElementsAs List(
-          Datum.create(key.head, "datum1", false),
-          Datum.create(key.head, "datum2", false)
-        )
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) should contain theSameElementsAs List(
+              Datum.create(key.head, "datum1", false),
+              Datum.create(key.head, "datum2", false)
+            )
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
       _ = r2 shouldBe Right(None)
       //store is not empty - we have 2 As stored
     } yield (store.isEmpty shouldBe false)
@@ -102,12 +102,12 @@ trait StorageActionsTests[F[_]]
 
     for {
       r <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe List("ch1")
-        store.getPatterns(txn, key) shouldBe List(patterns)
-        store.getData(txn, key) shouldBe Nil
-        store.getWaitingContinuation(txn, key) should not be empty
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe List("ch1")
+            store.getPatterns(txn, key) shouldBe List(patterns)
+            store.getData(txn, key) shouldBe Nil
+            store.getWaitingContinuation(txn, key) should not be empty
+          }
       _ = r shouldBe Right(None)
       //there is a continuation stored in the storage
     } yield (store.isEmpty shouldBe false)
@@ -122,12 +122,12 @@ trait StorageActionsTests[F[_]]
 
     for {
       r <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe List(patterns)
-        store.getData(txn, key) shouldBe Nil
-        store.getWaitingContinuation(txn, key) should not be empty
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe List(patterns)
+            store.getData(txn, key) shouldBe Nil
+            store.getWaitingContinuation(txn, key) should not be empty
+          }
       _ = r shouldBe Right(None)
       //continuation is left in the storage
     } yield (store.isEmpty shouldBe false)
@@ -141,22 +141,22 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(key.head, "datum", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
       _ = r1 shouldBe Right(None)
 
       r2 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = false)
       _  = store.isEmpty shouldBe true
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe Nil
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) shouldBe Nil
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe Nil
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) shouldBe Nil
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
       _ = r2 shouldBe defined
       _ = runK(r2)
       _ = getK(r2).results should contain theSameElementsAs List(List("datum"))
@@ -199,45 +199,45 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
-        store.getPatterns(txn, produceKey1) shouldBe Nil
-        store.getData(txn, produceKey1) shouldBe List(
-          Datum.create(produceKey1.head, "datum1", persist = false)
-        )
-        store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
+            store.getPatterns(txn, produceKey1) shouldBe Nil
+            store.getData(txn, produceKey1) shouldBe List(
+              Datum.create(produceKey1.head, "datum1", persist = false)
+            )
+            store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
+          }
       _ = r1 shouldBe Right(None)
 
       r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
-        store.getPatterns(txn, produceKey1) shouldBe Nil
-        store.getData(txn, produceKey1) shouldBe List(
-          Datum.create(produceKey1.head, "datum1", persist = false)
-        )
-        store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
-        store.getChannels(txn, consumeKeyHash) shouldBe consumeKey
-        store.getPatterns(txn, consumeKey) shouldBe List(consumePattern)
-        store.getData(txn, consumeKey) shouldBe Nil
-        store.getWaitingContinuation(txn, consumeKey) should not be empty
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
+            store.getPatterns(txn, produceKey1) shouldBe Nil
+            store.getData(txn, produceKey1) shouldBe List(
+              Datum.create(produceKey1.head, "datum1", persist = false)
+            )
+            store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
+            store.getChannels(txn, consumeKeyHash) shouldBe consumeKey
+            store.getPatterns(txn, consumeKey) shouldBe List(consumePattern)
+            store.getData(txn, consumeKey) shouldBe Nil
+            store.getWaitingContinuation(txn, consumeKey) should not be empty
+          }
       _  = r2 shouldBe Right(None)
       r3 <- space.produce(produceKey2.head, "datum2", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey1Hash) shouldBe Nil
-        store.getPatterns(txn, produceKey1) shouldBe Nil
-        store.getData(txn, produceKey1) shouldBe Nil
-        store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
-        store.getChannels(txn, consumeKeyHash) shouldBe Nil
-        store.getPatterns(txn, consumeKey) shouldBe Nil
-        store.getData(txn, consumeKey) shouldBe Nil
-        store.getWaitingContinuation(txn, consumeKey) shouldBe Nil
-        store.getChannels(txn, produceKey2Hash) shouldBe Nil
-        store.getPatterns(txn, produceKey2) shouldBe Nil
-        store.getData(txn, produceKey2) shouldBe Nil
-        store.getWaitingContinuation(txn, produceKey2) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey1Hash) shouldBe Nil
+            store.getPatterns(txn, produceKey1) shouldBe Nil
+            store.getData(txn, produceKey1) shouldBe Nil
+            store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
+            store.getChannels(txn, consumeKeyHash) shouldBe Nil
+            store.getPatterns(txn, consumeKey) shouldBe Nil
+            store.getData(txn, consumeKey) shouldBe Nil
+            store.getWaitingContinuation(txn, consumeKey) shouldBe Nil
+            store.getChannels(txn, produceKey2Hash) shouldBe Nil
+            store.getPatterns(txn, produceKey2) shouldBe Nil
+            store.getData(txn, produceKey2) shouldBe Nil
+            store.getWaitingContinuation(txn, produceKey2) shouldBe Nil
+          }
       _ = r3 shouldBe defined
       _ = runK(r3)
       _ = getK(r3).results should contain theSameElementsAs List(List("datum1", "datum2"))
@@ -259,42 +259,42 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
-        store.getPatterns(txn, produceKey1) shouldBe Nil
-        store.getData(txn, produceKey1) shouldBe List(
-          Datum.create(produceKey1.head, "datum1", false)
-        )
-        store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
+            store.getPatterns(txn, produceKey1) shouldBe Nil
+            store.getData(txn, produceKey1) shouldBe List(
+              Datum.create(produceKey1.head, "datum1", false)
+            )
+            store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
+          }
       _  = r1 shouldBe Right(None)
       r2 <- space.produce(produceKey2.head, "datum2", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey2Hash) shouldBe produceKey2
-        store.getPatterns(txn, produceKey2) shouldBe Nil
-        store.getData(txn, produceKey2) shouldBe List(
-          Datum.create(produceKey2.head, "datum2", false)
-        )
-        store.getWaitingContinuation(txn, produceKey2) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey2Hash) shouldBe produceKey2
+            store.getPatterns(txn, produceKey2) shouldBe Nil
+            store.getData(txn, produceKey2) shouldBe List(
+              Datum.create(produceKey2.head, "datum2", false)
+            )
+            store.getWaitingContinuation(txn, produceKey2) shouldBe Nil
+          }
       _  = r2 shouldBe Right(None)
       r3 <- space.produce(produceKey3.head, "datum3", persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, produceKey3Hash) shouldBe produceKey3
-        store.getPatterns(txn, produceKey3) shouldBe Nil
-        store.getData(txn, produceKey3) shouldBe List(
-          Datum.create(produceKey3.head, "datum3", false)
-        )
-        store.getWaitingContinuation(txn, produceKey3) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, produceKey3Hash) shouldBe produceKey3
+            store.getPatterns(txn, produceKey3) shouldBe Nil
+            store.getData(txn, produceKey3) shouldBe List(
+              Datum.create(produceKey3.head, "datum3", false)
+            )
+            store.getWaitingContinuation(txn, produceKey3) shouldBe Nil
+          }
       _  = r3 shouldBe Right(None)
       r4 <- space.consume(List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, consumeKeyHash) shouldBe Nil
-        store.getPatterns(txn, consumeKey) shouldBe Nil
-        store.getData(txn, consumeKey) shouldBe Nil
-        store.getWaitingContinuation(txn, consumeKey) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, consumeKeyHash) shouldBe Nil
+            store.getPatterns(txn, consumeKey) shouldBe Nil
+            store.getData(txn, consumeKey) shouldBe Nil
+            store.getWaitingContinuation(txn, consumeKey) shouldBe Nil
+          }
       _ = r4 shouldBe defined
       _ = runK(r4)
       _ = getK(r4).results should contain theSameElementsAs List(List("datum1", "datum2", "datum3"))
@@ -318,12 +318,12 @@ trait StorageActionsTests[F[_]]
       r4 <- space.consume(key, List(Wildcard), captor, persist = false)
       r5 <- space.consume(key, List(Wildcard), captor, persist = false)
       r6 <- space.consume(key, List(Wildcard), captor, persist = false)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, store.hashChannels(key)) shouldBe Nil
-        store.getData(txn, key) shouldBe Nil
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, store.hashChannels(key)) shouldBe Nil
+            store.getData(txn, key) shouldBe Nil
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
       continuations = List(r4, r5, r6)
       _             = continuations.forall(_.right.get.isDefined) shouldBe true
       _ = continuations
@@ -523,16 +523,16 @@ trait StorageActionsTests[F[_]]
       _ = r1 shouldBe Right(None)
       _ = r2 shouldBe Right(None)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1", "ch2")) shouldBe Nil
-        store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", false))
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1", "ch2")) shouldBe Nil
+            store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", false))
+          }
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
-        store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-        store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
+            store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+            store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+          }
 
     } yield (store.isEmpty shouldBe false)
   }
@@ -561,10 +561,10 @@ trait StorageActionsTests[F[_]]
         .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
         .foreach(runK)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe Nil
-        store.getData(txn, List("ch2")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe Nil
+            store.getData(txn, List("ch2")) shouldBe Nil
+          }
 
       _ = getK(r3).results should contain theSameElementsAs List(List("datum1"))
       _ = getK(r4).results should contain theSameElementsAs List(List("datum2"))
@@ -590,13 +590,13 @@ trait StorageActionsTests[F[_]]
         r3 <- space.produce("ch1", "datum1", persist = false)
         r4 <- space.produce("ch2", "datum2", persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
-          store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-          store.getWaitingContinuation(txn, List("ch2")) shouldBe Nil
-          store.getData(txn, List("ch1")) shouldBe Nil
-          store.getData(txn, List("ch2")) shouldBe List(Datum.create("ch2", "datum2", false))
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
+              store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+              store.getWaitingContinuation(txn, List("ch2")) shouldBe Nil
+              store.getData(txn, List("ch1")) shouldBe Nil
+              store.getData(txn, List("ch2")) shouldBe List(Datum.create("ch2", "datum2", false))
+            }
 
         _ = r3 shouldBe defined
         _ = r4 shouldBe Right(None)
@@ -605,10 +605,10 @@ trait StorageActionsTests[F[_]]
 
         _ = getK(r3).results should contain theSameElementsAs List(List("datum1"))
         //ensure that joins are cleaned-up after all
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
-          store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
+              store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
+            }
 
       } yield (store.isEmpty shouldBe false)
     }
@@ -624,12 +624,12 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.produce(key.head, "datum", persist = false)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe key
-        store.getPatterns(txn, key) shouldBe Nil
-        store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
-        store.getWaitingContinuation(txn, key) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe key
+            store.getPatterns(txn, key) shouldBe Nil
+            store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
+            store.getWaitingContinuation(txn, key) shouldBe Nil
+          }
 
       _ = r1 shouldBe Right(None)
 
@@ -646,12 +646,12 @@ trait StorageActionsTests[F[_]]
 
       // the data has been consumed, so the write will "stick"
       r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getChannels(txn, keyHash) shouldBe List("ch1")
-        store.getPatterns(txn, key) shouldBe List(List(Wildcard))
-        store.getData(txn, key) shouldBe Nil
-        store.getWaitingContinuation(txn, key) should not be empty
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getChannels(txn, keyHash) shouldBe List("ch1")
+            store.getPatterns(txn, key) shouldBe List(List(Wildcard))
+            store.getData(txn, key) shouldBe Nil
+            store.getWaitingContinuation(txn, key) should not be empty
+          }
     } yield (r3 shouldBe Right(None))
   }
 
@@ -665,12 +665,12 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.produce(key.head, "datum1", persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getChannels(txn, keyHash) shouldBe key
-          store.getPatterns(txn, key) shouldBe Nil
-          store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
-          store.getWaitingContinuation(txn, key) shouldBe Nil
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getChannels(txn, keyHash) shouldBe key
+              store.getPatterns(txn, key) shouldBe Nil
+              store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
+              store.getWaitingContinuation(txn, key) shouldBe Nil
+            }
 
         _ = r1 shouldBe Right(None)
 
@@ -688,23 +688,23 @@ trait StorageActionsTests[F[_]]
         // All matching data has been consumed, so the write will "stick"
         r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getChannels(txn, keyHash) shouldBe List("ch1")
-          store.getPatterns(txn, key) shouldBe List(List(Wildcard))
-          store.getData(txn, key) shouldBe Nil
-          store.getWaitingContinuation(txn, key) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getChannels(txn, keyHash) shouldBe List("ch1")
+              store.getPatterns(txn, key) shouldBe List(List(Wildcard))
+              store.getData(txn, key) shouldBe Nil
+              store.getWaitingContinuation(txn, key) should not be empty
+            }
 
         _ = r3 shouldBe Right(None)
 
         r4 <- space.produce(key.head, "datum2", persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getChannels(txn, keyHash) shouldBe List("ch1")
-          store.getPatterns(txn, key) shouldBe List(List(Wildcard))
-          store.getData(txn, key) shouldBe Nil
-          store.getWaitingContinuation(txn, key) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getChannels(txn, keyHash) shouldBe List("ch1")
+              store.getPatterns(txn, key) shouldBe List(List(Wildcard))
+              store.getData(txn, key) shouldBe Nil
+              store.getWaitingContinuation(txn, key) should not be empty
+            }
 
         _ = r4 shouldBe defined
 
@@ -720,19 +720,19 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getData(txn, List("ch1")) shouldBe Nil
-          store.getWaitingContinuation(txn, List("ch1")) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getData(txn, List("ch1")) shouldBe Nil
+              store.getWaitingContinuation(txn, List("ch1")) should not be empty
+            }
 
         _ = r1 shouldBe Right(None)
 
         r2 <- space.produce("ch1", "datum1", persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getData(txn, List("ch1")) shouldBe Nil
-          store.getWaitingContinuation(txn, List("ch1")) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getData(txn, List("ch1")) shouldBe Nil
+              store.getWaitingContinuation(txn, List("ch1")) should not be empty
+            }
 
         _ = r2 shouldBe defined
 
@@ -742,10 +742,10 @@ trait StorageActionsTests[F[_]]
 
         r3 <- space.produce("ch1", "datum2", persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getData(txn, List("ch1")) shouldBe Nil
-          store.getWaitingContinuation(txn, List("ch1")) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getData(txn, List("ch1")) shouldBe Nil
+              store.getWaitingContinuation(txn, List("ch1")) should not be empty
+            }
 
         _ = r3 shouldBe defined
 
@@ -776,12 +776,11 @@ trait StorageActionsTests[F[_]]
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
       _  = r3 shouldBe Right(None)
-
-    } yield
-      (store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      })
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
+    } yield ()
   }
 
   "consuming, doing a persistient produce, and consuming again" should "work" in withTestSpace {
@@ -807,19 +806,19 @@ trait StorageActionsTests[F[_]]
         // All matching continuations have been produced, so the write will "stick"
         r3 <- space.produce("ch1", "datum1", persist = true)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-          store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+              store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+            }
 
         _ = r3 shouldBe Right(None)
 
         r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-          store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+              store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+            }
 
         _ = r4 shouldBe defined
 
@@ -834,19 +833,19 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.produce("ch1", "datum1", persist = true)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
 
       _ = r1 shouldBe Right(None)
 
       r2 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
 
       _ = r2 shouldBe defined
 
@@ -856,10 +855,10 @@ trait StorageActionsTests[F[_]]
 
       r3 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
 
       _ = r3 shouldBe defined
 
@@ -883,14 +882,14 @@ trait StorageActionsTests[F[_]]
       // Matching data exists so the write will not "stick"
       r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) should contain atLeastOneOf (
-          Datum.create("ch1", "datum1", false),
-          Datum.create("ch1", "datum2", false),
-          Datum.create("ch1", "datum3", false)
-        )
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) should contain atLeastOneOf (
+              Datum.create("ch1", "datum1", false),
+              Datum.create("ch1", "datum2", false),
+              Datum.create("ch1", "datum3", false)
+            )
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
 
       _ = r4 shouldBe defined
 
@@ -901,14 +900,14 @@ trait StorageActionsTests[F[_]]
       // Matching data exists so the write will not "stick"
       r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) should contain oneOf (
-          Datum.create("ch1", "datum1", false),
-          Datum.create("ch1", "datum2", false),
-          Datum.create("ch1", "datum3", false)
-        )
-        store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) should contain oneOf (
+              Datum.create("ch1", "datum1", false),
+              Datum.create("ch1", "datum2", false),
+              Datum.create("ch1", "datum3", false)
+            )
+            store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
+          }
 
       _ = r5 shouldBe defined
 
@@ -930,10 +929,10 @@ trait StorageActionsTests[F[_]]
       // All matching data has been consumed, so the write will "stick"
       r7 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ = store.withTxn(store.createTxnRead()) { txn =>
-        store.getData(txn, List("ch1")) shouldBe Nil
-        store.getWaitingContinuation(txn, List("ch1")) should not be empty
-      }
+      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+            store.getData(txn, List("ch1")) shouldBe Nil
+            store.getWaitingContinuation(txn, List("ch1")) should not be empty
+          }
 
     } yield (r7 shouldBe Right(None))
 
@@ -996,12 +995,12 @@ trait StorageActionsTests[F[_]]
       for {
         r <- space.consume(key, patterns, new StringsCaptor, persist = false)
 
-        _ = store.withTxn(store.createTxnRead()) { txn =>
-          store.getChannels(txn, keyHash) shouldBe List("ch1")
-          store.getPatterns(txn, key) shouldBe List(patterns)
-          store.getData(txn, key) shouldBe Nil
-          store.getWaitingContinuation(txn, key) should not be empty
-        }
+        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+              store.getChannels(txn, keyHash) shouldBe List("ch1")
+              store.getPatterns(txn, key) shouldBe List(patterns)
+              store.getData(txn, key) shouldBe Nil
+              store.getWaitingContinuation(txn, key) should not be empty
+            }
 
         _ = r shouldBe Right(None)
         _ = store.isEmpty shouldBe false

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1397,9 +1397,10 @@ trait LegacyStorageActionsTests
 }
 
 trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, A, R, K] {
-  override implicit val syncF: Sync[Id]   = coop.rchain.catscontrib.effect.implicits.syncId
+  override implicit val concurrentF: Concurrent[Id] =
+    coop.rchain.catscontrib.effect.implicits.concurrentId
   override implicit val logF: Log[Id]     = Log.log[Id]
-  override implicit val monadF: Monad[Id] = syncF
+  override implicit val monadF: Monad[Id] = concurrentF
   override implicit val contextShiftF: ContextShift[Id] =
     coop.rchain.rspace.test.contextShiftId
 
@@ -1411,13 +1412,14 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, A, R, K] {
   import coop.rchain.catscontrib.TaskContrib._
   import scala.concurrent.ExecutionContext
 
-  override implicit val syncF: Sync[Task] = new monix.eval.instances.CatsEffectForTask()(
-    monix.execution.Scheduler.Implicits.global,
-    Task.defaultOptions
-  )
+  override implicit val concurrentF: Concurrent[Task] =
+    new monix.eval.instances.CatsConcurrentEffectForTask()(
+      monix.execution.Scheduler.Implicits.global,
+      Task.defaultOptions
+    )
   implicit val logF: Log[Task] = Log.log[Task]
 
-  override implicit val monadF: Monad[Task] = syncF
+  override implicit val monadF: Monad[Task] = concurrentF
   override implicit val contextShiftF: ContextShift[Task] = new ContextShift[Task] {
     override def shift: Task[Unit] =
       Task.shift

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -5,6 +5,7 @@ import java.lang.{Byte => JByte}
 import cats._
 import cats.effect._
 import cats.implicits._
+import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Log
 import coop.rchain.rspace.StableHashProvider._
 import coop.rchain.rspace.examples.StringExamples._
@@ -17,6 +18,7 @@ import org.scalacheck.Prop
 import org.scalatest._
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
 import scodec.Codec
+
 import scala.collection.immutable.Seq
 import coop.rchain.rspace.test.ArbitraryInstances._
 import org.scalatest.enablers.Definition
@@ -1398,8 +1400,9 @@ trait LegacyStorageActionsTests
 trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, A, R, K] {
   override implicit val concurrentF: Concurrent[Id] =
     coop.rchain.catscontrib.effect.implicits.concurrentId
-  override implicit val logF: Log[Id]     = Log.log[Id]
-  override implicit val monadF: Monad[Id] = concurrentF
+  override implicit val logF: Log[Id]         = Log.log[Id]
+  override implicit val metricsF: Metrics[Id] = new Metrics.MetricsNOP[Id]()(concurrentF)
+  override implicit val monadF: Monad[Id]     = concurrentF
   override implicit val contextShiftF: ContextShift[Id] =
     coop.rchain.rspace.test.contextShiftId
 
@@ -1416,7 +1419,8 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, A, R, K] {
       monix.execution.Scheduler.Implicits.global,
       Task.defaultOptions
     )
-  implicit val logF: Log[Task] = Log.log[Task]
+  implicit val logF: Log[Task]         = Log.log[Task]
+  implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
   override implicit val monadF: Monad[Task] = concurrentF
   override implicit val contextShiftF: ContextShift[Task] = new ContextShift[Task] {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -306,7 +306,7 @@ abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
                   )
       testStore = testSpace.store
       trieStore = testStore.trieStore
-      _         = testStore.withTxn(testStore.createTxnWrite())(testStore.clear)
+      _         <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
       _         = trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear)
       _         = initialize(trieStore, branch)
       res       <- f(testSpace)
@@ -350,7 +350,7 @@ abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
                   )
       testStore = testSpace.store
       trieStore = testStore.trieStore
-      _         <- testStore.withTxn(testStore.createTxnWrite())(testStore.clear).pure[F]
+      _         <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
       _         <- trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear).pure[F]
       _         = initialize(trieStore, branch)
       res       <- f(testSpace)
@@ -381,7 +381,7 @@ abstract class LMDBStoreStorageExamplesTestBase[F[_]]
                     testStore,
                     Branch.MASTER
                   )
-      _   = testStore.withTxn(testStore.createTxnWrite())(txn => testStore.clear(txn))
+      _   <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
       res <- f(testSpace)
     } yield {
       try {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -296,7 +296,8 @@ abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
 
     val branch = Branch("inmem")
 
-    val ctx: Context[Channel, Pattern, Entry, EntriesCaptor] = Context.createMixed(dbDir, mapSize)
+    val ctx: Context[F, Channel, Pattern, Entry, EntriesCaptor] =
+      Context.createMixed(dbDir, mapSize)
 
     run(for {
       testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
@@ -340,7 +341,7 @@ abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
 
     val branch = Branch("inmem")
 
-    val ctx: Context[Channel, Pattern, Entry, EntriesCaptor] = Context.createInMemory()
+    val ctx: Context[F, Channel, Pattern, Entry, EntriesCaptor] = Context.createInMemory()
 
     run(for {
       testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
@@ -373,8 +374,8 @@ abstract class LMDBStoreStorageExamplesTestBase[F[_]]
   val noTls: Boolean = false
 
   override def withTestSpace[R](f: T => F[R]): R = {
-    val context   = Context.create[Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
-    val testStore = LMDBStore.create[Channel, Pattern, Entry, EntriesCaptor](context)
+    val context   = Context.create[F, Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
+    val testStore = LMDBStore.create[F, Channel, Pattern, Entry, EntriesCaptor](context)
     run(for {
       testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
                     testStore,

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
   type T = ISpace[F, C, P, E, A, A, K]
 
-  implicit def syncF: Sync[F]
+  implicit def concurrentF: Concurrent[F]
   implicit def logF: Log[F]
   implicit def monadF: Monad[F]
   implicit def contextShiftF: ContextShift[F]

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -149,13 +149,12 @@ abstract class InMemoryStoreTestsBase[F[_]]
       testStore = testSpace.store
       trieStore = testStore.trieStore
       _ <- testStore
-            .withTxn(testStore.createTxnWrite()) { txn =>
+            .withTxnF(testStore.createTxnWriteF()) { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)
               }
             }
-            .pure[F]
       _   <- history.initialize(trieStore, branch).pure[F]
       _   <- testSpace.createCheckpoint()
       res <- f(testSpace)
@@ -195,13 +194,12 @@ abstract class LMDBStoreTestsBase[F[_]]
                   )
       testStore = testSpace.store
       _ <- testStore
-            .withTxn(testStore.createTxnWrite()) { txn =>
+            .withTxnF(testStore.createTxnWriteF()) { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)
               }
             }
-            .pure[F]
       _   <- history.initialize(testStore.trieStore, testBranch).pure[F]
       _   <- testSpace.createCheckpoint()
       res <- f(testSpace)
@@ -242,13 +240,12 @@ abstract class MixedStoreTestsBase[F[_]]
                   )
       testStore = testSpace.store
       _ <- testStore
-            .withTxn(testStore.createTxnWrite()) { txn =>
+            .withTxnF(testStore.createTxnWriteF()) { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)
               }
             }
-            .pure[F]
       _   <- history.initialize(testStore.trieStore, testBranch).pure[F]
       _   <- testSpace.createCheckpoint()
       res <- f(testSpace)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import cats.effect._
 import com.typesafe.scalalogging.Logger
 import com.google.common.collect.HashMultiset
-import coop.rchain.rspace.ISpace.IdISpace
+import coop.rchain.metrics.Metrics
 
 import scala.collection.JavaConverters._
 import coop.rchain.rspace.examples.StringExamples._
@@ -29,6 +29,7 @@ trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with 
 
   implicit def concurrentF: Concurrent[F]
   implicit def logF: Log[F]
+  implicit def metricsF: Metrics[F]
   implicit def monadF: Monad[F]
   implicit def contextShiftF: ContextShift[F]
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -139,7 +139,7 @@ abstract class InMemoryStoreTestsBase[F[_]]
     implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
     val branch                                = Branch("inmem")
 
-    val ctx: Context[String, Pattern, String, StringsCaptor] = Context.createInMemory()
+    val ctx: Context[F, String, Pattern, String, StringsCaptor] = Context.createInMemory()
 
     run(for {
       testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](
@@ -186,7 +186,7 @@ abstract class LMDBStoreTestsBase[F[_]]
     implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
 
     val testBranch = Branch("test")
-    val env        = Context.create[String, Pattern, String, StringsCaptor](dbDir, mapSize)
+    val env        = Context.create[F, String, Pattern, String, StringsCaptor](dbDir, mapSize)
 
     run(for {
       testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](
@@ -233,7 +233,7 @@ abstract class MixedStoreTestsBase[F[_]]
     implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
 
     val testBranch = Branch("test")
-    val env        = Context.createMixed[String, Pattern, String, StringsCaptor](dbDir, mapSize)
+    val env        = Context.createMixed[F, String, Pattern, String, StringsCaptor](dbDir, mapSize)
 
     run(for {
       testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
@@ -4,6 +4,7 @@ import org.scalatest._
 
 import monix.eval.Task
 import scala.collection._
+import scala.collection.immutable.Seq
 
 class MultiLockTest extends FlatSpec with Matchers {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
@@ -83,6 +83,7 @@ class MultiLockTest extends FlatSpec with Matchers {
 
   "FunctionalMultiLock" should "not allow concurrent modifications of same keys" in {
     import cats.effect.{Concurrent, ContextShift, IO}
+    import cats.implicits._
 
     implicit val ioContextShift: ContextShift[IO] =
       IO.contextShift(scala.concurrent.ExecutionContext.Implicits.global)
@@ -93,11 +94,13 @@ class MultiLockTest extends FlatSpec with Matchers {
 
     def acquire(seq: List[String]) =
       tested.acquire(seq) {
-        for {
-          k <- seq
-          v = m.getOrElse(k, 0) + 1
-          _ = m.put(k, v)
-        } yield ()
+        seq.pure[IO].map { keys =>
+          for {
+            k <- keys
+            v = m.getOrElse(k, 0) + 1
+            _ = m.put(k, v)
+          } yield ()
+        }
       }
 
     (for {
@@ -109,7 +112,7 @@ class MultiLockTest extends FlatSpec with Matchers {
       _ <- acquire(List("a", "d"))
     } yield ()).unsafeRunSync
 
-    m.toList should contain theSameElementsAs (Map("d" -> 2, "b" -> 1, "c" -> 4, "a" -> 5).toList)
+    m.toList should contain theSameElementsAs Map("d" -> 2, "b" -> 1, "c" -> 4, "a" -> 5).toList
 
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -1,4 +1,5 @@
 package coop.rchain.rspace.concurrent
+import cats.Id
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.catscontrib.TaskContrib._
@@ -21,7 +22,7 @@ class TwoStepLockTest extends FlatSpec with Matchers {
   }
 
   def acquireLock(
-      lock: TwoStepLock[String],
+      lock: TwoStepLock[Id, String],
       a: List[String],
       b: List[String],
       update: => Unit

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -1,5 +1,5 @@
 package coop.rchain.rspace.concurrent
-import cats.Id
+
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.catscontrib.TaskContrib._
@@ -10,7 +10,7 @@ class TwoStepLockTest extends FlatSpec with Matchers {
   implicit val s = Scheduler.fixedPool("test-scheduler", 8)
 
   "DefaultTwoStepLock" should "gate concurrent access to shared resources" in {
-    val lock = new DefaultTwoStepLock[String]
+    val lock = new ConcurrentTwoStepLockF[Task, String]
     var a    = 0
     val t1   = acquireLock(lock, List("a", "b"), List("w1", "w2"), { a = a + 1 })
     val t2   = acquireLock(lock, List("a", "b"), List("w1", "w2"), { a = a - 3 })
@@ -22,10 +22,10 @@ class TwoStepLockTest extends FlatSpec with Matchers {
   }
 
   def acquireLock(
-      lock: TwoStepLock[Id, String],
+      lock: TwoStepLock[Task, String],
       a: List[String],
       b: List[String],
       update: => Unit
   ): Task[Unit] =
-    Task { lock.acquire(a)(() => b)(update) }
+    lock.acquire(a)(() => Task.delay(b))(Task.delay(update))
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionsTests.scala
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
 
 import cats.Id
+import cats.effect.Sync
 import coop.rchain.rspace.{Context, InMemTransaction}
 import coop.rchain.rspace.test._
 import coop.rchain.shared.PathOps._
@@ -439,6 +440,8 @@ trait LMDBWithTestTrieStore[F[_], K]
   val dbDir: Path   = Files.createTempDirectory("rchain-storage-history-test-")
   val mapSize: Long = 1024L * 1024L * 1024L
 
+  implicit val syncF: Sync[F]
+
   override def withTestTrieStore[R](
       f: (ITrieStore[Txn[ByteBuffer], K, ByteVector], Branch) => R
   ): R = {
@@ -494,7 +497,8 @@ class LMDBHistoryActionsTests
     extends HistoryActionsTests[Id, Txn[ByteBuffer]]
     with GenerativeHistoryActionsTests[Id, Txn[ByteBuffer], TestKey4]
     with LMDBWithTestTrieStore[Id, TestKey4] {
-  implicit val arbitraryMap = ArbitraryInstances.arbitraryNonEmptyMapTestKeyByteVector
+  implicit val arbitraryMap    = ArbitraryInstances.arbitraryNonEmptyMapTestKeyByteVector
+  implicit val syncF: Sync[Id] = coop.rchain.catscontrib.effect.implicits.syncId
 }
 
 class LMDBHistoryActionsTestsKey32
@@ -503,6 +507,7 @@ class LMDBHistoryActionsTestsKey32
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey32]  = TestKey32.codecTestKey
   implicit val arbitraryMap              = ArbitraryInstances.arbitraryNonEmptyMapTestKey32ByteVector
+  implicit val syncF: Sync[Id]           = coop.rchain.catscontrib.effect.implicits.syncId
 }
 
 class InMemoryHistoryActionsTestsKey32

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryTestsBase.scala
@@ -9,13 +9,13 @@ import org.scalatest.{FlatSpec, Matchers, OptionValues, Outcome}
 import scodec.Codec
 import scodec.bits.ByteVector
 
-trait HistoryTestsBase[T, K, V]
+trait HistoryTestsBase[F[_], T, K, V]
     extends FlatSpec
     with Matchers
     with OptionValues
     with GeneratorDrivenPropertyChecks
     with Configuration
-    with WithTestStore[T, K, V] {
+    with WithTestStore[F, T, K, V] {
 
   def getRoot(store: ITrieStore[T, K, V], branch: Branch): Option[Blake2b256Hash] =
     store.withTxn(store.createTxnRead())(txn => store.getRoot(txn, branch))
@@ -57,7 +57,7 @@ trait HistoryTestsBase[T, K, V]
   }
 }
 
-trait WithTestStore[T, K, V] {
+trait WithTestStore[F[_], T, K, V] {
 
   implicit def codecK: Codec[K]
   implicit def codecV: Codec[V]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
@@ -2,6 +2,7 @@ package coop.rchain.rspace.history
 
 import java.nio.ByteBuffer
 
+import cats.effect.Sync
 import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.test.{printTree, TestKey4}
 import org.lmdbjava.Txn
@@ -9,10 +10,11 @@ import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
 
-class TrieStructureTests[F[_]]
+class TrieStructureTests[F[_]: Sync]
     extends HistoryTestsBase[F, Txn[ByteBuffer], TestKey4, ByteVector]
     with LMDBWithTestTrieStore[F, TestKey4] {
 
+  val syncF: Sync[F]                     = Sync[F]
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey4]   = TestKey4.codecTestKey
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTests.scala
@@ -9,9 +9,9 @@ import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
 
-class TrieStructureTests
-    extends HistoryTestsBase[Txn[ByteBuffer], TestKey4, ByteVector]
-    with LMDBWithTestTrieStore[TestKey4] {
+class TrieStructureTests[F[_]]
+    extends HistoryTestsBase[F, Txn[ByteBuffer], TestKey4, ByteVector]
+    with LMDBWithTestTrieStore[F, TestKey4] {
 
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey4]   = TestKey4.codecTestKey

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTestsKeyLength5.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTestsKeyLength5.scala
@@ -2,16 +2,19 @@ package coop.rchain.rspace.history
 
 import java.nio.ByteBuffer
 
+import cats.Id
+import cats.effect.Sync
 import coop.rchain.rspace.test.TestKey5
 import org.lmdbjava.Txn
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs.{bytes, int64, variableSizeBytesLong}
 
-class TrieStructureTestsKeyLength5[F[_]]
+class TrieStructureTestsKeyLength5[F[_]: Sync]
     extends HistoryTestsBase[F, Txn[ByteBuffer], TestKey5, ByteVector]
     with LMDBWithTestTrieStore[F, TestKey5] {
 
+  val syncF: Sync[F]                     = Sync[F]
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey5]   = TestKey5.codecTestKey
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTestsKeyLength5.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/TrieStructureTestsKeyLength5.scala
@@ -8,9 +8,9 @@ import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs.{bytes, int64, variableSizeBytesLong}
 
-class TrieStructureTestsKeyLength5
-    extends HistoryTestsBase[Txn[ByteBuffer], TestKey5, ByteVector]
-    with LMDBWithTestTrieStore[TestKey5] {
+class TrieStructureTestsKeyLength5[F[_]]
+    extends HistoryTestsBase[F, Txn[ByteBuffer], TestKey5, ByteVector]
+    with LMDBWithTestTrieStore[F, TestKey5] {
 
   implicit val codecV: Codec[ByteVector] = variableSizeBytesLong(int64, bytes)
   implicit val codecK: Codec[TestKey5]   = TestKey5.codecTestKey

--- a/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
@@ -3,10 +3,7 @@ package coop.rchain.catscontrib.effect
 import cats._
 import cats.effect.ExitCase.{Completed, Error}
 import cats.effect._
-import scala.concurrent.ExecutionContext
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Promise}
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
@@ -22,7 +19,7 @@ package object implicits {
       ): Id[Either[(A, Fiber[Id, B]), (Fiber[Id, A], B)]]                          = ???
       override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Id[A]      = ???
       override def asyncF[A](k: (Either[Throwable, A] => Unit) => Id[Unit]): Id[A] = ???
-      override def suspend[A](thunk: => Id[A]): Id[A]                              = syncId.suspend(thunk)
+      override def suspend[A](thunk: => Id[A]): Id[A] = syncId.suspend(thunk)
       override def bracketCase[A, B](acquire: Id[A])(use: A => Id[B])(
           release: (A, ExitCase[Throwable]) => Id[Unit]
       ): Id[B]                                                           = syncId.bracketCase(acquire)(use)(release)

--- a/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
@@ -19,7 +19,7 @@ package object implicits {
       ): Id[Either[(A, Fiber[Id, B]), (Fiber[Id, A], B)]]                          = ???
       override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Id[A]      = ???
       override def asyncF[A](k: (Either[Throwable, A] => Unit) => Id[Unit]): Id[A] = ???
-      override def suspend[A](thunk: => Id[A]): Id[A] = syncId.suspend(thunk)
+      override def suspend[A](thunk: => Id[A]): Id[A]                              = syncId.suspend(thunk)
       override def bracketCase[A, B](acquire: Id[A])(use: A => Id[B])(
           release: (A, ExitCase[Throwable]) => Id[Unit]
       ): Id[B]                                                           = syncId.bracketCase(acquire)(use)(release)

--- a/shared/src/main/scala/coop/rchain/shared/Log.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Log.scala
@@ -39,12 +39,12 @@ class LogSourceMacros(val c: blackbox.Context) {
 
 trait Log[F[_]] {
   def isTraceEnabled(implicit ev: LogSource): F[Boolean]
-  def trace(msg: String)(implicit ev: LogSource): F[Unit]
-  def debug(msg: String)(implicit ev: LogSource): F[Unit]
-  def info(msg: String)(implicit ev: LogSource): F[Unit]
-  def warn(msg: String)(implicit ev: LogSource): F[Unit]
-  def error(msg: String)(implicit ev: LogSource): F[Unit]
-  def error(msg: String, cause: Throwable)(implicit ev: LogSource): F[Unit]
+  def trace(msg: => String)(implicit ev: LogSource): F[Unit]
+  def debug(msg: => String)(implicit ev: LogSource): F[Unit]
+  def info(msg: => String)(implicit ev: LogSource): F[Unit]
+  def warn(msg: => String)(implicit ev: LogSource): F[Unit]
+  def error(msg: => String)(implicit ev: LogSource): F[Unit]
+  def error(msg: => String, cause: Throwable)(implicit ev: LogSource): F[Unit]
 }
 
 object Log extends LogInstances {
@@ -52,24 +52,24 @@ object Log extends LogInstances {
 
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit L: Log[F]): Log[T[F, ?]] =
     new Log[T[F, ?]] {
-      def isTraceEnabled(implicit ev: LogSource): T[F, Boolean]  = L.isTraceEnabled.liftM[T]
-      def trace(msg: String)(implicit ev: LogSource): T[F, Unit] = L.trace(msg)(ev).liftM[T]
-      def debug(msg: String)(implicit ev: LogSource): T[F, Unit] = L.debug(msg)(ev).liftM[T]
-      def info(msg: String)(implicit ev: LogSource): T[F, Unit]  = L.info(msg)(ev).liftM[T]
-      def warn(msg: String)(implicit ev: LogSource): T[F, Unit]  = L.warn(msg)(ev).liftM[T]
-      def error(msg: String)(implicit ev: LogSource): T[F, Unit] = L.error(msg)(ev).liftM[T]
-      def error(msg: String, cause: Throwable)(implicit ev: LogSource): T[F, Unit] =
+      def isTraceEnabled(implicit ev: LogSource): T[F, Boolean]     = L.isTraceEnabled.liftM[T]
+      def trace(msg: => String)(implicit ev: LogSource): T[F, Unit] = L.trace(msg)(ev).liftM[T]
+      def debug(msg: => String)(implicit ev: LogSource): T[F, Unit] = L.debug(msg)(ev).liftM[T]
+      def info(msg: => String)(implicit ev: LogSource): T[F, Unit]  = L.info(msg)(ev).liftM[T]
+      def warn(msg: => String)(implicit ev: LogSource): T[F, Unit]  = L.warn(msg)(ev).liftM[T]
+      def error(msg: => String)(implicit ev: LogSource): T[F, Unit] = L.error(msg)(ev).liftM[T]
+      def error(msg: => String, cause: Throwable)(implicit ev: LogSource): T[F, Unit] =
         L.error(msg, cause)(ev).liftM[T]
     }
 
   class NOPLog[F[_]: Applicative] extends Log[F] {
-    def isTraceEnabled(implicit ev: LogSource): F[Boolean]                    = false.pure[F]
-    def trace(msg: String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
-    def debug(msg: String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
-    def info(msg: String)(implicit ev: LogSource): F[Unit]                    = ().pure[F]
-    def warn(msg: String)(implicit ev: LogSource): F[Unit]                    = ().pure[F]
-    def error(msg: String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
-    def error(msg: String, cause: Throwable)(implicit ev: LogSource): F[Unit] = ().pure[F]
+    def isTraceEnabled(implicit ev: LogSource): F[Boolean]                       = false.pure[F]
+    def trace(msg: => String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
+    def debug(msg: => String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
+    def info(msg: => String)(implicit ev: LogSource): F[Unit]                    = ().pure[F]
+    def warn(msg: => String)(implicit ev: LogSource): F[Unit]                    = ().pure[F]
+    def error(msg: => String)(implicit ev: LogSource): F[Unit]                   = ().pure[F]
+    def error(msg: => String, cause: Throwable)(implicit ev: LogSource): F[Unit] = ().pure[F]
   }
 
 }
@@ -83,17 +83,17 @@ sealed abstract class LogInstances {
 
     def isTraceEnabled(implicit ev: LogSource): F[Boolean] =
       Sync[F].delay(Logger(ev.clazz).underlying.isTraceEnabled())
-    def trace(msg: String)(implicit ev: LogSource): F[Unit] =
+    def trace(msg: => String)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).trace(msg))
-    def debug(msg: String)(implicit ev: LogSource): F[Unit] =
+    def debug(msg: => String)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).debug(msg))
-    def info(msg: String)(implicit ev: LogSource): F[Unit] =
+    def info(msg: => String)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).info(msg))
-    def warn(msg: String)(implicit ev: LogSource): F[Unit] =
+    def warn(msg: => String)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).warn(msg))
-    def error(msg: String)(implicit ev: LogSource): F[Unit] =
+    def error(msg: => String)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).error(msg))
-    def error(msg: String, cause: Throwable)(implicit ev: LogSource): F[Unit] =
+    def error(msg: => String, cause: Throwable)(implicit ev: LogSource): F[Unit] =
       Sync[F].delay(Logger(ev.clazz).error(msg, cause))
   }
 

--- a/shared/src/test/scala/coop/rchain/shared/MetricsTestImpl.scala
+++ b/shared/src/test/scala/coop/rchain/shared/MetricsTestImpl.scala
@@ -1,10 +1,9 @@
 package coop.rchain.shared
 
 import scala.collection.mutable.{Map => MutableMap}
-
 import cats.effect.Sync
-
-import coop.rchain.metrics.Metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.metrics.Metrics.Source
 
 final case class Record(value: Long, count: Long)
 
@@ -49,4 +48,5 @@ class MetricsTestImpl[F[_]: Sync] extends Metrics[F] {
       set(name, recordsSeq)(records)
     }
   override def timer[A](name: String, block: F[A])(implicit ev: Metrics.Source): F[A] = block
+  override def span(source: Source): F[Span[F]]                                       = Sync[F].pure(NoopSpan())
 }


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Introduce F in IStore and align all the pieces of `produce` and `consume` methods to be suspended in F.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-3022


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
