### PR TITLE
Improve handling of unavailable peers

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -173,12 +173,12 @@ object HashSetCasperTestNode {
       _ <- nodes.traverse(
             m =>
               n.connectionsCell
-                .flatModify(_.addConn[F](m.local)(Monad[F], n.logEff, n.metricEff))
+                .flatModify(_.addConn[F](m.local))
           )
       _ <- nodes.traverse(
             m =>
               m.connectionsCell
-                .flatModify(_.addConn[F](n.local)(Monad[F], m.logEff, m.metricEff))
+                .flatModify(_.addConn[F](n.local))
           )
     } yield nodes ++ (n :: Nil)
   }
@@ -359,7 +359,7 @@ object HashSetCasperTestNode {
               f.flatMap(
                 _ =>
                   n.connectionsCell.flatModify(
-                    _.addConn[F](m.local)(Monad[F], n.logEff, n.metricEff)
+                    _.addConn[F](m.local)
                   )
               )
           }

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -86,12 +86,11 @@ object Connect {
   def clearConnections[F[_]: Sync: Monad: Time: ConnectionsCell: RPConfAsk: TransportLayer: Log: Metrics]
     : F[Int] = {
 
-    def sendHeartbeat(peer: PeerNode): F[(PeerNode, CommErr[Protocol])] =
+    def sendHeartbeat(peer: PeerNode): F[(PeerNode, CommErr[Unit])] =
       for {
-        local   <- RPConfAsk[F].reader(_.local)
-        timeout <- RPConfAsk[F].reader(_.defaultTimeout)
-        hb      = heartbeat(local)
-        res     <- TransportLayer[F].roundTrip(peer, hb, timeout)
+        local <- RPConfAsk[F].reader(_.local)
+        hb    = heartbeat(local)
+        res   <- TransportLayer[F].send(peer, hb)
       } yield (peer, res)
 
     def clear(connections: Connections): F[Int] =

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -153,6 +153,10 @@ class GrpcTransportClient(
             withClient(peer, timeout(packet), enforce = false)(
               GrpcTransport.stream(peer, Blob(sender, packet), messageSize)
             ).flatMap {
+              case Left(error @ PeerUnavailable(_)) =>
+                log.debug(
+                  s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
+                )
               case Left(error) =>
                 log.error(
                   s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -82,7 +82,7 @@ object EffectsTestInstances {
     def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]] =
       Sync[F].delay {
         requests = requests :+ Request(peer, msg)
-        Right(())
+        reqresp.get.apply(peer).apply(msg).void
       }
 
     def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]] = Sync[F].delay {

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -43,7 +43,7 @@ rnode {
     map-size = 1G
 
     # Maximum number of peers allowed to connect to the node
-    max-connections = 500
+    max-connections = 20
 
     # Maximum size of message that can be sent via transport layer
     max-message-size = 256K


### PR DESCRIPTION
## Overview
- Log streaming to unavailable clients with DEBUG level instead of ERROR
- Change default server max-connections from 500 to 20
- Split adding and removing connections from reporting metrics and logging
- Clear connections with a send heartbeat instead of a roundtrip.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-840

### Notes
We are preparing to remove roundtrips from comm.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
