### PR TITLE
RCHAIN-3113: Add curly brackets around receive in match case when pretty printing

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -319,7 +319,8 @@ final case class PrettyPrinter(
 
   private def buildMatchCase(matchCase: MatchCase, indent: Int): Coeval[String] = {
     val patternFree: Int = matchCase.freeCount
-    val isReceive        = matchCase.source.receives.nonEmpty
+    val openBrace        = pure(s"{\n${indentStr * (indent + 1)}")
+    val closeBrace       = pure(s"\n${indentStr * indent}}")
     this
       .copy(
         freeShift = boundShift,
@@ -327,12 +328,11 @@ final case class PrettyPrinter(
         freeId = boundId,
         baseId = setBaseId()
       )
-      .buildStringM(matchCase.pattern, indent) |+| pure(" => ") |+|
-      pure(if (!isReceive) "" else s"{\n${indentStr * (indent + 1)}") |+|
+      .buildStringM(matchCase.pattern, indent) |+| pure(" => ") |+| openBrace |+|
       this
         .copy(boundShift = boundShift + patternFree)
-        .buildStringM(matchCase.source, if (!isReceive) indent else indent + 1) |+|
-      pure(if (!isReceive) "" else s"\n${indentStr * indent}}")
+        .buildStringM(matchCase.source, indent + 1) |+|
+      closeBrace
   }
 
   private def isEmpty(p: Par) =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -319,6 +319,7 @@ final case class PrettyPrinter(
 
   private def buildMatchCase(matchCase: MatchCase, indent: Int): Coeval[String] = {
     val patternFree: Int = matchCase.freeCount
+    val isReceive        = matchCase.source.receives.nonEmpty
     this
       .copy(
         freeShift = boundShift,
@@ -327,9 +328,11 @@ final case class PrettyPrinter(
         baseId = setBaseId()
       )
       .buildStringM(matchCase.pattern, indent) |+| pure(" => ") |+|
+      pure(if (!isReceive) "" else s"{\n${indentStr * (indent + 1)}") |+|
       this
         .copy(boundShift = boundShift + patternFree)
-        .buildStringM(matchCase.source, indent)
+        .buildStringM(matchCase.source, if (!isReceive) indent else indent + 1) |+|
+      pure(if (!isReceive) "" else s"\n${indentStr * indent}}")
   }
 
   private def isEmpty(p: Par) =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -440,8 +440,12 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     checkRoundTrip(
       """for( @{x0}, @{x1} <- @{0} ) {
         |  match x0 {
-        |    =x0 => Nil
-        |    =x1 => Nil
+        |    =x0 => {
+        |      Nil
+        |    }
+        |    =x1 => {
+        |      Nil
+        |    }
         |  }
         |}""".stripMargin
     )
@@ -664,8 +668,12 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
         |    for( @{x6} <- @{x4} ) {
         |      x6 |
         |      match x6 {
-        |        42 => Nil
-        |        x7 => x3
+        |        42 => {
+        |          Nil
+        |        }
+        |        x7 => {
+        |          x3
+        |        }
         |      }
         |    }
         |  }
@@ -739,8 +747,12 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       """@{Nil}!(47) |
         |for( @{x0} <- @{Nil} ) {
         |  match x0 {
-        |    42 => Nil
-        |    x1 => Nil
+        |    42 => {
+        |      Nil
+        |    }
+        |    x1 => {
+        |      Nil
+        |    }
         |  }
         |}""".stripMargin
   }
@@ -769,8 +781,12 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     result shouldBe
       """match true {
-        |  true => @{Nil}!(47)
-        |  false => Nil
+        |  true => {
+        |    @{Nil}!(47)
+        |  }
+        |  false => {
+        |    Nil
+        |  }
         |}""".stripMargin
   }
 
@@ -800,11 +816,15 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
       )
     result shouldBe
       """match (47 == 47) {
-        |  true => new x0 in {
-        |    x0!(47)
+        |  true => {
+        |    new x0 in {
+        |      x0!(47)
+        |    }
         |  }
-        |  false => new x0 in {
-        |    x0!(47)
+        |  false => {
+        |    new x0 in {
+        |      x0!(47)
+        |    }
         |  }
         |}""".stripMargin
   }
@@ -827,7 +847,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     val result = PrettyPrinter().buildString(
       ProcNormalizeMatcher.normalizeMatch[Coeval](input, inputs).value.par
     )
-    result shouldBe """for( @{match x0 | x1 { 47 => Nil }} <- @{Nil} ) {
+    result shouldBe """for( @{match x0 | x1 { 47 => { Nil } }} <- @{Nil} ) {
                       |  Nil
                       |}""".stripMargin
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -745,6 +745,18 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
         |}""".stripMargin
   }
 
+  it should "Print receive in curly brackets" in {
+    checkRoundTrip(
+      """match Nil {
+        |  _ => {
+        |    for( @{_} <- @{Nil} ) {
+        |      Nil
+        |    }
+        |  }
+        |}""".stripMargin
+    )
+  }
+
   "PIf" should "Print as a match" in {
     val condition = new PGround(new GroundBool(new BoolTrue()))
     val listSend  = new ListProc()


### PR DESCRIPTION
## Overview
Without this fix the PrettyPrinter outputs Rholang that is not parsable.

Another solution might be to change the grammar in `rholang_mercury.cf` from
```
-- Match Cases
CaseImpl. Case ::= Proc13 "=>" Proc3 ;
```
to
```
-- Match Cases
CaseImpl. Case ::= Proc13 "=>" Proc1 ;
```
This would result in `match Nil { _ => for(_ <- @Nil) {Nil} }` to be parsable.
I didn't go that route because it looks to me as if there is *some* reason that the bnfc rule is what it is.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3113

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.