### PR TITLE
Refactoring/extract par builder from interpreter

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -12,7 +12,7 @@ import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.{BlockException, PrettyPrinter}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.{BlockMetadata, Par}
-import coop.rchain.rholang.interpreter.Interpreter
+import coop.rchain.rholang.interpreter.{Interpreter, ParBuilder}
 import coop.rchain.rspace.ReplayException
 import coop.rchain.shared.{Log, LogSource}
 import monix.eval.Coeval
@@ -22,7 +22,7 @@ object InterpreterUtil {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def mkTerm(rho: String): Either[Throwable, Par] =
-    Interpreter[Coeval].buildNormalizedTerm(rho).runAttempt
+    ParBuilder[Coeval].buildNormalizedTerm(rho).runAttempt
 
   //Returns (None, checkpoints) if the block's tuplespace hash
   //does not match the computed hash based on the deploys

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -12,7 +12,7 @@ import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.{BlockException, PrettyPrinter}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.{BlockMetadata, Par}
-import coop.rchain.rholang.interpreter.{Interpreter, ParBuilder}
+import coop.rchain.rholang.interpreter.ParBuilder
 import coop.rchain.rspace.ReplayException
 import coop.rchain.shared.{Log, LogSource}
 import monix.eval.Coeval

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -13,7 +13,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.Resources.mkRuntime
-import coop.rchain.rholang.interpreter.{accounting, Interpreter, ParBuilder}
+import coop.rchain.rholang.interpreter.{accounting, ParBuilder}
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.shared.Log
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -13,7 +13,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.Resources.mkRuntime
-import coop.rchain.rholang.interpreter.{accounting, Interpreter}
+import coop.rchain.rholang.interpreter.{accounting, Interpreter, ParBuilder}
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.shared.Log
 import monix.eval.Task
@@ -65,7 +65,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
                           val initialPhlo = Cost(accounting.MAX_VALUE)
                           for {
                             _             <- runtime.reducer.setPhlo(initialPhlo)
-                            term          <- Interpreter[Task].buildNormalizedTerm(deploy.term)
+                            term          <- ParBuilder[Task].buildNormalizedTerm(deploy.term)
                             _             <- runtime.reducer.inj(term)
                             phlosLeft     <- runtime.reducer.phlo
                             reductionCost = initialPhlo - phlosLeft

--- a/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
@@ -41,7 +41,7 @@ private[api] class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler)
     extends ReplGrpcMonix.Repl {
 
   def exec(source: String): Task[ReplResponse] =
-    Interpreter[Task]
+    ParBuilder[Task]
       .buildNormalizedTerm(source)
       .attempt
       .flatMap {

--- a/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.build
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.Interpreter
+import coop.rchain.rholang.interpreter.ParBuilder
 import monix.eval.Coeval
 
 import scala.io.Source
@@ -14,7 +14,7 @@ object CompiledRholangSource {
 
   def apply(classpath: String): CompiledRholangSource = new CompiledRholangSource {
     override val code: String = Source.fromResource(classpath).mkString
-    override val term: Par    = Interpreter[Coeval].buildNormalizedTerm(code).value()
+    override val term: Par    = ParBuilder[Coeval].buildNormalizedTerm(code).value()
   }
 
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -27,12 +27,6 @@ final case class EvaluateResult(cost: Cost, errors: Vector[Throwable])
 
 trait Interpreter[F[_]] {
 
-  def buildNormalizedTerm(source: String): F[Par]
-
-  def buildNormalizedTerm(reader: Reader): F[Par]
-
-  def buildPar(proc: Proc): F[Par]
-
   def evaluate(runtime: Runtime[F], term: String): F[EvaluateResult]
   def evaluate(runtime: Runtime[F], term: String, initialPhlo: Cost): F[EvaluateResult]
 
@@ -49,21 +43,6 @@ object Interpreter {
   def apply[F[_]](implicit interpreter: Interpreter[F]): Interpreter[F] = interpreter
 
   implicit def interpreter[F[_]](implicit F: Sync[F]): Interpreter[F] = new Interpreter[F] {
-
-    def buildNormalizedTerm(source: String): F[Par] =
-      buildNormalizedTerm(new StringReader(source))
-
-    def buildNormalizedTerm(reader: Reader): F[Par] =
-      for {
-        proc <- buildAST(reader)
-        par  <- buildPar(proc)
-      } yield par
-
-    def buildPar(proc: Proc): F[Par] =
-      for {
-        par       <- normalizeTerm(proc)
-        sortedPar <- Sortable[Par].sortMatch(par)
-      } yield sortedPar.term
 
     def evaluate(runtime: Runtime[F], term: String): F[EvaluateResult] =
       evaluate(runtime, term, Cost.Max)
@@ -89,7 +68,7 @@ object Interpreter {
       if (phloAfterParsing.value <= 0)
         EvaluateResult(parsingCost, Vector(OutOfPhlogistonsError)).pure[F]
       else
-        Interpreter[F].buildNormalizedTerm(term).attempt.flatMap {
+        ParBuilder[F].buildNormalizedTerm(term).attempt.flatMap {
           case Right(parsed) =>
             for {
               _         <- reducer.setPhlo(phloAfterParsing)
@@ -106,77 +85,5 @@ object Interpreter {
         }
     }
 
-    private def buildAST(reader: Reader): F[Proc] =
-      for {
-        lexer  <- lexer(reader)
-        parser <- parser(lexer)
-        proc <- F.delay(parser.pProc()).adaptError {
-                 case ex: Exception if ex.getMessage.startsWith("Syntax error") =>
-                   SyntaxError(ex.getMessage)
-                 case er: Error
-                     if er.getMessage.startsWith("Unterminated string at EOF, beginning at") =>
-                   LexerError(er.getMessage)
-                 case er: Error if er.getMessage.startsWith("Illegal Character") =>
-                   LexerError(er.getMessage)
-                 case er: Error if er.getMessage.startsWith("Unterminated string on line") =>
-                   LexerError(er.getMessage)
-                 case th: Throwable => UnrecognizedInterpreterError(th)
-               }
-      } yield proc
-
-    private def normalizeTerm(term: Proc): F[Par] =
-      ProcNormalizeMatcher
-        .normalizeMatch[F](
-          term,
-          ProcVisitInputs(VectorPar(), IndexMapChain[VarSort](), DebruijnLevelMap[VarSort]())
-        )
-        .flatMap { normalizedTerm =>
-          if (normalizedTerm.knownFree.count > 0) {
-            if (normalizedTerm.knownFree.wildcards.isEmpty && normalizedTerm.knownFree.logicalConnectives.isEmpty) {
-              val topLevelFreeList = normalizedTerm.knownFree.env.map {
-                case (name, (_, _, line, col)) => s"$name at $line:$col"
-              }
-              F.raiseError(
-                TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString("", ", ", ""))
-              )
-            } else if (normalizedTerm.knownFree.logicalConnectives.nonEmpty) {
-              def connectiveInstanceToString(conn: ConnectiveInstance): String =
-                if (conn.isConnAndBody) "/\\ (conjunction)"
-                else if (conn.isConnOrBody) "\\/ (disjunction)"
-                else if (conn.isConnNotBody) "~ (negation)"
-                else conn.toString
-
-              val connectives = normalizedTerm.knownFree.logicalConnectives
-                .map {
-                  case (connType, line, col) =>
-                    s"${connectiveInstanceToString(connType)} at $line:$col"
-                }
-                .mkString("", ", ", "")
-              F.raiseError(TopLevelLogicalConnectivesNotAllowedError(connectives))
-            } else {
-              val topLevelWildcardList = normalizedTerm.knownFree.wildcards.map {
-                case (line, col) => s"_ (wildcard) at $line:$col"
-              }
-              F.raiseError(
-                TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", ""))
-              )
-            }
-          } else normalizedTerm.pure[F].map(_.par)
-        }
-
-    /**
-      * @note In lieu of a purely functional wrapper around the lexer and parser
-      *       [[F.adaptError]] is used as a catch-all for errors thrown in their
-      *       constructors.
-      */
-    private def lexer(fileReader: Reader): F[Yylex] =
-      F.delay(new Yylex(fileReader)).adaptError {
-        case th: Throwable => LexerError("Lexer construction error: " + th.getMessage)
-      }
-
-    private def parser(lexer: Yylex): F[parser] =
-      F.delay(new parser(lexer, lexer.getSymbolFactory)).adaptError {
-        case th: Throwable => ParserError("Parser construction error: " + th.getMessage)
-      }
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -1,27 +1,10 @@
 package coop.rchain.rholang.interpreter
 
-import java.io.{Reader, StringReader}
-
 import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.Connective.ConnectiveInstance
-import coop.rchain.models.Par
-import coop.rchain.models.rholang.implicits.VectorPar
-import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.accounting.Cost
-import coop.rchain.rholang.interpreter.errors.{
-  LexerError,
-  OutOfPhlogistonsError,
-  ParserError,
-  SyntaxError,
-  TopLevelFreeVariablesNotAllowedError,
-  TopLevelLogicalConnectivesNotAllowedError,
-  TopLevelWildcardsNotAllowedError,
-  UnrecognizedInterpreterError
-}
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
 final case class EvaluateResult(cost: Cost, errors: Vector[Throwable])
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
@@ -1,0 +1,128 @@
+package coop.rchain.rholang.interpreter
+
+import java.io.{Reader, StringReader}
+
+import cats.effect.Sync
+import cats.implicits._
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.models.Connective.ConnectiveInstance
+import coop.rchain.models.Par
+import coop.rchain.models.rholang.implicits.VectorPar
+import coop.rchain.models.rholang.sorter.Sortable
+import coop.rchain.rholang.interpreter.accounting.Cost
+import coop.rchain.rholang.interpreter.errors.{
+  LexerError,
+  OutOfPhlogistonsError,
+  ParserError,
+  SyntaxError,
+  TopLevelFreeVariablesNotAllowedError,
+  TopLevelLogicalConnectivesNotAllowedError,
+  TopLevelWildcardsNotAllowedError,
+  UnrecognizedInterpreterError
+}
+import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+
+trait ParBuilder[F[_]] {
+  def buildNormalizedTerm(source: String): F[Par]
+
+  def buildNormalizedTerm(reader: Reader): F[Par]
+
+  def buildPar(proc: Proc): F[Par]
+}
+
+object ParBuilder {
+
+  def apply[F[_]](implicit parBuilder: ParBuilder[F]): ParBuilder[F] = parBuilder
+
+  implicit def parBuilder[F[_]](implicit F: Sync[F]): ParBuilder[F] = new ParBuilder[F] {
+    def buildNormalizedTerm(source: String): F[Par] =
+      buildNormalizedTerm(new StringReader(source))
+
+    def buildNormalizedTerm(reader: Reader): F[Par] =
+      for {
+        proc <- buildAST(reader)
+        par  <- buildPar(proc)
+      } yield par
+
+    def buildPar(proc: Proc): F[Par] =
+      for {
+        par       <- normalizeTerm(proc)
+        sortedPar <- Sortable[Par].sortMatch(par)
+      } yield sortedPar.term
+
+    private def buildAST(reader: Reader): F[Proc] =
+      for {
+        lexer  <- lexer(reader)
+        parser <- parser(lexer)
+        proc <- F.delay(parser.pProc()).adaptError {
+                 case ex: Exception if ex.getMessage.startsWith("Syntax error") =>
+                   SyntaxError(ex.getMessage)
+                 case er: Error
+                     if er.getMessage.startsWith("Unterminated string at EOF, beginning at") =>
+                   LexerError(er.getMessage)
+                 case er: Error if er.getMessage.startsWith("Illegal Character") =>
+                   LexerError(er.getMessage)
+                 case er: Error if er.getMessage.startsWith("Unterminated string on line") =>
+                   LexerError(er.getMessage)
+                 case th: Throwable => UnrecognizedInterpreterError(th)
+               }
+      } yield proc
+
+    private def normalizeTerm(term: Proc): F[Par] =
+      ProcNormalizeMatcher
+        .normalizeMatch[F](
+          term,
+          ProcVisitInputs(VectorPar(), IndexMapChain[VarSort](), DebruijnLevelMap[VarSort]())
+        )
+        .flatMap { normalizedTerm =>
+          if (normalizedTerm.knownFree.count > 0) {
+            if (normalizedTerm.knownFree.wildcards.isEmpty && normalizedTerm.knownFree.logicalConnectives.isEmpty) {
+              val topLevelFreeList = normalizedTerm.knownFree.env.map {
+                case (name, (_, _, line, col)) => s"$name at $line:$col"
+              }
+              F.raiseError(
+                TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString("", ", ", ""))
+              )
+            } else if (normalizedTerm.knownFree.logicalConnectives.nonEmpty) {
+              def connectiveInstanceToString(conn: ConnectiveInstance): String =
+                if (conn.isConnAndBody) "/\\ (conjunction)"
+                else if (conn.isConnOrBody) "\\/ (disjunction)"
+                else if (conn.isConnNotBody) "~ (negation)"
+                else conn.toString
+
+              val connectives = normalizedTerm.knownFree.logicalConnectives
+                .map {
+                  case (connType, line, col) =>
+                    s"${connectiveInstanceToString(connType)} at $line:$col"
+                }
+                .mkString("", ", ", "")
+              F.raiseError(TopLevelLogicalConnectivesNotAllowedError(connectives))
+            } else {
+              val topLevelWildcardList = normalizedTerm.knownFree.wildcards.map {
+                case (line, col) => s"_ (wildcard) at $line:$col"
+              }
+              F.raiseError(
+                TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", ""))
+              )
+            }
+          } else normalizedTerm.pure[F].map(_.par)
+        }
+
+    /**
+      * @note In lieu of a purely functional wrapper around the lexer and parser
+      *       [[F.adaptError]] is used as a catch-all for errors thrown in their
+      *       constructors.
+      */
+    private def lexer(fileReader: Reader): F[Yylex] =
+      F.delay(new Yylex(fileReader)).adaptError {
+        case th: Throwable => LexerError("Lexer construction error: " + th.getMessage)
+      }
+
+    private def parser(lexer: Yylex): F[parser] =
+      F.delay(new parser(lexer, lexer.getSymbolFactory)).adaptError {
+        case th: Throwable => ParserError("Parser construction error: " + th.getMessage)
+      }
+  }
+
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
@@ -4,24 +4,13 @@ import java.io.{Reader, StringReader}
 
 import cats.effect.Sync
 import cats.implicits._
-import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Connective.ConnectiveInstance
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sorter.Sortable
-import coop.rchain.rholang.interpreter.accounting.Cost
-import coop.rchain.rholang.interpreter.errors.{
-  LexerError,
-  OutOfPhlogistonsError,
-  ParserError,
-  SyntaxError,
-  TopLevelFreeVariablesNotAllowedError,
-  TopLevelLogicalConnectivesNotAllowedError,
-  TopLevelWildcardsNotAllowedError,
-  UnrecognizedInterpreterError
-}
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
 
 trait ParBuilder[F[_]] {
   def buildNormalizedTerm(source: String): F[Par]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -130,7 +130,7 @@ object RholangCLI {
 
     val source = reader(fileName)
 
-    Interpreter[Coeval]
+    ParBuilder[Coeval]
       .buildNormalizedTerm(source)
       .runAttempt
       .fold(_.printStackTrace(Console.err), processTerm)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -83,18 +83,19 @@ object SystemProcesses {
       private def illegalArgumentException(msg: String): F[Unit] =
         F.raiseError(new IllegalArgumentException(msg))
 
-      def verifySignatureContract(name : String,
-                                  algorithm : (Array[Byte], Array[Byte], Array[Byte]) => Boolean)
-      : (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
+      def verifySignatureContract(
+          name: String,
+          algorithm: (Array[Byte], Array[Byte], Array[Byte]) => Boolean
+      ): (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case isContractCall(
-          produce,
-          Seq(
-            RhoType.ByteArray(data),
-            RhoType.ByteArray(signature),
-            RhoType.ByteArray(pub),
-            ack
-          )
-        ) =>
+            produce,
+            Seq(
+              RhoType.ByteArray(data),
+              RhoType.ByteArray(signature),
+              RhoType.ByteArray(pub),
+              ack
+            )
+            ) =>
           for {
             verified <- F.fromTry(Try(algorithm(data, signature, pub)))
             _        <- produce(Seq(RhoType.Bool(verified)), ack)
@@ -105,9 +106,10 @@ object SystemProcesses {
           )
       }
 
-      def hashContract(name : String,
-                       algorithm : Array[Byte] => Array[Byte])
-      : (Seq[ListParWithRandomAndPhlos], Int) => F[Unit]= {
+      def hashContract(
+          name: String,
+          algorithm: Array[Byte] => Array[Byte]
+      ): (Seq[ListParWithRandomAndPhlos], Int) => F[Unit] = {
         case isContractCall(produce, Seq(RhoType.ByteArray(input), ack)) =>
           for {
             hash <- F.fromTry(Try(algorithm(input)))
@@ -183,7 +185,10 @@ object SystemProcesses {
         case isContractCall(produce, Seq(ack)) =>
           for {
             params <- shortLeashParams.getParams
-            _ <-produce(Seq(params.codeHash, params.phloRate, params.userId, params.timestamp), ack)
+            _ <- produce(
+                  Seq(params.codeHash, params.phloRate, params.userId, params.timestamp),
+                  ack
+                )
           } yield ()
         case _ =>
           illegalArgumentException("deployParameters expects only a return channel")

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang
 
 import coop.rchain.models.PrettyPrinted
-import coop.rchain.rholang.interpreter.Interpreter
+import coop.rchain.rholang.interpreter.ParBuilder
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
 import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
 import monix.eval.Coeval
@@ -20,7 +20,7 @@ class ProcGenTest extends FlatSpec with PropertyChecks with Matchers {
   it should "generate correct procs that are normalized successfully" in {
 
     forAll { p: PrettyPrinted[Proc] =>
-      Interpreter[Coeval].buildPar(p.value).apply
+      ParBuilder[Coeval].buildPar(p.value).apply
     }
   }
 
@@ -31,7 +31,7 @@ class ProcGenTest extends FlatSpec with PropertyChecks with Matchers {
       ProcGen.procShrinker
         .shrink(original.value)
         .headOption
-        .map(shrinked => Interpreter[Coeval].buildPar(shrinked).apply)
+        .map(shrinked => ParBuilder[Coeval].buildPar(shrinked).apply)
         .getOrElse(true)
 
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -8,7 +8,7 @@ import coop.rchain.models._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.StackSafetySpec.findMaxRecursionDepth
-import coop.rchain.rholang.interpreter.{Interpreter, PrettyPrinter}
+import coop.rchain.rholang.interpreter.{Interpreter, ParBuilder, PrettyPrinter}
 import coop.rchain.rspace.Serialize
 import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
@@ -187,7 +187,7 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
          |""".stripMargin
 
     isolateStackOverflow {
-      val ast = Interpreter[Coeval].buildNormalizedTerm(rho).value()
+      val ast = ParBuilder[Coeval].buildNormalizedTerm(rho).value()
       PrettyPrinter().buildString(ast)
       checkSuccess(rho) {
         mkRuntime(tmpPrefix, mapSize).use { runtime =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpolateRholang.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpolateRholang.scala
@@ -42,5 +42,5 @@ object InterpolateRholang {
     * @return term after interpolation
     */
   def interpolate(term: String, interpolateMap: Map[String, Par]): Coeval[Par] =
-    Interpreter[Coeval].buildNormalizedTerm(term).map(Interpolate.interpolate(_, interpolateMap))
+    ParBuilder[Coeval].buildNormalizedTerm(term).map(Interpolate.interpolate(_, interpolateMap))
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class LexerTest extends FlatSpec with Matchers {
 
   def attemptMkTerm(input: String): Either[Throwable, Par] =
-    Interpreter[Coeval].buildNormalizedTerm(input).runAttempt()
+    ParBuilder[Coeval].buildNormalizedTerm(input).runAttempt()
 
   "Lexer" should "return LexerError for unterminated string at EOF" in {
     val attempt = attemptMkTerm("""{{ @"ack!(0) }}""")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -59,7 +59,7 @@ class CollectMatcherSpec extends FlatSpec with Matchers {
     IndexMapChain[VarSort]().newBindings(List(("P", ProcSort, 0, 0), ("x", NameSort, 0, 0))),
     DebruijnLevelMap[VarSort]()
   )
-  def getNormalizedPar(rho: String): Par = Interpreter[Coeval].buildNormalizedTerm(rho).value()
+  def getNormalizedPar(rho: String): Par = ParBuilder[Coeval].buildNormalizedTerm(rho).value()
   def assertEqualNormalized(rho1: String, rho2: String): Assertion =
     assert(getNormalizedPar(rho1) == getNormalizedPar(rho2))
 
@@ -426,45 +426,45 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PSend" should "Not compile if data contains negation" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(~1) }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""new x in { x!(~1) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains conjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(1 /\ 2) }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""new x in { x!(1 /\ 2) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains disjunction" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""new x in { x!(1 \/ 2) }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""new x in { x!(1 \/ 2) }""").value()
     }
   }
 
   "PSend" should "Not compile if data contains wildcard" in {
     an[TopLevelWildcardsNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""@"x"!(_)""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""@"x"!(_)""").value()
     }
   }
 
   "PSend" should "Not compile if data contains free variable" in {
     an[TopLevelFreeVariablesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""@"x"!(y)""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""@"x"!(y)""").value()
     }
   }
 
   "PSend" should "not compile if name contains connectives" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""@{Nil /\ Nil}!(1)""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""@{Nil /\ Nil}!(1)""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""@{Nil \/ Nil}!(1)""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""@{Nil \/ Nil}!(1)""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""@{~Nil}!(1)""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""@{~Nil}!(1)""").value()
     }
   }
 
@@ -784,45 +784,45 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PInput" should "not compile when connectives are used in the channel" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm("""for(x <- @{Nil \/ Nil}){ Nil }""")
         .value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm("""for(x <- @{Nil /\ Nil}){ Nil }""")
         .value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @{~Nil}){ Nil }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""for(x <- @{~Nil}){ Nil }""").value()
     }
   }
 
   "PInput" should "not compile when connectives are the top level expression in the body" in {
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 /\ 2 }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 /\ 2 }""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 \/ 2 }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""for(x <- @Nil){ 1 \/ 2 }""").value()
     }
 
     an[TopLevelLogicalConnectivesNotAllowedError] should be thrownBy {
-      Interpreter[Coeval].buildNormalizedTerm("""for(x <- @Nil){ ~1 }""").value()
+      ParBuilder[Coeval].buildNormalizedTerm("""for(x <- @Nil){ ~1 }""").value()
     }
   }
 
   "PInput" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
     an[PatternReceiveError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm("""new x in { for(@{Nil \/ Nil} <- x) { Nil } }""")
         .value()
     }
 
     an[PatternReceiveError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm("""new x in { for(@{~Nil} <- x) { Nil } }""")
         .value()
     }
@@ -830,7 +830,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PInput" should "compile when logical AND is used in the pattern of the receive" in {
     noException should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm("""new x in { for(@{Nil /\ Nil} <- x) { Nil } }""")
         .value()
     }
@@ -838,7 +838,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PContr" should "not compile when logical OR or NOT is used in the pattern of the receive" in {
     an[PatternReceiveError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ {Nil \/ Nil}}) = { Nil } }""")
         )
@@ -846,7 +846,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
     }
 
     an[PatternReceiveError] should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ ~Nil}) = { Nil } }""")
         )
@@ -856,7 +856,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PContr" should "compile when logical AND is used in the pattern of the receive" in {
     noException should be thrownBy {
-      Interpreter[Coeval]
+      ParBuilder[Coeval]
         .buildNormalizedTerm(
           new StringReader("""new x in { contract x(@{ y /\ {Nil /\ Nil}}) = { Nil } }""")
         )
@@ -1518,7 +1518,7 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
            }
          }
        """
-        Interpreter[Coeval].buildNormalizedTerm(rho).value()
+        ParBuilder[Coeval].buildNormalizedTerm(rho).value()
         assert(true)
       } catch {
         case e: Throwable =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -834,7 +834,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     assert(parseAndPrint(prettySource) == prettySource)
 
   private def parseAndPrint(source: String): String = PrettyPrinter().buildString(
-    Interpreter[Coeval].buildNormalizedTerm(new StringReader(source)).runAttempt().right.get
+    ParBuilder[Coeval].buildNormalizedTerm(new StringReader(source)).runAttempt().right.get
   )
 }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -210,7 +210,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         r!("0897e9533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2".hexToBytes(), "result2")
       }"""
 
-    val lookupPar: Par = Interpreter[Coeval].buildNormalizedTerm(lookupString).value
+    val lookupPar: Par = ParBuilder[Coeval].buildNormalizedTerm(lookupString).value
 
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(1)
@@ -269,7 +269,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
             }
           }
         }"""
-    val insertPar: Par                      = Interpreter[Coeval].buildNormalizedTerm(insertString).value
+    val insertPar: Par                      = ParBuilder[Coeval].buildNormalizedTerm(insertString).value
     val completePar                         = insertPar.addSends(rootSend, branchSend)
     implicit val evalRand: Blake2b512Random = baseRand.splitByte(2)
 
@@ -385,7 +385,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           }
         }
       }"""
-    val deletePar: Par                  = Interpreter[Coeval].buildNormalizedTerm(deleteString).value
+    val deletePar: Par                  = ParBuilder[Coeval].buildNormalizedTerm(deleteString).value
     val completePar                     = deletePar.addSends(rootSend, fullBranchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(3)
 
@@ -475,7 +475,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         r!(`rho:id:bnm61w3958nhr5u6wx9yx6c4js77hcxmftc9o1yo4y9yxdu7g8bnq3`, "result0") |
         r!(`rho:id:bnmzm3i5h5hj8qyoh3ubmbu57zuqn56xrk175bw5sf6kook9bq8ny3`, "result1")
       }"""
-    val lookupPar: Par                  = Interpreter[Coeval].buildNormalizedTerm(lookupString).value
+    val lookupPar: Par                  = ParBuilder[Coeval].buildNormalizedTerm(lookupString).value
     val completePar                     = lookupPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(4)
     val newRand                         = rand.splitByte(2)
@@ -500,7 +500,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           rl!(uri, "result1")
         }
       }"""
-    val registerPar: Par                = Interpreter[Coeval].buildNormalizedTerm(registerString).value
+    val registerPar: Par                = ParBuilder[Coeval].buildNormalizedTerm(registerString).value
     val completePar                     = registerPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(5)
     val newRand                         = rand.splitByte(2)
@@ -593,7 +593,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
           }
         }
       }"""
-    val registerPar: Par                = Interpreter[Coeval].buildNormalizedTerm(registerString).value
+    val registerPar: Par                = ParBuilder[Coeval].buildNormalizedTerm(registerString).value
     val completePar                     = registerPar.addSends(rootSend, branchSend)
     implicit val rand: Blake2b512Random = baseRand.splitByte(6)
     val newRand                         = rand.splitByte(2)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -39,7 +39,7 @@ class CostAccountingPropertyTest extends FlatSpec with PropertyChecks with Match
 
   implicit val taskExecutionDuration: FiniteDuration = 5.seconds
 
-  def cost(proc: Proc): Cost = Cost(Interpreter[Coeval].buildPar(proc).apply)
+  def cost(proc: Proc): Cost = Cost(ParBuilder[Coeval].buildPar(proc).apply)
 
   behavior of "Cost accounting in Reducer"
 
@@ -87,15 +87,12 @@ object CostAccountingPropertyTest {
       .map { _.sliding(2).forall { case List(r1, r2) => r1 == r2 } }
       .runSyncUnsafe(duration)
 
-  def execute[F[_]: Sync](runtime: Runtime[F], p: Proc): F[Long] = {
-    val interpreter = Interpreter[F]
-
+  def execute[F[_]: Sync](runtime: Runtime[F], p: Proc): F[Long] =
     for {
-      program <- interpreter.buildPar(p)
+      program <- ParBuilder[F].buildPar(p)
       res     <- evaluatePar(runtime, program)
       cost    = res.cost
     } yield cost.value
-  }
 
   def evaluatePar[F[_]: Sync](
       runtime: Runtime[F],

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -10,7 +10,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
-import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
+import coop.rchain.rholang.interpreter.{ParBuilder, Runtime}
 import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.StoreType
 import coop.rchain.shared.Log
@@ -35,7 +35,7 @@ trait EvalBenchStateBase {
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
 
-    term = Interpreter[Coeval]
+    term = ParBuilder[Coeval]
       .buildNormalizedTerm(resourceFileReader(rhoScriptSource))
       .runAttempt match {
       case Right(par) => Some(par)

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -12,7 +12,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.accounting._
-import coop.rchain.rholang.interpreter.{Interpreter, Runtime}
+import coop.rchain.rholang.interpreter.{ParBuilder, Runtime}
 import coop.rchain.shared.{Log, StoreType}
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
@@ -53,14 +53,14 @@ abstract class WideBenchBaseState {
   @Setup(value = Level.Iteration)
   def doSetup(): Unit = {
     deleteOldStorage(dbDir)
-    setupTerm = Interpreter[Coeval]
+    setupTerm = ParBuilder[Coeval]
       .buildNormalizedTerm(resourceFileReader(rhoSetupScriptPath))
       .runAttempt match {
       case Right(par) => Some(par)
       case Left(err)  => throw err
     }
 
-    term = Interpreter[Coeval]
+    term = ParBuilder[Coeval]
       .buildNormalizedTerm(resourceFileReader(rhoScriptSource))
       .runAttempt match {
       case Right(par) => Some(par)


### PR DESCRIPTION
## Overview
Extracts functions which create instances of `Par` into a separate type class. This segregates concerns and should allow for easier introduction of the `_cost` capability into the `Interpreter`

### JIRA ticket:
Prerequisite for: https://rchain.atlassian.net/browse/RCHAIN-2984


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
