### PR TITLE
RCHAIN-2925 machine verifiable dag

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -253,6 +253,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
           TopoSortLengthIsTooBig(sortOffset - startBlockNumber + topoSortVector.length)
         )
       }
+    // TODO should startBlockNumber have topoSortVector.length - 1 (off by one error)?
     def topoSortTail(tailLength: Int): F[Vector[Vector[BlockHash]]] = {
       val startBlockNumber = Math.max(0L, sortOffset - (tailLength - topoSortVector.length))
       topoSort(startBlockNumber)

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -248,11 +248,9 @@ object BlockAPI {
 
     def casperResponse(implicit casper: MultiParentCasper[F]): Effect[F, A] =
       for {
-        dag         <- MultiParentCasper[F].blockDag
-        maxHeight   <- dag.topoSort(0L).map(_.length - 1)
-        startHeight = math.max(0, maxHeight - depth)
-        topoSort    <- dag.topoSortTail(depth)
-        result      <- doIt(casper, topoSort)
+        dag      <- MultiParentCasper[F].blockDag
+        topoSort <- dag.topoSortTail(depth)
+        result   <- doIt(casper, topoSort)
       } yield result
 
     MultiParentCasperRef.withCasper[F, ApiErr[A]](

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -248,11 +248,10 @@ object BlockAPI {
 
     def casperResponse(implicit casper: MultiParentCasper[F]): Effect[F, A] =
       for {
-        dag       <- MultiParentCasper[F].blockDag
-        maxHeight <- dag.topoSort(0L).map(_.length - 1)
-        depth     = maybeDepth.getOrElse(maxHeight)
-        topoSort  <- dag.topoSortTail(depth)
-        result    <- doIt(casper, topoSort)
+        dag      <- MultiParentCasper[F].blockDag
+        depth    <- maybeDepth.fold(dag.topoSort(0L).map(_.length - 1))(_.pure[F])
+        topoSort <- dag.topoSortTail(depth)
+        result   <- doIt(casper, topoSort)
       } yield result
 
     MultiParentCasperRef.withCasper[F, ApiErr[A]](

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -270,8 +270,8 @@ object BlockAPI {
     toposortDag[F, VisualizeBlocksResponse](depth) {
       case (casper, topoSort) =>
         for {
-          lastFinalizedBlock <- casper.lastFinalizedBlock
-          graph              <- visualizer(topoSort, PrettyPrinter.buildString(lastFinalizedBlock.blockHash))
+          lfb   <- casper.lastFinalizedBlock
+          graph <- visualizer(topoSort, PrettyPrinter.buildString(lfb.blockHash))
         } yield VisualizeBlocksResponse(stringify(graph)).asRight[Error]
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
@@ -39,7 +39,5 @@ object MachineVerifiableDag {
             }
           } yield entries ++ acc
       }
-      .map(_.reverse)
   }
-
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
@@ -1,0 +1,45 @@
+package coop.rchain.casper.api
+
+import coop.rchain.casper._
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.crypto.codec.Base16
+import cats._, cats.data._, cats.implicits._
+
+final case class VerifiableEdge(from: String, to: String)
+
+object VerifiableEdge {
+
+  implicit def showBlockHash: Show[BlockHash] = new Show[BlockHash] {
+    def show(blockHash: BlockHash): String =
+      Base16.encode(blockHash.toByteArray)
+  }
+
+  implicit def showVerifiableEdge: Show[VerifiableEdge] = new Show[VerifiableEdge] {
+    def show(ve: VerifiableEdge): String = s"${ve.from} - ${ve.to}"
+  }
+}
+
+object MachineVerifiableDag {
+  def apply[F[_]: Monad](
+      toposort: TopoSort,
+      fetchParents: BlockHash => F[List[BlockHash]]
+  ): F[List[VerifiableEdge]] = {
+    import VerifiableEdge._
+
+    toposort
+      .foldM(List.empty[VerifiableEdge]) {
+        case (acc, blockHashes) =>
+          for {
+            parents          <- blockHashes.toList.traverse(fetchParents)
+            blocks           = blockHashes.toList.map(_.show)
+            blocksAndParents = blocks.zip(parents.map(_.map(p => p.show)))
+            entries = blocksAndParents.flatMap {
+              case (b, bp) => bp.map(VerifiableEdge(b, _))
+            }
+          } yield entries ++ acc
+      }
+      .map(_.reverse)
+  }
+
+}

--- a/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
@@ -30,14 +30,17 @@ object MachineVerifiableDag {
     toposort
       .foldM(List.empty[VerifiableEdge]) {
         case (acc, blockHashes) =>
-          for {
-            parents          <- blockHashes.toList.traverse(fetchParents)
-            blocks           = blockHashes.toList.map(_.show)
-            blocksAndParents = blocks.zip(parents.map(_.map(p => p.show)))
-            entries = blocksAndParents.flatMap {
-              case (b, bp) => bp.map(VerifiableEdge(b, _))
+          blockHashes.toList
+            .traverse { blockHash =>
+              fetchParents(blockHash).map(parents => (blockHash.show, parents.map(p => p.show)))
             }
-          } yield entries ++ acc
+            .map { blocksAndParents =>
+              blocksAndParents.flatMap {
+                case (b, bp) => bp.map(VerifiableEdge(b, _))
+              }
+            }
+            .map(_ ++ acc)
+
       }
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
@@ -16,7 +16,7 @@ object VerifiableEdge {
   }
 
   implicit def showVerifiableEdge: Show[VerifiableEdge] = new Show[VerifiableEdge] {
-    def show(ve: VerifiableEdge): String = s"${ve.from} - ${ve.to}"
+    def show(ve: VerifiableEdge): String = s"${ve.from} ${ve.to}"
   }
 }
 

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -6,6 +6,7 @@ import coop.rchain.metrics.Metrics
 package object casper {
 
   type BlockHash = ByteString
+  type TopoSort  = Vector[Vector[BlockHash]]
 
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CasperPacketHandler.scala
@@ -597,7 +597,8 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       override def init: T[F, Unit] = C.init.liftM[T]
 
       override def handle(peer: PeerNode): PartialFunction[Packet, T[F, Unit]] = {
-        case (p: Packet) => C.handle(peer)(p).liftM[T]
+        case (p: Packet) =>
+          C.handle(peer)(p).liftM[T]
       }
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -47,6 +47,9 @@ object DeployRuntime {
   ): F[Unit] =
     gracefulExit(DeployService[F].visualizeDag(VisualizeDagQuery(depth, showJustificationLines)))
 
+  def machineVerifiableDag[F[_]: Monad: Sync: DeployService]: F[Unit] =
+    gracefulExit(DeployService[F].machineVerifiableDag(MachineVerifyQuery()))
+
   def listenForDataAtName[F[_]: Functor: Sync: DeployService: Time](
       name: Id[Name]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -18,6 +18,7 @@ trait DeployService[F[_]] {
   def showBlock(q: BlockQuery): F[Either[Seq[String], String]]
   def showBlocks(q: BlocksQuery): F[Either[Seq[String], String]]
   def visualizeDag(q: VisualizeDagQuery): F[Either[Seq[String], String]]
+  def machineVerifiableDag(q: MachineVerifyQuery): F[Either[Seq[String], String]]
   def listenForDataAtName(request: DataAtNameQuery): F[Either[Seq[String], Seq[DataWithBlockInfo]]]
   def listenForContinuationAtName(
       request: ContinuationAtNameQuery
@@ -52,6 +53,9 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
 
   def visualizeDag(q: VisualizeDagQuery): Task[Either[Seq[String], String]] =
     stub.visualizeDag(q).map(_.toEither[VisualizeBlocksResponse].map(_.content))
+
+  def machineVerifiableDag(q: MachineVerifyQuery): Task[Either[Seq[String], String]] =
+    stub.machineVerifiableDag(q).map(_.toEither[MachineVerifyResponse].map(_.content))
 
   def showBlocks(q: BlocksQuery): Task[Either[Seq[String], String]] =
     stub

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -70,7 +70,7 @@ class ManyValidatorsTest
       casperRef          <- MultiParentCasperRef.of[Task]
       _                  <- casperRef.set(casperEffect)
       cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
-      result <- BlockAPI.showBlocks[Task](Int.MaxValue)(
+      result <- BlockAPI.showBlocks[Task](Some(Int.MaxValue))(
                  Monad[Task],
                  casperRef,
                  logEff,

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -174,7 +174,8 @@ class BlocksResponseAPITest
                            cliqueOracleEffect,
                            blockStore
                          )
-      } yield blocksResponse.length should be(8) // TODO: Switch to 4 when we implement block height correctly
+      } yield
+        blocksResponse.right.get.length should be(8) // TODO: Switch to 4 when we implement block height correctly
   }
 
   it should "return until depth" in withStorage { implicit blockStore => implicit blockDagStorage =>
@@ -246,6 +247,7 @@ class BlocksResponseAPITest
                          cliqueOracleEffect,
                          blockStore
                        )
-    } yield blocksResponse.length should be(2) // TODO: Switch to 3 when we implement block height correctly
+    } yield
+      blocksResponse.right.get.length should be(2) // TODO: Switch to 3 when we implement block height correctly
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -167,7 +167,7 @@ class BlocksResponseAPITest
         casperRef          <- MultiParentCasperRef.of[Task]
         _                  <- casperRef.set(casperEffect)
         cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
-        blocksResponse <- BlockAPI.showBlocks[Task](Int.MaxValue)(
+        blocksResponse <- BlockAPI.showBlocks[Task](Some(Int.MaxValue))(
                            Sync[Task],
                            casperRef,
                            logEff,
@@ -240,7 +240,7 @@ class BlocksResponseAPITest
       casperRef          <- MultiParentCasperRef.of[Task]
       _                  <- casperRef.set(casperEffect)
       cliqueOracleEffect = SafetyOracle.cliqueOracle[Task](Sync[Task], logEff)
-      blocksResponse <- BlockAPI.showBlocks[Task](2)(
+      blocksResponse <- BlockAPI.showBlocks[Task](Some(2))(
                          Sync[Task],
                          casperRef,
                          logEff,

--- a/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
@@ -1,0 +1,43 @@
+package coop.rchain.casper.api
+
+import coop.rchain.casper._
+import coop.rchain.crypto.hash.Blake2b256
+
+import coop.rchain.shared.ByteStringOps._
+import cats._, cats.data._, cats.implicits._
+import org.scalatest.{FunSpec, Matchers}
+
+class MachineVerifiableDagSpec extends FunSpec with Matchers {
+
+  import VerifiableEdge._
+
+  describe("MachineVerifiableDag") {
+
+    it("should create dag for simple two blocks with one merge block") {
+      // given
+      val genesis = Blake2b256.hash("genesis".getBytes).toByteString
+      val block1  = Blake2b256.hash("block1".getBytes).toByteString
+      val block2  = Blake2b256.hash("block2".getBytes).toByteString
+      val block3  = Blake2b256.hash("block3".getBytes).toByteString
+
+      val toposort: TopoSort = Vector(
+        Vector(block1, block2),
+        Vector(block3)
+      )
+
+      val fetch: BlockHash => Id[List[BlockHash]] = {
+        case b if b == block1 => List(genesis)
+        case b if b == block2 => List(genesis)
+        case b if b == block3 => List(block1, block2)
+      }
+      // when
+      val result: List[VerifiableEdge] = MachineVerifiableDag[Id](toposort, fetch)
+      // then
+      result should contain(VerifiableEdge(block3.show, block1.show))
+      result should contain(VerifiableEdge(block3.show, block2.show))
+      result should contain(VerifiableEdge(block1.show, genesis.show))
+      result should contain(VerifiableEdge(block2.show, genesis.show))
+    }
+  }
+
+}

--- a/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
@@ -33,11 +33,10 @@ class MachineVerifiableDagSpec extends FunSpec with Matchers {
       // when
       val result: List[VerifiableEdge] = MachineVerifiableDag[Id](toposort, fetch)
       // then
-      result should contain(VerifiableEdge(block3.show, block1.show))
-      result should contain(VerifiableEdge(block3.show, block2.show))
-      result should contain(VerifiableEdge(block1.show, genesis.show))
-      result should contain(VerifiableEdge(block2.show, genesis.show))
+      result(0) should be(VerifiableEdge(block3.show, block1.show))
+      result(1) should be(VerifiableEdge(block3.show, block2.show))
+      result(2) should be(VerifiableEdge(block1.show, genesis.show))
+      result(3) should be(VerifiableEdge(block2.show, genesis.show))
     }
   }
-
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -79,6 +79,24 @@ object RhoSpec {
       result <- testResultCollector.getResult
     } yield result
 
+  def defaultGenesisSetup[F[_]: Concurrent](runtimeManager: RuntimeManager[F]): F[BlockMessage] = {
+    val (_, validators) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
+    val bonds           = createBonds(validators)
+    val posValidators   = bonds.map(bond => Validator(bond._1, bond._2)).toSeq
+    val ethAddress      = "0x041e1eec23d118f0c4ffc814d4f415ac3ef3dcff"
+    val initBalance     = 37
+    val wallet          = PreWallet(ethAddress, initBalance)
+    Genesis.createGenesisBlock(
+      runtimeManager,
+      Genesis(
+        "RhoSpec-shard",
+        1,
+        wallet :: Nil,
+        ProofOfStake(0, Long.MaxValue, bonds.map(Validator.tupled).toSeq),
+        false
+      )
+    )
+  }
 }
 
 class RhoSpec(

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -78,25 +78,6 @@ object RhoSpec {
 
       result <- testResultCollector.getResult
     } yield result
-
-  def defaultGenesisSetup[F[_]: Concurrent](runtimeManager: RuntimeManager[F]): F[BlockMessage] = {
-    val (_, validators) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
-    val bonds           = createBonds(validators)
-    val posValidators   = bonds.map(bond => Validator(bond._1, bond._2)).toSeq
-    val ethAddress      = "0x041e1eec23d118f0c4ffc814d4f415ac3ef3dcff"
-    val initBalance     = 37
-    val wallet          = PreWallet(ethAddress, initBalance)
-    Genesis.createGenesisBlock(
-      runtimeManager,
-      Genesis(
-        "RhoSpec-shard",
-        1,
-        wallet :: Nil,
-        ProofOfStake(0, Long.MaxValue, bonds.map(Validator.tupled).toSeq),
-        false
-      )
-    )
-  }
 }
 
 class RhoSpec(

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -40,6 +40,7 @@ service DeployService {
   // Get dag
   // Returns on success VisualizeBlocksResponse
   rpc visualizeDag(VisualizeDagQuery) returns (Either) {}
+  rpc machineVerifiableDag(MachineVerifyQuery) returns (Either) {}
   // Returns on success BlockInfoWithoutTuplespace
   rpc showMainChain(BlocksQuery) returns (stream Either) {}
   // Get a summary of blocks on the blockchain.
@@ -128,6 +129,14 @@ message VisualizeDagQuery {
 }
 
 message VisualizeBlocksResponse {
+  string content = 1;
+}
+
+message MachineVerifyQuery {
+
+}
+
+message MachineVerifyResponse {
   string content = 1;
 }
 

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -89,9 +89,10 @@ object Main {
       case ShowBlocks(depth) => DeployRuntime.showBlocks[Task](depth)
       case VisualizeDag(depth, showJustificationLines) =>
         DeployRuntime.visualizeDag[Task](depth, showJustificationLines)
-      case DataAtName(name)  => DeployRuntime.listenForDataAtName[Task](name)
-      case ContAtName(names) => DeployRuntime.listenForContinuationAtName[Task](names)
-      case Run               => nodeProgram(conf)
+      case MachineVerifiableDag => DeployRuntime.machineVerifiableDag[Task]
+      case DataAtName(name)     => DeployRuntime.listenForDataAtName[Task](name)
+      case ContAtName(names)    => DeployRuntime.listenForContinuationAtName[Task](names)
+      case Run                  => nodeProgram(conf)
       case BondingDeployGen(bondKey, ethAddress, amount, secKey, pubKey) =>
         implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
         BondingUtil

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -1,10 +1,8 @@
 package coop.rchain.node.api
 
-import cats._
-import cats.data._
+import cats._, cats.data._, cats.implicits._
 import cats.effect.concurrent.Semaphore
 import cats.effect.Concurrent
-import cats.implicits._
 import cats.mtl.implicits._
 
 import coop.rchain.blockstorage.BlockStore
@@ -81,7 +79,14 @@ private[api] object DeployGrpcService {
 
       override def showBlocks(request: BlocksQuery): Observable[GrpcEither] =
         Observable
-          .fromTask(deferList(BlockAPI.showBlocks[F](request.depth)))
+          .fromTask(
+            deferList[BlockInfoWithoutTuplespace](
+              Functor[F].map(BlockAPI.showBlocks[F](request.depth)) {
+                case Right(list) => list
+                case Left(_)     => List.empty
+              }
+            )
+          )
           .flatMap(Observable.fromIterable)
 
       override def listenForDataAtName(request: DataAtNameQuery): Task[GrpcEither] =

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -66,7 +66,7 @@ private[api] object DeployGrpcService {
         implicit val ser: GraphSerializer[Effect]       = new StringSerializer[Effect]
         val stringify: Effect[Graphz[Effect]] => String = _.runS(new StringBuffer).toString
 
-        val depth  = if (q.depth <= 0) None else Some(q.depth)
+        val depth  = if (q.depth <= 0) 0 else q.depth
         val config = GraphConfig(q.showJustificationLines)
 
         defer(

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -84,10 +84,9 @@ private[api] object DeployGrpcService {
         Observable
           .fromTask(
             deferList[BlockInfoWithoutTuplespace](
-              Functor[F].map(BlockAPI.showBlocks[F](Some(request.depth))) {
-                case Right(list) => list
-                case Left(_)     => List.empty
-              }
+              Functor[F].map(BlockAPI.showBlocks[F](Some(request.depth)))(
+                _.getOrElse(List.empty[BlockInfoWithoutTuplespace])
+              )
             )
           )
           .flatMap(Observable.fromIterable)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -203,9 +203,10 @@ object Configuration {
       case Some(options.visualizeBlocks) =>
         import options.visualizeBlocks._
         VisualizeDag(depth.getOrElse(-1), showJustificationLines.getOrElse(false))
-      case Some(options.run)        => Run
-      case Some(options.dataAtName) => DataAtName(options.dataAtName.name())
-      case Some(options.contAtName) => ContAtName(options.contAtName.name())
+      case Some(options.machineVerifiableDag) => MachineVerifiableDag
+      case Some(options.run)                  => Run
+      case Some(options.dataAtName)           => DataAtName(options.dataAtName.name())
+      case Some(options.contAtName)           => ContAtName(options.contAtName.name())
       case Some(options.bondingDeployGen) =>
         import options.bondingDeployGen._
         BondingDeployGen(bondKey(), ethAddr(), amount(), privateKey(), publicKey())

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -437,6 +437,13 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(visualizeBlocks)
 
+  val machineVerifiableDag = new Subcommand("mvdag") {
+    descr(
+      "Machine Verifiable Dag"
+    )
+  }
+  addSubcommand(machineVerifiableDag)
+
   def listenAtName[R](name: String, desc: String)(
       implicit conv: ValueConverter[List[String] => R]
   ) = new Subcommand(name) {

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -69,6 +69,7 @@ final case object Propose                                                  exten
 final case class ShowBlock(hash: String)                                   extends Command
 final case class ShowBlocks(depth: Int)                                    extends Command
 final case class VisualizeDag(depth: Int, showJustificationLines: Boolean) extends Command
+final case object MachineVerifiableDag                                     extends Command
 final case object Run                                                      extends Command
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command

--- a/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ByteStringOps.scala
@@ -16,4 +16,8 @@ object ByteStringOps {
       buffer
     }
   }
+
+  implicit class RichByteArray(arr: Array[Byte]) {
+    def toByteString: ByteString = ByteString.copyFrom(arr)
+  }
 }


### PR DESCRIPTION
## Overview
New tool that does following: 

```
./bin/rnode --grpc-port 10401 mvdag          
75b0f982aef51f44b767cd257c64749b641d5b67896d4d72479a7550a9927553 cffdadbf5ef137ae85ecf5245a949bb910eb16ff65f8a7eb9c2c56a1bfe00287
cffdadbf5ef137ae85ecf5245a949bb910eb16ff65f8a7eb9c2c56a1bfe00287 f5474499577894cdd1ec78f2d970542f32317d1d770694325df2644977a867e2
```

Some refactoring were made during the process. Next PR will introduce property based test to check that DAGs are exactly the same no matter what and that they can be compared line by line. Also the DAG should be transported in stream fashion if it is to work with bigger DAGs in a future.


### JIRA ticket:
RCHAIN-2925
