### PR TITLE
Kamon UDP InfluxDB reporter

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -58,6 +58,7 @@ rnode {
     metrics {
       prometheus = false
       influxdb = false
+      influxdb-udp = false
       zipkin = false
       sigar = false
     }
@@ -141,5 +142,30 @@ rnode {
 
     # Timestamp for the deploys
     # deploy-timestamp = 0
+  }
+
+  influxdb {
+    # Hostname and UDP port in which your InfluxDB is running
+    hostname = "127.0.0.1"
+    port = 8089
+
+    # Max packet size for UDP metrics data sent to InfluxDB.
+    max-packet-size = 1024 bytes
+
+    # For histograms, which percentiles to count
+    percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
+
+    # Allow including environment information as tags on all reported metrics.
+    additional-tags {
+
+      # Define whether specific environment settings will be included as tags in all exposed metrics. When enabled,
+      # the service, host and instance tags will be added using the values from Kamon.environment().
+      service = yes
+      host = yes
+      instance = yes
+
+      # Specifies which Kamon environment tags should be ignored. All unmatched tags will be always added to al metrics.
+      blacklisted-tags = []
+    }
   }
 }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -147,6 +147,7 @@ class NodeRuntime private[node] (
       _ <- Task.delay {
             Kamon.reconfigure(conf.underlying.withFallback(Kamon.config()))
             if (conf.kamon.influxDb) Kamon.addReporter(new kamon.influxdb.InfluxDBReporter())
+            if (conf.kamon.influxDbUdp) Kamon.addReporter(new UdpInfluxDBReporter())
             if (conf.kamon.prometheus) Kamon.addReporter(prometheusReporter)
             if (conf.kamon.zipkin) Kamon.addReporter(new ZipkinReporter())
             Kamon.addReporter(new JmxReporter())

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -64,6 +64,7 @@ object ConfigMapper {
         val add = addToMap(Key)
         add(keys.Prometheus, run.prometheus)
         add(keys.Influxdb, run.influxdb)
+        add(keys.InfluxdbUdp, run.influxdbUdp)
         add(keys.Zipkin, run.zipkin)
         add(keys.Sigar, run.sigar)
       }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -228,6 +228,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val influxdb =
       opt[Flag](descr = "Enable the InfluxDB metrics reporter")
 
+    val influxdbUdp =
+      opt[Flag](descr = "Enable the InfluxDB UDP metrics reporter")
+
     val zipkin =
       opt[Flag](descr = "Enable the Zipkin span reporter")
 

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -119,10 +119,11 @@ object Kamon {
   val Key = s"${Server.Key}.metrics"
 
   object keys {
-    val Prometheus = "prometheus"
-    val Influxdb   = "influxdb"
-    val Zipkin     = "zipkin"
-    val Sigar      = "sigar"
+    val Prometheus  = "prometheus"
+    val Influxdb    = "influxdb"
+    val InfluxdbUdp = "influxdb-udp"
+    val Zipkin      = "zipkin"
+    val Sigar       = "sigar"
   }
 
   def fromConfig(config: Config): configuration.Kamon = {
@@ -131,6 +132,7 @@ object Kamon {
     configuration.Kamon(
       prometheus = kamon.getBoolean(keys.Prometheus),
       influxDb = kamon.getBoolean(keys.Influxdb),
+      influxDbUdp = kamon.getBoolean(keys.InfluxdbUdp),
       zipkin = kamon.getBoolean(keys.Zipkin),
       sigar = kamon.getBoolean(keys.Sigar)
     )

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -43,6 +43,7 @@ final case class Tls(
 final case class Kamon(
     prometheus: Boolean,
     influxDb: Boolean,
+    influxDbUdp: Boolean,
     zipkin: Boolean,
     sigar: Boolean
 )

--- a/node/src/main/scala/coop/rchain/node/diagnostics/UdpInfluxDBReporter.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/UdpInfluxDBReporter.scala
@@ -1,0 +1,211 @@
+package coop.rchain.node.diagnostics
+
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+
+import coop.rchain.node.diagnostics.UdpInfluxDBReporter.{MetricDataPacketBuffer, Settings}
+
+import com.typesafe.config.Config
+import kamon.{Kamon, MetricReporter}
+import kamon.metric._
+import kamon.util.EnvironmentTagBuilder
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+class UdpInfluxDBReporter(config: Config = Kamon.config()) extends MetricReporter {
+
+  @SuppressWarnings(Array("org.wartremover.warts.Var"))
+  private var settings: Settings             = readConfiguration(config)
+  private val clientChannel: DatagramChannel = DatagramChannel.open()
+
+  override def start(): Unit = {}
+
+  override def stop(): Unit = {}
+
+  override def reconfigure(config: Config): Unit =
+    settings = readConfiguration(config)
+
+  private def readConfiguration(config: Config): Settings = {
+    import scala.collection.JavaConverters._
+    val influxConfig = config.getConfig("rnode.influxdb")
+    val address =
+      new InetSocketAddress(influxConfig.getString("hostname"), influxConfig.getInt("port"))
+    val maxPacketSize  = influxConfig.getBytes("max-packet-size")
+    val percentiles    = influxConfig.getDoubleList("percentiles").asScala.map(_.toDouble)
+    val additionalTags = EnvironmentTagBuilder.create(influxConfig.getConfig("additional-tags"))
+
+    Settings(address, maxPacketSize, percentiles, additionalTags)
+  }
+
+  def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
+    import snapshot.metrics._
+    val packetBuffer =
+      new MetricDataPacketBuffer(settings.maxPacketSize, clientChannel, settings.address)
+    val builder   = StringBuilder.newBuilder
+    val timestamp = snapshot.to.toEpochMilli
+
+    counters.foreach { c =>
+      writeMetricValue(builder, c, "count", timestamp)
+      packetBuffer.appendMeasurement(builder.toString)
+      builder.clear()
+    }
+
+    gauges.foreach { g =>
+      writeMetricValue(builder, g, "value", timestamp)
+      packetBuffer.appendMeasurement(builder.toString)
+      builder.clear()
+    }
+
+    histograms.foreach { h =>
+      writeMetricDistribution(builder, h, settings.percentiles, timestamp)
+      packetBuffer.appendMeasurement(builder.toString)
+      builder.clear()
+    }
+
+    rangeSamplers.foreach { rs =>
+      writeMetricDistribution(builder, rs, settings.percentiles, timestamp)
+      packetBuffer.appendMeasurement(builder.toString)
+      builder.clear()
+    }
+  }
+
+  private def writeMetricValue(
+      builder: StringBuilder,
+      metric: MetricValue,
+      fieldName: String,
+      timestamp: Long
+  ): Unit = {
+    writeNameAndTags(builder, metric.name, metric.tags)
+    writeIntField(builder, fieldName, metric.value, appendSeparator = false)
+    writeTimestamp(builder, timestamp)
+  }
+
+  private def writeMetricDistribution(
+      builder: StringBuilder,
+      metric: MetricDistribution,
+      percentiles: Seq[Double],
+      timestamp: Long
+  ): Unit = {
+    writeNameAndTags(builder, metric.name, metric.tags)
+    writeIntField(builder, "count", metric.distribution.count)
+    writeIntField(builder, "sum", metric.distribution.sum)
+    writeIntField(builder, "min", metric.distribution.min)
+
+    percentiles.foreach(p => {
+      writeDoubleField(
+        builder,
+        "p" + String.valueOf(p),
+        metric.distribution.percentile(p).value.toDouble
+      )
+    })
+
+    writeIntField(builder, "max", metric.distribution.max, appendSeparator = false)
+    writeTimestamp(builder, timestamp)
+  }
+
+  private def writeNameAndTags(
+      builder: StringBuilder,
+      name: String,
+      metricTags: Map[String, String]
+  ): Unit = {
+    builder.append(name)
+
+    val tags =
+      if (settings.additionalTags.nonEmpty) metricTags ++ settings.additionalTags
+      else metricTags
+
+    if (tags.nonEmpty) {
+      tags.foreach {
+        case (key, value) =>
+          builder
+            .append(',')
+            .append(escapeString(key))
+            .append("=")
+            .append(escapeString(value))
+      }
+    }
+
+    builder.append(' ')
+  }
+
+  private def escapeString(in: String): String =
+    in.replace(" ", "\\ ")
+      .replace("=", "\\=")
+      .replace(",", "\\,")
+
+  def writeDoubleField(
+      builder: StringBuilder,
+      fieldName: String,
+      value: Double,
+      appendSeparator: Boolean = true
+  ): Unit = {
+    builder
+      .append(fieldName)
+      .append('=')
+      .append(String.valueOf(value))
+
+    if (appendSeparator)
+      builder.append(',')
+  }
+
+  def writeIntField(
+      builder: StringBuilder,
+      fieldName: String,
+      value: Long,
+      appendSeparator: Boolean = true
+  ): Unit = {
+    builder
+      .append(fieldName)
+      .append('=')
+      .append(String.valueOf(value))
+      .append('i')
+
+    if (appendSeparator)
+      builder.append(',')
+  }
+
+  def writeTimestamp(builder: StringBuilder, timestamp: Long): Unit =
+    builder
+      .append(' ')
+      .append(timestamp)
+}
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object UdpInfluxDBReporter {
+
+  private final class MetricDataPacketBuffer(
+      maxPacketSizeInBytes: Long,
+      channel: DatagramChannel,
+      remote: InetSocketAddress
+  ) {
+    private val metricSeparator = "\n"
+    private val buffer          = StringBuilder.newBuilder
+
+    def appendMeasurement(measurementData: String): Unit =
+      if (fitsOnBuffer(metricSeparator + measurementData)) {
+        val mSeparator = if (buffer.nonEmpty) metricSeparator else ""
+        buffer.append(mSeparator).append(measurementData)
+      } else {
+        flush()
+        buffer.append(measurementData)
+      }
+
+    private def fitsOnBuffer(data: String): Boolean =
+      (buffer.length + data.length) <= maxPacketSizeInBytes
+
+    def flush(): Unit = {
+      flushToUDP(buffer.toString)
+      buffer.clear()
+    }
+
+    private def flushToUDP(data: String): Unit =
+      channel.send(ByteBuffer.wrap(data.getBytes), remote)
+  }
+
+  final case class Settings(
+      address: InetSocketAddress,
+      maxPacketSize: Long,
+      percentiles: Seq[Double],
+      additionalTags: Map[String, String]
+  )
+}

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -98,6 +98,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "run",
         "--prometheus",
         "--influxdb",
+        "--influxdb-udp",
         "--zipkin",
         "--sigar"
       ).mkString(" ")
@@ -109,6 +110,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
       configuration.Kamon(
         prometheus = true,
         influxDb = true,
+        influxDbUdp = true,
         zipkin = true,
         sigar = true
       )

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -101,6 +101,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         |    metrics {
         |      prometheus = true
         |      influxdb = true
+        |      influxdb-udp = true
         |      zipkin = true
         |      sigar = true
         |    }
@@ -112,6 +113,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
       configuration.Kamon(
         prometheus = true,
         influxDb = true,
+        influxDbUdp = true,
         zipkin = true,
         sigar = true
       )


### PR DESCRIPTION
## Overview
Add a Kamon UDP InfluxDB reporter. The default Kamon InfluxDB reporter doesn't support UDP and reports metrics with seconds precision.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3021

### Notes
Requires to enable UDP in the InfluxDB configuration.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
