### PR TITLE
fix getDeployParams

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -208,14 +208,11 @@ object SystemProcesses {
       ): (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case isContractCall(produce, Seq(ack)) =>
           for {
-            parameters <- shortLeashParams.getParams
-            _ <- parameters match {
-                  case ShortLeashParameters(codeHash, phloRate, userId, timestamp) =>
-                    produce(Seq(codeHash, phloRate, userId, timestamp), ack)
-                  case _ =>
-                    illegalArgumentException("deployParameters expects only a return channel")
-                }
+            params <- shortLeashParams.getParams
+            _ <-produce(Seq(params.codeHash, params.phloRate, params.userId, params.timestamp), ack)
           } yield ()
+        case _ =>
+          illegalArgumentException("deployParameters expects only a return channel")
       }
 
       def blockTime(


### PR DESCRIPTION
## Overview
fix system process getDeployParams

The implementation is obviously wrong as it should fail with invalid argument exception if the isContract doesn't match.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2966



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
