### PR TITLE
Add gRPC API max message size option

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -78,6 +78,9 @@ rnode {
 
     # Port used for external gRPC API
     port-internal = 40402
+
+    # Maximum size of message that can be sent via gRPC API
+    max-message-size = 4M
   }
 
   # Casper configuration

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -44,19 +44,19 @@ object Main {
       new GrpcReplClient(
         conf.grpcServer.host,
         conf.grpcServer.portInternal,
-        conf.server.maxMessageSize
+        conf.grpcServer.maxMessageSize
       )
     implicit val diagnosticsService: GrpcDiagnosticsService =
       new diagnostics.client.GrpcDiagnosticsService(
         conf.grpcServer.host,
         conf.grpcServer.portInternal,
-        conf.server.maxMessageSize
+        conf.grpcServer.maxMessageSize
       )
     implicit val deployService: GrpcDeployService =
       new GrpcDeployService(
         conf.grpcServer.host,
         conf.grpcServer.portExternal,
-        conf.server.maxMessageSize
+        conf.grpcServer.maxMessageSize
       )
 
     implicit val time: Time[Task] = effects.time

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -113,7 +113,7 @@ class NodeRuntime private[node] (
                               port,
                               conf.tls.certificate,
                               conf.tls.key,
-                              conf.server.maxMessageSize,
+                              conf.grpcServer.maxMessageSize,
                               conf.server.dataDir.resolve("tmp").resolve("comm"),
                               conf.server.messageConsumers
                             )(grpcScheduler, log)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -153,6 +153,14 @@ object Configuration {
           server.maxMessageSize
         )
       )
+    val grpcMaxMessageSize: Int =
+      Math.max(
+        MaxMessageSizeMinimumValue,
+        Math.min(
+          MaxMessageSizeMaximumValue,
+          grpcServer.maxMessageSize
+        )
+      )
 
     new Configuration(
       config,
@@ -160,7 +168,7 @@ object Configuration {
       profile,
       configFile,
       server.copy(maxMessageSize = maxMessageSize),
-      grpcServer,
+      grpcServer.copy(maxMessageSize = grpcMaxMessageSize),
       tls,
       casper.copy(createGenesis = server.standalone),
       blockStorage,

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -26,6 +26,7 @@ object ConfigMapper {
       add(keys.Host, options.grpcHost)
       add(keys.PortExternal, options.grpcPort)
       add(keys.PortInternal, options.grpcPortInternal)
+      add(keys.MaxMessageSize, options.grpcMaxMessageSize)
     }
 
     if (options.subcommand.contains(options.run)) {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -143,6 +143,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val grpcHost =
     opt[String](descr = "Hostname or IP of node on which gRPC service is running.")
 
+  val grpcMaxMessageSize =
+    opt[Int](descr = "Maximum size of message that can be sent via gRPC API")
+
   val diagnostics = new Subcommand("diagnostics") {
     descr("Node diagnostics")
   }

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -147,9 +147,10 @@ object GrpcServer {
   val Key = s"${Configuration.Key}.grpc"
 
   object keys {
-    val Host         = "host"
-    val PortExternal = "port-external"
-    val PortInternal = "port-internal"
+    val Host           = "host"
+    val PortExternal   = "port-external"
+    val PortInternal   = "port-internal"
+    val MaxMessageSize = "max-message-size"
   }
 
   def fromConfig(config: Config): configuration.GrpcServer = {
@@ -158,7 +159,8 @@ object GrpcServer {
     configuration.GrpcServer(
       host = grpc.getString(keys.Host),
       portExternal = grpc.getInt(keys.PortExternal),
-      portInternal = grpc.getInt(keys.PortInternal)
+      portInternal = grpc.getInt(keys.PortInternal),
+      maxMessageSize = grpc.getBytes(keys.MaxMessageSize).toInt
     )
   }
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -30,7 +30,8 @@ final case class Server(
 final case class GrpcServer(
     host: String,
     portExternal: Int,
-    portInternal: Int
+    portInternal: Int,
+    maxMessageSize: Int
 )
 
 final case class Tls(

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -126,7 +126,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
       Seq(
         "--grpc-host localhost",
         "--grpc-port 40401",
-        "--grpc-port-internal 40402"
+        "--grpc-port-internal 40402",
+        "--grpc-max-message-size 256"
       ).mkString(" ")
 
     val options = Options(args.split(' '))
@@ -136,7 +137,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
       configuration.GrpcServer(
         "localhost",
         40401,
-        40402
+        40402,
+        256
       )
 
     val grpc = hocon.GrpcServer.fromConfig(config)

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -132,6 +132,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         |    host = localhost
         |    port-external = 40401
         |    port-internal = 40402
+        |    max-message-size = 4M
         |  }
         |}
       """.stripMargin
@@ -140,7 +141,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
       configuration.GrpcServer(
         "localhost",
         40401,
-        40402
+        40402,
+        4 * 1024 * 1024
       )
 
     val grpc = GrpcServer.fromConfig(ConfigFactory.parseString(conf))


### PR DESCRIPTION
## Overview
ATM we use server max message size option for both client and server. However, the API client can't use the `--max-message-size` command line option and uses always the default value for this option. Add gRPC API max message command line option `--grpc-max-message-size`

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3101

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
