### PR TITLE
Align hash calculating algorithm for all IStore implementations

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -62,7 +62,7 @@ class InMemoryStore[F[_], T, C, P, A, K](
     }
 
   private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash =
-    StableHashProvider.hash(channels)
+    StableHashProvider.hash(channels)(Serialize.fromCodec(codecC))
 
   override def withTrieTxn[R](txn: Transaction)(f: TrieTransaction => R): R =
     trieStore.withTxn(trieStore.createTxnWrite()) { ttxn =>

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -100,7 +100,7 @@ class LockFreeInMemoryStore[F[_], T, C, P, A, K](
     entriesGauge.set(stateGNAT.readOnlySnapshot.size.toLong)
 
   private[rspace] def hashChannels(channels: Seq[C]): Blake2b256Hash =
-    StableHashProvider.hash(channels)
+    StableHashProvider.hash(channels)(Serialize.fromCodec(codecC))
 
   override def withTrieTxn[R](txn: Transaction)(f: TrieTransaction => R): R =
     trieStore.withTxn(trieStore.createTxnWrite()) { ttxn =>


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Allow mixed, in mem and lmdb backed RSpace to be able to use same data (genesis and blocks).


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-3131


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
