### PR TITLE
Replace the algorithm for storing past roots

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ITrieStore.scala
@@ -22,8 +22,6 @@ trait ITrieStore[T, K, V] {
 
   private[rspace] def putRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
-  private[rspace] def getAllPastRoots(txn: T): Seq[Blake2b256Hash]
-
   private[rspace] def validateAndPutRoot(txn: T, branch: Branch, hash: Blake2b256Hash): Unit
 
   private[rspace] def getEmptyRoot(txn: T): Blake2b256Hash

--- a/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/InMemoryTrieStore.scala
@@ -9,7 +9,7 @@ import kamon.Kamon
 final case class State[K, V](
     _dbTrie: Map[Blake2b256Hash, Trie[K, V]],
     _dbRoot: Map[Branch, Blake2b256Hash],
-    _dbPastRoots: Map[Branch, Seq[Blake2b256Hash]],
+    _dbPastRoots: Set[Blake2b256Hash],
     _dbEmptyRoot: Option[Blake2b256Hash]
 ) {
 
@@ -19,7 +19,7 @@ final case class State[K, V](
   def changeRoot(newRoot: Map[Branch, Blake2b256Hash]): State[K, V] =
     State(_dbTrie, newRoot, _dbPastRoots, _dbEmptyRoot)
 
-  def changePastRoots(newPastRoots: Map[Branch, Seq[Blake2b256Hash]]): State[K, V] =
+  def changePastRoots(newPastRoots: Set[Blake2b256Hash]): State[K, V] =
     State(_dbTrie, _dbRoot, newPastRoots, _dbEmptyRoot)
 
   def changeEmptyRoot(emptyRoot: Blake2b256Hash): State[K, V] =
@@ -27,7 +27,7 @@ final case class State[K, V](
 }
 
 object State {
-  def empty[K, V]: State[K, V] = State[K, V](Map.empty, Map.empty, Map.empty, None)
+  def empty[K, V]: State[K, V] = State[K, V](Map.empty, Map.empty, Set.empty, None)
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.Throw", "org.wartremover.warts.NonUnitStatements")) // TODO stop throwing exceptions
@@ -58,22 +58,11 @@ class InMemoryTrieStore[K, V]
   ): Option[Blake2b256Hash] =
     getRoot(txn, branch)
       .map { currentRoot =>
-        val pastRoots = getPastRootsInBranch(txn, branch).filter(_ != currentRoot)
-        (currentRoot, currentRoot +: pastRoots)
+        txn.writeState(
+          state => (state.changePastRoots(state._dbPastRoots + currentRoot), ())
+        )
+        currentRoot
       }
-      .map {
-        case (currentRoot, updatedPastRoots) =>
-          txn.writeState(
-            state => (state.changePastRoots(state._dbPastRoots + (branch -> updatedPastRoots)), ())
-          )
-          currentRoot
-      }
-
-  private[this] def getPastRootsInBranch(
-      txn: InMemTransaction[State[K, V]],
-      branch: Branch
-  ): Seq[Blake2b256Hash] =
-    txn.readState(state => state._dbPastRoots.getOrElse(branch, Seq.empty))
 
   override private[rspace] def putRoot(
       txn: InMemTransaction[State[K, V]],
@@ -82,12 +71,11 @@ class InMemoryTrieStore[K, V]
   ): Unit =
     txn.writeState(state => (state.changeRoot(state._dbRoot + (branch -> hash)), ()))
 
-  override private[rspace] def getAllPastRoots(
+  private[rspace] def getAllPastRoots(
       txn: InMemTransaction[State[K, V]]
-  ): Seq[Blake2b256Hash] =
+  ): Set[Blake2b256Hash] =
     txn.readState(
-      state =>
-        state._dbPastRoots.values.foldLeft(Seq.empty[Blake2b256Hash])((acc, value) => acc ++ value)
+      state => state._dbPastRoots
     )
 
   override private[rspace] def validateAndPutRoot(
@@ -97,14 +85,6 @@ class InMemoryTrieStore[K, V]
   ): Unit =
     getRoot(txn, branch)
       .find(_ == hash)
-      .orElse {
-        getPastRootsInBranch(txn, branch)
-          .find(_ == hash)
-          .map { blake: Blake2b256Hash =>
-            putRoot(txn, branch, blake)
-            blake
-          }
-      }
       .orElse {
         getAllPastRoots(txn)
           .find(_ == hash)


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

It no longer makes sense to store past roots per branch. Instead the dbPastRoots holds the root hashes as keys.
Values do not matter at the moment, the last seen branch is used.
This will fix the data corruption observed on testnet.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-2987

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
