### PR TITLE
New rspace/join removal shouldnt fail

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -190,13 +190,13 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
       continuations <- getContinuations(join)
       _ <- if (continuations.isEmpty) S.flatModify { cache =>
             val index = cache.joins(channel).indexOf(join)
-            removeIndex(cache.joins(channel), index) >>= { updated =>
+            if (index != -1) removeIndex(cache.joins(channel), index) >>= { updated =>
               Sync[F]
                 .delay {
                   cache.joins.put(channel, updated)
                 }
                 .map(_ => cache)
-            }
+            } else cache.pure[F]
           } else Applicative[F].unit
     } yield ()
 

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -55,12 +55,10 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
               case None =>
                 for {
                   historyContinuations <- HR.getContinuations(channels)
-                  _ <- S.flatModify { c =>
+                  _ <- S.flatModify { cache =>
                         Sync[F]
-                          .delay(c.continuations.putIfAbsent(channels, historyContinuations))
-                          .map { _ =>
-                            c
-                          }
+                          .delay(cache.continuations.putIfAbsent(channels, historyContinuations))
+                          .as(cache)
                       }
                 } yield (historyContinuations)
               case Some(continuations) => Applicative[F].pure(continuations)
@@ -71,7 +69,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
     for {
       continuations <- internalGetContinuations(channels)
       _ <- S.flatModify { cache =>
-            Sync[F].delay(cache.continuations.put(channels, wc +: continuations)).map(_ => cache)
+            Sync[F].delay(cache.continuations.put(channels, wc +: continuations)).as(cache)
           }
     } yield ()
 
@@ -101,7 +99,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
                       case None    => cache.continuations.put(channels, updated)
                     }
                   }
-                  .map(_ => cache)
+                  .as(cache)
               }
             }
     } yield ()
@@ -113,8 +111,8 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
               case None =>
                 for {
                   historyData <- HR.getData(channel)
-                  _ <- S.flatModify { c =>
-                        Sync[F].delay(c.data.putIfAbsent(channel, historyData)).map(_ => c)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.data.putIfAbsent(channel, historyData)).as(cache)
                       }
                 } yield (historyData)
               case Some(data) => Applicative[F].pure(data)
@@ -125,7 +123,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
     for {
       data <- getData(channel)
       _ <- S.flatModify { cache =>
-            Sync[F].delay(cache.data.put(channel, datum +: data)).map(_ => cache)
+            Sync[F].delay(cache.data.put(channel, datum +: data)).as(cache)
           }
     } yield ()
 
@@ -138,7 +136,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
                 .delay {
                   cache.data.put(channel, updated)
                 }
-                .map(_ => cache)
+                .as(cache)
             }
           }
     } yield ()
@@ -156,8 +154,8 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
               case None =>
                 for {
                   historyJoins <- HR.getJoins(channel)
-                  _ <- S.flatModify { c =>
-                        Sync[F].delay(c.joins.putIfAbsent(channel, historyJoins)).map(_ => c)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.joins.putIfAbsent(channel, historyJoins)).as(cache)
                       }
                 } yield (historyJoins)
               case Some(joins) => Applicative[F].pure(joins)
@@ -168,7 +166,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
     for {
       joins <- getJoins(channel)
       _ <- if (!joins.contains(join)) S.flatModify { cache =>
-            Sync[F].delay(cache.joins.put(channel, join +: joins)).map(_ => cache)
+            Sync[F].delay(cache.joins.put(channel, join +: joins)).as(cache)
           } else Applicative[F].unit
     } yield ()
 
@@ -195,7 +193,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
                 .delay {
                   cache.joins.put(channel, updated)
                 }
-                .map(_ => cache)
+                .as(cache)
             } else cache.pure[F]
           } else Applicative[F].unit
     } yield ()

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -218,7 +218,12 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _     <- history.putContinuations(channels, historyContinuations)
             res   <- hotStore.removeContinuation(channels, index).attempt
             cache <- state.read
-            _     <- checkRemoval(res, cache.continuations(channels), historyContinuations, index)
+            _ <- checkRemovalWorksOrFailsOnError(
+                  res,
+                  cache.continuations(channels),
+                  historyContinuations,
+                  index
+                )
           } yield ()
         }
       }
@@ -245,7 +250,12 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                 )
             res   <- hotStore.removeContinuation(channels, index).attempt
             cache <- state.read
-            _     <- checkRemoval(res, cache.continuations(channels), cachedContinuations, index)
+            _ <- checkRemovalWorksOrFailsOnError(
+                  res,
+                  cache.continuations(channels),
+                  cachedContinuations,
+                  index
+                )
           } yield ()
         }
       }
@@ -280,7 +290,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   } else
                   // index of the removed continuation includes the installed
                   hotStore.getContinuations(channels) >>= { continuations =>
-                    checkRemoval(
+                    checkRemovalWorksOrFailsOnError(
                       res,
                       continuations,
                       installedContinuation +: cachedContinuations,
@@ -392,7 +402,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _     <- history.putData(channel, historyData)
             res   <- hotStore.removeDatum(channel, index).attempt
             cache <- state.read
-            _     <- checkRemoval(res, cache.data(channel), historyData, index)
+            _     <- checkRemovalWorksOrFailsOnError(res, cache.data(channel), historyData, index)
           } yield ()
         }
       }
@@ -419,7 +429,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                 )
             res   <- hotStore.removeDatum(channel, index).attempt
             cache <- state.read
-            _     <- checkRemoval(res, cache.data(channel), cachedData, index)
+            _     <- checkRemovalWorksOrFailsOnError(res, cache.data(channel), cachedData, index)
           } yield ()
         }
       }
@@ -630,7 +640,12 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             toRemove = historyJoins.get(index.toLong).getOrElse(join)
             res      <- hotStore.removeJoin(channel, toRemove).attempt
             cache    <- state.read
-            _        <- checkRemoval(res, cache.joins(channel), historyJoins, index, shouldFail = false)
+            _ <- checkRemovalWorksOrIgnoresErrors(
+                  res,
+                  cache.joins(channel),
+                  historyJoins,
+                  index
+                )
           } yield ()
         }
       }
@@ -660,7 +675,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   )
               res   <- hotStore.removeJoin(channel, toRemove).attempt
               cache <- state.read
-              _     <- checkRemoval(res, cache.joins(channel), cachedJoins, index, shouldFail = false)
+              _     <- checkRemovalWorksOrIgnoresErrors(res, cache.joins(channel), cachedJoins, index)
             } yield ()
           }
         }
@@ -847,18 +862,31 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       }
   }
 
-  private def checkRemoval[T](
+  private def checkRemovalWorksOrFailsOnError[T](
       res: Either[Throwable, Unit],
       actual: Seq[T],
       initial: Seq[T],
-      index: Int,
-      shouldFail: Boolean = true
+      index: Int
   ): F[Assertion] = S.delay {
     if (index < 0 || index >= initial.size) {
-      if (shouldFail)
-        res shouldBe a[Left[_, _]]
-      else
-        res shouldBe a[Right[_, _]]
+      res shouldBe a[Left[_, _]]
+      actual shouldEqual initial
+    } else {
+      res shouldBe a[Right[_, _]]
+      actual shouldEqual initial.zipWithIndex
+        .filter { case (_, i) => i != index }
+        .map(_._1)
+    }
+  }
+
+  private def checkRemovalWorksOrIgnoresErrors[T](
+      res: Either[Throwable, Unit],
+      actual: Seq[T],
+      initial: Seq[T],
+      index: Int
+  ): F[Assertion] = S.delay {
+    if (index < 0 || index >= initial.size) {
+      res shouldBe a[Right[_, _]]
       actual shouldEqual initial
     } else {
       res shouldBe a[Right[_, _]]

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageActionsTests.scala
@@ -406,7 +406,7 @@ trait StorageActionsTests[F[_]]
   }
 
   "A joined consume with the same channel given twice followed by a produce" should
-    "not raise any errors (CORE-365)" ignore withTestSpace { (store, space) =>
+    "not raise any errors (CORE-365)" in withTestSpace { (store, space) =>
     val channels = List("ch1", "ch1")
 
     for {


### PR DESCRIPTION
## Overview
Aligns join removal with the previous implementation - failure to remove a join shouldn't raise errors


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3256


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
