### PR TITLE
[Rchain 3049]: expose RevAddress in Rholang

### DIFF
--- a/casper/src/test/rholang/RevAddressTest.rho
+++ b/casper/src/test/rholang/RevAddressTest.rho
@@ -1,0 +1,38 @@
+//scalapackage coop.rchain.rholang.rev
+
+//requires RhoSpec
+new
+  rl(`rho:registry:lookup`), RhoSpecCh,
+  revAddress(`rho:rev:address`),
+  stdlog(`rho:io:stdlog`),
+  setup,
+  test_valid_address, test_invalid_address
+in {
+  rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *RhoSpecCh) |
+  for(@(_, RhoSpec) <- RhoSpecCh) {
+    @RhoSpec!("testSuite", *setup,
+      [
+        ("Validating a valid address returns Nil", *test_valid_address),
+        ("Validating a invalid address returns a non-Nil value", *test_invalid_address),
+      ])
+  } |
+
+  contract setup(returnCh) = {
+    returnCh!([])
+  } |
+
+  contract test_invalid_address(rhoSpec, _, ackCh) = {
+    new retCh in {
+      revAddress!("validate", "some_obviously_invalid_address", *retCh) |
+      rhoSpec!("assert", (Nil, "!= <-", *retCh), "Expecting a non-Nil value containing the error message", *ackCh)
+    }
+  } |
+
+  contract test_valid_address(rhoSpec, _, ackCh) = {
+    stdlog!("info", "test valid address") |
+    new retCh in {
+      revAddress!("validate", "1111K9MczqzZrNkUNmNGrNFyz7F7LiCUgaCHXd28g2k5PxiaNuCAi", *retCh) |
+      rhoSpec!("assert", (Nil, "== <-", *retCh), "expecting a Nil value since there are no errors", *ackCh)
+    }
+  }
+}

--- a/casper/src/test/rholang/RhoSpecContract.rho
+++ b/casper/src/test/rholang/RhoSpecContract.rho
@@ -37,6 +37,12 @@ in {
                     assert!(testName, attempt, (expected, "==", actual), clue, *ackCh)
                   }
                 }
+                (unexpected, "!= <-", actualCh) => {
+                  for (@actual <- @actualCh) {
+                    stdlog!("info", {"actual": actual, "unexpected": unexpected}) |
+                    assert!(testName, attempt, (unexpected, "!=", actual), clue, *ackCh)
+                  }
+                }
                 assertion => {
                   assert!(testName, attempt, assertion, clue, *ackCh)
                 }
@@ -80,6 +86,7 @@ in {
 
 
         contract runTest(@(testName, testBody), ackCh) = {
+          stdlog!("info", "Running test: " ++ testName) |
           runTest!((testName, testBody, 1), *ackCh)
         } |
 

--- a/casper/src/test/rholang/RhoSpecContractTest.rho
+++ b/casper/src/test/rholang/RhoSpecContractTest.rho
@@ -4,9 +4,10 @@ new rl(`rho:registry:lookup`),
     RhoSpecCh,
     setup,
     stdlog(`rho:io:stdlog`),
-    testSetup, testAssertEquals, testAssertTrue, testAssertMany,
+    testSetup, testAssertEquals, testAssertNotEquals, testAssertTrue, testAssertMany,
     testAssertEqualsFromChannel, testAssertManyEqualsFromChannel,
-    testAssertEqualsForVariables,  testMultipleAttempts
+    testAssertEqualsForVariables,  testMultipleAttempts,
+    testAssertNotEqualsFromChannel
 in {
   stdlog!("info", "starting SuccessfulResultCollector...") |
   rl!(`rho:id:6wnujzcraztjfg941skrtbdkdgbko8nuaqihuhn15s66oz8ro5gwbb`, *RhoSpecCh) |
@@ -15,9 +16,11 @@ in {
     [
       ("setup runs correctly", *testSetup),
       ("assert equality", *testAssertEquals),
+      ("assert non equality", *testAssertNotEquals),
       ("assert boolean conditions", *testAssertTrue),
       ("assert many conditions", *testAssertMany),
       ("assert '== <-'", *testAssertEqualsFromChannel),
+      ("assert '!= <-'", *testAssertNotEqualsFromChannel),
       ("assertMany '== <-'", *testAssertManyEqualsFromChannel),
       ("run the test function multiple times", *testMultipleAttempts, 10)
     ])
@@ -41,6 +44,17 @@ in {
     }
   } |
 
+  contract testAssertNotEquals(rhoSpec, self, ackCh) = {
+    stdlog ! ("info", "testing nonequality") |
+    new privateAck in {
+      rhoSpec ! ("assert", ("abc", "!=", "xyz"), "strings should be not equal", *privateAck) |
+
+      for( _ <- privateAck) {
+        rhoSpec ! ("assert", (1, "!=", 0), "ints should not be equal", *ackCh)
+      }
+    }
+  } |
+
   contract testAssertTrue(rhoSpec, self, ackCh) = {
     rhoSpec ! ("assert", true, "boolean assertions should work", *ackCh)
   } |
@@ -58,6 +72,14 @@ in {
     new ch in {
       ch ! (1) |
       rhoSpec ! ("assert", (1, "== <-", *ch), "assert equals from channel", *ackCh)
+    }
+  } |
+
+  contract testAssertNotEqualsFromChannel(rhoSpec, self, ackCh) = {
+    stdlog ! ("info", "testing nonequality from channel") |
+    new ch in {
+      ch ! (1) |
+      rhoSpec ! ("assert", (0, "!= <-", *ch), "assert not equals from channel", *ackCh)
     }
   } |
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -1,0 +1,7 @@
+package coop.rchain.casper.genesis.contracts
+import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.rholang.rev.RevAddressTest
+
+import scala.concurrent.duration._
+
+class RevAddressSpec extends RhoSpec(RevAddressTest, Seq.empty, 10.seconds)

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoLogger.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoLogger.scala
@@ -1,32 +1,20 @@
 package coop.rchain.casper.helper
+import cats.effect.Sync
 import coop.rchain.models.{ListParWithRandomAndPhlos, Par}
-import coop.rchain.rholang.interpreter.PrettyPrinter
+import coop.rchain.rholang.interpreter.{ContractCall, PrettyPrinter}
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.shared.{Log, LogSource}
 
 object RhoLogger {
   val prettyPrinter = PrettyPrinter()
 
-  object IsLogMessage {
-    def unapply(p: Seq[ListParWithRandomAndPhlos]): Option[(String, Par)] =
-      p match {
-        case Seq(
-            ListParWithRandomAndPhlos(
-              Seq(IsString(logLevel), par),
-              _,
-              _
-            )
-            ) =>
-          Some((logLevel, par))
-        case _ => None
-      }
-  }
-
-  def handleMessage[F[_]: Log](
+  def handleMessage[F[_]: Log : Sync](
       ctx: SystemProcess.Context[F]
-  )(message: Seq[ListParWithRandomAndPhlos], x: Int): F[Unit] =
+  )(message: (Seq[ListParWithRandomAndPhlos], Int)): F[Unit] = {
+    val isContractCall = new ContractCall(ctx.space, ctx.dispatcher)
+
     message match {
-      case IsLogMessage(logLevel, par) =>
+      case isContractCall(_, Seq(IsString(logLevel), par)) =>
         val msg         = prettyPrinter.buildString(par)
         implicit val ev = LogSource.matLogSource
 
@@ -38,4 +26,5 @@ object RhoLogger {
           case "error" => Log[F].error(msg)
         }
     }
+  }
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -17,7 +17,7 @@ object RhoSpec {
 
   private def mkRuntime(testResultCollector: TestResultCollector[Task]) = {
     val testResultCollectorService =
-      Seq((5, "assertAck", 24), (1, "testSuiteCompleted", 25))
+      Seq((5, "assertAck", 25), (1, "testSuiteCompleted", 26))
         .map {
           case (arity, name, n) =>
             SystemProcess.Definition[Task](
@@ -30,9 +30,9 @@ object RhoSpec {
         } ++ Seq(
         SystemProcess.Definition[Task](
           "rho:io:stdlog",
-          Runtime.byteName(26),
+          Runtime.byteName(27),
           2,
-          26L,
+          27L,
           RhoLogger.handleMessage[Task]
         )
       )
@@ -74,6 +74,8 @@ class RhoSpec(
           assertions.foreach {
             case RhoAssertEquals(_, expected, actual, clue) =>
               actual should be(expected) withClue clueMsg(clue)
+            case RhoAssertNotEquals(_, unexpected, actual, clue) =>
+              actual should not be (unexpected) withClue clueMsg(clue)
             case RhoAssertTrue(_, v, clue) => v should be(true) withClue clueMsg(clue)
           }
         }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -25,7 +25,7 @@ object RhoSpec {
               Runtime.byteName(n.toByte),
               arity,
               n.toLong,
-              testResultCollector.handleMessage
+              ctx => testResultCollector.handleMessage(ctx)(_,_)
             )
         } ++ Seq(
         SystemProcess.Definition[Task](
@@ -33,7 +33,7 @@ object RhoSpec {
           Runtime.byteName(27),
           2,
           27L,
-          RhoLogger.handleMessage[Task]
+          ctx => RhoLogger.handleMessage(ctx)(_,_)
         )
       )
     TestUtil.runtime(testResultCollectorService)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -1,0 +1,58 @@
+package coop.rchain.rholang.interpreter
+import cats.effect.Sync
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.models.{ListParWithRandom, ListParWithRandomAndPhlos, Par, TaggedContinuation}
+import coop.rchain.rholang.interpreter.Runtime.RhoISpace
+import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rholang.interpreter.storage.implicits.matchListPar
+import coop.rchain.rspace.util.unpackCont
+import cats.implicits._
+
+class ContractCall[F[_]: Sync](
+    space: RhoISpace[F],
+    dispatcher: Dispatch[F, ListParWithRandomAndPhlos, TaggedContinuation]
+) {
+
+  type Producer = (Seq[Par], Par) => F[Unit]
+
+  private val UNLIMITED_MATCH_PHLO = matchListPar(Cost(Integer.MAX_VALUE))
+
+  private def produce(
+      rand: Blake2b512Random,
+      sequenceNumber: Int
+  )(values: Seq[Par], ch: Par): F[Unit] =
+    for {
+      produceResult <- space.produce(
+                        ch,
+                        ListParWithRandom(values, rand),
+                        persist = false,
+                        sequenceNumber
+                      )(UNLIMITED_MATCH_PHLO)
+      _ <- produceResult.fold(
+            _ => Sync[F].raiseError(OutOfPhlogistonsError),
+            _.fold(Sync[F].unit) {
+              case (cont, channels) =>
+                dispatcher.dispatch(unpackCont(cont), channels.map(_.value), cont.sequenceNumber)
+            }
+          )
+    } yield ()
+
+  def unapply(contractArgs: (Seq[ListParWithRandomAndPhlos], Int)): Option[
+    (Producer, Seq[Par])
+  ] =
+    contractArgs match {
+      case (
+          Seq(
+            ListParWithRandomAndPhlos(
+              args,
+              rand,
+              _
+            )
+          ),
+          sequenceNumber
+          ) =>
+        Some((produce(rand, sequenceNumber), args))
+      case _ => None
+    }
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -143,6 +143,7 @@ object Runtime {
     val REG_NONCE_INSERT_CALLBACK: Long    = 21L
     val GET_DEPLOY_PARAMS: Long            = 22L
     val GET_TIMESTAMP: Long                = 23L
+    val REV_ADDRESS: Long                  = 24L
   }
 
   def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
@@ -162,6 +163,7 @@ object Runtime {
     val REG_INSERT_SIGNED: Par = byteName(11)
     val GET_DEPLOY_PARAMS: Par = byteName(12)
     val GET_TIMESTAMP: Par     = byteName(13)
+    val REV_ADDRESS: Par       = byteName(14)
   }
 
   // because only we do installs
@@ -272,6 +274,14 @@ object Runtime {
       1,
       BodyRefs.GET_TIMESTAMP, { ctx =>
         ctx.systemProcesses.blockTime(ctx.blockTime)
+      }
+    ),
+    SystemProcess.Definition[F](
+      "rho:rev:address",
+      FixedChannels.REV_ADDRESS,
+      3,
+      BodyRefs.REV_ADDRESS, { ctx =>
+        ctx.systemProcesses.validateRevAddress
       }
     )
   )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -39,6 +39,23 @@ trait SystemProcesses[F[_]] {
   def validateRevAddress: (Seq[ListParWithRandomAndPhlos], Int) => F[Unit]
 }
 
+object RhoType {
+  object ByteArray {
+    import coop.rchain.models.rholang.implicits._
+    def unapply(p: Par): Option[Array[Byte]] =
+      p.singleExpr().collect {
+        case Expr(GByteArray(bs)) => bs.toByteArray
+      }
+  }
+
+  object String {
+    def unapply(p: Par): Option[String] =
+      p.singleExpr().collect {
+        case Expr(GString(bs)) => bs
+      }
+  }
+}
+
 object SystemProcesses {
 
   def apply[F[_]](
@@ -118,7 +135,7 @@ object SystemProcesses {
         case (
             Seq(
               ListParWithRandomAndPhlos(
-                Seq(IsString("validate"), IsString(address), ack),
+                Seq(RhoType.String("validate"), RhoType.String(address), ack),
                 rand,
                 _
               )
@@ -137,26 +154,11 @@ object SystemProcesses {
           } yield ()
       }
 
-      object IsByteArray {
-        import coop.rchain.models.rholang.implicits._
-        def unapply(p: Par): Option[Array[Byte]] =
-          p.singleExpr().collect {
-            case Expr(GByteArray(bs)) => bs.toByteArray
-          }
-      }
-
-      object IsString {
-        def unapply(p: Par): Option[String] =
-          p.singleExpr().collect {
-            case Expr(GString(bs)) => bs
-          }
-      }
-
       def secp256k1Verify: (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case (
             Seq(
               ListParWithRandomAndPhlos(
-                Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack),
+                Seq(RhoType.ByteArray(data), RhoType.ByteArray(signature), RhoType.ByteArray(pub), ack),
                 rand,
                 _
               )
@@ -184,7 +186,7 @@ object SystemProcesses {
         case (
             Seq(
               ListParWithRandomAndPhlos(
-                Seq(IsByteArray(data), IsByteArray(signature), IsByteArray(pub), ack),
+                Seq(RhoType.ByteArray(data), RhoType.ByteArray(signature), RhoType.ByteArray(pub), ack),
                 rand,
                 _
               )
@@ -210,7 +212,7 @@ object SystemProcesses {
 
       def sha256Hash: (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case (
-            Seq(ListParWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)),
+            Seq(ListParWithRandomAndPhlos(Seq(RhoType.ByteArray(input), ack), rand, _)),
             sequenceNumber
             ) =>
           for {
@@ -235,7 +237,7 @@ object SystemProcesses {
 
       def keccak256Hash: (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case (
-            Seq(ListParWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)),
+            Seq(ListParWithRandomAndPhlos(Seq(RhoType.ByteArray(input), ack), rand, _)),
             sequenceNumber
             ) =>
           for {
@@ -261,7 +263,7 @@ object SystemProcesses {
 
       def blake2b256Hash: (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case (
-            Seq(ListParWithRandomAndPhlos(Seq(IsByteArray(input), ack), rand, _)),
+            Seq(ListParWithRandomAndPhlos(Seq(RhoType.ByteArray(input), ack), rand, _)),
             sequenceNumber
             ) =>
           for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/AddressTools.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/AddressTools.scala
@@ -55,11 +55,12 @@ class AddressTools(prefix: Array[Byte], keyLength: Int, checksumLength: Int) {
     }
 
     for {
-      decodedAddress <- Base58.decode(address)
-                              .toRight("Invalid Base58 encoding")
-      _              <- validateLength(decodedAddress)
-      payload        <- validateChecksum(decodedAddress)
-      address        <- parsePayload(payload)
+      decodedAddress <- Base58
+                         .decode(address)
+                         .toRight("Invalid Base58 encoding")
+      _       <- validateLength(decodedAddress)
+      payload <- validateChecksum(decodedAddress)
+      address <- parsePayload(payload)
     } yield address
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
@@ -6,7 +6,8 @@ import org.scalatest._
 
 class RevAddressSpec extends FlatSpec with Matchers {
   "fromPublicKey" should "work correctly" in {
-    val pk = PublicKey(Base16.decode("00322ba649cebf90d8bd0eeb0658ea7957bcc59ecee0676c86f4fec517c06251"))
+    val pk =
+      PublicKey(Base16.decode("00322ba649cebf90d8bd0eeb0658ea7957bcc59ecee0676c86f4fec517c06251"))
     RevAddress.fromPublicKey(pk) should be(
       Some("1111K9MczqzZrNkUNmNGrNFyz7F7LiCUgaCHXd28g2k5PxiaNuCAi")
     )


### PR DESCRIPTION
## Overview
expose RevAddress validation as a system process
refactor SystemProcesses in order to remove the duplication


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3049



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
