### PR TITLE
_cost synchronization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ lazy val shared = (project in file("shared"))
       scodecCore,
       scodecBits,
       scalapbRuntimegGrpc,
+      catsEffectLawsTest,
       catsLawsTest,
       catsLawsTestkitTest
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -64,7 +64,7 @@ object TestUtil {
       _ <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
       _ <- runtime.reducer.inj(term)
       _ <- runtime.reducer.phlo
-    } yield ()).runSyncUnsafe(5.seconds)
+    } yield ()).runSyncUnsafe(10.seconds)
 
   def eval(
       code: String,

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployDataContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployDataContract.scala
@@ -1,5 +1,5 @@
 package coop.rchain.casper.helper
-import cats.effect.Sync
+import cats.effect.Concurrent
 import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.models.{ListParWithRandom, Par}
@@ -7,7 +7,7 @@ import coop.rchain.models.{ListParWithRandom, Par}
 object DeployDataContract {
   import cats.implicits._
 
-  def set[F[_]: Sync](
+  def set[F[_]: Concurrent](
       ctx: SystemProcess.Context[F]
   )(message: (Seq[ListParWithRandom], Int)): F[Unit] = {
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
@@ -1,5 +1,5 @@
 package coop.rchain.casper.helper
-import cats.effect.Sync
+import cats.effect.Concurrent
 import coop.rchain.models.ListParWithRandom
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.rholang.interpreter.{ContractCall, PrettyPrinter, RhoType}
@@ -8,7 +8,7 @@ import coop.rchain.shared.{Log, LogSource}
 object RhoLoggerContract {
   val prettyPrinter = PrettyPrinter()
 
-  def handleMessage[F[_]: Log: Sync](
+  def handleMessage[F[_]: Log: Concurrent](
       ctx: SystemProcess.Context[F]
   )(message: (Seq[ListParWithRandom], Int)): F[Unit] = {
     val isContractCall = new ContractCall(ctx.space, ctx.dispatcher)

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
@@ -1,5 +1,5 @@
 package coop.rchain.casper.helper
-import cats.effect.Sync
+import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
@@ -79,13 +79,13 @@ case class TestResult(
 case class AckedActionCtx(ackChannel: Par, rand: Blake2b512Random, sequenceNumber: Long)
 
 object TestResultCollector {
-  def apply[F[_]: Sync]: F[TestResultCollector[F]] =
+  def apply[F[_]: Concurrent]: F[TestResultCollector[F]] =
     Ref
       .of(TestResult(Map.empty, hasFinished = false))
       .map(new TestResultCollector(_))
 }
 
-class TestResultCollector[F[_]: Sync](result: Ref[F, TestResult]) {
+class TestResultCollector[F[_]: Concurrent](result: Ref[F, TestResult]) {
 
   def getResult: F[TestResult] = result.get
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
   val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"
   val catsEffect          = "org.typelevel"              %% "cats-effect"               % catsEffectVersion
+  val catsEffectLawsTest  = "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion % "test"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rholang.interpreter
-import cats.effect.Sync
+
+import cats.effect.{Concurrent, Sync}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.{ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
@@ -28,7 +29,7 @@ import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
   * @param space the rspace instance
   * @param dispatcher the dispatcher
   */
-class ContractCall[F[_]: Sync](
+class ContractCall[F[_]: Concurrent](
     space: RhoISpace[F],
     dispatcher: Dispatch[F, ListParWithRandom, TaggedContinuation]
 ) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rholang.interpreter
 
 import cats.effect.{Concurrent, Sync}
+import cats.effect.concurrent.Semaphore
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.{ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.Runtime.RhoISpace
@@ -41,8 +42,7 @@ class ContractCall[F[_]: Concurrent](
       sequenceNumber: Int
   )(values: Seq[Par], ch: Par): F[Unit] =
     for {
-      costAlg <- CostAccounting.of(Cost.UNSAFE_MAX)
-      cost    = loggingCost(costAlg, noOpCostLog[F])
+      cost <- CostAccounting.initialCost(Cost.UNSAFE_MAX)
       produceResult <- space.produce(
                         ch,
                         ListParWithRandom(values, rand),

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -61,7 +61,7 @@ object Interpreter {
                       case Right(parsed) =>
                         for {
                           result    <- reducer.inj(parsed).attempt
-                          phlosLeft <- C.get
+                          phlosLeft <- C.inspect(identity)
                           oldErrors <- errorLog.readAndClearErrorVector()
                           newErrors = result.swap.toSeq.toVector
                           allErrors = oldErrors |+| newErrors
@@ -72,6 +72,7 @@ object Interpreter {
                   case Left(error) =>
                     EvaluateResult(parsingCost, Vector(error)).pure[F]
                 }
+          _ <- C.get
         } yield res
 
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Interpreter.scala
@@ -1,12 +1,12 @@
 package coop.rchain.rholang.interpreter
 
 import cats._
-import cats.effect.Sync
+import cats.effect._
 import cats.implicits._
 import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.rholang.interpreter.accounting._
-import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
+import coop.rchain.rholang.interpreter.errors._
 
 final case class EvaluateResult(cost: Cost, errors: Vector[Throwable])
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -66,8 +66,7 @@ object Reduce {
       parallel: cats.Parallel[M, F],
       s: Sync[M],
       fTell: FunctorTell[M, Throwable],
-      cost: _cost[M],
-      err: _error[M]
+      cost: _cost[M]
   ) extends Reduce[M] {
 
     /**

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -203,7 +203,7 @@ object Runtime {
     }.sequence
 
   object SystemProcess {
-    final case class Context[F[_]: Sync](
+    final case class Context[F[_]: Concurrent](
         space: RhoISpace[F],
         dispatcher: RhoDispatch[F],
         registry: Registry[F],
@@ -422,7 +422,7 @@ object Runtime {
   }
 
   def injectEmptyRegistryRoot[F[_]](space: RhoISpace[F], replaySpace: RhoReplayISpace[F])(
-      implicit F: Sync[F]
+      implicit F: Concurrent[F]
   ): F[Unit] = {
     // This random value stays dead in the tuplespace, so we can have some fun.
     // This is from Jeremy Bentham's "Defence of Usury"

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -308,9 +308,9 @@ object Runtime {
       executionContext: ExecutionContext
   ): F[Runtime[F]] =
     (for {
-      costAccounting <- CostAccounting.empty[F]
+      cost <- CostAccounting.emptyCost[F]
       runtime <- {
-        implicit val cost: _cost[F] = loggingCost(costAccounting, noOpCostLog)
+        implicit val c = cost
         create(dataDir, mapSize, storeType, extraSystemProcesses)
       }
     } yield (runtime))
@@ -433,8 +433,7 @@ object Runtime {
     )
 
     for {
-      costAlg <- CostAccounting.of[F](Cost.UNSAFE_MAX)
-      cost    = loggingCost(costAlg, noOpCostLog[F])
+      cost <- CostAccounting.initialCost[F](Cost.UNSAFE_MAX)
       spaceResult <- space.produce(
                       Registry.registryRoot,
                       ListParWithRandom(Seq(Registry.emptyMap), rand),

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.interpreter
 
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
@@ -39,7 +39,7 @@ object SystemProcesses {
   def apply[F[_]](
       dispatcher: Dispatch[F, ListParWithRandom, TaggedContinuation],
       space: RhoISpace[F]
-  )(implicit F: Sync[F]): SystemProcesses[F] =
+  )(implicit F: Concurrent[F]): SystemProcesses[F] =
     new SystemProcesses[F] {
 
       type ContWithMetaData = ContResult[Par, BindPattern, TaggedContinuation]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter.accounting
 
-import cats.effect.Sync
-import cats.effect.concurrent.Ref
+import cats.effect.Concurrent
+import cats.effect.concurrent.MVar
 import cats.implicits._
 import cats.mtl._
 import cats.{FlatMap, Monad}
@@ -9,20 +9,28 @@ import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
 object CostAccounting {
 
-  def of[F[_]: Sync](init: Cost): F[MonadState[F, Cost]] =
-    Ref[F]
+  def of[F[_]: Concurrent](init: Cost): F[MonadState[F, Cost]] =
+    MVar[F]
       .of(init)
-      .map(
-        state =>
-          new DefaultMonadState[F, Cost] {
-            val monad: cats.Monad[F]                      = implicitly[Monad[F]]
-            def get: F[Cost]                              = state.get
-            def set(s: Cost): F[Unit]                     = state.set(s)
-            override def modify(f: Cost => Cost): F[Unit] = state.update(f)
-          }
-      )
+      .map(defaultMonadState)
 
-  def empty[F[_]: Sync]: F[MonadState[F, Cost]] =
-    this.of(Cost(0, "init"))
+  def empty[F[_]: Concurrent]: F[MonadState[F, Cost]] =
+    MVar[F]
+      .empty[Cost]
+      .map(defaultMonadState)
 
+  private[this] def defaultMonadState[F[_]: Monad] =
+    (state: MVar[F, Cost]) =>
+      new DefaultMonadState[F, Cost] {
+        val monad: cats.Monad[F]                    = implicitly[Monad[F]]
+        def get: F[Cost]                            = state.take
+        def set(s: Cost): F[Unit]                   = state.put(s)
+        override def inspect[A](f: Cost => A): F[A] = state.read.map(f)
+        override def modify(f: Cost => Cost): F[Unit] =
+          for {
+            s <- get
+            _ <- set(f(s))
+          } yield ()
+
+      }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/CostAccounting.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter.accounting
 
 import cats.effect.Concurrent
-import cats.effect.concurrent.MVar
+import cats.effect.concurrent._
 import cats.implicits._
 import cats.mtl._
 import cats.{FlatMap, Monad}
@@ -10,27 +10,34 @@ import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 object CostAccounting {
 
   def of[F[_]: Concurrent](init: Cost): F[MonadState[F, Cost]] =
-    MVar[F]
+    Ref[F]
       .of(init)
       .map(defaultMonadState)
 
   def empty[F[_]: Concurrent]: F[MonadState[F, Cost]] =
-    MVar[F]
-      .empty[Cost]
+    Ref[F]
+      .of(Cost(0, "init"))
       .map(defaultMonadState)
 
-  private[this] def defaultMonadState[F[_]: Monad] =
-    (state: MVar[F, Cost]) =>
-      new DefaultMonadState[F, Cost] {
-        val monad: cats.Monad[F]                    = implicitly[Monad[F]]
-        def get: F[Cost]                            = state.take
-        def set(s: Cost): F[Unit]                   = state.put(s)
-        override def inspect[A](f: Cost => A): F[A] = state.read.map(f)
-        override def modify(f: Cost => Cost): F[Unit] =
-          for {
-            s <- get
-            _ <- set(f(s))
-          } yield ()
+  def emptyCost[F[_]: Concurrent]: F[_cost[F]] =
+    for {
+      s <- Semaphore(1)
+      c <- empty
+    } yield (loggingCost(c, noOpCostLog, s))
 
+  def initialCost[F[_]: Concurrent](init: Cost): F[_cost[F]] =
+    for {
+      s <- Semaphore(1)
+      c <- of(init)
+    } yield (loggingCost(c, noOpCostLog, s))
+
+  private[this] def defaultMonadState[F[_]: Monad: Concurrent] =
+    (state: Ref[F, Cost]) =>
+      new DefaultMonadState[F, Cost] {
+        val monad: cats.Monad[F]  = implicitly[Monad[F]]
+        def get: F[Cost]          = state.get
+        def set(s: Cost): F[Unit] = state.set(s)
+
+        override def modify(f: Cost => Cost): F[Unit] = state.modify(f.map((_, ())))
       }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/package.scala
@@ -3,61 +3,72 @@ package coop.rchain.rholang.interpreter
 import cats._
 import cats.data._
 import cats.effect.ExitCase._
+import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import cats.mtl._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 
 package object accounting extends Costs {
 
-  type _cost[F[_]] = MonadState[F, Cost] with FunctorTell[F, Chain[Cost]]
+  type _cost[F[_]] = Semaphore[F] with MonadState[F, Cost] with FunctorTell[F, Chain[Cost]]
 
   def _cost[F[_]](implicit ev: _cost[F]): _cost[F] = ev
 
   def loggingCost[F[_]: Monad](
       state: MonadState[F, Cost],
-      fTell: FunctorTell[F, Chain[Cost]]
-  ): _cost[F] =
-    new MonadState[F, Cost] with FunctorTell[F, Chain[Cost]] {
-      override val functor: Functor[F]                   = Functor[F]
-      override def tell(l: Chain[Cost]): F[Unit]         = fTell.tell(l)
-      override def tuple[A](ta: (Chain[Cost], A)): F[A]  = fTell.tuple(ta)
-      override def writer[A](a: A, l: Chain[Cost]): F[A] = fTell.writer(a, l)
+      fTell: FunctorTell[F, Chain[Cost]],
+      semaphore: Semaphore[F]
+  ): _cost[F] = new Semaphore[F] with MonadState[F, Cost] with FunctorTell[F, Chain[Cost]] {
+    override val functor: Functor[F]                   = Functor[F]
+    override def tell(l: Chain[Cost]): F[Unit]         = fTell.tell(l)
+    override def tuple[A](ta: (Chain[Cost], A)): F[A]  = fTell.tuple(ta)
+    override def writer[A](a: A, l: Chain[Cost]): F[A] = fTell.writer(a, l)
 
-      override val monad: Monad[F]                  = Monad[F]
-      override def get: F[Cost]                     = state.get
-      override def inspect[A](f: Cost => A): F[A]   = state.inspect(f)
-      override def modify(f: Cost => Cost): F[Unit] = state.modify(f)
-      override def set(s: Cost): F[Unit]            = state.set(s)
-    }
+    override val monad: Monad[F]                  = Monad[F]
+    override def get: F[Cost]                     = state.get
+    override def inspect[A](f: Cost => A): F[A]   = state.inspect(f)
+    override def modify(f: Cost => Cost): F[Unit] = state.modify(f)
+    override def set(s: Cost): F[Unit]            = state.set(s)
+
+    override def acquireN(n: Long): F[Unit]       = semaphore.acquireN(n)
+    override def available: F[Long]               = semaphore.available
+    override def count: F[Long]                   = semaphore.count
+    override def releaseN(n: Long): F[Unit]       = semaphore.releaseN(n)
+    override def tryAcquireN(n: Long): F[Boolean] = semaphore.tryAcquireN(n)
+    override def withPermit[A](t: F[A]): F[A]     = semaphore.withPermit(t)
+
+  }
 
   def charge[F[_]: Monad](
       amount: Cost
   )(implicit cost: _cost[F], error: _error[F]): F[Unit] =
     for {
-      _ <- error.bracketCase(cost.get)(
-            c =>
-              Monad[F].ifM[Unit]((c.value < 0).pure[F])(
-                ifTrue = {
-                  for {
-                    _ <- error.raiseError[Unit](OutOfPhlogistonsError)
-                  } yield (())
-                },
-                ifFalse = {
-                  for {
-                    _        <- cost.tell(Chain.one(amount))
-                    newValue = c - amount
-                    _        <- cost.set(newValue)
-                  } yield (())
-                }
-              )
-          ) {
-            case (_, Completed)    => error.unit
-            case (oldValue @ _, _) => cost.set(oldValue)
+      _ <- error.bracket(cost.acquire)(
+            _ =>
+              for {
+                c <- cost.get
+                _ <- Monad[F].ifM[Unit]((c.value < 0).pure[F])(
+                      ifTrue = {
+                        for {
+                          _ <- error.raiseError[Unit](OutOfPhlogistonsError)
+                        } yield (())
+                      },
+                      ifFalse = {
+                        for {
+                          _        <- cost.tell(Chain.one(amount))
+                          newValue = c - amount
+                          _        <- cost.set(newValue)
+                        } yield (())
+                      }
+                    )
+              } yield ()
+          ) { _ =>
+            cost.release
           }
       _ <- error.ensure(cost.inspect(identity))(OutOfPhlogistonsError)(_.value >= 0)
     } yield ()
 
-  def noOpCostLog[M[_]: Applicative]: FunctorTell[M, Chain[Cost]] =
+  implicit def noOpCostLog[M[_]: Applicative]: FunctorTell[M, Chain[Cost]] =
     new DefaultFunctorTell[M, Chain[Cost]] {
       override val functor: Functor[M]  = implicitly[Functor[M]]
       def tell(l: Chain[Cost]): M[Unit] = Applicative[M].pure(())
@@ -66,7 +77,7 @@ package object accounting extends Costs {
   implicit def ntCostLog[F[_]: Monad, G[_]: Monad](
       nt: F ~> G
   )(implicit C: _cost[F]): _cost[G] =
-    new MonadState[G, Cost] with FunctorTell[G, Chain[Cost]] {
+    new Semaphore[G] with MonadState[G, Cost] with FunctorTell[G, Chain[Cost]] {
       override val functor: Functor[G]                  = Functor[G]
       override def tell(l: Chain[Cost]): G[Unit]        = nt(C.tell(l))
       override def tuple[A](ta: (Chain[Cost], A)): G[A] = nt(C.tuple(ta))
@@ -77,6 +88,13 @@ package object accounting extends Costs {
       override def inspect[A](f: Cost => A): G[A]        = nt(C.inspect(f))
       override def modify(f: Cost => Cost): G[Unit]      = nt(C.modify(f))
       override def set(s: Cost): G[Unit]                 = nt(C.set(s))
+
+      override def acquireN(n: Long): G[Unit]       = nt(C.acquireN(n))
+      override def available: G[Long]               = nt(C.available)
+      override def count: G[Long]                   = nt(C.count)
+      override def releaseN(n: Long): G[Unit]       = nt(C.releaseN(n))
+      override def tryAcquireN(n: Long): G[Boolean] = nt(C.tryAcquireN(n))
+      override def withPermit[A](t: G[A]): G[A]     = ???
     }
 
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/package.scala
@@ -50,18 +50,12 @@ package object accounting extends Costs {
               for {
                 c <- cost.get
                 _ <- Monad[F].ifM[Unit]((c.value < 0).pure[F])(
-                      ifTrue = {
-                        for {
-                          _ <- error.raiseError[Unit](OutOfPhlogistonsError)
-                        } yield (())
-                      },
-                      ifFalse = {
-                        for {
-                          _        <- cost.tell(Chain.one(amount))
-                          newValue = c - amount
-                          _        <- cost.set(newValue)
-                        } yield (())
-                      }
+                      ifTrue = error.raiseError[Unit](OutOfPhlogistonsError),
+                      ifFalse = for {
+                        _        <- cost.tell(Chain.one(amount))
+                        newValue = c - amount
+                        _        <- cost.set(newValue)
+                      } yield (())
                     )
               } yield ()
           ) { _ =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -1,7 +1,8 @@
 package coop.rchain.rholang.interpreter.matcher
 
 import cats.data._
-import cats.effect.Sync
+import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import cats.mtl._
 import cats.mtl.implicits._
@@ -43,13 +44,14 @@ object SpatialMatcher extends SpatialMatcherInstances {
   //Also, the following workaround is needed b/c of precisely this reason:
   type Alternative[F[_]] = Alternative_[F]
 
-  def spatialMatchAndCharge[M[_]: Sync](target: Par, pattern: Par)(
+  def spatialMatchAndCharge[M[_]: Sync: _error](target: Par, pattern: Par)(
       implicit
       cost: _cost[M]
   ): M[Option[(FreeMap, Unit)]] = {
     type R[A] = MatcherMonadT[M, A]
 
-    implicit val _ = matcherMonadCostLog[M]
+    implicit val _                            = matcherMonadCostLog[M]
+    implicit val matcherMonadError: _error[R] = implicitly[Sync[R]]
 
     val doMatch: R[Unit] = SpatialMatcher.spatialMatch[R, Par, Par](target, pattern)
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
@@ -194,7 +194,6 @@ trait StreamTInstances2 {
   implicit def streamTSync[F[_]](implicit F0: Sync[F]): Sync[StreamT[F, ?]] =
     new StreamTSync[F]() {
       implicit val F = F0
-
     }
 }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -3,6 +3,8 @@ package coop.rchain.rholang.interpreter
 import cats._
 import cats.arrow.FunctionK
 import cats.data._
+import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import cats.mtl._
 import cats.mtl.implicits._

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/package.scala
@@ -23,7 +23,7 @@ package object matcher {
 
   import coop.rchain.rholang.interpreter.matcher.StreamT
 
-  implicit def matcherMonadCostLog[F[_]: Monad: _cost](): _cost[MatcherMonadT[F, ?]] =
+  implicit def matcherMonadCostLog[F[_]: Monad: Sync: _cost](): _cost[MatcherMonadT[F, ?]] =
     λ[F ~> MatcherMonadT[F, ?]](fa => StateT.liftF(StreamT.liftF(fa)))
 
   // The naming convention means: this is an effect-type alias.

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/package.scala
@@ -1,11 +1,11 @@
 package coop.rchain.rholang
 
-import coop.rchain.rholang.interpreter.errors.InterpreterError
-import cats.mtl.FunctorRaise
+import cats.effect.Bracket
 
 package object interpreter {
 
-  type _error[F[_]] = FunctorRaise[F, InterpreterError]
+  type _error[F[_]] = Bracket[F, Throwable]
 
   def _error[F[_]](implicit ev: _error[F]): _error[F] = ev
+
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -30,7 +30,7 @@ object ChargingRSpace {
 
   def pureRSpace[F[_]: Sync](
       space: RhoISpace[F]
-  )(implicit cost: _cost[F], error: _error[F]) =
+  )(implicit cost: _cost[F]) =
     new RhoPureSpace[F] {
 
       implicit val m: StorageMatch[F, BindPattern, ListParWithRandom, ListParWithRandom] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/implicits.scala
@@ -8,6 +8,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
+import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.matcher._
 import coop.rchain.rspace.{Serialize, Match => StorageMatch}
@@ -35,7 +36,8 @@ object implicits {
           data: ListParWithRandom
       ): F[Option[ListParWithRandom]] = {
         type R[A] = MatcherMonadT[F, A]
-        implicit val _ = matcherMonadCostLog[F]()
+        implicit val _                 = matcherMonadCostLog[F]()
+        implicit val matcherMonadError = implicitly[Sync[R]]
         for {
           matchResult <- runFirst[F, Seq[Par]](
                           SpatialMatcher

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Files, Path}
 import cats.Applicative
 import cats.effect.ExitCase.Error
 import cats.effect.{Concurrent, ContextShift, Resource}
+import cats.effect.concurrent.Semaphore
 import com.typesafe.scalalogging.Logger
 import coop.rchain.metrics.Metrics
 import coop.rchain.models._
@@ -76,9 +77,9 @@ object Resources {
       .flatMap { tmpDir =>
         Resource.make[Task, Runtime[Task]] {
           for {
-            costAccounting <- CostAccounting.empty[Task]
+            cost <- CostAccounting.emptyCost[Task]
             runtime <- {
-              implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog)
+              implicit val c = cost
               Runtime.create[Task, Task.Par](tmpDir, storageSize, storeType)
             }
           } yield (runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -87,11 +87,10 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
 
     implicit val errorLog = new ErrorLog[Task]()
     implicit val rand     = Blake2b512Random(128)
-    implicit val costAlg: _cost[Task] =
-      CostAccounting.initialCost[Task](Cost(1000)).runSyncUnsafe(1.second)
-    val reducer = new DebruijnInterpreter[Task, Task.Par](tuplespaceAlg, Map.empty)
-    val send    = Send(Par(exprs = Seq(GString("x"))), Seq(Par()))
-    val test    = reducer.inj(send).attempt.runSyncUnsafe(1.second)
+    implicit val cost     = CostAccounting.initialCost[Task](Cost(1000)).runSyncUnsafe(1.second)
+    val reducer           = new DebruijnInterpreter[Task, Task.Par](tuplespaceAlg, Map.empty)
+    val send              = Send(Par(exprs = Seq(GString("x"))), Seq(Par()))
+    val test              = reducer.inj(send).attempt.runSyncUnsafe(1.second)
     assert(test === Left(OutOfPhlogistonsError))
   }
 
@@ -120,7 +119,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
       )
     ] = {
 
-      implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
+      implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
 
       lazy val (_, reducer, _) =
         RholangAndScalaDispatcher

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -45,10 +45,7 @@ trait PersistentStoreTester {
     implicit val logF: Log[Task]           = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-    implicit val cost: _cost[Task] =
-      (for {
-        costAlg <- CostAccounting.empty[Task]
-      } yield loggingCost(costAlg, noOpCostLog[Task])).unsafeRunSync
+    implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
 
     val space = (RSpace
       .create[
@@ -839,12 +836,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val result = withTestSpace(errorLog) {
       case TestFixture(space, _) =>
-        implicit val cost: _cost[Task] =
-          (for {
-            costAlg <- CostAccounting.empty[Task]
-          } yield loggingCost(costAlg, noOpCostLog[Task])).unsafeRunSync
-
-        def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
+        implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
+        def byteName(b: Byte): Par     = GPrivate(ByteString.copyFrom(Array[Byte](b)))
         val reducer = RholangOnlyDispatcher
           .create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42)))
           ._2

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -45,7 +45,7 @@ trait PersistentStoreTester {
     implicit val logF: Log[Task]           = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-    implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
+    implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
 
     val space = (RSpace
       .create[
@@ -836,8 +836,8 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
     val result = withTestSpace(errorLog) {
       case TestFixture(space, _) =>
-        implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
-        def byteName(b: Byte): Par     = GPrivate(ByteString.copyFrom(Array[Byte](b)))
+        implicit val cost          = CostAccounting.emptyCost[Task].unsafeRunSync
+        def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
         val reducer = RholangOnlyDispatcher
           .create[Task, Task.Par](space, Map("rho:test:foo" -> byteName(42)))
           ._2

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -55,8 +55,8 @@ trait RegistryTester extends PersistentStoreTester {
   ): R =
     withTestSpace(errorLog) {
       case TestFixture(space, _) =>
-        val _                          = errorLog.readAndClearErrorVector().runSyncUnsafe(1.second)
-        implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
+        val _             = errorLog.readAndClearErrorVector().runSyncUnsafe(1.second)
+        implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
 
         lazy val dispatchTable: RhoDispatchMap[Task] = dispatchTableCreator(registry)
         lazy val (dispatcher @ _, reducer, registry) =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -55,10 +55,8 @@ trait RegistryTester extends PersistentStoreTester {
   ): R =
     withTestSpace(errorLog) {
       case TestFixture(space, _) =>
-        val _ = errorLog.readAndClearErrorVector().runSyncUnsafe(1.second)
-        implicit val costAccounting =
-          CostAccounting.empty[Task].runSyncUnsafe(1.second)
-        implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog[Task])
+        val _                          = errorLog.readAndClearErrorVector().runSyncUnsafe(1.second)
+        implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
 
         lazy val dispatchTable: RhoDispatchMap[Task] = dispatchTableCreator(registry)
         lazy val (dispatcher @ _, reducer, registry) =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
@@ -17,7 +17,7 @@ object TestRuntime {
       extraSystemProcesses: Seq[Runtime.SystemProcess.Definition[F]] = Seq.empty
   )(implicit P: Parallel[F, M], executionContext: ExecutionContext): F[Runtime[F]] =
     for {
-      costAccounting <- CostAccounting.of[F](Cost.UNSAFE_MAX)
+      costAccounting <- CostAccounting.empty[F]
       runtime <- {
         implicit val cost: _cost[F] = loggingCost(costAccounting, noOpCostLog)
         Runtime.create[F, M](Paths.get("/not/a/path"), -1, InMem, extraSystemProcesses)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/TestRuntime.scala
@@ -17,9 +17,9 @@ object TestRuntime {
       extraSystemProcesses: Seq[Runtime.SystemProcess.Definition[F]] = Seq.empty
   )(implicit P: Parallel[F, M], executionContext: ExecutionContext): F[Runtime[F]] =
     for {
-      costAccounting <- CostAccounting.empty[F]
+      cost <- CostAccounting.emptyCost[F]
       runtime <- {
-        implicit val cost: _cost[F] = loggingCost(costAccounting, noOpCostLog)
+        implicit val c = cost
         Runtime.create[F, M](Paths.get("/not/a/path"), -1, InMem, extraSystemProcesses)
       }
     } yield (runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -110,8 +110,9 @@ object CostAccountingPropertyTest {
 
     for {
       runtime <- TestRuntime.create[Task, Task.Par]()
+      _       <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
       _       <- Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)
-      costAlg <- CostAccounting.of[Task](Cost.UNSAFE_MAX)
+      costAlg <- CostAccounting.empty[Task]
       cost    = loggingCost[Task](costAlg, noOpCostLog)
       res <- {
         implicit val c = cost

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -112,8 +112,7 @@ object CostAccountingPropertyTest {
       runtime <- TestRuntime.create[Task, Task.Par]()
       _       <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
       _       <- Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)
-      costAlg <- CostAccounting.empty[Task]
-      cost    = loggingCost[Task](costAlg, noOpCostLog)
+      cost    <- CostAccounting.emptyCost[Task]
       res <- {
         implicit val c = cost
         procs.toStream

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
+class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with AppendedClues {
 
   private[this] def evaluateWithCostLog(
       initialPhlo: Long,
@@ -136,11 +136,11 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks {
       val costs = costLog.map(_.value).toList
       // The sum of all costs but last needs to be <= initialPhlo, otherwise
       // the last cost should have not been logged
-      costs.init.sum.toLong should be <= (initialPhlo)
+      costs.init.sum.toLong should be <= (initialPhlo) withClue (s", cost log was: $costLog")
 
       // The sum of ALL costs needs to be > initialPhlo, otherwise an error
       // should not have been reported
-      costs.sum.toLong > (initialPhlo)
+      costs.sum.toLong > (initialPhlo) withClue (s", cost log was: $costLog")
     })
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter.accounting
 
 import java.nio.file.Files
 
-import cats.effect.concurrent.Semaphore
+import cats.effect._
 import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
@@ -38,10 +38,8 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     (for {
-      s       <- Semaphore[Task](1)
-      costAlg <- CostAccounting.empty[Task]
-      costL   <- costLog[Task]
-      cost    = loggingCost(costAlg, costL, s)
+      costL <- costLog[Task]
+      cost  <- CostAccounting.emptyCost[Task](Concurrent[Task], costL)
       costsLoggingProgram <- {
         costL.listen({
           implicit val c = cost

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -2,6 +2,7 @@ package coop.rchain.rholang.interpreter.accounting
 
 import java.nio.file.Files
 
+import cats.effect.concurrent.Semaphore
 import coop.rchain.catscontrib.mtl.implicits._
 import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
@@ -37,9 +38,10 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     (for {
+      s       <- Semaphore[Task](1)
       costAlg <- CostAccounting.empty[Task]
       costL   <- costLog[Task]
-      cost    = loggingCost(costAlg, costL)
+      cost    = loggingCost(costAlg, costL, s)
       costsLoggingProgram <- {
         costL.listen({
           implicit val c = cost
@@ -48,8 +50,8 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
                         .create[Task, Task.Par](dbDir, size, StoreType.LMDB)
             res <- Interpreter[Task]
                     .evaluate(runtime, contract, Cost(initialPhlo.toLong))
-            _ <- runtime.close()
-            _ <- Task.eval(dbDir.recursivelyDelete())
+            _ <- Task.delay(runtime.close())
+            _ <- Task.now(dbDir.recursivelyDelete())
           } yield (res)
         })
       }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -786,7 +786,7 @@ class RholangMethodsCostsSpec
   def withReducer[R](f: ChargingReducer[Task] => Task[R])(implicit errLog: ErrorLog[Task]): R = {
 
     val test = for {
-      costAlg <- CostAccounting.of[Task](Cost(0))
+      costAlg <- CostAccounting.empty[Task]
       reducer = {
         implicit val cost: _cost[Task] = loggingCost(costAlg, noOpCostLog[Task])
         RholangOnlyDispatcher.create[Task, Task.Par](space)._2

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -786,9 +786,9 @@ class RholangMethodsCostsSpec
   def withReducer[R](f: ChargingReducer[Task] => Task[R])(implicit errLog: ErrorLog[Task]): R = {
 
     val test = for {
-      costAlg <- CostAccounting.empty[Task]
+      costAlg <- CostAccounting.emptyCost[Task]
       reducer = {
-        implicit val cost: _cost[Task] = loggingCost(costAlg, noOpCostLog[Task])
+        implicit val cost: _cost[Task] = costAlg
         RholangOnlyDispatcher.create[Task, Task.Par](space)._2
       }
       _   <- reducer.setPhlo(Cost.UNSAFE_MAX)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -18,7 +18,7 @@ import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
 import coop.rchain.models.rholang.sorter.Sortable
-import coop.rchain.rholang.interpreter.PrettyPrinter
+import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.accounting.utils._
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, OutOfPhlogistonsError}
@@ -33,6 +33,7 @@ import scalapb.GeneratedMessage
 import scala.collection.immutable.BitSet
 
 class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleEqualsSupport {
+  /*
   import SpatialMatcher._
   import coop.rchain.models.rholang.implicits._
 
@@ -648,13 +649,13 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   }
 
   /** Example:
-    *
-    * bundle { @7!(42) | @"0"!(43) } match {
-    *   w => …
-    * }
-    *
-    * here we match on the entire bundle, not its components.
-    */
+ *
+ * bundle { @7!(42) | @"0"!(43) } match {
+ *   w => …
+ * }
+ *
+ * here we match on the entire bundle, not its components.
+ */
   it should "be possible to match on entire bundle" in {
     val target: Bundle = Bundle(
       Par()
@@ -991,4 +992,5 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     res should be(Left(OutOfPhlogistonsError))
     phloLeft.value shouldBe -2
   }
+ */
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -936,10 +936,8 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
 
     (for {
-      costAlg <- CostAccounting.of[Task](Cost(initialPhlo))
-      s       <- Semaphore[Task](1)
-      costL   <- costLog[Task]
-      cost    = loggingCost(costAlg, costL, s)
+      costL <- costLog[Task]
+      cost  <- CostAccounting.initialCost[Task](Cost(initialPhlo))(Concurrent[Task], costL)
       program = {
         implicit val c = cost
         spatialMatchAndCharge[Task](target, pattern).attempt

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -3,8 +3,6 @@ package coop.rchain.rholang.interpreter.matcher
 import cats._
 import cats.data._
 import cats.effect._
-import cats.effect.concurrent.Ref
-import cats.implicits._
 import cats.mtl._
 import cats.mtl.implicits._
 import cats.{Eval => _}
@@ -22,7 +20,6 @@ import coop.rchain.rholang.interpreter._
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.accounting.utils._
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, OutOfPhlogistonsError}
-import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
@@ -31,41 +28,45 @@ import org.scalatest.concurrent.TimeLimits
 import scalapb.GeneratedMessage
 
 import scala.collection.immutable.BitSet
+import scala.concurrent.duration._
 
 class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleEqualsSupport {
-  /*
   import SpatialMatcher._
   import coop.rchain.models.rholang.implicits._
 
   private val printer = PrettyPrinter()
 
-  def assertSpatialMatch[T <: GeneratedMessage, P <: GeneratedMessage](
-      target: T,
-      pattern: P,
+  type F[A] = MatcherMonadT[Task, A]
+
+  def assertSpatialMatch(
+      target: Par,
+      pattern: Par,
       expectedCaptures: Option[FreeMap]
-  )(
-      implicit sm: SpatialMatcher[NonDetFreeMapWithCost, T, P],
-      ts: Sortable[T],
-      ps: Sortable[P]
   ): Assertion = {
+
     println(explainMatch(target, pattern, expectedCaptures))
     assertSorted(target, "target")
     assertSorted(pattern, "pattern")
     expectedCaptures.foreach(
       _.values.foreach((v: Par) => assertSorted(v, "expected captured term"))
     )
-    val intermediate: Either[InterpreterError, (Cost, Option[(FreeMap, Unit)])] =
-      spatialMatch[NonDetFreeMapWithCost, T, P](target, pattern)
-        .runFirstWithCost(Cost.UNSAFE_MAX)
-    assert(intermediate.isRight)
-    val result = intermediate.right.get._2.map(_._1)
-    assert(prettyCaptures(result) == prettyCaptures(expectedCaptures))
-    assert(result === expectedCaptures)
+
+    implicit val matcherMonadError = implicitly[Sync[F]]
+    (for {
+      costAccounting <- CostAccounting.of[Task](Cost.UNSAFE_MAX)
+      maybeResultWithCost <- {
+        implicit val cost            = loggingCost(costAccounting, noOpCostLog[Task])
+        implicit val costF: _cost[F] = matcherMonadCostLog[Task]
+        runFirst(spatialMatch[F, Par, Par](target, pattern))
+      }
+      result = maybeResultWithCost.map(_._1)
+      _      = assert(prettyCaptures(result) == prettyCaptures(expectedCaptures))
+    } yield (assert(result === expectedCaptures))).runSyncUnsafe(5.seconds)
   }
 
-  private def explainMatch[P <: GeneratedMessage, T <: GeneratedMessage](
-      target: T,
-      pattern: P,
+  private def explainMatch(
+      target: Par,
+      pattern: Par,
       expectedCaptures: Option[FreeMap]
   ): String = {
 
@@ -82,15 +83,13 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
        |""".stripMargin
   }
 
-  private def prettyCaptures[T <: GeneratedMessage, P <: GeneratedMessage](
+  private def prettyCaptures(
       expectedCaptures: Option[FreeMap]
   ): Option[Map[Int, String]] =
     expectedCaptures.map(_.map(c => (c._1, printer.buildString(c._2))))
 
-  private def assertSorted[T <: GeneratedMessage](term: T, termName: String)(
-      implicit ts: Sortable[T]
-  ): Assertion = {
-    val sortedTerm = Sortable[T].sortMatch[Coeval](term).value.term
+  private def assertSorted(term: Par, termName: String): Assertion = {
+    val sortedTerm = Sortable[Par].sortMatch[Coeval](term).value.term
     val clue       = s"Invalid test case - ${termName} is not sorted"
     assert(printer.buildString(term) == printer.buildString(sortedTerm), clue)
     assert(term == sortedTerm, clue)
@@ -141,9 +140,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     val pattern: Par = EVar(FreeVar(0))
 
     import org.scalatest.time.SpanSugar._
-    failAfter(5 seconds) {
-      assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> target)))
-    }
+    assertSpatialMatch(target, pattern, Some(Map[Int, Par](0 -> target)))
   }
 
   "Matching a send's channel" should "work" in {
@@ -649,13 +646,13 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
   }
 
   /** Example:
- *
- * bundle { @7!(42) | @"0"!(43) } match {
- *   w => …
- * }
- *
- * here we match on the entire bundle, not its components.
- */
+    *
+    * bundle { @7!(42) | @"0"!(43) } match {
+    *   w => …
+    * }
+    *
+    * here we match on the entire bundle, not its components.
+    */
   it should "be possible to match on entire bundle" in {
     val target: Bundle = Bundle(
       Par()
@@ -932,15 +929,6 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     assertSpatialMatch(failTarget, pattern, None)
   }
 
-  "spatialMatch" should "short-circuit when runs out of phlo in the middle of matching" in {
-    val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
-    val pattern: Par =
-      EList(Seq(GInt(1), EVar(FreeVar(0)), EVar(FreeVar(1))), connectiveUsed = true)
-    val res =
-      spatialMatch[NonDetFreeMapWithCost, Par, Par](target, pattern).runFirstWithCost(Cost(0))
-    res should be(Left(OutOfPhlogistonsError))
-  }
-
   private def doMatchAndCharge(initialPhlo: Long) = {
     val target: Par = EList(Seq(GInt(1), GInt(2), GInt(3)))
     val pattern: Par =
@@ -992,5 +980,4 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
     res should be(Left(OutOfPhlogistonsError))
     phloLeft.value shouldBe -2
   }
- */
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -29,7 +29,8 @@ class MatcherMonadSpec extends FlatSpec with Matchers {
 
   implicit val cost: _cost[Task] =
     loggingCost(CostAccounting.empty[Task].unsafeRunSync, noOpCostLog[Task])
-  implicit val costF: _cost[F] = matcherMonadCostLog[Task]
+  implicit val costF: _cost[F]   = matcherMonadCostLog[Task]
+  implicit val matcherMonadError = implicitly[Sync[F]]
 
   private def combineK[FF[_]: MonoidK, G[_]: Foldable, A](gfa: G[FF[A]]): FF[A] =
     gfa.foldLeft(MonoidK[FF].empty[A])(SemigroupK[FF].combineK[A])
@@ -116,7 +117,7 @@ class MatcherMonadSpec extends FlatSpec with Matchers {
 
   it should "fail all branches when using `_error[F].raise`" in {
     val a: F[Int] = 1.pure[F]
-    val b: F[Int] = 2.pure[F] >> _error[F].raise[Int](OutOfPhlogistonsError)
+    val b: F[Int] = 2.pure[F] >> _error[F].raiseError[Int](OutOfPhlogistonsError)
     val c: F[Int] = 3.pure[F]
 
     val combined = combineK(List(a, b, c))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -15,7 +15,6 @@ import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.accounting.CostAccounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.matcher.{run => runMatcher, _}
-import coop.rchain.rholang.interpreter.matcher.NonDetFreeMapWithCost._
 import org.scalatest._
 
 import monix.eval.Task

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -26,7 +26,7 @@ class MatcherMonadSpec extends FlatSpec with Matchers {
 
   val A: Alternative[F] = Alternative[F]
 
-  implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
+  implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
 
   implicit val costF: _cost[F]   = matcherMonadCostLog[Task]
   implicit val matcherMonadError = implicitly[Sync[F]]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -26,8 +26,8 @@ class MatcherMonadSpec extends FlatSpec with Matchers {
 
   val A: Alternative[F] = Alternative[F]
 
-  implicit val cost: _cost[Task] =
-    loggingCost(CostAccounting.empty[Task].unsafeRunSync, noOpCostLog[Task])
+  implicit val cost: _cost[Task] = CostAccounting.emptyCost[Task].unsafeRunSync
+
   implicit val costF: _cost[F]   = matcherMonadCostLog[Task]
   implicit val matcherMonadError = implicitly[Sync[F]]
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -3,6 +3,8 @@ package coop.rchain.rholang.interpreter.matcher
 import cats.arrow.FunctionK
 import cats.data.{EitherT, WriterT}
 import cats.implicits._
+import cats.effect.laws.discipline.SyncTests
+import cats.effect.laws.discipline.arbitrary._
 import cats.laws.discipline.{AlternativeTests, MonadErrorTests, MonadTests}
 import cats.mtl.laws.discipline.MonadLayerControlTests
 import cats.tests.CatsSuite
@@ -13,6 +15,9 @@ import coop.rchain.rholang.interpreter.matcher.StreamT.{SCons, Step}
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
+
+import cats.instances.AllInstances
+import cats.syntax.AllSyntax
 
 class StreamTSpec extends FlatSpec with Matchers {
 
@@ -104,7 +109,11 @@ class StreamTSpec extends FlatSpec with Matchers {
   }
 }
 
-class StreamTLawsSpec extends CatsSuite with LowPriorityDerivations {
+class StreamTLawsSpec
+    extends CatsSuite
+    with LowPriorityDerivations
+    with AllInstances
+    with AllSyntax {
 
   type Safe[A]          = Coeval[A]
   type Err[A]           = EitherT[Safe, String, A]
@@ -141,8 +150,10 @@ class StreamTLawsSpec extends CatsSuite with LowPriorityDerivations {
       )
     )
 
-  implicit def eqEff[A: Eq]: Eq[Effect[A]]       = Eq.by(x => x.value.value.value())
+  implicit def eqEff[A: Eq]: Eq[Effect[A]]       = Eq.by(x => x.value.value.attempt())
   implicit def eqFA[A: Eq]: Eq[StreamTEffect[A]] = Eq.by(StreamT.run[Effect, A])
+
+  implicit def eqT: Eq[Throwable] = Eq.allEqual
 
   checkAll(
     "StreamT.MonadLaws",
@@ -169,6 +180,7 @@ class StreamTLawsSpec extends CatsSuite with LowPriorityDerivations {
     MonadErrorTests[StreamTEffect, Unit].monadError[Int, Int, String]
   )
 
+  checkAll("StreamT.SyncLaws", SyncTests[StreamTEffect].sync[Int, Int, String])
 }
 
 trait LowPriorityDerivations {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter.matcher
 import cats.arrow.FunctionK
 import cats.data.{EitherT, WriterT}
 import cats.implicits._
-import cats.effect.laws.discipline.SyncTests
+import cats.effect.laws.discipline.{BracketTests, SyncTests}
 import cats.effect.laws.discipline.arbitrary._
 import cats.laws.discipline.{AlternativeTests, MonadErrorTests, MonadTests}
 import cats.mtl.laws.discipline.MonadLayerControlTests
@@ -181,6 +181,18 @@ class StreamTLawsSpec
   )
 
   checkAll("StreamT.SyncLaws", SyncTests[StreamTEffect].sync[Int, Int, String])
+
+  checkAll(
+    "StreamT.SyncLaws", {
+      val fromEffect =
+        λ[Effect ~> StreamTEffect[?]](
+          e => StreamT.liftF(e)
+        )
+      BracketTests[StreamTEffect[?], Throwable].bracketTrans[Effect, Int, Int](
+        fromEffect
+      )
+    }
+  )
 }
 
 trait LowPriorityDerivations {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -345,9 +345,8 @@ class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with 
     val cost: _cost[Task] =
       loggingCost(CostAccounting.empty[Task].runSyncUnsafe(1.second), noOpCostLog)
     def mkChargingRspace(rhoISpace: RhoISpace[Task]): Task[ChargingRSpace] = {
-      val s     = implicitly[Sync[Task]]
-      val error = FunctorRaise[Task, InterpreterError]
-      Task.delay(ChargingRSpace.pureRSpace(rhoISpace)(s, cost, error))
+      val s = implicitly[Sync[Task]]
+      Task.delay(ChargingRSpace.pureRSpace(rhoISpace)(s, cost))
     }
 
     val chargingRSpaceResource =

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -145,10 +145,7 @@ object BasicBench {
         )
         .unsafeRunSync
 
-    implicit val cost: _cost[Task] = loggingCost(
-      CostAccounting.of[Task](Cost.UNSAFE_MAX).unsafeRunSync,
-      noOpCostLog
-    )
+    implicit val cost: _cost[Task] = CostAccounting.initialCost[Task](Cost.UNSAFE_MAX).unsafeRunSync
 
     implicit val matcher = matchListPar
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -145,8 +145,7 @@ object BasicBench {
         )
         .unsafeRunSync
 
-    implicit val cost: _cost[Task] = CostAccounting.initialCost[Task](Cost.UNSAFE_MAX).unsafeRunSync
-
+    implicit val cost    = CostAccounting.initialCost[Task](Cost.UNSAFE_MAX).unsafeRunSync
     implicit val matcher = matchListPar
 
     val initSeed = 123456789L

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/wide/WideBenchBaseState.scala
@@ -42,9 +42,9 @@ abstract class WideBenchBaseState {
 
   def createRuntime(): Runtime[Task] =
     (for {
-      costAccounting <- CostAccounting.empty[Task]
+      cost <- CostAccounting.emptyCost[Task]
       runtime <- {
-        implicit val cost: _cost[Task] = loggingCost(costAccounting, noOpCostLog)
+        implicit val c: _cost[Task] = cost
         Runtime.create[Task, Task.Par](dbDir, mapSize, StoreType.LMDB)
       }
     } yield (runtime)).unsafeRunSync


### PR DESCRIPTION
## Overview
~~Replaces the underlying Ref in _cost with an MVar~~. Introduces a Semaphore and Bracket in the _cost capability for synchronization. This needs to be done due to the fact that Ref does not provide synchronization by itself, which means that concurrent branches of execution would not always see the latest amount of available phlogistons and continue executing also if the account was in the meantime depleted 

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3077


### Notes
Caveat: MVar doesn't work well with Bracket. Upon task cancellation the release function is provided with an outdated value


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
