### PR TITLE
RChain-2990: Share the _cost capability with the rspace matcher.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ChargingReducer.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ChargingReducer.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.{Expr, Par}
-import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
+import coop.rchain.rholang.interpreter.accounting.{_cost, Cost, CostAccounting}
 
 // TODO: After refactoring Reduce to not include implicits in methods,
 //       make ChargingReducer extend Reduce.
@@ -31,13 +31,13 @@ object ChargingReducer {
 
   implicit def chargingReducer[F[_]](
       implicit reducer: Reduce[F],
-      costAccounting: CostAccounting[F]
+      cost: _cost[F]
   ): ChargingReducer[F] = new ChargingReducer[F] {
     def phlo: F[Cost] =
-      costAccounting.get()
+      cost.get
 
     def setPhlo(limit: Cost): F[Unit] =
-      costAccounting.set(limit)
+      cost.set(limit)
 
     def eval(
         par: Par

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -3,7 +3,7 @@ import cats.effect.Sync
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.{ListParWithRandom, ListParWithRandomAndPhlos, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
-import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.implicits.matchListPar
 import coop.rchain.rspace.util.unpackCont
@@ -16,8 +16,6 @@ class ContractCall[F[_]: Sync](
 
   type Producer = (Seq[Par], Par) => F[Unit]
 
-  private val UNLIMITED_MATCH_PHLO = matchListPar(Cost(Integer.MAX_VALUE))
-
   private def produce(
       rand: Blake2b512Random,
       sequenceNumber: Int
@@ -28,7 +26,7 @@ class ContractCall[F[_]: Sync](
                         ListParWithRandom(values, rand),
                         persist = false,
                         sequenceNumber
-                      )(UNLIMITED_MATCH_PHLO)
+                      )(matchListPar(Cost(Integer.MAX_VALUE)))
       _ <- produceResult.fold(
             _ => Sync[F].raiseError(OutOfPhlogistonsError),
             _.fold(Sync[F].unit) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -16,6 +16,9 @@ class ContractCall[F[_]: Sync](
 
   type Producer = (Seq[Par], Par) => F[Unit]
 
+  implicit val cost: _cost[F] =
+    loggingCost(CostAccounting.unsafe[F](Cost(Integer.MAX_VALUE)), noOpCostLog)
+
   private def produce(
       rand: Blake2b512Random,
       sequenceNumber: Int
@@ -26,7 +29,7 @@ class ContractCall[F[_]: Sync](
                         ListParWithRandom(values, rand),
                         persist = false,
                         sequenceNumber
-                      )(matchListPar(Cost(Integer.MAX_VALUE)))
+                      )(matchListPar)
       _ <- produceResult.fold(
             _ => Sync[F].raiseError(OutOfPhlogistonsError),
             _.fold(Sync[F].unit) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -313,8 +313,7 @@ object Runtime {
   )(
       implicit P: Parallel[F, M],
       executionContext: ExecutionContext,
-      cost: _cost[F],
-      costAccounting: CostAccounting[F]
+      cost: _cost[F]
   ): F[Runtime[F]] = {
     val errorLog                               = new ErrorLog[F]()
     implicit val ft: FunctorTell[F, Throwable] = errorLog

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -182,11 +182,12 @@ object Runtime {
             freeCount = arity
           )
         )
-        val continuation                   = TaggedContinuation(ScalaBodyRef(ref))
-        implicit val MATCH_UNLIMITED_PHLOS = matchListPar(Cost(Integer.MAX_VALUE))
+        val continuation = TaggedContinuation(ScalaBodyRef(ref))
         List(
-          space.install(channels, patterns, continuation),
-          replaySpace.install(channels, patterns, continuation)
+          space.install(channels, patterns, continuation)(matchListPar(Cost(Integer.MAX_VALUE))),
+          replaySpace.install(channels, patterns, continuation)(
+            matchListPar(Cost(Integer.MAX_VALUE))
+          )
         )
     }.sequence
 
@@ -420,20 +421,20 @@ object Runtime {
         "for what rate of interest is there that can naturally be more proper than another?")
         .getBytes()
     )
-    implicit val MATCH_UNLIMITED_PHLOS = matchListPar(Cost(Integer.MAX_VALUE))
+
     for {
       spaceResult <- space.produce(
                       Registry.registryRoot,
                       ListParWithRandom(Seq(Registry.emptyMap), rand),
                       false,
                       0
-                    )
+                    )(matchListPar(Cost(Integer.MAX_VALUE)))
       replayResult <- replaySpace.produce(
                        Registry.registryRoot,
                        ListParWithRandom(Seq(Registry.emptyMap), rand),
                        false,
                        0
-                     )
+                     )(matchListPar(Cost(Integer.MAX_VALUE)))
       _ <- spaceResult match {
             case Right(None) =>
               replayResult match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -83,18 +83,19 @@ object SystemProcesses {
       private def illegalArgumentException(msg: String): F[Unit] =
         F.raiseError(new IllegalArgumentException(msg))
 
-      def verifySignatureContract(name : String,
-                                  algorithm : (Array[Byte], Array[Byte], Array[Byte]) => Boolean)
-      : (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
+      def verifySignatureContract(
+          name: String,
+          algorithm: (Array[Byte], Array[Byte], Array[Byte]) => Boolean
+      ): (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case isContractCall(
-          produce,
-          Seq(
-            RhoType.ByteArray(data),
-            RhoType.ByteArray(signature),
-            RhoType.ByteArray(pub),
-            ack
-          )
-        ) =>
+            produce,
+            Seq(
+              RhoType.ByteArray(data),
+              RhoType.ByteArray(signature),
+              RhoType.ByteArray(pub),
+              ack
+            )
+            ) =>
           for {
             verified <- F.fromTry(Try(algorithm(data, signature, pub)))
             _        <- produce(Seq(RhoType.Bool(verified)), ack)
@@ -105,9 +106,10 @@ object SystemProcesses {
           )
       }
 
-      def hashContract(name : String,
-                       algorithm : Array[Byte] => Array[Byte])
-      : (Seq[ListParWithRandomAndPhlos], Int) => F[Unit]= {
+      def hashContract(
+          name: String,
+          algorithm: Array[Byte] => Array[Byte]
+      ): (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case isContractCall(produce, Seq(RhoType.ByteArray(input), ack)) =>
           for {
             hash <- F.fromTry(Try(algorithm(input)))
@@ -183,7 +185,10 @@ object SystemProcesses {
         case isContractCall(produce, Seq(ack)) =>
           for {
             params <- shortLeashParams.getParams
-            _ <-produce(Seq(params.codeHash, params.phloRate, params.userId, params.timestamp), ack)
+            _ <- produce(
+                  Seq(params.codeHash, params.phloRate, params.userId, params.timestamp),
+                  ack
+                )
           } yield ()
         case _ =>
           illegalArgumentException("deployParameters expects only a return channel")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -2,6 +2,9 @@ package coop.rchain.rholang.interpreter.accounting
 
 import coop.rchain.models.{ProtoM, StacksafeMessage}
 
+/* TODO: Make Chargeable instances for requisite rspace type parameters. Then, create an instance of PureRSpace
+         that uses the generic instances, _cost, and _error for a single, charging PureRSpace. */
+
 trait Chargeable[A] {
   def cost(a: A): Long
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -91,7 +91,7 @@ object RholangAndScalaDispatcher {
     lazy val tuplespaceAlg = Tuplespace.rspaceTuplespace(chargingRSpace, dispatcher)
 
     lazy val chargingRSpace: RhoPureSpace[M] =
-      ChargingRSpace.pureRSpace(s, costAccounting, tuplespace)
+      ChargingRSpace.pureRSpace(tuplespace)
 
     val chargingReducer: ChargingReducer[M] = ChargingReducer[M]
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -76,7 +76,6 @@ object RholangAndScalaDispatcher {
   )(
       implicit
       cost: _cost[M],
-      costAccounting: CostAccounting[M],
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -45,7 +45,7 @@ package object matcher {
   ): F[Stream[(FreeMap, A)]] =
     StreamT.run(f.run(emptyMap))
 
-  private[matcher] def runFirst[F[_]: Monad, A](
+  private[rholang] def runFirst[F[_]: Monad, A](
       f: MatcherMonadT[F, A]
   ): F[Option[(FreeMap, A)]] =
     StreamT

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -31,7 +31,7 @@ object ChargingRSpace {
 
   def pureRSpace[F[_]: Sync](
       space: RhoISpace[F]
-  )(implicit costAlg: CostAccounting[F], cost: _cost[F], error: _error[F]) =
+  )(implicit cost: _cost[F], error: _error[F]) =
     new RhoPureSpace[F] {
 
       override def consume(
@@ -45,7 +45,7 @@ object ChargingRSpace {
       ]]] =
         for {
           _       <- charge[F](storageCostConsume(channels, patterns, continuation))
-          balance <- costAlg.get()
+          balance <- cost.get
           consRes <- space.consume(channels, patterns, continuation, persist, sequenceNumber)(
                       matchListPar(balance)
                     )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -29,7 +29,7 @@ object ChargingRSpace {
   def storageCostProduce(channel: Par, data: ListParWithRandom): Cost =
     channel.storageCost + data.pars.storageCost
 
-  def pureRSpace[F[_]: Sync](implicit costAlg: CostAccounting[F], space: RhoISpace[F]) =
+  def pureRSpace[F[_]: Sync](space: RhoISpace[F])(implicit costAlg: CostAccounting[F]) =
     new RhoPureSpace[F] {
 
       override def consume(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -3,13 +3,12 @@ package coop.rchain.rholang.interpreter.storage
 import cats.effect.Sync
 import cats.implicits._
 import cats.mtl.implicits._
+import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.rholang.interpreter.accounting._
-import coop.rchain.rholang.interpreter.errors.InterpreterError
-import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
 import coop.rchain.rholang.interpreter.matcher._
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
 
@@ -30,43 +29,39 @@ object implicits {
       init: Cost
   ): StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] =
     new StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] {
-
-      private def calcUsed(init: Cost, left: Cost): Cost = init - left
-
       def get(
           pattern: BindPattern,
           data: ListParWithRandom
-      ): F[Option[ListParWithRandomAndPhlos]] =
-        Sync[F]
-          .delay {
-            SpatialMatcher
-              .foldMatch[NonDetFreeMapWithCost, Par, Par](
-                data.pars,
-                pattern.patterns,
-                pattern.remainder
+      ): F[Option[ListParWithRandomAndPhlos]] = {
+        type R[A] = MatcherMonadT[F, A]
+        implicit val cost: _cost[F] = loggingCost(CostAccounting.unsafe[F](init), noOpCostLog)
+        implicit val _              = matcherMonadCostLog[F]()
+        for {
+          matchResult <- runFirst[F, Seq[Par]](
+                          SpatialMatcher
+                            .foldMatch[R, Par, Par](
+                              data.pars,
+                              pattern.patterns,
+                              pattern.remainder
+                            )
+                        )
+          left <- cost.get
+        } yield {
+          matchResult.map {
+            case (freeMap, caughtRem) =>
+              val remainderMap = pattern.remainder match {
+                case Some(Var(FreeVar(level))) =>
+                  freeMap + (level -> VectorPar().addExprs(EList(caughtRem.toVector)))
+                case _ => freeMap
+              }
+              ListParWithRandomAndPhlos(
+                toSeq(remainderMap, pattern.freeCount),
+                data.randomState,
+                (init - left).value
               )
-              .runFirstWithCost(init)
           }
-          .flatMap {
-            case Left(err) => Sync[F].raiseError(err)
-            case Right((left, resultMatch)) =>
-              val cost = calcUsed(init, left)
-              resultMatch
-                .map {
-                  case (freeMap: FreeMap, caughtRem: Seq[Par]) =>
-                    val remainderMap = pattern.remainder match {
-                      case Some(Var(FreeVar(level))) =>
-                        freeMap + (level -> VectorPar().addExprs(EList(caughtRem.toVector)))
-                      case _ => freeMap
-                    }
-                    ListParWithRandomAndPhlos(
-                      toSeq(remainderMap, pattern.freeCount),
-                      data.randomState,
-                      cost.value
-                    )
-                }
-                .pure[F]
-          }
+        }
+      }
     }
 
   /* Serialize instances */

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -26,7 +26,8 @@ object implicits {
     }
 
   def matchListPar[F[_]: Sync](
-      init: Cost
+      implicit
+      cost: _cost[F]
   ): StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] =
     new StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandomAndPhlos] {
       def get(
@@ -34,9 +35,9 @@ object implicits {
           data: ListParWithRandom
       ): F[Option[ListParWithRandomAndPhlos]] = {
         type R[A] = MatcherMonadT[F, A]
-        implicit val cost: _cost[F] = loggingCost(CostAccounting.unsafe[F](init), noOpCostLog)
-        implicit val _              = matcherMonadCostLog[F]()
+        implicit val _ = matcherMonadCostLog[F]()
         for {
+          init <- cost.get
           matchResult <- runFirst[F, Seq[Par]](
                           SpatialMatcher
                             .foldMatch[R, Par, Par](

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -39,7 +39,7 @@ trait PersistentStoreTester {
 
   def withTestSpace[R](
       errorLog: ErrorLog[Task]
-  )(f: TestFixture => R)(implicit CA: CostAccounting[Task], C: _cost[Task]): R = {
+  )(f: TestFixture => R)(implicit C: _cost[Task]): R = {
     val dbDir                              = Files.createTempDirectory("rholang-interpreter-test-")
     val context: RhoContext[Task]          = Context.create(dbDir, mapSize = 1024L * 1024L * 1024L)
     implicit val logF: Log[Task]           = new Log.NOPLog[Task]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -21,20 +21,12 @@ object RholangOnlyDispatcher {
   def create[M[_], F[_]](tuplespace: RhoISpace[M], urnMap: Map[String, Par] = Map.empty)(
       implicit
       cost: _cost[M],
-      costAccounting: CostAccounting[M],
       parallel: Parallel[M, F],
       s: Sync[M],
       ft: FunctorTell[M, Throwable]
   ): (Dispatch[M, ListParWithRandomAndPhlos, TaggedContinuation], ChargingReducer[M]) = {
 
-    implicit val matchCost: Match[
-      M,
-      BindPattern,
-      ListParWithRandom,
-      ListParWithRandomAndPhlos
-    ] = matchListPar(Cost(Integer.MAX_VALUE))
-
-    val pureSpace = PureRSpace[M].of(tuplespace)
+    val pureSpace = PureRSpace[M].of(tuplespace)(matchListPar)
 
     lazy val dispatcher: Dispatch[M, ListParWithRandomAndPhlos, TaggedContinuation] =
       new RholangOnlyDispatcher

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -99,8 +99,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
       cost    = loggingCost(costAlg, costL)
       costsLoggingProgram <- {
         costL.listen({
-          implicit val ca = costAlg
-          implicit val c  = cost
+          implicit val c = cost
           for {
             runtime <- Runtime
                         .create[Task, Task.Par](dbDir, size, StoreType.LMDB)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -339,7 +339,7 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
     def mkChargingRspace(rhoISpace: RhoISpace[Task]): Task[ChargingRSpace] = {
       val pureRSpace = ChargingRSpaceTest.createTestISpace(rhoISpace)
       val s          = implicitly[Sync[Task]]
-      Task.delay(ChargingRSpace.pureRSpace(s, costAlg, pureRSpace))
+      Task.delay(ChargingRSpace.pureRSpace(pureRSpace)(s, costAlg))
     }
 
     val chargingRSpaceResource =


### PR DESCRIPTION
## Overview
This PR shares standardizes the `_cost[F]` effect across the RSpace matcher and the rest of the interpreter, including the `ChargingRSpace` type. As a result, the `CostAccounting[F]` implicit parameters are eliminated and only used to instantiate `_cost[F]`.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2990

### Notes
`ChargingRSpace` used to charge for matching based on the size of the data being matched. This PR eliminates that charge since the complexity of matching data does not influence the space complexity of persistent storage. Now, the only matching charges are those that exist within the matcher itself.