### PR TITLE
Add Ref based Cell implementation

### DIFF
--- a/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
@@ -13,110 +13,179 @@ class CellSpec extends FunSpec with Matchers with BeforeAndAfterEach {
 
   implicit val io: SchedulerService = Scheduler.io("test")
 
-  describe("Cell flatModify") {
+  val increment: Int => Task[Int] = (i: Int) => Task.delay(i + 1)
 
-    val increment: Int => Task[Int] = (i: Int) => Task.delay(i + 1)
+  def justIncrement(cell: Cell[Task, Int]): Task[Unit] =
+    cell.flatModify(increment)
 
-    def justIncrement(cell: Cell[Task, Int]): Task[Unit] =
-      cell.flatModify(increment)
+  def incrementAndStore(
+      name: String,
+      cell: Cell[Task, Int],
+      external: TrieMap[String, Int]
+  ): Task[Unit] =
+    cell.flatModify(
+      i =>
+        for {
+          newI <- increment(i)
+          _    <- Task.delay(external += (name -> newI))
+        } yield newI
+    )
 
-    def incrementAndStore(
-        name: String,
-        cell: Cell[Task, Int],
-        external: TrieMap[String, Int]
-    ): Task[Unit] =
-      cell.flatModify(
-        i =>
-          for {
-            newI <- increment(i)
-            _    <- Task.delay(external += (name -> newI))
-          } yield newI
-      )
+  describe("MVar Cell") {
 
-    it("should allow thread-safe concurrent state modification") {
-      run(
-        cell =>
-          for {
-            f1  <- justIncrement(cell).start
-            f2  <- justIncrement(cell).start
-            f3  <- justIncrement(cell).start
-            _   <- f1.join
-            _   <- f2.join
-            _   <- f3.join
-            res <- cell.read
-            _   <- Task.delay(res shouldBe 3)
-          } yield ()
-      )
+    def run(test: Cell[Task, Int] => Task[Unit]): Unit =
+      (for {
+        cell <- Cell.mvarCell[Task, Int](0)
+        _    <- test(cell)
+      } yield ()).unsafeRunSync
+
+    describe("flatModify") {
+      it("should allow thread-safe concurrent state modification") {
+        run(
+          cell =>
+            for {
+              f1  <- justIncrement(cell).start
+              f2  <- justIncrement(cell).start
+              f3  <- justIncrement(cell).start
+              _   <- f1.join
+              _   <- f2.join
+              _   <- f3.join
+              res <- cell.read
+              _   <- Task.delay(res shouldBe 3)
+            } yield ()
+        )
+      }
+
+      /**
+        * While modifing the state, other effects can take place. In this example
+        * external datasource (TrieMap) is being modified
+        */
+      it("should allow effectful state modification") {
+
+        val external: TrieMap[String, Int] = TrieMap.empty[String, Int]
+
+        run(
+          cell =>
+            for {
+              f1  <- incrementAndStore("worker1", cell, external).start
+              f2  <- incrementAndStore("worker2", cell, external).start
+              f3  <- incrementAndStore("worker3", cell, external).start
+              _   <- f1.join
+              _   <- f2.join
+              _   <- f3.join
+              res <- cell.read
+              _   <- Task.delay(res shouldBe 3)
+              _   <- Task.delay(external.keys should contain allOf ("worker1", "worker2", "worker3"))
+              _   <- Task.delay(external.values should contain allOf (1, 2, 3))
+            } yield ()
+        )
+      }
+
+      it("should restore state after a failed modify") {
+        def failWithError(cell: Cell[Task, Int]): Task[Unit] =
+          cell.flatModify(_ => Task.raiseError(new RuntimeException))
+
+        run(
+          cell =>
+            for {
+              _   <- justIncrement(cell)
+              _   <- failWithError(cell).attempt
+              _   <- justIncrement(cell)
+              res <- cell.read
+              _   <- Task.delay(res shouldBe 2)
+            } yield ()
+        )
+      }
+
     }
 
-    /**
-      * While modifing the state, other effects can take place. In this example
-      * external datasource (TrieMap) is being modified
-      */
-    it("should allow effectful state modification") {
+    describe("modify") {
+      def justIncrement(cell: Cell[Task, Int]): Task[Unit] =
+        cell.modify(_ + 1)
 
-      val external: TrieMap[String, Int] = TrieMap.empty[String, Int]
-
-      run(
-        cell =>
-          for {
-            f1  <- incrementAndStore("worker1", cell, external).start
-            f2  <- incrementAndStore("worker2", cell, external).start
-            f3  <- incrementAndStore("worker3", cell, external).start
-            _   <- f1.join
-            _   <- f2.join
-            _   <- f3.join
-            res <- cell.read
-            _   <- Task.delay(res shouldBe 3)
-            _   <- Task.delay(external.keys should contain allOf ("worker1", "worker2", "worker3"))
-            _   <- Task.delay(external.values should contain allOf (1, 2, 3))
-          } yield ()
-      )
-    }
-
-    it("should restore state after a failed modify") {
-      def failWithError(cell: Cell[Task, Int]): Task[Unit] =
-        cell.flatModify(_ => Task.raiseError(new RuntimeException))
-
-      run(
-        cell =>
-          for {
-            _   <- justIncrement(cell)
-            _   <- failWithError(cell).attempt
-            _   <- justIncrement(cell)
-            res <- cell.read
-            _   <- Task.delay(res shouldBe 2)
-          } yield ()
-      )
+      it("should allow thread-safe concurrent state modification") {
+        run(
+          cell =>
+            for {
+              f1  <- justIncrement(cell).start
+              f2  <- justIncrement(cell).start
+              f3  <- justIncrement(cell).start
+              _   <- f1.join
+              _   <- f2.join
+              _   <- f3.join
+              res <- cell.read
+              _   <- Task.delay(res shouldBe 3)
+            } yield ()
+        )
+      }
     }
 
   }
+  describe("Ref Cell") {
 
-  describe("Cell modify") {
-    def justIncrement(cell: Cell[Task, Int]): Task[Unit] =
-      cell.modify(_ + 1)
+    def run(test: Cell[Task, Int] => Task[Unit]): Unit =
+      (for {
+        cell <- Cell.refCell[Task, Int](0)
+        _    <- test(cell)
+      } yield ()).unsafeRunSync
 
-    it("should allow thread-safe concurrent state modification") {
-      run(
-        cell =>
-          for {
-            f1  <- justIncrement(cell).start
-            f2  <- justIncrement(cell).start
-            f3  <- justIncrement(cell).start
-            _   <- f1.join
-            _   <- f2.join
-            _   <- f3.join
-            res <- cell.read
-            _   <- Task.delay(res shouldBe 3)
-          } yield ()
-      )
+    describe("flatModify") {
+      it("should allow thread-safe concurrent state modification") {
+        run(
+          cell =>
+            for {
+              f1  <- justIncrement(cell).start
+              f2  <- justIncrement(cell).start
+              f3  <- justIncrement(cell).start
+              _   <- f1.join
+              _   <- f2.join
+              _   <- f3.join
+              res <- cell.read
+              _   <- Task.delay(res should (be >= 1 and be <= 3))
+            } yield ()
+        )
+      }
+
+      /**
+        * While modifing the state, other effects can take place. In this example
+        * external datasource (TrieMap) is being modified
+        */
+      it("should allow effectful state modification") {
+
+        val external: TrieMap[String, Int] = TrieMap.empty[String, Int]
+
+        run(
+          cell =>
+            for {
+              f1  <- incrementAndStore("worker1", cell, external).start
+              f2  <- incrementAndStore("worker2", cell, external).start
+              f3  <- incrementAndStore("worker3", cell, external).start
+              _   <- f1.join
+              _   <- f2.join
+              _   <- f3.join
+              res <- cell.read
+              _   <- Task.delay(res should (be >= 1 and be <= 3))
+              _   <- Task.delay(external.keys should contain allOf ("worker1", "worker2", "worker3"))
+            } yield ()
+        )
+      }
+
+      it("should restore state after a failed modify") {
+        def failWithError(cell: Cell[Task, Int]): Task[Unit] =
+          cell.flatModify(_ => Task.raiseError(new RuntimeException))
+
+        run(
+          cell =>
+            for {
+              _   <- justIncrement(cell)
+              _   <- failWithError(cell).attempt
+              _   <- justIncrement(cell)
+              res <- cell.read
+              _   <- Task.delay(res shouldBe 2)
+            } yield ()
+        )
+      }
+
     }
   }
-
-  private def run(test: Cell[Task, Int] => Task[Unit]): Unit =
-    (for {
-      cell <- Cell.mvarCell[Task, Int](0)
-      _    <- test(cell)
-    } yield ()).unsafeRunSync
-
 }


### PR DESCRIPTION
## Overview
Adds a Ref based Cell implementation requiring synchronization from the outside. Needed for it's `flatModify` operation which allows side-effects in the function passed as it's argument

### JIRA ticket:
Prerequisite for https://rchain.atlassian.net/browse/RCHAIN-3141


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
