### PR TITLE
Add network version ID

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -466,6 +466,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
 
       signedInvalidBlockPacketMessage = packet(
         nodes(0).local,
+        "test",
         transport.BlockMessage,
         signedInvalidBlock.toByteString
       )

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -62,7 +62,9 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
 
     def testProgram(blockApiLock: Semaphore[Effect])(
         implicit casperRef: MultiParentCasperRef[Effect]
-    ): Effect[(ApiErr[DeployServiceResponse], ApiErr[DeployServiceResponse], ApiErr[DeployServiceResponse])] =
+    ): Effect[
+      (ApiErr[DeployServiceResponse], ApiErr[DeployServiceResponse], ApiErr[DeployServiceResponse])
+    ] =
       EitherT.liftF(
         for {
           t1 <- createBlock(deploys.head, blockApiLock).value.start

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -49,6 +49,7 @@ class CasperPacketHandlerSpec extends WordSpec {
   private def setup() = new {
     implicit val log     = new LogStub[Task]
     implicit val metrics = new MetricsNOP[Task]
+    val networkId        = "test"
     val scheduler        = Scheduler.io("test")
     val runtimeDir       = BlockDagStorageTestFixture.blockStorageDir
     val activeRuntime =
@@ -158,6 +159,7 @@ class CasperPacketHandlerSpec extends WordSpec {
           blockApproval = BlockApproverProtocol.getBlockApproval(expectedCandidate, validatorId)
           expectedPacket = ProtocolHelper.packet(
             local,
+            networkId,
             transport.BlockApproval,
             blockApproval.toByteString
           )
@@ -187,6 +189,7 @@ class CasperPacketHandlerSpec extends WordSpec {
           head = transportLayer.requests.head
           response = packet(
             local,
+            networkId,
             transport.NoApprovedBlockAvailable,
             NoApprovedBlockAvailable(approvedBlockRequest.identifier, local.toString).toByteString
           )
@@ -328,6 +331,7 @@ class CasperPacketHandlerSpec extends WordSpec {
           _ = assert(
             transportLayer.requests.head.msg == packet(
               local,
+              networkId,
               transport.ForkChoiceTipRequest,
               ByteString.EMPTY
             )
@@ -396,7 +400,7 @@ class CasperPacketHandlerSpec extends WordSpec {
           _     <- blockStore.put(genesis.blockHash, genesis)
           _     <- casperPacketHandler.handle(local)(requestPacket)
           head  = transportLayer.requests.head
-          block = packet(local, transport.BlockMessage, genesis.toByteString)
+          block = packet(local, networkId, transport.BlockMessage, genesis.toByteString)
           _     = assert(head.peer == local && head.msg == block)
         } yield ()
 

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -79,7 +79,7 @@ class TransportLayerTestImpl[F[_]: Monad]()(
     stream(Seq(peer), blob)
 
   def stream(peers: Seq[PeerNode], blob: Blob): F[Unit] =
-    broadcast(peers, protocol(blob.sender).withPacket(blob.packet)).void
+    broadcast(peers, protocol(blob.sender, "test").withPacket(blob.packet)).void
 
   def clear(peer: PeerNode): F[Unit] =
     TestNetwork.clear(peer)

--- a/comm/src/main/protobuf/coop/rchain/comm/protocol/kademlia.proto
+++ b/comm/src/main/protobuf/coop/rchain/comm/protocol/kademlia.proto
@@ -16,19 +16,23 @@ message Node {
 }
 
 message Ping {
-  Node   sender         = 1;
+  Node   sender    = 1;
+  string networkId = 2;
 }
 
 message Pong {
+  string networkId = 1;
 }
 
 message Lookup {
-  bytes  id     = 1;
-  Node   sender = 2;
+  bytes  id        = 1;
+  Node   sender    = 2;
+  string networkId = 3;
 }
-        
+
 message LookupResponse {
     repeated Node nodes = 1;
+    string networkId    = 2;
 }
 
 service KademliaRPCService {

--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -50,11 +50,10 @@ class GrpcKademliaRPC(networkId: String, timeout: FiniteDuration)(
                       _.sendLookup(lookup)
                         .timer("lookup-time")
                     ).attempt
-    } yield
-      responseErr.fold(
-        kp(Seq.empty[PeerNode]),
-        r => if (r.networkId == networkId) r.nodes.map(toPeerNode) else Seq.empty[PeerNode]
-      )
+    } yield responseErr.fold(
+      kp(Seq.empty[PeerNode]),
+      r => if (r.networkId == networkId) r.nodes.map(toPeerNode) else Seq.empty[PeerNode]
+    )
 
   private def withClient[A](peer: PeerNode, timeout: FiniteDuration, enforce: Boolean = false)(
       f: KademliaRPCServiceStub => Task[A]

--- a/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/GrpcKademliaRPC.scala
@@ -17,7 +17,7 @@ import io.grpc.netty._
 import monix.eval._
 import monix.execution._
 
-class GrpcKademliaRPC(timeout: FiniteDuration)(
+class GrpcKademliaRPC(networkId: String, timeout: FiniteDuration)(
     implicit
     scheduler: Scheduler,
     peerNodeAsk: PeerNodeAsk[Task],
@@ -31,23 +31,30 @@ class GrpcKademliaRPC(timeout: FiniteDuration)(
     for {
       _     <- Metrics[Task].incrementCounter("ping")
       local <- peerNodeAsk.ask
-      ping  = Ping().withSender(toNode(local))
+      ping  = Ping().withSender(toNode(local)).withNetworkId(networkId)
       pongErr <- withClient(peer, timeout)(
                   _.sendPing(ping)
                     .timer("ping-time")
                 ).attempt
-    } yield pongErr.fold(kp(false), kp(true))
+    } yield pongErr.fold(kp(false), _.networkId == networkId)
 
   def lookup(key: Seq[Byte], peer: PeerNode): Task[Seq[PeerNode]] =
     for {
-      _      <- Metrics[Task].incrementCounter("protocol-lookup-send")
-      local  <- peerNodeAsk.ask
-      lookup = Lookup().withId(ByteString.copyFrom(key.toArray)).withSender(toNode(local))
+      _     <- Metrics[Task].incrementCounter("protocol-lookup-send")
+      local <- peerNodeAsk.ask
+      lookup = Lookup()
+        .withId(ByteString.copyFrom(key.toArray))
+        .withSender(toNode(local))
+        .withNetworkId(networkId)
       responseErr <- withClient(peer, timeout)(
                       _.sendLookup(lookup)
                         .timer("lookup-time")
                     ).attempt
-    } yield responseErr.fold(kp(Seq.empty[PeerNode]), _.nodes.map(toPeerNode))
+    } yield
+      responseErr.fold(
+        kp(Seq.empty[PeerNode]),
+        r => if (r.networkId == networkId) r.nodes.map(toPeerNode) else Seq.empty[PeerNode]
+      )
 
   private def withClient[A](peer: PeerNode, timeout: FiniteDuration, enforce: Boolean = false)(
       f: KademliaRPCServiceStub => Task[A]

--- a/comm/src/main/scala/coop/rchain/comm/discovery/package.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/package.scala
@@ -13,6 +13,7 @@ package object discovery {
     Metrics.Source(CommMetricsSource, "discovery.kademlia")
 
   def acquireKademliaRPCServer(
+      networkId: String,
       port: Int,
       pingHandler: PeerNode => Task[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => Task[Seq[PeerNode]]
@@ -23,7 +24,10 @@ package object discovery {
         .executor(scheduler)
         .addService(
           KademliaGrpcMonix
-            .bindService(new GrpcKademliaRPCServer(pingHandler, lookupHandler), scheduler)
+            .bindService(
+              new GrpcKademliaRPCServer(networkId, pingHandler, lookupHandler),
+              scheduler
+            )
         )
         .build
     )

--- a/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
@@ -1,11 +1,10 @@
 package coop.rchain.comm.rp
 
-import com.google.protobuf.ByteString
-import com.google.protobuf.any.{Any => AnyProto}
-import coop.rchain.comm.CommError._
 import coop.rchain.comm._
+import coop.rchain.comm.CommError._
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.comm.transport.{Blob, PacketType}
+
 import com.google.protobuf.ByteString
 
 object ProtocolHelper {
@@ -14,9 +13,10 @@ object ProtocolHelper {
   def toProtocolBytes(x: Array[Byte]): ByteString = ByteString.copyFrom(x)
   def toProtocolBytes(x: Seq[Byte]): ByteString   = ByteString.copyFrom(x.toArray)
 
-  def header(src: PeerNode): Header =
+  def header(src: PeerNode, networkId: String): Header =
     Header()
       .withSender(node(src))
+      .withNetworkId(networkId)
 
   def node(n: PeerNode): Node =
     Node()
@@ -34,41 +34,41 @@ object ProtocolHelper {
   def toPeerNode(n: Node): PeerNode =
     PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host.toStringUtf8, n.tcpPort, n.udpPort))
 
-  def protocol(src: PeerNode): Protocol =
-    Protocol().withHeader(header(src))
+  def protocol(src: PeerNode, networkId: String): Protocol =
+    Protocol().withHeader(header(src, networkId))
 
-  def protocolHandshake(src: PeerNode): Protocol =
-    protocol(src).withProtocolHandshake(ProtocolHandshake())
+  def protocolHandshake(src: PeerNode, networkId: String): Protocol =
+    protocol(src, networkId).withProtocolHandshake(ProtocolHandshake())
 
   def toProtocolHandshake(proto: Protocol): CommErr[ProtocolHandshake] =
     proto.message.protocolHandshake.fold[CommErr[ProtocolHandshake]](
       Left(UnknownProtocolError(s"Was expecting ProtocolHandshake, got ${proto.message}"))
     )(Right(_))
 
-  def protocolHandshakeResponse(src: PeerNode): Protocol =
-    protocol(src).withProtocolHandshakeResponse(ProtocolHandshakeResponse())
+  def protocolHandshakeResponse(src: PeerNode, networkId: String): Protocol =
+    protocol(src, networkId).withProtocolHandshakeResponse(ProtocolHandshakeResponse())
 
-  def heartbeat(src: PeerNode): Protocol =
-    protocol(src).withHeartbeat(Heartbeat())
+  def heartbeat(src: PeerNode, networkId: String): Protocol =
+    protocol(src, networkId).withHeartbeat(Heartbeat())
 
   def toHeartbeat(proto: Protocol): CommErr[Heartbeat] =
     proto.message.heartbeat.fold[CommErr[Heartbeat]](
       Left(UnknownProtocolError(s"Was expecting Heartbeat, got ${proto.message}"))
     )(Right(_))
 
-  def packet(src: PeerNode, pType: PacketType, content: Array[Byte]): Protocol =
-    packet(src, pType, ByteString.copyFrom(content))
+  def packet(src: PeerNode, networkId: String, pType: PacketType, content: Array[Byte]): Protocol =
+    packet(src, networkId, pType, ByteString.copyFrom(content))
 
-  def packet(src: PeerNode, pType: PacketType, content: ByteString): Protocol =
-    protocol(src).withPacket(Packet(pType.id, content))
+  def packet(src: PeerNode, networkId: String, pType: PacketType, content: ByteString): Protocol =
+    protocol(src, networkId).withPacket(Packet(pType.id, content))
 
   def toPacket(proto: Protocol): CommErr[Packet] =
     proto.message.packet.fold[CommErr[Packet]](
       Left(UnknownProtocolError(s"Was expecting Packet, got ${proto.message}"))
     )(Right(_))
 
-  def disconnect(src: PeerNode): Protocol =
-    protocol(src).withDisconnect(Disconnect())
+  def disconnect(src: PeerNode, networkId: String): Protocol =
+    protocol(src, networkId).withDisconnect(Disconnect())
 
   def toDisconnect(proto: Protocol): CommErr[Disconnect] =
     proto.message.disconnect.fold[CommErr[Disconnect]](

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -6,6 +6,7 @@ import coop.rchain.comm.PeerNode
 
 final case class RPConf(
     local: PeerNode,
+    networkId: String,
     bootstrap: Option[PeerNode],
     defaultTimeout: FiniteDuration,
     maxNumOfConnections: Int,

--- a/comm/src/main/scala/coop/rchain/comm/transport/Chunker.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/Chunker.scala
@@ -7,7 +7,7 @@ import monix.eval._
 
 object Chunker {
 
-  def chunkIt(blob: Blob, maxMessageSize: Int): Task[Iterator[Chunk]] =
+  def chunkIt(networkId: String, blob: Blob, maxMessageSize: Int): Task[Iterator[Chunk]] =
     Task.delay {
       val raw      = blob.packet.content.toByteArray
       val kb500    = 1024 * 500
@@ -21,6 +21,7 @@ object Chunker {
             .withContentLength(raw.length)
             .withSender(ProtocolHelper.node(blob.sender))
             .withTypeId(blob.packet.typeId)
+            .withNetworkId(networkId)
         )
       val buffer    = 2 * 1024 // 2 kbytes for protobuf related stuff
       val chunkSize = maxMessageSize - buffer

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
@@ -96,9 +96,9 @@ object GrpcTransport {
                })
     } yield result
 
-  def stream(peer: PeerNode, blob: Blob, packetChunkSize: Int): Request[Unit] =
+  def stream(networkId: String, peer: PeerNode, blob: Blob, packetChunkSize: Int): Request[Unit] =
     ReaderT(
-      _.stream(Observable.fromIterator(Chunker.chunkIt(blob, packetChunkSize))).attempt
+      _.stream(Observable.fromIterator(Chunker.chunkIt(networkId, blob, packetChunkSize))).attempt
         .map(r => processError(peer, r.map(kp(()))))
     )
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -1,27 +1,27 @@
 package coop.rchain.comm.transport
 
-import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.comm.protocol.routing.TLResponse.Payload
 import coop.rchain.crypto.util.CertificateHelper
 import coop.rchain.shared.{Log, LogSource}
+
 import io.grpc._
 import javax.net.ssl.SSLSession
 
-class SslSessionClientInterceptor() extends ClientInterceptor {
+class SslSessionClientInterceptor(networkID: String) extends ClientInterceptor {
   def interceptCall[ReqT, RespT](
       method: MethodDescriptor[ReqT, RespT],
       callOptions: CallOptions,
       next: Channel
   ): ClientCall[ReqT, RespT] =
-    new SslSessionClientCallInterceptor(next.newCall(method, callOptions))
+    new SslSessionClientCallInterceptor(next.newCall(method, callOptions), networkID)
 }
 
 /**
-  * This wart exists because that's how grpc works. They looooovveee throwing exceptions
+  * This wart exists because that's how grpc works
   */
-@SuppressWarnings(Array("org.wartremover.warts.Throw"))
-class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT])
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT], networkID: String)
     extends ClientCall[ReqT, RespT] {
   self =>
 
@@ -42,36 +42,49 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
   private class InterceptionListener(next: ClientCall.Listener[RespT])
       extends ClientCall.Listener[RespT] {
-    override def onClose(status: Status, trailers: Metadata): Unit = next.onClose(status, trailers)
-    override def onReady(): Unit                                   = next.onReady()
-    override def onHeaders(headers: Metadata): Unit                = next.onHeaders(headers)
+    @volatile
+    private var closeWithStatus = Option.empty[Status]
+
+    override def onClose(status: Status, trailers: Metadata): Unit =
+      closeWithStatus.fold(next.onClose(status, trailers))(next.onClose(_, new Metadata()))
+
+    override def onReady(): Unit                    = next.onReady()
+    override def onHeaders(headers: Metadata): Unit = next.onHeaders(headers)
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.NoResponse(NoResponse(Some(Header(Some(sender)))))) =>
-          val sslSession: Option[SSLSession] = Option(
-            self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)
-          )
-          if (sslSession.isEmpty) {
-            log.warn("No TLS Session. Closing connection")
-            close()
-          } else {
-            sslSession.foreach { session =>
-              val verified = CertificateHelper
-                .publicAddress(session.getPeerCertificates.head.getPublicKey)
-                .exists(_ sameElements sender.id.toByteArray)
-              if (verified)
-                next.onMessage(message)
-              else {
-                log.warn("Certificate verification failed. Closing connection")
-                close()
+        case TLResponse(Payload.NoResponse(NoResponse(Some(Header(Some(sender), nid))))) =>
+          if (nid == networkID) {
+            val sslSession: Option[SSLSession] = Option(
+              self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)
+            )
+            if (sslSession.isEmpty) {
+              log.warn("No TLS Session. Closing connection")
+              close(Status.UNAUTHENTICATED.withDescription("No TLS Session"))
+            } else {
+              sslSession.foreach { session =>
+                val verified = CertificateHelper
+                  .publicAddress(session.getPeerCertificates.head.getPublicKey)
+                  .exists(_ sameElements sender.id.toByteArray)
+                if (verified)
+                  next.onMessage(message)
+                else {
+                  log.warn("Certificate verification failed. Closing connection")
+                  close(Status.UNAUTHENTICATED.withDescription("Certificate verification failed"))
+                }
               }
             }
+          } else {
+            log.warn(s"Wrong network id $nid. Closing connection")
+            close(Status.PERMISSION_DENIED.withDescription(s"Wrong network id $nid"))
           }
+        case TLResponse(_) =>
+          log.warn(s"Malformed response $message")
+          close(Status.INVALID_ARGUMENT.withDescription("Malformed message"))
         case _ => next.onMessage(message)
       }
 
-    private def close(): Unit =
-      throw Status.UNAUTHENTICATED.withDescription("Wrong public key").asRuntimeException()
+    private def close(status: Status): Unit =
+      closeWithStatus = Some(status)
   }
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -68,7 +68,10 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
             }
           } else {
             log.warn(s"Wrong network id $nid. Closing connection")
-            close(Status.PERMISSION_DENIED.withDescription(s"Wrong network id $nid"))
+            close(
+              Status.PERMISSION_DENIED
+                .withDescription(s"Wrong network id $nid. This node runs on network $networkID")
+            )
           }
         case TLRequest(_) =>
           log.warn(s"Malformed message $message")

--- a/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
@@ -19,6 +19,7 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
   implicit val log: Log[Task]         = new Log.NOPLog[Task]
   implicit val scheduler: Scheduler   = Scheduler.Implicits.global
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP
+  private val networkId               = "test"
 
   def createEnvironment(port: Int): Task[GrpcEnvironment] =
     Task.delay {
@@ -36,7 +37,7 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
         def ask: Task[PeerNode]            = Task.pure(env.peer)
       }
     Task.delay {
-      new GrpcKademliaRPC(500.millis)
+      new GrpcKademliaRPC(networkId, 500.millis)
     }
   }
 
@@ -46,7 +47,7 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
       env: GrpcEnvironment,
       pingHandler: PeerNode => Task[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => Task[Seq[PeerNode]]
-  ): Task[Server[Task]] = acquireKademliaRPCServer(env.port, pingHandler, lookupHandler)
+  ): Task[Server[Task]] = acquireKademliaRPCServer(networkId, env.port, pingHandler, lookupHandler)
 }
 
 case class GrpcEnvironment(

--- a/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
@@ -27,6 +27,7 @@ class ClearConnectionsSpec
   import ScalaTestCats._
 
   val src: PeerNode      = peer("src")
+  val networkId          = "test"
   implicit val transport = new TransportLayerStub[Id]
   implicit val log       = new Log.NOPLog[Id]
   implicit val metric    = new Metrics.MetricsNOP[Id]
@@ -141,13 +142,14 @@ class ClearConnectionsSpec
         clearConnections = ClearConnectionsConf(numOfConnectionsPinged),
         defaultTimeout = 1.milli,
         local = peer("src"),
+        networkId = networkId,
         bootstrap = None,
         maxNumOfConnections = maxNumOfConnections
       )
     )
 
   def alwaysSuccess: Protocol => CommErr[Protocol] =
-    kp(Right(heartbeat(peer("src"))))
+    kp(Right(heartbeat(peer("src"), networkId)))
 
   def alwaysFail: Protocol => CommErr[Protocol] =
     kp(Left(timeout))

--- a/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
@@ -25,6 +25,7 @@ class ConnectSpec
   val defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS)
   val src: PeerNode                  = peerNode("src", 40400)
   val remote: PeerNode               = peerNode("remote", 40401)
+  val networkId                      = "test"
 
   type Effect[A] = CommErrT[Id, A]
 
@@ -65,7 +66,7 @@ class ConnectSpec
   }
 
   def alwaysSuccess: Protocol => CommErr[Protocol] =
-    kp(Right(protocolHandshake(src)))
+    kp(Right(protocolHandshake(src, networkId)))
 
   private def endpoint(port: Int): Endpoint = Endpoint("host", port, port)
   private def peerNode(name: String, port: Int): PeerNode =

--- a/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
@@ -120,6 +120,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
         clearConnections = ClearConnectionsConf(numOfConnectionsPinged),
         defaultTimeout = defaultTimeout,
         local = peer("src"),
+        networkId = "test",
         bootstrap = None,
         maxNumOfConnections = maxNumOfConnections
       )

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -21,6 +21,8 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
 
   implicit val log = new Log.NOPLog[Task]()
 
+  val networkId = "test"
+
   var tempFolder: Path = null
 
   override def beforeEach(): Unit =
@@ -141,7 +143,11 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   }
 
   private def handleStream(stream: Observable[Chunk], folder: Path = tempFolder): StreamMessage =
-    StreamHandler.handleStream(folder, stream, circuitBreaker = neverBreak).unsafeRunSync.right.get
+    StreamHandler
+      .handleStream(networkId, folder, stream, circuitBreaker = neverBreak)
+      .unsafeRunSync
+      .right
+      .get
 
   private def handleStreamErr(
       stream: Observable[Chunk],
@@ -149,7 +155,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       circuitBreaker: StreamHandler.CircuitBreaker = neverBreak
   ): Throwable =
     StreamHandler
-      .handleStream(folder, stream, circuitBreaker = circuitBreaker)
+      .handleStream(networkId, folder, stream, circuitBreaker = circuitBreaker)
       .unsafeRunSync
       .left
       .get
@@ -173,7 +179,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     val packet  = Packet(BlockMessage.id, ByteString.copyFrom(content))
     val sender  = peerNode("sender")
     val blob    = Blob(sender, packet)
-    Chunker.chunkIt(blob, messageSize)
+    Chunker.chunkIt(networkId, blob, messageSize)
   }
 
   private def peerNode(name: String): PeerNode =

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -1,14 +1,16 @@
 package coop.rchain.comm.transport
 
+import java.nio.file._
+
 import scala.concurrent.duration.Duration
 
 import coop.rchain.comm._
+import coop.rchain.comm.rp.Connect.RPConfAsk
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.util.{CertificateHelper, CertificatePrinter}
-import coop.rchain.shared.Log
-import java.nio.file._
-
 import coop.rchain.metrics.Metrics
+import coop.rchain.p2p.EffectsTestInstances._
+import coop.rchain.shared.Log
 
 import monix.catnap.MVar
 import monix.eval.Task
@@ -50,6 +52,7 @@ class TcpTransportLayerSpec
   ): Task[TransportLayer[Task]] =
     Task.delay(
       new GrpcTransportClient(
+        networkId,
         env.cert,
         env.key,
         maxMessageSize,
@@ -66,7 +69,8 @@ class TcpTransportLayerSpec
 
   def createTransportLayerServer(env: TcpTlsEnvironment): Task[TransportLayerServer[Task]] =
     Task.delay {
-      new GrpcTransportServer(env.port, env.cert, env.key, maxMessageSize, tempFolder, 4)
+      implicit val rPConfAsk: RPConfAsk[Task] = createRPConfAsk[Task](env.peer)
+      new GrpcTransportServer(networkId, env.port, env.cert, env.key, maxMessageSize, tempFolder, 4)
     }
 }
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -19,6 +19,8 @@ import coop.rchain.shared.Resources
 
 abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
 
+  val networkId = "test"
+
   def createEnvironment(port: Int): F[E]
 
   def createTransportLayer(env: E): F[TransportLayer[F]]
@@ -196,7 +198,7 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
       local: PeerNode,
       remote: PeerNode
   ): F[CommErr[Unit]] = {
-    val msg = ProtocolHelper.heartbeat(local)
+    val msg = ProtocolHelper.heartbeat(local, networkId)
     transport.send(remote, msg)
   }
 
@@ -205,7 +207,7 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
       local: PeerNode,
       remotes: PeerNode*
   ): F[Seq[CommErr[Unit]]] = {
-    val msg = ProtocolHelper.heartbeat(local)
+    val msg = ProtocolHelper.heartbeat(local, networkId)
     transport.broadcast(remotes, msg)
   }
 

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -18,6 +18,8 @@ import coop.rchain.comm.protocol.routing._
 /** Eagerly evaluated instances to do reasoning about applied effects */
 object EffectsTestInstances {
 
+  val networkId = "test"
+
   class LogicalTime[F[_]: Sync] extends Time[F] {
     var clock: Long = 0
 
@@ -54,7 +56,7 @@ object EffectsTestInstances {
       clearConnections: ClearConnectionsConf = ClearConnectionsConf(1)
   ) =
     new ConstApplicativeAsk[F, RPConf](
-      RPConf(local, Some(local), defaultTimeout, 20, clearConnections)
+      RPConf(local, networkId, Some(local), defaultTimeout, 20, clearConnections)
     )
 
   class TransportLayerStub[F[_]: Sync: Applicative] extends TransportLayer[F] {
@@ -94,7 +96,7 @@ object EffectsTestInstances {
       stream(Seq(peer), blob)
 
     def stream(peers: Seq[PeerNode], blob: Blob): F[Unit] =
-      broadcast(peers, ProtocolHelper.protocol(blob.sender).withPacket(blob.packet)).void
+      broadcast(peers, ProtocolHelper.protocol(blob.sender, networkId).withPacket(blob.packet)).void
 
     def disconnect(peer: PeerNode): F[Unit] =
       Sync[F].delay {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -18,6 +18,7 @@ message Node {
 
 message Header {
   Node   sender         = 1;
+  string networkId      = 2;
 }
 
 message Heartbeat {
@@ -82,6 +83,7 @@ message ChunkHeader {
   string typeId             = 2;
   bool   compressed         = 3;
   int32  contentLength      = 4;
+  string networkId          = 5;
 }
 
 message ChunkData {

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -2,6 +2,9 @@
 rnode {
 
   server {
+    # ID of the RChain network
+    network-id = "testnet"
+
     # host name or IP address of this node
     # If this attribute is not set then the node will try to guess its IP address
     # host = 127.0.0.1

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -3,11 +3,13 @@ package coop.rchain.node
 import scala.collection.JavaConverters._
 import scala.tools.jline.console._
 import completer.StringsCompleter
+
 import cats.implicits._
+
 import coop.rchain.casper.util.comm._
+import coop.rchain.casper.util.BondingUtil
 import coop.rchain.catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.casper.util.BondingUtil
 import coop.rchain.comm._
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
@@ -16,6 +18,7 @@ import coop.rchain.node.diagnostics.client.GrpcDiagnosticsService
 import coop.rchain.node.effects._
 import coop.rchain.shared._
 import coop.rchain.shared.StringOps._
+
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.slf4j.LoggerFactory
@@ -143,7 +146,8 @@ object Main {
           log.info(s"Starting with profile ${conf.profile}"),
           log.info(s"Using configuration file: ${conf.configurationFile}"),
           if (!conf.configurationFile.toFile.exists()) log.warn("Configuration file not found!")
-          else Task.unit
+          else Task.unit,
+          log.info(s"Running on network: ${conf.server.networkId}")
         )
       )
       .void

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -107,6 +107,7 @@ class NodeRuntime private[node] (
     for {
       kademliaRPCServer <- discovery
                             .acquireKademliaRPCServer(
+                              conf.server.networkId,
                               kademliaPort,
                               KademliaHandleRPC.handlePing[Task],
                               KademliaHandleRPC.handleLookup[Task]
@@ -383,7 +384,11 @@ class NodeRuntime private[node] (
                     commTmpFolder
                   )(grpcScheduler, log, metrics)
                   .toEffect
-    kademliaRPC   = effects.kademliaRPC(defaultTimeout)(grpcScheduler, peerNodeAsk, metrics)
+    kademliaRPC = effects.kademliaRPC(conf.server.networkId, defaultTimeout)(
+      grpcScheduler,
+      peerNodeAsk,
+      metrics
+    )
     kademliaStore = effects.kademliaStore(id)(kademliaRPC, metrics)
     _             <- initPeer.fold(Task.unit.toEffect)(p => kademliaStore.updateLastSeen(p).toEffect)
     nodeDiscovery = effects.nodeDiscovery(id)(kademliaStore, kademliaRPC)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -35,6 +35,7 @@ object ConfigMapper {
       {
         import Server._
         val add = addToMap(Key)
+        add(keys.NetworkId, run.network)
         add(keys.Host, run.host)
         add(keys.HostDynamic, run.dynamicHostAddress)
         add(keys.Upnp, run.noUpnp.map(kp(false)))

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -177,6 +177,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val secureRandomNonBlocking =
       opt[Flag](descr = "Use a non blocking secure random instance")
 
+    val network =
+      opt[String](descr = "ID of the RChain network")
+
     val port =
       opt[Int](short = 'p', descr = s"Network port to use. Defaults to $DefaultPort")
 

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -34,6 +34,7 @@ object Server {
   val Key = s"${Configuration.Key}.server"
 
   object keys {
+    val NetworkId        = "network-id"
     val Bootstrap        = "bootstrap"
     val StoreType        = "store-type"
     val Host             = "host"
@@ -76,6 +77,7 @@ object Server {
     val messageConsumers = Math.max(Runtime.getRuntime.availableProcessors(), 2)
 
     configuration.Server(
+      networkId = server.getString(keys.NetworkId),
       host = server.getStringOpt(keys.Host),
       dynamicHostAddress = server.getBoolean(keys.HostDynamic),
       noUpnp = !server.getBoolean(keys.Upnp),

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -3,12 +3,14 @@ package coop.rchain.node.configuration
 import java.nio.file.Path
 
 import scala.concurrent.duration.FiniteDuration
+
 import coop.rchain.casper.util.comm.ListenAtName.Name
 import coop.rchain.comm.PeerNode
-import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.crypto.PrivateKey
 import coop.rchain.shared.StoreType
 
 final case class Server(
+    networkId: String,
     host: Option[String],
     port: Int,
     httpPort: Int,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -45,12 +45,12 @@ package object effects {
       def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
     }
 
-  def kademliaRPC(timeout: FiniteDuration)(
+  def kademliaRPC(networkId: String, timeout: FiniteDuration)(
       implicit
       scheduler: Scheduler,
       peerNodeAsk: PeerNodeAsk[Task],
       metrics: Metrics[Task]
-  ): KademliaRPC[Task] = new GrpcKademliaRPC(timeout)
+  ): KademliaRPC[Task] = new GrpcKademliaRPC(networkId, timeout)
 
   def transportClient(
       networkId: String,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -53,6 +53,7 @@ package object effects {
   ): KademliaRPC[Task] = new GrpcKademliaRPC(timeout)
 
   def transportClient(
+      networkId: String,
       certPath: Path,
       keyPath: Path,
       maxMessageSize: Int,
@@ -66,7 +67,7 @@ package object effects {
     Task.delay {
       val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
       val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
-      new GrpcTransportClient(cert, key, maxMessageSize, packetChunkSize, folder, 1000)
+      new GrpcTransportClient(networkId, cert, key, maxMessageSize, packetChunkSize, folder, 1000)
     }
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -19,6 +19,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
     val args =
       Seq(
         "run",
+        "--network testnet",
         "--host 1.2.3.4",
         "--dynamic-host-address",
         "--no-upnp",
@@ -43,6 +44,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
 
     val expectedServer =
       configuration.Server(
+        networkId = "testnet",
         host = Some("1.2.3.4"),
         port = 40400,
         httpPort = 40403,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -19,6 +19,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
       """
       |rnode {
       |  server {
+      |    network-id = "testnet"
       |    host = 1.2.3.4
       |    host-dynamic = true
       |    upnp = false
@@ -42,6 +43,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
 
     val expectedServer =
       configuration.Server(
+        networkId = "testnet",
         host = Some("1.2.3.4"),
         port = 40400,
         httpPort = 40403,

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpace.scala
@@ -37,9 +37,9 @@ class RSpace[F[_], C, P, A, R, K] private[rspace] (
 ) extends RSpaceOps[F, C, P, A, R, K](store, branch)
     with ISpace[F, C, P, A, R, K] {
 
-  override protected[this] val logger: Logger = Logger[this.type]
+  protected[this] override val logger: Logger = Logger[this.type]
 
-  private[this] implicit val MetricsSource: Source = RSpaceMetricsSource
+  implicit private[this] val MetricsSource: Source = RSpaceMetricsSource
   private[this] val consumeCommLabel               = "comm.consume"
   private[this] val produceCommLabel               = "comm.produce"
   private[this] val consumeSpanLabel               = Metrics.Source(MetricsSource, "consume")
@@ -281,11 +281,10 @@ class RSpace[F[_], C, P, A, R, K] private[rspace] (
                            matchCandidates,
                            channelToIndexedDataList.toMap
                          )
-          } yield
-            firstMatch match {
-              case None             => remaining.asLeft[MaybeProduceCandidate]
-              case produceCandidate => produceCandidate.asRight[Seq[CandidateChannels]]
-            }
+          } yield firstMatch match {
+            case None             => remaining.asLeft[MaybeProduceCandidate]
+            case produceCandidate => produceCandidate.asRight[Seq[CandidateChannels]]
+          }
       }
     groupedChannels.tailRecM(go)
   }
@@ -421,7 +420,7 @@ class RSpace[F[_], C, P, A, R, K] private[rspace] (
 
   override def createCheckpoint(): F[Checkpoint] = ???
 
-  override protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean] = ???
+  protected[rspace] override def isDirty(root: Blake2b256Hash): F[Boolean] = ???
 
   def toMap: Map[Seq[C], Row[P, A, K]] = ???
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
@@ -70,7 +70,7 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, R, K] {
   import coop.rchain.catscontrib.TaskContrib._
   import scala.concurrent.ExecutionContext
 
-  override implicit val concurrentF: Concurrent[Task] =
+  implicit override val concurrentF: Concurrent[Task] =
     new monix.eval.instances.CatsConcurrentEffectForTask()(
       monix.execution.Scheduler.Implicits.global,
       Task.defaultOptions
@@ -78,8 +78,8 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, R, K] {
   implicit val logF: Log[Task]         = Log.log[Task]
   implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
 
-  override implicit val monadF: Monad[Task] = concurrentF
-  override implicit val contextShiftF: ContextShift[Task] = new ContextShift[Task] {
+  implicit override val monadF: Monad[Task] = concurrentF
+  implicit override val contextShiftF: ContextShift[Task] = new ContextShift[Task] {
     override def shift: Task[Unit] =
       Task.shift
     override def evalOn[B](ec: ExecutionContext)(fa: Task[B]): Task[B] =


### PR DESCRIPTION
## Overview
Add a network ID to all messages in node discovery and RChain protocol. Reject peers from other networks. The default network ID is ATM `testnet`. A network ID can be provided in the configuration file (`rchain.server.network-id`) or as a command line option `--network <id>`.
 
### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3230

### Notes
This change is not backward compatible. The new rnode will reject to talk to all previous versions of the rnode.

### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
