### PR TITLE
Block streaming timeouts

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/UPnP.scala
+++ b/comm/src/main/scala/coop/rchain/comm/UPnP.scala
@@ -133,7 +133,7 @@ object UPnP {
     for {
       _       <- Log[F].info("trying to open ports using UPnP....")
       devices <- Sync[F].delay(discover)
-      res <- if (devices.gateways.isEmpty) logGatewayEmpty(devices) *> None.pure[F]
+      res <- if (devices.gateways.isEmpty) logGatewayEmpty(devices) >> None.pure[F]
             else tryOpenPorts(ports, devices)
     } yield res
 

--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -122,7 +122,7 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
 
     cell.read.flatMap { s =>
       if (s.shutdown) Task.unit
-      else shutdownServer *> disconnectFromPeers
+      else shutdownServer >> disconnectFromPeers
     }
   }
 

--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -42,7 +42,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Monad: Sync: Log: Time: Met
     } yield ()
 
   private def pingHandler(peer: PeerNode): F[Unit] =
-    addNode(peer) *> Metrics[F].incrementCounter("handle.ping")
+    addNode(peer) >> Metrics[F].incrementCounter("handle.ping")
 
   private def lookupHandler(peer: PeerNode, id: Array[Byte]): F[Seq[PeerNode]] =
     for {
@@ -61,7 +61,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Monad: Sync: Log: Time: Met
       _     <- peers.traverse(addNode)
     } yield ()
 
-    initRPC *> findNewAndAdd.forever
+    initRPC >> findNewAndAdd.forever
   }
 
   /**

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -32,7 +32,7 @@ final case class UnexpectedMessage(msgStr: String)                  extends Comm
 final case object SenderNotAvailable                                extends CommError
 final case class PongNotReceivedForPing(peer: PeerNode)             extends CommError
 final case class UnableToStorePacket(packet: Packet, th: Throwable) extends CommError
-final case class UnabletoRestorePacket(path: Path, th: Throwable)   extends CommError
+final case class UnableToRestorePacket(path: Path, th: Throwable)   extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -66,7 +66,7 @@ object CommError {
   def timeout: CommError                                 = TimeOut
   def unableToStorePacket(packet: Packet, th: Throwable): CommError =
     UnableToStorePacket(packet, th)
-  def unabletoRestorePacket(path: Path, th: Throwable) = UnabletoRestorePacket(path, th)
+  def unableToRestorePacket(path: Path, th: Throwable) = UnableToRestorePacket(path, th)
 
   def errorMessage(ce: CommError): String =
     ce match {
@@ -77,6 +77,10 @@ object CommError {
       case TimeOut                         => "Timeout"
       case InternalCommunicationError(msg) => s"Internal communication error. $msg"
       case UnknownProtocolError(msg)       => s"Unknown protocol error. $msg"
+      case UnableToStorePacket(p, er) =>
+        s"Could not serialize packet $p. Error message: ${er.getMessage}"
+      case UnableToRestorePacket(p, er) =>
+        s"Could not deserialize packet $p. Error message: ${er.getMessage}"
       case ProtocolException(t) =>
         val msg = Option(t.getMessage).getOrElse("")
         s"Protocol error. $msg"

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -45,7 +45,7 @@ object Connect {
           case (_, rest) => rest ++ toBeAdded
         }
         val size = newConnections.size.toLong
-        Log[F].info(s"Peers: $size.") *>
+        Log[F].info(s"Peers: $size.") >>
           Metrics[F].setGauge("peers", size).as(newConnections)
       }
 
@@ -58,7 +58,7 @@ object Connect {
           case (_, rest) => rest
         }
         val size = newConnections.size.toLong
-        Log[F].info(s"Peers: $size.") *>
+        Log[F].info(s"Peers: $size.") >>
           Metrics[F].setGauge("peers", size).as(newConnections)
       }
     }

--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -46,7 +46,7 @@ object HandleMessages {
       case Protocol.Message.Disconnect(disconnect) => handleDisconnect[F](sender, disconnect)
       case Protocol.Message.Packet(packet)         => handlePacket[F](sender, packet)
       case msg =>
-        Log[F].error(s"Unexpected message type $msg") *> notHandled(unexpectedMessage(msg.toString))
+        Log[F].error(s"Unexpected message type $msg") >> notHandled(unexpectedMessage(msg.toString))
           .pure[F]
     }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -152,13 +152,13 @@ class GrpcTransportClient(
               GrpcTransport.stream(peer, Blob(sender, packet), messageSize)
             ).flatMap {
               case Left(error) =>
-                log.error(s"Error while streaming packet, error: $error") >> delay(
-                  handle(retryCount - 1)
-                )
-              case Right(_) =>
-                log.info(s"Streamed packet $path to $peer")
+                log.error(
+                  s"Error while streaming packet to $peer: ${error.message}"
+                ) >> delay(handle(retryCount - 1))
+              case Right(_) => log.info(s"Streamed packet $path to $peer")
             }
-          case Left(error) => log.error(s"Error while streaming packet, error: $error")
+          case Left(error) =>
+            log.error(s"Error while streaming packet $path to $peer: ${error.message}")
         } else log.debug(s"Giving up on streaming packet $path to $peer")
 
     handle(retries)

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -143,9 +143,9 @@ class TransportServer(server: GrpcTransportServer) {
     val dis: Protocol => Task[CommunicationResponse] = msg =>
       dispatch(msg).value.flatMap {
         case Left(err) =>
-          Log[Task].error(s"Error while handling message. Error: ${err.message}") *> Task.now(
-            notHandled(err)
-          )
+          Log[Task].error(
+            s"Error while handling message. Error: ${err.message}"
+          ) >> Task.now(notHandled(err))
         case Right(m) => Task.now(m)
       }
     val hb: Blob => Task[Unit] = b =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/PacketOps.scala
@@ -22,8 +22,8 @@ object PacketOps {
       packetErr <- Sync[F].delay(Packet.parseFrom(fin)).attempt
       resErr <- packetErr match {
                  case Left(th) =>
-                   gracefullyClose(fin) *> Left(unabletoRestorePacket(file, th)).pure[F]
-                 case Right(packet) => gracefullyClose(fin) *> Right(packet).pure[F]
+                   gracefullyClose(fin) >> Left(unableToRestorePacket(file, th)).pure[F]
+                 case Right(packet) => gracefullyClose(fin) >> Right(packet).pure[F]
                }
     } yield resErr
 
@@ -39,7 +39,7 @@ object PacketOps {
                 }.attempt
         resErr <- orErr match {
                    case Left(th) =>
-                     gracefullyClose(fos) *> Left(unableToStorePacket(packet, th)).pure[F]
+                     gracefullyClose(fos) >> Left(unableToStorePacket(packet, th)).pure[F]
                    case Right(_) =>
                      gracefullyClose(fos) map {
                        case Left(th) => Left(unableToStorePacket(packet, th))


### PR DESCRIPTION
## Overview
Improve error messages for block streaming in the transport layer. Change the streaming timeout from fixed 10 minutes to a dynamic value based on the block size.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3017

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
