### PR TITLE
Change transaction management in IStore

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoLogger.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoLogger.scala
@@ -8,7 +8,7 @@ import coop.rchain.shared.{Log, LogSource}
 object RhoLogger {
   val prettyPrinter = PrettyPrinter()
 
-  def handleMessage[F[_]: Log : Sync](
+  def handleMessage[F[_]: Log: Sync](
       ctx: SystemProcess.Context[F]
   )(message: (Seq[ListParWithRandomAndPhlos], Int)): F[Unit] = {
     val isContractCall = new ContractCall(ctx.space, ctx.dispatcher)

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -25,7 +25,7 @@ object RhoSpec {
               Runtime.byteName(n.toByte),
               arity,
               n.toLong,
-              ctx => testResultCollector.handleMessage(ctx)(_,_)
+              ctx => testResultCollector.handleMessage(ctx)(_, _)
             )
         } ++ Seq(
         SystemProcess.Definition[Task](
@@ -33,7 +33,7 @@ object RhoSpec {
           Runtime.byteName(27),
           2,
           27L,
-          ctx => RhoLogger.handleMessage(ctx)(_,_)
+          ctx => RhoLogger.handleMessage(ctx)(_, _)
         )
       )
     TestUtil.runtime(testResultCollectorService)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -114,7 +114,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
       }
       (result, costLog) = costsLoggingProgram
       res               <- errorLog.readAndClearErrorVector
-      _                 <- Task.now(res should be (Vector.empty))
+      _                 <- Task.now(res should be(Vector.empty))
     } yield ((result, costLog))).unsafeRunSync
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -22,13 +22,9 @@ trait IStore[F[_], C, P, A, K] {
 
   private[rspace] type TrieTransaction
 
-  private[rspace] def createTxnReadF(): F[Transaction]
+  private[rspace] def withReadTxnF[R](f: Transaction => R): F[R]
 
-  private[rspace] def createTxnWriteF(): F[Transaction]
-
-  private[rspace] def withTxnF[R](txn: F[Transaction])(f: Transaction => R): F[R]
-
-  private[rspace] def withTxnFlatF[R](txn: F[Transaction])(f: Transaction => F[R]): F[R]
+  private[rspace] def withWriteTxnF[R](f: Transaction => R): F[R]
 
   private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -9,6 +9,7 @@ import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
 import coop.rchain.rspace.history.{Branch, Leaf}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace.Consume
+import coop.rchain.shared.Log
 import coop.rchain.shared.SyncVarOps._
 
 import scala.collection.immutable.Seq
@@ -22,7 +23,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
-    serializeK: Serialize[K]
+    serializeK: Serialize[K],
+    logF: Log[F]
 ) extends SpaceMatcher[F, C, P, E, A, R, K] {
 
   implicit val codecC = serializeC.toCodec
@@ -40,6 +42,15 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
   }
 
+  protected[this] def installLockF(
+      channels: Seq[C]
+  )(
+      thunk: => F[Option[(K, Seq[R])]]
+  ): F[Option[(K, Seq[R])]] = {
+    val hashes = channels.map(ch => StableHashProvider.hash(ch))
+    lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
+  }
+
   protected[this] def produceLockF(
       channel: C
   )(
@@ -47,7 +58,7 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
   ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     lockF.acquire(Seq(StableHashProvider.hash(channel)))(
       () =>
-        store.withTxnF(store.createTxnReadF()) { txn =>
+        store.withReadTxnF { txn =>
           val groupedChannels: Seq[Seq[C]] = store.getJoin(txn, channel)
           groupedChannels.flatten.map(StableHashProvider.hash(_))
         }
@@ -61,72 +72,87 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     installs
   }
 
-  protected[this] def restoreInstalls(txn: store.Transaction): F[Unit] =
+  protected[this] def restoreInstalls(): F[Unit] =
     installs.get.toList
       .traverse {
         case (channels, Install(patterns, continuation, _match)) =>
-          install(txn, channels, patterns, continuation)(_match)
+          install(channels, patterns, continuation)(_match)
       }
       .as(())
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   // TODO stop throwing exceptions
-  private[this] def install(
-      txn: store.Transaction,
+  private[this] def lockedInstall(
       channels: Seq[C],
       patterns: Seq[P],
       continuation: K
-  )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] = syncF.defer {
+  )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] =
     if (channels.length =!= patterns.length) {
       val msg = "channels.length must equal patterns.length"
       logger.error(msg)
       throw new IllegalArgumentException(msg)
+    } else {
+      /*
+       * Here, we create a cache of the data at each channel as `channelToIndexedData`
+       * which is used for finding matches.  When a speculative match is found, we can
+       * remove the matching datum from the remaining data candidates in the cache.
+       *
+       * Put another way, this allows us to speculatively remove matching data without
+       * affecting the actual store contents.
+       */
+
+      for {
+        _          <- logF.debug(s"""|install: searching for data matching <patterns: $patterns>
+                                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+        consumeRef = Consume.create(channels, patterns, continuation, true, 0)
+        channelToIndexedData <- channels.toList
+                                 .traverse { c: C =>
+                                   store.withReadTxnF(
+                                     txn =>
+                                       c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
+                                   )
+                                 }
+                                 .map(_.toMap)
+        options <- extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil)
+                    .map(_.sequence)
+        result <- options match {
+                   case None =>
+                     for {
+                       _ <- syncF.delay {
+                             installs.update(
+                               _.updated(channels, Install(patterns, continuation, m))
+                             )
+                           }
+                       _ <- store.withWriteTxnF { txn =>
+                             store.installWaitingContinuation(
+                               txn,
+                               channels,
+                               WaitingContinuation(
+                                 patterns,
+                                 continuation,
+                                 persist = true,
+                                 consumeRef
+                               )
+                             )
+                             for (channel <- channels) store.addJoin(txn, channel, channels)
+                           }
+
+                       _ <- logF.debug(
+                             s"""|storing <(patterns, continuation): ($patterns, $continuation)>
+                              |at <channels: $channels>""".stripMargin.replace('\n', ' ')
+                           )
+                     } yield None
+                   case Some(_) =>
+                     throw new RuntimeException("Installing can be done only on startup")
+                 }
+      } yield result
     }
-    logger.debug(s"""|install: searching for data matching <patterns: $patterns>
-                     |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-
-    val consumeRef = Consume.create(channels, patterns, continuation, true, 0)
-
-    /*
-     * Here, we create a cache of the data at each channel as `channelToIndexedData`
-     * which is used for finding matches.  When a speculative match is found, we can
-     * remove the matching datum from the remaining data candidates in the cache.
-     *
-     * Put another way, this allows us to speculatively remove matching data without
-     * affecting the actual store contents.
-     */
-
-    val channelToIndexedData = channels.map { (c: C) =>
-      c -> Random.shuffle(store.getData(txn, Seq(c)).zipWithIndex)
-    }.toMap
-
-    val options: F[Option[Seq[DataCandidate[C, R]]]] =
-      extractDataCandidates(channels.zip(patterns), channelToIndexedData, Nil)
-        .map(_.sequence)
-
-    options.map {
-      case None =>
-        installs.update(_.updated(channels, Install(patterns, continuation, m)))
-        store.installWaitingContinuation(
-          txn,
-          channels,
-          WaitingContinuation(patterns, continuation, persist = true, consumeRef)
-        )
-        for (channel <- channels) store.addJoin(txn, channel, channels)
-        logger.debug(s"""|storing <(patterns, continuation): ($patterns, $continuation)>
-                         |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-        None
-      case Some(_) =>
-        throw new RuntimeException("Installing can be done only on startup")
-    }
-
-  }
 
   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
       implicit m: Match[F, P, A, R]
   ): F[Option[(K, Seq[R])]] =
-    store.withTxnFlatF(store.createTxnWriteF()) { txn =>
-      install(txn, channels, patterns, continuation)
+    installLockF(channels) {
+      lockedInstall(channels, patterns, continuation)
     }
 
   override def retrieve(
@@ -138,26 +164,28 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     }
 
   override def reset(root: Blake2b256Hash): F[Unit] =
-    store.withTxnFlatF(store.createTxnWriteF()) { txn =>
-      for {
-        leaves <- syncF.delay {
-                   store
-                     .withTrieTxn(txn) { trieTxn =>
-                       store.trieStore.validateAndPutRoot(trieTxn, store.trieBranch, root)
-                       store.trieStore.getLeaves(trieTxn, root)
-                     }
-                 }
-        _ <- syncF.delay { eventLog.update(kp(Seq.empty)) }
-        _ <- syncF.delay { store.getAndClearTrieUpdates() }
-        _ <- syncF.delay { store.clear(txn) }
-        _ <- restoreInstalls(txn)
-        _ <- syncF.delay { store.bulkInsert(txn, leaves.map { case Leaf(k, v) => (k, v) }) }
-      } yield ()
-    }
+    for {
+      leaves <- store.withWriteTxnF { txn =>
+                 store
+                   .withTrieTxn(txn) { trieTxn =>
+                     store.trieStore.validateAndPutRoot(trieTxn, store.trieBranch, root)
+                     store.trieStore.getLeaves(trieTxn, root)
+                   }
+               }
+      _ <- syncF.delay { eventLog.update(kp(Seq.empty)) }
+      _ <- syncF.delay { store.getAndClearTrieUpdates() }
+      _ <- store.withWriteTxnF { txn =>
+            store.clear(txn)
+          }
+      _ <- restoreInstalls()
+      _ <- store.withWriteTxnF { txn =>
+            store.bulkInsert(txn, leaves.map { case Leaf(k, v) => (k, v) })
+          }
+    } yield ()
 
   override def clear(): F[Unit] =
     store
-      .withTxnF(store.createTxnReadF()) { txn =>
+      .withReadTxnF { txn =>
         store.withTrieTxn(txn) { trieTxn =>
           store.trieStore.getEmptyRoot(trieTxn)
         }

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -71,12 +71,12 @@ private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, 
     }
 
   def getData(channel: C): F[Seq[Datum[A]]] =
-    store.withTxnF(store.createTxnReadF()) { txn =>
+    store.withReadTxnF { txn =>
       store.getData(txn, Seq(channel))
     }
 
   def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
-    store.withTxnF(store.createTxnReadF()) { txn =>
+    store.withReadTxnF { txn =>
       store.getWaitingContinuation(txn, channels)
     }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -46,7 +46,7 @@ trait HistoryActionsTests[F[_]]
       store: IStore[F, String, Pattern, String, StringsCaptor],
       branch: Branch
   ): F[Blake2b256Hash] =
-    store.withTxnF(store.createTxnReadF()) { txn =>
+    store.withReadTxnF { txn =>
       store.withTrieTxn(txn) { trieTxn =>
         store.trieStore.getRoot(trieTxn, branch).get
       }
@@ -310,7 +310,7 @@ trait HistoryActionsTests[F[_]]
         root1                                                            = checkpoint1.root
         contents1: Map[Seq[String], Row[Pattern, String, StringsCaptor]] = space.store.toMap
         _                                                                = space.store.isEmpty shouldBe false
-        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+        _ <- space.store.withReadTxnF { txn =>
               space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
               space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
             }
@@ -318,7 +318,7 @@ trait HistoryActionsTests[F[_]]
         // Rollback to first checkpoint
         _ <- space.reset(root0)
         _ = space.store.isEmpty shouldBe true
-        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+        _ <- space.store.withReadTxnF { txn =>
               space.store.getJoin(txn, "ch1") shouldBe Nil
               space.store.getJoin(txn, "ch2") shouldBe Nil
             }
@@ -326,7 +326,7 @@ trait HistoryActionsTests[F[_]]
         // Rollback to second checkpoint
         _ <- space.reset(root1)
         _ = space.store.isEmpty shouldBe false
-        _ <- space.store.withTxnF(space.store.createTxnReadF()) { txn =>
+        _ <- space.store.withReadTxnF { txn =>
               space.store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
               space.store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
             }

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -30,7 +30,7 @@ trait IStoreTests
         val datum                                                         = Datum.create(channel, datumValue, false)
 
         store
-          .withTxnF(store.createTxnWriteF()) { txn =>
+          .withWriteTxnF { txn =>
             store.putDatum(txn, key, datum)
             store.getData(txn, key) should contain theSameElementsAs (Seq(datum))
             store.clear(txn)
@@ -46,7 +46,7 @@ trait IStoreTests
         val datum1 = Datum.create(channel, datumValue, false)
         val datum2 = Datum.create(channel, datumValue + "2", false)
 
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.putDatum(txn, key, datum1)
           store.putDatum(txn, key, datum2)
           store.getData(txn, key) should contain theSameElementsAs (Seq(datum1, datum2))
@@ -76,7 +76,7 @@ trait IStoreTests
             Datum.create(channel, datumValue + i, false)
           }
 
-          store.withTxnF(store.createTxnWriteF()) { txn =>
+          store.withWriteTxnF { txn =>
             data.foreach { d =>
               store.putDatum(txn, key, d)
             }
@@ -95,7 +95,7 @@ trait IStoreTests
         val store = space.store
         val key   = List(channel)
         val hash  = store.hashChannels(key)
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.putDatum(txn, key, Datum.create(channel, datum, persist = false))
           // collectGarbage is called in removeDatum:
           store.removeDatum(txn, key, 0)
@@ -115,7 +115,7 @@ trait IStoreTests
         val wc: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, patterns, continuation, false)
 
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.putWaitingContinuation(txn, key, wc)
           store.getWaitingContinuation(txn, key) shouldBe List(wc)
           store.clear(txn)
@@ -136,7 +136,7 @@ trait IStoreTests
         val wc2: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, List(StringMatch(pattern + 2)), continuation, false)
 
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.putWaitingContinuation(txn, key, wc1)
           store.putWaitingContinuation(txn, key, wc2)
           store.getWaitingContinuation(txn, key) should contain theSameElementsAs List(wc1, wc2)
@@ -157,7 +157,7 @@ trait IStoreTests
         val wc2: WaitingContinuation[Pattern, StringsCaptor] =
           WaitingContinuation.create(key, List(StringMatch(pattern + 2)), continuation, false)
 
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.putWaitingContinuation(txn, key, wc1)
           store.putWaitingContinuation(txn, key, wc2)
           store.removeWaitingContinuation(txn, key, 0)
@@ -171,7 +171,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.addJoin(txn, channel, channels)
           store.getJoin(txn, channel) shouldBe List(channels)
           store.clear(txn)
@@ -183,7 +183,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.addJoin(txn, channel, channels)
           store.removeJoin(txn, channel, channels)
           store.getJoin(txn, channel) shouldBe empty
@@ -196,7 +196,7 @@ trait IStoreTests
     forAll("channel", "channels") { (channel: String, channels: List[String]) =>
       withTestSpace { space =>
         val store = space.store
-        store.withTxnF(store.createTxnWriteF()) { txn =>
+        store.withWriteTxnF { txn =>
           store.addJoin(txn, channel, channels)
           store.addJoin(txn, channel, List("otherChannel"))
           store.removeJoin(txn, channel, channels)

--- a/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
@@ -12,7 +12,7 @@ trait JoinOperationsTests
     val store = space.store
 
     for {
-      _ <- store.withTxnF(store.createTxnWriteF()) { txn =>
+      _ <- store.withWriteTxnF { txn =>
             store.putDatum(txn, List("ch1"), Datum.create("ch1", "datum1", persist = false))
             store.putDatum(txn, List("ch2"), Datum.create("ch2", "datum2", persist = false))
             store.addJoin(txn, "ch1", List("ch1", "ch2"))
@@ -23,17 +23,17 @@ trait JoinOperationsTests
             store.addJoin(txn, "ch2", List("ch1", "ch2"))
           }
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
             store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
           }
 
-      _ <- store.withTxnF(store.createTxnWriteF()) { txn =>
+      _ <- store.withWriteTxnF { txn =>
             store.removeJoin(txn, "ch1", List("ch1", "ch2"))
             store.removeJoin(txn, "ch2", List("ch1", "ch2"))
           }
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getJoin(txn, "ch1") shouldBe List.empty[List[String]]
             store.getJoin(txn, "ch2") shouldBe List.empty[List[String]]
           }
@@ -42,7 +42,7 @@ trait JoinOperationsTests
 
       //now ensure that garbage-collection works and all joins
       //are removed when we remove As
-      _ <- store.withTxnF(store.createTxnWriteF()) { txn =>
+      _ <- store.withWriteTxnF { txn =>
             store.removeDatum(txn, List("ch1"), 0)
             store.removeDatum(txn, List("ch2"), 0)
           }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -54,7 +54,7 @@ trait StorageActionsTests[F[_]]
     for {
       r <- space.produce(key.head, "datum", persist = false)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", persist = false))
@@ -74,7 +74,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(key.head, "datum1", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
@@ -82,7 +82,7 @@ trait StorageActionsTests[F[_]]
           }
       _  = r1 shouldBe Right(None)
       r2 <- space.produce(key.head, "datum2", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) should contain theSameElementsAs List(
@@ -105,7 +105,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe List("ch1")
             store.getPatterns(txn, key) shouldBe List(patterns)
             store.getData(txn, key) shouldBe Nil
@@ -125,7 +125,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r <- space.consume(key, patterns, new StringsCaptor, persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe List(patterns)
             store.getData(txn, key) shouldBe Nil
@@ -144,7 +144,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(key.head, "datum", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
@@ -154,7 +154,7 @@ trait StorageActionsTests[F[_]]
 
       r2 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = false)
       _  = store.isEmpty shouldBe true
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe Nil
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) shouldBe Nil
@@ -202,7 +202,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
             store.getPatterns(txn, produceKey1) shouldBe Nil
             store.getData(txn, produceKey1) shouldBe List(
@@ -213,7 +213,7 @@ trait StorageActionsTests[F[_]]
       _ = r1 shouldBe Right(None)
 
       r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
             store.getPatterns(txn, produceKey1) shouldBe Nil
             store.getData(txn, produceKey1) shouldBe List(
@@ -227,7 +227,7 @@ trait StorageActionsTests[F[_]]
           }
       _  = r2 shouldBe Right(None)
       r3 <- space.produce(produceKey2.head, "datum2", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey1Hash) shouldBe Nil
             store.getPatterns(txn, produceKey1) shouldBe Nil
             store.getData(txn, produceKey1) shouldBe Nil
@@ -262,7 +262,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey1Hash) shouldBe produceKey1
             store.getPatterns(txn, produceKey1) shouldBe Nil
             store.getData(txn, produceKey1) shouldBe List(
@@ -272,7 +272,7 @@ trait StorageActionsTests[F[_]]
           }
       _  = r1 shouldBe Right(None)
       r2 <- space.produce(produceKey2.head, "datum2", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey2Hash) shouldBe produceKey2
             store.getPatterns(txn, produceKey2) shouldBe Nil
             store.getData(txn, produceKey2) shouldBe List(
@@ -282,7 +282,7 @@ trait StorageActionsTests[F[_]]
           }
       _  = r2 shouldBe Right(None)
       r3 <- space.produce(produceKey3.head, "datum3", persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey3Hash) shouldBe produceKey3
             store.getPatterns(txn, produceKey3) shouldBe Nil
             store.getData(txn, produceKey3) shouldBe List(
@@ -292,7 +292,7 @@ trait StorageActionsTests[F[_]]
           }
       _  = r3 shouldBe Right(None)
       r4 <- space.consume(List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, consumeKeyHash) shouldBe Nil
             store.getPatterns(txn, consumeKey) shouldBe Nil
             store.getData(txn, consumeKey) shouldBe Nil
@@ -321,7 +321,7 @@ trait StorageActionsTests[F[_]]
       r4 <- space.consume(key, List(Wildcard), captor, persist = false)
       r5 <- space.consume(key, List(Wildcard), captor, persist = false)
       r6 <- space.consume(key, List(Wildcard), captor, persist = false)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, store.hashChannels(key)) shouldBe Nil
             store.getData(txn, key) shouldBe Nil
             store.getPatterns(txn, key) shouldBe Nil
@@ -526,12 +526,12 @@ trait StorageActionsTests[F[_]]
       _ = r1 shouldBe Right(None)
       _ = r2 shouldBe Right(None)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1", "ch2")) shouldBe Nil
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", false))
           }
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
             store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
             store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
@@ -564,7 +564,7 @@ trait StorageActionsTests[F[_]]
         .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
         .foreach(runK)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe Nil
             store.getData(txn, List("ch2")) shouldBe Nil
           }
@@ -593,7 +593,7 @@ trait StorageActionsTests[F[_]]
         r3 <- space.produce("ch1", "datum1", persist = false)
         r4 <- space.produce("ch2", "datum2", persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getWaitingContinuation(txn, List("ch1", "ch2")) should not be empty
               store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
               store.getWaitingContinuation(txn, List("ch2")) shouldBe Nil
@@ -608,7 +608,7 @@ trait StorageActionsTests[F[_]]
 
         _ = getK(r3).results should contain theSameElementsAs List(List("datum1"))
         //ensure that joins are cleaned-up after all
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getJoin(txn, "ch1") shouldBe List(List("ch1", "ch2"))
               store.getJoin(txn, "ch2") shouldBe List(List("ch1", "ch2"))
             }
@@ -627,7 +627,7 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.produce(key.head, "datum", persist = false)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
             store.getPatterns(txn, key) shouldBe Nil
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
@@ -649,7 +649,7 @@ trait StorageActionsTests[F[_]]
 
       // the data has been consumed, so the write will "stick"
       r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe List("ch1")
             store.getPatterns(txn, key) shouldBe List(List(Wildcard))
             store.getData(txn, key) shouldBe Nil
@@ -668,7 +668,7 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.produce(key.head, "datum1", persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getChannels(txn, keyHash) shouldBe key
               store.getPatterns(txn, key) shouldBe Nil
               store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
@@ -691,7 +691,7 @@ trait StorageActionsTests[F[_]]
         // All matching data has been consumed, so the write will "stick"
         r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getChannels(txn, keyHash) shouldBe List("ch1")
               store.getPatterns(txn, key) shouldBe List(List(Wildcard))
               store.getData(txn, key) shouldBe Nil
@@ -702,7 +702,7 @@ trait StorageActionsTests[F[_]]
 
         r4 <- space.produce(key.head, "datum2", persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getChannels(txn, keyHash) shouldBe List("ch1")
               store.getPatterns(txn, key) shouldBe List(List(Wildcard))
               store.getData(txn, key) shouldBe Nil
@@ -723,7 +723,7 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getData(txn, List("ch1")) shouldBe Nil
               store.getWaitingContinuation(txn, List("ch1")) should not be empty
             }
@@ -732,7 +732,7 @@ trait StorageActionsTests[F[_]]
 
         r2 <- space.produce("ch1", "datum1", persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getData(txn, List("ch1")) shouldBe Nil
               store.getWaitingContinuation(txn, List("ch1")) should not be empty
             }
@@ -745,7 +745,7 @@ trait StorageActionsTests[F[_]]
 
         r3 <- space.produce("ch1", "datum2", persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getData(txn, List("ch1")) shouldBe Nil
               store.getWaitingContinuation(txn, List("ch1")) should not be empty
             }
@@ -779,7 +779,7 @@ trait StorageActionsTests[F[_]]
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
       _  = r3 shouldBe Right(None)
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
           }
@@ -809,7 +809,7 @@ trait StorageActionsTests[F[_]]
         // All matching continuations have been produced, so the write will "stick"
         r3 <- space.produce("ch1", "datum1", persist = true)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
               store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
             }
@@ -818,7 +818,7 @@ trait StorageActionsTests[F[_]]
 
         r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
               store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
             }
@@ -836,7 +836,7 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.produce("ch1", "datum1", persist = true)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
           }
@@ -845,7 +845,7 @@ trait StorageActionsTests[F[_]]
 
       r2 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
           }
@@ -858,7 +858,7 @@ trait StorageActionsTests[F[_]]
 
       r3 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
           }
@@ -885,7 +885,7 @@ trait StorageActionsTests[F[_]]
       // Matching data exists so the write will not "stick"
       r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) should contain atLeastOneOf (
               Datum.create("ch1", "datum1", false),
               Datum.create("ch1", "datum2", false),
@@ -903,7 +903,7 @@ trait StorageActionsTests[F[_]]
       // Matching data exists so the write will not "stick"
       r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) should contain oneOf (
               Datum.create("ch1", "datum1", false),
               Datum.create("ch1", "datum2", false),
@@ -932,7 +932,7 @@ trait StorageActionsTests[F[_]]
       // All matching data has been consumed, so the write will "stick"
       r7 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
 
-      _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+      _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe Nil
             store.getWaitingContinuation(txn, List("ch1")) should not be empty
           }
@@ -998,7 +998,7 @@ trait StorageActionsTests[F[_]]
       for {
         r <- space.consume(key, patterns, new StringsCaptor, persist = false)
 
-        _ <- store.withTxnF(store.createTxnReadF()) { txn =>
+        _ <- store.withReadTxnF { txn =>
               store.getChannels(txn, keyHash) shouldBe List("ch1")
               store.getPatterns(txn, key) shouldBe List(patterns)
               store.getData(txn, key) shouldBe Nil

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -307,7 +307,7 @@ abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
                   )
       testStore = testSpace.store
       trieStore = testStore.trieStore
-      _         <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
+      _         <- testStore.withWriteTxnF(testStore.clear)
       _         = trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear)
       _         = initialize(trieStore, branch)
       res       <- f(testSpace)
@@ -351,7 +351,7 @@ abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
                   )
       testStore = testSpace.store
       trieStore = testStore.trieStore
-      _         <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
+      _         <- testStore.withWriteTxnF(testStore.clear)
       _         <- trieStore.withTxn(trieStore.createTxnWrite())(trieStore.clear).pure[F]
       _         = initialize(trieStore, branch)
       res       <- f(testSpace)
@@ -382,7 +382,7 @@ abstract class LMDBStoreStorageExamplesTestBase[F[_]]
                     testStore,
                     Branch.MASTER
                   )
-      _   <- testStore.withTxnF(testStore.createTxnWriteF())(testStore.clear)
+      _   <- testStore.withWriteTxnF(testStore.clear)
       res <- f(testSpace)
     } yield {
       try {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -156,7 +156,7 @@ abstract class InMemoryStoreTestsBase[F[_]]
       testStore = testSpace.store
       trieStore = testStore.trieStore
       _ <- testStore
-            .withTxnF(testStore.createTxnWriteF()) { txn =>
+            .withWriteTxnF { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)
@@ -201,7 +201,7 @@ abstract class LMDBStoreTestsBase[F[_]]
                   )
       testStore = testSpace.store
       _ <- testStore
-            .withTxnF(testStore.createTxnWriteF()) { txn =>
+            .withWriteTxnF { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)
@@ -247,7 +247,7 @@ abstract class MixedStoreTestsBase[F[_]]
                   )
       testStore = testSpace.store
       _ <- testStore
-            .withTxnF(testStore.createTxnWriteF()) { txn =>
+            .withWriteTxnF { txn =>
               testStore.withTrieTxn(txn) { trieTxn =>
                 testStore.clear(txn)
                 testStore.trieStore.clear(trieTxn)


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
LMDB and monix do not play well together. This makes it hard to suspend
a LMDB txn in Task and have it be properly carried with a thread switching Task.

This change is a partial revert to a version that will allow cost accounting.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-3073


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
