### PR TITLE
RCHAIN-2729: Return an error if phloLimit passed to deploy command is less than intrinsic phlo

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -8,8 +8,6 @@ import coop.rchain.casper.PrettyPrinter
 import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.{DeployData, _}
-import coop.rchain.casper.util.ProtoUtil.basicDeployData
-import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.casper.util.implicits._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
@@ -506,6 +504,16 @@ object ProtoUtil {
       timestamp = timestamp,
       term = source,
       phloLimit = phlos
+    )
+
+  def sourceDeployNowWithPhlo[F[_]: Monad: Time](source: String, phlos: Long): F[DeployData] =
+    Time[F].currentMillis.map(
+      now =>
+        sourceDeploy(
+          source,
+          now,
+          phlos
+        )
     )
 
   def sourceDeployNow(source: String): DeployData =

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/DeployStatus.scala
@@ -21,13 +21,22 @@ final case class ReplayStatusMismatch(replay: DeployStatus, orig: DeployStatus) 
 final case object UnknownFailure                                                extends Failed
 final case class UserErrors(errors: Vector[Throwable])                          extends Failed
 final case class InternalErrors(errors: Vector[Throwable])                      extends Failed
+
+sealed trait InvalidDeployError                     extends Throwable
+final case class InsufficientRevError(msg: String)  extends InvalidDeployError
+final case class InvalidSequenceError(msg: String)  extends InvalidDeployError
+final case class InsufficientPhloError(msg: String) extends InvalidDeployError
+final case class InvalidSignatureError(msg: String) extends InvalidDeployError
+final case class MissingFieldError(msg: String)     extends InvalidDeployError
+
 //TODO add fatal error related to rspace closed after https://github.com/rchain/rchain/pull/1339 is merged
 
 object DeployStatus {
   def fromErrors(errors: Vector[Throwable]): DeployStatus = {
     val (userErrors, internalErrors) = errors.partition {
-      case _: InterpreterError => true
-      case _                   => false
+      case _: InvalidDeployError => true
+      case _: InterpreterError   => true
+      case _                     => false
     }
 
     internalErrors


### PR DESCRIPTION
## Overview
This PR changes `RuntimeInterpreter` to throw an error if the deploy being evaluated provides phlo less than the minimum cost of evaluating a deploy. It is the first of a series of validity checks that deploys will be subject to.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2729