### PR TITLE
Fix RegistrySigGen to derive the unforgable name properly

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
@@ -1,8 +1,8 @@
 package coop.rchain.casper.util.rholang
 
 import com.google.protobuf.ByteString
-
 import coop.rchain.casper.protocol.DeployData
+import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.{Blake2b256, Blake2b512Random}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
@@ -177,7 +177,7 @@ object RegistrySigGen {
         .withDeployer(ByteString.copyFrom(deployer))
         .withTimestamp(timestamp)
 
-    val rnd = Blake2b512Random(DeployData.toByteArray(seed))
+    val rnd = Blake2b512Random(DeployData.toByteArray(ProtoUtil.stripDeployData(seed)))
 
     rnd.next()
   }


### PR DESCRIPTION
Previously, using RegistrySigGen to obtain the proper registry signature
required a multi-step process of:

1. fixing the (timestamp, sk) pair in the deploy to be signed
2. printing out the resulting unforgable name used for registration
3. passing the uname as parameter to RegistrySigGen

Currently, it's enough to pick a (timestamp, sk) pair, the uname
is going to be properly derived based on their values.

## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3204



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.