### PR TITLE
Remove joining fees from proof of stake contract

### DIFF
--- a/casper/src/main/rholang/MakePoS.rho
+++ b/casper/src/main/rholang/MakePoS.rho
@@ -18,12 +18,11 @@ in {
   for(@(_, ListOps) <- ListOpsCh; @(_, Either) <- EitherCh) {
     contract MakePoS(purse, @minimumBond, @maximumBond, @initBonds, return) = {
       new 
-        this, bondsCh, joiningFeeCh, clonePurse, depositPurse, 
-        updateBonds, feeDistribution, paymentStore
+        this, bondsCh, clonePurse, depositPurse,
+        updateBonds, paymentStore
       in {
         bondsCh!(initBonds) |
-        joiningFeeCh!!(minimumBond) | //joining fee equal to minimum bond amount
-      
+
         //The purpose of this contract is to move the contents
         //of an existing purse into a new purse. This prevents
         //the owner of the given purse from modifying the balance
@@ -46,9 +45,9 @@ in {
         contract this(@"validateBondAmount", @bondPurse, return) = {
           new balanceCh in {
             @bondPurse!("getBalance", *balanceCh) |
-            for(@balance <- balanceCh; @joiningFee <- joiningFeeCh) {
-              if      (balance - joiningFee < minimumBond) { return!(("Left", "Bond less than minimum!")) }
-              else if (balance - joiningFee > maximumBond) { return!(("Left", "Bond greater than maximum!")) }
+            for(@balance <- balanceCh) {
+              if      (balance < minimumBond) { return!(("Left", "Bond less than minimum!")) }
+              else if (balance > maximumBond) { return!(("Left", "Bond greater than maximum!")) }
               else                                         { return!(("Right", bondPurse)) }
             }
           }
@@ -80,55 +79,11 @@ in {
             bondsCh!(bonds) | return!(bonds)
           }
         } |
-        
-        contract feeDistribution(@n, @joiningFee, return) = {
-          new rangeCh, feeDistFunc, feeDistCh, sum, nCh, totalCh in {
-            contract sum(@x, @y, return) = { return!(x + y) } |
-            contract feeDistFunc(@k, return) = { return!((2 * joiningFee * (n + 1 - k)) / (n * (n + 1))) } |
-            @ListOps!("range", 1, n + 1, *rangeCh) |
-            for(@range <- rangeCh) {
-              @ListOps!("map", range, *feeDistFunc, *feeDistCh) |
-              for(@feeDist <- feeDistCh) {
-                @ListOps!("fold", feeDist, 0, *sum, *totalCh) |
-                for(@total <- totalCh) {
-                  return!(
-                    //give remainder (non-zero from rounding) to first validator
-                    [feeDist.nth(0) + joiningFee - total] ++
-                      feeDist.slice(1, n)
-                  )
-                }
-              }
-            }
-          }
-        } |
 
         contract updateBonds(@publicKey, @sigVerify, @bondAmount, @rewardsForwarder, return) = {
-          new feeDistCh, bondUpdateLoop, bondsWithFeeCh in {
-            //update the stakes of existing validators with their share of the joining fee
-            contract bondUpdateLoop(@bondsMap, @feeDist, @updatedMap, return) = {
-              match bondsMap {
-                {key:(stake, sigVerify, rewardsForwarder, index) ...rest} => { 
-                  bondUpdateLoop!(
-                    rest, 
-                    feeDist, 
-                    updatedMap.set(key, (stake + feeDist.nth(index - 1), sigVerify, rewardsForwarder, index)),
-                    *return
-                  )
-                }
-                
-                _ => { return!(updatedMap) }
-              }
-            } |
-            for(@bonds <- bondsCh; @joiningFee <- joiningFeeCh) {
-              feeDistribution!(bonds.size(), joiningFee, *feeDistCh) |
-              for(@feeDist <- feeDistCh) {
-                bondUpdateLoop!(bonds, feeDist, {}, *bondsWithFeeCh) |
-                for(@bondsWithFee <- bondsWithFeeCh) {
-                  bondsCh!(bondsWithFee.set(publicKey, (bondAmount - joiningFee, sigVerify, rewardsForwarder, bonds.size() + 1))) |
-                  return!((true, "Bond successful!"))
-                }
-              }
-            }
+          for(@bonds <- bondsCh) {
+            bondsCh!(bonds.set(publicKey, (bondAmount, sigVerify, rewardsForwarder, bonds.size() + 1))) |
+            return!((true, "Bond successful!"))
           }
         } |
 

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -669,7 +669,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield result
   }
 
-  it should "allow bonding and distribute the joining fee" in effectTest {
+  it should "allow bonding" in effectTest {
     for {
       nodes <- HashSetCasperTestNode.networkEff(
                 validatorKeys :+ otherSk,
@@ -780,22 +780,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
           }
         )
 
-      joiningFee = minimumBond
-      n          = validatorBondsAndRanks.size
-      joiningFeeDistribution = (1 to n).map { k =>
-        k -> ((2L * minimumBond * (n + 1 - k)) / (n * (n + 1)))
-      }.toMap
-      total = joiningFeeDistribution.values.sum
-      finalFeesDist = joiningFeeDistribution.updated(
-        1,
-        joiningFeeDistribution(1) + joiningFee - total
-      )
       correctBonds = validatorBondsAndRanks.map {
-        case (key, stake, rank) =>
-          Bond(key, stake + finalFeesDist(rank))
+        case (keyA, stake, _) =>
+          Bond(keyA, stake)
       }.toSet + Bond(
         ByteString.copyFrom(otherPk),
-        wallets.head.initRevBalance.toLong - joiningFee
+        wallets.head.initRevBalance.toLong
       )
 
       newBonds = block2.getBody.getState.bonds


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Based on https://rchain.atlassian.net/wiki/spaces/CORE/pages/669188235/2019-02-14+Meeting+notes+validation+and+Casper (see paragraph 4 decision), we are removing joining fees.

See https://github.com/rchain/rchain/pull/1572 for PR that introduced joining fees for context.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-2410

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
