### PR TITLE
Make genesis as default latest message for newly bonded validators

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -8,7 +8,11 @@ import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 
 trait BlockDagStorage[F[_]] {
   def getRepresentation: F[BlockDagRepresentation[F]]
-  def insert(block: BlockMessage, invalid: Boolean): F[BlockDagRepresentation[F]]
+  def insert(
+      block: BlockMessage,
+      genesis: BlockMessage,
+      invalid: Boolean
+  ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
   def checkpoint(): F[Unit]
   def clear(): F[Unit]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -88,7 +88,11 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
       _              <- lock.release
     } yield InMemBlockDagRepresentation(latestMessages, childMap, dataLookup, topoSort)
 
-  override def insert(block: BlockMessage, invalid: Boolean): F[BlockDagRepresentation[F]] =
+  override def insert(
+      block: BlockMessage,
+      genesis: BlockMessage,
+      invalid: Boolean
+  ): F[BlockDagRepresentation[F]] =
     for {
       _ <- lock.acquire
       _ <- dataLookupRef.update(_.updated(block.blockHash, BlockMetadata.fromBlock(block, invalid)))
@@ -105,21 +109,27 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
         .map(_.validator)
         .toSet
         .diff(block.justifications.map(_.validator).toSet)
-      newValidatorsWithSender <- if (block.sender.isEmpty) {
-                                  // Ignore empty sender for special cases such as genesis block
-                                  Log[F].warn(
-                                    s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
-                                  ) *> newValidators.pure[F]
-                                } else if (block.sender.size() == 32) {
-                                  (newValidators + block.sender).pure[F]
-                                } else {
-                                  Sync[F].raiseError[Set[ByteString]](
-                                    BlockSenderIsMalformed(block)
-                                  )
-                                }
+      newValidatorsLatestMessages = newValidators.map(v => (v, genesis.blockHash))
+      newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
+                                                // Ignore empty sender for special cases such as genesis block
+                                                Log[F].warn(
+                                                  s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
+                                                ) *> newValidatorsLatestMessages.pure[F]
+                                              } else if (block.sender.size() == 32) {
+                                                (newValidatorsLatestMessages + (
+                                                  (
+                                                    block.sender,
+                                                    block.blockHash
+                                                  )
+                                                )).pure[F]
+                                              } else {
+                                                Sync[F].raiseError[Set[(ByteString, ByteString)]](
+                                                  BlockSenderIsMalformed(block)
+                                                )
+                                              }
       _ <- latestMessagesRef.update { latestMessages =>
-            newValidatorsWithSender.foldLeft(latestMessages) {
-              case (acc, v) => acc.updated(v, block.blockHash)
+            newValidatorsWithSenderLatestMessages.foldLeft(latestMessages) {
+              case (acc, (validator, blockHash)) => acc.updated(validator, blockHash)
             }
           }
       _   <- lock.release

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -452,7 +452,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
       case Valid =>
         // Add successful! Send block to peers, log success, try to add other blocks
         for {
-          updatedDag <- BlockDagStorage[F].insert(block, invalid = false)
+          updatedDag <- BlockDagStorage[F].insert(block, genesis, invalid = false)
           _          <- CommUtil.sendBlock[F](block)
           _ <- Log[F].info(
                 s"Added ${PrettyPrinter.buildString(block.blockHash)}"
@@ -485,7 +485,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
                       }
                 } yield ()
               }
-          updatedDag <- BlockDagStorage[F].insert(block, invalid = false)
+          updatedDag <- BlockDagStorage[F].insert(block, genesis, invalid = false)
           _          <- CommUtil.sendBlock[F](block)
           _ <- Log[F].info(
                 s"Added admissible equivocation child block ${PrettyPrinter.buildString(block.blockHash)}"
@@ -577,7 +577,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
   ): F[BlockDagRepresentation[F]] =
     Log[F].warn(
       s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}."
-    ) >> BlockDagStorage[F].insert(block, invalid = true)
+    ) >> BlockDagStorage[F].insert(block, genesis, invalid = true)
 
   private def reAttemptBuffer(
       dag: BlockDagRepresentation[F]

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -593,7 +593,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   ): F[Unit] =
     for {
       _ <- BlockStore[F].put(genesis.blockHash, genesis)
-      _ <- BlockDagStorage[F].insert(genesis, invalid = false)
+      _ <- BlockDagStorage[F].insert(genesis, genesis, invalid = false)
       _ <- BlockStore[F].putApprovedBlock(approvedBlock)
     } yield ()
 

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -30,31 +30,32 @@ class CliqueOracleTest
       m: mutable.Map[Validator, BlockMessage]
   ): Map[Validator, BlockMessage] = m.toMap
 
-  def createBlock(bonds: Seq[Bond])(creator: ByteString)(
+  def createBlock(bonds: Seq[Bond])(genesis: BlockMessage)(creator: ByteString)(
       parent: BlockMessage,
       justifications: Map[Validator, BlockMessage]
   )(implicit store: BlockStore[Task], dagStore: IndexedBlockDagStorage[Task]): Task[BlockMessage] =
     createBlock[Task](
       Seq(parent.blockHash),
-      creator,
-      bonds,
-      justifications.map { case (v, bm) => (v, bm.blockHash) }
+      genesis,
+      creator = creator,
+      bonds = bonds,
+      justifications = justifications.map { case (v, bm) => (v, bm.blockHash) }
     )
 
   // See [[/docs/casper/images/cbc-casper_ping_pong_diagram.png]]
   it should "detect finality as appropriate" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val v1       = generateValidator("Validator One")
-      val v2       = generateValidator("Validator Two")
-      val v1Bond   = Bond(v1, 2)
-      val v2Bond   = Bond(v2, 3)
-      val bonds    = Seq(v1Bond, v2Bond)
-      val creator1 = createBlock(bonds)(v1) _
-      val creator2 = createBlock(bonds)(v2) _
+      val v1     = generateValidator("Validator One")
+      val v2     = generateValidator("Validator Two")
+      val v1Bond = Bond(v1, 2)
+      val v2Bond = Bond(v2, 3)
+      val bonds  = Seq(v1Bond, v2Bond)
 
       implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       for {
-        genesis              <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis              <- createGenesis[Task](bonds = bonds)
+        creator1             = createBlock(bonds)(genesis)(v1) _
+        creator2             = createBlock(bonds)(genesis)(v2) _
         genesisJustification = HashMap(v1 -> genesis, v2 -> genesis)
         b2                   <- creator2(genesis, genesisJustification)
         b3                   <- creator1(genesis, genesisJustification)
@@ -79,20 +80,20 @@ class CliqueOracleTest
   // See [[/docs/casper/images/no_finalizable_block_mistake_with_no_disagreement_check.png]]
   it should "detect possible disagreements appropriately" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val v1       = generateValidator("Validator One")
-      val v2       = generateValidator("Validator Two")
-      val v3       = generateValidator("Validator Three")
-      val v1Bond   = Bond(v1, 25)
-      val v2Bond   = Bond(v2, 20)
-      val v3Bond   = Bond(v3, 15)
-      val bonds    = Seq(v1Bond, v2Bond, v3Bond)
-      val creator1 = createBlock(bonds)(v1) _
-      val creator2 = createBlock(bonds)(v2) _
-      val creator3 = createBlock(bonds)(v3) _
+      val v1     = generateValidator("Validator One")
+      val v2     = generateValidator("Validator Two")
+      val v3     = generateValidator("Validator Three")
+      val v1Bond = Bond(v1, 25)
+      val v2Bond = Bond(v2, 20)
+      val v3Bond = Bond(v3, 15)
+      val bonds  = Seq(v1Bond, v2Bond, v3Bond)
 
       implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       for {
-        genesis              <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis              <- createGenesis[Task](bonds = bonds)
+        creator1             = createBlock(bonds)(genesis)(v1) _
+        creator2             = createBlock(bonds)(genesis)(v2) _
+        creator3             = createBlock(bonds)(genesis)(v3) _
         genesisJustification = HashMap(v1 -> genesis, v2 -> genesis, v3 -> genesis)
         b2                   <- creator2(genesis, genesisJustification)
         b3                   <- creator1(genesis, genesisJustification)
@@ -118,17 +119,12 @@ class CliqueOracleTest
   // See [[/docs/casper/images/no_majority_fork_safe_after_union.png]]
   it should "identify no majority fork safe after union" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val v0       = generateValidator("Validator Zero")
-      val v1       = generateValidator("Validator One")
-      val v2       = generateValidator("Validator Two")
-      val v3       = generateValidator("Validator Three")
-      val v4       = generateValidator("Validator Four")
-      val bonds    = Seq(Bond(v0, 500), Bond(v1, 450), Bond(v2, 600), Bond(v3, 400), Bond(v4, 525))
-      val creator0 = createBlock(bonds)(v0) _
-      val creator1 = createBlock(bonds)(v1) _
-      val creator2 = createBlock(bonds)(v2) _
-      val creator3 = createBlock(bonds)(v3) _
-      val creator4 = createBlock(bonds)(v4) _
+      val v0    = generateValidator("Validator Zero")
+      val v1    = generateValidator("Validator One")
+      val v2    = generateValidator("Validator Two")
+      val v3    = generateValidator("Validator Three")
+      val v4    = generateValidator("Validator Four")
+      val bonds = Seq(Bond(v0, 500), Bond(v1, 450), Bond(v2, 600), Bond(v3, 400), Bond(v4, 525))
 
       implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       /*
@@ -141,8 +137,13 @@ class CliqueOracleTest
        */
 
       for {
-        ge  <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
-        gjL = mutable.HashMap(v0 -> ge, v1 -> ge, v2 -> ge, v3 -> ge, v4 -> ge)
+        ge       <- createGenesis[Task](bonds = bonds)
+        creator0 = createBlock(bonds)(ge)(v0) _
+        creator1 = createBlock(bonds)(ge)(v1) _
+        creator2 = createBlock(bonds)(ge)(v2) _
+        creator3 = createBlock(bonds)(ge)(v3) _
+        creator4 = createBlock(bonds)(ge)(v4) _
+        gjL      = mutable.HashMap(v0 -> ge, v1 -> ge, v2 -> ge, v3 -> ge, v4 -> ge)
 
         /*
          create left hand side of fork and check for no safety

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
@@ -46,16 +46,16 @@ class EstimatorHelperTest
     implicit blockStore => implicit blockDagStorage =>
       for {
         deploys <- (0 until 6).toList.traverse(i => basicProcessedDeploy[Task](i))
-        genesis <- createBlock[Task](Seq())
-        b2      <- createBlock[Task](Seq(genesis.blockHash), deploys = Seq(deploys(0)))
-        b3      <- createBlock[Task](Seq(genesis.blockHash), deploys = Seq(deploys(1)))
-        b4      <- createBlock[Task](Seq(b2.blockHash), deploys = Seq(deploys(2)))
-        b5      <- createBlock[Task](Seq(b3.blockHash), deploys = Seq(deploys(2)))
-        b6      <- createBlock[Task](Seq(b2.blockHash, b3.blockHash), deploys = Seq(deploys(2)))
-        b7      <- createBlock[Task](Seq(b6.blockHash), deploys = Seq(deploys(3)))
-        b8      <- createBlock[Task](Seq(b6.blockHash), deploys = Seq(deploys(5)))
-        b9      <- createBlock[Task](Seq(b7.blockHash), deploys = Seq(deploys(5)))
-        b10     <- createBlock[Task](Seq(b8.blockHash), deploys = Seq(deploys(4)))
+        genesis <- createGenesis[Task]()
+        b2      <- createBlock[Task](Seq(genesis.blockHash), genesis, deploys = Seq(deploys(0)))
+        b3      <- createBlock[Task](Seq(genesis.blockHash), genesis, deploys = Seq(deploys(1)))
+        b4      <- createBlock[Task](Seq(b2.blockHash), genesis, deploys = Seq(deploys(2)))
+        b5      <- createBlock[Task](Seq(b3.blockHash), genesis, deploys = Seq(deploys(2)))
+        b6      <- createBlock[Task](Seq(b2.blockHash, b3.blockHash), genesis, deploys = Seq(deploys(2)))
+        b7      <- createBlock[Task](Seq(b6.blockHash), genesis, deploys = Seq(deploys(3)))
+        b8      <- createBlock[Task](Seq(b6.blockHash), genesis, deploys = Seq(deploys(5)))
+        b9      <- createBlock[Task](Seq(b7.blockHash), genesis, deploys = Seq(deploys(5)))
+        b10     <- createBlock[Task](Seq(b8.blockHash), genesis, deploys = Seq(deploys(4)))
 
         dag <- blockDagStorage.getRepresentation
         result <- mkRuntimeManager("casper-util-test").use { runtimeManager =>
@@ -69,6 +69,7 @@ class EstimatorHelperTest
                      (postGenStateHash, postGenProcessedDeploys) = computeBlockCheckpointResult
                      _ <- injectPostStateHash[Task](
                            0,
+                           genesis,
                            genesis,
                            postGenStateHash,
                            postGenProcessedDeploys

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
@@ -22,45 +22,52 @@ class EstimatorTest extends FlatSpec with Matchers with BlockGenerator with Bloc
       val v2Bond = Bond(v2, 3)
       val bonds  = Seq(v1Bond, v2Bond)
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis <- createGenesis[Task](bonds = bonds)
         b2 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
              )
         b3 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
              )
         b4 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash)
              )
         b5 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash)
              )
         b6 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
              )
         b7 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
              )
         b8 <- createBlock[Task](
                Seq(b7.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash)
@@ -83,45 +90,52 @@ class EstimatorTest extends FlatSpec with Matchers with BlockGenerator with Bloc
       val v2Bond = Bond(v2, 3)
       val bonds  = Seq(v1Bond, v2Bond)
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis <- createGenesis[Task](bonds = bonds)
         b2 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
              )
         b3 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash)
              )
         b4 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash)
              )
         b5 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash)
              )
         b6 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
              )
         b7 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b5.blockHash, v2 -> b4.blockHash)
              )
         b8 <- createBlock[Task](
                Seq(b7.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b7.blockHash, v2 -> b4.blockHash)
@@ -152,45 +166,52 @@ class EstimatorTest extends FlatSpec with Matchers with BlockGenerator with Bloc
       val v3Bond = Bond(v3, 15)
       val bonds  = Seq(v1Bond, v2Bond, v3Bond)
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis <- createGenesis[Task](bonds = bonds)
         b2 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b3 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b4 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
              )
         b5 <- createBlock[Task](
                Seq(b3.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
              )
         b6 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
              )
         b7 <- createBlock[Task](
                Seq(b5.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
              )
         b8 <- createBlock[Task](
                Seq(b6.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -45,13 +45,13 @@ class ManyValidatorsTest
                           blockStore
                         )
       indexedBlockDagStorage <- IndexedBlockDagStorage.create(blockDagStorage)
-      genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)(
+      genesis <- createGenesis[Task](bonds = bonds)(
                   Monad[Task],
                   Time[Task],
                   blockStore,
                   indexedBlockDagStorage
                 )
-      b <- createBlock[Task](Seq(genesis.blockHash), v1, bonds, bonds.map {
+      b <- createBlock[Task](Seq(genesis.blockHash), genesis, v1, bonds, bonds.map {
             case Bond(validator, _) => validator -> genesis.blockHash
           }.toMap)(Monad[Task], Time[Task], blockStore, indexedBlockDagStorage)
       _                     <- indexedBlockDagStorage.close()

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -32,7 +32,10 @@ class BlockQueryResponseAPITest
   val genesisHashString = "0000000000000000000000000000000000000000000000000000000000000000"
   val version           = 1L
 
-  val bondsValidator = Bond(ByteString.copyFromUtf8("random"), 1)
+  val senderString: String =
+    "3456789101112131415161718192345678910111213141516171819261718192"
+  val sender: ByteString = ProtoUtil.stringToByteString(senderString)
+  val bondsValidator = Bond(sender, 1)
 
   def genesisBlock(genesisHashString: String, version: Long): BlockMessage = {
     val genesisHash = ProtoUtil.stringToByteString(genesisHashString)
@@ -63,17 +66,15 @@ class BlockQueryResponseAPITest
   val parentsString                    = List(genesisHashString, "0000000001")
   val parentsHashList: List[BlockHash] = parentsString.map(ProtoUtil.stringToByteString)
   val header: Header                   = ProtoUtil.blockHeader(body, parentsHashList, version, timestamp)
-  val secondBlockSenderString: String =
-    "3456789101112131415161718192345678910111213141516171819261718192"
-  val secondBlockSender: ByteString = ProtoUtil.stringToByteString(secondBlockSenderString)
   val shardId: String               = "abcdefgh"
   val secondBlock: BlockMessage =
     BlockMessage()
       .withBlockHash(blockHash)
       .withHeader(header)
       .withBody(body)
-      .withSender(secondBlockSender)
+      .withSender(sender)
       .withShardId(shardId)
+      .withJustifications(Seq(Justification(bondsValidator.validator, genesisBlock.blockHash)))
 
   val faultTolerance = 1f
 
@@ -105,7 +106,7 @@ class BlockQueryResponseAPITest
             blockInfo.faultTolerance should be(faultTolerance)
             blockInfo.mainParentHash should be(genesisHashString)
             blockInfo.parentsHashList should be(parentsString)
-            blockInfo.sender should be(secondBlockSenderString)
+            blockInfo.sender should be(senderString)
             blockInfo.shardId should be(shardId)
             blockInfo.bondsValidatorList should be(bondValidatorHashList)
             blockInfo.deployCost should be(deployCostList)
@@ -159,7 +160,7 @@ class BlockQueryResponseAPITest
             blockInfo.faultTolerance should be(faultTolerance)
             blockInfo.mainParentHash should be(genesisHashString)
             blockInfo.parentsHashList should be(parentsString)
-            blockInfo.sender should be(secondBlockSenderString)
+            blockInfo.sender should be(senderString)
             blockInfo.shardId should be(shardId)
             blockInfo.bondsValidatorList should be(bondValidatorHashList)
             blockInfo.deployCost should be(deployCostList)

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -195,8 +195,8 @@ class BlockQueryResponseAPITest
       blockDagStorage: BlockDagStorage[Task]
   ): Task[(LogStub[Task], MultiParentCasperRef[Task], SafetyOracle[Task])] =
     for {
-      _ <- blockDagStorage.insert(genesisBlock, false)
-      _ <- blockDagStorage.insert(secondBlock, false)
+      _ <- blockDagStorage.insert(genesisBlock, genesisBlock, false)
+      _ <- blockDagStorage.insert(secondBlock, genesisBlock, false)
       casperEffect <- NoOpsCasperEffect[Task](
                        HashMap[BlockHash, BlockMessage](
                          (ProtoUtil.stringToByteString(genesisHashString), genesisBlock),

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -34,45 +34,52 @@ class BlocksResponseAPITest
   "showMainChain" should "return only blocks in the main chain" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis <- createGenesis[Task](bonds = bonds)
         b2 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b3 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b4 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
              )
         b5 <- createBlock[Task](
                Seq(b3.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
              )
         b6 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
              )
         b7 <- createBlock[Task](
                Seq(b5.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
              )
         b8 <- createBlock[Task](
                Seq(b6.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
@@ -100,45 +107,52 @@ class BlocksResponseAPITest
   "showBlocks" should "return all blocks" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        genesis <- createGenesis[Task](bonds = bonds)
         b2 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b3 <- createBlock[Task](
                Seq(genesis.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
              )
         b4 <- createBlock[Task](
                Seq(b2.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
              )
         b5 <- createBlock[Task](
                Seq(b3.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
              )
         b6 <- createBlock[Task](
                Seq(b4.blockHash),
+               genesis,
                v1,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
              )
         b7 <- createBlock[Task](
                Seq(b5.blockHash),
+               genesis,
                v3,
                bonds,
                HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
              )
         b8 <- createBlock[Task](
                Seq(b6.blockHash),
+               genesis,
                v2,
                bonds,
                HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
@@ -166,45 +180,52 @@ class BlocksResponseAPITest
 
   it should "return until depth" in withStorage { implicit blockStore => implicit blockDagStorage =>
     for {
-      genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
+      genesis <- createGenesis[Task](bonds = bonds)
       b2 <- createBlock[Task](
              Seq(genesis.blockHash),
+             genesis,
              v2,
              bonds,
              HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
            )
       b3 <- createBlock[Task](
              Seq(genesis.blockHash),
+             genesis,
              v1,
              bonds,
              HashMap(v1 -> genesis.blockHash, v2 -> genesis.blockHash, v3 -> genesis.blockHash)
            )
       b4 <- createBlock[Task](
              Seq(b2.blockHash),
+             genesis,
              v3,
              bonds,
              HashMap(v1 -> genesis.blockHash, v2 -> b2.blockHash, v3 -> b2.blockHash)
            )
       b5 <- createBlock[Task](
              Seq(b3.blockHash),
+             genesis,
              v2,
              bonds,
              HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
            )
       b6 <- createBlock[Task](
              Seq(b4.blockHash),
+             genesis,
              v1,
              bonds,
              HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash, v3 -> b4.blockHash)
            )
       b7 <- createBlock[Task](
              Seq(b5.blockHash),
+             genesis,
              v3,
              bonds,
              HashMap(v1 -> b3.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
            )
       b8 <- createBlock[Task](
              Seq(b6.blockHash),
+             genesis,
              v2,
              bonds,
              HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -37,7 +37,7 @@ object BlockGenerator {
                                        runtimeManager
                                      )
       (postStateHash, processedDeploys) = computeBlockCheckpointResult
-      _                                 <- injectPostStateHash[F](id, b, postStateHash, processedDeploys)
+      _                                 <- injectPostStateHash[F](id, b, genesis, postStateHash, processedDeploys)
     } yield b
 
   def computeBlockCheckpoint[F[_]: Sync: BlockStore](
@@ -55,6 +55,7 @@ object BlockGenerator {
   def injectPostStateHash[F[_]: Monad: BlockStore: IndexedBlockDagStorage](
       id: Int,
       b: BlockMessage,
+      genesis: BlockMessage,
       postGenStateHash: StateHash,
       processedDeploys: Seq[ProcessedDeploy]
   ): F[Unit] = {
@@ -63,12 +64,12 @@ object BlockGenerator {
       b.getBody.withState(updatedBlockPostState).withDeploys(processedDeploys)
     val updatedBlock = b.withBody(updatedBlockBody)
     BlockStore[F].put(b.blockHash, updatedBlock) *>
-      IndexedBlockDagStorage[F].inject(id, updatedBlock, false)
+      IndexedBlockDagStorage[F].inject(id, updatedBlock, genesis, false)
   }
 }
 
 trait BlockGenerator {
-  def createBlock[F[_]: Monad: Time: BlockStore: IndexedBlockDagStorage](
+  private def buildBlock[F[_]: Monad: Time](
       parentsHashList: Seq[BlockHash],
       creator: Validator = ByteString.EMPTY,
       bonds: Seq[Bond] = Seq.empty[Bond],
@@ -107,7 +108,59 @@ trait BlockGenerator {
         shardId = shardId,
         seqNum = seqNum
       )
-      modifiedBlock <- IndexedBlockDagStorage[F].insertIndexed(block, false)
-      _             <- BlockStore[F].put(serializedBlockHash, modifiedBlock)
+    } yield block
+
+  def createGenesis[F[_]: Monad: Time: BlockStore: IndexedBlockDagStorage](
+      creator: Validator = ByteString.EMPTY,
+      bonds: Seq[Bond] = Seq.empty[Bond],
+      justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
+      deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
+      tsHash: ByteString = ByteString.EMPTY,
+      shardId: String = "rchain",
+      preStateHash: ByteString = ByteString.EMPTY,
+      seqNum: Int = 0
+  ): F[BlockMessage] =
+    for {
+      genesis <- buildBlock[F](
+                  Seq.empty,
+                  creator,
+                  bonds,
+                  justifications,
+                  deploys,
+                  tsHash,
+                  shardId,
+                  preStateHash,
+                  seqNum
+                )
+      modifiedBlock <- IndexedBlockDagStorage[F].insertIndexed(genesis, genesis, false)
+      _             <- BlockStore[F].put(genesis.blockHash, modifiedBlock)
+    } yield modifiedBlock
+
+  def createBlock[F[_]: Monad: Time: BlockStore: IndexedBlockDagStorage](
+      parentsHashList: Seq[BlockHash],
+      genesis: BlockMessage,
+      creator: Validator = ByteString.EMPTY,
+      bonds: Seq[Bond] = Seq.empty[Bond],
+      justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
+      deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
+      tsHash: ByteString = ByteString.EMPTY,
+      shardId: String = "rchain",
+      preStateHash: ByteString = ByteString.EMPTY,
+      seqNum: Int = 0
+  ): F[BlockMessage] =
+    for {
+      block <- buildBlock[F](
+                parentsHashList,
+                creator,
+                bonds,
+                justifications,
+                deploys,
+                tsHash,
+                shardId,
+                preStateHash,
+                seqNum
+              )
+      modifiedBlock <- IndexedBlockDagStorage[F].insertIndexed(block, genesis, false)
+      _             <- BlockStore[F].put(block.blockHash, modifiedBlock)
     } yield modifiedBlock
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
@@ -30,9 +30,9 @@ class CasperUtilTest
   "isInMainChain" should "classify appropriately" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        genesis <- createBlock[Task](Seq())
-        b2      <- createBlock[Task](Seq(genesis.blockHash))
-        b3      <- createBlock[Task](Seq(b2.blockHash))
+        genesis <- createGenesis[Task]()
+        b2      <- createBlock[Task](Seq(genesis.blockHash), genesis)
+        b3      <- createBlock[Task](Seq(b2.blockHash), genesis)
 
         dag <- blockDagStorage.getRepresentation
 
@@ -46,10 +46,10 @@ class CasperUtilTest
   "isInMainChain" should "classify diamond DAGs appropriately" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
-        genesis <- createBlock[Task](Seq())
-        b2      <- createBlock[Task](Seq(genesis.blockHash))
-        b3      <- createBlock[Task](Seq(genesis.blockHash))
-        b4      <- createBlock[Task](Seq(b2.blockHash, b3.blockHash))
+        genesis <- createGenesis[Task]()
+        b2      <- createBlock[Task](Seq(genesis.blockHash), genesis)
+        b3      <- createBlock[Task](Seq(genesis.blockHash), genesis)
+        b4      <- createBlock[Task](Seq(b2.blockHash, b3.blockHash), genesis)
 
         dag <- blockDagStorage.getRepresentation
 
@@ -68,14 +68,14 @@ class CasperUtilTest
       val v2 = generateValidator("Validator Two")
 
       for {
-        genesis <- createBlock[Task](Seq(), ByteString.EMPTY)
-        b2      <- createBlock[Task](Seq(genesis.blockHash), v2)
-        b3      <- createBlock[Task](Seq(genesis.blockHash), v1)
-        b4      <- createBlock[Task](Seq(b2.blockHash), v2)
-        b5      <- createBlock[Task](Seq(b2.blockHash), v1)
-        b6      <- createBlock[Task](Seq(b4.blockHash), v2)
-        b7      <- createBlock[Task](Seq(b4.blockHash), v1)
-        b8      <- createBlock[Task](Seq(b7.blockHash), v1)
+        genesis <- createGenesis[Task]()
+        b2      <- createBlock[Task](Seq(genesis.blockHash), genesis, v2)
+        b3      <- createBlock[Task](Seq(genesis.blockHash), genesis, v1)
+        b4      <- createBlock[Task](Seq(b2.blockHash), genesis, v2)
+        b5      <- createBlock[Task](Seq(b2.blockHash), genesis, v1)
+        b6      <- createBlock[Task](Seq(b4.blockHash), genesis, v2)
+        b7      <- createBlock[Task](Seq(b4.blockHash), genesis, v1)
+        b8      <- createBlock[Task](Seq(b7.blockHash), genesis, v1)
 
         dag <- blockDagStorage.getRepresentation
 

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -25,11 +25,11 @@ class DagOperationsTest
 
   "lowest common ancestor" should "be computed properly" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      def createBlockWithMeta(bh: BlockHash*): Task[BlockMetadata] =
-        createBlock[Task](bh.toSeq).map(b => BlockMetadata.fromBlock(b, false))
+      def createBlockWithMeta(genesis: BlockMessage, bh: BlockHash*): Task[BlockMetadata] =
+        createBlock[Task](bh.toSeq, genesis).map(b => BlockMetadata.fromBlock(b, false))
 
-      def createBlockWithMetaAndSeq(seqNum: Int, bh: BlockHash*): Task[BlockMetadata] =
-        createBlock[Task](bh.toSeq, seqNum = seqNum).map(b => BlockMetadata.fromBlock(b, false))
+      def createBlockWithMetaAndSeq(genesis: BlockMessage, seqNum: Int, bh: BlockHash*): Task[BlockMetadata] =
+        createBlock[Task](bh.toSeq, genesis, seqNum = seqNum).map(b => BlockMetadata.fromBlock(b, false))
 
       implicit def blockMetadataToBlockHash(bm: BlockMetadata): BlockHash = bm.blockHash
 
@@ -51,17 +51,17 @@ class DagOperationsTest
        *         genesis
        */
       for {
-        genesis <- createBlock[Task](Seq.empty)
-        b1      <- createBlockWithMeta(genesis.blockHash)
-        b2      <- createBlockWithMetaAndSeq(seqNum = 2, b1)
-        b3      <- createBlockWithMetaAndSeq(seqNum = 2, b1)
-        b4      <- createBlockWithMeta(b3)
-        b5      <- createBlockWithMeta(b3)
-        b6      <- createBlockWithMeta(b2, b4)
-        b7      <- createBlockWithMeta(b4, b5)
-        b8      <- createBlockWithMeta(b6, b7)
-        b9      <- createBlockWithMeta(b8)
-        b10     <- createBlockWithMeta(b8)
+        genesis <- createGenesis[Task]()
+        b1      <- createBlockWithMeta(genesis, genesis.blockHash)
+        b2      <- createBlockWithMetaAndSeq(genesis, seqNum = 2, b1)
+        b3      <- createBlockWithMetaAndSeq(genesis, seqNum = 2, b1)
+        b4      <- createBlockWithMeta(genesis, b3)
+        b5      <- createBlockWithMeta(genesis, b3)
+        b6      <- createBlockWithMeta(genesis, b2, b4)
+        b7      <- createBlockWithMeta(genesis, b4, b5)
+        b8      <- createBlockWithMeta(genesis, b6, b7)
+        b9      <- createBlockWithMeta(genesis, b8)
+        b10     <- createBlockWithMeta(genesis, b8)
 
         dag <- blockDagStorage.getRepresentation
 
@@ -93,14 +93,14 @@ class DagOperationsTest
          */
         implicit def toMetadata(b: BlockMessage) = BlockMetadata.fromBlock(b, false)
         for {
-          genesis <- createBlock[Task](Seq.empty)
-          b1      <- createBlock[Task](Seq(genesis.blockHash))
-          b2      <- createBlock[Task](Seq(genesis.blockHash))
-          b3      <- createBlock[Task](Seq(b1.blockHash))
-          b4      <- createBlock[Task](Seq(b3.blockHash))
-          b5      <- createBlock[Task](Seq(b3.blockHash))
-          b6      <- createBlock[Task](Seq(b4.blockHash, b5.blockHash))
-          b7      <- createBlock[Task](Seq(b2.blockHash, b5.blockHash))
+          genesis <- createGenesis[Task]()
+          b1      <- createBlock[Task](Seq(genesis.blockHash), genesis)
+          b2      <- createBlock[Task](Seq(genesis.blockHash), genesis)
+          b3      <- createBlock[Task](Seq(b1.blockHash), genesis)
+          b4      <- createBlock[Task](Seq(b3.blockHash), genesis)
+          b5      <- createBlock[Task](Seq(b3.blockHash), genesis)
+          b6      <- createBlock[Task](Seq(b4.blockHash, b5.blockHash), genesis)
+          b7      <- createBlock[Task](Seq(b2.blockHash, b5.blockHash), genesis)
 
           dag <- blockDagStorage.getRepresentation
 


### PR DESCRIPTION
## Overview
Adds `genesis` parameter for `BlockDagStorage.insert` method and uses it as a latest message for newly bonded validators.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3150




### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
