### PR TITLE
Remove obsolete cost accounting code

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -311,8 +311,7 @@ object Runtime {
     (for {
       costAccounting <- CostAccounting.empty[F]
       runtime <- {
-        implicit val ca: CostAccounting[F] = costAccounting
-        implicit val cost: _cost[F]        = loggingCost(ca, noOpCostLog)
+        implicit val cost: _cost[F] = loggingCost(costAccounting, noOpCostLog)
         create(dataDir, mapSize, storeType, extraSystemProcesses)
       }
     } yield (runtime))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
@@ -7,54 +7,24 @@ import cats.mtl._
 import cats.{FlatMap, Monad}
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
-trait CostAccounting[F[_]] {
-  def charge(cost: Cost): F[Unit]
-  def get(): F[Cost]
-  def set(cost: Cost): F[Unit]
-  def refund(refund: Cost): F[Unit]
-  private[accounting] def update(f: Cost => Cost): F[Unit]
-}
-
 object CostAccounting {
-  def of[F[_]: Sync](init: Cost): F[CostAccounting[F]] =
+
+  def of[F[_]: Sync](init: Cost): F[MonadState[F, Cost]] =
     Ref[F].of(init).map(ref => new CostAccountingImpl[F](ref))
-  def empty[F[_]: Sync]: F[CostAccounting[F]] =
+
+  def empty[F[_]: Sync]: F[MonadState[F, Cost]] =
     this.of(Cost(0, "init"))
 
-  def apply[F[_]](implicit ev: CostAccounting[F]): CostAccounting[F] = ev
-
-  def unsafe[F[_]](init: Cost)(implicit F: Sync[F]): CostAccounting[F] = {
+  def unsafe[F[_]](init: Cost)(implicit F: Sync[F]): MonadState[F, Cost] = {
     val ref = Ref.unsafe[F, Cost](init)
     new CostAccountingImpl[F](ref)
   }
 
-  private class CostAccountingImpl[F[_]](state: Ref[F, Cost])(implicit F: Sync[F])
-      extends CostAccounting[F] {
-    override def charge(cost: Cost): F[Unit] = chargeInternal(_ - cost)
-
-    private def chargeInternal(f: Cost => Cost): F[Unit] =
-      for {
-        _ <- failOnOutOfPhlo
-        _ <- state.update(f)
-        _ <- failOnOutOfPhlo
-      } yield ()
-
-    override def get: F[Cost] = state.get
-    override def set(cost: Cost): F[Unit] =
-      state.set(cost)
-    override def update(f: Cost => Cost): F[Unit] = state.update(f)
-
-    override def refund(refund: Cost): F[Unit] = state.update(_ + refund)
-    private val failOnOutOfPhlo: F[Unit] =
-      FlatMap[F].ifM(state.get.map(_.value < 0))(F.raiseError(OutOfPhlogistonsError), F.unit)
-  }
-
-  implicit def costAccountingMonadState[F[_]: Monad](
-      costAccounting: CostAccounting[F]
-  ): MonadState[F, Cost] = new DefaultMonadState[F, Cost] {
+  private class CostAccountingImpl[F[_]: Monad](state: Ref[F, Cost])
+      extends DefaultMonadState[F, Cost] {
     val monad: cats.Monad[F]                      = implicitly[Monad[F]]
-    def get: F[Cost]                              = costAccounting.get
-    def set(s: Cost): F[Unit]                     = costAccounting.set(s)
-    override def modify(f: Cost => Cost): F[Unit] = costAccounting.update(f)
+    def get: F[Cost]                              = state.get
+    def set(s: Cost): F[Unit]                     = state.set(s)
+    override def modify(f: Cost => Cost): F[Unit] = state.update(f)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
@@ -15,11 +15,6 @@ object CostAccounting {
   def empty[F[_]: Sync]: F[MonadState[F, Cost]] =
     this.of(Cost(0, "init"))
 
-  def unsafe[F[_]](init: Cost)(implicit F: Sync[F]): MonadState[F, Cost] = {
-    val ref = Ref.unsafe[F, Cost](init)
-    new CostAccountingImpl[F](ref)
-  }
-
   private class CostAccountingImpl[F[_]: Monad](state: Ref[F, Cost])
       extends DefaultMonadState[F, Cost] {
     val monad: cats.Monad[F]                      = implicitly[Monad[F]]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -63,8 +63,7 @@ object RholangAndScalaDispatcher {
       s: Sync[M],
       ft: FunctorTell[M, Throwable]
   ): (Dispatch[M, ListParWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
-    implicit val costAlg: CostAccounting[M] = CostAccounting.unsafe[M](Cost(0))
-    implicit val cost: _cost[M]             = loggingCost(costAlg, noOpCostLog)
+    implicit val cost: _cost[M] = loggingCost(CostAccounting.unsafe[M](Cost(0)), noOpCostLog)
     create(tuplespace, dispatchTable, urnMap)
 
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -53,21 +53,6 @@ class RholangAndScalaDispatcher[M[_]] private (
 
 object RholangAndScalaDispatcher {
 
-  def createWithEmptyCost[M[_], F[_]](
-      tuplespace: RhoISpace[M],
-      dispatchTable: => Map[Long, (Seq[ListParWithRandom], Int) => M[Unit]],
-      urnMap: Map[String, Par]
-  )(
-      implicit
-      parallel: Parallel[M, F],
-      s: Sync[M],
-      ft: FunctorTell[M, Throwable]
-  ): (Dispatch[M, ListParWithRandom, TaggedContinuation], ChargingReducer[M], Registry[M]) = {
-    implicit val cost: _cost[M] = loggingCost(CostAccounting.unsafe[M](Cost(0)), noOpCostLog)
-    create(tuplespace, dispatchTable, urnMap)
-
-  }
-
   def create[M[_], F[_]](
       tuplespace: RhoISpace[M],
       dispatchTable: => Map[Long, (Seq[ListParWithRandom], Int) => M[Unit]],

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -79,8 +79,7 @@ object Resources {
           for {
             costAccounting <- CostAccounting.empty[Task]
             runtime <- {
-              implicit val ca: CostAccounting[Task] = costAccounting
-              implicit val cost: _cost[Task]        = loggingCost(ca, noOpCostLog)
+              implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog)
               Runtime.create[Task, Task.Par](tmpDir, storageSize, storeType)
             }
           } yield (runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -110,9 +110,15 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
       )
     ] = {
 
+      implicit val cost: _cost[Task] =
+        (for {
+          costAlg <- CostAccounting.of[Task](Cost(0))
+        } yield loggingCost(costAlg, noOpCostLog[Task]))
+          .runSyncUnsafe(1.second)
+
       lazy val (_, reducer, _) =
         RholangAndScalaDispatcher
-          .createWithEmptyCost[Task, Task.Par](pureRSpace, Map.empty, Map.empty)
+          .create[Task, Task.Par](pureRSpace, Map.empty, Map.empty)
 
       def plainSendCost(p: Par): Cost = {
         val storageCost = ChargingRSpace.storageCostProduce(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -36,7 +36,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     val termCost          = Chargeable[Par].cost(substTerm)
     val initCost          = Cost(1000)
     implicit val costAlg: _cost[Coeval] =
-      loggingCost(CostAccounting.unsafe[Coeval](initCost), noOpCostLog)
+      loggingCost(CostAccounting.of[Coeval](initCost).value, noOpCostLog)
     val res = Substitute.charge(Coeval.pure(substTerm), Cost(10000)).attempt.value
     assert(res === Right(substTerm))
     assert(costAlg.get() === (initCost - Cost(termCost)))
@@ -48,7 +48,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     val originalTermCost  = Chargeable[Par].cost(varTerm)
     val initCost          = Cost(1000)
     implicit val costAlg: _cost[Coeval] =
-      loggingCost(CostAccounting.unsafe[Coeval](initCost), noOpCostLog)
+      loggingCost(CostAccounting.of[Coeval](initCost).value, noOpCostLog)
 
     val res = Substitute
       .charge(Coeval.raiseError[Par](new RuntimeException("")), Cost(originalTermCost))
@@ -78,7 +78,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     implicit val errorLog = new ErrorLog[Task]()
     implicit val rand     = Blake2b512Random(128)
     implicit val costAlg: _cost[Task] =
-      loggingCost(CostAccounting.unsafe[Task](Cost(1000)), noOpCostLog)
+      loggingCost(CostAccounting.of[Task](Cost(1000)).runSyncUnsafe(1.second), noOpCostLog)
     val reducer = new DebruijnInterpreter[Task, Task.Par](tuplespaceAlg, Map.empty)
     val send    = Send(Par(exprs = Seq(GString("x"))), Seq(Par()))
     val test    = reducer.inj(send).attempt.runSyncUnsafe(1.second)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -72,8 +72,10 @@ trait PersistentStoreTester {
 class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
 
-  implicit val costAlg: CostAccounting[Task] = CostAccounting.unsafe[Task](Cost(0))
-  implicit val cost: _cost[Task]             = loggingCost(costAlg, noOpCostLog[Task])
+  implicit val cost: _cost[Task] =
+    (for {
+      costAlg <- CostAccounting.of[Task](Cost(0))
+    } yield loggingCost(costAlg, noOpCostLog[Task])).unsafeRunSync
 
   def checkData(
       result: Map[

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
 trait RegistryTester extends PersistentStoreTester {
   implicit val errorLog = new ErrorLog[Task]()
   implicit val costAccounting =
-    CostAccounting.unsafe[Task](Cost.UNSAFE_MAX)
+    CostAccounting.of[Task](Cost.UNSAFE_MAX).runSyncUnsafe(1.second)
   implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog[Task])
 
   private[this] def dispatchTableCreator(registry: Registry[Task]): RhoDispatchMap[Task] = {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
@@ -19,8 +19,7 @@ object TestRuntime {
     for {
       costAccounting <- CostAccounting.of[F](Cost.UNSAFE_MAX)
       runtime <- {
-        implicit val ca: CostAccounting[F] = costAccounting
-        implicit val cost: _cost[F]        = loggingCost(ca, noOpCostLog)
+        implicit val cost: _cost[F] = loggingCost(costAccounting, noOpCostLog)
         Runtime.create[F, M](Paths.get("/not/a/path"), -1, InMem, extraSystemProcesses)
       }
     } yield (runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -25,63 +25,6 @@ import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class LegacyCostAccountingSpec extends FlatSpec with TripleEqualsSupport {
-
-  behavior of "CostAccountingAlg"
-
-  val defaultCost = Cost(33)
-
-  def withCostAccAlg[T](
-      initState: Cost = defaultCost
-  )(f: CostAccounting[Task] => Task[T]): T = {
-    val test = for {
-      alg <- CostAccounting.of[Task](initState)
-      res <- f(alg)
-    } yield res
-    Await.result(test.runToFuture, 5.seconds)
-  }
-
-  "get" should "return current cost account" in withCostAccAlg() { alg =>
-    for {
-      s <- alg.get()
-    } yield assert(s === defaultCost)
-  }
-
-  "charge" should "modify underlying cost account" in withCostAccAlg() { alg =>
-    val c = Cost(13)
-    for {
-      _ <- alg.charge(c)
-      s <- alg.get()
-    } yield assert(defaultCost - c === s)
-  }
-
-  def assertOutOfPhloError[A](test: Task[A]): Task[Assertion] =
-    test.attempt.map(res => assert(res === Left(OutOfPhlogistonsError)))
-
-  it should "fail when cost account goes below zero" in withCostAccAlg() { alg =>
-    val cost = Cost(100)
-    val test = for {
-      _ <- alg.charge(cost)
-      s <- alg.get()
-    } yield s
-
-    assertOutOfPhloError(test)
-  }
-
-  it should "fail when tries to charge on the cost account that is already negative" in withCostAccAlg(
-    Cost(-100)
-  ) { alg =>
-    val cost = Cost(1)
-    val test = for {
-      _ <- alg.charge(cost)
-      s <- alg.get()
-    } yield s
-
-    assertOutOfPhloError(test)
-  }
-
-}
-
 class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
 
   private[this] def evaluateWithCostLog(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -28,7 +28,7 @@ class MatcherMonadSpec extends FlatSpec with Matchers {
   val A: Alternative[F] = Alternative[F]
 
   implicit val cost: _cost[Task] =
-    loggingCost(CostAccounting.unsafe[Task](Cost(0)), noOpCostLog[Task])
+    loggingCost(CostAccounting.empty[Task].unsafeRunSync, noOpCostLog[Task])
   implicit val costF: _cost[F] = matcherMonadCostLog[Task]
 
   private def combineK[FF[_]: MonoidK, G[_]: Foldable, A](gfa: G[FF[A]]): FF[A] =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -342,7 +342,8 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
   override type FixtureParam = TestFixture
 
   override protected def withFixture(test: OneArgTest): Outcome = {
-    val cost: _cost[Task] = loggingCost(CostAccounting.unsafe[Task](Cost(0)), noOpCostLog)
+    val cost: _cost[Task] =
+      loggingCost(CostAccounting.empty[Task].runSyncUnsafe(1.second), noOpCostLog)
     def mkChargingRspace(rhoISpace: RhoISpace[Task]): Task[ChargingRSpace] = {
       val s     = implicitly[Sync[Task]]
       val error = FunctorRaise[Task, InterpreterError]
@@ -360,7 +361,8 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
 
   private def actualMatchCost(patterns: Seq[BindPattern], data: Seq[ListParWithRandom])(
       implicit
-      _cost: _cost[Task] = loggingCost(CostAccounting.unsafe[Task](Cost(1000)), noOpCostLog)
+      _cost: _cost[Task] =
+        loggingCost(CostAccounting.of[Task](Cost(1000)).runSyncUnsafe(1.second), noOpCostLog)
   ): Task[Cost] = {
     import cats.implicits._
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -148,7 +148,7 @@ object BasicBench {
         .unsafeRunSync
 
     implicit val cost: _cost[Task] = loggingCost(
-      CostAccounting.unsafe[Task](Cost.UNSAFE_MAX),
+      CostAccounting.of[Task](Cost.UNSAFE_MAX).unsafeRunSync,
       noOpCostLog
     )
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -27,9 +27,7 @@ trait EvalBenchStateBase {
   lazy val runtime: Runtime[Task] =
     Runtime.createWithEmptyCost[Task, Task.Par](dbDir, mapSize, StoreType.LMDB).unsafeRunSync
   val rand: Blake2b512Random = Blake2b512Random(128)
-  val costAccountAlg: CostAccounting[Task] =
-    CostAccounting.unsafe[Task](Cost.UNSAFE_MAX)
-  var term: Option[Par] = None
+  var term: Option[Par]      = None
 
   @Setup
   def doSetup(): Unit = {

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -44,8 +44,7 @@ abstract class WideBenchBaseState {
     (for {
       costAccounting <- CostAccounting.empty[Task]
       runtime <- {
-        implicit val ca: CostAccounting[Task] = costAccounting
-        implicit val cost: _cost[Task]        = loggingCost(ca, noOpCostLog)
+        implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog)
         Runtime.create[Task, Task.Par](dbDir, mapSize, StoreType.LMDB)
       }
     } yield (runtime)).unsafeRunSync


### PR DESCRIPTION
## Overview
As the title states, removes cost accounting code which has become obsolete.
It is a prerequisite for introducing MVar instead of Ref for synchronization

### JIRA ticket:
Prerequisite for: https://rchain.atlassian.net/browse/RCHAIN-3077


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
