### PR TITLE
Only release blockApiLock if we succeeded in grabbing it

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -75,8 +75,11 @@ object BlockAPI {
             } yield result
           case false =>
             "Error: There is another propose in progress.".asLeft[DeployServiceResponse].pure[F]
-        } { _ =>
-          blockApiLock.release
+        } {
+          case true =>
+            blockApiLock.release
+          case false =>
+            ().pure[F]
         }
       },
       default = Log[F]


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Thanks to help from @itegulov . I know this needs a unit test but I can't think of an easy way to do it and this is a real blocker on testnet right now: the unit test ticket is https://rchain.atlassian.net/browse/RCHAIN-3235 

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3115

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
