### PR TITLE
Move findCreatorJustificationAncestorWithSeqNum to EquivocationDetector

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -101,25 +101,6 @@ object ProtoUtil {
           validator == block.sender
       }
 
-  def findCreatorJustificationAncestorWithSeqNum[F[_]: Monad: BlockStore](
-      blockDag: BlockDagRepresentation[F],
-      b: BlockMessage,
-      seqNum: SequenceNumber
-  ): F[Option[BlockHash]] =
-    if (b.seqNum == seqNum) {
-      Option(b.blockHash).pure[F]
-    } else {
-      DagOperations
-        .bfTraverseF(List(b.blockHash)) { blockHash =>
-          getCreatorJustificationAsListUntilGoalInMemory[F](blockDag, blockHash)
-        }
-        .findF { blockHash =>
-          for {
-            blockMeta <- blockDag.lookup(blockHash)
-          } yield blockMeta.get.seqNum == seqNum
-        }
-    }
-
   /**
     * Since the creator justification is unique
     * we don't need to return a list. However, the bfTraverseF


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

The EquivocationDetector is the only place we call the
function and so it naturally should be there.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
