### PR TITLE
Do not allow installing/inserting duplicate joins

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -175,10 +175,11 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
   def installJoin(channel: C, join: Seq[C]): F[Unit] = S.flatModify { cache =>
     Sync[F]
       .delay {
-        val installed = cache.installedJoins.get(channel)
-        if (!installed.map(_.contains(join)).getOrElse(false))
+        val installed = cache.installedJoins.get(channel).getOrElse(Seq.empty)
+
+        if (!installed.contains(join))
           cache.installedJoins
-            .put(channel, join +: installed.getOrElse(Seq.empty))
+            .put(channel, join +: installed)
       }
       .map(_ => cache)
   }


### PR DESCRIPTION
## Overview
Fixes a bug which surfaced when porting RSpace tests to work with the new HotStore (within https://github.com/rchain/rchain/pull/2365)
Duplicate joins per channel should not be allowed

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3141


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
