### PR TITLE
Logging improvements

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -1,5 +1,9 @@
 <configuration>
 
+  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+    <resetJUL>true</resetJUL>
+  </contextListener>
+
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -23,10 +23,6 @@ import org.slf4j.bridge.SLF4JBridgeHandler
 
 object Main {
 
-  // https://www.slf4j.org/legacy.html#jul-to-slf4j
-  SLF4JBridgeHandler.removeHandlersForRootLogger()
-  SLF4JBridgeHandler.install()
-
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private implicit val log: Log[Task]       = effects.log
 
@@ -115,6 +111,11 @@ object Main {
   }
 
   private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] = {
+    // XXX: Enable it earlier once we have JDK with https://bugs.openjdk.java.net/browse/JDK-8218960 fixed
+    // https://www.slf4j.org/legacy.html#jul-to-slf4j
+    SLF4JBridgeHandler.removeHandlersForRootLogger()
+    SLF4JBridgeHandler.install()
+
     val node =
       for {
         _       <- log.info(VersionInfo.get).toEffect

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -19,8 +19,13 @@ import coop.rchain.shared.StringOps._
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.slf4j.LoggerFactory
+import org.slf4j.bridge.SLF4JBridgeHandler
 
 object Main {
+
+  // https://www.slf4j.org/legacy.html#jul-to-slf4j
+  SLF4JBridgeHandler.removeHandlersForRootLogger()
+  SLF4JBridgeHandler.install()
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private implicit val log: Log[Task]       = effects.log

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -18,6 +18,7 @@ import coop.rchain.shared._
 import coop.rchain.shared.StringOps._
 import monix.eval.Task
 import monix.execution.Scheduler
+import org.slf4j.LoggerFactory
 
 object Main {
 
@@ -26,6 +27,11 @@ object Main {
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def main(args: Array[String]): Unit = {
+    // Catch-all for unhandled exceptions. Use only JDK and SLF4J.
+    Thread.setDefaultUncaughtExceptionHandler((thread, ex) => {
+      LoggerFactory.getLogger(getClass).error("Unhandled exception in thread " + thread.getName, ex)
+      ex.printStackTrace()
+    })
 
     val configuration = Configuration.build(args)
     System.setProperty("rnode.data.dir", configuration.server.dataDir.toString) // NonUnitStatements

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,6 +71,7 @@ object Dependencies {
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
   val tomlScala           = "tech.sparse"                %% "toml-scala"                % "0.1.1"
+  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
   // format: on
 
   val overrides = Seq(
@@ -95,7 +96,7 @@ object Dependencies {
 
   private val testing = Seq(scalactic, scalatest, scalacheck)
 
-  private val logging = Seq(scalaLogging, logbackClassic)
+  private val logging = Seq(scalaLogging, logbackClassic, logstashLogback)
 
   private val circeDependencies: Seq[ModuleID] =
     Seq(circeCore, circeGeneric, circeGenericExtras, circeParser, circeLiteral)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   val catsVersion       = "1.5.0"
   val catsEffectVersion = "1.2.0"
   val catsMtlVersion    = "0.4.0"
+  val slf4jVersion      = "1.7.25"
 
   // format: off
   val bouncyCastle        = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.60"
@@ -72,6 +73,7 @@ object Dependencies {
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
   val tomlScala           = "tech.sparse"                %% "toml-scala"                % "0.1.1"
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
+  val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
   // format: on
 
   val overrides = Seq(
@@ -96,7 +98,7 @@ object Dependencies {
 
   private val testing = Seq(scalactic, scalatest, scalacheck)
 
-  private val logging = Seq(scalaLogging, logbackClassic, logstashLogback)
+  private val logging = Seq(slf4j, scalaLogging, logbackClassic, logstashLogback)
 
   private val circeDependencies: Seq[ModuleID] =
     Seq(circeCore, circeGeneric, circeGenericExtras, circeParser, circeLiteral)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,6 +74,7 @@ object Dependencies {
   val tomlScala           = "tech.sparse"                %% "toml-scala"                % "0.1.1"
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
+  val julToSlf4j          = "org.slf4j"                   % "jul-to-slf4j"              % slf4jVersion
   // format: on
 
   val overrides = Seq(
@@ -98,7 +99,7 @@ object Dependencies {
 
   private val testing = Seq(scalactic, scalatest, scalacheck)
 
-  private val logging = Seq(slf4j, scalaLogging, logbackClassic, logstashLogback)
+  private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 
   private val circeDependencies: Seq[ModuleID] =
     Seq(circeCore, circeGeneric, circeGenericExtras, circeParser, circeLiteral)


### PR DESCRIPTION
This doesn't add any additional logging library/framework. SLF4J is merely now direct, instead of transitive dependency. jul-to-SLF4j is bridge from java.util.logging to SLF4J, see the relevant commit for details. Logstash encoder is to allow for sending log messages to Logstash over network for processing (alerting).