### PR TITLE
Remove use of BlockStore from Validate.blockNumber

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -320,7 +320,7 @@ object Validate {
     for {
       parents <- ProtoUtil.parentHashes(b).toList.traverse { parentHash =>
                   dag.lookup(parentHash).flatMap {
-                    case Some(p) => Sync[F].delay(p)
+                    case Some(p) => p.pure[F]
                     case None =>
                       Sync[F].raiseError[BlockMetadata](
                         new Exception(


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

An optimization so that we don't have to access the block store.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3047

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
