### PR TITLE
rename Base16.decode to unsafeDecode

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -53,7 +53,7 @@ object CasperConf {
               Source
                 .fromFile(file)
                 .getLines()
-                .map(line => ByteString.copyFrom(Base16.decode(line)))
+                .map(line => ByteString.copyFrom(Base16.unsafeDecode(line)))
                 .toSet
             )
           }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -1,0 +1,30 @@
+package coop.rchain.casper
+
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.crypto.signatures._
+import com.google.protobuf.ByteString
+
+object SignDeployment {
+
+  private def fill(
+      deployData: DeployData
+  )(user: PublicKey, sig: Array[Byte], sigAlgorithm: String): DeployData =
+    deployData
+      .withUser(ByteString.copyFrom(user.bytes))
+      .withSig(ByteString.copyFrom(sig))
+      .withSigAlgorithm(sigAlgorithm)
+
+  private def clear(deployData: DeployData): DeployData =
+    fill(deployData)(PublicKey(Array.empty[Byte]), Array.empty[Byte], "")
+
+  def apply(key: PrivateKey, deployData: DeployData): DeployData = {
+    val toSign    = clear(deployData).toByteString.toByteArray
+    val hash      = Blake2b256.hash(toSign)
+    val signature = Ed25519.sign(hash, key.bytes)
+
+    fill(deployData)(PublicKey(Ed25519.toPublic(key.bytes)), signature, "Ed25519".toLowerCase)
+  }
+
+}

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -24,7 +24,7 @@ object SignDeployment {
     val hash      = Blake2b256.hash(toSign)
     val signature = alg.sign(hash, key)
 
-    fill(deployData)(alg.toPublic(key)), signature, alg.name)
+    fill(deployData)(alg.toPublic(key), signature, alg.name)
   }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -22,9 +22,9 @@ object SignDeployment {
   def apply(key: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
     val toSign    = clear(deployData).toByteString.toByteArray
     val hash      = Blake2b256.hash(toSign)
-    val signature = alg.sign(hash, key.bytes)
+    val signature = alg.sign(hash, key)
 
-    fill(deployData)(PublicKey(alg.toPublic(key.bytes)), signature, alg.name)
+    fill(deployData)(alg.toPublic(key)), signature, alg.name)
   }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -19,12 +19,12 @@ object SignDeployment {
   private def clear(deployData: DeployData): DeployData =
     fill(deployData)(PublicKey(Array.empty[Byte]), Array.empty[Byte], "")
 
-  def apply(key: PrivateKey, deployData: DeployData): DeployData = {
+  def apply(key: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
     val toSign    = clear(deployData).toByteString.toByteArray
     val hash      = Blake2b256.hash(toSign)
-    val signature = Ed25519.sign(hash, key.bytes)
+    val signature = alg.sign(hash, key.bytes)
 
-    fill(deployData)(PublicKey(Ed25519.toPublic(key.bytes)), signature, "Ed25519".toLowerCase)
+    fill(deployData)(PublicKey(alg.toPublic(key.bytes)), signature, alg.name)
   }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -41,8 +41,8 @@ object ValidatorIdentity {
       conf: CasperConf,
       privateKeyBase16: String
   ) = {
-    val privateKey     = Base16.decode(privateKeyBase16)
-    val maybePublicKey = conf.publicKeyBase16.map(Base16.decode)
+    val privateKey     = Base16.unsafeDecode(privateKeyBase16)
+    val maybePublicKey = conf.publicKeyBase16.map(Base16.unsafeDecode)
 
     val publicKey =
       CasperConf.publicKey(maybePublicKey, conf.sigAlgorithm, privateKey)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -232,7 +232,7 @@ object Genesis {
                 .getLines()
                 .map(line => {
                   val Array(pk, _) = line.trim.split(" ")
-                  ByteString.copyFrom(Base16.decode(pk))
+                  ByteString.copyFrom(Base16.unsafeDecode(pk))
                 })
                 .toSet
             }
@@ -261,7 +261,7 @@ object Genesis {
                 .getLines()
                 .map(line => {
                   val Array(pk, stake) = line.trim.split(" ")
-                  Base16.decode(pk) -> (stake.toLong)
+                  Base16.unsafeDecode(pk) -> (stake.toLong)
                 })
                 .toMap
             }

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -45,7 +45,12 @@ object BondingUtil {
   )(
       implicit runtimeManager: RuntimeManager[F]
   ): F[String] =
-    preWalletUnlockDeploy(ethAddress, pubKey, Base16.unsafeDecode(secKey), s"${ethAddress}_unlockOut")
+    preWalletUnlockDeploy(
+      ethAddress,
+      pubKey,
+      Base16.unsafeDecode(secKey),
+      s"${ethAddress}_unlockOut"
+    )
 
   def issuanceBondDeploy[F[_]: Concurrent](
       amount: Long,
@@ -70,7 +75,9 @@ object BondingUtil {
       secKey: Array[Byte],
       statusOut: String
   )(implicit runtimeManager: RuntimeManager[F]): F[String] = {
-    require(Base16.encode(Keccak256.hash(Base16.unsafeDecode(pubKey)).drop(12)) == ethAddress.drop(2))
+    require(
+      Base16.encode(Keccak256.hash(Base16.unsafeDecode(pubKey)).drop(12)) == ethAddress.drop(2)
+    )
     val unlockSigDataTerm =
       sourceDeploy(
         s""" @"__SCALA__"!(["$pubKey", "$statusOut"].toByteArray())""",

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -45,7 +45,7 @@ object BondingUtil {
   )(
       implicit runtimeManager: RuntimeManager[F]
   ): F[String] =
-    preWalletUnlockDeploy(ethAddress, pubKey, Base16.decode(secKey), s"${ethAddress}_unlockOut")
+    preWalletUnlockDeploy(ethAddress, pubKey, Base16.unsafeDecode(secKey), s"${ethAddress}_unlockOut")
 
   def issuanceBondDeploy[F[_]: Concurrent](
       amount: Long,
@@ -61,7 +61,7 @@ object BondingUtil {
       bondingForwarderAddress(ethAddress),
       transferStatusOut(ethAddress),
       pubKey,
-      Base16.decode(secKey)
+      Base16.unsafeDecode(secKey)
     )
 
   def preWalletUnlockDeploy[F[_]: Concurrent](
@@ -70,7 +70,7 @@ object BondingUtil {
       secKey: Array[Byte],
       statusOut: String
   )(implicit runtimeManager: RuntimeManager[F]): F[String] = {
-    require(Base16.encode(Keccak256.hash(Base16.decode(pubKey)).drop(12)) == ethAddress.drop(2))
+    require(Base16.encode(Keccak256.hash(Base16.unsafeDecode(pubKey)).drop(12)) == ethAddress.drop(2))
     val unlockSigDataTerm =
       sourceDeploy(
         s""" @"__SCALA__"!(["$pubKey", "$statusOut"].toByteArray())""",
@@ -85,7 +85,7 @@ object BondingUtil {
       sigBytes      = capturedResults.head.exprs.head.getGByteArray.toByteArray
       unlockSigData = Keccak256.hash(sigBytes)
       unlockSig     = Secp256k1.sign(unlockSigData, secKey)
-      _             = assert(Secp256k1.verify(unlockSigData, unlockSig, Base16.decode("04" + pubKey)))
+      _             = assert(Secp256k1.verify(unlockSigData, unlockSig, Base16.unsafeDecode("04" + pubKey)))
       sigString     = Base16.encode(unlockSig)
     } yield s"""new rl(`rho:registry:lookup`), WalletCheckCh in {
            |  rl!(`rho:id:oqez475nmxx9ktciscbhps18wnmnwtm6egziohc3rkdzekkmsrpuyt`, *WalletCheckCh) |
@@ -240,7 +240,7 @@ object BondingUtil {
     runtimeManagerResource.use(
       implicit runtimeManager =>
         for {
-          bondCode    <- faucetBondDeploy[F](amount, sigAlgorithm, pubKey, Base16.decode(secKey))
+          bondCode    <- faucetBondDeploy[F](amount, sigAlgorithm, pubKey, Base16.unsafeDecode(secKey))
           forwardCode = bondingForwarderDeploy(pubKey, pubKey)
           _           <- writeFile[F](s"forward_${pubKey}.rho", forwardCode)
           _           <- writeFile[F](s"bond_${pubKey}.rho", bondCode)

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -485,7 +485,7 @@ object ProtoUtil {
   def hashString(b: BlockMessage): String = Base16.encode(b.blockHash.toByteArray)
 
   def stringToByteString(string: String): ByteString =
-    ByteString.copyFrom(Base16.decode(string))
+    ByteString.copyFrom(Base16.unsafeDecode(string))
 
   def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
     Time[F].currentMillis.map(

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
@@ -109,7 +109,7 @@ object Args {
 
     val id =
       unforgeableNameStr
-        .map(Base16.decode(_))
+        .map(Base16.unsafeDecode(_))
         .getOrElse(RegistrySigGen.generateUnforgeableNameId(keyPair._1, timestamp))
 
     // Now we can determine the unforgeable name
@@ -127,14 +127,14 @@ object Args {
         Args(
           contractName,
           timestampStr.toLong,
-          Some(Base16.decode(skBase16)),
+          Some(Base16.unsafeDecode(skBase16)),
           Some(unforgeableName)
         )
       case Array(contractName, timestampStr, skBase16) =>
         Args(
           contractName,
           timestampStr.toLong,
-          Some(Base16.decode(skBase16))
+          Some(Base16.unsafeDecode(skBase16))
         )
       case Array(contractName, timestampStr) => Args(contractName, timestampStr.toLong)
       case Array(contractName)               => Args(contractName)

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -136,7 +136,7 @@ class ValidateTest
         _            <- createChain[Task](6)
         (_, wrongPk) = Ed25519.newKeyPair
         empty        = ByteString.EMPTY
-        invalidKey   = ByteString.copyFrom(Base16.decode("abcdef1234567890"))
+        invalidKey   = ByteString.copyFrom(Base16.unsafeDecode("abcdef1234567890"))
         block0       <- signedBlock(0).map(_.withSender(empty))
         block1       <- signedBlock(1).map(_.withSender(invalidKey))
         block2       <- signedBlock(2).map(_.withSender(ByteString.copyFrom(wrongPk)))

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -151,7 +151,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
         _     = log.infos.isEmpty should be(true)
         result = validators
           .map {
-            case (v, i) => Bond(ByteString.copyFrom(Base16.decode(v)), i.toLong)
+            case (v, i) => Bond(ByteString.copyFrom(Base16.unsafeDecode(v)), i.toLong)
           }
           .forall(
             bonds.contains(_)
@@ -199,7 +199,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
         _       = log.infos.length should be(1)
         result = validators
           .map {
-            case (v, i) => Bond(ByteString.copyFrom(Base16.decode(v)), i.toLong)
+            case (v, i) => Bond(ByteString.copyFrom(Base16.unsafeDecode(v)), i.toLong)
           }
           .forall(
             bonds.contains(_)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -55,7 +55,7 @@ class RevIssuanceTest extends FlatSpec with Matchers {
         Faucet.noopFaucet
       )
 
-    val secKey = Base16.decode("a68a6e6cca30f81bd24a719f3145d20e8424bd7b396309b0708a16c7d8000b76")
+    val secKey = Base16.unsafeDecode("a68a6e6cca30f81bd24a719f3145d20e8424bd7b396309b0708a16c7d8000b76")
     val pubKey =
       "f700a417754b775d95421973bdbdadb2d23c8a5af46f1829b1431f5c136e549e8a0d61aa0c793f1a614f8e437711c7758473c6ceb0859ac7e9e07911ca66b5c4"
 

--- a/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
@@ -1,19 +1,41 @@
 package coop.rchain.crypto.codec
+import scala.util.Try
 
 object Base16 {
   def encode(input: Array[Byte]): String = bytes2hex(input, None)
 
-  def decode(input: String): Array[Byte] = {
+  /**
+    * Decodes an input string by ignoring the non-hex characters. It always succeeds.
+    * @param input
+    * @return
+    */
+  def unsafeDecode(input: String): Array[Byte] = decode(input, "[^0-9A-Fa-f]").get
+
+  /**
+    * Decodes an input string by ignoring the separator characters
+    * @param input
+    * @param separatorsRx the regex matching the allowed separators
+    * @return None if any non-hex and non-separator characters are encountered in the input
+    *         Some otherwise
+    */
+  def decode(input: String, separatorsRx : String = ""): Option[Array[Byte]] = {
     val paddedInput =
       if (input.length % 2 == 0) input
       else "0" + input
 
-    hex2bytes(paddedInput)
+    hex2bytes(paddedInput, separatorsRx)
   }
 
   private def bytes2hex(bytes: Array[Byte], sep: Option[String]): String =
     bytes.map("%02x".format(_)).mkString(sep.getOrElse(""))
 
-  private def hex2bytes(hex: String): Array[Byte] =
-    hex.replaceAll("[^0-9A-Fa-f]", "").sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+  private def hex2bytes(hex: String, separatorsRx : String): Option[Array[Byte]] =
+    Try {
+      val digitsOnly = hex.replaceAll(separatorsRx, "")
+
+      digitsOnly
+        .sliding(2, 2)
+        .toArray
+        .map(Integer.parseInt(_, 16).toByte)
+    }.toOption
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/codec/Base16.scala
@@ -18,7 +18,7 @@ object Base16 {
     * @return None if any non-hex and non-separator characters are encountered in the input
     *         Some otherwise
     */
-  def decode(input: String, separatorsRx : String = ""): Option[Array[Byte]] = {
+  def decode(input: String, separatorsRx: String = ""): Option[Array[Byte]] = {
     val paddedInput =
       if (input.length % 2 == 0) input
       else "0" + input
@@ -29,7 +29,7 @@ object Base16 {
   private def bytes2hex(bytes: Array[Byte], sep: Option[String]): String =
     bytes.map("%02x".format(_)).mkString(sep.getOrElse(""))
 
-  private def hex2bytes(hex: String, separatorsRx : String): Option[Array[Byte]] =
+  private def hex2bytes(hex: String, separatorsRx: String): Option[Array[Byte]] =
     Try {
       val digitsOnly = hex.replaceAll(separatorsRx, "")
 

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -6,6 +6,8 @@ object Ed25519 extends SignaturesAlg {
 
   val publicKeyLength = 32
 
+  val name: String = "Ed25519".toLowerCase
+
   //TODO: Make use of strongly typed keys
   def newKeyPair: (Array[Byte], Array[Byte]) = {
     val key = new SigningKey()

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -75,4 +75,7 @@ object Ed25519 extends SignaturesAlg {
   ): Array[Byte] =
     new SigningKey(sec).sign(data)
 
+  override def toPublic(
+      sec: crypto.PrivateKey): crypto.PublicKey =
+    crypto.PublicKey(toPublic(sec.bytes))
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Ed25519.scala
@@ -1,5 +1,6 @@
 package coop.rchain.crypto.signatures
 
+import coop.rchain.crypto
 import org.abstractj.kalium.keys._
 
 object Ed25519 extends SignaturesAlg {
@@ -11,22 +12,21 @@ object Ed25519 extends SignaturesAlg {
   //TODO: Make use of strongly typed keys
   def newKeyPair: (Array[Byte], Array[Byte]) = {
     val key = new SigningKey()
-    val sec = key.toBytes()
-    val pub = key.getVerifyKey().toBytes()
+    val sec = key.toBytes
+    val pub = key.getVerifyKey.toBytes
     (sec, pub)
   }
 
   /**
     * Ed25519 Compute Pubkey - computes public key from secret key
     *
-    * @param seckey Ed25519 Secret key, 32 bytes
+    * @param sec Ed25519 Secret key, 32 bytes
     *
-    * Return values
-    * @param pubkey Ed25519 Public key, 32 bytes
+    * @return Ed25519 Public key, 32 bytes
     */
   def toPublic(sec: Array[Byte]): Array[Byte] = {
     val key = new SigningKey(sec)
-    key.getVerifyKey().toBytes()
+    key.getVerifyKey.toBytes
   }
 
   /**
@@ -65,8 +65,7 @@ object Ed25519 extends SignaturesAlg {
     * @param data Message hash, 32 bytes
     * @param sec Secret key, 32 bytes
     *
-    * Return value
-    * byte array of signature
+    * @return byte array of signature
     *
     */
   def sign(

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -13,8 +13,9 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object Secp256k1 extends SignaturesAlg {
 
-  private val provider  = new BouncyCastleProvider()
-  private val curveName = "secp256k1"
+  private val provider = new BouncyCastleProvider()
+
+  val name: String = "secp256k1"
 
   /**
     * Verifies the given secp256k1 signature in native code.
@@ -25,7 +26,7 @@ object Secp256k1 extends SignaturesAlg {
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def newKeyPair: (PrivateKey, PublicKey) = {
     val kpg = KeyPairGenerator.getInstance("ECDSA", provider)
-    kpg.initialize(new ECGenParameterSpec(curveName), SecureRandomUtil.secureRandomNonBlocking)
+    kpg.initialize(new ECGenParameterSpec(name), SecureRandomUtil.secureRandomNonBlocking)
     val kp = kpg.generateKeyPair
 
     val padded =

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -9,6 +9,7 @@ import coop.rchain.crypto.util.SecureRandomUtil
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import org.bitcoin._
 import com.google.common.base.Strings
+import coop.rchain.crypto
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 object Secp256k1 extends SignaturesAlg {
@@ -91,10 +92,11 @@ object Secp256k1 extends SignaturesAlg {
     *
     * @param seckey ECDSA Secret key, 32 bytes
     *
-    * Return values
-    * @param pubkey ECDSA Public key, 33 or 65 bytes
+    * Return values ECDSA Public key, 33 or 65 bytes
     */
   def toPublic(seckey: Array[Byte]): Array[Byte] =
     NativeSecp256k1.computePubkey(seckey)
 
+  override def toPublic(sec: crypto.PrivateKey): crypto.PublicKey =
+    crypto.PublicKey(toPublic(sec.bytes))
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -32,7 +32,7 @@ object Secp256k1 extends SignaturesAlg {
 
     val padded =
       Strings.padStart(kp.getPrivate.asInstanceOf[ECPrivateKey].getS.toString(16), 64, '0')
-    val sec = Base16.decode(padded)
+    val sec = Base16.unsafeDecode(padded)
     val pub = Secp256k1.toPublic(sec)
 
     (PrivateKey(sec), PublicKey(pub))

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
@@ -1,10 +1,16 @@
 package coop.rchain.crypto.signatures
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 
 trait SignaturesAlg {
   def verify(data: Array[Byte], signature: Array[Byte], pub: Array[Byte]): Boolean
   def sign(data: Array[Byte], sec: Array[Byte]): Array[Byte]
-  def toPublic(sec: Array[Byte]): Array[Byte]
+  def toPublic(sec: PrivateKey): PublicKey
   def name: String
+
+
+  def verify(data: Array[Byte], signature: Array[Byte], pub: PublicKey): Boolean =
+    verify(data, signature, pub.bytes)
+  def sign(data: Array[Byte], sec: PrivateKey): Array[Byte] = sign(data, sec.bytes)
 }
 
 object SignaturesAlg {

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
@@ -3,6 +3,8 @@ package coop.rchain.crypto.signatures
 trait SignaturesAlg {
   def verify(data: Array[Byte], signature: Array[Byte], pub: Array[Byte]): Boolean
   def sign(data: Array[Byte], sec: Array[Byte]): Array[Byte]
+  def toPublic(sec: Array[Byte]): Array[Byte]
+  def name: String
 }
 
 object SignaturesAlg {

--- a/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
@@ -1,14 +1,34 @@
 package coop.rchain.crypto.codec
 
+import org.scalacheck.Shrink
 import org.scalatest._
 import prop._
 
 class Base16Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+  implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
+
   property("decode after encode returns the original input") {
     forAll { (input: Array[Byte]) =>
       val encoded = Base16.encode(input)
-      val decoded = Base16.decode(encoded)
+      val decoded = Base16.decode(encoded).get
       decoded should equal(input)
+    }
+  }
+
+  property("decode fails if given non-hex characters") {
+    forAll { (input: String) =>
+      val decoded = Base16.decode(input, "")
+      val hasInvalidCharacters = input.replaceAll("[^0-9A-Fa-f]", "") != input
+      decoded.isEmpty should equal(hasInvalidCharacters)
+    }
+  }
+
+  property("unsafeDecode is always successful") {
+    forAll { (input: String) =>
+      try { Base16.unsafeDecode(input)}
+      catch {
+        case _ : Exception => Base16.unsafeDecode(input)
+      }
     }
   }
 }

--- a/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
@@ -6,12 +6,12 @@ import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
 class Curve25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Curve25519 elliptic curve cryptography") {
 
-    val bobSec   = Base16.decode("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")
-    val bobPub   = Base16.decode("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")
-    val aliceSec = Base16.decode("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
-    val alicePub = Base16.decode("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")
-    val nonce    = Base16.decode("69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37")
-    val message = Base16.decode(
+    val bobSec   = Base16.unsafeDecode("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb")
+    val bobPub   = Base16.unsafeDecode("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f")
+    val aliceSec = Base16.unsafeDecode("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
+    val alicePub = Base16.unsafeDecode("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")
+    val nonce    = Base16.unsafeDecode("69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37")
+    val message = Base16.unsafeDecode(
       "be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffce5ecbaaf33bd751a1ac728d45e6c61296cdc3c01233561f41db66cce314adb310e3be8250c46f06dceea3a7fa1348057e2f6556ad6b1318a024a838f21af1fde048977eb48f59ffd4924ca1c60902e52f0a089bc76897040e082f937763848645e0705"
     )
     val cipher = Curve25519.encrypt(alicePub, bobSec, nonce, message)

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
@@ -6,28 +6,28 @@ class Ed25519Test extends FunSpec with Matchers with BeforeAndAfterEach with App
   describe("Ed25519") {
 
     it("computes public key from secret key") {
-      val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+      val sec = Base16.unsafeDecode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
       Base16.encode(Ed25519.toPublic(sec)) shouldBe "77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb"
 
     }
     it("verifies the given Ed25519 signature") {
-      val data = Base16.decode(
+      val data = Base16.unsafeDecode(
         "916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40"
       )
-      val sig = Base16.decode(
+      val sig = Base16.unsafeDecode(
         "6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509"
       )
-      val pub = Base16.decode("77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb")
+      val pub = Base16.unsafeDecode("77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb")
       Ed25519.verify(data, sig, pub) shouldBe true
     }
     it("creates an Ed25519 signature.") {
-      val data = Base16.decode(
+      val data = Base16.unsafeDecode(
         "916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be6031522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c9983372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c18f613f2ae2e856af40"
       )
-      val sig = Base16.decode(
+      val sig = Base16.unsafeDecode(
         "6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9edbad3901b64ab09cc5ef7b9bcc3c40c0ff7509"
       )
-      val sec = Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+      val sec = Base16.unsafeDecode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
       Ed25519.sign(data, sec).deep shouldBe sig.deep
     }
   }

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
@@ -15,27 +15,27 @@ class Secp256k1Test extends FunSpec with Matchers with BeforeAndAfterEach with A
     }
     it("verifies the given secp256k1 signature in native code") {
       val data = Sha256.hash("testing".getBytes)
-      val sig = Base16.decode(
+      val sig = Base16.unsafeDecode(
         "3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589"
       )
-      val pub = Base16.decode(
+      val pub = Base16.unsafeDecode(
         "040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40"
       )
       Secp256k1.verify(data, sig, pub)
     }
     it("packaged in libsecp256k1 creates an ECDSA signature") {
       val data = Sha256.hash("testing".getBytes)
-      val sec  = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      val sec  = Base16.unsafeDecode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
       Base16
         .encode(Secp256k1.sign(data, sec))
         .toUpperCase() shouldBe "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9"
     }
     it("verify returns true if valid, false if invalid") {
-      val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      val sec = Base16.unsafeDecode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
       Secp256k1.secKeyVerify(sec) shouldBe true
     }
     it("computes public key from secret key") {
-      val sec = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      val sec = Base16.unsafeDecode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
       Base16
         .encode(Secp256k1.toPublic(sec))
         .toUpperCase() shouldBe "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6"

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Base16Converter.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Base16Converter.scala
@@ -8,7 +8,8 @@ object Base16Converter extends ValueConverter[Array[Byte]] {
       case (name, strings) => strings.map((name, _))
     } match {
       case List((name, v)) =>
-        Base16.decode(v.toLowerCase)
+        Base16
+          .decode(v.toLowerCase)
           .toRight(s"Error parsing $name. Invalid base16 encoding.")
           .map(Some(_))
       case List() => Right(None)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Base16Converter.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Base16Converter.scala
@@ -2,17 +2,14 @@ package coop.rchain.node.configuration.commandline
 import coop.rchain.crypto.codec.Base16
 import org.rogach.scallop.{ArgType, ValueConverter}
 
-import scala.util.Try
-import cats.implicits._
-
 object Base16Converter extends ValueConverter[Array[Byte]] {
   override def parse(args: List[(String, List[String])]): Either[String, Option[Array[Byte]]] =
     args.flatMap {
       case (name, strings) => strings.map((name, _))
     } match {
       case List((name, v)) =>
-        Try { Base16.decode(v.toLowerCase) }.toEither
-          .leftMap(_ => s"Error parsing $name. Invalid base16 encoding.")
+        Base16.decode(v.toLowerCase)
+          .toRight(s"Error parsing $name. Invalid base16 encoding.")
           .map(Some(_))
       case List() => Right(None)
       case _      => Left("Expecting a single argument encoded as base16.")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -978,7 +978,7 @@ object Reduce {
                 )
               for {
                 _           <- charge[M](hexToBytesCost(encoded))
-                encodingRes = Try(ByteString.copyFrom(Base16.decode(encoded)))
+                encodingRes = Try(ByteString.copyFrom(Base16.unsafeDecode(encoded)))
                 res <- encodingRes.fold(
                         th => s.raiseError(decodingError(th)),
                         ba => Applicative[M].pure[Par](Expr(GByteArray(ba)))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -1007,7 +1007,7 @@ class RegistryImpl[F[_]](
 object Registry {
   val registryRoot = GPrivate(
     ByteString
-      .copyFrom(Base16.decode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697"))
+      .copyFrom(Base16.unsafeDecode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697"))
   )
 
   val emptyMap: Par = EMapBody(ParMap(SortedParMap.empty))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -1007,7 +1007,9 @@ class RegistryImpl[F[_]](
 object Registry {
   val registryRoot = GPrivate(
     ByteString
-      .copyFrom(Base16.unsafeDecode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697"))
+      .copyFrom(
+        Base16.unsafeDecode("a4fd447dedfc960485983ee817632cf36d79f45fd1796019edfb4a84a81d1697")
+      )
   )
 
   val emptyMap: Par = EMapBody(ParMap(SortedParMap.empty))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -132,7 +132,7 @@ object SystemProcesses {
         case isContractCall(
             produce,
             Seq(RhoType.String("fromPublicKey"), RhoType.ByteArray(publicKey), ack)
-        ) =>
+            ) =>
           val response =
             RevAddress
               .fromPublicKey(PublicKey(publicKey))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
@@ -7,7 +7,7 @@ final case class RevAddress(val keyHash: Array[Byte])
 object RevAddress {
   private val coinId  = "000000"
   private val version = "00"
-  private val prefix  = Base16.decode(coinId + version)
+  private val prefix  = Base16.unsafeDecode(coinId + version)
 
   private val tools = new AddressTools(prefix, keyLength = 32, checksumLength = 4)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -136,10 +136,10 @@ class CryptoChannelsSpec
 
       val secp256k1VerifyhashChannel = GString("secp256k1Verify")
 
-      val pubKey = Base16.decode(
+      val pubKey = Base16.unsafeDecode(
         "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6"
       )
-      val secKey = Base16.decode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
+      val secKey = Base16.unsafeDecode("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530")
 
       val ackChannel                  = GString("x")
       implicit val emptyEnv: Env[Par] = Env[Par]()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -924,7 +924,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         implicit val env = Env.makeEnv[Par](Expr(GString("deadbeef")))
         Await.result(reducer.evalExprToPar(hexToBytesCall).runToFuture, 3.seconds)
     }
-    val expectedResult: Par = Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))
+    val expectedResult: Par = Expr(GByteArray(ByteString.copyFrom(Base16.unsafeDecode("deadbeef"))))
     directResult should be(expectedResult)
 
     errorLog.readAndClearErrorVector.unsafeRunSync should be(Vector.empty[InterpreterError])
@@ -1418,14 +1418,14 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         val inspectTask = reducer.evalExpr(
           EPlusPlusBody(
             EPlusPlus(
-              GByteArray(ByteString.copyFrom(Base16.decode("dead"))),
-              GByteArray(ByteString.copyFrom(Base16.decode("beef")))
+              GByteArray(ByteString.copyFrom(Base16.unsafeDecode("dead"))),
+              GByteArray(ByteString.copyFrom(Base16.unsafeDecode("beef")))
             )
           )
         )
         Await.result(inspectTask.runToFuture, 3.seconds)
     }
-    result.exprs should be(Seq(Expr(GByteArray(ByteString.copyFrom(Base16.decode("deadbeef"))))))
+    result.exprs should be(Seq(Expr(GByteArray(ByteString.copyFrom(Base16.unsafeDecode("deadbeef"))))))
     errorLog.readAndClearErrorVector.unsafeRunSync should be(Vector.empty[InterpreterError])
   }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -83,7 +83,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val ninetySevenByteArray: Par = GByteArray(ByteString.copyFrom(Array[Byte](0x97.toByte)))
   val branchName: Par = GPrivate(
     ByteString
-      .copyFrom(Base16.decode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e"))
+      .copyFrom(Base16.unsafeDecode("d5fd3d8daf9f295aa590b37b50d5518803b4596ed6940aa42d46b1413a1bb16e"))
   )
   // format: off
   val rootSend: Send = Send(
@@ -100,16 +100,16 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   val efByteArray: Par        = GByteArray(ByteString.copyFrom(Array[Byte](0xef.toByte)))
   val emptyByteArray: Par     = GByteArray(ByteString.EMPTY)
   val branch1: Par = GByteArray(
-    ByteString.copyFrom(Base16.decode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2"))
+    ByteString.copyFrom(Base16.unsafeDecode("533fd9c5c26e7ea3fe07f99a4dbbde31eb2c59f84810d03e078e7d31c2"))
   )
   val branch2: Par = GByteArray(
-    ByteString.copyFrom(Base16.decode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e"))
+    ByteString.copyFrom(Base16.unsafeDecode("e6bbe6f893b810e66615867bede6e16fcf22a5dd869bb17ca8415f0b8e"))
   )
   val branch3: Par = GByteArray(
-    ByteString.copyFrom(Base16.decode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0"))
+    ByteString.copyFrom(Base16.unsafeDecode("763354e4266d31c74b7a5be55fbfeb464fe65ce56ce9ccbfd9a1fddef0"))
   )
   val branch4: Par = GByteArray(
-    ByteString.copyFrom(Base16.decode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3"))
+    ByteString.copyFrom(Base16.unsafeDecode("7e047d2fc591185812e4a9526ded5509544e6586092c25a17abf366ea3"))
   )
   val branchSend: Send = Send(
     chan = branchName,
@@ -647,7 +647,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
 
     val expectedUri = Registry.buildURI(
       Blake2b256
-        .hash(Base16.decode("11afb9a5fa2b3e194b701987b3531a93dbdf790dac26f8a2502cfa5d529f6b4d"))
+        .hash(Base16.unsafeDecode("11afb9a5fa2b3e194b701987b3531a93dbdf790dac26f8a2502cfa5d529f6b4d"))
     )
 
     val result = evaluate(completePar)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 class RevAddressSpec extends FlatSpec with Matchers {
   "fromPublicKey" should "work correctly" in {
     val pk =
-      PublicKey(Base16.decode("00322ba649cebf90d8bd0eeb0658ea7957bcc59ecee0676c86f4fec517c06251"))
+      PublicKey(Base16.unsafeDecode("00322ba649cebf90d8bd0eeb0658ea7957bcc59ecee0676c86f4fec517c06251"))
     RevAddress.fromPublicKey(pk) should be(
       Some("1111K9MczqzZrNkUNmNGrNFyz7F7LiCUgaCHXd28g2k5PxiaNuCAi")
     )

--- a/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
@@ -58,7 +58,7 @@ object Blake2b256Hash {
     new Blake2b256Hash(ByteVector(Blake2b256.hash(byteVector)))
 
   def fromHex(string: String): Blake2b256Hash =
-    new Blake2b256Hash(ByteVector(Base16.decode(string)))
+    new Blake2b256Hash(ByteVector(Base16.unsafeDecode(string)))
 
   def fromByteArray(bytes: Array[Byte]): Blake2b256Hash =
     new Blake2b256Hash(ByteVector(bytes))


### PR DESCRIPTION
# Note: this is built on top of #2293  Please review that first. The commit log will be cleaner as soon as the parent PR is merged

## Overview
The existing Base16.decode accepts any characters in it. I'm renaming it to unsafeDecode and adding a new function Base16.decode which fails if the input contains invalid characters



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
