### PR TITLE
Enable filebased storage

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -481,7 +481,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: BlockStore: RaiseIO
                       }
                     }
                 _ <- updateLatestMessagesFile(
-                      (newValidators + block.sender).toList,
+                      newValidatorsWithSender.toList,
                       block.blockHash
                     )
                 _ <- updateDataLookupFile(blockMetadata)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -63,8 +63,8 @@ package object io {
   def isRegularFile[F[_]: Sync: RaiseIOError](path: Path): F[Boolean] =
     handleIo(Files.isRegularFile(path), UnexpectedIOError.apply)
 
-  def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Boolean] =
-    handleIo(dirPath.toFile.mkdirs(), UnexpectedIOError.apply)
+  def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Path] =
+    handleIo(Files.createDirectories(dirPath), UnexpectedIOError.apply)
 
   def listInDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[List[Path]] =
     for {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -64,7 +64,7 @@ package object io {
     handleIo(Files.isRegularFile(path), UnexpectedIOError.apply)
 
   def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Boolean] =
-    handleIo(dirPath.toFile.mkdir(), UnexpectedIOError.apply)
+    handleIo(dirPath.toFile.mkdirs(), UnexpectedIOError.apply)
 
   def listInDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[List[Path]] =
     for {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -203,7 +203,11 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     val (list, latestMessageHashes, latestMessages, topoSort, topoSortTail) = lookupResult
     val realLatestMessages = blockElements.foldLeft(Map.empty[Validator, BlockMetadata]) {
       case (lm, b) =>
-        lm.updated(b.sender, BlockMetadata.fromBlock(b, false))
+        // Ignore empty sender for genesis block
+        if (b.sender != ByteString.EMPTY)
+          lm.updated(b.sender, BlockMetadata.fromBlock(b, false))
+        else
+          lm
     }
     list.zip(blockElements).foreach {
       case ((blockMetadata, latestMessageHash, latestMessage, children, contains), b) =>
@@ -219,10 +223,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           )
         contains shouldBe true
     }
-    latestMessageHashes shouldBe blockElements.map(b => b.sender -> b.blockHash).toMap
-    latestMessages shouldBe blockElements
-      .map(b => b.sender -> BlockMetadata.fromBlock(b, false))
-      .toMap
+    latestMessageHashes shouldBe realLatestMessages.mapValues(_.blockHash)
+    latestMessages shouldBe realLatestMessages
 
     def normalize(topoSort: Vector[Vector[BlockHash]]): Vector[Vector[BlockHash]] =
       if (topoSort.size == 1 && topoSort.head.isEmpty)
@@ -246,6 +248,28 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           result        <- lookupElements(blockElements, secondStorage)
           _             <- secondStorage.close()
         } yield testLookupElementsResult(result, blockElements)
+      }
+    }
+  }
+
+  it should "be able to restore latest messages with genesis with empty sender field" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      val blockElementsWithGenesis = blockElements match {
+        case x :: xs =>
+          val genesis = x.withSender(ByteString.EMPTY)
+          genesis :: xs
+        case Nil =>
+          Nil
+      }
+      withDagStorageLocation { (dagDataDir, blockStore) =>
+        for {
+          firstStorage  <- createAtDefaultLocation(dagDataDir)(blockStore)
+          _             <- blockElementsWithGenesis.traverse_(firstStorage.insert(_, false))
+          _             <- firstStorage.close()
+          secondStorage <- createAtDefaultLocation(dagDataDir)(blockStore)
+          result        <- lookupElements(blockElementsWithGenesis, secondStorage)
+          _             <- secondStorage.close()
+        } yield testLookupElementsResult(result, blockElementsWithGenesis)
       }
     }
   }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -1,7 +1,6 @@
 package coop.rchain.node
 
-import java.nio.file.Path
-
+import java.nio.file.{Files, Path}
 import scala.concurrent.duration._
 import cats._
 import cats.data._
@@ -304,7 +303,8 @@ class NodeRuntime private[node] (
     RPConf(local, bootstrapNode, defaultTimeout, rpClearConnConf)
 
   // TODO this should use existing algebra
-  private def mkDirs(path: Path): Effect[Unit] = Sync[Effect].delay(path.toFile.mkdirs())
+  private def mkDirs(path: Path): Effect[Unit] =
+    Sync[Effect].delay(Files.createDirectories(path))
 
   /**
     * Main node entry. It will:

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -401,7 +401,6 @@ class NodeRuntime private[node] (
                         Log.eitherTLog(Monad[Task], log),
                         blockStore
                       )
-    _      <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
     oracle = SafetyOracle.cliqueOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
     runtime <- {
       implicit val s                = rspaceScheduler


### PR DESCRIPTION
## Overview
This PR enables file based storages. Here is the current status of the system.
https://rchain.atlassian.net/browse/RCHAIN-3011

### What's working

You can initialize nodes and run typical p2p network where rnodes exchange messages. Deploy and propose works without issues. I could get up to 100 blocks easily.

### What's not working

#### Log warn

When booting up rnode, warning messages are being displayed

```
17:16:29.269 [main] WARN  c.r.b.BlockDagFileStorage$ - CRC file /Users/rabbit/.rnode1/dagstorage/latestMessagesCrcPath did not contain a valid CRC value
17:16:29.285 [main] WARN  c.r.b.BlockDagFileStorage$ - CRC file /Users/rabbit/.rnode1/dagstorage/blockMetadataCrcPath did not contain a valid CRC value
17:16:29.296 [main] WARN  c.r.b.BlockDagFileStorage$ - CRC file /Users/rabbit/.rnode1/dagstorage/equivocationsTrackerCrcPath did not contain a valid CRC value
```

This can be trace back to:

```
  private def readCrc[F[_]: Sync: Log: RaiseIOError](crcPath: Path): F[Long] =
    for {
      _          <- createNewFile[F](crcPath)
      (...)
      result <- Sync[F].delay { byteBuffer.getLong() }.handleErrorWith {
                 case _: BufferUnderflowException =>
                   for {
                     _ <- Log[F].warn(s"CRC file $crcPath did not contain a valid CRC value")
                   } yield 0
                 case exception => Sync[F].raiseError(exception)
```

I don't understand behaviour, but I'm pretty sure it should be addressed. Did not see it affect the way rnode works

### Restore fails

Even though the rnode behaves correctly when nodes are botted for the first time, trying to reboot the node after previously killing it will cause errros:

```
➜  ~ rn_validator 2
running validator nr 2 bootstrapping from rnode://a9a35d1563af6d65be24992bb8318af6adbd0945@127.0.0.1?protocol=10400&discovery=10404
18:03:10.909 [main] INFO  c.r.n.configuration.Configuration$ - Trying to load configuration file: /Users/rabbit/.rnode2/rnode.conf
18:03:11.012 [main] INFO  c.r.n.configuration.Configuration$ - Starting with profile default
18:03:11.556 [main] INFO  coop.rchain.node.Main$ - RChain Node 0.8.3.git1e2dcb05 (1e2dcb052cb1e523c66705290bec0b222f36dec7)
18:03:11.566 [main] INFO  coop.rchain.node.NodeEnvironment$ - Using data dir: /Users/rabbit/.rnode2
18:03:12.835 [main] ERROR c.r.b.BlockDagFileStorage$ - Latest messages log is malformed
Exception in thread "main" coop.rchain.blockstorage.LatestMessagesLogIsMalformed$
	at coop.rchain.blockstorage.LatestMessagesLogIsMalformed$.<clinit>(errors.scala)
	at coop.rchain.blockstorage.BlockDagFileStorage$.$anonfun$readLatestMessagesData$6(BlockDagFileStorage.scala:631)
	at cats.data.EitherT.$anonfun$flatMap$1(EitherT.scala:93)
	at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:147)
	at monix.eval.Task$.unsafeStartNow(Task.scala:4249)
	at monix.eval.internal.TaskBracket$BaseStart$$anon$1.onSuccess(TaskBracket.scala:143)
	at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:143)
	at monix.eval.Task$.unsafeStartNow(Task.scala:4249)
	at monix.eval.internal.TaskBracket$BaseStart.apply(TaskBracket.scala:131)
	at monix.eval.internal.TaskBracket$BaseStart.apply(TaskBracket.scala:121)
	at monix.eval.internal.TaskRestartCallback.run(TaskRestartCallback.scala:65)
	at monix.execution.internal.Trampoline.monix$execution$internal$Trampoline$$immediateLoop(Trampoline.scala:66)
	at monix.execution.internal.Trampoline.startLoop(Trampoline.scala:32)
	at monix.execution.schedulers.TrampolineExecutionContext$JVMOptimalTrampoline.startLoop(TrampolineExecutionContext.scala:146)
	at monix.execution.internal.Trampoline.execute(Trampoline.scala:39)
	at monix.execution.schedulers.TrampolineExecutionContext.execute(TrampolineExecutionContext.scala:65)
	at monix.execution.schedulers.BatchingScheduler.execute(BatchingScheduler.scala:50)
	at monix.execution.schedulers.BatchingScheduler.execute$(BatchingScheduler.scala:47)
	at monix.execution.schedulers.ExecutorScheduler.execute(ExecutorScheduler.scala:34)
	at monix.execution.Callback$Base.onSuccess(Callback.scala:229)
	at monix.execution.Callback.apply(Callback.scala:49)
	at monix.execution.Callback.apply(Callback.scala:41)
```

The way to repoduce it:

1. run 3 nodes as validators, form p2p network
2. run few deploys and proposes on each of the node
3. kill one of the nodes gracefully (Ctrl+C)
4. bring that node back

What is expected: node will reuse file storages to restore DAG
What happens: above exception is thrown