### PR TITLE
Do not enforce immutable.Seq

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
@@ -15,9 +15,6 @@ object EventConverter {
   private implicit def byteStringToBlake2b256Hash(hash: ByteString): Blake2b256Hash =
     Blake2b256Hash.fromByteArray(hash.toByteArray)
 
-  private implicit def byteStringsToBlake2b256Hashes(hashes: Seq[ByteString]): Seq[Blake2b256Hash] =
-    hashes.map(byteStringToBlake2b256Hash)
-
   private implicit def blake2b256HashToByteString(hash: Blake2b256Hash): ByteString =
     ByteString.copyFrom(hash.bytes.toArray)
 

--- a/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
@@ -10,7 +10,6 @@ import coop.rchain.rspace.trace.{
   Event => RspaceEvent,
   Produce => RspaceProduce
 }
-import scala.collection.immutable.Seq
 
 object EventConverter {
   private implicit def byteStringToBlake2b256Hash(hash: ByteString): Blake2b256Hash =

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
@@ -3,7 +3,11 @@ package coop.rchain.casper
 import cats.implicits._
 import coop.rchain.casper.ConstructDeploy.basicProcessedDeploy
 import coop.rchain.casper.EstimatorHelper.conflicts
-import coop.rchain.casper.helper.BlockGenerator.{computeBlockCheckpoint, injectPostStateHash, updateChainWithBlockStateUpdate}
+import coop.rchain.casper.helper.BlockGenerator.{
+  computeBlockCheckpoint,
+  injectPostStateHash,
+  updateChainWithBlockStateUpdate
+}
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -75,13 +75,16 @@ object RhoSpec {
     val ethAddress      = "0x041e1eec23d118f0c4ffc814d4f415ac3ef3dcff"
     val initBalance     = 37
     val wallet          = PreWallet(ethAddress, initBalance)
-    Genesis.createGenesisBlock(runtimeManager, Genesis(
-      "RhoSpec-shard",
-      1,
-      wallet :: Nil,
-      ProofOfStake(0, Long.MaxValue, bonds.map(Validator.tupled).toSeq),
-      false
-    ))
+    Genesis.createGenesisBlock(
+      runtimeManager,
+      Genesis(
+        "RhoSpec-shard",
+        1,
+        wallet :: Nil,
+        ProofOfStake(0, Long.MaxValue, bonds.map(Validator.tupled).toSeq),
+        false
+      )
+    )
   }
 }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -18,7 +18,6 @@ import coop.rchain.rspace.util._
 import org.lightningj.util.ZBase32
 
 import scala.annotation.tailrec
-import scala.collection.immutable.Seq
 import scala.collection.{Seq => RootSeq}
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -27,7 +27,6 @@ import coop.rchain.rspace.pure.PureRSpace
 import coop.rchain.shared.{Log, StoreType}
 import coop.rchain.shared.StoreType._
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 
 class Runtime[F[_]: Sync] private (
@@ -184,7 +183,7 @@ object Runtime {
       space: RhoISpace[F],
       replaySpace: RhoISpace[F],
       processes: List[(Name, Arity, Remainder, BodyRef)]
-  ): F[List[Option[(TaggedContinuation, immutable.Seq[ListParWithRandom])]]] =
+  ): F[List[Option[(TaggedContinuation, Seq[ListParWithRandom])]]] =
     processes.flatMap {
       case (name, arity, remainder, ref) =>
         val channels = List(name)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -11,8 +11,6 @@ import coop.rchain.rholang.interpreter.storage.implicits.matchListPar
 import coop.rchain.rspace.util._
 import coop.rchain.rspace.{Blake2b256Hash, Checkpoint, ContResult, Result, Match => StorageMatch}
 
-import scala.collection.immutable.Seq
-
 object ChargingRSpace {
   def storageCostConsume(
       channels: Seq[Par],

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -24,7 +24,6 @@ import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rspace.internal
 import coop.rchain.shared.Log
 
-import scala.collection.immutable
 import scala.concurrent.duration._
 
 class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEqualsSupport {
@@ -115,7 +114,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     def testImplementation(pureRSpace: RhoISpace[Task]): Task[
       (
           Either[Throwable, Unit],
-          Map[immutable.Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]]
+          Map[Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]]
       )
     ] = {
 
@@ -167,7 +166,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     )
 
     def stored(
-        map: Map[immutable.Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]],
+        map: Map[Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]],
         p: Par,
         rand: Blake2b512Random
     ): Boolean =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -76,7 +76,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   def checkData(
       result: Map[
-        scala.collection.immutable.Seq[Par],
+        Seq[Par],
         Row[BindPattern, ListParWithRandom, TaggedContinuation]
       ]
   )(channel: Par, data: Seq[Par], rand: Blake2b512Random): Assertion =
@@ -101,7 +101,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
 
   def checkContinuation(
       result: Map[
-        scala.collection.immutable.Seq[Par],
+        Seq[Par],
         Row[BindPattern, ListParWithRandom, TaggedContinuation]
       ]
   )(channels: List[Par], bindPatterns: List[BindPattern], body: ParWithRandom): Assertion =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -175,7 +175,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
 
   def checkResult(
       result: Map[
-        scala.collection.immutable.Seq[Par],
+        Seq[Par],
         Row[BindPattern, ListParWithRandom, TaggedContinuation]
       ],
       s: String,

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ExamplesSerializerBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ExamplesSerializerBench.scala
@@ -82,8 +82,6 @@ abstract class ExamplesSerializerBenchState {
     phone = "555-6969"
   )
 
-  import collection.immutable.Seq
-
   val channel      = Channel("colleagues")
   val channels     = List(channel, Channel("friends"))
   val datum        = Datum.create(channel, data, false)

--- a/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Blake2b256Hash.scala
@@ -1,14 +1,11 @@
 package coop.rchain.rspace
 
-import scala.collection.immutable.Seq
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.rspace.internal.codecSeq
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
-
-import scala.collection.immutable.Seq
 
 /**
   * Represents a Blake2b256 Hash

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -3,8 +3,6 @@ package coop.rchain.rspace
 import cats.Id
 import coop.rchain.rspace.internal._
 
-import scala.collection.immutable.Seq
-
 final case class Result[R](value: R, persistent: Boolean)
 final case class ContResult[C, P, R](
     value: R,

--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -4,7 +4,6 @@ import coop.rchain.catscontrib.ski._
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import monix.execution.atomic.AtomicAny
-import scala.collection.immutable.Seq
 
 /** The interface for the underlying store
   *

--- a/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/InMemoryStore.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace
 
 import cats.effect.Sync
 
-import scala.collection.immutable.Seq
 import cats.implicits._
 import coop.rchain.catscontrib.ski.kp
 import coop.rchain.rspace.history.{Branch, ITrieStore}

--- a/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LMDBStore.scala
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import cats.effect.Sync
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.canonicalize

--- a/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/LockFreeInMemoryStore.scala
@@ -5,7 +5,6 @@ import cats.implicits._
 import coop.rchain.catscontrib.ski.kp
 
 import scala.collection.concurrent.TrieMap
-import scala.collection.immutable.Seq
 import coop.rchain.rspace.history.{Branch, ITrieStore}
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.util.canonicalize

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -16,7 +16,6 @@ import coop.rchain.shared.SyncVarOps._
 import org.lmdbjava.Txn
 import scodec.Codec
 
-import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -13,7 +13,6 @@ import coop.rchain.rspace.trace.Consume
 import coop.rchain.shared.Log
 import coop.rchain.shared.SyncVarOps._
 
-import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 import scala.util.Random
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -14,7 +14,6 @@ import coop.rchain.shared.Log
 import scodec.Codec
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
 
 class ReplayRSpace[F[_], C, P, A, R, K](store: IStore[F, C, P, A, K], branch: Branch)(

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -10,7 +10,6 @@ import coop.rchain.rspace.trace.Log
 import coop.rchain.shared.SyncVarOps
 
 import scala.annotation.tailrec
-import scala.collection.immutable.Seq
 import scala.concurrent.SyncVar
 
 /** The interface for RSpace

--- a/rspace/src/main/scala/coop/rchain/rspace/StableHashProvider.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/StableHashProvider.scala
@@ -1,7 +1,6 @@
 package coop.rchain.rspace
 
 import internal._
-import scala.collection.immutable.Seq
 import cats.implicits._
 import scodec.bits.ByteVector
 import scodec.{Attempt, Codec, Encoder}

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/MultiLock.scala
@@ -3,7 +3,6 @@ package coop.rchain.rspace.concurrent
 import cats.implicits._
 import cats.effect.Concurrent
 import cats.effect.concurrent.Semaphore
-import scala.collection.immutable.Seq
 
 import scala.collection.concurrent.TrieMap
 

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace.concurrent
 
 import cats.implicits._
 import cats.effect.Concurrent
-import scala.collection.immutable.Seq
 
 trait TwoStepLock[F[_], K] {
   def acquire[R, S, W](keysA: Seq[K])(phaseTwo: () => F[Seq[K]])(thunk: => F[W])(

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -16,8 +16,6 @@ import coop.rchain.rspace.util._
 import scala.concurrent.ExecutionContext
 import scodec.bits.ByteVector
 
-import scala.collection.immutable.Seq
-import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -69,7 +67,7 @@ object AddressBookExample {
   class EntriesCaptor extends ((Seq[Entry]) => Unit) with Serializable {
 
     @transient
-    private final lazy val res: ListBuffer[Seq[Entry]] = mutable.ListBuffer.empty[Seq[Entry]]
+    private final lazy val res: ListBuffer[Seq[Entry]] = ListBuffer.empty[Seq[Entry]]
 
     final def results: Seq[Seq[Entry]] = res.toList
 

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/StringExamples.scala
@@ -9,7 +9,6 @@ import scodec.bits.ByteVector
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import scala.collection.immutable.Seq
 
 object StringExamples {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -14,7 +14,6 @@ import scodec.Codec
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 
 package object history {
 
@@ -116,9 +115,9 @@ package object history {
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   // TODO stop throwing exceptions
-  def lookup[T, K, V](store: ITrieStore[T, K, V], branch: Branch, keys: immutable.Seq[K])(
+  def lookup[T, K, V](store: ITrieStore[T, K, V], branch: Branch, keys: Seq[K])(
       implicit codecK: Codec[K]
-  ): Option[immutable.Seq[V]] =
+  ): Option[Seq[V]] =
     if (keys.isEmpty) {
       throw new IllegalArgumentException("keys can't be empty")
     } else {

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -7,9 +7,6 @@ import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs.{bool, bytes, int32, int64, variableSizeBytesLong}
 
-import scala.collection.immutable.Seq
-import scala.collection.mutable
-
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 object internal {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/pure/PureRSpace.scala
@@ -5,8 +5,6 @@ import cats.effect.Sync
 import coop.rchain.rspace.ISpace.IdISpace
 import coop.rchain.rspace._
 
-import scala.collection.immutable.Seq
-
 trait PureRSpace[F[_], C, P, A, R, K] {
   def consume(
       channels: Seq[C],

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -6,7 +6,6 @@ import coop.rchain.rspace.util._
 import cats.implicits._
 import coop.rchain.rspace.{Blake2b256Hash, Serialize}
 import coop.rchain.rspace.internal.codecSeq
-import scala.collection.immutable.Seq
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
@@ -2,11 +2,9 @@ package coop.rchain.rspace
 
 import coop.rchain.rspace.internal.MultisetMultiMap
 
-import scala.collection.immutable
-
 package object trace {
 
-  type Log = immutable.Seq[Event]
+  type Log = Seq[Event]
 
   type ReplayData = MultisetMultiMap[IOEvent, COMM]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -4,8 +4,6 @@ import cats.Functor
 import coop.rchain.rspace.internal.GNAT
 import scodec.bits.ByteVector
 
-import scala.collection.immutable.Seq
-
 package object util {
 
   implicit def unpackSeq[C, P, K, R](

--- a/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HistoryActionsTests.scala
@@ -17,8 +17,6 @@ import org.scalacheck.Prop
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
 import scodec.Codec
 
-import scala.collection.immutable.Seq
-
 //noinspection ZeroIndexToHead
 trait HistoryActionsTests[F[_]]
     extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -20,7 +20,6 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
 
-import scala.collection.immutable
 import scala.util.{Random, Right}
 
 object SchedulerPools {
@@ -67,7 +66,7 @@ trait ReplayRSpaceTests
       persist: Boolean
   )(
       implicit matcher: Match[Task, P, A, R]
-  ): Task[List[Option[(ContResult[C, P, K], immutable.Seq[Result[R]])]]] =
+  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
     (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
       logger.debug("Started produce {}", i)
       space.produce(channelCreator(i), datumCreator(i), persist).map { r =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -19,7 +19,6 @@ import org.scalatest._
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
 import scodec.Codec
 
-import scala.collection.immutable.Seq
 import coop.rchain.rspace.test.ArbitraryInstances._
 import monix.eval.Coeval
 import org.scalatest.enablers.Definition

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -18,7 +18,6 @@ import coop.rchain.shared.PathOps._
 import coop.rchain.shared.Log
 import org.scalatest._
 
-import scala.collection.immutable.{Seq, Set}
 import scala.concurrent.ExecutionContext
 import scodec.Codec
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/seq.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/seq.scala
@@ -2,8 +2,6 @@ package coop.rchain.catscontrib
 
 import cats.{Always, Applicative, Eval, Traverse}
 
-import scala.collection.immutable.Seq
-
 object seq extends SeqInstances
 
 trait SeqInstances {

--- a/shared/src/main/scala/coop/rchain/scodec/codecs/SeqCodec.scala
+++ b/shared/src/main/scala/coop/rchain/scodec/codecs/SeqCodec.scala
@@ -3,8 +3,6 @@ package coop.rchain.scodec.codecs
 import scodec.bits.BitVector
 import scodec.{Attempt, Codec, DecodeResult, Decoder, Encoder, SizeBound}
 
-import scala.collection.immutable.Seq
-
 final class SeqCodec[A](codec: Codec[A], limit: Option[Int] = None) extends Codec[Seq[A]] {
 
   def sizeBound: SizeBound = limit match {
@@ -12,7 +10,8 @@ final class SeqCodec[A](codec: Codec[A], limit: Option[Int] = None) extends Code
     case Some(lim) => codec.sizeBound * lim.toLong
   }
 
-  def encode(list: Seq[A]): Attempt[BitVector] = Encoder.encodeSeq(codec)(list)
+  def encode(list: Seq[A]): Attempt[BitVector] =
+    Encoder.encodeSeq(codec)(scala.collection.immutable.Seq(list: _*))
 
   def decode(buffer: BitVector): Attempt[DecodeResult[Seq[A]]] =
     Decoder.decodeCollect[Seq, A](codec, limit)(buffer)

--- a/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
+++ b/shared/src/main/scala/coop/rchain/scodec/codecs/package.scala
@@ -3,7 +3,6 @@ package coop.rchain.scodec
 import scodec.{Attempt, Codec, Err}
 
 import cats._, cats.data._, cats.implicits._
-import scala.collection.immutable.Seq
 
 package object codecs {
 

--- a/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/SeqOps.scala
@@ -1,7 +1,5 @@
 package coop.rchain.shared
 
-import scala.collection.immutable.Seq
-
 object SeqOps {
 
   /** Drops the 'i'th element of a list.


### PR DESCRIPTION
## Overview
Enforcing `immutable.Seq` in order to make `scodec` happy requires manually adding the import everywhere in rspace. The value of this enforcement is disputable, because the containers in `scala.collection` are by default immutable and offer no means to mutate the internal state. This PR is a first step to straighten this out 

### JIRA ticket:
Can be treated as prerequisite for https://rchain.atlassian.net/browse/RCHAIN-3142, because the new `HotStore` does not enforce `immutable.Seq`


### Notes
In https://github.com/scala/scala/releases/v2.13.0-M4 `scala.Seq` was changed to be an alias for `immutable.Seq`



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
