### PR TITLE
Rchain 3176: use private key file instead of private key in command line arguments for deploy

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -376,13 +376,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         "Set this value to one less than the current block height: you have 50 blocks to get this transaction into the chain."
     )
 
-    val privateKey = opt[PrivateKey](
-      descr = "The deployer's ed25519 private key encoded as Base16.",
+    val privateKey = opt[String](
+      descr = "The text file containing the deployer's ed25519 private key encoded as Base16.",
       required = false
-    )(
-      Base16Converter
-        .flatMap(validateLength(Ed25519.keyLength))
-        .map(PrivateKey)
     )
 
     val location = trailArg[String](required = true)

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -59,7 +59,7 @@ final case class Deploy(
     phloLimit: Long,
     phloPrice: Long,
     validAfterBlock: Int,
-    privateKey: Option[PrivateKey],
+    privateKey: Option[String],
     location: String
 ) extends Command
 final case object Propose                                                  extends Command


### PR DESCRIPTION
## Overview
Fix the security issue of passing the private key as a command line argument to subcommand deploy



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3176



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
