### PR TITLE
Revert "Launch slowcooking test on a merge to dev"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,9 +26,6 @@ __pr_build_condiditions: &pr_build_conditions
 
 __buildenv: &buildenv
   image: rchain/buildenv:latest
-  when:
-    instance:
-      - drone.rchain-dev.tk
 
 __sbtcompileenv: &sbtcompileenv
   <<: *buildenv
@@ -141,6 +138,7 @@ pipeline:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
+
   notify:
     <<: *buildenv
     commands:
@@ -155,15 +153,3 @@ pipeline:
       event: [ push, tag ]
       branch: [ master, release*, testing* ]
       status: [ changed, failure ]
-
-  slowcooker:
-    <<: *buildenv
-    commands:
-      - sbt slowcooker:test
-    when:
-      instance:
-        - slow-cooking.rchain-dev.tk
-      event:
-        - push
-      branch:
-        - dev


### PR DESCRIPTION
Double back on the way slow-cooker test is started.  Drone doesn't handle multiple instances well (it confuses build statuses).  Now, the test is triggered by a standalone bot.

This reverts commit ec1214354185f6cb85afb950b6160edc1599e14f.