### PR TITLE
RCHAIN-2907: Return via F in rspace matcher

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -166,10 +166,7 @@ object Runtime {
     val REV_ADDRESS: Par       = byteName(14)
   }
 
-  // because only we do installs
-  private val MATCH_UNLIMITED_PHLOS = matchListPar(Cost(Integer.MAX_VALUE))
-
-  private def introduceSystemProcesses[F[_]: Applicative](
+  private def introduceSystemProcesses[F[_]: Sync](
       space: RhoISpace[F],
       replaySpace: RhoISpace[F],
       processes: List[(Name, Arity, Remainder, BodyRef)]
@@ -184,10 +181,11 @@ object Runtime {
             freeCount = arity
           )
         )
-        val continuation = TaggedContinuation(ScalaBodyRef(ref))
+        val continuation                   = TaggedContinuation(ScalaBodyRef(ref))
+        implicit val MATCH_UNLIMITED_PHLOS = matchListPar(Cost(Integer.MAX_VALUE))
         List(
-          space.install(channels, patterns, continuation)(MATCH_UNLIMITED_PHLOS),
-          replaySpace.install(channels, patterns, continuation)(MATCH_UNLIMITED_PHLOS)
+          space.install(channels, patterns, continuation),
+          replaySpace.install(channels, patterns, continuation)
         )
     }.sequence
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -28,8 +28,8 @@ object implicits {
 
   def matchListPar[F[_]: Sync](
       init: Cost
-  ): StorageMatch[F, BindPattern, InterpreterError, ListParWithRandom, ListParWithRandomAndPhlos] =
-    new StorageMatch[F, BindPattern, InterpreterError, ListParWithRandom, ListParWithRandomAndPhlos] {
+  ): StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] =
+    new StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] {
 
       private def calcUsed(init: Cost, left: Cost): Cost = init - left
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -25,6 +25,7 @@ object RholangOnlyDispatcher {
   ): (Dispatch[M, ListParWithRandomAndPhlos, TaggedContinuation], ChargingReducer[M]) = {
 
     implicit val matchCost: Match[
+      M,
       BindPattern,
       errors.InterpreterError,
       ListParWithRandom,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -27,7 +27,6 @@ object RholangOnlyDispatcher {
     implicit val matchCost: Match[
       M,
       BindPattern,
-      errors.InterpreterError,
       ListParWithRandom,
       ListParWithRandomAndPhlos
     ] = matchListPar(Cost(Integer.MAX_VALUE))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -390,7 +390,6 @@ object ChargingRSpaceTest {
         implicit m: Match[
           Task,
           BindPattern,
-          errors.InterpreterError,
           ListParWithRandom,
           ListParWithRandomAndPhlos
         ]
@@ -418,7 +417,6 @@ object ChargingRSpaceTest {
         implicit m: Match[
           Task,
           BindPattern,
-          errors.InterpreterError,
           ListParWithRandom,
           ListParWithRandomAndPhlos
         ]
@@ -448,7 +446,6 @@ object ChargingRSpaceTest {
         implicit m: Match[
           Task,
           BindPattern,
-          errors.InterpreterError,
           ListParWithRandom,
           ListParWithRandomAndPhlos
         ]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -388,6 +388,7 @@ object ChargingRSpaceTest {
         sequenceNumber: Int
     )(
         implicit m: Match[
+          Task,
           BindPattern,
           errors.InterpreterError,
           ListParWithRandom,
@@ -415,6 +416,7 @@ object ChargingRSpaceTest {
         sequenceNumber: Int
     )(
         implicit m: Match[
+          Task,
           BindPattern,
           errors.InterpreterError,
           ListParWithRandom,
@@ -444,6 +446,7 @@ object ChargingRSpaceTest {
         continuation: TaggedContinuation
     )(
         implicit m: Match[
+          Task,
           BindPattern,
           errors.InterpreterError,
           ListParWithRandom,

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -55,11 +55,11 @@ trait ISpace[F[_], C, P, E, A, R, K] {
       persist: Boolean,
       sequenceNumber: Int = 0
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Option[(K, Seq[R])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
@@ -86,7 +86,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int = 0)(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   /** Creates a checkpoint.

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -55,11 +55,11 @@ trait ISpace[F[_], C, P, E, A, R, K] {
       persist: Boolean,
       sequenceNumber: Int = 0
   )(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Option[(K, Seq[R])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
@@ -86,7 +86,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     * @param persist Whether or not to attempt to persist the data
     */
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int = 0)(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
 
   /** Creates a checkpoint.

--- a/rspace/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Match.scala
@@ -8,7 +8,7 @@ package coop.rchain.rspace
   * @tparam A A type representing data
   * @tparam R A type representing a match result
   */
-trait Match[P, E, A, R] {
+trait Match[F[_], P, E, A, R] {
 
-  def get(p: P, a: A): Either[E, Option[R]]
+  def get(p: P, a: A): F[Either[E, Option[R]]]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Match.scala
@@ -4,11 +4,10 @@ package coop.rchain.rspace
   * Type class for matching patterns with data.
   *
   * @tparam P A type representing patterns
-  * @tparam E A type representing illegal state
   * @tparam A A type representing data
   * @tparam R A type representing a match result
   */
-trait Match[F[_], P, E, A, R] {
+trait Match[F[_], P, A, R] {
 
   def get(p: P, a: A): F[Option[R]]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Match.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Match.scala
@@ -10,5 +10,5 @@ package coop.rchain.rspace
   */
 trait Match[F[_], P, E, A, R] {
 
-  def get(p: P, a: A): F[Either[E, Option[R]]]
+  def get(p: P, a: A): F[Option[R]]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -148,7 +148,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       persist: Boolean,
       sequenceNumber: Int
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
     def storeWC(consumeRef: Consume) =
       storeWaitingContinuation(channels, patterns, continuation, persist, consumeRef)
@@ -242,7 +242,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
       groupedChannels: Seq[Seq[C]],
       batChannel: C,
       data: Datum[A]
-  )(implicit m: Match[F, P, E, A, R]): F[Either[E, Option[ProduceCandidate[C, P, R, K]]]] = {
+  )(implicit m: Match[F, P, A, R]): F[Either[E, Option[ProduceCandidate[C, P, R, K]]]] = {
     type MaybeProduceCandidate = Option[ProduceCandidate[C, P, R, K]]
     type CandidateChannels     = Seq[C]
     def go(
@@ -396,7 +396,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
     } yield Right(None)
 
   override def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       for {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -194,13 +194,11 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
                                    channels.zip(patterns),
                                    channelToIndexedData,
                                    Nil
-                                 ).map(_.sequence.map(_.sequence))
+                                 ).map(_.sequence)
                        _ <- span.mark("extract-consume-candidate")
                        result <- options match {
-                                  case Left(e) =>
-                                    e.asLeft[MaybeDataCandidate].pure[F]
-                                  case Right(None) => storeWC(consumeRef)
-                                  case Right(Some(dataCandidates)) =>
+                                  case None => storeWC(consumeRef)
+                                  case Some(dataCandidates) =>
                                     for {
                                       _ <- metricsF.incrementCounter(consumeCommLabel)
                                       _ <- syncF.delay {
@@ -297,9 +295,8 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
                          )
           } yield
             firstMatch match {
-              case Left(e)     => e.asLeft[MaybeProduceCandidate].asRight[Seq[CandidateChannels]]
-              case Right(None) => remaining.asLeft[Either[E, MaybeProduceCandidate]]
-              case Right(produceCandidate) =>
+              case None => remaining.asLeft[Either[E, MaybeProduceCandidate]]
+              case produceCandidate =>
                 produceCandidate.asRight[E].asRight[Seq[CandidateChannels]]
             }
       }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -55,8 +55,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
 
   protected[this] val logger: Logger
 
-  private[this] val installs: SyncVar[Installs[F, C, P, E, A, R, K]] = {
-    val installs = new SyncVar[Installs[F, C, P, E, A, R, K]]()
+  private[this] val installs: SyncVar[Installs[F, C, P, A, R, K]] = {
+    val installs = new SyncVar[Installs[F, C, P, A, R, K]]()
     installs.put(Map.empty)
     installs
   }
@@ -76,7 +76,7 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
       channels: Seq[C],
       patterns: Seq[P],
       continuation: K
-  )(implicit m: Match[F, P, E, A, R]): F[Option[(K, Seq[R])]] = syncF.defer {
+  )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] = syncF.defer {
     if (channels.length =!= patterns.length) {
       val msg = "channels.length must equal patterns.length"
       logger.error(msg)
@@ -123,7 +123,7 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
   }
 
   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Option[(K, Seq[R])]] =
     store.withTxnFlatF(store.createTxnWriteF()) { txn =>
       install(txn, channels, patterns, continuation)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -1,20 +1,21 @@
 package coop.rchain.rspace
 
+import cats.effect.{Concurrent, ContextShift}
+import cats.implicits._
+import com.google.common.collect.Multiset
+import com.typesafe.scalalogging.Logger
+import coop.rchain.catscontrib.Catscontrib._
+import coop.rchain.catscontrib._
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.rspace.history.Branch
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.trace.{Produce, _}
+import coop.rchain.shared.Log
+import scodec.Codec
+
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
-import cats.effect.{Concurrent, ContextShift}
-import cats.implicits._
-import coop.rchain.catscontrib._
-import Catscontrib._
-import coop.rchain.shared.Log
-import coop.rchain.rspace.history.Branch
-import coop.rchain.rspace.internal._
-import coop.rchain.rspace.trace.{Produce, Log => RSpaceLog, _}
-import com.google.common.collect.Multiset
-import com.typesafe.scalalogging.Logger
-import coop.rchain.metrics.{Metrics, Span}
-import scodec.Codec
 
 class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(
     implicit
@@ -47,7 +48,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       persist: Boolean,
       sequenceNumber: Int
   )(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       if (channels.length =!= patterns.length) {
@@ -74,7 +75,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       sequenceNumber: Int,
       span: Span[F]
   )(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[MaybeConsumeResult] = {
     def runMatcher(comm: COMM): F[Option[Seq[DataCandidate[C, R]]]] =
       for {
@@ -88,13 +89,8 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
                                        }
                                        .map(v => c -> v) // TODO inculde map in traverse?
                                    }
-        result <- syncF.delay {
-                   extractDataCandidates(
-                     channels.zip(patterns),
-                     channelToIndexedDataList.toMap,
-                     Nil
-                   ).flatMap(_.toOption).sequence
-                 }
+        result <- extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
+                   .map(_.flatMap(_.toOption).sequence)
       } yield result
 
     def storeWaitingContinuation(
@@ -204,7 +200,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
   }
 
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       for {
@@ -225,7 +221,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       sequenceNumber: Int,
       span: Span[F]
   )(
-      implicit m: Match[P, E, A, R]
+      implicit m: Match[F, P, E, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
     def runMatcher(
         comm: COMM,
@@ -260,12 +256,17 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
                                              }
                                            }
                                          }
-              result = extractFirstMatch(channels, matchCandidates, channelToIndexedDataList.toMap) match {
+              firstMatch <- extractFirstMatch(
+                   channels,
+                   matchCandidates,
+                   channelToIndexedDataList.toMap
+                 )
+            } yield
+              firstMatch match {
                 case Right(None)             => remaining.asLeft[MaybeProduceCandidate]
                 case Right(produceCandidate) => produceCandidate.asRight[Seq[Seq[C]]]
                 case Left(_)                 => ???
               }
-            } yield result
         }
       groupedChannels.tailRecM(go)
     }

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -90,7 +90,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
                                        .map(v => c -> v) // TODO inculde map in traverse?
                                    }
         result <- extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
-                   .map(_.flatMap(_.toOption).sequence)
+                   .map(_.sequence)
       } yield result
 
     def storeWaitingContinuation(
@@ -257,15 +257,14 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
                                            }
                                          }
               firstMatch <- extractFirstMatch(
-                   channels,
-                   matchCandidates,
-                   channelToIndexedDataList.toMap
-                 )
+                             channels,
+                             matchCandidates,
+                             channelToIndexedDataList.toMap
+                           )
             } yield
               firstMatch match {
-                case Right(None)             => remaining.asLeft[MaybeProduceCandidate]
-                case Right(produceCandidate) => produceCandidate.asRight[Seq[Seq[C]]]
-                case Left(_)                 => ???
+                case None             => remaining.asLeft[MaybeProduceCandidate]
+                case produceCandidate => produceCandidate.asRight[Seq[Seq[C]]]
               }
         }
       groupedChannels.tailRecM(go)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -48,7 +48,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       persist: Boolean,
       sequenceNumber: Int
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       if (channels.length =!= patterns.length) {
@@ -75,7 +75,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       sequenceNumber: Int,
       span: Span[F]
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[MaybeConsumeResult] = {
     def runMatcher(comm: COMM): F[Option[Seq[DataCandidate[C, R]]]] =
       for {
@@ -200,7 +200,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
   }
 
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     contextShift.evalOn(scheduler) {
       for {
@@ -221,7 +221,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
       sequenceNumber: Int,
       span: Span[F]
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
     def runMatcher(
         comm: COMM,

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -38,6 +38,8 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
 
   /* Consume */
 
+  type MatchingDataCandidate = (DataCandidate[C, R], Seq[(Datum[A], Int)])
+
   /** Searches through data, looking for a match with a given pattern.
     *
     * If there is a match, we return the matching [[DataCandidate]],
@@ -51,7 +53,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
       prefix: Seq[(Datum[A], Int)]
   )(
       implicit m: Match[F, P, A, R]
-  ): F[Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])]] =
+  ): F[Option[MatchingDataCandidate]] =
     data match {
       case (indexedDatum @ (Datum(matchCandidate, persist, produceRef), dataIndex)) +: remaining =>
         m.get(pattern, matchCandidate).flatMap {
@@ -65,7 +67,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
               prefix ++ remaining
             ).some.pure[F]
         }
-      case _ => none[(DataCandidate[C, R], Seq[(Datum[A], Int)])].pure[F]
+      case _ => none[MatchingDataCandidate].pure[F]
     }
 
   def getData(channel: C): F[Seq[Datum[A]]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -50,7 +50,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
       pattern: P,
       prefix: Seq[(Datum[A], Int)]
   )(
-      implicit m: Match[F, P, E, A, R]
+      implicit m: Match[F, P, A, R]
   ): F[Option[(DataCandidate[C, R], Seq[(Datum[A], Int)])]] =
     data match {
       case (indexedDatum @ (Datum(matchCandidate, persist, produceRef), dataIndex)) +: remaining =>
@@ -90,7 +90,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
       channelPatternPairs: Seq[(C, P)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
       acc: Seq[Option[DataCandidate[C, R]]]
-  )(implicit m: Match[F, P, E, A, R]): F[Seq[Option[DataCandidate[C, R]]]] =
+  )(implicit m: Match[F, P, A, R]): F[Seq[Option[DataCandidate[C, R]]]] =
     channelPatternPairs match {
       case (channel, pattern) +: tail =>
         for {
@@ -120,7 +120,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
       channels: Seq[C],
       matchCandidates: Seq[(WaitingContinuation[P, K], Int)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]]
-  )(implicit m: Match[F, P, E, A, R]): F[Option[ProduceCandidate[C, P, R, K]]] =
+  )(implicit m: Match[F, P, A, R]): F[Option[ProduceCandidate[C, P, R, K]]] =
     matchCandidates match {
       case (p @ WaitingContinuation(patterns, _, _, _), index) +: remaining =>
         for {

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -165,7 +165,7 @@ object AddressBookExample {
       */
     implicit def matchPatternEntry[F[_]](
         implicit apF: Applicative[F]
-    ): Match[F, Pattern, Nothing, Entry, Entry] =
+    ): Match[F, Pattern, Entry, Entry] =
       (p: Pattern, a: Entry) =>
         p match {
           case NameMatch(last) if a.name.last == last        => apF.pure(Some(a))

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -168,10 +168,10 @@ object AddressBookExample {
     ): Match[F, Pattern, Nothing, Entry, Entry] =
       (p: Pattern, a: Entry) =>
         p match {
-          case NameMatch(last) if a.name.last == last        => apF.pure(Right(Some(a)))
-          case CityMatch(city) if a.address.city == city     => apF.pure(Right(Some(a)))
-          case StateMatch(state) if a.address.state == state => apF.pure(Right(Some(a)))
-          case _                                             => apF.pure(Right(None))
+          case NameMatch(last) if a.name.last == last        => apF.pure(Some(a))
+          case CityMatch(city) if a.address.city == city     => apF.pure(Some(a))
+          case StateMatch(state) if a.address.state == state => apF.pure(Some(a))
+          case _                                             => apF.pure(None)
         }
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -3,7 +3,7 @@ package coop.rchain.rspace.examples
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
 import java.nio.file.{Files, Path}
 
-import cats.Id
+import cats.{Applicative, Id}
 import cats.effect.{Concurrent, ContextShift}
 import coop.rchain.metrics.Metrics
 import coop.rchain.rspace.ISpace.IdISpace
@@ -163,16 +163,16 @@ object AddressBookExample {
     /**
       * An instance of [[Match]] for [[Pattern]] and [[Entry]]
       */
-    implicit object matchPatternEntry extends Match[Pattern, Nothing, Entry, Entry] {
-      def get(p: Pattern, a: Entry): Either[Nothing, Option[Entry]] =
+    implicit def matchPatternEntry[F[_]](
+        implicit apF: Applicative[F]
+    ): Match[F, Pattern, Nothing, Entry, Entry] =
+      (p: Pattern, a: Entry) =>
         p match {
-          case NameMatch(last) if a.name.last == last        => Right(Some(a))
-          case CityMatch(city) if a.address.city == city     => Right(Some(a))
-          case StateMatch(state) if a.address.state == state => Right(Some(a))
-          case _                                             => Right(None)
+          case NameMatch(last) if a.name.last == last        => apF.pure(Right(Some(a)))
+          case CityMatch(city) if a.address.city == city     => apF.pure(Right(Some(a)))
+          case StateMatch(state) if a.address.state == state => apF.pure(Right(Some(a)))
+          case _                                             => apF.pure(Right(None))
         }
-
-    }
   }
 
   import implicits._

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -51,7 +51,7 @@ object StringExamples {
 
   object implicits {
 
-    implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, Nothing, String, String] =
+    implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, String, String] =
       (p: Pattern, a: String) => Sync[F].pure(Some(a).filter(p.isMatch))
 
     implicit object stringSerialize extends Serialize[String] {

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -2,6 +2,7 @@ package coop.rchain.rspace.examples
 
 import java.nio.charset.StandardCharsets
 
+import cats.effect.Sync
 import coop.rchain.shared.Language.ignore
 import coop.rchain.rspace.{Match, Serialize}
 import scodec.bits.ByteVector
@@ -50,10 +51,8 @@ object StringExamples {
 
   object implicits {
 
-    implicit object stringMatch extends Match[Pattern, Nothing, String, String] {
-      def get(p: Pattern, a: String): Either[Nothing, Option[String]] =
-        Right(Some(a).filter(p.isMatch))
-    }
+    implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, Nothing, String, String] =
+      (p: Pattern, a: String) => Sync[F].pure(Right(Some(a).filter(p.isMatch)))
 
     implicit object stringSerialize extends Serialize[String] {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -52,7 +52,7 @@ object StringExamples {
   object implicits {
 
     implicit def stringMatch[F[_]: Sync]: Match[F, Pattern, Nothing, String, String] =
-      (p: Pattern, a: String) => Sync[F].pure(Right(Some(a).filter(p.isMatch)))
+      (p: Pattern, a: String) => Sync[F].pure(Some(a).filter(p.isMatch))
 
     implicit object stringSerialize extends Serialize[String] {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -143,13 +143,13 @@ object internal {
       }
   }
 
-  final case class Install[P, E, A, R, K](
+  final case class Install[F[_], P, E, A, R, K](
       patterns: Seq[P],
       continuation: K,
-      _match: Match[P, E, A, R]
+      _match: Match[F, P, E, A, R]
   )
 
-  type Installs[C, P, E, A, R, K] = Map[Seq[C], Install[P, E, A, R, K]]
+  type Installs[F[_], C, P, E, A, R, K] = Map[Seq[C], Install[F, P, E, A, R, K]]
 
   import scodec.{Attempt, Err}
 

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -143,13 +143,13 @@ object internal {
       }
   }
 
-  final case class Install[F[_], P, E, A, R, K](
+  final case class Install[F[_], P, A, R, K](
       patterns: Seq[P],
       continuation: K,
-      _match: Match[F, P, E, A, R]
+      _match: Match[F, P, A, R]
   )
 
-  type Installs[F[_], C, P, E, A, R, K] = Map[Seq[C], Install[F, P, E, A, R, K]]
+  type Installs[F[_], C, P, A, R, K] = Map[Seq[C], Install[F, P, A, R, K]]
 
   import scodec.{Attempt, Err}
 

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -38,7 +38,7 @@ object PureRSpace {
   final class PureRSpaceApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
     def of[C, P, E, A, R, K](
         space: ISpace[F, C, P, E, A, R, K]
-    )(implicit mat: Match[F, P, E, A, R]): PureRSpace[F, C, P, E, A, R, K] =
+    )(implicit mat: Match[F, P, A, R]): PureRSpace[F, C, P, E, A, R, K] =
       new PureRSpace[F, C, P, E, A, R, K] {
         def consume(
             channels: Seq[C],

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -38,7 +38,7 @@ object PureRSpace {
   final class PureRSpaceApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
     def of[C, P, E, A, R, K](
         space: ISpace[F, C, P, E, A, R, K]
-    )(implicit mat: Match[P, E, A, R]): PureRSpace[F, C, P, E, A, R, K] =
+    )(implicit mat: Match[F, P, E, A, R]): PureRSpace[F, C, P, E, A, R, K] =
       new PureRSpace[F, C, P, E, A, R, K] {
         def consume(
             channels: Seq[C],

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -46,7 +46,7 @@ trait ReplayRSpaceTests
       continuationCreator: Int => K,
       persist: Boolean
   )(
-      implicit matcher: Match[Task, P, Nothing, A, R]
+      implicit matcher: Match[Task, P, A, R]
   ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started consume {}", i)
@@ -67,7 +67,7 @@ trait ReplayRSpaceTests
       datumCreator: Int => A,
       persist: Boolean
   )(
-      implicit matcher: Match[Task, P, Nothing, A, R]
+      implicit matcher: Match[Task, P, A, R]
   ): Task[List[Option[(ContResult[C, P, K], immutable.Seq[Result[R]])]]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started produce {}", i)

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -46,7 +46,7 @@ trait ReplayRSpaceTests
       continuationCreator: Int => K,
       persist: Boolean
   )(
-      implicit matcher: Match[P, Nothing, A, R]
+      implicit matcher: Match[Task, P, Nothing, A, R]
   ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started consume {}", i)
@@ -67,7 +67,7 @@ trait ReplayRSpaceTests
       datumCreator: Int => A,
       persist: Boolean
   )(
-      implicit matcher: Match[P, Nothing, A, R]
+      implicit matcher: Match[Task, P, Nothing, A, R]
   ): Task[List[Option[(ContResult[C, P, K], immutable.Seq[Result[R]])]]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started produce {}", i)


### PR DESCRIPTION
## Overview
This PR adds returns F in SpatialMatcher, eliminates the `Either` in the return type in the `Match` type-class, and eliminates the redundant `E` type parameter that results.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2907