### PR TITLE
Rhospec uses genesis

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
@@ -18,6 +18,8 @@ class Rev[A](
   private val minimumBond = posParams.minimumBond
   private val maximumBond = posParams.maximumBond
 
+  final val path = "<synthetic in Rev.scala>"
+
   final val code = s"""
     |//requires MakeMint, BasicWallet, WalletCheck, MakePoS
     |new

--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -65,7 +65,7 @@ object HashSetCasperActions {
   def deploy(
       node: HashSetCasperTestNode[Effect],
       deployData: DeployData
-  ): Effect[Either[Throwable, Unit]] =
+  ): Effect[Either[DeployError, Unit]] =
     node.casperEff.deploy(deployData)
 
   def create(node: HashSetCasperTestNode[Effect]): EitherT[Task, CommError, BlockMessage] =

--- a/casper/src/test/resources/RevVaultTest.rho
+++ b/casper/src/test/resources/RevVaultTest.rho
@@ -164,7 +164,6 @@ match (
       } |
 
       contract testInvalidRevAddress(rhoSpec, RevVault, ackCh) = {
-        stdout!("testInvalidRevAddress") |
         new aliceVaultCh, res, resOk in {
           withVaultAndIdentityOf!(alicePubKey, *aliceVaultCh) |
           for (aliceVault, @aliceVaultKey <- aliceVaultCh) {
@@ -188,8 +187,7 @@ match (
                 for (@(true, vault) <- vaultCh; _ <- identityChanged) {
                   @RevVault!("deployerAuthKey", *authKeyCh) |
                   for (@authKey <- authKeyCh) {
-                    ret!(vault, authKey) |
-                    @authKey!("challenge", *stdout)
+                    ret!(vault, authKey)
                   }
                 }
               }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -35,7 +35,7 @@ class BlockQueryResponseAPITest
   val senderString: String =
     "3456789101112131415161718192345678910111213141516171819261718192"
   val sender: ByteString = ProtoUtil.stringToByteString(senderString)
-  val bondsValidator = Bond(sender, 1)
+  val bondsValidator     = Bond(sender, 1)
 
   def genesisBlock(genesisHashString: String, version: Long): BlockMessage = {
     val genesisHash = ProtoUtil.stringToByteString(genesisHashString)
@@ -66,7 +66,7 @@ class BlockQueryResponseAPITest
   val parentsString                    = List(genesisHashString, "0000000001")
   val parentsHashList: List[BlockHash] = parentsString.map(ProtoUtil.stringToByteString)
   val header: Header                   = ProtoUtil.blockHeader(body, parentsHashList, version, timestamp)
-  val shardId: String               = "abcdefgh"
+  val shardId: String                  = "abcdefgh"
   val secondBlock: BlockMessage =
     BlockMessage()
       .withBlockHash(blockHash)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
@@ -8,6 +8,6 @@ import scala.concurrent.duration._
 class AuthKeySpec
     extends RhoSpec(
       CompiledRholangSource("AuthKeyTest.rho"),
-      Seq(StandardDeploys.authKey),
+      Seq.empty,
       10.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -7,6 +7,6 @@ import scala.concurrent.duration._
 class EitherSpec
     extends RhoSpec(
       CompiledRholangSource("EitherTest.rho"),
-      Seq(StandardDeploys.either),
+      Seq.empty,
       10.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
@@ -6,6 +6,6 @@ import scala.concurrent.duration._
 class LockboxSpec
     extends RhoSpec(
       CompiledRholangSource("LockboxTest.rho"),
-      Seq(StandardDeploys.lockbox),
+      Seq.empty,
       10.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -8,9 +8,6 @@ import scala.concurrent.duration._
 class MakeMintSpec
     extends RhoSpec(
       CompiledRholangSource("MakeMintTest.rho"),
-      Seq(
-        StandardDeploys.nonNegativeNumber,
-        StandardDeploys.makeMint
-      ),
+      Seq.empty,
       10.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -7,6 +7,6 @@ import scala.concurrent.duration._
 class NonNegativeNumberSpec
     extends RhoSpec(
       CompiledRholangSource("NonNegativeNumberTest.rho"),
-      Seq(StandardDeploys.nonNegativeNumber),
+      Seq.empty,
       10.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -38,7 +38,7 @@ class RevIssuanceTest extends FlatSpec with Matchers {
   }
 
   "Rev" should "be issued and accessible based on inputs from Ethereum" in {
-    val activeRuntime  = TestUtil.runtime()
+    val activeRuntime  = TestUtil.runtime[Task, Task.Par]().runSyncUnsafe(5.seconds)
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
     val emptyHash      = runtimeManager.emptyStateHash
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -8,12 +8,6 @@ import scala.concurrent.duration._
 class RevVaultSpec
     extends RhoSpec(
       CompiledRholangSource("RevVaultTest.rho"),
-      Seq(
-        StandardDeploys.nonNegativeNumber,
-        StandardDeploys.makeMint,
-        StandardDeploys.authKey,
-        StandardDeploys.either,
-        StandardDeploys.revVault
-      ),
+      Seq.empty,
       20.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -15,5 +15,5 @@ class RevVaultSpec
         StandardDeploys.either,
         StandardDeploys.revVault
       ),
-      10.seconds
+      20.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -1,11 +1,8 @@
 package coop.rchain.casper.genesis.contracts
 
-import java.nio.file.Paths
-
 import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.InterpreterUtil.mkTerm
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
@@ -16,7 +13,6 @@ import coop.rchain.rholang.interpreter.TestRuntime
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.interpreter.accounting.Cost
-import coop.rchain.shared.StoreType.InMem
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -78,14 +74,15 @@ object TestUtil {
   def runTestsWithDeploys(
       tests: CompiledRholangSource,
       otherLibs: Seq[DeployData],
-      runtime: Runtime[Task]
+      additionalSystemProcesses: Seq[SystemProcess.Definition[Task]]
   )(
       implicit scheduler: Scheduler
   ): Unit = {
-    val rand = Blake2b512Random(128)
+    val runtime = TestUtil.runtime(additionalSystemProcesses)
     evalDeploy(StandardDeploys.listOps, runtime)(implicitly)
     evalDeploy(rhoSpecDeploy, runtime)(implicitly)
     otherLibs.foreach(evalDeploy(_, runtime))
+    val rand = Blake2b512Random(128)
     eval(tests.code, runtime)(implicitly, rand.splitShort(1))
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
@@ -10,7 +10,7 @@ class TimeoutResultCollectorSpec extends FlatSpec with AppendedClues with Matche
   it should "testFinished should be false if execution hasn't finished within timeout" in {
     RhoSpec
       .getResults(CompiledRholangSource("TimeoutResultCollectorTest.rho"), Seq.empty)
-      .runSyncUnsafe(Duration.Zero)
+      .runSyncUnsafe(5.seconds)
       .hasFinished should be(false)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -48,6 +48,7 @@ object RhoSpec {
 
   def getResults(testObject: CompiledRholangSource, otherLibs: Seq[DeployData]): Task[TestResult] =
     for {
+      _                   <- logger.info("Starting tests from " + testObject.path)
       testResultCollector <- TestResultCollector[Task]
 
       _ <- Task.delay {

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -54,13 +54,11 @@ object RhoSpec {
       _                   <- logger.info("Starting tests from " + testObject.path)
       testResultCollector <- TestResultCollector[Task]
 
-      _ <- Task.delay {
-            TestUtil.runTestsWithDeploys(
-              testObject,
-              otherLibs,
-              testFrameworkContracts(testResultCollector)
-            )
-          }
+      _ <- TestUtil.runTestsWithDeploys[Task, Task.Par](
+            testObject,
+            otherLibs,
+            testFrameworkContracts(testResultCollector)
+          )
 
       result <- testResultCollector.getResult
     } yield result

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -28,8 +28,13 @@ class DagOperationsTest
       def createBlockWithMeta(genesis: BlockMessage, bh: BlockHash*): Task[BlockMetadata] =
         createBlock[Task](bh.toSeq, genesis).map(b => BlockMetadata.fromBlock(b, false))
 
-      def createBlockWithMetaAndSeq(genesis: BlockMessage, seqNum: Int, bh: BlockHash*): Task[BlockMetadata] =
-        createBlock[Task](bh.toSeq, genesis, seqNum = seqNum).map(b => BlockMetadata.fromBlock(b, false))
+      def createBlockWithMetaAndSeq(
+          genesis: BlockMessage,
+          seqNum: Int,
+          bh: BlockHash*
+      ): Task[BlockMetadata] =
+        createBlock[Task](bh.toSeq, genesis, seqNum = seqNum)
+          .map(b => BlockMetadata.fromBlock(b, false))
 
       implicit def blockMetadataToBlockHash(bm: BlockMetadata): BlockHash = bm.blockHash
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -55,7 +55,7 @@ class Interactive private (runtime: Runtime[Task])(implicit scheduler: Scheduler
   def tuplespace: String = StoragePrinter.prettyPrint(runtime.space.store)
 
   def eval(code: String): Unit = {
-    TestUtil.eval(code, runtime)
+    TestUtil.eval(code, runtime).runSyncUnsafe(Duration.Inf)
     val errors = runtime.errorLog.readAndClearErrorVector().unsafeRunSync
     if (errors.nonEmpty) {
       println("Errors during execution:")

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -18,6 +18,8 @@ import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
 import coop.rchain.catscontrib.TaskContrib._
 import scala.collection.mutable
 
+import scala.concurrent.duration._
+
 /**
   * This is a really handy class for working interactively with
   * Rholang at the Scala console.
@@ -95,6 +97,6 @@ object Interactive {
   def apply(): Interactive = {
     implicit val scheduler = Scheduler.io("rhoang-interpreter")
     implicit val log       = new Log.NOPLog[Task]
-    new Interactive(TestUtil.runtime())
+    new Interactive(TestUtil.runtime[Task, Task.Par]().runSyncUnsafe(5.seconds))
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -6,6 +6,7 @@ import monix.eval.Coeval
 import scala.io.Source
 
 trait CompiledRholangSource {
+  val path: String
   val term: Par
   val code: String
 }
@@ -13,6 +14,7 @@ trait CompiledRholangSource {
 object CompiledRholangSource {
 
   def apply(classpath: String): CompiledRholangSource = new CompiledRholangSource {
+    override val path: String = classpath
     override val code: String = Source.fromResource(classpath).mkString
     override val term: Par    = ParBuilder[Coeval].buildNormalizedTerm(code).value()
   }


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Make all RhoSpec run with all genesis contracts

This will also make less likely the mistake of registering a contract
in StandardDeploys but not putting it in Genesis - which I've done twice
already.

This is also a first step for customizing the genesis block - including
initial ~~wallets~~ vaults - for purposes of particular tests.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
