### PR TITLE
Change RSpace reset to skip resetting to already selected root

### DIFF
--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/Ed25519PubKeyConverterSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/Ed25519PubKeyConverterSpec.scala
@@ -13,9 +13,9 @@ class Ed25519PubKeyConverterSpec extends PropSpec with GeneratorDrivenPropertyCh
     val gen = Gen.listOfN(Ed25519.publicKeyLength, Arbitrary.arbByte.arbitrary).map(_.toArray)
 
     forAll(gen) { bytes: Array[Byte] =>
-      val asHex           = Base16.encode(bytes)
+      val asHex = Base16.encode(bytes)
 
-      def getResult(s : String) =
+      def getResult(s: String) =
         Ed25519PubKeyConverter.parse(List(("--user-id", List(s)))).right.get.get.bytes
 
       getResult(asHex) should be(bytes)
@@ -40,7 +40,9 @@ class Ed25519PubKeyConverterSpec extends PropSpec with GeneratorDrivenPropertyCh
     forAll { s: String =>
       val args = List(("--user-id", List(s)))
 
-      val isBadEncoding = s.isEmpty || s.exists(c => !(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))
+      val isBadEncoding = s.isEmpty || s.exists(
+        c => !(c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+      )
 
       Ed25519PubKeyConverter.parse(args).isLeft should be(isBadEncoding)
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -132,7 +132,7 @@ object SystemProcesses {
         case isContractCall(
             produce,
             Seq(RhoType.String("fromPublicKey"), RhoType.ByteArray(publicKey), ack)
-        ) =>
+            ) =>
           val response =
             RevAddress
               .fromPublicKey(PublicKey(publicKey))

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -117,6 +117,13 @@ trait ISpace[F[_], C, P, A, R, K] {
     */
   def close(): F[Unit]
 
+  /**
+    * checks it the internal state is consistent with the passed root hash
+    *
+    * @param root to verify the state against
+    */
+  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
+
   val store: IStore[F, C, P, A, K]
 }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -450,6 +450,14 @@ class RSpace[F[_], C, P, A, R, K] private[rspace] (
       eventLog.put(Seq.empty)
       Checkpoint(root, events)
     }
+
+  override protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean] = store.withWriteTxnF {
+    txn =>
+      store
+        .withTrieTxn(txn) { trieTxn =>
+          (store.trieStore.getRoot(trieTxn, store.trieBranch).get != root) || eventLog.get.nonEmpty
+        }
+  }
 }
 
 object RSpace {

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -422,6 +422,8 @@ class ReplayRSpace[F[_], C, P, A, R, K](store: IStore[F, C, P, A, K], branch: Br
           }
       _ <- super.clear()
     } yield ()
+
+  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean] = true.pure[F]
 }
 
 object ReplayRSpace {


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
It is wasteful to reset to the same root in RSpace if it was not changed.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
umbrella ticket: https://rchain.atlassian.net/browse/RCHAIN-3060 


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
