### PR TITLE
Fix duplicate genesis blocks on testnet

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -3,7 +3,7 @@ package coop.rchain.blockstorage
 import cats.Applicative
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
 
 import scala.language.higherKinds
 
@@ -27,6 +27,12 @@ trait BlockStore[F[_]] {
 
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
     get(blockHash).map(_.isDefined)
+
+  def getApprovedBlock(implicit applicativeF: Applicative[F]): F[Option[ApprovedBlock]] =
+    Option.empty[ApprovedBlock].pure[F]
+
+  def putApprovedBlock(block: ApprovedBlock)(implicit applicativeF: Applicative[F]): F[Unit] =
+    ().pure[F]
 
   def checkpoint(): F[Unit]
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -28,11 +28,9 @@ trait BlockStore[F[_]] {
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
     get(blockHash).map(_.isDefined)
 
-  def getApprovedBlock(implicit applicativeF: Applicative[F]): F[Option[ApprovedBlock]] =
-    Option.empty[ApprovedBlock].pure[F]
+  def getApprovedBlock: F[Option[ApprovedBlock]]
 
-  def putApprovedBlock(block: ApprovedBlock)(implicit applicativeF: Applicative[F]): F[Unit] =
-    ().pure[F]
+  def putApprovedBlock(block: ApprovedBlock): F[Unit]
 
   def checkpoint(): F[Unit]
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/LMDBBlockStore.scala
@@ -9,7 +9,7 @@ import cats._
 import cats.effect.{ExitCase, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.Resources.withResource
 import com.google.protobuf.ByteString
@@ -106,6 +106,12 @@ class LMDBBlockStore[F[_]] private (val env: Env[ByteBuffer], path: Path, blocks
               }
             }
     } yield ret
+
+  def getApprovedBlock: F[Option[ApprovedBlock]] =
+    none[ApprovedBlock].pure[F]
+
+  def putApprovedBlock(block: ApprovedBlock): F[Unit] =
+    ().pure[F]
 
   def checkpoint(): F[Unit] =
     ().pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -63,8 +63,6 @@ sealed abstract class MultiParentCasperInstances {
       shardId: String
   ): F[MultiParentCasper[F]] =
     for {
-      // Initialize DAG storage with genesis block in case it is empty
-      _   <- BlockDagStorage[F].insert(genesis, false)
       dag <- BlockDagStorage[F].getRepresentation
       maybePostGenesisStateHash <- InterpreterUtil
                                     .validateBlockCheckpoint[F](

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -633,7 +633,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   ): F[Unit] =
     for {
       _ <- BlockStore[F].put(genesis.blockHash, genesis)
-      _ <- BlockDagStorage[F].insert(genesis, false)
+      _ <- BlockDagStorage[F].insert(genesis, invalid = false)
       _ <- BlockStore[F].putApprovedBlock(approvedBlock)
     } yield ()
 

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -99,8 +99,9 @@ class CasperPacketHandlerSpec extends WordSpec {
       })
     implicit val lab =
       LastApprovedBlock.of[Task].unsafeRunSync(monix.execution.Scheduler.Implicits.global)
-    implicit val blockMap   = Ref.unsafe[Task, Map[BlockHash, BlockMessage]](Map.empty)
-    implicit val blockStore = InMemBlockStore.create[Task]
+    implicit val blockMap         = Ref.unsafe[Task, Map[BlockHash, BlockMessage]](Map.empty)
+    implicit val approvedBlockRef = Ref.unsafe[Task, Option[ApprovedBlock]](None)
+    implicit val blockStore       = InMemBlockStore.create[Task]
     implicit val blockDagStorage = InMemBlockDagStorage
       .create[Task]
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -162,6 +162,7 @@ object Configuration {
       FileLMDBIndexBlockStore.Config(
         dataDir.resolve("casper-block-store").resolve("storage"),
         dataDir.resolve("casper-block-store").resolve("index"),
+        dataDir.resolve("casper-block-store").resolve("approved-block"),
         dataDir.resolve("casper-block-store").resolve("checkpoints"),
         server.storeSize
       )


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Adds logic in casper packet handler to save and restore approved block and implements save/restore in the block store. If we have an approved block already saved, then we don't generate a new one when the standalone node is restarted.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3089
https://rchain.atlassian.net/browse/RCHAIN-3090

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
