### PR TITLE
Refund in terms of negative charge

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -104,7 +104,7 @@ object ChargingRSpace {
             for {
               _ <- if (refundValue == Cost(0))
                     Sync[F].unit
-                  else cost.modify(_ + refundValue)
+                  else charge[F](Cost(-refundValue.value, "storage refund"))
             } yield ()
         }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -62,6 +62,10 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
 
   val contracts = Table(
     ("contract", "expectedTotalCost"),
+    ("""@0!(2)""", 33L),
+    ("""@0!(2) | @1!(1)""", 69L),
+    ("""for(x <- @0){ Nil }""", 64L),
+    ("""for(x <- @0){ Nil } | @0!(2)""", 76L),
     ("""new loop in {
          contract loop(@n) = {
            match n {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -70,8 +70,8 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
            }
          } |
          loop!(10)
-       }""".stripMargin, 1766L),
-    ("""42 | @0!(2) | for (x <- @0) { Nil }""", 48L),
+       }""".stripMargin, 1936L),
+    ("""42 | @0!(2) | for (x <- @0) { Nil }""", 83L),
     ("""@1!(1) |
         for(x <- @1) { Nil } |
         new x in { x!(10) | for(X <- x) { @2!(Set(X!(7)).add(*X).contains(10)) }} |
@@ -79,10 +79,10 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
           38 => Nil
           42 => @3!(42)
         }
-     """.stripMargin, 432L)
+     """.stripMargin, 634L)
   )
 
-  "Total cost of evaluation" should "be equal to the sum of all costs in the log" ignore forAll(
+  "Total cost of evaluation" should "be equal to the sum of all costs in the log" in forAll(
     contracts
   ) { (contract: String, expectedTotalCost: Long) =>
     val initialPhlo       = 10000L


### PR DESCRIPTION
## Overview
Unignores one of the recently added cost accounting tests. Previously the sum of operations in the cost log wasn't correct because of refund bypassing the accounting.charge method

### JIRA ticket:
Part of https://rchain.atlassian.net/browse/RCHAIN-2989


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
