### PR TITLE
RCHAIN-3109: Remove E from ISpace

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -48,13 +48,10 @@ class ContractCall[F[_]: Sync](
                         persist = false,
                         sequenceNumber
                       )(matchListPar(Sync[F], cost))
-      _ <- produceResult.fold(
-            _ => Sync[F].raiseError(OutOfPhlogistonsError),
-            _.fold(Sync[F].unit) {
-              case (cont, channels) =>
-                dispatcher.dispatch(unpackCont(cont), channels.map(_.value), cont.sequenceNumber)
-            }
-          )
+      _ <- produceResult.fold(Sync[F].unit) {
+            case (cont, channels) =>
+              dispatcher.dispatch(unpackCont(cont), channels.map(_.value), cont.sequenceNumber)
+          }
     } yield ()
 
   def unapply(contractArgs: (Seq[ListParWithRandom], Int)): Option[(Producer, Seq[Par])] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -260,14 +260,13 @@ class RegistryImpl[F[_]](
 
   private def parByteArray(bs: ByteString): Par = GByteArray(bs)
 
-  private def handleResult[E <: Throwable](
-      resultF: F[Either[E, Option[(TaggedContinuation, Seq[ListParWithRandom], Int)]]]
+  private def handleResult(
+      resultF: F[Option[(TaggedContinuation, Seq[ListParWithRandom], Int)]]
   ): F[Unit] =
     resultF.flatMap({
-      case Right(Some((continuation, dataList, sequenceNumber))) =>
+      case Some((continuation, dataList, sequenceNumber)) =>
         dispatcher.dispatch(continuation, dataList, sequenceNumber)
-      case Right(None) => F.unit
-      case Left(err)   => F.raiseError(err)
+      case None => F.unit
     })
 
   private def singleSend(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -51,9 +51,9 @@ class Runtime[F[_]: Sync] private (
 
 object Runtime {
 
-  type RhoISpace[F[_]]       = TCPARK[F, ISpace]
-  type RhoPureSpace[F[_]]    = TCPARK[F, PureRSpace]
-  type RhoReplayISpace[F[_]] = TCPARK[F, IReplaySpace]
+  type RhoISpace[F[_]]       = TCPARK0[F, ISpace]
+  type RhoPureSpace[F[_]]    = TCPARK0[F, PureRSpace]
+  type RhoReplayISpace[F[_]] = TCPARK1[F, IReplaySpace]
 
   type RhoIStore[F[_]]  = CPAK[F, IStore]
   type RhoContext[F[_]] = CPAK[F, Context]
@@ -65,7 +65,17 @@ object Runtime {
   type CPAK[M[_], F[_[_], _, _, _, _]] =
     F[M, Par, BindPattern, ListParWithRandom, TaggedContinuation]
 
-  type TCPARK[M[_], F[_[_], _, _, _, _, _, _]] =
+  type TCPARK0[M[_], F[_[_], _, _, _, _, _]] =
+    F[
+      M,
+      Par,
+      BindPattern,
+      ListParWithRandom,
+      ListParWithRandom,
+      TaggedContinuation
+    ]
+
+  type TCPARK1[M[_], F[_[_], _, _, _, _, _, _]] =
     F[
       M,
       Par,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -476,7 +476,6 @@ object Runtime {
                   F,
                   Par,
                   BindPattern,
-                  InterpreterError,
                   ListParWithRandom,
                   ListParWithRandom,
                   TaggedContinuation

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -450,18 +450,16 @@ object Runtime {
                        0
                      )(matchListPar(F, cost))
       _ <- spaceResult match {
-            case Right(None) =>
+            case None =>
               replayResult match {
-                case Right(None) => F.unit
-                case Right(Some(_)) =>
+                case None => F.unit
+                case Some(_) =>
                   F.raiseError(
                     new SetupError("Registry insertion in replay fired continuation.")
                   )
-                case Left(err) => F.raiseError(err)
               }
-            case Right(Some(_)) =>
+            case Some(_) =>
               F.raiseError(new SetupError("Registry insertion fired continuation."))
-            case Left(err) => F.raiseError(err)
           }
     } yield ()
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -51,9 +51,9 @@ class Runtime[F[_]: Sync] private (
 
 object Runtime {
 
-  type RhoISpace[F[_]]       = TCPARK0[F, ISpace]
-  type RhoPureSpace[F[_]]    = TCPARK0[F, PureRSpace]
-  type RhoReplayISpace[F[_]] = TCPARK1[F, IReplaySpace]
+  type RhoISpace[F[_]]       = TCPARK[F, ISpace]
+  type RhoPureSpace[F[_]]    = TCPARK[F, PureRSpace]
+  type RhoReplayISpace[F[_]] = TCPARK[F, IReplaySpace]
 
   type RhoIStore[F[_]]  = CPAK[F, IStore]
   type RhoContext[F[_]] = CPAK[F, Context]
@@ -65,22 +65,11 @@ object Runtime {
   type CPAK[M[_], F[_[_], _, _, _, _]] =
     F[M, Par, BindPattern, ListParWithRandom, TaggedContinuation]
 
-  type TCPARK0[M[_], F[_[_], _, _, _, _, _]] =
+  type TCPARK[M[_], F[_[_], _, _, _, _, _]] =
     F[
       M,
       Par,
       BindPattern,
-      ListParWithRandom,
-      ListParWithRandom,
-      TaggedContinuation
-    ]
-
-  type TCPARK1[M[_], F[_[_], _, _, _, _, _, _]] =
-    F[
-      M,
-      Par,
-      BindPattern,
-      InterpreterError,
       ListParWithRandom,
       ListParWithRandom,
       TaggedContinuation

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -484,7 +484,6 @@ object Runtime {
                         F,
                         Par,
                         BindPattern,
-                        InterpreterError,
                         ListParWithRandom,
                         ListParWithRandom,
                         TaggedContinuation

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
@@ -41,13 +41,10 @@ object Tuplespace {
     ): F[Unit] = {
       // TODO: Handle the environment in the store
       def go(
-          res: Either[InterpreterError, Option[
-            (TaggedContinuation, Seq[ListParWithRandom], Int)
-          ]]
+          res: Option[(TaggedContinuation, Seq[ListParWithRandom], Int)]
       ): F[Unit] =
         res match {
-          case Left(oope) => F.raiseError(oope)
-          case Right(Some((continuation, dataList, updatedSequenceNumber))) =>
+          case Some((continuation, dataList, updatedSequenceNumber)) =>
             if (persistent) {
               Parallel
                 .parProduct(
@@ -58,8 +55,7 @@ object Tuplespace {
             } else {
               dispatcher.dispatch(continuation, dataList, updatedSequenceNumber)
             }
-
-          case Right(None) => F.unit
+          case None => F.unit
         }
 
       for {
@@ -79,13 +75,10 @@ object Tuplespace {
         case _ =>
           val (patterns: Seq[BindPattern], sources: Seq[Par]) = binds.unzip
           def go(
-              res: Either[InterpreterError, Option[
-                (TaggedContinuation, Seq[ListParWithRandom], Int)
-              ]]
+              res: Option[(TaggedContinuation, Seq[ListParWithRandom], Int)]
           ): F[Unit] =
             res match {
-              case Left(oope) => F.raiseError(oope)
-              case Right(Some((continuation, dataList, updatedSequenceNumber))) =>
+              case Some((continuation, dataList, updatedSequenceNumber)) =>
                 if (persistent) {
                   Parallel
                     .parProduct(
@@ -96,7 +89,7 @@ object Tuplespace {
                 } else {
                   dispatcher.dispatch(continuation, dataList, updatedSequenceNumber)
                 }
-              case Right(None) => F.unit
+              case None => F.unit
             }
 
           for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/Tuplespace.scala
@@ -26,7 +26,6 @@ object Tuplespace {
         F,
         Par,
         BindPattern,
-        InterpreterError,
         ListParWithRandom,
         ListParWithRandom,
         TaggedContinuation

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -53,7 +53,6 @@ object Resources {
         F,
         Par,
         BindPattern,
-        InterpreterError,
         ListParWithRandom,
         ListParWithRandom,
         TaggedContinuation

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -50,7 +50,6 @@ trait PersistentStoreTester {
         Task,
         Par,
         BindPattern,
-        InterpreterError,
         ListParWithRandom,
         ListParWithRandom,
         TaggedContinuation

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -50,7 +50,6 @@ trait RegistryTester extends PersistentStoreTester {
             Task,
             Par,
             BindPattern,
-            InterpreterError,
             ListParWithRandom,
             ListParWithRandom,
             TaggedContinuation

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -813,7 +813,6 @@ class RholangMethodsCostsSpec
         Task,
         Par,
         BindPattern,
-        InterpreterError,
         ListParWithRandom,
         ListParWithRandom,
         TaggedContinuation

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -127,7 +127,6 @@ object BasicBench {
       Task,
       Par,
       BindPattern,
-      InterpreterError,
       ListParWithRandom,
       ListParWithRandom,
       TaggedContinuation

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -136,7 +136,6 @@ object BasicBench {
           Task,
           Par,
           BindPattern,
-          InterpreterError,
           ListParWithRandom,
           ListParWithRandom,
           TaggedContinuation

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -50,13 +50,13 @@ class BasicBench {
         )(state.matcher)
         .unsafeRunSync
 
-      assert(c1.right.get.isEmpty)
+      assert(c1.isEmpty)
       bh.consume(c1)
 
       val r2 =
         space.produce(state.channels(i), state.data(i), false)(state.matcher).unsafeRunSync
 
-      assert(r2.right.get.nonEmpty)
+      assert(r2.nonEmpty)
       bh.consume(r2)
       if (state.debug) {
         assert(space.store.isEmpty)
@@ -75,7 +75,7 @@ class BasicBench {
       val r2 =
         space.produce(state.channels(i), state.data(i), false)(state.matcher).unsafeRunSync
 
-      assert(r2.right.get.isEmpty)
+      assert(r2.isEmpty)
       bh.consume(r2)
 
       val c1 = space
@@ -87,7 +87,7 @@ class BasicBench {
         )(state.matcher)
         .unsafeRunSync
 
-      assert(c1.right.get.nonEmpty)
+      assert(c1.nonEmpty)
       bh.consume(c1)
       if (state.debug) {
         assert(space.store.isEmpty)

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -26,7 +26,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 @org.openjdk.jmh.annotations.State(Scope.Thread)
 trait RSpaceBench {
 
-  var space: ISpace[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] = null
+  var space: ISpace[Id, Channel, Pattern, Entry, Entry, EntriesCaptor] = null
 
   val channel  = Channel("friends#" + 1.toString)
   val channels = List(channel)

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -49,7 +49,7 @@ trait RSpaceBench {
   def createTask(taskIndex: Int, iterations: Int): Task[Unit] =
     Task.delay {
       for (_ <- 1 to iterations) {
-        val r1 = space.produce(channel, bob, persist = false)
+        val r1 = unpackOption(space.produce(channel, bob, persist = false))
         runK(r1)
         getK(r1).results
       }

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RSpaceBench.scala
@@ -104,7 +104,7 @@ class LMDBBench extends RSpaceBench {
     val context   = Context.create[Id, Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[Id, Channel, Pattern, Entry, EntriesCaptor](context)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+    space = RSpace.create[Id, Channel, Pattern, Entry, Entry, EntriesCaptor](
       testStore,
       Branch.MASTER
     )
@@ -134,7 +134,7 @@ class InMemBench extends RSpaceBench {
     val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
       InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+    space = RSpace.create[Id, Channel, Pattern, Entry, Entry, EntriesCaptor](
       testStore,
       Branch.MASTER
     )
@@ -167,7 +167,7 @@ class MixedBench extends RSpaceBench {
     val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
       InMemoryStore.create(context.trieStore, Branch.MASTER)
     assert(testStore.toMap.isEmpty)
-    space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+    space = RSpace.create[Id, Channel, Pattern, Entry, Entry, EntriesCaptor](
       testStore,
       Branch.MASTER
     )

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -76,7 +76,7 @@ object ReplayRSpaceBench {
       val testStore: IStore[Id, Channel, Pattern, Entry, EntriesCaptor] =
         InMemoryStore.create(context.trieStore, Branch.MASTER)
       assert(testStore.toMap.isEmpty)
-      space = RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      space = RSpace.create[Id, Channel, Pattern, Entry, Entry, EntriesCaptor](
         testStore,
         Branch.MASTER
       )

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -55,7 +55,7 @@ object ReplayRSpaceBench {
 
   abstract class ReplayRSpaceBenchState {
     var space: IdISpace[Channel, Pattern, Entry, Entry, EntriesCaptor] = null
-    var replaySpace: IReplaySpace[cats.Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] =
+    var replaySpace: IReplaySpace[cats.Id, Channel, Pattern, Entry, Entry, EntriesCaptor] =
       null
     implicit val logF: Log[Id]            = new Log.NOPLog[Id]
     implicit val noopMetrics: Metrics[Id] = new metrics.Metrics.MetricsNOP[Id]

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -54,7 +54,7 @@ object ReplayRSpaceBench {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   abstract class ReplayRSpaceBenchState {
-    var space: IdISpace[Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] = null
+    var space: IdISpace[Channel, Pattern, Entry, Entry, EntriesCaptor] = null
     var replaySpace: IReplaySpace[cats.Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor] =
       null
     implicit val logF: Log[Id]            = new Log.NOPLog[Id]

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -80,7 +80,7 @@ object ReplayRSpaceBench {
         testStore,
         Branch.MASTER
       )
-      replaySpace = ReplayRSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      replaySpace = ReplayRSpace.create[Id, Channel, Pattern, Entry, Entry, EntriesCaptor](
         context,
         Branch.REPLAY
       )

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/ReplayRSpaceBench.scala
@@ -27,7 +27,7 @@ class ReplayRSpaceBench {
   @Measurement(iterations = 1)
   def singleProduce(bh: Blackhole, state: ProduceInMemBenchState) = {
     val res = state.replaySpace.produce(state.produceChannel, bob, persist = true)
-    assert(res.right.get.isDefined)
+    assert(res.isDefined)
     bh.consume(res)
   }
 
@@ -44,7 +44,7 @@ class ReplayRSpaceBench {
       state.captor,
       persist = true
     )
-    assert(res.right.get.isDefined)
+    assert(res.isDefined)
     bh.consume(res)
   }
 }

--- a/rspace/src/it/scala/coop/rchain/rspace/ConcurrencyTests.scala
+++ b/rspace/src/it/scala/coop/rchain/rspace/ConcurrencyTests.scala
@@ -11,7 +11,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.Duration
 
 trait ConcurrencyTests
-    extends StorageTestsBase[Coeval, Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    extends StorageTestsBase[Coeval, Channel, Pattern, Entry, EntriesCaptor]
     with TestImplicitHelpers {
 
   def version: String
@@ -34,11 +34,11 @@ trait ConcurrencyTests
             persist = false
           ).apply()
 
-          r1 shouldBe Right(None)
+          r1 shouldBe None
 
           val r2 = space.produce(channel, bob, persist = false).apply()
 
-          r2 shouldBe Right(None)
+          r2 shouldBe None
 
           val r3 = space.produce(channel, bob, persist = false).apply()
 
@@ -106,11 +106,11 @@ trait ConcurrencyTests
         for (_ <- 1 to iterations) {
           val r1 = space.produce(channel, bob, persist = false).apply()
 
-          r1 shouldBe Right(None)
+          r1 shouldBe None
 
           val r2 = space.produce(channel, bob, persist = false).apply()
 
-          r2 shouldBe Right(None)
+          r2 shouldBe None
 
           val r3 = space
             .consume(
@@ -162,14 +162,14 @@ trait ConcurrencyTests
 
 class InMemoryStoreConcurrencyTests
     extends InMemoryStoreStorageExamplesTestsBase[Coeval]
-    with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with ConcurrencyTests {
   override def version: String = "InMemory"
 }
 
 class LMDBStoreConcurrencyTestsWithTls
     extends LMDBStoreStorageExamplesTestBase[Coeval]
-      with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+      with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with ConcurrencyTests {
   override def version: String = "LMDB with TLS"
 
@@ -178,7 +178,7 @@ class LMDBStoreConcurrencyTestsWithTls
 
 class LMDBStoreConcurrencyTestsNoTls
     extends LMDBStoreStorageExamplesTestBase[Coeval]
-      with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+      with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with ConcurrencyTests {
 
   override def version: String = "LMDB NO_TLS"

--- a/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import coop.rchain.rspace.trace._
 import coop.rchain.rspace.internal._
 
-trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
+trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, A, R, K] {
 
   private[rspace] val replayData: ReplayData = ReplayData.empty
 

--- a/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import coop.rchain.rspace.trace._
 import coop.rchain.rspace.internal._
 
-trait IReplaySpace[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, A, R, K] {
+trait IReplaySpace[F[_], C, P, A, R, K] extends ISpace[F, C, P, A, R, K] {
 
   private[rspace] val replayData: ReplayData = ReplayData.empty
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -18,12 +18,11 @@ final case class ContResult[C, P, R](
   *
   * @tparam C a type representing a channel
   * @tparam P a type representing a pattern
-  * @tparam E a type representing an illegal state in matching algorithm
   * @tparam A a type representing an arbitrary piece of data
   * @tparam R a type representing a match result
   * @tparam K a type representing a continuation
   */
-trait ISpace[F[_], C, P, E, A, R, K] {
+trait ISpace[F[_], C, P, A, R, K] {
 
   /** Searches the store for data matching all the given patterns at the given channels.
     *
@@ -122,5 +121,5 @@ trait ISpace[F[_], C, P, E, A, R, K] {
 }
 
 object ISpace {
-  type IdISpace[C, P, E, A, R, K] = ISpace[Id, C, P, E, A, R, K]
+  type IdISpace[C, P, A, R, K] = ISpace[Id, C, P, A, R, K]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -56,7 +56,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
       sequenceNumber: Int = 0
   )(
       implicit m: Match[F, P, A, R]
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
       implicit m: Match[F, P, A, R]
@@ -87,7 +87,7 @@ trait ISpace[F[_], C, P, E, A, R, K] {
     */
   def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int = 0)(
       implicit m: Match[F, P, A, R]
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
   /** Creates a checkpoint.
     *

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -22,7 +22,7 @@ object A {
   def main(args: Array[String]): Unit = {}
 }
 
-class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
+class RSpace[F[_], C, P, A, R, K] private[rspace] (
     store: IStore[F, C, P, A, K],
     branch: Branch
 )(
@@ -453,7 +453,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
 
 object RSpace {
 
-  def create[F[_], C, P, E, A, R, K](context: Context[F, C, P, A, K], branch: Branch)(
+  def create[F[_], C, P, A, R, K](context: Context[F, C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
@@ -483,7 +483,7 @@ object RSpace {
     }
   }
 
-  def create[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(
+  def create[F[_], C, P, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
@@ -502,7 +502,7 @@ object RSpace {
     implicit val codecK: Codec[K] = sk.toCodec
 
     val space: ISpace[F, C, P, A, R, K] =
-      new RSpace[F, C, P, E, A, R, K](store, branch)
+      new RSpace[F, C, P, A, R, K](store, branch)
 
     /*
      * history.initialize returns true if the history trie contains no root (i.e. is empty).

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -37,7 +37,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
 ) extends RSpaceOps[F, C, P, E, A, R, K](store, branch)
-    with ISpace[F, C, P, E, A, R, K] {
+    with ISpace[F, C, P, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]
 
@@ -464,7 +464,7 @@ object RSpace {
       contextShift: ContextShift[F],
       scheduler: ExecutionContext,
       metricsF: Metrics[F]
-  ): F[ISpace[F, C, P, E, A, R, K]] = {
+  ): F[ISpace[F, C, P, A, R, K]] = {
     type InMemTXN    = InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]]
     type ByteBuffTXN = Txn[ByteBuffer]
 
@@ -494,14 +494,14 @@ object RSpace {
       contextShift: ContextShift[F],
       scheduler: ExecutionContext,
       metricsF: Metrics[F]
-  ): F[ISpace[F, C, P, E, A, R, K]] = {
+  ): F[ISpace[F, C, P, A, R, K]] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
     implicit val codecA: Codec[A] = sa.toCodec
     implicit val codecK: Codec[K] = sk.toCodec
 
-    val space: ISpace[F, C, P, E, A, R, K] =
+    val space: ISpace[F, C, P, A, R, K] =
       new RSpace[F, C, P, E, A, R, K](store, branch)
 
     /*

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -36,7 +36,7 @@ class RSpace[F[_], C, P, E, A, R, K] private[rspace] (
     contextShift: ContextShift[F],
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
-) extends RSpaceOps[F, C, P, E, A, R, K](store, branch)
+) extends RSpaceOps[F, C, P, A, R, K](store, branch)
     with ISpace[F, C, P, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -4,7 +4,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
 import coop.rchain.catscontrib._
-import ski._
+import coop.rchain.catscontrib.ski._
 import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
 import coop.rchain.rspace.history.{Branch, Leaf}
 import coop.rchain.rspace.internal._
@@ -33,11 +33,13 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
 
   private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF()
 
+  type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[R]])]
+
   protected[this] def consumeLockF(
       channels: Seq[C]
   )(
-      thunk: => F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
-  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] = {
+      thunk: => F[MaybeActionResult]
+  ): F[MaybeActionResult] = {
     val hashes = channels.map(ch => StableHashProvider.hash(ch))
     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
   }
@@ -54,8 +56,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
   protected[this] def produceLockF(
       channel: C
   )(
-      thunk: => F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
-  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
+      thunk: => F[MaybeActionResult]
+  ): F[MaybeActionResult] =
     lockF.acquire(Seq(StableHashProvider.hash(channel)))(
       () =>
         store.withReadTxnF { txn =>

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -36,8 +36,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
   protected[this] def consumeLockF(
       channels: Seq[C]
   )(
-      thunk: => F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] = {
+      thunk: => F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] = {
     val hashes = channels.map(ch => StableHashProvider.hash(ch))
     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
   }
@@ -54,8 +54,8 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
   protected[this] def produceLockF(
       channel: C
   )(
-      thunk: => F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
+      thunk: => F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
     lockF.acquire(Seq(StableHashProvider.hash(channel)))(
       () =>
         store.withReadTxnF { txn =>

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
 
-abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
+abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
     val store: IStore[F, C, P, A, K],
     val branch: Branch
 )(

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -25,7 +25,7 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, E, A, R, K](
     serializeP: Serialize[P],
     serializeK: Serialize[K],
     logF: Log[F]
-) extends SpaceMatcher[F, C, P, E, A, R, K] {
+) extends SpaceMatcher[F, C, P, A, R, K] {
 
   implicit val codecC = serializeC.toCodec
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 
-class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(
+class ReplayRSpace[F[_], C, P, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
@@ -427,7 +427,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
 
 object ReplayRSpace {
 
-  def create[F[_], C, P, E, A, R, K](context: Context[F, C, P, A, K], branch: Branch)(
+  def create[F[_], C, P, A, R, K](context: Context[F, C, P, A, K], branch: Branch)(
       implicit
       sc: Serialize[C],
       sp: Serialize[P],
@@ -438,7 +438,7 @@ object ReplayRSpace {
       contextShift: ContextShift[F],
       scheduler: ExecutionContext,
       metricsF: Metrics[F]
-  ): F[ReplayRSpace[F, C, P, E, A, R, K]] = {
+  ): F[ReplayRSpace[F, C, P, A, R, K]] = {
 
     implicit val codecC: Codec[C] = sc.toCodec
     implicit val codecP: Codec[P] = sp.toCodec
@@ -456,7 +456,7 @@ object ReplayRSpace {
         LockFreeInMemoryStore.create(mixedContext.trieStore, branch)
     }
 
-    val replaySpace = new ReplayRSpace[F, C, P, E, A, R, K](mainStore, branch)
+    val replaySpace = new ReplayRSpace[F, C, P, A, R, K](mainStore, branch)
 
     /*
      * history.initialize returns true if the history trie contains no root (i.e. is empty).

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -28,7 +28,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
     contextShift: ContextShift[F],
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
-) extends RSpaceOps[F, C, P, E, A, R, K](store, branch)
+) extends RSpaceOps[F, C, P, A, R, K](store, branch)
     with IReplaySpace[F, C, P, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -29,7 +29,7 @@ class ReplayRSpace[F[_], C, P, E, A, R, K](store: IStore[F, C, P, A, K], branch:
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
 ) extends RSpaceOps[F, C, P, E, A, R, K](store, branch)
-    with IReplaySpace[F, C, P, E, A, R, K] {
+    with IReplaySpace[F, C, P, A, R, K] {
 
   override protected[this] val logger: Logger = Logger[this.type]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -22,7 +22,7 @@ import scala.concurrent.SyncVar
   * @tparam R a type representing a match result
   * @tparam K a type representing a continuation
   */
-private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, E, A, R, K] {
+private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, A, R, K] {
 
   /**
     * A store which satisfies the [[IStore]] interface.

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -17,12 +17,11 @@ import scala.concurrent.SyncVar
   *
   * @tparam C a type representing a channel
   * @tparam P a type representing a pattern
-  * @tparam E a type representing an illegal state in matching algorithm
   * @tparam A a type representing an arbitrary piece of data
   * @tparam R a type representing a match result
   * @tparam K a type representing a continuation
   */
-private[rspace] trait SpaceMatcher[F[_], C, P, E, A, R, K] extends ISpace[F, C, P, A, R, K] {
+private[rspace] trait SpaceMatcher[F[_], C, P, A, R, K] extends ISpace[F, C, P, A, R, K] {
 
   /**
     * A store which satisfies the [[IStore]] interface.

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -222,15 +222,13 @@ object AddressBookExample {
           Seq(CityMatch(city = "Crystal Lake")),
           new Printer,
           persist = true
-        )
-        .right
-        .get // it should be fine to do that -- type of left side is Nothing (no invalid states)
+        ) // it should be fine to do that -- type of left side is Nothing (no invalid states)
 
     assert(cres.isEmpty)
 
-    val pres1 = space.produce(Channel("friends"), alice, persist = false).right.get
-    val pres2 = space.produce(Channel("friends"), bob, persist = false).right.get
-    val pres3 = space.produce(Channel("friends"), carol, persist = false).right.get
+    val pres1 = space.produce(Channel("friends"), alice, persist = false)
+    val pres2 = space.produce(Channel("friends"), bob, persist = false)
+    val pres3 = space.produce(Channel("friends"), carol, persist = false)
 
     assert(pres1.nonEmpty)
     assert(pres2.nonEmpty)
@@ -257,9 +255,9 @@ object AddressBookExample {
 
     Console.printf("\nExample Two: Let's produce and then consume...\n")
 
-    val pres1 = space.produce(Channel("friends"), alice, persist = false).right.get
-    val pres2 = space.produce(Channel("friends"), bob, persist = false).right.get
-    val pres3 = space.produce(Channel("friends"), carol, persist = false).right.get
+    val pres1 = space.produce(Channel("friends"), alice, persist = false)
+    val pres2 = space.produce(Channel("friends"), bob, persist = false)
+    val pres3 = space.produce(Channel("friends"), carol, persist = false)
 
     assert(pres1.isEmpty)
     assert(pres2.isEmpty)
@@ -273,8 +271,6 @@ object AddressBookExample {
           new Printer,
           persist = false
         )
-        .right
-        .get
 
     val cres1 = consumer()
     val cres2 = consumer()
@@ -302,8 +298,6 @@ object AddressBookExample {
           new Printer,
           persist = false
         )
-        .right
-        .get
 
     assert(cres.isEmpty)
 
@@ -311,7 +305,7 @@ object AddressBookExample {
     val checkpointHash = space.createCheckpoint().root
 
     def produceAlice(): Option[(Printer, Seq[Entry], Int)] =
-      space.produce(Channel("friends"), alice, persist = false).right.get
+      unpackOption(space.produce(Channel("friends"), alice, persist = false))
 
     println("Rollback example: First produce result should return some data")
     assert(produceAlice.isDefined)

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -331,7 +331,7 @@ object AddressBookExample {
   }
 
   private[this] def withSpace(
-      f: IdISpace[Channel, Pattern, Nothing, Entry, Entry, Printer] => Unit
+      f: IdISpace[Channel, Pattern, Entry, Entry, Printer] => Unit
   ) = {
 
     implicit val log: Log[Id]          = Log.log

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -211,7 +211,7 @@ object AddressBookExample {
     val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
     val space =
-      RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
+      RSpace.create[Id, Channel, Pattern, Entry, Entry, Printer](context, Branch.MASTER)
 
     Console.printf("\nExample One: Let's consume and then produce...\n")
 
@@ -251,7 +251,7 @@ object AddressBookExample {
     val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
 
     val space =
-      RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
+      RSpace.create[Id, Channel, Pattern, Entry, Entry, Printer](context, Branch.MASTER)
 
     Console.printf("\nExample Two: Let's produce and then consume...\n")
 
@@ -342,7 +342,7 @@ object AddressBookExample {
     // Let's define our store
     val context = Context.create[Id, Channel, Pattern, Entry, Printer](storePath, 1024L * 1024L)
     val space =
-      RSpace.create[Id, Channel, Pattern, Nothing, Entry, Entry, Printer](context, Branch.MASTER)
+      RSpace.create[Id, Channel, Pattern, Entry, Entry, Printer](context, Branch.MASTER)
     try {
       f(space)
     } finally {

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -7,7 +7,7 @@ import coop.rchain.rspace._
 
 import scala.collection.immutable.Seq
 
-trait PureRSpace[F[_], C, P, E, A, R, K] {
+trait PureRSpace[F[_], C, P, A, R, K] {
   def consume(
       channels: Seq[C],
       patterns: Seq[P],
@@ -37,9 +37,9 @@ object PureRSpace {
 
   final class PureRSpaceApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
     def of[C, P, E, A, R, K](
-        space: ISpace[F, C, P, E, A, R, K]
-    )(implicit mat: Match[F, P, A, R]): PureRSpace[F, C, P, E, A, R, K] =
-      new PureRSpace[F, C, P, E, A, R, K] {
+        space: ISpace[F, C, P, A, R, K]
+    )(implicit mat: Match[F, P, A, R]): PureRSpace[F, C, P, A, R, K] =
+      new PureRSpace[F, C, P, A, R, K] {
         def consume(
             channels: Seq[C],
             patterns: Seq[P],

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -14,7 +14,7 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
       continuation: K,
       persist: Boolean,
       sequenceNumber: Int = 0
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[R])]]
 
@@ -23,7 +23,7 @@ trait PureRSpace[F[_], C, P, E, A, R, K] {
       data: A,
       persist: Boolean,
       sequenceNumber: Int = 0
-  ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
 
   def createCheckpoint(): F[Checkpoint]
 
@@ -46,7 +46,7 @@ object PureRSpace {
             continuation: K,
             persist: Boolean,
             sequenceNumber: Int
-        ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
+        ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
           space.consume(channels, patterns, continuation, persist, sequenceNumber)
 
         def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[R])]] =
@@ -57,7 +57,7 @@ object PureRSpace {
             data: A,
             persist: Boolean,
             sequenceNumber: Int
-        ): F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
+        ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]] =
           space.produce(channel, data, persist, sequenceNumber)
 
         def createCheckpoint(): F[Checkpoint] = space.createCheckpoint()

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -36,7 +36,7 @@ object PureRSpace {
   def apply[F[_]](implicit F: Sync[F]): PureRSpaceApplyBuilders[F] = new PureRSpaceApplyBuilders(F)
 
   final class PureRSpaceApplyBuilders[F[_]](val F: Sync[F]) extends AnyVal {
-    def of[C, P, E, A, R, K](
+    def of[C, P, A, R, K](
         space: ISpace[F, C, P, A, R, K]
     )(implicit mat: Match[F, P, A, R]): PureRSpace[F, C, P, A, R, K] =
       new PureRSpace[F, C, P, A, R, K] {

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -18,7 +18,7 @@ package object util {
   ): Either[E, Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
-  implicit def unpackEither[F[_], C, P, E, K, R](
+  implicit def unpackEitherF[F[_], C, P, E, K, R](
       v: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
   )(implicit ev: Functor[F]): F[Either[E, Option[(K, Seq[R], Int)]]] =
     ev.map(v)(_.map(unpackOption))
@@ -27,6 +27,11 @@ package object util {
       v: Option[(ContResult[C, P, K], Seq[Result[R]])]
   ): Option[(K, Seq[R], Int)] =
     v.map(unpackTuple)
+
+  implicit def unpackOptionF[F[_], C, P, K, R](
+      v: F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+  )(implicit ev: Functor[F]): F[Option[(K, Seq[R], Int)]] =
+    ev.map(v)(unpackOption)
 
   implicit def unpackTuple[C, P, K, R](v: (ContResult[C, P, K], Seq[Result[R]])): (K, Seq[R], Int) =
     v match {
@@ -40,16 +45,16 @@ package object util {
   /**
     * Extracts a continuation from a produce result
     */
-  def getK[A, K](t: Option[(K, A)]): K =
+  def getK[A, K](t: Option[(K, A, Int)]): K =
     t.map(_._1).get
 
-  def getK[A, K](e: Either[_, Option[(K, A)]]): K =
+  def getK[A, K](e: Either[_, Option[(K, A, Int)]]): K =
     e.map(_.map(_._1).get).right.get
 
   /** Runs a continuation with the accompanying data
     */
-  def runK[T](e: Either[Nothing, Option[((T) => Unit, T, Int)]]): Unit =
-    e.right.get.foreach { case (k, data, _) => k(data) }
+  def runK[T](e: Option[((T) => Unit, T, Int)]): Unit =
+    e.foreach { case (k, data, _) => k(data) }
 
   /** Runs a list of continuations with the accompanying data
     */

--- a/rspace/src/main/tut/Tutorial.md
+++ b/rspace/src/main/tut/Tutorial.md
@@ -190,13 +190,12 @@ Here is the definition of the `Match` type class.
   * Type class for matching patterns with data.
   *
   * @tparam P A type representing patterns
-  * @tparam E A type representing illegal state
   * @tparam A A type representing data
   * @tparam R A type representing a match result
   */
-trait Match[P, E, A, R] {
+trait Match[F[_], P, A, R] {
 
-  def get(p: P, a: A): Either[E, Option[R]]
+  def get(p: P, a: A): F[Option[R]]
 }
 ```
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.Seq
 
 //noinspection ZeroIndexToHead
 trait HistoryActionsTests[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
@@ -530,7 +530,7 @@ trait HistoryActionsTests[F[_]]
 }
 
 trait LegacyHistoryActionsTests
-    extends StorageTestsBase[Coeval, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[Coeval, String, Pattern, String, StringsCaptor]
     with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
@@ -549,14 +549,14 @@ class MixedStoreHistoryActionsTests
     extends MixedStoreTestsBase[Coeval]
     with HistoryActionsTests[Coeval]
     with LegacyHistoryActionsTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
 class LMDBStoreHistoryActionsTests
     extends LMDBStoreTestsBase[Coeval]
     with HistoryActionsTests[Coeval]
     with LegacyHistoryActionsTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
 class InMemStoreHistoryActionsTests
     extends InMemoryStoreTestsBase[Coeval]
     with HistoryActionsTests[Coeval]
     with LegacyHistoryActionsTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -243,7 +243,7 @@ trait HistoryActionsTests[F[_]]
 
       for {
         r1         <- space.consume(channels, List(Wildcard), new StringsCaptor, persist = false)
-        _          = r1 shouldBe Right(None)
+        _          = r1 shouldBe None
         r2         <- space.produce(channels.head, "datum", persist = false)
         _          = r2 shouldBe defined
         _          = history.lookup(space.store.trieStore, space.store.trieBranch, channelsHash) shouldBe None

--- a/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/IStoreTests.scala
@@ -15,7 +15,7 @@ import org.scalatest.AppendedClues
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 trait IStoreTests
-    extends StorageTestsBase[Coeval, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[Coeval, String, Pattern, String, StringsCaptor]
     with GeneratorDrivenPropertyChecks
     with AppendedClues {
 
@@ -300,12 +300,12 @@ trait IStoreTests
 class InMemoryStoreTests
     extends InMemoryStoreTestsBase[Coeval]
     with IStoreTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
 class LMDBStoreTests
     extends LMDBStoreTestsBase[Coeval]
     with IStoreTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
 class MixedStoreTests
     extends MixedStoreTestsBase[Coeval]
     with IStoreTests
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]

--- a/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/JoinOperationsTests.scala
@@ -5,8 +5,7 @@ import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.internal._
 import monix.eval.Coeval
 
-trait JoinOperationsTests
-    extends StorageTestsBase[Coeval, String, Pattern, Nothing, String, StringsCaptor] {
+trait JoinOperationsTests extends StorageTestsBase[Coeval, String, Pattern, String, StringsCaptor] {
 
   "joins" should "remove joins if no PsK" in withTestSpace { space =>
     val store = space.store

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -962,7 +962,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
       .unsafeRunSync
     val replaySpace =
       ReplayRSpace
-        .create[Task, C, P, E, A, A, K](context, Branch.REPLAY)(
+        .create[Task, C, P, A, A, K](context, Branch.REPLAY)(
           sc,
           sp,
           sa,
@@ -1005,7 +1005,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
     val context = Context.createMixed[Task, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
     val space   = RSpace.create[Task, C, P, A, A, K](context, Branch.MASTER).unsafeRunSync
     val replaySpace =
-      ReplayRSpace.create[Task, C, P, E, A, A, K](context, Branch.REPLAY).unsafeRunSync
+      ReplayRSpace.create[Task, C, P, A, A, K](context, Branch.REPLAY).unsafeRunSync
 
     try {
       f(space, replaySpace).unsafeRunSync
@@ -1035,7 +1035,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
 
     val ctx: Context[Task, C, P, A, K] = Context.createInMemory()
     val space                          = RSpace.create[Task, C, P, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
-    val replaySpace                    = ReplayRSpace.create[Task, C, P, E, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
+    val replaySpace                    = ReplayRSpace.create[Task, C, P, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
 
     try {
       f(space, replaySpace).unsafeRunSync
@@ -1078,7 +1078,7 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
           throw new RuntimeException("Couldn't write to underlying store")
       }
 
-    val replaySpace = new ReplayRSpace[Task, C, P, E, A, A, K](store, Branch.REPLAY)
+    val replaySpace = new ReplayRSpace[Task, C, P, A, A, K](store, Branch.REPLAY)
 
     try {
       f(space, replaySpace).unsafeRunSync

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -38,7 +38,7 @@ trait ReplayRSpaceTests
   implicit val log: Log[Task] = new Log.NOPLog[Task]
 
   def consumeMany[C, P, A, R, K](
-      space: ISpace[Task, C, P, Nothing, A, R, K],
+      space: ISpace[Task, C, P, A, R, K],
       range: Range,
       shuffle: Boolean,
       channelsCreator: Int => List[C],
@@ -59,7 +59,7 @@ trait ReplayRSpaceTests
     }
 
   def produceMany[C, P, A, R, K](
-      space: ISpace[Task, C, P, Nothing, A, R, K],
+      space: ISpace[Task, C, P, A, R, K],
       range: Range,
       shuffle: Boolean,
       channelCreator: Int => C,
@@ -918,7 +918,7 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
   }
 
   def withTestSpaces[S](
-      f: (ISpace[Task, C, P, E, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -932,7 +932,7 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
 trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, E, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -989,7 +989,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
 trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, E, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -1021,7 +1021,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
 trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, E, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -1049,7 +1049,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
 trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, E, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -53,9 +53,8 @@ trait ReplayRSpaceTests
       space
         .consume(channelsCreator(i), patterns, continuationCreator(i), persist)
         .map { r =>
-          val unpacked = r.right.get
           logger.debug("Finished consume {}", i)
-          unpacked
+          r
         }
     }
 
@@ -72,9 +71,8 @@ trait ReplayRSpaceTests
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started produce {}", i)
       space.produce(channelCreator(i), datumCreator(i), persist).map { r =>
-        val unpacked = r.right.get
         logger.debug("Finished produce {}", i)
-        unpacked
+        r
       }
     }
 
@@ -109,7 +107,7 @@ trait ReplayRSpaceTests
         resultProduce <- space.produce(channels(0), datum, false)
         rigPont       <- space.createCheckpoint()
 
-        _ = resultConsume shouldBe Right(None)
+        _ = resultConsume shouldBe None
         _ = resultProduce shouldBe defined
 
         _ <- replaySpace.rig(emptyPoint.root, rigPont.log)
@@ -118,7 +116,7 @@ trait ReplayRSpaceTests
         replayResultProduce <- replaySpace.produce(channels(0), datum, false)
         finalPoint          <- space.createCheckpoint()
 
-        _ = replayResultConsume shouldBe Right(None)
+        _ = replayResultConsume shouldBe None
         _ = replayResultProduce shouldBe resultProduce
         _ = finalPoint.root shouldBe rigPont.root
         _ = replaySpace.replayData shouldBe empty
@@ -758,14 +756,14 @@ trait ReplayRSpaceTests
         emptyPoint <- space.createCheckpoint()
 
         consume1 <- space.consume(channels, patterns, continuation, false)
-        _        = consume1 shouldBe Right(None)
+        _        = consume1 shouldBe None
 
         rigPoint <- space.createCheckpoint()
 
         _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
 
         consume2 <- replaySpace.consume(channels, patterns, continuation, false)
-        _        = consume2 shouldBe Right(None)
+        _        = consume2 shouldBe None
 
         replayStore = replaySpace.store
 
@@ -798,14 +796,14 @@ trait ReplayRSpaceTests
         emptyPoint <- space.createCheckpoint()
 
         consume1 <- space.consume(channels, patterns, continuation, false)
-        _        = consume1 shouldBe Right(None)
+        _        = consume1 shouldBe None
 
         rigPoint <- space.createCheckpoint()
 
         _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
 
         consume2 <- replaySpace.consume(channels, patterns, continuation, false)
-        _        = consume2 shouldBe Right(None)
+        _        = consume2 shouldBe None
 
         replayStore = replaySpace.store
 
@@ -853,7 +851,7 @@ trait ReplayRSpaceTests
     }
 
   "replay" should "not allow for ambiguous executions" in withTestSpaces { (space, replaySpace) =>
-    val noMatch                 = Right(None)
+    val noMatch                 = None
     val channel1                = "ch1"
     val channel2                = "ch2"
     val key1                    = List(channel1, channel2)
@@ -880,13 +878,11 @@ trait ReplayRSpaceTests
       _ <- space.produce(channel2, data1, false, 0) shouldBeF noMatch
 
       _ <- space
-            .consume(key1, patterns, continuation1, false, 0)
-            .map(_.right.get) shouldNotBeF Option.empty
+            .consume(key1, patterns, continuation1, false, 0) shouldNotBeF Option.empty
       //continuation1 produces data1 on ch2
       _ <- space.produce(channel2, data1, false, 1) shouldBeF noMatch
       _ <- space
-            .consume(key1, patterns, continuation2, false, 0)
-            .map(_.right.get) shouldNotBeF Option.empty
+            .consume(key1, patterns, continuation2, false, 0) shouldNotBeF Option.empty
       //continuation2 produces data2 on ch2
       _         <- space.produce(channel2, data2, false, 2) shouldBeF noMatch
       afterPlay <- space.createCheckpoint()
@@ -901,12 +897,10 @@ trait ReplayRSpaceTests
       _ <- replaySpace.consume(key1, patterns, continuation2, false, 0) shouldBeF noMatch
 
       _ <- replaySpace
-            .consume(key1, patterns, continuation1, false, 0)
-            .map(_.right.get) shouldNotBeF Option.empty
+            .consume(key1, patterns, continuation1, false, 0) shouldNotBeF Option.empty
       //continuation1 produces data1 on ch2
       _ <- replaySpace
-            .produce(channel2, data1, false, 1)
-            .map(_.right.get) shouldNotBeF Option.empty //matches continuation2
+            .produce(channel2, data1, false, 1) shouldNotBeF Option.empty //matches continuation2
       //continuation2 produces data2 on ch2
       _ <- replaySpace.produce(channel2, data2, false, 1) shouldBeF noMatch
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -30,7 +30,7 @@ object SchedulerPools {
 
 //noinspection ZeroIndexToHead,NameBooleanParameters
 trait ReplayRSpaceTests
-    extends ReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
+    extends ReplayRSpaceTestsBase[String, Pattern, String, String]
     with TestImplicitHelpers {
 
   import SchedulerPools.global
@@ -909,7 +909,7 @@ trait ReplayRSpaceTests
   }
 }
 
-trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
+trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionValues {
   val logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   override def withFixture(test: NoArgTest): Outcome = {
@@ -929,7 +929,7 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
   ): S
 }
 
-trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -986,7 +986,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
   }
 }
 
-trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -1018,7 +1018,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
   }
 }
 
-trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -1046,7 +1046,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
   }
 }
 
-trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
+trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -948,7 +948,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
     val dbDir   = Files.createTempDirectory("rchain-storage-test-")
     val context = Context.create[Task, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
     val space = RSpace
-      .create[Task, C, P, E, A, A, K](context, Branch.MASTER)(
+      .create[Task, C, P, A, A, K](context, Branch.MASTER)(
         sc,
         sp,
         sa,
@@ -1003,7 +1003,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
 
     val dbDir   = Files.createTempDirectory("rchain-storage-test-")
     val context = Context.createMixed[Task, C, P, A, K](dbDir, 1024L * 1024L * 4096L)
-    val space   = RSpace.create[Task, C, P, E, A, A, K](context, Branch.MASTER).unsafeRunSync
+    val space   = RSpace.create[Task, C, P, A, A, K](context, Branch.MASTER).unsafeRunSync
     val replaySpace =
       ReplayRSpace.create[Task, C, P, E, A, A, K](context, Branch.REPLAY).unsafeRunSync
 
@@ -1034,7 +1034,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
     implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
     val ctx: Context[Task, C, P, A, K] = Context.createInMemory()
-    val space                          = RSpace.create[Task, C, P, E, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
+    val space                          = RSpace.create[Task, C, P, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
     val replaySpace                    = ReplayRSpace.create[Task, C, P, E, A, A, K](ctx, Branch.REPLAY).unsafeRunSync
 
     try {
@@ -1067,7 +1067,7 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsB
         trieStore,
         Branch.REPLAY
       )
-    val space = RSpace.create[Task, C, P, E, A, A, K](mainStore, Branch.REPLAY).unsafeRunSync
+    val space = RSpace.create[Task, C, P, A, A, K](mainStore, Branch.REPLAY).unsafeRunSync
     val store =
       new InMemoryStore[Task, InMemTransaction[history.State[Blake2b256Hash, GNAT[C, P, A, K]]], C, P, A, K](
         trieStore,

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -929,7 +929,7 @@ trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with Opti
   ): S
 }
 
-trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+trait LMDBReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -986,7 +986,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
   }
 }
 
-trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+trait MixedReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -1091,7 +1091,7 @@ trait FaultyStoreReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase
 }
 
 class LMDBReplayRSpaceTests
-    extends LMDBReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
+    extends LMDBReplayRSpaceTestsBase[String, Pattern, String, String]
     with ReplayRSpaceTests {}
 
 class InMemoryReplayRSpaceTests

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1018,7 +1018,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
   }
 }
 
-trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -1095,7 +1095,7 @@ class LMDBReplayRSpaceTests
     with ReplayRSpaceTests {}
 
 class InMemoryReplayRSpaceTests
-    extends InMemoryReplayRSpaceTestsBase[String, Pattern, Nothing, String, String]
+    extends InMemoryReplayRSpaceTestsBase[String, Pattern, String, String]
     with ReplayRSpaceTests {}
 
 class FaultyReplayRSpaceTests

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1046,7 +1046,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
   }
 }
 
-trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+trait FaultyStoreReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
       f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
@@ -1099,7 +1099,7 @@ class InMemoryReplayRSpaceTests
     with ReplayRSpaceTests {}
 
 class FaultyReplayRSpaceTests
-    extends FaultyStoreReplayRSpaceTestsBase[String, Pattern, Nothing, String, String] {
+    extends FaultyStoreReplayRSpaceTestsBase[String, Pattern, String, String] {
   import SchedulerPools.global
 
   "an exception thrown inside a consume" should "not make replay rspace unresponsive" in

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -918,7 +918,7 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
   }
 
   def withTestSpaces[S](
-      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -932,7 +932,7 @@ trait ReplayRSpaceTestsBase[C, P, E, A, K] extends FlatSpec with Matchers with O
 trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -989,7 +989,7 @@ trait LMDBReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, 
 trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -1021,7 +1021,7 @@ trait MixedReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C,
 trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],
@@ -1049,7 +1049,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase
 trait FaultyStoreReplayRSpaceTestsBase[C, P, E, A, K] extends ReplayRSpaceTestsBase[C, P, E, A, K] {
   import SchedulerPools.global
   override def withTestSpaces[S](
-      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, E, A, A, K]) => Task[S]
+      f: (ISpace[Task, C, P, A, A, K], IReplaySpace[Task, C, P, A, A, K]) => Task[S]
   )(
       implicit
       sc: Serialize[C],

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -27,7 +27,7 @@ import org.scalatest.enablers.Definition
 import scala.util.Random
 
 trait StorageActionsTests[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
@@ -1298,7 +1298,7 @@ trait StorageActionsTests[F[_]]
 
 }
 trait MonadicStorageActionsTests[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
@@ -1350,7 +1350,7 @@ trait MonadicStorageActionsTests[F[_]]
 }
 
 trait LegacyStorageActionsTests
-    extends StorageTestsBase[Coeval, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[Coeval, String, Pattern, String, StringsCaptor]
     with TestImplicitHelpers
     with GeneratorDrivenPropertyChecks
     with Checkers {
@@ -1399,7 +1399,7 @@ trait LegacyStorageActionsTests
   }
 }
 
-trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, A, R, K] {
+trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, R, K] {
   override implicit val concurrentF: Concurrent[Id] =
     coop.rchain.catscontrib.effect.implicits.concurrentId
   override implicit val logF: Log[Id]         = Log.log[Id]
@@ -1411,7 +1411,7 @@ trait IdTests[C, P, A, R, K] extends StorageTestsBase[Id, C, P, A, R, K] {
   override def run[RES](f: Id[RES]): RES = f
 }
 
-trait CoevalTests[C, P, A, R, K] extends StorageTestsBase[Coeval, C, P, A, R, K] {
+trait CoevalTests[C, P, R, K] extends StorageTestsBase[Coeval, C, P, R, K] {
   override implicit val concurrentF: Concurrent[Coeval] =
     coop.rchain.rspace.test.concurrentCoeval
   override implicit val logF: Log[Coeval]         = Log.log[Coeval]
@@ -1424,7 +1424,7 @@ trait CoevalTests[C, P, A, R, K] extends StorageTestsBase[Coeval, C, P, A, R, K]
 }
 
 import monix.eval.Task
-trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, A, R, K] {
+trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, R, K] {
   import coop.rchain.catscontrib.TaskContrib._
   import scala.concurrent.ExecutionContext
 
@@ -1468,13 +1468,13 @@ class MixedStoreStorageActionsTests
 
 class LegacyInMemoryStoreStorageActionsTests
     extends InMemoryStoreTestsBase[Coeval]
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
     with JoinOperationsTests
     with LegacyStorageActionsTests
 
 class LegacyLMDBStoreActionsTests
     extends LMDBStoreTestsBase[Coeval]
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
     with StorageActionsTests[Coeval]
     with JoinOperationsTests
     with BeforeAndAfterAll
@@ -1482,7 +1482,7 @@ class LegacyLMDBStoreActionsTests
 
 class LegacyMixedStoreActionsTests
     extends MixedStoreTestsBase[Coeval]
-    with CoevalTests[String, Pattern, Nothing, String, StringsCaptor]
+    with CoevalTests[String, Pattern, String, StringsCaptor]
     with StorageActionsTests[Coeval]
     with JoinOperationsTests
     with BeforeAndAfterAll

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -61,7 +61,7 @@ trait StorageActionsTests[F[_]]
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
 
-      _ = r shouldBe Right(None)
+      _ = r shouldBe None
       //store is not empty - we have 'A' stored
     } yield (store.isEmpty shouldBe false)
   }
@@ -80,7 +80,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum1", false))
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
-      _  = r1 shouldBe Right(None)
+      _  = r1 shouldBe None
       r2 <- space.produce(key.head, "datum2", persist = false)
       _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, keyHash) shouldBe key
@@ -91,7 +91,7 @@ trait StorageActionsTests[F[_]]
             )
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
-      _ = r2 shouldBe Right(None)
+      _ = r2 shouldBe None
       //store is not empty - we have 2 As stored
     } yield (store.isEmpty shouldBe false)
   }
@@ -111,7 +111,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, key) shouldBe Nil
             store.getWaitingContinuation(txn, key) should not be empty
           }
-      _ = r shouldBe Right(None)
+      _ = r shouldBe None
       //there is a continuation stored in the storage
     } yield (store.isEmpty shouldBe false)
   }
@@ -131,7 +131,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, key) shouldBe Nil
             store.getWaitingContinuation(txn, key) should not be empty
           }
-      _ = r shouldBe Right(None)
+      _ = r shouldBe None
       //continuation is left in the storage
     } yield (store.isEmpty shouldBe false)
   }
@@ -150,7 +150,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, key) shouldBe List(Datum.create(key.head, "datum", false))
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       r2 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = false)
       _  = store.isEmpty shouldBe true
@@ -172,9 +172,9 @@ trait StorageActionsTests[F[_]]
       r1 <- space.produce("ch1", "datum1", persist = false)
       r2 <- space.produce("ch1", "datum2", persist = false)
       r3 <- space.produce("ch1", "datum3", persist = false)
-      _  = r1 shouldBe Right(None)
-      _  = r2 shouldBe Right(None)
-      _  = r3 shouldBe Right(None)
+      _  = r1 shouldBe None
+      _  = r2 shouldBe None
+      _  = r3 shouldBe None
       r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
       _  = runK(r4)
       _  = getK(r4).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
@@ -210,7 +210,7 @@ trait StorageActionsTests[F[_]]
             )
             store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
           }
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
       _ <- store.withReadTxnF { txn =>
@@ -225,7 +225,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, consumeKey) shouldBe Nil
             store.getWaitingContinuation(txn, consumeKey) should not be empty
           }
-      _  = r2 shouldBe Right(None)
+      _  = r2 shouldBe None
       r3 <- space.produce(produceKey2.head, "datum2", persist = false)
       _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey1Hash) shouldBe Nil
@@ -270,7 +270,7 @@ trait StorageActionsTests[F[_]]
             )
             store.getWaitingContinuation(txn, produceKey1) shouldBe Nil
           }
-      _  = r1 shouldBe Right(None)
+      _  = r1 shouldBe None
       r2 <- space.produce(produceKey2.head, "datum2", persist = false)
       _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey2Hash) shouldBe produceKey2
@@ -280,7 +280,7 @@ trait StorageActionsTests[F[_]]
             )
             store.getWaitingContinuation(txn, produceKey2) shouldBe Nil
           }
-      _  = r2 shouldBe Right(None)
+      _  = r2 shouldBe None
       r3 <- space.produce(produceKey3.head, "datum3", persist = false)
       _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, produceKey3Hash) shouldBe produceKey3
@@ -290,7 +290,7 @@ trait StorageActionsTests[F[_]]
             )
             store.getWaitingContinuation(txn, produceKey3) shouldBe Nil
           }
-      _  = r3 shouldBe Right(None)
+      _  = r3 shouldBe None
       r4 <- space.consume(List("ch1", "ch2", "ch3"), patterns, new StringsCaptor, persist = false)
       _ <- store.withReadTxnF { txn =>
             store.getChannels(txn, consumeKeyHash) shouldBe Nil
@@ -315,9 +315,9 @@ trait StorageActionsTests[F[_]]
       r1 <- space.produce(key.head, "datum1", persist = false)
       r2 <- space.produce(key.head, "datum2", persist = false)
       r3 <- space.produce(key.head, "datum3", persist = false)
-      _  = r1 shouldBe Right(None)
-      _  = r2 shouldBe Right(None)
-      _  = r3 shouldBe Right(None)
+      _  = r1 shouldBe None
+      _  = r2 shouldBe None
+      _  = r3 shouldBe None
       r4 <- space.consume(key, List(Wildcard), captor, persist = false)
       r5 <- space.consume(key, List(Wildcard), captor, persist = false)
       r6 <- space.consume(key, List(Wildcard), captor, persist = false)
@@ -328,9 +328,9 @@ trait StorageActionsTests[F[_]]
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
       continuations = List(r4, r5, r6)
-      _             = continuations.forall(_.right.get.isDefined) shouldBe true
+      _             = continuations.forall(_.isDefined) shouldBe true
       _ = continuations
-        .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
+        .map(unpackOption)
         .foreach(runK)
       _ = captor.results should contain theSameElementsAs List(
         List("datum3"),
@@ -357,7 +357,7 @@ trait StorageActionsTests[F[_]]
         _  = r3 shouldBe defined
 
         _ = List(r1, r2, r3)
-          .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
+          .map(unpackOption)
           .foreach(runK)
 
         _ = getK(r1).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
@@ -402,7 +402,7 @@ trait StorageActionsTests[F[_]]
       _ = r3 shouldBe defined
 
       _ = List(r1, r2, r3)
-        .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
+        .map(unpackOption)
         .foreach(runK)
 
       _ = getK(r1).results shouldBe List(List("datum1"))
@@ -427,8 +427,8 @@ trait StorageActionsTests[F[_]]
       r2 <- space.produce("ch1", "datum1", persist = false)
       r3 <- space.produce("ch2", "datum2", persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
       _ = r3 shouldBe defined
 
       _ = runK(r3)
@@ -456,8 +456,8 @@ trait StorageActionsTests[F[_]]
       r2 <- space.produce("ch1", "datum1", persist = false)
       r3 <- space.produce("ch1", "datum1", persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
       _ = r3 shouldBe defined
 
       _ = runK(r3)
@@ -492,15 +492,15 @@ trait StorageActionsTests[F[_]]
       r5 <- space.produce("ch1", "datum1", persist = false)
       r6 <- space.produce("ch2", "datum2", persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
-      _ = r3 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
       _ = r4 shouldBe defined
-      _ = r5 shouldBe Right(None)
+      _ = r5 shouldBe None
       _ = r6 shouldBe defined
 
       _ = List(r4, r6)
-        .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
+        .map(unpackOption)
         .foreach(runK)
 
       _ = getK(r4).results should contain theSameElementsAs List(List("datum3", "datum4"))
@@ -523,8 +523,8 @@ trait StorageActionsTests[F[_]]
            )
       r2 <- space.produce("ch1", "datum1", persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
 
       _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1", "ch2")) shouldBe Nil
@@ -561,7 +561,7 @@ trait StorageActionsTests[F[_]]
       r4 <- space.produce("ch2", "datum2", persist = false)
 
       _ = List(r1, r2, r3, r4)
-        .map(unpackEither[Id, String, Pattern, Nothing, StringsCaptor, String])
+        .map(unpackOption)
         .foreach(runK)
 
       _ <- store.withReadTxnF { txn =>
@@ -602,7 +602,7 @@ trait StorageActionsTests[F[_]]
             }
 
         _ = r3 shouldBe defined
-        _ = r4 shouldBe Right(None)
+        _ = r4 shouldBe None
 
         _ = runK(r3)
 
@@ -634,7 +634,7 @@ trait StorageActionsTests[F[_]]
             store.getWaitingContinuation(txn, key) shouldBe Nil
           }
 
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       // Data exists so the write will not "stick"
       r2 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
@@ -655,7 +655,7 @@ trait StorageActionsTests[F[_]]
             store.getData(txn, key) shouldBe Nil
             store.getWaitingContinuation(txn, key) should not be empty
           }
-    } yield (r3 shouldBe Right(None))
+    } yield (r3 shouldBe None)
   }
 
   "producing, doing a persistent consume, and producing again on the same channel" should
@@ -675,7 +675,7 @@ trait StorageActionsTests[F[_]]
               store.getWaitingContinuation(txn, key) shouldBe Nil
             }
 
-        _ = r1 shouldBe Right(None)
+        _ = r1 shouldBe None
 
         // Matching data exists so the write will not "stick"
         r2 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
@@ -698,7 +698,7 @@ trait StorageActionsTests[F[_]]
               store.getWaitingContinuation(txn, key) should not be empty
             }
 
-        _ = r3 shouldBe Right(None)
+        _ = r3 shouldBe None
 
         r4 <- space.produce(key.head, "datum2", persist = false)
 
@@ -728,7 +728,7 @@ trait StorageActionsTests[F[_]]
               store.getWaitingContinuation(txn, List("ch1")) should not be empty
             }
 
-        _ = r1 shouldBe Right(None)
+        _ = r1 shouldBe None
 
         r2 <- space.produce("ch1", "datum1", persist = false)
 
@@ -763,7 +763,7 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       // A matching continuation exists so the write will not "stick"
       r2 <- space.produce("ch1", "datum1", persist = true)
@@ -778,7 +778,7 @@ trait StorageActionsTests[F[_]]
 
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
-      _  = r3 shouldBe Right(None)
+      _  = r3 shouldBe None
       _ <- store.withReadTxnF { txn =>
             store.getData(txn, List("ch1")) shouldBe List(Datum.create("ch1", "datum1", true))
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
@@ -793,7 +793,7 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
-        _ = r1 shouldBe Right(None)
+        _ = r1 shouldBe None
 
         // A matching continuation exists so the write will not "stick"
         r2 <- space.produce("ch1", "datum1", persist = true)
@@ -814,7 +814,7 @@ trait StorageActionsTests[F[_]]
               store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
             }
 
-        _ = r3 shouldBe Right(None)
+        _ = r3 shouldBe None
 
         r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
@@ -841,7 +841,7 @@ trait StorageActionsTests[F[_]]
             store.getWaitingContinuation(txn, List("ch1")) shouldBe Nil
           }
 
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       r2 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
 
@@ -878,9 +878,9 @@ trait StorageActionsTests[F[_]]
       r2 <- space.produce("ch1", "datum2", persist = false)
       r3 <- space.produce("ch1", "datum3", persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
-      _ = r3 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
 
       // Matching data exists so the write will not "stick"
       r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
@@ -937,7 +937,7 @@ trait StorageActionsTests[F[_]]
             store.getWaitingContinuation(txn, List("ch1")) should not be empty
           }
 
-    } yield (r7 shouldBe Right(None))
+    } yield (r7 shouldBe None)
 
   }
 
@@ -948,7 +948,7 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.produce(channel, data = "datum", persist = true)
 
-        _ = r1 shouldBe Right(None)
+        _ = r1 shouldBe None
 
         r2 <- space.consume(
                List(channel, channel),
@@ -973,7 +973,7 @@ trait StorageActionsTests[F[_]]
       for {
         checkpoint0 <- space.createCheckpoint()
         r           <- space.consume(key, patterns, new StringsCaptor, persist = false)
-        _           = r shouldBe Right(None)
+        _           = r shouldBe None
         _           = store.isEmpty shouldBe false
         _           = store.getTrieUpdates.length shouldBe 1
         _           = store.getTrieUpdateCount shouldBe 1
@@ -1005,7 +1005,7 @@ trait StorageActionsTests[F[_]]
               store.getWaitingContinuation(txn, key) should not be empty
             }
 
-        _ = r shouldBe Right(None)
+        _ = r shouldBe None
         _ = store.isEmpty shouldBe false
         _ = store.getTrieUpdates.length shouldBe 1
         _ = store.getTrieUpdateCount shouldBe 1
@@ -1235,7 +1235,7 @@ trait StorageActionsTests[F[_]]
       for {
         r1 <- space.consume(channels, List(Wildcard), new StringsCaptor, persist = false)
 
-        _ = r1 shouldBe Right(None)
+        _ = r1 shouldBe None
 
         r2 <- space.produce(channels.head, "datum", persist = false)
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -19,7 +19,7 @@ import scodec.Codec
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait StorageExamplesTests[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor]
     with TestImplicitHelpers {
 
   "CORE-365: A joined consume on duplicate channels followed by two produces on that channel" should
@@ -280,7 +280,7 @@ trait StorageExamplesTests[F[_]]
 }
 
 abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
@@ -329,7 +329,7 @@ abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
 }
 
 abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Nothing, Entry, EntriesCaptor] {
+    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor] {
 
   override def withTestSpace[R](f: T => F[R]): R = {
 
@@ -367,7 +367,7 @@ abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
 }
 
 abstract class LMDBStoreStorageExamplesTestBase[F[_]]
-    extends StorageTestsBase[F, Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path    = Files.createTempDirectory("rchain-storage-test-")
@@ -403,15 +403,15 @@ abstract class LMDBStoreStorageExamplesTestBase[F[_]]
 
 class InMemoryStoreStorageExamplesTests
     extends InMemoryStoreStorageExamplesTestsBase[Coeval]
-    with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with StorageExamplesTests[Coeval]
 
 class MixedInMemoryStoreStorageExamplesTests
     extends MixedInMemoryStoreStorageExamplesTestsBase[Coeval]
-    with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with StorageExamplesTests[Coeval]
 
 class LMDBStoreStorageExamplesTest
     extends LMDBStoreStorageExamplesTestBase[Coeval]
-    with CoevalTests[Channel, Pattern, Nothing, Entry, EntriesCaptor]
+    with CoevalTests[Channel, Pattern, Entry, EntriesCaptor]
     with StorageExamplesTests[Coeval]

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -34,9 +34,9 @@ trait StorageExamplesTests[F[_]]
                new EntriesCaptor,
                persist = false
              )
-      _  = r1 shouldBe Right(None)
+      _  = r1 shouldBe None
       r2 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r2 shouldBe Right(None)
+      _  = r2 shouldBe None
       r3 <- space.produce(Channel("friends"), bob, persist = false)
       _  = r3 shouldBe defined
       _  = runK(r3)
@@ -50,9 +50,9 @@ trait StorageExamplesTests[F[_]]
 
     for {
       r1 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r1 shouldBe Right(None)
+      _  = r1 shouldBe None
       r2 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r2 shouldBe Right(None)
+      _  = r2 shouldBe None
       r3 <- space
              .consume(
                List(Channel("friends"), Channel("friends")),
@@ -82,11 +82,11 @@ trait StorageExamplesTests[F[_]]
                new EntriesCaptor,
                persist = false
              )
-      _  = r1 shouldBe Right(None)
+      _  = r1 shouldBe None
       r2 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r2 shouldBe Right(None)
+      _  = r2 shouldBe None
       r3 <- space.produce(Channel("friends"), bob, persist = false)
-      _  = r3 shouldBe Right(None)
+      _  = r3 shouldBe None
       r4 <- space.produce(Channel("colleagues"), alice, persist = false)
       _  = r4 shouldBe defined
       _  = runK(r4)
@@ -127,7 +127,7 @@ trait StorageExamplesTests[F[_]]
                new EntriesCaptor,
                persist = false
              )
-      _   = r1 shouldBe Right(None)
+      _   = r1 shouldBe None
       r2  <- space.produce(Channel("friends"), bob, persist = false)
       r3  <- space.produce(Channel("family"), carol, persist = false)
       r4  <- space.produce(Channel("colleagues"), alice, persist = false)
@@ -138,14 +138,14 @@ trait StorageExamplesTests[F[_]]
       r9  <- space.produce(Channel("family"), carol, persist = false)
       r10 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r2 shouldBe Right(None)
-      _ = r3 shouldBe Right(None)
-      _ = r4 shouldBe Right(None)
-      _ = r5 shouldBe Right(None)
-      _ = r6 shouldBe Right(None)
-      _ = r7 shouldBe Right(None)
-      _ = r8 shouldBe Right(None)
-      _ = r9 shouldBe Right(None)
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
+      _ = r4 shouldBe None
+      _ = r5 shouldBe None
+      _ = r6 shouldBe None
+      _ = r7 shouldBe None
+      _ = r8 shouldBe None
+      _ = r9 shouldBe None
       _ = r10 shouldBe defined
 
       _ = runK(r10)
@@ -171,15 +171,15 @@ trait StorageExamplesTests[F[_]]
       r8 <- space.produce(Channel("family"), carol, persist = false)
       r9 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r1 shouldBe Right(None)
-      _ = r2 shouldBe Right(None)
-      _ = r3 shouldBe Right(None)
-      _ = r4 shouldBe Right(None)
-      _ = r5 shouldBe Right(None)
-      _ = r6 shouldBe Right(None)
-      _ = r7 shouldBe Right(None)
-      _ = r8 shouldBe Right(None)
-      _ = r9 shouldBe Right(None)
+      _ = r1 shouldBe None
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
+      _ = r4 shouldBe None
+      _ = r5 shouldBe None
+      _ = r6 shouldBe None
+      _ = r7 shouldBe None
+      _ = r8 shouldBe None
+      _ = r9 shouldBe None
 
       r10 <- space
               .consume(
@@ -249,7 +249,7 @@ trait StorageExamplesTests[F[_]]
                persist = false
              )
 
-      _ = r1 shouldBe Right(None)
+      _ = r1 shouldBe None
 
       r2  <- space.produce(Channel("friends"), bob, persist = false)
       r3  <- space.produce(Channel("family"), carol, persist = false)
@@ -261,14 +261,14 @@ trait StorageExamplesTests[F[_]]
       r9  <- space.produce(Channel("family"), carol, persist = false)
       r10 <- space.produce(Channel("family"), carol, persist = false)
 
-      _ = r2 shouldBe Right(None)
-      _ = r3 shouldBe Right(None)
-      _ = r4 shouldBe Right(None)
-      _ = r5 shouldBe Right(None)
-      _ = r6 shouldBe Right(None)
-      _ = r7 shouldBe Right(None)
-      _ = r8 shouldBe Right(None)
-      _ = r9 shouldBe Right(None)
+      _ = r2 shouldBe None
+      _ = r3 shouldBe None
+      _ = r4 shouldBe None
+      _ = r5 shouldBe None
+      _ = r6 shouldBe None
+      _ = r7 shouldBe None
+      _ = r8 shouldBe None
+      _ = r9 shouldBe None
       _ = r10 shouldBe defined
 
       _ = runK(r10)

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -301,7 +301,7 @@ abstract class MixedInMemoryStoreStorageExamplesTestsBase[F[_]]
       Context.createMixed(dbDir, mapSize)
 
     run(for {
-      testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testSpace <- RSpace.create[F, Channel, Pattern, Entry, Entry, EntriesCaptor](
                     ctx,
                     branch
                   )
@@ -345,7 +345,7 @@ abstract class InMemoryStoreStorageExamplesTestsBase[F[_]]
     val ctx: Context[F, Channel, Pattern, Entry, EntriesCaptor] = Context.createInMemory()
 
     run(for {
-      testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testSpace <- RSpace.create[F, Channel, Pattern, Entry, Entry, EntriesCaptor](
                     ctx,
                     branch
                   )
@@ -378,7 +378,7 @@ abstract class LMDBStoreStorageExamplesTestBase[F[_]]
     val context   = Context.create[F, Channel, Pattern, Entry, EntriesCaptor](dbDir, mapSize, noTls)
     val testStore = LMDBStore.create[F, Channel, Pattern, Entry, EntriesCaptor](context)
     run(for {
-      testSpace <- RSpace.create[F, Channel, Pattern, Nothing, Entry, Entry, EntriesCaptor](
+      testSpace <- RSpace.create[F, Channel, Pattern, Entry, Entry, EntriesCaptor](
                     testStore,
                     Branch.MASTER
                   )

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -24,7 +24,7 @@ import scodec.Codec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
+trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with OptionValues {
   type T = ISpace[F, C, P, A, A, K]
 
   implicit def concurrentF: Concurrent[F]
@@ -137,7 +137,7 @@ trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with 
 }
 
 abstract class InMemoryStoreTestsBase[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   override def withTestSpace[S](f: T => F[S]): S = {
@@ -180,7 +180,7 @@ abstract class InMemoryStoreTestsBase[F[_]]
 }
 
 abstract class LMDBStoreTestsBase[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
@@ -226,7 +226,7 @@ abstract class LMDBStoreTestsBase[F[_]]
 }
 
 abstract class MixedStoreTestsBase[F[_]]
-    extends StorageTestsBase[F, String, Pattern, Nothing, String, StringsCaptor]
+    extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with BeforeAndAfterAll {
 
   val dbDir: Path   = Files.createTempDirectory("rchain-mixed-storage-test-")

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -149,7 +149,7 @@ abstract class InMemoryStoreTestsBase[F[_]]
     val ctx: Context[F, String, Pattern, String, StringsCaptor] = Context.createInMemory()
 
     run(for {
-      testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](
+      testSpace <- RSpace.create[F, String, Pattern, String, String, StringsCaptor](
                     ctx,
                     branch
                   )
@@ -195,7 +195,7 @@ abstract class LMDBStoreTestsBase[F[_]]
     val env        = Context.create[F, String, Pattern, String, StringsCaptor](dbDir, mapSize)
 
     run(for {
-      testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](
+      testSpace <- RSpace.create[F, String, Pattern, String, String, StringsCaptor](
                     env,
                     testBranch
                   )
@@ -241,7 +241,7 @@ abstract class MixedStoreTestsBase[F[_]]
     val env        = Context.createMixed[F, String, Pattern, String, StringsCaptor](dbDir, mapSize)
 
     run(for {
-      testSpace <- RSpace.create[F, String, Pattern, Nothing, String, String, StringsCaptor](
+      testSpace <- RSpace.create[F, String, Pattern, String, String, StringsCaptor](
                     env,
                     testBranch
                   )

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -25,7 +25,7 @@ import scodec.Codec
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait StorageTestsBase[F[_], C, P, E, A, K] extends FlatSpec with Matchers with OptionValues {
-  type T = ISpace[F, C, P, E, A, A, K]
+  type T = ISpace[F, C, P, A, A, K]
 
   implicit def concurrentF: Concurrent[F]
   implicit def logF: Log[F]


### PR DESCRIPTION
## Overview
Since `ISpace` is officially pure, we can move error handling into the abstract effect stack `F`. This PR removes the `Either[E, ...]` wrapper from `ISpace`, removes the `E` from all store instances.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3109
