### PR TITLE
Make number of incoming message consumers configurable

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -62,7 +62,7 @@ class TcpTransportLayerSpec
 
   def createTransportLayerServer(env: TcpTlsEnvironment): Task[TransportLayerServer[Task]] =
     Task.delay {
-      new GrpcTransportServer(env.port, env.cert, env.key, 4 * 1024 * 1024, tempFolder)
+      new GrpcTransportServer(env.port, env.cert, env.key, 4 * 1024 * 1024, tempFolder, 4)
     }
 }
 

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -48,6 +48,10 @@ rnode {
     # Maximum size of message that can be sent via transport layer
     max-message-size = 256K
 
+    # Number of incoming message consumers
+    # Defaults to number of cores
+    # message-consumers = 4
+
     # TLS certificate settings
     tls {
       # certificate = ${data-dir}"/node.certificate.pem"

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -113,7 +113,8 @@ class NodeRuntime private[node] (
                               conf.tls.certificate,
                               conf.tls.key,
                               conf.server.maxMessageSize,
-                              conf.server.dataDir.resolve("tmp").resolve("comm")
+                              conf.server.dataDir.resolve("tmp").resolve("comm"),
+                              conf.server.messageConsumers
                             )(grpcScheduler, log)
                           )
                           .toEffect

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -49,6 +49,7 @@ object ConfigMapper {
         add(keys.MapSize, run.mapSize)
         add(keys.MaxConnections, run.maxNumOfConnections)
         add(keys.MaxMessageSize, run.maxMessageSize)
+        add(keys.MessageConsumers, run.messageConsumers)
       }
 
       {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -279,6 +279,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val maxMessageSize =
       opt[Int](descr = "Maximum size of message that can be sent via transport layer")
 
+    val messageConsumers =
+      opt[Int](descr = "Number of incoming message consumers. Defaults to number of CPU cores")
+
     val threadPoolSize =
       opt[Int](descr = "Maximum number of threads used by rnode", hidden = true)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -22,6 +22,7 @@ object Configuration {
 
     def getStringOpt(path: String): Option[String] = getOpt(path, _.getString)
     def getLongOpt(path: String): Option[Long]     = getOpt(path, _.getLong)
+    def getIntOpt(path: String): Option[Int]       = getOpt(path, _.getInt)
     def getPath(path: String): Path                = Paths.get(underlying.getString(path))
     def getPathOpt(path: String): Option[Path]     = getOpt(path, _.getPath)
     def getFiniteDuration(path: String): FiniteDuration =
@@ -33,21 +34,22 @@ object Server {
   val Key = s"${Configuration.Key}.server"
 
   object keys {
-    val Bootstrap      = "bootstrap"
-    val StoreType      = "store-type"
-    val Host           = "host"
-    val HostDynamic    = "host-dynamic"
-    val Upnp           = "upnp"
-    val Port           = "port"
-    val PortHttp       = "port-http"
-    val PortKademlia   = "port-kademlia"
-    val SendTimeout    = "send-timeout"
-    val Standalone     = "standalone"
-    val DataDir        = "data-dir"
-    val StoreSize      = "store-size"
-    val MapSize        = "map-size"
-    val MaxConnections = "max-connections"
-    val MaxMessageSize = "max-message-size"
+    val Bootstrap        = "bootstrap"
+    val StoreType        = "store-type"
+    val Host             = "host"
+    val HostDynamic      = "host-dynamic"
+    val Upnp             = "upnp"
+    val Port             = "port"
+    val PortHttp         = "port-http"
+    val PortKademlia     = "port-kademlia"
+    val SendTimeout      = "send-timeout"
+    val Standalone       = "standalone"
+    val DataDir          = "data-dir"
+    val StoreSize        = "store-size"
+    val MapSize          = "map-size"
+    val MaxConnections   = "max-connections"
+    val MaxMessageSize   = "max-message-size"
+    val MessageConsumers = "message-consumers"
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -70,6 +72,7 @@ object Server {
           s"$storeTypeStr is not a supported store type"
         )
     }
+    val messageConsumers = Math.max(Runtime.getRuntime.availableProcessors(), 2)
 
     configuration.Server(
       host = server.getStringOpt(keys.Host),
@@ -86,7 +89,8 @@ object Server {
       storeSize = server.getBytes(keys.StoreSize),
       mapSize = server.getBytes(keys.MapSize),
       maxNumOfConnections = server.getInt(keys.MaxConnections),
-      maxMessageSize = server.getBytes(keys.MaxMessageSize).toInt
+      maxMessageSize = server.getBytes(keys.MaxMessageSize).toInt,
+      messageConsumers = server.getIntOpt(keys.MessageConsumers).getOrElse(messageConsumers)
     )
   }
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -23,7 +23,8 @@ final case class Server(
     storeType: StoreType,
     storeSize: Long,
     maxNumOfConnections: Int,
-    maxMessageSize: Int
+    maxMessageSize: Int,
+    messageConsumers: Int
 )
 
 final case class GrpcServer(

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -33,7 +33,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--casper-block-store-size 2000",
         "--map-size 1000",
         "--max-num-of-connections 500",
-        "--max-message-size 256"
+        "--max-message-size 256",
+        "--message-consumers 8"
       ).mkString(" ")
 
     val options = Options(args.split(' '))
@@ -60,7 +61,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         StoreType.LMDB,
         2000,
         500,
-        256
+        256,
+        8
       )
 
     val server = hocon.Server.fromConfig(config)

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -34,6 +34,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
       |    map-size = 1G
       |    max-connections = 500
       |    max-message-size = 256K
+      |    message-consumers = 8
       |  }
       |}
     """.stripMargin
@@ -59,7 +60,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         StoreType.LMDB,
         1024 * 1024 * 1024,
         500,
-        256 * 1024
+        256 * 1024,
+        8
       )
 
     val server = Server.fromConfig(ConfigFactory.parseString(conf))


### PR DESCRIPTION
## Overview
Make the number of incoming message consumers configurable. Remove Casper workaround of only 1 message consumer.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3036

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
