### PR TITLE
Add log message to see if init of CPH has executed

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -444,7 +444,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       private val cphI: Ref[F, CasperPacketHandlerInternal[F]]
   ) extends CasperPacketHandler[F] {
 
-    override def init: F[Unit] = cphI.get >>= (_.init)
+    override def init: F[Unit] =
+      Log[F].info("Executing init of CasperPacketHandlerImpl") >> cphI.get >>= (_.init)
 
     override def handle(peer: PeerNode): PartialFunction[Packet, F[Unit]] =
       Function


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

To become 100% sure whether the issue is that we never reach CPH.init when we fail to receive the approved block.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3218



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
