### PR TITLE
Hot store rewrite/adapt replay rspace

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpace.scala
@@ -33,13 +33,8 @@ class RSpace[F[_], C, P, A, R, K] private[rspace] (
     contextShift: ContextShift[F],
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
-) extends RSpaceOps[F, C, P, A, R, K](storeAtom, branch)
+) extends RSpaceOps[F, C, P, A, R, K](historyRepository, storeAtom, branch)
     with ISpace[F, C, P, A, R, K] {
-
-  //TODO close in some F state abstraction
-  val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
-    historyRepository
-  )
 
   def store: HotStore[F, C, P, A, K] = storeAtom.get()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpaceOps.scala
@@ -9,6 +9,7 @@ import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace.Consume
+import coop.rchain.rspace.nextgenrspace.history.HistoryRepository
 import coop.rchain.shared.{Cell, Log}
 import coop.rchain.shared.SyncVarOps._
 import monix.execution.atomic.AtomicAny
@@ -18,6 +19,7 @@ import scala.util.Random
 import scodec.Codec
 
 abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
+    historyRepository: HistoryRepository[F, C, P, A, K],
     val storeAtom: AtomicAny[HotStore[F, C, P, A, K]],
     val branch: Branch
 )(
@@ -27,6 +29,11 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
     serializeK: Serialize[K],
     logF: Log[F]
 ) extends SpaceMatcher[F, C, P, A, R, K] {
+
+  //TODO close in some F state abstraction
+  protected val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
+    historyRepository
+  )
 
   def store: HotStore[F, C, P, A, K]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/RSpaceOps.scala
@@ -9,12 +9,13 @@ import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.trace.Consume
-import coop.rchain.shared.Log
+import coop.rchain.shared.{Cell, Log}
 import coop.rchain.shared.SyncVarOps._
 import monix.execution.atomic.AtomicAny
 
 import scala.concurrent.SyncVar
 import scala.util.Random
+import scodec.Codec
 
 abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
     val storeAtom: AtomicAny[HotStore[F, C, P, A, K]],
@@ -168,5 +169,17 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
   protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
 
   override def clear(): F[Unit] = ???
+
+  protected def createCache: F[Cell[F, Cache[C, P, A, K]]] =
+    Cell.refCell[F, Cache[C, P, A, K]](Cache())
+
+  protected def createNewHotStore(
+      historyReader: HistoryReader[F, C, P, A, K]
+  )(implicit cp: Codec[P], ck: Codec[K]): F[Unit] =
+    for {
+      cache        <- createCache
+      nextHotStore = HotStore.inMem(Sync[F], cache, historyReader, cp, ck)
+      _            = storeAtom.set(nextHotStore)
+    } yield ()
 
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpace.scala
@@ -35,18 +35,13 @@ class ReplayRSpace[F[_], C, P, A, R, K](
     contextShift: ContextShift[F],
     scheduler: ExecutionContext,
     metricsF: Metrics[F]
-) extends RSpaceOps[F, C, P, A, R, K](storeAtom, branch)
+) extends RSpaceOps[F, C, P, A, R, K](historyRepository, storeAtom, branch)
     with IReplaySpace[F, C, P, A, R, K] {
 
   protected[this] override val logger: Logger = Logger[this.type]
 
   implicit private[this] val MetricsSource: Metrics.Source =
     Metrics.Source(RSpaceMetricsSource, "replay")
-
-  //TODO close in some F state abstraction
-  val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
-    historyRepository
-  )
 
   def store: HotStore[F, C, P, A, K] = storeAtom.get()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpace.scala
@@ -1,0 +1,425 @@
+package coop.rchain.rspace.nextgenrspace
+
+import cats.Applicative
+import cats.effect.{Concurrent, ContextShift}
+import cats.implicits._
+import com.google.common.collect.Multiset
+import com.typesafe.scalalogging.Logger
+import coop.rchain.catscontrib.Catscontrib._
+import coop.rchain.catscontrib._
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.rspace._
+import coop.rchain.rspace.history.Branch
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.trace.{Produce, _}
+import coop.rchain.shared.Log
+import scodec.Codec
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+class ReplayRSpace[F[_], C, P, A, R, K](store: HotStore[F, C, P, A, K], branch: Branch)(
+    implicit
+    serializeC: Serialize[C],
+    serializeP: Serialize[P],
+    serializeA: Serialize[A],
+    serializeK: Serialize[K],
+    val concurrent: Concurrent[F],
+    logF: Log[F],
+    contextShift: ContextShift[F],
+    scheduler: ExecutionContext,
+    metricsF: Metrics[F]
+) extends RSpaceOps[F, C, P, A, R, K](store, branch)
+    with IReplaySpace[F, C, P, A, R, K] {
+
+  protected[this] override val logger: Logger = Logger[this.type]
+
+  implicit private[this] val MetricsSource: Metrics.Source =
+    Metrics.Source(RSpaceMetricsSource, "replay")
+
+  private[this] val consumeCommLabel = "comm.consume"
+  private[this] val produceCommLabel = "comm.produce"
+  private[this] val consumeSpanLabel = Metrics.Source(MetricsSource, "consume")
+  private[this] val produceSpanLabel = Metrics.Source(MetricsSource, "produce")
+
+  def consume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      sequenceNumber: Int
+  )(
+      implicit m: Match[F, P, A, R]
+  ): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      if (channels.length =!= patterns.length) {
+        val msg = "channels.length must equal patterns.length"
+        logF.error(msg) *> syncF.raiseError(new IllegalArgumentException(msg))
+      } else
+        for {
+          span <- metricsF.span(consumeSpanLabel)
+          _    <- span.mark("before-consume-lock")
+          result <- consumeLockF(channels) {
+                     lockedConsume(channels, patterns, continuation, persist, sequenceNumber, span)
+                   }
+          _ <- span.mark("post-consume-lock")
+        } yield result
+    }
+
+  private[this] def lockedConsume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      sequenceNumber: Int,
+      span: Span[F]
+  )(
+      implicit m: Match[F, P, A, R]
+  ): F[MaybeActionResult] = {
+    def runMatcher(comm: COMM): F[Option[Seq[DataCandidate[C, R]]]] =
+      for {
+        channelToIndexedDataList <- channels.traverse { c: C =>
+                                     store
+                                       .getData(c)
+                                       .map(_.zipWithIndex.filter {
+                                         case (Datum(_, _, source), _) =>
+                                           comm.produces.contains(source)
+                                       })
+                                       .map(v => c -> v)
+                                   }
+        result <- extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
+                   .map(_.sequence)
+      } yield result
+
+    def storeWaitingContinuation(
+        consumeRef: Consume,
+        maybeCommRef: Option[COMM]
+    ): F[MaybeActionResult] =
+      for {
+        _ <- store.putContinuation(
+              channels,
+              WaitingContinuation(patterns, continuation, persist, consumeRef)
+            )
+        _ <- channels.traverse(channel => store.putJoin(channel, channels))
+        _ <- logF.debug(s"""|consume: no data found,
+                            |storing <(patterns, continuation): ($patterns, $continuation)>
+                            |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+      } yield None
+
+    def handleMatches(
+        mats: Seq[DataCandidate[C, R]],
+        consumeRef: Consume,
+        comms: Multiset[COMM]
+    ): F[MaybeActionResult] =
+      for {
+        _       <- metricsF.incrementCounter(consumeCommLabel)
+        commRef <- syncF.delay { COMM(consumeRef, mats.map(_.datum.source)) }
+        //fixme replace with raiseError
+        _ = assert(comms.contains(commRef), "COMM Event was not contained in the trace")
+        r <- mats.toList
+              .sortBy(_.datumIndex)(Ordering[Int].reverse)
+              .traverse {
+                case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                  if (!persistData) {
+                    store.removeDatum(candidateChannel, dataIndex)
+                  } else ().pure[F]
+              }
+              .flatMap { _ =>
+                logF.debug(
+                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
+                )
+              }
+              .map { _ =>
+                removeBindingsFor(commRef)
+                val contSequenceNumber = commRef.nextSequenceNumber
+                Some(
+                  (
+                    ContResult(continuation, persist, channels, patterns, contSequenceNumber),
+                    mats.map(dc => Result(dc.datum.a, dc.datum.persist))
+                  )
+                )
+              }
+      } yield r
+
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    // TODO stop throwing exceptions
+    def getCommOrDataCandidates(comms: Seq[COMM]): F[Either[COMM, Seq[DataCandidate[C, R]]]] = {
+      type COMMOrData = Either[COMM, Seq[DataCandidate[C, R]]]
+      def go(comms: Seq[COMM]): F[Either[Seq[COMM], Either[COMM, Seq[DataCandidate[C, R]]]]] =
+        comms match {
+          case Nil =>
+            val msg = "List comms must not be empty"
+            //fixme replace with raiseError
+            logger.error(msg)
+            throw new IllegalArgumentException(msg)
+          case commRef :: Nil =>
+            runMatcher(commRef).map {
+              case Some(x) => x.asRight[COMM].asRight[Seq[COMM]]
+              case None    => commRef.asLeft[Seq[DataCandidate[C, R]]].asRight[Seq[COMM]]
+            }
+          case commRef :: rem =>
+            runMatcher(commRef).map {
+              case Some(x) => x.asRight[COMM].asRight[Seq[COMM]]
+              case None    => rem.asLeft[COMMOrData]
+            }
+        }
+      comms.tailRecM(go)
+    }
+
+    for {
+      _ <- logF.debug(s"""|consume: searching for data matching <patterns: $patterns>
+                          |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+      consumeRef <- syncF.delay {
+                     Consume.create(channels, patterns, continuation, persist, sequenceNumber)
+                   }
+      _ <- span.mark("after-compute-consumeref")
+      r <- replayData.get(consumeRef) match {
+            case None =>
+              storeWaitingContinuation(consumeRef, None)
+            case Some(comms) =>
+              val commOrDataCandidates: F[Either[COMM, Seq[DataCandidate[C, R]]]] =
+                getCommOrDataCandidates(comms.iterator().asScala.toList)
+
+              val x: F[MaybeActionResult] = commOrDataCandidates.flatMap {
+                case Left(commRef) =>
+                  storeWaitingContinuation(consumeRef, Some(commRef))
+                case Right(dataCandidates) =>
+                  handleMatches(dataCandidates, consumeRef, comms)
+              }
+              x
+          }
+    } yield r
+  }
+
+  def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int)(
+      implicit m: Match[F, P, A, R]
+  ): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      for {
+        span <- metricsF.span(produceSpanLabel)
+        _    <- span.mark("before-produce-lock")
+        result <- produceLockF(channel) {
+                   lockedProduce(channel, data, persist, sequenceNumber, span)
+                 }
+        _ <- span.mark("post-produce-lock")
+        _ <- span.close()
+      } yield result
+    }
+
+  private[this] def lockedProduce(
+      channel: C,
+      data: A,
+      persist: Boolean,
+      sequenceNumber: Int,
+      span: Span[F]
+  )(
+      implicit m: Match[F, P, A, R]
+  ): F[MaybeActionResult] = {
+
+    type MaybeProduceCandidate = Option[ProduceCandidate[C, P, R, K]]
+
+    def runMatcher(
+        comm: COMM,
+        produceRef: Produce,
+        groupedChannels: Seq[Seq[C]]
+    ): F[MaybeProduceCandidate] = {
+
+      def go(groupedChannels: Seq[Seq[C]]): F[Either[Seq[Seq[C]], MaybeProduceCandidate]] =
+        groupedChannels match {
+          case Nil => none[ProduceCandidate[C, P, R, K]].asRight[Seq[Seq[C]]].pure[F]
+          case channels :: remaining =>
+            for {
+              continuations <- store.getContinuations(channels)
+              matchCandidates = continuations.zipWithIndex.filter {
+                case (WaitingContinuation(_, _, _, source), _) =>
+                  comm.consume == source
+              }
+              channelToIndexedDataList <- channels.traverse { c: C =>
+                                           (for {
+                                             data <- store.getData(c)
+                                           } yield (data.zipWithIndex.filter {
+                                             case (Datum(_, _, source), _) =>
+                                               comm.produces.contains(source)
+                                           })).map(
+                                             as =>
+                                               c -> {
+                                                 if (c == channel)
+                                                   Seq((Datum(data, persist, produceRef), -1))
+                                                 else as
+                                               }
+                                           )
+                                         }
+              firstMatch <- extractFirstMatch(
+                             channels,
+                             matchCandidates,
+                             channelToIndexedDataList.toMap
+                           )
+            } yield firstMatch match {
+              case None             => remaining.asLeft[MaybeProduceCandidate]
+              case produceCandidate => produceCandidate.asRight[Seq[Seq[C]]]
+            }
+        }
+      groupedChannels.tailRecM(go)
+    }
+
+    @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+    // TODO stop throwing exceptions
+    def getCommOrProduceCandidate(
+        comms: Seq[COMM],
+        produceRef: Produce,
+        groupedChannels: Seq[Seq[C]]
+    ): F[Either[COMM, ProduceCandidate[C, P, R, K]]] = {
+      type COMMOrProduce = Either[COMM, ProduceCandidate[C, P, R, K]]
+      def go(comms: Seq[COMM]): F[Either[Seq[COMM], COMMOrProduce]] =
+        comms match {
+          case Nil =>
+            val msg = "comms must not be empty"
+            //fixme replace with raiseError
+            logger.error(msg)
+            throw new IllegalArgumentException(msg)
+          case commRef :: Nil =>
+            runMatcher(commRef, produceRef, groupedChannels) map {
+              case Some(x) => x.asRight[COMM].asRight[Seq[COMM]]
+              case None    => commRef.asLeft[ProduceCandidate[C, P, R, K]].asRight[Seq[COMM]]
+            }
+          case commRef :: rem =>
+            runMatcher(commRef, produceRef, groupedChannels) map {
+              case Some(x) => x.asRight[COMM].asRight[Seq[COMM]]
+              case None    => rem.asLeft[COMMOrProduce]
+            }
+        }
+      comms.tailRecM(go)
+    }
+
+    def storeDatum(
+        produceRef: Produce,
+        maybeCommRef: Option[COMM]
+    ): F[MaybeActionResult] =
+      for {
+        _ <- store.putDatum(channel, Datum(data, persist, produceRef))
+        _ <- logF.debug(s"""|produce: no matching continuation found
+                            |storing <data: $data> at <channel: $channel>""".stripMargin)
+      } yield None
+
+    def handleMatch(
+        mat: ProduceCandidate[C, P, R, K],
+        produceRef: Produce,
+        comms: Multiset[COMM]
+    ): F[MaybeActionResult] =
+      mat match {
+        case ProduceCandidate(
+            channels,
+            WaitingContinuation(patterns, continuation, persistK, consumeRef),
+            continuationIndex,
+            dataCandidates
+            ) =>
+          for {
+            _       <- metricsF.incrementCounter(produceCommLabel)
+            commRef <- syncF.delay { COMM(consumeRef, dataCandidates.map(_.datum.source)) }
+            //fixme replace with raiseError
+            _ = assert(comms.contains(commRef), "COMM Event was not contained in the trace")
+            _ <- if (!persistK) {
+                  store.removeContinuation(channels, continuationIndex)
+                } else {
+                  ().pure[F]
+                }
+            _ <- dataCandidates.toList
+                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                  .traverse {
+                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                      (if (!persistData && dataIndex >= 0) {
+                         store.removeDatum(candidateChannel, dataIndex)
+                       } else Applicative[F].unit) *>
+                        store.removeJoin(candidateChannel, channels)
+                  }
+            _ <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
+            r <- syncF.delay {
+                  removeBindingsFor(commRef)
+                  val contSequenceNumber = commRef.nextSequenceNumber
+                  Some(
+                    (
+                      ContResult(continuation, persistK, channels, patterns, contSequenceNumber),
+                      dataCandidates.map(dc => Result(dc.datum.a, dc.datum.persist))
+                    )
+                  )
+                }
+          } yield r
+      }
+
+    for {
+      groupedChannels <- store.getJoins(channel)
+      _               <- span.mark("after-fetch-joins")
+      _ <- logF.debug(
+            s"""|produce: searching for matching continuations
+                |at <groupedChannels: $groupedChannels>""".stripMargin
+              .replace('\n', ' ')
+          )
+      produceRef <- syncF.delay { Produce.create(channel, data, persist, sequenceNumber) }
+      _          <- span.mark("after-compute-produceref")
+      result <- replayData.get(produceRef) match {
+                 case None =>
+                   storeDatum(produceRef, None)
+                 case Some(comms) =>
+                   val commOrProduceCandidate: F[Either[COMM, ProduceCandidate[C, P, R, K]]] =
+                     getCommOrProduceCandidate(
+                       comms.iterator().asScala.toList,
+                       produceRef,
+                       groupedChannels
+                     )
+                   val r: F[MaybeActionResult] = commOrProduceCandidate.flatMap {
+                     case Left(comm) =>
+                       storeDatum(produceRef, Some(comm))
+                     case Right(produceCandidate) =>
+                       handleMatch(produceCandidate, produceRef, comms)
+                   }
+                   r
+               }
+    } yield result
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  @inline
+  private def removeBindingsFor(
+      commRef: COMM
+  ): Unit =
+    commRef.produces.foldLeft(replayData.removeBinding(commRef.consume, commRef)) {
+      case (updatedReplays, produceRef) =>
+        updatedReplays.removeBinding(produceRef, commRef)
+    }
+
+  def createCheckpoint(): F[Checkpoint] = ???
+
+  override def clear(): F[Unit] =
+    for {
+      _ <- syncF.delay {
+            replayData.clear()
+          }
+      _ <- super.clear()
+    } yield ()
+
+  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean] = true.pure[F]
+
+  def toMap: Map[Seq[C], Row[P, A, K]] = Map.empty
+}
+
+object ReplayRSpace {
+
+  def create[F[_], C, P, A, R, K](store: HotStore[F, C, P, A, K], branch: Branch)(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K],
+      concurrent: Concurrent[F],
+      logF: Log[F],
+      contextShift: ContextShift[F],
+      scheduler: ExecutionContext,
+      metricsF: Metrics[F]
+  ): F[ReplayRSpace[F, C, P, A, R, K]] = {
+
+    val space: ReplayRSpace[F, C, P, A, R, K] =
+      new ReplayRSpace[F, C, P, A, R, K](store, branch)
+
+    space.pure[F]
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -115,14 +115,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         resultConsume <- space.consume(channels, patterns, continuation, false)
         resultProduce <- space.produce(channels(0), datum, false)
-        rigPont       <- space.createCheckpoint()
+        rigPoint       <- space.createCheckpoint()
 
         _ = resultConsume shouldBe None
         _ = resultProduce shouldBe Some(
           (ContResult(continuation, false, channels, patterns, 1), List(Result(datum, false)))
         )
 
-        _ <- replaySpace.rig(emptyPoint.root, rigPont.log)
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
 
         replayResultConsume <- replaySpace.consume(channels, patterns, continuation, false)
         replayResultProduce <- replaySpace.produce(channels(0), datum, false)
@@ -130,7 +130,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ = replayResultConsume shouldBe None
         _ = replayResultProduce shouldBe resultProduce
-        _ = finalPoint.root shouldBe rigPont.root
+        _ = finalPoint.root shouldBe rigPoint.root
         _ = replaySpace.replayData shouldBe empty
       } yield ()
     }

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -118,7 +118,9 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         rigPont       <- space.createCheckpoint()
 
         _ = resultConsume shouldBe None
-        _ = resultProduce shouldBe defined
+        _ = resultProduce shouldBe Some(
+          (ContResult(continuation, false, channels, patterns, 1), List(Result(datum, false)))
+        )
 
         _ <- replaySpace.rig(emptyPoint.root, rigPont.log)
 

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -500,7 +500,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       } yield ()
     }
 
-  "Picking 100 datums from 100 waiting datums while doing a bunch of other junk" should "replay correctly" ignore
+  "Picking 100 datums from 100 waiting datums while doing a bunch of other junk" should "replay correctly" in
     fixture { (store, replayStore, space, replaySpace) =>
       for {
         emptyPoint <- space.createCheckpoint()

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -859,7 +859,6 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
       for {
         emptyCh <- space.createCheckpoint()
-        //some maliciously 'random' play order
         _ <- space.produce(channel1, data3, false, 0) shouldBeF noMatch
         _ <- space.produce(channel1, data3, false, 0) shouldBeF noMatch
         _ <- space.produce(channel2, data1, false, 0) shouldBeF noMatch
@@ -877,7 +876,6 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         //rig
         _ <- replaySpace.rig(emptyCh.root, afterPlay.log)
 
-        //some maliciously 'random' replay order
         _ <- replaySpace.produce(channel1, data3, false, 0) shouldBeF noMatch
         _ <- replaySpace.produce(channel1, data3, false, 0) shouldBeF noMatch
         _ <- replaySpace.produce(channel2, data1, false, 0) shouldBeF noMatch

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -61,7 +61,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
   )(
       implicit matcher: Match[Task, P, A, R]
   ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
-    range.toList.parTraverse { i: Int =>
+    shuffle(range).toList.parTraverse { i: Int =>
       logger.debug("Started consume {}", i)
       space
         .consume(channelsCreator(i), patterns, continuationCreator(i), persist)
@@ -80,7 +80,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
   )(
       implicit matcher: Match[Task, P, A, R]
   ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
-    range.toList.parTraverse { i: Int =>
+    shuffle(range).toList.parTraverse { i: Int =>
       logger.debug("Started produce {}", i)
       space.produce(channelCreator(i), datumCreator(i), persist).map { r =>
         logger.debug("Finished produce {}", i)
@@ -163,7 +163,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
           _        <- replaySpace.rig(emptyPoint.root, rigPoint.log)
           _ <- produceMany(
                 replaySpace,
-                shuffle(range),
+                range,
                 channelCreator = kp("ch1"),
                 datumCreator = i => s"datum$i",
                 persist = false
@@ -211,14 +211,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
           _ <- produceMany(
                 replaySpace,
-                shuffle(range),
+                range,
                 channelCreator = kp("ch1"),
                 datumCreator = i => s"datum$i",
                 persist = false
               )
           replayResults <- consumeMany(
                             replaySpace,
-                            shuffle(range),
+                            range,
                             channelsCreator = kp(List("ch1")),
                             patterns = List(Wildcard),
                             continuationCreator = i => s"continuation$i",
@@ -263,14 +263,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- produceMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelCreator = kp("ch1"),
               datumCreator = i => s"datum$i",
               persist = true
             )
         replayResults <- consumeMany(
                           replaySpace,
-                          shuffle(range),
+                          range,
                           channelsCreator = kp(List("ch1")),
                           patterns = List(Wildcard),
                           continuationCreator = i => s"continuation$i",
@@ -309,7 +309,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         _        <- replaySpace.rig(emptyPoint.root, rigPoint.log)
         _ <- consumeMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelsCreator = kp(List("ch1")),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -359,7 +359,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- consumeMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelsCreator = kp(List("ch1")),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -367,7 +367,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         replayResults <- produceMany(
                           replaySpace,
-                          shuffle(range),
+                          range,
                           channelCreator = kp("ch1"),
                           datumCreator = i => s"datum$i",
                           persist = false
@@ -411,7 +411,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- consumeMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelsCreator = kp(List("ch1")),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -419,7 +419,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         replayResults <- produceMany(
                           replaySpace,
-                          shuffle(range),
+                          range,
                           channelCreator = kp("ch1"),
                           datumCreator = i => s"datum$i",
                           persist = false
@@ -470,7 +470,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- consumeMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelsCreator = kp(List("ch1", "ch2")),
               patterns = List(Wildcard, Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -478,14 +478,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         _ <- produceMany(
               replaySpace,
-              shuffle(range),
+              range,
               channelCreator = kp("ch1"),
               datumCreator = kp("datum1"),
               persist = false
             )
         replayResults <- produceMany(
                           replaySpace,
-                          shuffle(range),
+                          range,
                           channelCreator = kp("ch2"),
                           datumCreator = kp("datum2"),
                           persist = false
@@ -542,14 +542,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- produceMany(
               replaySpace,
-              range = shuffle(0 until n toList),
+              range = 0 until n toList,
               channelCreator = kp("ch1"),
               datumCreator = i => s"datum$i",
               persist = false
             )
         _ <- consumeMany(
               replaySpace,
-              range = shuffle(n + 1 until n + 10 toList),
+              range = n + 1 until n + 10 toList,
               channelsCreator = i => List(s"ch$i"),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -557,14 +557,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         _ <- produceMany(
               replaySpace,
-              range = shuffle(n + 11 until n + 20 toList),
+              range = n + 11 until n + 20 toList,
               channelCreator = i => s"ch$i",
               datumCreator = i => s"datum$i",
               persist = false
             )
         replayResults <- consumeMany(
                           replaySpace,
-                          range = shuffle(0 until n toList),
+                          range = 0 until n toList,
                           channelsCreator = kp(List("ch1")),
                           patterns = List(Wildcard),
                           continuationCreator = i => s"continuation$i",
@@ -622,7 +622,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- consumeMany(
               replaySpace,
-              range = shuffle(0 until n toList),
+              range = 0 until n toList,
               channelsCreator = i => List(s"ch$i"),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -630,14 +630,14 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         _ <- produceMany(
               replaySpace,
-              range = shuffle(n + 1 until n + 10 toList),
+              range = n + 1 until n + 10 toList,
               channelCreator = kp("ch1"),
               datumCreator = i => s"datum$i",
               persist = false
             )
         _ <- consumeMany(
               replaySpace,
-              range = shuffle(n + 11 until n + 20 toList),
+              range = n + 11 until n + 20 toList,
               channelsCreator = kp(List("ch1")),
               patterns = List(Wildcard),
               continuationCreator = i => s"continuation$i",
@@ -645,7 +645,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
             )
         replayResults <- produceMany(
                           replaySpace,
-                          range = shuffle(0 until n toList),
+                          range = 0 until n toList,
                           channelCreator = i => s"ch$i",
                           datumCreator = i => s"datum$i",
                           persist = false

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -731,7 +731,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
     cp1.root shouldBe cp2.root
   }
 
-  "an install" should "be available after resetting to a checkpoint" ignore fixture {
+  "an install" should "be available after resetting to a checkpoint" in fixture {
     (store, replayStore, space, replaySpace) =>
       val channel      = "ch1"
       val datum        = "datum1"

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/ReplayRSpaceTests.scala
@@ -1,0 +1,1002 @@
+package coop.rchain.rspace.nextgenrspace
+
+import java.nio.file.{Files, Path, Paths}
+
+import cats.Functor
+import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.catscontrib.ski._
+import cats.effect._
+import cats.implicits._
+import com.typesafe.scalalogging.Logger
+import coop.rchain.metrics.Metrics
+import coop.rchain.rspace._
+import coop.rchain.rspace.examples.StringExamples._
+import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.history._
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.nextgenrspace.history.{
+  HistoryRepository,
+  HistoryRepositoryInstances,
+  LMDBRSpaceStorageConfig,
+  StoreConfig
+}
+import coop.rchain.rspace.trace.Consume
+import coop.rchain.rspace.test._
+import coop.rchain.shared.Cell
+import coop.rchain.shared.PathOps._
+import coop.rchain.shared.Log
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.execution.atomic.AtomicAny
+import org.scalatest._
+
+import scala.util.{Random, Right}
+import scodec.Codec
+
+import org.lmdbjava.EnvFlags
+
+object SchedulerPools {
+  implicit val global = Scheduler.fixedPool("GlobalPool", 20)
+  val rspacePool      = Scheduler.fixedPool("RSpacePool", 5)
+}
+
+//noinspection ZeroIndexToHead,NameBooleanParameters
+trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, String] {
+
+  import SchedulerPools.global
+
+  implicit val log: Log[Task] = new Log.NOPLog[Task]
+
+  def consumeMany[C, P, A, R, K](
+      space: ISpace[Task, C, P, A, R, K],
+      range: Range,
+      shuffle: Boolean,
+      channelsCreator: Int => List[C],
+      patterns: List[P],
+      continuationCreator: Int => K,
+      persist: Boolean
+  )(
+      implicit matcher: Match[Task, P, A, R]
+  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
+    (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
+      logger.debug("Started consume {}", i)
+      space
+        .consume(channelsCreator(i), patterns, continuationCreator(i), persist)
+        .map { r =>
+          logger.debug("Finished consume {}", i)
+          r
+        }
+    }
+
+  def produceMany[C, P, A, R, K](
+      space: ISpace[Task, C, P, A, R, K],
+      range: Range,
+      shuffle: Boolean,
+      channelCreator: Int => C,
+      datumCreator: Int => A,
+      persist: Boolean
+  )(
+      implicit matcher: Match[Task, P, A, R]
+  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[R]])]]] =
+    (if (shuffle) Random.shuffle(range.toList) else range.toList).parTraverse { i: Int =>
+      logger.debug("Started produce {}", i)
+      space.produce(channelCreator(i), datumCreator(i), persist).map { r =>
+        logger.debug("Finished produce {}", i)
+        r
+      }
+    }
+
+  "reset to a checkpoint from a different branch" should "work" in fixture {
+    (store, replayStore, space, replaySpace) =>
+      for {
+        root0 <- replaySpace.createCheckpoint().map(_.root)
+        _     = replayStore.get().isEmpty.map(_ shouldBe true)
+
+        _     <- space.produce("ch1", "datum1", false)
+        root1 <- space.createCheckpoint().map(_.root)
+
+        _ <- replaySpace.reset(root1)
+        _ <- replayStore.get().isEmpty.map(_ shouldBe true)
+
+        _ <- space.reset(root0)
+        _ <- store.get().isEmpty.map(_ shouldBe true)
+      } yield ()
+  }
+
+  "Creating a COMM Event" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      val channels     = List("ch1")
+      val patterns     = List(Wildcard)
+      val continuation = "continuation"
+      val datum        = "datum1"
+
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        resultConsume <- space.consume(channels, patterns, continuation, false)
+        resultProduce <- space.produce(channels(0), datum, false)
+        rigPont       <- space.createCheckpoint()
+
+        _ = resultConsume shouldBe None
+        _ = resultProduce shouldBe defined
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPont.log)
+
+        replayResultConsume <- replaySpace.consume(channels, patterns, continuation, false)
+        replayResultProduce <- replaySpace.produce(channels(0), datum, false)
+        finalPoint          <- space.createCheckpoint()
+
+        _ = replayResultConsume shouldBe None
+        _ = replayResultProduce shouldBe resultProduce
+        _ = finalPoint.root shouldBe rigPont.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking a datum from 100 waiting datums" should "replay correctly" in
+    fixture { (_, _, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+        _ <- produceMany(
+              space,
+              range,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        result <- space.consume(
+                   channels = List("ch1"),
+                   patterns = List(Wildcard),
+                   continuation = "continuation1",
+                   persist = false
+                 )
+        rigPoint <- space.createCheckpoint()
+        _        <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+        _ <- produceMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        replayResult <- replaySpace.consume(
+                         channels = List("ch1"),
+                         patterns = List(Wildcard),
+                         continuation = "continuation1",
+                         persist = false
+                       )
+        finalPoint <- replaySpace.createCheckpoint()
+        _          = replayResult shouldBe result
+        _          = replaySpace.replayData shouldBe empty
+        _          = finalPoint.root shouldBe rigPoint.root
+      } yield ()
+    }
+
+  "Picking 100 datums from 100 waiting datums" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+
+        _ <- produceMany(
+              space,
+              range,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        results <- consumeMany(
+                    space,
+                    range,
+                    shuffle = false,
+                    channelsCreator = kp(List("ch1")),
+                    patterns = List(Wildcard),
+                    continuationCreator = i => s"continuation$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- produceMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        replayResults <- consumeMany(
+                          replaySpace,
+                          range,
+                          shuffle = true,
+                          channelsCreator = kp(List("ch1")),
+                          patterns = List(Wildcard),
+                          continuationCreator = i => s"continuation$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking 100 datums from 100 persistent waiting datums" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+
+        _ <- produceMany(
+              space,
+              range,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = true
+            )
+        results <- consumeMany(
+                    space,
+                    range,
+                    shuffle = false,
+                    channelsCreator = kp(List("ch1")),
+                    patterns = List(Wildcard),
+                    continuationCreator = i => s"continuation$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- produceMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = true
+            )
+        replayResults <- consumeMany(
+                          replaySpace,
+                          range,
+                          shuffle = true,
+                          channelsCreator = kp(List("ch1")),
+                          patterns = List(Wildcard),
+                          continuationCreator = i => s"continuation$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking a continuation from 100 waiting continuations" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+        range      = 0 until 100
+        _ <- consumeMany(
+              space,
+              range,
+              shuffle = false,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        result <- space.produce(
+                   channel = "ch1",
+                   data = "datum1",
+                   persist = false
+                 )
+        rigPoint <- space.createCheckpoint()
+        _        <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+        _ <- consumeMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        replayResult <- replaySpace.produce(
+                         channel = "ch1",
+                         data = "datum1",
+                         persist = false
+                       )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResult shouldBe result
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking 100 continuations from 100 waiting continuations" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+
+        _ <- consumeMany(
+              space,
+              range,
+              shuffle = false,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        results <- produceMany(
+                    space,
+                    range,
+                    shuffle = false,
+                    channelCreator = kp("ch1"),
+                    datumCreator = i => s"datum$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- consumeMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        replayResults <- produceMany(
+                          replaySpace,
+                          range,
+                          shuffle = true,
+                          channelCreator = kp("ch1"),
+                          datumCreator = i => s"datum$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking 100 continuations from 100 persistent waiting continuations" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+
+        _ <- consumeMany(
+              space,
+              range,
+              shuffle = false,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = true
+            )
+        results <- produceMany(
+                    space,
+                    range,
+                    shuffle = false,
+                    channelCreator = kp("ch1"),
+                    datumCreator = i => s"datum$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- consumeMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = true
+            )
+        replayResults <- produceMany(
+                          replaySpace,
+                          range,
+                          shuffle = true,
+                          channelCreator = kp("ch1"),
+                          datumCreator = i => s"datum$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Pick 100 continuations from 100 waiting continuations stored at two channels" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        range = 0 until 100
+
+        _ <- consumeMany(
+              space,
+              range,
+              shuffle = false,
+              channelsCreator = kp(List("ch1", "ch2")),
+              patterns = List(Wildcard, Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              space,
+              range,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = kp("datum1"),
+              persist = false
+            )
+        results <- produceMany(
+                    space,
+                    range,
+                    shuffle = false,
+                    channelCreator = kp("ch2"),
+                    datumCreator = kp("datum2"),
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- consumeMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelsCreator = kp(List("ch1", "ch2")),
+              patterns = List(Wildcard, Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              replaySpace,
+              range,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = kp("datum1"),
+              persist = false
+            )
+        replayResults <- produceMany(
+                          replaySpace,
+                          range,
+                          shuffle = true,
+                          channelCreator = kp("ch2"),
+                          datumCreator = kp("datum2"),
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking 100 datums from 100 waiting datums while doing a bunch of other junk" should "replay correctly" ignore
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        _ <- produceMany(
+              space,
+              range = 0 until 100,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        _ <- consumeMany(
+              space,
+              range = 100 until 200,
+              shuffle = false,
+              channelsCreator = i => List(s"ch$i"),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              space,
+              range = 200 until 300,
+              shuffle = false,
+              channelCreator = i => s"ch$i",
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        results <- consumeMany(
+                    space,
+                    range = 0 until 100,
+                    shuffle = false,
+                    channelsCreator = kp(List("ch1")),
+                    patterns = List(Wildcard),
+                    continuationCreator = i => s"continuation$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- produceMany(
+              replaySpace,
+              range = 0 until 100,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        _ <- consumeMany(
+              replaySpace,
+              range = 100 until 200,
+              shuffle = true,
+              channelsCreator = i => List(s"ch$i"),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              replaySpace,
+              range = 200 until 300,
+              shuffle = true,
+              channelCreator = i => s"ch$i",
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        replayResults <- consumeMany(
+                          replaySpace,
+                          range = 0 until 100,
+                          shuffle = true,
+                          channelsCreator = kp(List("ch1")),
+                          patterns = List(Wildcard),
+                          continuationCreator = i => s"continuation$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Picking 100 continuations from 100 persistent waiting continuations while doing a bunch of other junk" should "replay correctly" in
+    fixture { (store, replayStore, space, replaySpace) =>
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        _ <- consumeMany(
+              space,
+              range = 0 until 100,
+              shuffle = false,
+              channelsCreator = i => List(s"ch$i"),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              space,
+              range = 100 until 200,
+              shuffle = false,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        _ <- consumeMany(
+              space,
+              range = 200 until 300,
+              shuffle = false,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        results <- produceMany(
+                    space,
+                    range = 0 until 100,
+                    shuffle = false,
+                    channelCreator = i => s"ch$i",
+                    datumCreator = i => s"datum$i",
+                    persist = false
+                  )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ <- consumeMany(
+              replaySpace,
+              range = 0 until 100,
+              shuffle = true,
+              channelsCreator = i => List(s"ch$i"),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        _ <- produceMany(
+              replaySpace,
+              range = 100 until 200,
+              shuffle = true,
+              channelCreator = kp("ch1"),
+              datumCreator = i => s"datum$i",
+              persist = false
+            )
+        _ <- consumeMany(
+              replaySpace,
+              range = 200 until 300,
+              shuffle = true,
+              channelsCreator = kp(List("ch1")),
+              patterns = List(Wildcard),
+              continuationCreator = i => s"continuation$i",
+              persist = false
+            )
+        replayResults <- produceMany(
+                          replaySpace,
+                          range = 0 until 100,
+                          shuffle = true,
+                          channelCreator = i => s"ch$i",
+                          datumCreator = i => s"datum$i",
+                          persist = false
+                        )
+        finalPoint <- replaySpace.createCheckpoint()
+
+        _ = replayResults should contain theSameElementsAs results
+        _ = finalPoint.root shouldBe rigPoint.root
+        _ = replaySpace.replayData shouldBe empty
+      } yield ()
+    }
+
+  "Replay rspace" should "correctly remove things from replay data" in fixture {
+    (store, replayStore, space, replaySpace) =>
+      val channels = List("ch1")
+      val patterns = List[Pattern](Wildcard)
+      val k        = "continuation"
+      val datum    = "datum"
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        cr = Consume.create(channels, patterns, k, persist = false)
+
+        _ <- consumeMany(
+              space,
+              range = 0 to 1,
+              shuffle = false,
+              channelsCreator = kp(channels),
+              patterns = patterns,
+              continuationCreator = kp(k),
+              persist = false
+            )
+        _ <- produceMany(
+              space,
+              range = 0 to 1,
+              shuffle = false,
+              channelCreator = kp(channels(0)),
+              datumCreator = kp(datum),
+              persist = false
+            )
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        _ = replaySpace.replayData.get(cr).map(_.size).value shouldBe 2
+
+        _ <- replaySpace.consume(channels, patterns, k, persist = false)
+        _ <- replaySpace.consume(channels, patterns, k, persist = false)
+        _ <- replaySpace.produce(channels(0), datum, persist = false)
+
+        _ = replaySpace.replayData.get(cr).map(_.size).value shouldBe 1
+
+        _ <- replaySpace.produce(channels(0), datum, persist = false)
+        _ = replaySpace.replayData.get(cr) shouldBe None
+      } yield ()
+  }
+
+  "producing" should "return same, stable checkpoint root hashes" in {
+    def process(indices: Seq[Int]): Checkpoint = fixture {
+      (store, replayStore, space, replaySpace) =>
+        Task.delay {
+          for (i <- indices) {
+            replaySpace.produce("ch1", s"datum$i", false).unsafeRunSync
+          }
+          space.createCheckpoint().unsafeRunSync
+        }
+    }
+
+    val cp1 = process(0 to 10)
+    val cp2 = process(10 to 0 by -1)
+    cp1.root shouldBe cp2.root
+  }
+
+  "an install" should "be available after resetting to a checkpoint" ignore fixture {
+    (store, replayStore, space, replaySpace) =>
+      val channel      = "ch1"
+      val datum        = "datum1"
+      val key          = List(channel)
+      val patterns     = List(Wildcard)
+      val continuation = "continuation"
+
+      for {
+        _ <- space.install(key, patterns, continuation)
+        _ <- replaySpace.install(key, patterns, continuation)
+
+        produce1     <- space.produce(channel, datum, persist = false)
+        _            = produce1 shouldBe defined
+        afterProduce <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(afterProduce.root, afterProduce.log)
+
+        produce2 <- replaySpace.produce(channel, datum, persist = false)
+        _        = produce2 shouldBe defined
+      } yield ()
+  }
+
+  "reset" should
+    """|empty the replay store,
+       |reset the replay trie updates log,
+       |and reset the replay data""".stripMargin in
+    fixture { (_, replayStore, space, replaySpace) =>
+      val channels     = List("ch1")
+      val patterns     = List(Wildcard)
+      val continuation = "continuation"
+
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        consume1 <- space.consume(channels, patterns, continuation, false)
+        _        = consume1 shouldBe None
+
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        consume2 <- replaySpace.consume(channels, patterns, continuation, false)
+        _        = consume2 shouldBe None
+
+        _ <- replayStore.get().isEmpty.map(_ shouldBe false)
+        _ <- replayStore
+              .get()
+              .changes()
+              .map(collectActions[InsertContinuations[String, Pattern, String]])
+              .map(_.length shouldBe 1)
+
+        _ <- replaySpace.reset(emptyPoint.root)
+        _ <- replayStore.get().isEmpty.map(_ shouldBe true)
+        _ = replaySpace.replayData shouldBe empty
+
+        checkpoint1 <- replaySpace.createCheckpoint()
+        _           = checkpoint1.log shouldBe empty
+      } yield ()
+    }
+
+  "clear" should
+    """|empty the replay store,
+       |reset the replay event log,
+       |reset the replay trie updates log,
+       |and reset the replay data""".stripMargin in
+    fixture { (store, replayStore, space, replaySpace) =>
+      val channels     = List("ch1")
+      val patterns     = List(Wildcard)
+      val continuation = "continuation"
+
+      for {
+        emptyPoint <- space.createCheckpoint()
+
+        consume1 <- space.consume(channels, patterns, continuation, false)
+        _        = consume1 shouldBe None
+
+        rigPoint <- space.createCheckpoint()
+
+        _ <- replaySpace.rig(emptyPoint.root, rigPoint.log)
+
+        consume2 <- replaySpace.consume(channels, patterns, continuation, false)
+        _        = consume2 shouldBe None
+
+        _ <- replayStore.get().isEmpty.map(_ shouldBe false)
+        _ <- replayStore
+              .get()
+              .changes()
+              .map(collectActions[InsertContinuations[String, Pattern, String]])
+              .map(_.length shouldBe 1)
+
+        checkpoint0 <- replaySpace.createCheckpoint()
+        _           = checkpoint0.log shouldBe empty // we don't record trace logs in ReplayRspace
+
+        _ <- replaySpace.clear()
+        _ = replayStore.get().isEmpty.map(_ shouldBe true)
+        _ = replaySpace.replayData shouldBe empty
+
+        checkpoint1 <- replaySpace.createCheckpoint()
+        _           = checkpoint1.log shouldBe empty
+      } yield ()
+    }
+
+  "replay" should "not allow for ambiguous executions" in fixture {
+    (store, replayStore, space, replaySpace) =>
+      val noMatch                 = None
+      val channel1                = "ch1"
+      val channel2                = "ch2"
+      val key1                    = List(channel1, channel2)
+      val patterns: List[Pattern] = List(Wildcard, Wildcard)
+      val continuation1           = "continuation1"
+      val continuation2           = "continuation2"
+      val data1                   = "datum1"
+      val data2                   = "datum2"
+      val data3                   = "datum3"
+
+      implicit class AnyShouldF[F[_]: Functor, T](leftSideValue: F[T]) {
+        def shouldBeF(value: T): F[Assertion] =
+          leftSideValue.map(_ shouldBe value)
+
+        def shouldNotBeF(value: T): F[Assertion] =
+          leftSideValue.map(_ should not be value)
+      }
+
+      for {
+        emptyCh <- space.createCheckpoint()
+        //some maliciously 'random' play order
+        _ <- space.produce(channel1, data3, false, 0) shouldBeF noMatch
+        _ <- space.produce(channel1, data3, false, 0) shouldBeF noMatch
+        _ <- space.produce(channel2, data1, false, 0) shouldBeF noMatch
+
+        _ <- space
+              .consume(key1, patterns, continuation1, false, 0) shouldNotBeF Option.empty
+        //continuation1 produces data1 on ch2
+        _ <- space.produce(channel2, data1, false, 1) shouldBeF noMatch
+        _ <- space
+              .consume(key1, patterns, continuation2, false, 0) shouldNotBeF Option.empty
+        //continuation2 produces data2 on ch2
+        _         <- space.produce(channel2, data2, false, 2) shouldBeF noMatch
+        afterPlay <- space.createCheckpoint()
+
+        //rig
+        _ <- replaySpace.rig(emptyCh.root, afterPlay.log)
+
+        //some maliciously 'random' replay order
+        _ <- replaySpace.produce(channel1, data3, false, 0) shouldBeF noMatch
+        _ <- replaySpace.produce(channel1, data3, false, 0) shouldBeF noMatch
+        _ <- replaySpace.produce(channel2, data1, false, 0) shouldBeF noMatch
+        _ <- replaySpace.consume(key1, patterns, continuation2, false, 0) shouldBeF noMatch
+
+        _ <- replaySpace
+              .consume(key1, patterns, continuation1, false, 0) shouldNotBeF Option.empty
+        //continuation1 produces data1 on ch2
+        _ <- replaySpace
+              .produce(channel2, data1, false, 1) shouldNotBeF Option.empty //matches continuation2
+        //continuation2 produces data2 on ch2
+        _ <- replaySpace.produce(channel2, data2, false, 1) shouldBeF noMatch
+
+        _ = replaySpace.replayData.isEmpty shouldBe true
+      } yield ()
+  }
+}
+
+trait ReplayRSpaceTestsBase[C, P, A, K] extends FlatSpec with Matchers with OptionValues {
+  val logger = Logger(this.getClass.getName.stripSuffix("$"))
+
+  override def withFixture(test: NoArgTest): Outcome = {
+    logger.debug(s"Test: ${test.name}")
+    super.withFixture(test)
+  }
+
+  def fixture[S](
+      f: (
+          AtomicAny[HotStore[Task, C, P, A, K]],
+          AtomicAny[HotStore[Task, C, P, A, K]],
+          ISpace[Task, C, P, A, A, K],
+          IReplaySpace[Task, C, P, A, A, K]
+      ) => Task[S]
+  )(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): S
+}
+
+trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C, P, A, K] {
+  import SchedulerPools.global
+  override def fixture[S](
+      f: (
+          AtomicAny[HotStore[Task, C, P, A, K]],
+          AtomicAny[HotStore[Task, C, P, A, K]],
+          ISpace[Task, C, P, A, A, K],
+          IReplaySpace[Task, C, P, A, A, K]
+      ) => Task[S]
+  )(
+      implicit
+      sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K]
+  ): S = {
+    implicit val log: Log[Task]          = Log.log[Task]
+    implicit val metricsF: Metrics[Task] = new Metrics.MetricsNOP[Task]()
+
+    val branch = Branch("inmem")
+
+    val dbDir: Path   = Files.createTempDirectory("replayrspace-test-")
+    val mapSize: Long = 1024L * 1024L * 1024L
+
+    def storeConfig(name: String): StoreConfig =
+      StoreConfig(
+        Files.createDirectories(dbDir.resolve(name)).toString,
+        mapSize,
+        2,
+        2048,
+        List(EnvFlags.MDB_NOTLS)
+      )
+
+    val config = LMDBRSpaceStorageConfig(
+      storeConfig("cold"),
+      storeConfig("history"),
+      storeConfig("pointers"),
+      storeConfig("roots")
+    )
+
+    implicit val cc = sc.toCodec
+    implicit val cp = sp.toCodec
+    implicit val ca = sa.toCodec
+    implicit val ck = sk.toCodec
+
+    (for {
+      historyRepository <- HistoryRepositoryInstances.lmdbRepository[Task, C, P, A, K](config)
+      cache <- Cell.refCell[Task, Cache[C, P, A, K]](
+                Cache[C, P, A, K]()
+              )
+      store = {
+        implicit val hr = historyRepository
+        implicit val c  = cache
+        AtomicAny(HotStore.inMem[Task, C, P, A, K])
+      }
+      space = new RSpace[Task, C, P, A, A, K](
+        historyRepository,
+        store,
+        branch
+      )
+      historyCache <- Cell.refCell[Task, Cache[C, P, A, K]](
+                       Cache[C, P, A, K]()
+                     )
+      replayStore = {
+        implicit val hr = historyRepository
+        implicit val c  = historyCache
+        AtomicAny(HotStore.inMem[Task, C, P, A, K])
+      }
+      replaySpace = new ReplayRSpace[Task, C, P, A, A, K](
+        historyRepository,
+        replayStore,
+        branch
+      )
+      res <- f(store, replayStore, space, replaySpace)
+      _   <- Sync[Task].delay(dbDir.recursivelyDelete())
+    } yield { res }).unsafeRunSync
+  }
+}
+
+class InMemoryReplayRSpaceTests
+    extends InMemoryReplayRSpaceTestsBase[String, Pattern, String, String]
+    with ReplayRSpaceTests

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageActionsTests.scala
@@ -5,6 +5,8 @@ import cats.implicits._
 import coop.rchain.rspace._
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.history.{Leaf, LeafPointer, Node, NodePointer, PointerBlock, Skip, Trie}
+import coop.rchain.rspace.test._
 import coop.rchain.rspace.util._
 import coop.rchain.rspace.internal._
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageExamplesTests.scala
@@ -13,6 +13,7 @@ import coop.rchain.rspace.examples.AddressBookExample.implicits._
 import coop.rchain.rspace.history.{initialize, Branch, ITrieStore, InMemoryTrieStore, LMDBTrieStore}
 import coop.rchain.rspace.internal.{codecGNAT, GNAT}
 import coop.rchain.rspace.util._
+import coop.rchain.rspace.test._
 import coop.rchain.shared.Cell
 import coop.rchain.shared.PathOps._
 import monix.eval.Coeval

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
@@ -59,15 +59,6 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
 
   def run[S](f: F[S]): S
 
-  import scala.reflect.ClassTag
-  def collectActions[HA <: HotStoreAction: ClassTag](changes: Seq[HotStoreAction]): Seq[HA] = {
-    val clazz = implicitly[ClassTag[HA]].runtimeClass
-    changes
-      .collect {
-        case e: HA if clazz.isInstance(e) => e
-      }
-  }
-
   protected def setupTestingSpace[S, STORE](
       createISpace: (HR, ST, Branch) => F[(ST, AtST, T)],
       f: (ST, AtST, T) => F[S]

--- a/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -94,4 +94,12 @@ package object test {
       println("---------------------")
     }
 
+  import scala.reflect.ClassTag
+  def collectActions[HA <: HotStoreAction: ClassTag](changes: Seq[HotStoreAction]): Seq[HA] = {
+    val clazz = implicitly[ClassTag[HA]].runtimeClass
+    changes
+      .collect {
+        case e: HA if clazz.isInstance(e) => e
+      }
+  }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/test/package.scala
@@ -4,7 +4,8 @@ import java.nio.ByteBuffer
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import cats.Id
+import cats._
+import cats.implicits._
 import cats.effect.{Concurrent, ContextShift, ExitCase, Fiber}
 import coop.rchain.rspace.history.{Branch, ITrieStore, Leaf, Node, Skip, Trie}
 import coop.rchain.shared.Language.ignore
@@ -101,5 +102,10 @@ package object test {
       .collect {
         case e: HA if clazz.isInstance(e) => e
       }
+  }
+
+  implicit class StoreOps[F[_]: Functor, C, P, A, K](val store: HotStore[F, C, P, A, K]) {
+    def isEmpty(): F[Boolean] =
+      store.changes().map(collectActions[InsertAction]).map(_.isEmpty)
   }
 }


### PR DESCRIPTION
## Overview
Part of the RSpace reorganization epic. Adapts ReplayRSpace to work with the new HotStore


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3255


### Notes
Depends on:
https://github.com/rchain/rchain/pull/2392
https://github.com/rchain/rchain/pull/2394


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
