### PR TITLE
RCHAIN-3129 ignore incorrect deploy srv side

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -19,13 +19,16 @@ import coop.rchain.catscontrib.ski.kp2
 
 sealed trait DeployError
 final case class ParsingError(details: String) extends DeployError
+final case object MissingSignature             extends DeployError
 
 object DeployError {
   def parsingError(details: String): DeployError = ParsingError(details)
+  def missingSignature: DeployError              = MissingSignature
 
   implicit val showDeployError: Show[DeployError] = new Show[DeployError] {
     def show(error: DeployError): String = error match {
       case ParsingError(details) => s"Parsing error: $details"
+      case MissingSignature      => s"Missing signature"
     }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -23,6 +23,7 @@ final case object MissingSignature                      extends DeployError
 final case object MissingSignatureAlgorithm             extends DeployError
 final case object MissingUser                           extends DeployError
 final case class UnknownSignatureAlgorithm(alg: String) extends DeployError
+final case object SignatureVerificationFailed           extends DeployError
 
 object DeployError {
   def parsingError(details: String): DeployError          = ParsingError(details)
@@ -30,6 +31,7 @@ object DeployError {
   def missingSignatureAlgorithm: DeployError              = MissingSignatureAlgorithm
   def missingUser: DeployError                            = MissingUser
   def unknownSignatureAlgorithm(alg: String): DeployError = UnknownSignatureAlgorithm(alg)
+  def signatureVerificationFailed: DeployError            = SignatureVerificationFailed
 
   implicit val showDeployError: Show[DeployError] = new Show[DeployError] {
     def show(error: DeployError): String = error match {
@@ -38,6 +40,7 @@ object DeployError {
       case MissingSignatureAlgorithm      => s"Missing signature algorithm"
       case MissingUser                    => s"Missing user"
       case UnknownSignatureAlgorithm(alg) => s"Unknown signature algorithm '$alg'"
+      case SignatureVerificationFailed    => "Signature verification failed"
     }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -21,17 +21,20 @@ sealed trait DeployError
 final case class ParsingError(details: String) extends DeployError
 final case object MissingSignature             extends DeployError
 final case object MissingSignatureAlgorithm    extends DeployError
+final case object MissingUser                  extends DeployError
 
 object DeployError {
   def parsingError(details: String): DeployError = ParsingError(details)
   def missingSignature: DeployError              = MissingSignature
   def missingSignatureAlgorithm: DeployError     = MissingSignatureAlgorithm
+  def missingUser: DeployError                   = MissingUser
 
   implicit val showDeployError: Show[DeployError] = new Show[DeployError] {
     def show(error: DeployError): String = error match {
       case ParsingError(details)     => s"Parsing error: $details"
       case MissingSignature          => s"Missing signature"
-      case MissingSignatureAlgorithm => s"Missing signature algorithm"
+      case MissingSignatureAlgorithm => s"Missin signature algorithm"
+      case MissingUser               => s"Missin user"
     }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -20,15 +20,18 @@ import coop.rchain.catscontrib.ski.kp2
 sealed trait DeployError
 final case class ParsingError(details: String) extends DeployError
 final case object MissingSignature             extends DeployError
+final case object MissingSignatureAlgorithm    extends DeployError
 
 object DeployError {
   def parsingError(details: String): DeployError = ParsingError(details)
   def missingSignature: DeployError              = MissingSignature
+  def missingSignatureAlgorithm: DeployError     = MissingSignatureAlgorithm
 
   implicit val showDeployError: Show[DeployError] = new Show[DeployError] {
     def show(error: DeployError): String = error match {
-      case ParsingError(details) => s"Parsing error: $details"
-      case MissingSignature      => s"Missing signature"
+      case ParsingError(details)     => s"Parsing error: $details"
+      case MissingSignature          => s"Missing signature"
+      case MissingSignatureAlgorithm => s"Missing signature algorithm"
     }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -18,23 +18,26 @@ import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.ski.kp2
 
 sealed trait DeployError
-final case class ParsingError(details: String) extends DeployError
-final case object MissingSignature             extends DeployError
-final case object MissingSignatureAlgorithm    extends DeployError
-final case object MissingUser                  extends DeployError
+final case class ParsingError(details: String)          extends DeployError
+final case object MissingSignature                      extends DeployError
+final case object MissingSignatureAlgorithm             extends DeployError
+final case object MissingUser                           extends DeployError
+final case class UnknownSignatureAlgorithm(alg: String) extends DeployError
 
 object DeployError {
-  def parsingError(details: String): DeployError = ParsingError(details)
-  def missingSignature: DeployError              = MissingSignature
-  def missingSignatureAlgorithm: DeployError     = MissingSignatureAlgorithm
-  def missingUser: DeployError                   = MissingUser
+  def parsingError(details: String): DeployError          = ParsingError(details)
+  def missingSignature: DeployError                       = MissingSignature
+  def missingSignatureAlgorithm: DeployError              = MissingSignatureAlgorithm
+  def missingUser: DeployError                            = MissingUser
+  def unknownSignatureAlgorithm(alg: String): DeployError = UnknownSignatureAlgorithm(alg)
 
   implicit val showDeployError: Show[DeployError] = new Show[DeployError] {
     def show(error: DeployError): String = error match {
-      case ParsingError(details)     => s"Parsing error: $details"
-      case MissingSignature          => s"Missing signature"
-      case MissingSignatureAlgorithm => s"Missin signature algorithm"
-      case MissingUser               => s"Missin user"
+      case ParsingError(details)          => s"Parsing error: $details"
+      case MissingSignature               => s"Missing signature"
+      case MissingSignatureAlgorithm      => s"Missing signature algorithm"
+      case MissingUser                    => s"Missing user"
+      case UnknownSignatureAlgorithm(alg) => s"Unknown signature algorithm '$alg'"
     }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -149,9 +149,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
     case d if (d.user == ByteString.EMPTY) => missingUser.asLeft[Unit]
     case _ =>
       val maybeVerified = SignDeployment.verify(deployData)
-      maybeVerified.fold(unknownSignatureAlgorithm(deployData.sigAlgorithm).asLeft[Unit])(
-        kp(().asRight[DeployError])
-      )
+      maybeVerified.fold(unknownSignatureAlgorithm(deployData.sigAlgorithm).asLeft[Unit]) {
+        case false => signatureVerificationFailed.asLeft[Unit]
+        case true  => ().asRight[DeployError]
+      }
   }
 
   def deploy(d: DeployData): F[Either[DeployError, Unit]] =

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -143,8 +143,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
       bufferContains = state.blockBuffer.contains(b.blockHash)
     } yield (dagContains || bufferContains)
 
-  private def validateDeploy(d: DeployData): Either[DeployError, Unit] =
-    if (d.sig == ByteString.EMPTY) missingSignature.asLeft[Unit] else ().asRight[DeployError]
+  private def validateDeploy(deployData: DeployData): Either[DeployError, Unit] = deployData match {
+    case d if (d.sig == ByteString.EMPTY) => missingSignature.asLeft[Unit]
+    case d if (d.sigAlgorithm == "")      => missingSignatureAlgorithm.asLeft[Unit]
+    case _                                => ().asRight[DeployError]
+  }
 
   def deploy(d: DeployData): F[Either[DeployError, Unit]] =
     validateDeploy(d).fold(

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -144,9 +144,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
     } yield (dagContains || bufferContains)
 
   private def validateDeploy(deployData: DeployData): Either[DeployError, Unit] = deployData match {
-    case d if (d.sig == ByteString.EMPTY) => missingSignature.asLeft[Unit]
-    case d if (d.sigAlgorithm == "")      => missingSignatureAlgorithm.asLeft[Unit]
-    case _                                => ().asRight[DeployError]
+    case d if (d.sig == ByteString.EMPTY)  => missingSignature.asLeft[Unit]
+    case d if (d.sigAlgorithm == "")       => missingSignatureAlgorithm.asLeft[Unit]
+    case d if (d.user == ByteString.EMPTY) => missingUser.asLeft[Unit]
+    case _                                 => ().asRight[DeployError]
   }
 
   def deploy(d: DeployData): F[Either[DeployError, Unit]] =

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -142,13 +142,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
       bufferContains = state.blockBuffer.contains(b.blockHash)
     } yield (dagContains || bufferContains)
 
-  def deploy(d: DeployData): F[Either[Throwable, Unit]] =
+  def deploy(d: DeployData): F[Either[DeployError, Unit]] =
     InterpreterUtil.mkTerm(d.term) match {
-      case Right(_) =>
-        addDeploy(d).as(Right(()))
-
+      case Right(_) => addDeploy(d).as(Right(()))
       case Left(err) =>
-        Applicative[F].pure(Left(new Exception(s"Error in parsing term: \n$err")))
+        DeployError.parsingError(s"Error in parsing term: \n$err").asLeft[Unit].pure[F]
     }
 
   def addDeploy(deploy: DeployData): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -28,6 +28,10 @@ object SignDeployment {
   }
 
   def verify(deployData: DeployData): Option[Boolean] =
-    SignaturesAlg(deployData.sigAlgorithm).map(_ => true)
+    SignaturesAlg(deployData.sigAlgorithm).map { alg =>
+      val toVerify = clear(deployData).toByteString.toByteArray
+      val hash     = Blake2b256.hash(toVerify)
+      alg.verify(hash, deployData.sig.toByteArray, PublicKey(deployData.user.toByteArray))
+    }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -27,4 +27,7 @@ object SignDeployment {
     fill(deployData)(alg.toPublic(sec), signature, alg.name)
   }
 
+  def verify(deployData: DeployData): Option[Boolean] =
+    SignaturesAlg(deployData.sigAlgorithm).map(_ => true)
+
 }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -19,7 +19,7 @@ object SignDeployment {
   private def clear(deployData: DeployData): DeployData =
     fill(deployData)(PublicKey(Array.empty[Byte]), Array.empty[Byte], "")
 
-  def apply(sec: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
+  def sign(sec: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
     val toSign    = clear(deployData).toByteString.toByteArray
     val hash      = Blake2b256.hash(toSign)
     val signature = alg.sign(hash, sec)
@@ -31,7 +31,7 @@ object SignDeployment {
     SignaturesAlg(deployData.sigAlgorithm).map { alg =>
       val toVerify = clear(deployData).toByteString.toByteArray
       val hash     = Blake2b256.hash(toVerify)
-      alg.verify(hash, deployData.sig.toByteArray, PublicKey(deployData.user.toByteArray))
+      alg.verify(hash, deployData.sig.toByteArray, PublicKey(deployData.deployer.toByteArray))
     }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SignDeployment.scala
@@ -19,12 +19,12 @@ object SignDeployment {
   private def clear(deployData: DeployData): DeployData =
     fill(deployData)(PublicKey(Array.empty[Byte]), Array.empty[Byte], "")
 
-  def apply(key: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
+  def apply(sec: PrivateKey, deployData: DeployData, alg: SignaturesAlg = Ed25519): DeployData = {
     val toSign    = clear(deployData).toByteString.toByteArray
     val hash      = Blake2b256.hash(toSign)
-    val signature = alg.sign(hash, key)
+    val signature = alg.sign(hash, sec)
 
-    fill(deployData)(alg.toPublic(key), signature, alg.name)
+    fill(deployData)(alg.toPublic(sec), signature, alg.name)
   }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -9,6 +9,7 @@ import cats.implicits._
 
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper._
+import coop.rchain.casper.DeployError._
 import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
@@ -39,7 +40,7 @@ object BlockAPI {
     def casperDeploy(casper: MultiParentCasper[F]): Effect[F, DeployServiceResponse] =
       casper.deploy(d) map {
         case Right(_)  => DeployServiceResponse("Success!").asRight
-        case Left(err) => err.getMessage.asLeft
+        case Left(err) => err.show.asLeft
       }
 
     val errorMessage = "Could not deploy, casper instance was not available yet."

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -37,11 +37,13 @@ object BlockAPI {
   def deploy[F[_]: Monad: MultiParentCasperRef: Log](
       d: DeployData
   ): Effect[F, DeployServiceResponse] = {
+
     def casperDeploy(casper: MultiParentCasper[F]): Effect[F, DeployServiceResponse] =
-      casper.deploy(d) map {
-        case Right(_)  => DeployServiceResponse("Success!").asRight
-        case Left(err) => err.show.asLeft
-      }
+      casper
+        .deploy(d)
+        .map(
+          _.bimap(err => err.show, _ => DeployServiceResponse("Success!"))
+        )
 
     val errorMessage = "Could not deploy, casper instance was not available yet."
 

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -3,9 +3,10 @@ package coop.rchain.casper.util
 import cats._
 import cats.effect._
 import cats.implicits._
+import coop.rchain.casper.protocol._
+import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.casper.util.ProtoUtil.sourceDeploy
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
@@ -67,6 +68,14 @@ object BondingUtil {
       transferStatusOut(ethAddress),
       pubKey,
       Base16.unsafeDecode(secKey)
+    )
+
+  private def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
+    DeployData(
+      user = ByteString.EMPTY,
+      timestamp = timestamp,
+      term = source,
+      phloLimit = phlos
     )
 
   def preWalletUnlockDeploy[F[_]: Concurrent](

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -72,7 +72,7 @@ object BondingUtil {
 
   private def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
     DeployData(
-      user = ByteString.EMPTY,
+      deployer = ByteString.EMPTY,
       timestamp = timestamp,
       term = source,
       phloLimit = phlos

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -8,7 +8,6 @@ import coop.rchain.casper.PrettyPrinter
 import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.{DeployData, _}
-import coop.rchain.casper.util.ProtoUtil.basicDeployData
 import coop.rchain.casper.util.rholang.InterpreterUtil
 import coop.rchain.casper.util.implicits._
 import coop.rchain.crypto.codec.Base16
@@ -387,20 +386,6 @@ object ProtoUtil {
 
   def stringToByteString(string: String): ByteString =
     ByteString.copyFrom(Base16.unsafeDecode(string))
-
-  @deprecated
-  def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
-    Time[F].currentMillis.map(
-      now =>
-        DeployData()
-          .withDeployer(ByteString.EMPTY)
-          .withTimestamp(now)
-          .withTerm(s"@${id}!($id)")
-          .withPhloLimit(accounting.MAX_VALUE)
-    )
-
-  def basicProcessedDeploy[F[_]: Monad: Time](id: Int): F[ProcessedDeploy] =
-    basicDeployData[F](id).map(deploy => ProcessedDeploy(deploy = Some(deploy)))
 
   /**
     * Strip a deploy down to the fields we are using to seed the Deterministic name generator.

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -402,21 +402,6 @@ object ProtoUtil {
   def basicProcessedDeploy[F[_]: Monad: Time](id: Int): F[ProcessedDeploy] =
     basicDeployData[F](id).map(deploy => ProcessedDeploy(deploy = Some(deploy)))
 
-  def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
-    DeployData(
-      deployer = ByteString.EMPTY,
-      timestamp = timestamp,
-      term = source,
-      phloLimit = phlos
-    )
-
-  def sourceDeployNow(source: String): DeployData =
-    sourceDeploy(
-      source,
-      System.currentTimeMillis(),
-      accounting.MAX_VALUE
-    )
-
   /**
     * Strip a deploy down to the fields we are using to seed the Deterministic name generator.
     * Because we enforce that a deployment must be unique on the user, timestamp pair, we leave

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -388,6 +388,7 @@ object ProtoUtil {
   def stringToByteString(string: String): ByteString =
     ByteString.copyFrom(Base16.unsafeDecode(string))
 
+  @deprecated
   def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
     Time[F].currentMillis.map(
       now =>

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -99,23 +99,6 @@ object DeployRuntime {
       }
     )
 
-  //Simulates user requests by randomly deploying things to Casper.
-  def deployDemoProgram[F[_]: Monad: Sync: Time: DeployService]: F[Unit] =
-    singleDeploy[F].forever
-
-  private def singleDeploy[F[_]: Monad: Time: Sync: DeployService]: F[Unit] =
-    for {
-      id <- Sync[F].delay { scala.util.Random.nextInt(100) }
-      d  <- ProtoUtil.basicDeployData[F](id)
-      _ <- Sync[F].delay {
-            println(s"Sending the following to Casper: ${d.term}")
-          }
-      response <- DeployService[F].deploy(d)
-      msg      = response.fold(_.mkString(System.lineSeparator()), "Response: " + _)
-      _        <- Sync[F].delay(println(msg))
-      _        <- Time[F].sleep(4.seconds)
-    } yield ()
-
   private def gracefulExit[F[_]: Monad: Sync, A](
       program: F[Either[Seq[String], String]]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -92,7 +92,7 @@ object DeployRuntime {
               .withValidAfterBlockNumber(validAfterBlock)
               .withTimestamp(timestamp)
 
-            signedData = maybePrivateKey.fold(d)(SignDeployment(_, d))
+            signedData = maybePrivateKey.fold(d)(SignDeployment.sign(_, d))
 
             response <- DeployService[F].deploy(signedData)
           } yield response.map(r => s"Response: $r")

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -129,7 +129,7 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
 
   private def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
     DeployData(
-      user = ByteString.EMPTY,
+      deployer = ByteString.EMPTY,
       timestamp = timestamp,
       term = source,
       phloLimit = phlos

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -127,6 +127,14 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
         case Left(_)      => None
       }
 
+  private def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
+    DeployData(
+      user = ByteString.EMPTY,
+      timestamp = timestamp,
+      term = source,
+      phloLimit = phlos
+    )
+
   def computeBonds(hash: StateHash): F[Seq[Bond]] = {
     val bondsQuery =
       """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
@@ -137,8 +145,7 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
         |  }
         |}""".stripMargin
 
-    val bondsQueryTerm =
-      ProtoUtil.sourceDeploy(bondsQuery, 0L, accounting.MAX_VALUE)
+    val bondsQueryTerm = sourceDeploy(bondsQuery, 0L, accounting.MAX_VALUE)
     captureResults(hash, bondsQueryTerm)
       .ensureOr(
         bondsPar =>

--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -78,7 +78,7 @@ object HashSetCasperActions {
     )
 
   def deployment(i: Int, ts: Long = System.currentTimeMillis()): DeployData =
-    DeployGenerator.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
+    ConstructDeploy.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
 
   implicit class EffectOps[A](f: Effect[A]) {
     def result: A = f.value.unsafeRunSync.right.get

--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -78,7 +78,7 @@ object HashSetCasperActions {
     )
 
   def deployment(i: Int, ts: Long = System.currentTimeMillis()): DeployData =
-    ProtoUtil.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
+    DeployGenerator.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
 
   implicit class EffectOps[A](f: Effect[A]) {
     def result: A = f.value.unsafeRunSync.right.get

--- a/casper/src/test/scala/coop/rchain/casper/ConstructDeploy.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ConstructDeploy.scala
@@ -22,13 +22,15 @@ object ConstructDeploy {
       source: String,
       timestamp: Long,
       phlos: Long,
+      phloPrice: Long = 0L,
       sec: PrivateKey = defaultSec
   ): DeployData = {
     val data = DeployData(
       deployer = ByteString.copyFrom(Ed25519.toPublic(sec).bytes),
       timestamp = timestamp,
       term = source,
-      phloLimit = phlos
+      phloLimit = phlos,
+      phloPrice = phloPrice
     )
     sign(data, sec)
   }

--- a/casper/src/test/scala/coop/rchain/casper/ConstructDeploy.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ConstructDeploy.scala
@@ -9,7 +9,7 @@ import coop.rchain.shared.{Log, LogSource, Time}
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
 import cats._, cats.data._, cats.implicits._
 
-object DeployGenerator {
+object ConstructDeploy {
 
   val sec = PrivateKey(
     Base16.unsafeDecode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
@@ -17,13 +17,18 @@ object DeployGenerator {
 
   val pub = Ed25519.toPublic(sec)
 
-  private def sign(deploy: DeployData): DeployData =
+  def sign(deploy: DeployData): DeployData =
     SignDeployment.sign(sec, deploy, Ed25519)
 
-  def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
+  def sourceDeploy(
+      source: String,
+      timestamp: Long,
+      phlos: Long,
+      deployer: ByteString = ByteString.copyFrom(pub.bytes)
+  ): DeployData =
     sign(
       DeployData(
-        deployer = ByteString.copyFrom(pub.bytes),
+        deployer = deployer,
         timestamp = timestamp,
         term = source,
         phloLimit = phlos

--- a/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
@@ -12,18 +12,18 @@ import cats._, cats.data._, cats.implicits._
 object DeployGenerator {
 
   val sec = PrivateKey(
-    Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+    Base16.unsafeDecode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
   )
 
   val pub = Ed25519.toPublic(sec)
 
   private def sign(deploy: DeployData): DeployData =
-    SignDeployment(sec, deploy, Ed25519)
+    SignDeployment.sign(sec, deploy, Ed25519)
 
   def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
     sign(
       DeployData(
-        user = ByteString.copyFrom(pub.bytes),
+        deployer = ByteString.copyFrom(pub.bytes),
         timestamp = timestamp,
         term = source,
         phloLimit = phlos
@@ -41,7 +41,7 @@ object DeployGenerator {
     Time[F].currentMillis.map { now =>
       sign(
         DeployData()
-          .withUser(ByteString.copyFrom(pub.bytes))
+          .withDeployer(ByteString.copyFrom(pub.bytes))
           .withTimestamp(now)
           .withTerm(s"@${id}!($id)")
           .withPhloLimit(accounting.MAX_VALUE)

--- a/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
@@ -1,0 +1,19 @@
+package coop.rchain.casper
+
+import coop.rchain.casper.protocol._
+import coop.rchain.shared.{Log, LogSource, Time}
+import com.google.protobuf.{ByteString, Int32Value, StringValue}
+import cats._, cats.data._, cats.implicits._
+import coop.rchain.rholang.interpreter.accounting
+
+object DeployGenerator {
+  def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
+    Time[F].currentMillis.map(
+      now =>
+        DeployData()
+          .withUser(ByteString.EMPTY)
+          .withTimestamp(now)
+          .withTerm(s"@${id}!($id)")
+          .withPhloLimit(accounting.MAX_VALUE)
+    )
+}

--- a/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
@@ -1,17 +1,47 @@
 package coop.rchain.casper
 
+import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.casper.protocol._
+import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.shared.{Log, LogSource, Time}
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
 import cats._, cats.data._, cats.implicits._
-import coop.rchain.rholang.interpreter.accounting
 
 object DeployGenerator {
+
+  val sec = PrivateKey(
+    Base16.decode("b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd")
+  )
+
+  val pub = Ed25519.toPublic(sec)
+
+  private def sign(deploy: DeployData): DeployData =
+    SignDeployment(sec, deploy, Ed25519)
+
+  def sourceDeploy(source: String, timestamp: Long, phlos: Long): DeployData =
+    sign(
+      DeployData(
+        user = ByteString.copyFrom(pub.bytes),
+        timestamp = timestamp,
+        term = source,
+        phloLimit = phlos
+      )
+    )
+
+  def sourceDeployNow(source: String): DeployData =
+    sourceDeploy(
+      source,
+      System.currentTimeMillis(),
+      accounting.MAX_VALUE
+    )
+
   def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
     Time[F].currentMillis.map(
       now =>
         DeployData()
-          .withUser(ByteString.EMPTY)
+          .withUser(ByteString.copyFrom(pub.bytes))
           .withTimestamp(now)
           .withTerm(s"@${id}!($id)")
           .withPhloLimit(accounting.MAX_VALUE)

--- a/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/DeployGenerator.scala
@@ -38,12 +38,16 @@ object DeployGenerator {
     )
 
   def basicDeployData[F[_]: Monad: Time](id: Int): F[DeployData] =
-    Time[F].currentMillis.map(
-      now =>
+    Time[F].currentMillis.map { now =>
+      sign(
         DeployData()
           .withUser(ByteString.copyFrom(pub.bytes))
           .withTimestamp(now)
           .withTerm(s"@${id}!($id)")
           .withPhloLimit(accounting.MAX_VALUE)
-    )
+      )
+    }
+
+  def basicProcessedDeploy[F[_]: Monad: Time](id: Int): F[ProcessedDeploy] =
+    basicDeployData[F](id).map(deploy => ProcessedDeploy(deploy = Some(deploy)))
 }

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
@@ -10,7 +10,7 @@ import coop.rchain.casper.helper.BlockGenerator.{
 }
 import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
-import coop.rchain.casper.util.ProtoUtil.basicProcessedDeploy
+import coop.rchain.casper.ConstructDeploy.basicProcessedDeploy
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.EstimatorHelper.conflicts
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -45,7 +45,7 @@ class EstimatorHelperTest
 
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploys <- (0 until 6).toList.traverse(basicProcessedDeploy[Task])
+        deploys <- (0 until 6).toList.traverse(i => basicProcessedDeploy[Task](i))
         genesis <- createBlock[Task](Seq())
         b2      <- createBlock[Task](Seq(genesis.blockHash), deploys = Seq(deploys(0)))
         b3      <- createBlock[Task](Seq(genesis.blockHash), deploys = Seq(deploys(1)))

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -75,7 +75,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deploy <- ProtoUtil.basicDeployData[Effect](0)
+      deploy <- DeployGenerator.basicDeployData[Effect](0)
       _      <- MultiParentCasper[Effect].deploy(deploy)
 
       _      = logEff.infos.size should be(2)
@@ -90,7 +90,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     val casper    = node.casperEff
 
     val testProgram = for {
-      deploy <- ProtoUtil.basicDeployData[Effect](0)
+      deploy <- DeployGenerator.basicDeployData[Effect](0)
       _      <- casper.deploy(deploy)
       block  <- casper.createBlock.map { case Created(block) => block }
       result <- EitherT(
@@ -120,7 +120,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val casper = node.casperEff
 
     for {
-      deploy <- ProtoUtil.basicDeployData[Effect](0)
+      deploy <- DeployGenerator.basicDeployData[Effect](0)
       _      <- MultiParentCasper[Effect].deploy(deploy)
 
       createBlockResult <- MultiParentCasper[Effect].createBlock
@@ -144,7 +144,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deploy               <- ProtoUtil.basicDeployData[Effect](0)
+      deploy               <- DeployGenerator.basicDeployData[Effect](0)
       _                    <- MultiParentCasper[Effect].deploy(deploy)
       createBlockResult    <- MultiParentCasper[Effect].createBlock
       Created(signedBlock) = createBlockResult
@@ -271,7 +271,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      basicDeployData <- ProtoUtil.basicDeployData[Effect](0)
+      basicDeployData <- DeployGenerator.basicDeployData[Effect](0)
       createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
                             Effect
                           ].createBlock
@@ -321,7 +321,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      basicDeployData <- ProtoUtil.basicDeployData[Effect](0)
+      basicDeployData <- DeployGenerator.basicDeployData[Effect](0)
       createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
                             Effect
                           ].createBlock
@@ -335,7 +335,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "propose blocks it adds to peers" in effectTest {
     for {
       nodes                <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData           <- ProtoUtil.basicDeployData[Effect](0)
+      deployData           <- DeployGenerator.basicDeployData[Effect](0)
       createBlockResult    <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
       Created(signedBlock) = createBlockResult
       _                    <- nodes(0).casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
@@ -353,7 +353,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "add a valid block from peer" in effectTest {
     for {
       nodes                      <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData                 <- ProtoUtil.basicDeployData[Effect](1)
+      deployData                 <- DeployGenerator.basicDeployData[Effect](1)
       createBlockResult          <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
       Created(signedBlock1Prime) = createBlockResult
       _                          <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
@@ -372,8 +372,8 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "handle multi-parent blocks correctly" in effectTest {
     for {
       nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData0 <- ProtoUtil.basicDeployData[Effect](0)
-      deployData2 <- ProtoUtil.basicDeployData[Effect](2)
+      deployData0 <- DeployGenerator.basicDeployData[Effect](0)
+      deployData2 <- DeployGenerator.basicDeployData[Effect](2)
       deploys = Vector(
         deployData0,
         DeployGenerator.sourceDeploy(
@@ -468,7 +468,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
         current1,
         accounting.MAX_VALUE
       )
-      deploy2 <- ProtoUtil.basicDeployData[Effect](2)
+      deploy2 <- DeployGenerator.basicDeployData[Effect](2)
       deploys = Vector(
         deploy0,
         deploy1,
@@ -630,7 +630,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
         current1,
         accounting.MAX_VALUE
       )
-      deploy2 <- ProtoUtil.basicDeployData[Effect](2)
+      deploy2 <- DeployGenerator.basicDeployData[Effect](2)
       deploys = Vector(
         deploy0,
         deploy1,
@@ -1090,7 +1090,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult2 <- {
         val n = nodes(1)
         import n.casperEff._
-        (ProtoUtil.basicDeployData[Effect](0) >>= deploy) *> createBlock
+        (DeployGenerator.basicDeployData[Effect](0) >>= deploy) *> createBlock
       }
       Created(block2) = createBlockResult2
       status2         <- nodes(1).casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
@@ -1101,7 +1101,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult3 <- { //nodes(2) proposes a block
         val n = nodes(2)
         import n.casperEff._
-        (ProtoUtil.basicDeployData[Effect](1) >>= deploy) *> createBlock
+        (DeployGenerator.basicDeployData[Effect](1) >>= deploy) *> createBlock
       }
       Created(block3) = createBlockResult3
       status3         <- nodes(2).casperEff.addBlock(block3, ignoreDoppelgangerCheck[Effect])
@@ -1113,7 +1113,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult4 <- { //nodes(0) proposes a new block
         val n = nodes.head
         import n.casperEff._
-        (ProtoUtil.basicDeployData[Effect](2) >>= deploy) *> createBlock
+        (DeployGenerator.basicDeployData[Effect](2) >>= deploy) *> createBlock
       }
       Created(block4) = createBlockResult4
       status4         <- nodes.head.casperEff.addBlock(block4, ignoreDoppelgangerCheck[Effect])
@@ -1220,7 +1220,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       deployDatas <- (0 to 2).toList
-                      .traverse[Effect, DeployData](i => ProtoUtil.basicDeployData[Effect](i))
+                      .traverse[Effect, DeployData](i => DeployGenerator.basicDeployData[Effect](i))
       deployPrim0 = deployDatas(1)
         .withTimestamp(deployDatas(0).timestamp)
         .withDeployer(deployDatas(0).deployer) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
@@ -1426,11 +1426,11 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
 
       // Creates a pair that constitutes equivocation blocks
-      basicDeployData0 <- ProtoUtil.basicDeployData[Effect](0)
+      basicDeployData0 <- DeployGenerator.basicDeployData[Effect](0)
       createBlockResult1 <- nodes(0).casperEff
                              .deploy(basicDeployData0) *> nodes(0).casperEff.createBlock
       Created(signedBlock1) = createBlockResult1
-      basicDeployData1      <- ProtoUtil.basicDeployData[Effect](1)
+      basicDeployData1      <- DeployGenerator.basicDeployData[Effect](1)
       createBlockResult1Prime <- nodes(0).casperEff
                                   .deploy(basicDeployData1) *> nodes(0).casperEff.createBlock
       Created(signedBlock1Prime) = createBlockResult1Prime
@@ -1458,8 +1458,9 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   // See [[/docs/casper/images/minimal_equivocation_neglect.png]] but cross out genesis block
   it should "not ignore equivocation blocks that are required for parents of proper nodes" in effectTest {
     for {
-      nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deployDatas <- (0 to 5).toList.traverse[Effect, DeployData](ProtoUtil.basicDeployData[Effect])
+      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
+      deployDatas <- (0 to 5).toList
+                      .traverse[Effect, DeployData](DeployGenerator.basicDeployData[Effect])
 
       // Creates a pair that constitutes equivocation blocks
       createBlockResult1 <- nodes(0).casperEff
@@ -1549,7 +1550,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "prepare to slash an block that includes a invalid block pointer" in effectTest {
     for {
       nodes           <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deploys         <- (0 to 5).toList.traverse(i => ProtoUtil.basicDeployData[Effect](i))
+      deploys         <- (0 to 5).toList.traverse(i => DeployGenerator.basicDeployData[Effect](i))
       deploysWithCost = deploys.map(d => ProcessedDeploy(deploy = Some(d))).toIndexedSeq
 
       createBlockResult <- nodes(0).casperEff
@@ -1594,7 +1595,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
       _ <- (0 to 9).toList.traverse_[Effect, Unit] { i =>
             for {
-              deploy <- ProtoUtil.basicDeployData[Effect](i)
+              deploy <- DeployGenerator.basicDeployData[Effect](i)
               createBlockResult <- nodes(0).casperEff
                                     .deploy(deploy) *> nodes(0).casperEff.createBlock
               Created(block) = createBlockResult
@@ -1603,7 +1604,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
               _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
             } yield ()
           }
-      deployData10 <- ProtoUtil.basicDeployData[Effect](10)
+      deployData10 <- DeployGenerator.basicDeployData[Effect](10)
       createBlock11Result <- nodes(0).casperEff.deploy(deployData10) *> nodes(
                               0
                             ).casperEff.createBlock
@@ -1637,7 +1638,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       buildGenesis(Seq.empty, equalBonds, 1L, Long.MaxValue, Faucet.noopFaucet, 0L)
     for {
       nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesisWithEqualBonds)
-      deployDatas <- (0 to 7).toList.traverse(i => ProtoUtil.basicDeployData[Effect](i))
+      deployDatas <- (0 to 7).toList.traverse(i => DeployGenerator.basicDeployData[Effect](i))
 
       createBlock1Result <- nodes(0).casperEff
                              .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
@@ -1720,7 +1721,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deployData        <- ProtoUtil.basicDeployData[Effect](0).map(_.withPhloLimit(1))
+      deployData        <- DeployGenerator.basicDeployData[Effect](0).map(_.withPhloLimit(1))
       _                 <- node.casperEff.deploy(deployData)
       createBlockResult <- MultiParentCasper[Effect].createBlock
       Created(block)    = createBlockResult
@@ -1733,7 +1734,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deployData <- ProtoUtil.basicDeployData[Effect](0).map(_.withPhloLimit(100))
+      deployData <- DeployGenerator.basicDeployData[Effect](0).map(_.withPhloLimit(100))
       _          <- node.casperEff.deploy(deployData)
 
       createBlockResult <- MultiParentCasper[Effect].createBlock

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -97,6 +97,19 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield deployResult should be(Left(MissingSignature))
   }
 
+  it should "not allow deploy if deploy is missing signature algorithm" in effectTest {
+    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
+    val casper           = node.casperEff
+    implicit val timeEff = new LogicalTime[Effect]
+
+    for {
+      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      incorrectDeploy = correctDeploy.withSigAlgorithm("")
+      deployResult    <- casper.deploy(incorrectDeploy)
+      _               <- node.tearDown()
+    } yield deployResult should be(Left(MissingSignatureAlgorithm))
+  }
+
   it should "not allow multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
     val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler)

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -117,7 +117,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
     for {
       correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withUser(ByteString.EMPTY)
+      incorrectDeploy = correctDeploy.withDeployer(ByteString.EMPTY)
       deployResult    <- casper.deploy(incorrectDeploy)
       _               <- node.tearDown()
     } yield deployResult should be(Left(MissingUser))

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -1220,6 +1220,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
         accounting.MAX_VALUE,
         sec = PrivateKey(sk)
       )
+
     for {
       capturedResults <- node.runtimeManager
                           .captureResults(
@@ -1247,20 +1248,27 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
          |  }
          |}""".stripMargin
       paymentDeployData = ConstructDeploy
-        .sourceDeploy(paymentCode, timestamp, phloPrice, sec = PrivateKey(sk))
+        .sourceDeploy(
+          paymentCode,
+          timestamp,
+          accounting.MAX_VALUE,
+          phloPrice = phloPrice,
+          sec = PrivateKey(sk)
+        )
 
-      paymentQuery = ConstructDeploy.sourceDeploy(
-        """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
+      paymentQuery = ConstructDeploy
+        .sourceDeploy(
+          """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
         |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
         |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
         |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
         |    for(pos <- posCh){ pos!("lastPayment", "__SCALA__") }
         |  }
         |}""".stripMargin,
-        0L,
-        accounting.MAX_VALUE,
-        sec = PrivateKey(sk)
-      )
+          0L,
+          accounting.MAX_VALUE,
+          sec = PrivateKey(sk)
+        )
 
       deployQueryResult <- deployAndQuery(
                             node,

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -75,7 +75,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deploy <- DeployGenerator.basicDeployData[Effect](0)
+      deploy <- ConstructDeploy.basicDeployData[Effect](0)
       _      <- MultiParentCasper[Effect].deploy(deploy)
 
       _      = logEff.infos.size should be(2)
@@ -90,7 +90,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
       incorrectDeploy = correctDeploy.withSig(ByteString.EMPTY)
       deployResult    <- casper.deploy(incorrectDeploy)
       _               <- node.tearDown()
@@ -103,7 +103,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
       incorrectDeploy = correctDeploy.withSigAlgorithm("")
       deployResult    <- casper.deploy(incorrectDeploy)
       _               <- node.tearDown()
@@ -116,7 +116,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
       incorrectDeploy = correctDeploy.withDeployer(ByteString.EMPTY)
       deployResult    <- casper.deploy(incorrectDeploy)
       _               <- node.tearDown()
@@ -129,7 +129,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
       incorrectDeploy = correctDeploy.withSigAlgorithm("SOME_RANDOME_STUFF")
       deployResult    <- casper.deploy(incorrectDeploy)
       _               <- node.tearDown()
@@ -142,7 +142,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      correctDeploy <- DeployGenerator.basicDeployData[Effect](0)
+      correctDeploy <- ConstructDeploy.basicDeployData[Effect](0)
       incorrectDeploy = correctDeploy.withSig(
         ByteString.copyFrom(correctDeploy.sig.toByteArray.reverse)
       )
@@ -157,7 +157,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     val casper    = node.casperEff
 
     val testProgram = for {
-      deploy <- DeployGenerator.basicDeployData[Effect](0)
+      deploy <- ConstructDeploy.basicDeployData[Effect](0)
       _      <- casper.deploy(deploy)
       block  <- casper.createBlock.map { case Created(block) => block }
       result <- EitherT(
@@ -187,7 +187,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val casper = node.casperEff
 
     for {
-      deploy <- DeployGenerator.basicDeployData[Effect](0)
+      deploy <- ConstructDeploy.basicDeployData[Effect](0)
       _      <- MultiParentCasper[Effect].deploy(deploy)
 
       createBlockResult <- MultiParentCasper[Effect].createBlock
@@ -211,7 +211,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deploy               <- DeployGenerator.basicDeployData[Effect](0)
+      deploy               <- ConstructDeploy.basicDeployData[Effect](0)
       _                    <- MultiParentCasper[Effect].deploy(deploy)
       createBlockResult    <- MultiParentCasper[Effect].createBlock
       Created(signedBlock) = createBlockResult
@@ -229,7 +229,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     import node.casperEff
 
     def now = System.currentTimeMillis()
-    val registerDeploy = DeployGenerator.sourceDeploy(
+    val registerDeploy = ConstructDeploy.sourceDeploy(
       """new uriCh, rr(`rho:registry:insertArbitrary`), hello in {
         |  contract hello(@name, return) = { return!("Hello, ${name}!" %% {"name" : name}) } |
         |  rr!(bundle+{*hello}, *uriCh)
@@ -257,7 +257,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
                  .get
                  .split('`')(1)
              )
-      callDeploy = DeployGenerator.sourceDeploy(
+      callDeploy = ConstructDeploy.sourceDeploy(
         s"""new rl(`rho:registry:lookup`), helloCh, out in {
            |  rl!(`$id`, *helloCh) |
            |  for(hello <- helloCh){ hello!("World", *out) }
@@ -289,7 +289,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     val deployDatas = Vector(
       "contract @\"add\"(@x, @y, ret) = { ret!(x + y) }",
       "new unforgable in { @\"add\"!(5, 7, *unforgable) }"
-    ).zipWithIndex.map(s => DeployGenerator.sourceDeploy(s._1, start + s._2, accounting.MAX_VALUE))
+    ).zipWithIndex.map(s => ConstructDeploy.sourceDeploy(s._1, start + s._2, accounting.MAX_VALUE))
 
     for {
       createBlockResult1 <- MultiParentCasper[Effect].deploy(deployDatas.head) *> MultiParentCasper[
@@ -321,7 +321,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     val startTime = System.currentTimeMillis()
     val source    = " for(@x <- @0){ @0!(x) } | @0!(0) "
     val deploys = (source #:: source #:: Stream.empty[String]).zipWithIndex
-      .map(s => DeployGenerator.sourceDeploy(s._1, startTime + s._2, accounting.MAX_VALUE))
+      .map(s => ConstructDeploy.sourceDeploy(s._1, startTime + s._2, accounting.MAX_VALUE))
     for {
       _                 <- deploys.traverse_(MultiParentCasper[Effect].deploy(_))
       createBlockResult <- MultiParentCasper[Effect].createBlock
@@ -338,7 +338,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      basicDeployData <- DeployGenerator.basicDeployData[Effect](0)
+      basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
       createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
                             Effect
                           ].createBlock
@@ -356,7 +356,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
     val List(data0, data1) =
       (0 to 1)
-        .map(i => DeployGenerator.sourceDeploy(s"@$i!($i)", i.toLong, accounting.MAX_VALUE))
+        .map(i => ConstructDeploy.sourceDeploy(s"@$i!($i)", i.toLong, accounting.MAX_VALUE))
         .toList
 
     for {
@@ -390,7 +390,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      basicDeployData <- DeployGenerator.basicDeployData[Effect](0)
+      basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
       createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
                             Effect
                           ].createBlock
@@ -404,7 +404,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "propose blocks it adds to peers" in effectTest {
     for {
       nodes                <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData           <- DeployGenerator.basicDeployData[Effect](0)
+      deployData           <- ConstructDeploy.basicDeployData[Effect](0)
       createBlockResult    <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
       Created(signedBlock) = createBlockResult
       _                    <- nodes(0).casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
@@ -422,7 +422,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "add a valid block from peer" in effectTest {
     for {
       nodes                      <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData                 <- DeployGenerator.basicDeployData[Effect](1)
+      deployData                 <- ConstructDeploy.basicDeployData[Effect](1)
       createBlockResult          <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
       Created(signedBlock1Prime) = createBlockResult
       _                          <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
@@ -441,11 +441,11 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "handle multi-parent blocks correctly" in effectTest {
     for {
       nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData0 <- DeployGenerator.basicDeployData[Effect](0)
-      deployData2 <- DeployGenerator.basicDeployData[Effect](2)
+      deployData0 <- ConstructDeploy.basicDeployData[Effect](0)
+      deployData2 <- ConstructDeploy.basicDeployData[Effect](2)
       deploys = Vector(
         deployData0,
-        DeployGenerator.sourceDeploy(
+        ConstructDeploy.sourceDeploy(
           "@1!(1) | for(@x <- @1){ @1!(x) }",
           System.currentTimeMillis(),
           accounting.MAX_VALUE
@@ -492,8 +492,8 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       deploys = Vector(
-        DeployGenerator.sourceDeploy(echoContract(1), time + 1, accounting.MAX_VALUE),
-        DeployGenerator.sourceDeploy(echoContract(2), time + 2, accounting.MAX_VALUE)
+        ConstructDeploy.sourceDeploy(echoContract(1), time + 1, accounting.MAX_VALUE),
+        ConstructDeploy.sourceDeploy(echoContract(2), time + 2, accounting.MAX_VALUE)
       )
       createBlockResult0 <- nodes(0).casperEff.deploy(deploys(0)) *> nodes(0).casperEff.createBlock
       createBlockResult1 <- nodes(1).casperEff.deploy(deploys(1)) *> nodes(1).casperEff.createBlock
@@ -526,18 +526,18 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes    <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       current0 <- timeEff.currentMillis
-      deploy0 = DeployGenerator.sourceDeploy(
+      deploy0 = ConstructDeploy.sourceDeploy(
         "@1!(47)",
         current0,
         accounting.MAX_VALUE
       )
       current1 <- timeEff.currentMillis
-      deploy1 = DeployGenerator.sourceDeploy(
+      deploy1 = ConstructDeploy.sourceDeploy(
         "for(@x <- @1){ @1!(x) }",
         current1,
         accounting.MAX_VALUE
       )
-      deploy2 <- DeployGenerator.basicDeployData[Effect](2)
+      deploy2 <- ConstructDeploy.basicDeployData[Effect](2)
       deploys = Vector(
         deploy0,
         deploy1,
@@ -572,7 +572,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
   it should "not produce UnusedCommEvent while merging non conflicting blocks in the presence of conflicting ones" in effectTest {
     def defineDeploy(source: String, t: Long) =
-      DeployGenerator.sourceDeploy(
+      ConstructDeploy.sourceDeploy(
         source,
         t,
         accounting.MAX_VALUE
@@ -688,18 +688,18 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes    <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       current0 <- timeEff.currentMillis
-      deploy0 = DeployGenerator.sourceDeploy(
+      deploy0 = ConstructDeploy.sourceDeploy(
         "@1!(47)",
         current0,
         accounting.MAX_VALUE
       )
       current1 <- timeEff.currentMillis
-      deploy1 = DeployGenerator.sourceDeploy(
+      deploy1 = ConstructDeploy.sourceDeploy(
         "for(@x <- @1; @y <- @2){ @1!(x) }",
         current1,
         accounting.MAX_VALUE
       )
-      deploy2 <- DeployGenerator.basicDeployData[Effect](2)
+      deploy2 <- ConstructDeploy.basicDeployData[Effect](2)
       deploys = Vector(
         deploy0,
         deploy1,
@@ -752,7 +752,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
                              "unlockOut"
                            )(Concurrent[Effect], runtimeManager)
       bondingForwarderAddress = BondingUtil.bondingForwarderAddress(ethAddress)
-      bondingForwarderDeploy = DeployGenerator.sourceDeploy(
+      bondingForwarderDeploy = ConstructDeploy.sourceDeploy(
         BondingUtil.bondingForwarderDeploy(bondKey, ethAddress),
         System.currentTimeMillis(),
         accounting.MAX_VALUE
@@ -779,7 +779,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       block2Status    <- nodes(1).casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
       _               <- nodes.toList.traverse_(_.receive())
 
-      helloWorldDeploy = DeployGenerator.sourceDeploy(
+      helloWorldDeploy = ConstructDeploy.sourceDeploy(
         """new s(`rho:io:stdout`) in { s!("Hello, World!") }""",
         System.currentTimeMillis(),
         accounting.MAX_VALUE
@@ -805,7 +805,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       _ = block3PrimeStatus shouldBe Valid
       _ = nodes.forall(_.logEff.warns.isEmpty) shouldBe true
 
-      rankedValidatorQuery = DeployGenerator.sourceDeploy(
+      rankedValidatorQuery = ConstructDeploy.sourceDeploy(
         """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
           |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
           |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
@@ -888,16 +888,18 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
          |}""".stripMargin
 
     //with the fixed user+timestamp we know that walletCh is registered at `rho:id:mrs88izurkgki71dpjqamzg6tgcjd6sk476c9msks7tumw4a6e39or`
-    val createWalletDeploy = DeployGenerator
-      .sourceDeploy(createWalletCode, System.currentTimeMillis(), accounting.MAX_VALUE)
-      .withTimestamp(1540570144121L)
-      .withDeployer(ProtoUtil.stringToByteString(pkStr))
+    val createWalletDeploy = ConstructDeploy.sourceDeploy(
+      source = createWalletCode,
+      timestamp = 1540570144121L,
+      phlos = accounting.MAX_VALUE,
+      deployer = ProtoUtil.stringToByteString(pkStr)
+    )
 
     for {
       createBlockResult <- casperEff.deploy(createWalletDeploy) *> casperEff.createBlock
       Created(block)    = createBlockResult
       blockStatus       <- casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
-      balanceQuery = DeployGenerator.sourceDeploy(
+      balanceQuery = ConstructDeploy.sourceDeploy(
         s"""new
            |  rl(`rho:registry:lookup`), walletFeedCh
            |in {
@@ -933,12 +935,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
     for {
       bondingCode <- BondingUtil.faucetBondDeploy[Effect](amount, "ed25519", pkStr, sk)
-      forwardDeploy = DeployGenerator.sourceDeploy(
+      forwardDeploy = ConstructDeploy.sourceDeploy(
         forwardCode,
         System.currentTimeMillis(),
         accounting.MAX_VALUE
       )
-      bondingDeploy = DeployGenerator.sourceDeploy(
+      bondingDeploy = ConstructDeploy.sourceDeploy(
         bondingCode,
         forwardDeploy.timestamp + 1,
         accounting.MAX_VALUE
@@ -962,7 +964,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
   it should "allow bonding in an existing network" in effectTest {
     def deployment(i: Int): DeployData =
-      DeployGenerator.sourceDeploy(
+      ConstructDeploy.sourceDeploy(
         s"@$i!({$i})",
         System.currentTimeMillis() + i,
         accounting.MAX_VALUE
@@ -1005,12 +1007,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       val forwardCode             = BondingUtil.bondingForwarderDeploy(pkStr, pkStr)
       for {
         bondingCode <- BondingUtil.faucetBondDeploy[Effect](amount, "ed25519", pkStr, sk)
-        forwardDeploy = DeployGenerator.sourceDeploy(
+        forwardDeploy = ConstructDeploy.sourceDeploy(
           forwardCode,
           System.currentTimeMillis(),
           accounting.MAX_VALUE
         )
-        bondingDeploy = DeployGenerator.sourceDeploy(
+        bondingDeploy = ConstructDeploy.sourceDeploy(
           bondingCode,
           forwardDeploy.timestamp + 1,
           accounting.MAX_VALUE
@@ -1070,7 +1072,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       buildGenesis(wallets, bonds, minimumBond, Long.MaxValue, Faucet.basicWalletFaucet, 0L)
 
     def deployment(i: Int, ts: Long): DeployData =
-      DeployGenerator.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
+      ConstructDeploy.sourceDeploy(s"new x in { x!(0) }", ts, accounting.MAX_VALUE)
 
     def deploy(
         node: HashSetCasperTestNode[Effect],
@@ -1134,12 +1136,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
                         Concurrent[Effect],
                         rm
                       )
-      forwardDeploy = DeployGenerator.sourceDeploy(
+      forwardDeploy = ConstructDeploy.sourceDeploy(
         forwardCode,
         System.currentTimeMillis(),
         accounting.MAX_VALUE
       )
-      bondingDeploy = DeployGenerator.sourceDeploy(
+      bondingDeploy = ConstructDeploy.sourceDeploy(
         bondingCode,
         forwardDeploy.timestamp + 1,
         accounting.MAX_VALUE
@@ -1159,7 +1161,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult2 <- {
         val n = nodes(1)
         import n.casperEff._
-        (DeployGenerator.basicDeployData[Effect](0) >>= deploy) *> createBlock
+        (ConstructDeploy.basicDeployData[Effect](0) >>= deploy) *> createBlock
       }
       Created(block2) = createBlockResult2
       status2         <- nodes(1).casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
@@ -1170,7 +1172,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult3 <- { //nodes(2) proposes a block
         val n = nodes(2)
         import n.casperEff._
-        (DeployGenerator.basicDeployData[Effect](1) >>= deploy) *> createBlock
+        (ConstructDeploy.basicDeployData[Effect](1) >>= deploy) *> createBlock
       }
       Created(block3) = createBlockResult3
       status3         <- nodes(2).casperEff.addBlock(block3, ignoreDoppelgangerCheck[Effect])
@@ -1182,7 +1184,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       createBlockResult4 <- { //nodes(0) proposes a new block
         val n = nodes.head
         import n.casperEff._
-        (DeployGenerator.basicDeployData[Effect](2) >>= deploy) *> createBlock
+        (ConstructDeploy.basicDeployData[Effect](2) >>= deploy) *> createBlock
       }
       Created(block4) = createBlockResult4
       status4         <- nodes.head.casperEff.addBlock(block4, ignoreDoppelgangerCheck[Effect])
@@ -1205,7 +1207,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     val timestamp = System.currentTimeMillis()
     val phloPrice = 1L
     val amount    = 847L
-    val sigDeployData = DeployGenerator
+    val sigDeployData = ConstructDeploy
       .sourceDeploy(
         s"""new retCh in { @"blake2b256Hash"!([0, $amount, *retCh].toByteArray(), "__SCALA__") }""",
         timestamp,
@@ -1238,12 +1240,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
          |    }
          |  }
          |}""".stripMargin
-      paymentDeployData = DeployGenerator
+      paymentDeployData = ConstructDeploy
         .sourceDeploy(paymentCode, timestamp, accounting.MAX_VALUE)
         .withPhloPrice(phloPrice)
         .withDeployer(user)
 
-      paymentQuery = DeployGenerator.sourceDeploy(
+      paymentQuery = ConstructDeploy.sourceDeploy(
         """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
         |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
         |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
@@ -1289,10 +1291,12 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
       deployDatas <- (0 to 2).toList
-                      .traverse[Effect, DeployData](i => DeployGenerator.basicDeployData[Effect](i))
-      deployPrim0 = deployDatas(1)
-        .withTimestamp(deployDatas(0).timestamp)
-        .withDeployer(deployDatas(0).deployer) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
+                      .traverse[Effect, DeployData](i => ConstructDeploy.basicDeployData[Effect](i))
+      deployPrim0 = ConstructDeploy.sign(
+        deployDatas(1)
+          .withTimestamp(deployDatas(0).timestamp)
+          .withDeployer(deployDatas(0).deployer)
+      ) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
       createBlockResult1 <- nodes(0).casperEff
                              .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
       Created(signedBlock1) = createBlockResult1
@@ -1352,7 +1356,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       ).zipWithIndex
         .map(
           d =>
-            DeployGenerator
+            ConstructDeploy
               .sourceDeploy(d._1, System.currentTimeMillis() + d._2, accounting.MAX_VALUE)
         )
 
@@ -1427,7 +1431,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       .map(
         d =>
           () =>
-            DeployGenerator
+            ConstructDeploy
               .sourceDeploy(d._1, System.currentTimeMillis() + d._2, accounting.MAX_VALUE)
       )
     def deploy(node: HashSetCasperTestNode[Effect], dd: DeployData): Effect[BlockMessage] =
@@ -1495,11 +1499,11 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
 
       // Creates a pair that constitutes equivocation blocks
-      basicDeployData0 <- DeployGenerator.basicDeployData[Effect](0)
+      basicDeployData0 <- ConstructDeploy.basicDeployData[Effect](0)
       createBlockResult1 <- nodes(0).casperEff
                              .deploy(basicDeployData0) *> nodes(0).casperEff.createBlock
       Created(signedBlock1) = createBlockResult1
-      basicDeployData1      <- DeployGenerator.basicDeployData[Effect](1)
+      basicDeployData1      <- ConstructDeploy.basicDeployData[Effect](1)
       createBlockResult1Prime <- nodes(0).casperEff
                                   .deploy(basicDeployData1) *> nodes(0).casperEff.createBlock
       Created(signedBlock1Prime) = createBlockResult1Prime
@@ -1529,7 +1533,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     for {
       nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
       deployDatas <- (0 to 5).toList
-                      .traverse[Effect, DeployData](DeployGenerator.basicDeployData[Effect])
+                      .traverse[Effect, DeployData](ConstructDeploy.basicDeployData[Effect])
 
       // Creates a pair that constitutes equivocation blocks
       createBlockResult1 <- nodes(0).casperEff
@@ -1619,7 +1623,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
   it should "prepare to slash an block that includes a invalid block pointer" in effectTest {
     for {
       nodes           <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deploys         <- (0 to 5).toList.traverse(i => DeployGenerator.basicDeployData[Effect](i))
+      deploys         <- (0 to 5).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
       deploysWithCost = deploys.map(d => ProcessedDeploy(deploy = Some(d))).toIndexedSeq
 
       createBlockResult <- nodes(0).casperEff
@@ -1664,7 +1668,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
 
       _ <- (0 to 9).toList.traverse_[Effect, Unit] { i =>
             for {
-              deploy <- DeployGenerator.basicDeployData[Effect](i)
+              deploy <- ConstructDeploy.basicDeployData[Effect](i)
               createBlockResult <- nodes(0).casperEff
                                     .deploy(deploy) *> nodes(0).casperEff.createBlock
               Created(block) = createBlockResult
@@ -1673,7 +1677,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
               _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
             } yield ()
           }
-      deployData10 <- DeployGenerator.basicDeployData[Effect](10)
+      deployData10 <- ConstructDeploy.basicDeployData[Effect](10)
       createBlock11Result <- nodes(0).casperEff.deploy(deployData10) *> nodes(
                               0
                             ).casperEff.createBlock
@@ -1707,7 +1711,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
       buildGenesis(Seq.empty, equalBonds, 1L, Long.MaxValue, Faucet.noopFaucet, 0L)
     for {
       nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesisWithEqualBonds)
-      deployDatas <- (0 to 7).toList.traverse(i => DeployGenerator.basicDeployData[Effect](i))
+      deployDatas <- (0 to 7).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
 
       createBlock1Result <- nodes(0).casperEff
                              .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
@@ -1790,7 +1794,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deployData        <- DeployGenerator.basicDeployData[Effect](0).map(_.withPhloLimit(1))
+      deployData        <- ConstructDeploy.basicDeployData[Effect](0).map(_.withPhloLimit(1))
       _                 <- node.casperEff.deploy(deployData)
       createBlockResult <- MultiParentCasper[Effect].createBlock
       Created(block)    = createBlockResult
@@ -1803,7 +1807,7 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     implicit val timeEff = new LogicalTime[Effect]
 
     for {
-      deployData <- DeployGenerator.basicDeployData[Effect](0).map(_.withPhloLimit(100))
+      deployData <- ConstructDeploy.basicDeployData[Effect](0).map(_.withPhloLimit(100))
       _          <- node.casperEff.deploy(deployData)
 
       createBlockResult <- MultiParentCasper[Effect].createBlock

--- a/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/HashSetCasperTest.scala
@@ -123,6 +123,19 @@ class HashSetCasperTest extends FlatSpec with Matchers with Inspectors {
     } yield deployResult should be(Left(MissingUser))
   }
 
+  it should "not allow deploy if deploy is holding non-existing algorithm" in effectTest {
+    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
+    val casper           = node.casperEff
+    implicit val timeEff = new LogicalTime[Effect]
+
+    for {
+      correctDeploy   <- DeployGenerator.basicDeployData[Effect](0)
+      incorrectDeploy = correctDeploy.withSigAlgorithm("SOME_RANDOME_STUFF")
+      deployResult    <- casper.deploy(incorrectDeploy)
+      _               <- node.tearDown()
+    } yield deployResult should be(Left(UnknownSignatureAlgorithm("SOME_RANDOME_STUFF")))
+  }
+
   it should "not allow multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
     val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler)

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -35,7 +35,7 @@ class RholangBuildTest extends FlatSpec with Matchers {
         |    timeStore!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
         |  }
         |}""".stripMargin
-    val deploy = ProtoUtil.sourceDeploy(code, 1L, accounting.MAX_VALUE)
+    val deploy = DeployGenerator.sourceDeploy(code, 1L, accounting.MAX_VALUE)
     for {
       createBlockResult    <- MultiParentCasper[Effect].deploy(deploy) *> MultiParentCasper[Effect].createBlock
       Created(signedBlock) = createBlockResult

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -35,7 +35,7 @@ class RholangBuildTest extends FlatSpec with Matchers {
         |    timeStore!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
         |  }
         |}""".stripMargin
-    val deploy = DeployGenerator.sourceDeploy(code, 1L, accounting.MAX_VALUE)
+    val deploy = ConstructDeploy.sourceDeploy(code, 1L, accounting.MAX_VALUE)
     for {
       createBlockResult    <- MultiParentCasper[Effect].deploy(deploy) *> MultiParentCasper[Effect].createBlock
       Created(signedBlock) = createBlockResult

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -284,7 +284,7 @@ class ValidateTest
   "Future deploy validation" should "work" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- ProtoUtil.basicProcessedDeploy[Task](0)
+        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(-1)
         block <- createBlock[Task](
@@ -299,7 +299,7 @@ class ValidateTest
   "Future deploy validation" should "not accept blocks with a deploy for a future block number" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- ProtoUtil.basicProcessedDeploy[Task](0)
+        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(Long.MaxValue)
         blockWithFutureDeploy <- createBlock[Task](
@@ -314,7 +314,7 @@ class ValidateTest
   "Deploy expiration validation" should "work" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy <- ProtoUtil.basicProcessedDeploy[Task](0)
+        deploy <- DeployGenerator.basicProcessedDeploy[Task](0)
         block <- createBlock[Task](
                   Seq.empty[BlockHash],
                   deploys = Seq(deploy)
@@ -327,7 +327,7 @@ class ValidateTest
   "Deploy expiration validation" should "not accept blocks with a deploy that is expired" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- ProtoUtil.basicProcessedDeploy[Task](0)
+        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(Long.MinValue)
         blockWithExpiredDeploy <- createBlock[Task](
@@ -425,7 +425,7 @@ class ValidateTest
       ): F[BlockMessage] =
         for {
           current <- Time[F].currentMillis
-          deploy  <- ProtoUtil.basicProcessedDeploy[F](current.toInt)
+          deploy  <- DeployGenerator.basicProcessedDeploy[F](current.toInt)
           block <- createBlock[F](
                     parents.map(_.blockHash),
                     creator = validators(validator),
@@ -610,7 +610,7 @@ class ValidateTest
           validator: Int
       ): F[BlockMessage] =
         for {
-          deploy <- ProtoUtil.basicProcessedDeploy[F](0)
+          deploy <- DeployGenerator.basicProcessedDeploy[F](0)
           result <- createBlock[F](
                      parents.map(_.blockHash),
                      creator = validators(validator),

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -284,7 +284,7 @@ class ValidateTest
   "Future deploy validation" should "work" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
+        deploy            <- ConstructDeploy.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(-1)
         block <- createBlock[Task](
@@ -299,7 +299,7 @@ class ValidateTest
   "Future deploy validation" should "not accept blocks with a deploy for a future block number" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
+        deploy            <- ConstructDeploy.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(Long.MaxValue)
         blockWithFutureDeploy <- createBlock[Task](
@@ -314,7 +314,7 @@ class ValidateTest
   "Deploy expiration validation" should "work" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy <- DeployGenerator.basicProcessedDeploy[Task](0)
+        deploy <- ConstructDeploy.basicProcessedDeploy[Task](0)
         block <- createBlock[Task](
                   Seq.empty[BlockHash],
                   deploys = Seq(deploy)
@@ -327,7 +327,7 @@ class ValidateTest
   "Deploy expiration validation" should "not accept blocks with a deploy that is expired" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        deploy            <- DeployGenerator.basicProcessedDeploy[Task](0)
+        deploy            <- ConstructDeploy.basicProcessedDeploy[Task](0)
         deployData        = deploy.deploy.get
         updatedDeployData = deployData.withValidAfterBlockNumber(Long.MinValue)
         blockWithExpiredDeploy <- createBlock[Task](
@@ -425,7 +425,7 @@ class ValidateTest
       ): F[BlockMessage] =
         for {
           current <- Time[F].currentMillis
-          deploy  <- DeployGenerator.basicProcessedDeploy[F](current.toInt)
+          deploy  <- ConstructDeploy.basicProcessedDeploy[F](current.toInt)
           block <- createBlock[F](
                     parents.map(_.blockHash),
                     creator = validators(validator),
@@ -610,7 +610,7 @@ class ValidateTest
           validator: Int
       ): F[BlockMessage] =
         for {
-          deploy <- DeployGenerator.basicProcessedDeploy[F](0)
+          deploy <- ConstructDeploy.basicProcessedDeploy[F](0)
           result <- createBlock[F](
                      parents.map(_.blockHash),
                      creator = validators(validator),

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -56,7 +56,7 @@ class BlockQueryResponseAPITest
   val deployCount = 10
   val randomDeploys =
     (0 until deployCount).toList
-      .traverse(DeployGenerator.basicProcessedDeploy[Task])
+      .traverse(ConstructDeploy.basicProcessedDeploy[Task])
       .unsafeRunSync(scheduler)
   val body: Body                       = Body().withState(ps).withDeploys(randomDeploys)
   val parentsString                    = List(genesisHashString, "0000000001")

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -56,7 +56,7 @@ class BlockQueryResponseAPITest
   val deployCount = 10
   val randomDeploys =
     (0 until deployCount).toList
-      .traverse(ProtoUtil.basicProcessedDeploy[Task])
+      .traverse(DeployGenerator.basicProcessedDeploy[Task])
       .unsafeRunSync(scheduler)
   val body: Body                       = Body().withState(ps).withDeploys(randomDeploys)
   val parentsString                    = List(genesisHashString, "0000000001")

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -96,9 +96,9 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def addBlock(
       b: BlockMessage,
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus]                                     = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
-  def contains(b: BlockMessage): F[Boolean]             = underlying.contains(b)
-  def deploy(d: DeployData): F[Either[Throwable, Unit]] = underlying.deploy(d)
+  ): F[BlockStatus]                                       = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
+  def contains(b: BlockMessage): F[Boolean]               = underlying.contains(b)
+  def deploy(d: DeployData): F[Either[DeployError, Unit]] = underlying.deploy(d)
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     underlying.estimator(dag)
   def blockDag: F[BlockDagRepresentation[F]] = underlying.blockDag

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -52,7 +52,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
     val deploys = List(
       "@0!(0) | for(_ <- @0){ @1!(1) }",
       "for(_ <- @1){ @2!(2) }"
-    ).map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+    ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
 
     def createBlock(deploy: DeployData, blockApiLock: Semaphore[Effect])(
         implicit casperRef: MultiParentCasperRef[Effect]

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -52,7 +52,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
     val deploys = List(
       "@0!(0) | for(_ <- @0){ @1!(1) }",
       "for(_ <- @1){ @2!(2) }"
-    ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+    ).map(ConstructDeploy.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
 
     def createBlock(deploy: DeployData, blockApiLock: Semaphore[Effect])(
         implicit casperRef: MultiParentCasperRef[Effect]

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.api
 
 import cats.implicits._
 
-import coop.rchain.casper.{Created, HashSetCasperTest}
+import coop.rchain.casper.{Created, DeployGenerator, HashSetCasperTest}
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
@@ -70,7 +70,9 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
       implicit val timeEff = new LogicalTime[Effect]
       for {
         deployDatas <- (0 to 7).toList
-                        .traverse[Effect, DeployData](_ => ProtoUtil.basicDeployData[Effect](0))
+                        .traverse[Effect, DeployData](
+                          _ => DeployGenerator.basicDeployData[Effect](0)
+                        )
 
         createBlock1Result <- nodes(0).casperEff
                                .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.api
 
 import cats.implicits._
 
-import coop.rchain.casper.{Created, DeployGenerator, HashSetCasperTest}
+import coop.rchain.casper.{ConstructDeploy, Created, HashSetCasperTest}
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
@@ -33,11 +33,11 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
     def basicDeployData: DeployData = {
       val timestamp = System.currentTimeMillis()
-      DeployData()
-        .withDeployer(ByteString.EMPTY)
-        .withTimestamp(timestamp)
-        .withTerm("@{ 3 | 2 | 1 }!(0)")
-        .withPhloLimit(accounting.MAX_VALUE)
+      ConstructDeploy.sourceDeploy(
+        source = "@{ 3 | 2 | 1 }!(0)",
+        timestamp = timestamp,
+        phlos = accounting.MAX_VALUE
+      )
     }
 
     for {
@@ -71,7 +71,7 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
       for {
         deployDatas <- (0 to 7).toList
                         .traverse[Effect, DeployData](
-                          _ => DeployGenerator.basicDeployData[Effect](0)
+                          _ => ConstructDeploy.basicDeployData[Effect](0)
                         )
 
         createBlock1Result <- nodes(0).casperEff

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper.genesis.contracts
 import cats.effect.Concurrent
 import cats.implicits._
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.casper.DeployGenerator
 import coop.rchain.casper.HashSetCasperTest.createBonds
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.DeployData
@@ -111,7 +112,7 @@ object RevIssuanceTest {
       statusOut: String
   )(implicit runtimeManager: RuntimeManager[F]): F[DeployData] =
     BondingUtil.preWalletUnlockDeploy[F](ethAddress, pubKey, secKey, statusOut).map { code =>
-      ProtoUtil.sourceDeploy(
+      DeployGenerator.sourceDeploy(
         code,
         System.currentTimeMillis(),
         accounting.MAX_VALUE
@@ -136,7 +137,7 @@ object RevIssuanceTest {
         secKey
       )
       .map { code =>
-        ProtoUtil.sourceDeploy(
+        DeployGenerator.sourceDeploy(
           code,
           System.currentTimeMillis(),
           accounting.MAX_VALUE

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.genesis.contracts
 import cats.effect.Concurrent
 import cats.implicits._
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.casper.DeployGenerator
+import coop.rchain.casper.ConstructDeploy
 import coop.rchain.casper.HashSetCasperTest.createBonds
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.DeployData
@@ -112,7 +112,7 @@ object RevIssuanceTest {
       statusOut: String
   )(implicit runtimeManager: RuntimeManager[F]): F[DeployData] =
     BondingUtil.preWalletUnlockDeploy[F](ethAddress, pubKey, secKey, statusOut).map { code =>
-      DeployGenerator.sourceDeploy(
+      ConstructDeploy.sourceDeploy(
         code,
         System.currentTimeMillis(),
         accounting.MAX_VALUE
@@ -137,7 +137,7 @@ object RevIssuanceTest {
         secKey
       )
       .map { code =>
-        DeployGenerator.sourceDeploy(
+        ConstructDeploy.sourceDeploy(
           code,
           System.currentTimeMillis(),
           accounting.MAX_VALUE

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -4,6 +4,7 @@ import cats.effect.Sync
 import cats.implicits._
 import cats.{Applicative, Monad}
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.casper.DeployError
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -27,8 +28,8 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
       _ <- Sync[F].delay(blockStore.update(b.blockHash, b))
       _ <- BlockStore[F].put(b.blockHash, b)
     } yield BlockStatus.valid
-  def contains(b: BlockMessage): F[Boolean]             = false.pure[F]
-  def deploy(r: DeployData): F[Either[Throwable, Unit]] = Applicative[F].pure(Right(()))
+  def contains(b: BlockMessage): F[Boolean]               = false.pure[F]
+  def deploy(r: DeployData): F[Either[DeployError, Unit]] = Applicative[F].pure(Right(()))
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]

--- a/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
@@ -6,6 +6,11 @@ import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.catscontrib._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import cats.implicits._
+import cats.mtl.MonadState
+import cats.mtl.implicits._
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.casper.DeployGenerator
+import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.helper.BlockGenerator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator

--- a/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
@@ -9,7 +9,7 @@ import cats.implicits._
 import cats.mtl.MonadState
 import cats.mtl.implicits._
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.DeployGenerator
+import coop.rchain.casper.ConstructDeploy
 import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.helper.BlockGenerator
 import coop.rchain.casper.helper.BlockGenerator._

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -13,6 +13,7 @@ import coop.rchain.blockstorage.{
   BlockStore,
   IndexedBlockDagStorage
 }
+import coop.rchain.casper.DeployGenerator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol._
@@ -55,24 +56,24 @@ class InterpreterUtilTest
         "@1!(1)",
         "@2!(2)",
         "for(@a <- @1){ @123!(5 * a) }"
-      ).map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+      ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
       val genesisDeploysCost =
         genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1)))
 
       val b1Deploys = Vector(
         "@1!(1)",
         "for(@a <- @2){ @456!(5 * a) }"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b1DeploysCost = b1Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b2Deploys = Vector(
         "for(@a <- @123; @b <- @456){ @1!(a + b) }"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b2DeploysCost = b2Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b3Deploys = Vector(
         "@7!(7)"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b3DeploysCost = b3Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       /*
@@ -145,26 +146,26 @@ class InterpreterUtilTest
         "@1!(1)",
         "@2!(2)",
         "for(@a <- @1){ @123!(5 * a) }"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val genesisDeploysWithCost =
         genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1)))
 
       val b1Deploys = Vector(
         "@5!(5)",
         "for(@a <- @2){ @456!(5 * a) }"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b1DeploysWithCost =
         b1Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(2L)))
 
       val b2Deploys = Vector(
         "@6!(6)"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b2DeploysWithCost =
         b2Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b3Deploys = Vector(
         "for(@a <- @123; @b <- @456){ @1!(a + b) }"
-      ).map(ProtoUtil.sourceDeployNow)
+      ).map(DeployGenerator.sourceDeployNow)
       val b3DeploysWithCost =
         b3Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(5L)))
 
@@ -253,7 +254,7 @@ class InterpreterUtilTest
   """.stripMargin
 
   def prepareDeploys(v: Vector[String], c: PCost) = {
-    val genesisDeploys = v.map(ProtoUtil.sourceDeployNow)
+    val genesisDeploys = v.map(DeployGenerator.sourceDeployNow)
     genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(c))
   }
 
@@ -407,19 +408,19 @@ class InterpreterUtilTest
       implicit blockDagStorage =>
         //reference costs
         //deploy each Rholang program separately and record its cost
-        val deploy1 = ProtoUtil.sourceDeploy(
+        val deploy1 = DeployGenerator.sourceDeploy(
           "@1!(Nil)",
           System.currentTimeMillis(),
           accounting.MAX_VALUE
         )
         val deploy2 =
-          ProtoUtil.sourceDeploy(
+          DeployGenerator.sourceDeploy(
             "@3!([1,2,3,4])",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
           )
         val deploy3 =
-          ProtoUtil.sourceDeploy(
+          DeployGenerator.sourceDeploy(
             "for(@x <- @0) { @4!(x.toByteArray()) }",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -442,13 +443,13 @@ class InterpreterUtilTest
       withStorage { implicit blockStore => implicit blockDagStorage =>
         //deploy each Rholang program separately and record its cost
         val deploy1 =
-          ProtoUtil.sourceDeploy(
+          DeployGenerator.sourceDeploy(
             "@1!(Nil)",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
           )
         val deploy2 =
-          ProtoUtil.sourceDeploy(
+          DeployGenerator.sourceDeploy(
             "@2!([1,2,3,4])",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -462,7 +463,7 @@ class InterpreterUtilTest
 
             accCostsSep = cost1 ++ cost2
 
-            deployErr = ProtoUtil.sourceDeploy(
+            deployErr = DeployGenerator.sourceDeploy(
               "@3!(\"a\" + 3)",
               System.currentTimeMillis(),
               accounting.MAX_VALUE
@@ -476,7 +477,7 @@ class InterpreterUtilTest
 
   "validateBlockCheckpoint" should "not return a checkpoint for an invalid block" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val deploys = Vector("@1!(1)").map(ProtoUtil.sourceDeployNow)
+      val deploys = Vector("@1!(1)").map(DeployGenerator.sourceDeployNow)
       val processedDeploys =
         deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
       val invalidHash = ByteString.EMPTY
@@ -502,7 +503,7 @@ class InterpreterUtilTest
           "@2!(5)",
           "for (@x <- @1) { @2!(x) }",
           "for (@x <- @2) { @3!(x) }"
-        ).map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+        ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
       mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
         for {
           dag1 <- blockDagStorage.getRepresentation
@@ -555,7 +556,7 @@ class InterpreterUtilTest
       """.stripMargin
       ).map(
         s =>
-          ProtoUtil.sourceDeploy(
+          DeployGenerator.sourceDeploy(
             s,
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -617,7 +618,7 @@ class InterpreterUtilTest
           """)
           .map(
             s =>
-              ProtoUtil.sourceDeploy(
+              DeployGenerator.sourceDeploy(
                 s,
                 System.currentTimeMillis(),
                 accounting.MAX_VALUE
@@ -675,7 +676,7 @@ class InterpreterUtilTest
           |}""".stripMargin
         ).map(
           s =>
-            ProtoUtil.sourceDeploy(
+            DeployGenerator.sourceDeploy(
               s,
               System.currentTimeMillis(),
               accounting.MAX_VALUE
@@ -725,7 +726,7 @@ class InterpreterUtilTest
             |""".stripMargin
           ).map(
             s =>
-              ProtoUtil.sourceDeploy(
+              DeployGenerator.sourceDeploy(
                 s,
                 System.currentTimeMillis(),
                 accounting.MAX_VALUE
@@ -761,7 +762,7 @@ class InterpreterUtilTest
     implicit blockStore => implicit blockDagStorage =>
       val deploys = (0 until 1).map(i => {
         val code = s"for(_ <- @$i){ Nil } | @$i!($i)"
-        ProtoUtil.sourceDeployNow(code)
+        DeployGenerator.sourceDeployNow(code)
       })
 
       mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
@@ -813,7 +814,7 @@ class InterpreterUtilTest
             """
             |@"store"!("2")
           """.stripMargin
-          ).map(s => ProtoUtil.sourceDeployNow(s))
+          ).map(s => DeployGenerator.sourceDeployNow(s))
 
         mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
           for {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -13,7 +13,7 @@ import coop.rchain.blockstorage.{
   BlockStore,
   IndexedBlockDagStorage
 }
-import coop.rchain.casper.DeployGenerator
+import coop.rchain.casper.ConstructDeploy
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol._
@@ -56,24 +56,24 @@ class InterpreterUtilTest
         "@1!(1)",
         "@2!(2)",
         "for(@a <- @1){ @123!(5 * a) }"
-      ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+      ).map(ConstructDeploy.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
       val genesisDeploysCost =
         genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1)))
 
       val b1Deploys = Vector(
         "@1!(1)",
         "for(@a <- @2){ @456!(5 * a) }"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b1DeploysCost = b1Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b2Deploys = Vector(
         "for(@a <- @123; @b <- @456){ @1!(a + b) }"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b2DeploysCost = b2Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b3Deploys = Vector(
         "@7!(7)"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b3DeploysCost = b3Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       /*
@@ -146,26 +146,26 @@ class InterpreterUtilTest
         "@1!(1)",
         "@2!(2)",
         "for(@a <- @1){ @123!(5 * a) }"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val genesisDeploysWithCost =
         genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1)))
 
       val b1Deploys = Vector(
         "@5!(5)",
         "for(@a <- @2){ @456!(5 * a) }"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b1DeploysWithCost =
         b1Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(2L)))
 
       val b2Deploys = Vector(
         "@6!(6)"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b2DeploysWithCost =
         b2Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
 
       val b3Deploys = Vector(
         "for(@a <- @123; @b <- @456){ @1!(a + b) }"
-      ).map(DeployGenerator.sourceDeployNow)
+      ).map(ConstructDeploy.sourceDeployNow)
       val b3DeploysWithCost =
         b3Deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(5L)))
 
@@ -254,7 +254,7 @@ class InterpreterUtilTest
   """.stripMargin
 
   def prepareDeploys(v: Vector[String], c: PCost) = {
-    val genesisDeploys = v.map(DeployGenerator.sourceDeployNow)
+    val genesisDeploys = v.map(ConstructDeploy.sourceDeployNow)
     genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(c))
   }
 
@@ -408,19 +408,19 @@ class InterpreterUtilTest
       implicit blockDagStorage =>
         //reference costs
         //deploy each Rholang program separately and record its cost
-        val deploy1 = DeployGenerator.sourceDeploy(
+        val deploy1 = ConstructDeploy.sourceDeploy(
           "@1!(Nil)",
           System.currentTimeMillis(),
           accounting.MAX_VALUE
         )
         val deploy2 =
-          DeployGenerator.sourceDeploy(
+          ConstructDeploy.sourceDeploy(
             "@3!([1,2,3,4])",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
           )
         val deploy3 =
-          DeployGenerator.sourceDeploy(
+          ConstructDeploy.sourceDeploy(
             "for(@x <- @0) { @4!(x.toByteArray()) }",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -443,13 +443,13 @@ class InterpreterUtilTest
       withStorage { implicit blockStore => implicit blockDagStorage =>
         //deploy each Rholang program separately and record its cost
         val deploy1 =
-          DeployGenerator.sourceDeploy(
+          ConstructDeploy.sourceDeploy(
             "@1!(Nil)",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
           )
         val deploy2 =
-          DeployGenerator.sourceDeploy(
+          ConstructDeploy.sourceDeploy(
             "@2!([1,2,3,4])",
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -463,7 +463,7 @@ class InterpreterUtilTest
 
             accCostsSep = cost1 ++ cost2
 
-            deployErr = DeployGenerator.sourceDeploy(
+            deployErr = ConstructDeploy.sourceDeploy(
               "@3!(\"a\" + 3)",
               System.currentTimeMillis(),
               accounting.MAX_VALUE
@@ -477,7 +477,7 @@ class InterpreterUtilTest
 
   "validateBlockCheckpoint" should "not return a checkpoint for an invalid block" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val deploys = Vector("@1!(1)").map(DeployGenerator.sourceDeployNow)
+      val deploys = Vector("@1!(1)").map(ConstructDeploy.sourceDeployNow)
       val processedDeploys =
         deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(PCost(1L)))
       val invalidHash = ByteString.EMPTY
@@ -503,7 +503,7 @@ class InterpreterUtilTest
           "@2!(5)",
           "for (@x <- @1) { @2!(x) }",
           "for (@x <- @2) { @3!(x) }"
-        ).map(DeployGenerator.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
+        ).map(ConstructDeploy.sourceDeploy(_, System.currentTimeMillis(), accounting.MAX_VALUE))
       mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
         for {
           dag1 <- blockDagStorage.getRepresentation
@@ -556,7 +556,7 @@ class InterpreterUtilTest
       """.stripMargin
       ).map(
         s =>
-          DeployGenerator.sourceDeploy(
+          ConstructDeploy.sourceDeploy(
             s,
             System.currentTimeMillis(),
             accounting.MAX_VALUE
@@ -618,7 +618,7 @@ class InterpreterUtilTest
           """)
           .map(
             s =>
-              DeployGenerator.sourceDeploy(
+              ConstructDeploy.sourceDeploy(
                 s,
                 System.currentTimeMillis(),
                 accounting.MAX_VALUE
@@ -676,7 +676,7 @@ class InterpreterUtilTest
           |}""".stripMargin
         ).map(
           s =>
-            DeployGenerator.sourceDeploy(
+            ConstructDeploy.sourceDeploy(
               s,
               System.currentTimeMillis(),
               accounting.MAX_VALUE
@@ -726,7 +726,7 @@ class InterpreterUtilTest
             |""".stripMargin
           ).map(
             s =>
-              DeployGenerator.sourceDeploy(
+              ConstructDeploy.sourceDeploy(
                 s,
                 System.currentTimeMillis(),
                 accounting.MAX_VALUE
@@ -762,7 +762,7 @@ class InterpreterUtilTest
     implicit blockStore => implicit blockDagStorage =>
       val deploys = (0 until 1).map(i => {
         val code = s"for(_ <- @$i){ Nil } | @$i!($i)"
-        DeployGenerator.sourceDeployNow(code)
+        ConstructDeploy.sourceDeployNow(code)
       })
 
       mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
@@ -814,7 +814,7 @@ class InterpreterUtilTest
             """
             |@"store"!("2")
           """.stripMargin
-          ).map(s => DeployGenerator.sourceDeployNow(s))
+          ).map(s => ConstructDeploy.sourceDeployNow(s))
 
         mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
           for {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.util.rholang
 
+import coop.rchain.casper.DeployGenerator
 import cats.Id
 import cats.effect.Resource
 import coop.rchain.catscontrib.TaskContrib._
@@ -28,7 +29,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   "computeState" should "capture rholang errors" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) } | @"x"!(1) | @"y"!("hi") """
-    val deploy     = ProtoUtil.sourceDeployNow(badRholang)
+    val deploy     = DeployGenerator.sourceDeployNow(badRholang)
     val (_, Seq(result)) =
       runtimeManager
         .use(mgr => mgr.computeState(mgr.emptyStateHash, deploy :: Nil))
@@ -39,7 +40,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   it should "capture rholang parsing errors and charge for parsing" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!("hi") """
-    val deploy     = ProtoUtil.sourceDeployNow(badRholang)
+    val deploy     = DeployGenerator.sourceDeployNow(badRholang)
     val (_, Seq(result)) =
       runtimeManager
         .use(mgr => mgr.computeState(mgr.emptyStateHash, deploy :: Nil))
@@ -51,7 +52,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   it should "charge for parsing and execution" in {
     val correctRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!(2) }"""
-    val deploy         = ProtoUtil.sourceDeployNow(correctRholang)
+    val deploy         = DeployGenerator.sourceDeployNow(correctRholang)
 
     implicit val log: Log[Task]            = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
@@ -91,7 +92,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
   "captureResult" should "return the value at the specified channel after a rholang computation" in {
     val purseValue     = "37"
     val captureChannel = "__PURSEVALUE__"
-    val deployData = ProtoUtil.sourceDeploy(
+    val deployData = DeployGenerator.sourceDeploy(
       s"""new rl(`rho:registry:lookup`), NonNegativeNumberCh in {
          |  rl!(`rho:id:nd74ztexkao5awjhj95e3octkza7tydwiy7euthnyrt5ihgi9rj495`, *NonNegativeNumberCh) |
          |  for(@(_, NonNegativeNumber) <- NonNegativeNumberCh) {
@@ -112,7 +113,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
               mgr
                 .captureResults(
                   hash,
-                  ProtoUtil.sourceDeploy(
+                  DeployGenerator.sourceDeploy(
                     s""" for(nn <- @"nn"){ nn!("value", "$captureChannel") } """,
                     0L,
                     accounting.MAX_VALUE
@@ -130,7 +131,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
   it should "handle multiple results and no results appropriately" in {
     val n    = 8
     val code = (1 to n).map(i => s""" @"__SCALA__"!($i) """).mkString("|")
-    val term = ProtoUtil.sourceDeploy(code, 0L, accounting.MAX_VALUE)
+    val term = DeployGenerator.sourceDeploy(code, 0L, accounting.MAX_VALUE)
     val manyResults =
       runtimeManager
         .use(mgr => mgr.captureResults(mgr.emptyStateHash, term))
@@ -177,7 +178,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     def deployCost(p: Seq[InternalProcessedDeploy]): Long = p.map(_.cost.cost).sum
     val deploy = terms.map(
       t =>
-        ProtoUtil.sourceDeploy(
+        DeployGenerator.sourceDeploy(
           t,
           System.currentTimeMillis(),
           accounting.MAX_VALUE

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.util.rholang
 
-import coop.rchain.casper.DeployGenerator
+import coop.rchain.casper.ConstructDeploy
 import cats.Id
 import cats.effect.Resource
 import coop.rchain.catscontrib.TaskContrib._
@@ -29,7 +29,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   "computeState" should "capture rholang errors" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) } | @"x"!(1) | @"y"!("hi") """
-    val deploy     = DeployGenerator.sourceDeployNow(badRholang)
+    val deploy     = ConstructDeploy.sourceDeployNow(badRholang)
     val (_, Seq(result)) =
       runtimeManager
         .use(mgr => mgr.computeState(mgr.emptyStateHash, deploy :: Nil))
@@ -40,7 +40,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   it should "capture rholang parsing errors and charge for parsing" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!("hi") """
-    val deploy     = DeployGenerator.sourceDeployNow(badRholang)
+    val deploy     = ConstructDeploy.sourceDeployNow(badRholang)
     val (_, Seq(result)) =
       runtimeManager
         .use(mgr => mgr.computeState(mgr.emptyStateHash, deploy :: Nil))
@@ -52,7 +52,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
   it should "charge for parsing and execution" in {
     val correctRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!(2) }"""
-    val deploy         = DeployGenerator.sourceDeployNow(correctRholang)
+    val deploy         = ConstructDeploy.sourceDeployNow(correctRholang)
 
     implicit val log: Log[Task]            = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
@@ -92,7 +92,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
   "captureResult" should "return the value at the specified channel after a rholang computation" in {
     val purseValue     = "37"
     val captureChannel = "__PURSEVALUE__"
-    val deployData = DeployGenerator.sourceDeploy(
+    val deployData = ConstructDeploy.sourceDeploy(
       s"""new rl(`rho:registry:lookup`), NonNegativeNumberCh in {
          |  rl!(`rho:id:nd74ztexkao5awjhj95e3octkza7tydwiy7euthnyrt5ihgi9rj495`, *NonNegativeNumberCh) |
          |  for(@(_, NonNegativeNumber) <- NonNegativeNumberCh) {
@@ -113,7 +113,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
               mgr
                 .captureResults(
                   hash,
-                  DeployGenerator.sourceDeploy(
+                  ConstructDeploy.sourceDeploy(
                     s""" for(nn <- @"nn"){ nn!("value", "$captureChannel") } """,
                     0L,
                     accounting.MAX_VALUE
@@ -131,7 +131,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
   it should "handle multiple results and no results appropriately" in {
     val n    = 8
     val code = (1 to n).map(i => s""" @"__SCALA__"!($i) """).mkString("|")
-    val term = DeployGenerator.sourceDeploy(code, 0L, accounting.MAX_VALUE)
+    val term = ConstructDeploy.sourceDeploy(code, 0L, accounting.MAX_VALUE)
     val manyResults =
       runtimeManager
         .use(mgr => mgr.captureResults(mgr.emptyStateHash, term))
@@ -154,7 +154,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
     import cats.implicits._
 
-    val terms = DeployGenerator.basicDeployData[Id](0) :: Nil
+    val terms = ConstructDeploy.basicDeployData[Id](0) :: Nil
 
     def run =
       runtimeManager
@@ -178,7 +178,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     def deployCost(p: Seq[InternalProcessedDeploy]): Long = p.map(_.cost.cost).sum
     val deploy = terms.map(
       t =>
-        DeployGenerator.sourceDeploy(
+        ConstructDeploy.sourceDeploy(
           t,
           System.currentTimeMillis(),
           accounting.MAX_VALUE

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -154,7 +154,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
 
     import cats.implicits._
 
-    val terms = ProtoUtil.basicDeployData[Id](0) :: Nil
+    val terms = DeployGenerator.basicDeployData[Id](0) :: Nil
 
     def run =
       runtimeManager

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -278,11 +278,11 @@ class Node:
         return self.rnode_command('eval', rho_file_path)
 
     def deploy(self, rho_file_path: str) -> str:
-        return self.rnode_command('deploy', '--phlo-limit=1000000', '--phlo-price=1', rho_file_path)
+        return self.rnode_command('deploy', '--private-key=b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd', '--phlo-limit=1000000', '--phlo-price=1', rho_file_path)
 
     def deploy_string(self, rholang_code: str) -> str:
         quoted_rholang = shlex.quote(rholang_code)
-        return self.shell_out('sh', '-c', 'echo {quoted_rholang} >/tmp/deploy_string.rho && {rnode_binary} deploy --phlo-limit=10000000000 --phlo-price=1 /tmp/deploy_string.rho'.format(
+        return self.shell_out('sh', '-c', 'echo {quoted_rholang} >/tmp/deploy_string.rho && {rnode_binary} deploy --private-key=b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd --phlo-limit=10000000000 --phlo-price=1 /tmp/deploy_string.rho'.format(
             rnode_binary=rnode_binary,
             quoted_rholang=quoted_rholang,
         ))

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -81,7 +81,6 @@ object Main {
             privateKey,
             location
           )
-      case DeployDemo        => DeployRuntime.deployDemoProgram[Task]
       case Propose           => DeployRuntime.propose[Task]()
       case ShowBlock(hash)   => DeployRuntime.showBlock[Task](hash)
       case ShowBlocks(depth) => DeployRuntime.showBlocks[Task](depth)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -193,7 +193,6 @@ object Configuration {
           privateKey.toOption,
           location()
         )
-      case Some(options.deployDemo) => DeployDemo
       case Some(options.propose)    => Propose
       case Some(options.showBlock)  => ShowBlock(options.showBlock.hash())
       case Some(options.showBlocks) =>

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -193,8 +193,8 @@ object Configuration {
           privateKey.toOption,
           location()
         )
-      case Some(options.propose)    => Propose
-      case Some(options.showBlock)  => ShowBlock(options.showBlock.hash())
+      case Some(options.propose)   => Propose
+      case Some(options.showBlock) => ShowBlock(options.showBlock.hash())
       case Some(options.showBlocks) =>
         import options.showBlocks._
         ShowBlocks(depth.getOrElse(1))

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -341,13 +341,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(eval)
 
-  val deployDemo = new Subcommand("deploy-demo") {
-    descr(
-      "Demo sending some placeholder Deploy operations to Casper on an existing running node at regular intervals"
-    )
-  }
-  addSubcommand(deployDemo)
-
   val hexCheck: String => Boolean     = _.matches("[0-9a-fA-F]+")
   val addressCheck: String => Boolean = addr => addr.startsWith("0x") && hexCheck(addr.drop(2))
 

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -62,7 +62,6 @@ final case class Deploy(
     privateKey: Option[PrivateKey],
     location: String
 ) extends Command
-final case object DeployDemo                                               extends Command
 final case object Propose                                                  extends Command
 final case class ShowBlock(hash: String)                                   extends Command
 final case class ShowBlocks(depth: Int)                                    extends Command


### PR DESCRIPTION
## Overview
RNode should ignore deployment if `DeployData` is not signed or incorrectly signed.

Casper:
- should not allow deploy if deploy is missing signature
- should not allow deploy if deploy is missing signature algorithm
- should not allow deploy if deploy is missing user
- should not allow deploy if deploy is holding non-existing algorithm
- should not allow deploy if deploy is incorrectly signed

### JIRA ticket:
RCHAIN-3129
