### PR TITLE
Remove ski.id in favor of Predef.identity

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -12,7 +12,6 @@ import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, DagOperations, ProtoUtil}
 import coop.rchain.models.BlockMetadata
 import coop.rchain.shared.Log
-import coop.rchain.catscontrib.ski.id
 import coop.rchain.shared.{Log, StreamT}
 
 /*
@@ -176,7 +175,7 @@ sealed abstract class SafetyOracleInstances {
                        potentialDisagreement =>
                          computeCompatibility(blockDag, candidateBlockHash, potentialDisagreement)
                      }))
-          } yield result).fold(false)(id)
+          } yield result).fold(false)(identity)
 
         def computeAgreementGraphEdges: F[List[(Validator, Validator)]] =
           (for {

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -19,7 +19,6 @@ import java.nio.charset.StandardCharsets
 
 import cats.data.OptionT
 import cats.effect.Sync
-import coop.rchain.catscontrib.ski.id
 import coop.rchain.casper.protocol.Event.EventInstance.{Comm, Consume, Produce}
 
 import scala.collection.{immutable, BitSet}
@@ -124,7 +123,7 @@ object ProtoUtil {
       } else {
         List(creatorJustification.blockHash)
       }
-    } yield creatorJustificationAsList).fold(List.empty[BlockHash])(id)
+    } yield creatorJustificationAsList).fold(List.empty[BlockHash])(identity)
 
   def weightMap(blockMessage: BlockMessage): Map[ByteString, Long] =
     blockMessage.body match {

--- a/node/src/main/scala/coop/rchain/node/api/grpc.scala
+++ b/node/src/main/scala/coop/rchain/node/api/grpc.scala
@@ -35,7 +35,7 @@ class GrpcServer(server: Server) {
       _          <- Task.delay(server.shutdown())
       _          <- Task.delay(server.awaitTermination(1000, TimeUnit.MILLISECONDS))
       terminated <- Task.delay(server.isTerminated)
-    } yield terminated).attempt map (_.fold(kp(false), id))
+    } yield terminated).attempt map (_.fold(kp(false), identity))
 
   private def shutdownImmediately: Task[Unit] =
     Task.delay(server.shutdownNow()).attempt.as(())

--- a/shared/src/main/scala/coop/rchain/catscontrib/ski/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/ski/package.scala
@@ -16,8 +16,4 @@ package object ski {
   def kp[A, B](x: => B): A => B          = _ => x
   def kp2[A, B, C](x: => C): (A, B) => C = (_, _) => x
 
-  /**
-    * Returns a functiont that always returns its argument
-    */
-  def id[A]: A => A = x => x
 }


### PR DESCRIPTION
## Overview
Removes an unnecessary duplication

### JIRA ticket:
N/A

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
