### PR TITLE
RCHAIN-3007 Fix

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -81,7 +81,7 @@ object CommUtil {
       _     <- TransportLayer[F].stream(peers, msg)
     } yield ()
 
-  def requestApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Log: Time: Metrics: TransportLayer: ConnectionsCell: ErrorHandler: PacketHandler: RPConfAsk](
+  def requestApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Log: Time: Metrics: TransportLayer: ConnectionsCell: ErrorHandler: RPConfAsk](
       delay: FiniteDuration
   ): F[Unit] = {
     val request = ApprovedBlockRequest("PleaseSendMeAnApprovedBlock").toByteString

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -263,13 +263,16 @@ class CasperPacketHandlerSpec extends WordSpec {
 
         val validators = Set(ByteString.copyFrom(validatorPk))
 
+        val theInit = Task.unit
+
         // interval and duration don't really matter since we don't require and signs from validators
         val bootstrapCasper =
           new BootstrapCasperHandler[Task](
             runtimeManager,
             shardId,
             Some(validatorId),
-            validators
+            validators,
+            theInit
           )
 
         val approvedBlockCandidate = ApprovedBlockCandidate(block = Some(genesis))


### PR DESCRIPTION
## Overview
Postpone Casper initialization until comm receives first connection

CasperPacketHandler is seriously the weirdest set of design choices
I've seen in the past few weeks. I'm planning to refactor hell out of
it in incoming days, but for now this commit is focusing on fixing bug
RCHAIN-3007.

After this change, when initializing node (which is not bootstrap),
casper code will not be triggered until comm layer grabs at least
first connection. In 99% of cases the flow of the program will be
following:

1. node boots up
2. node puts bootstrap into its kademlia table
3. node waits for connection to bootstrap node
4. once connection is established:
a) CasperPachketHandler protocol is run (init method)
b) casperloop is triggered

After this change, new node will start catching up with the network
even if nobody is proposing to it (or other nodes) at the given moment

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3007

