### PR TITLE
Slashing invalid blocks

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -83,6 +83,23 @@ new  PoS,
                   deposit!(userPk, amount, *returnCh)
                 }
               }
+            } |
+
+            contract PoS(@"slash", @blockHash, return) = {
+              new userCh, invalidBlocksCh, getInvalidBlocks(`rho:casper:invalidBlocks`) in {
+                getInvalidBlocks!(*invalidBlocksCh) |
+                getUser!(*userCh) |
+                for (@invalidBlocks <- invalidBlocksCh; @bonds <- bondsCh; @userPk <- userCh) {
+                  new toBeSlashed in {
+                    toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
+                    for (@validator <- toBeSlashed) {
+                      // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
+                      bondsCh!(bonds.set(validator, [0, bonds.get(validator).nth(1)])) |
+                      return!(true)
+                    }
+                  }
+                }
+              }
             }
           }
         } |

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -94,7 +94,7 @@ new  PoS,
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
                       // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
-                      bondsCh!(bonds.set(validator, [0, bonds.get(validator).nth(1)])) |
+                      bondsCh!(bonds.set(validator, (0, bonds.get(validator).nth(1)))) |
                       return!(true)
                     }
                   }

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -52,7 +52,6 @@ object BlockCreator {
       maxBlockNumber        = ProtoUtil.maxBlockNumber(parents)
       invalidLatestMessages <- ProtoUtil.invalidLatestMessages[F](dag)
       _ <- invalidLatestMessages.values.toList.traverse { invalidBlockHash =>
-            // TODO: Note this snippet calls the new PoS contract so it will currently do nothing
             val encodedInvalidBlockHash = Base16.encode(invalidBlockHash.toByteArray)
             val deploy = ConstructDeploy.sourceDeploy(
               s"""

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -57,7 +57,7 @@ object BlockCreator {
             val deploy = ConstructDeploy.sourceDeploy(
               s"""
                  |new rl(`rho:registry:lookup`), posCh in {
-                 |  rl!(`rho:id:cnec3pa8prp4out3yc8facon6grm3xbsotpd4ckjfx8ghuw77xadzt`, *posCh) |
+                 |  rl!(`rho:rchain:pos`, *posCh) |
                  |  for(@(_, PoS) <- posCh) {
                  |    @PoS!("slash", "$encodedInvalidBlockHash".hexToBytes(), "IGNOREFORNOW")
                  |  }

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -55,13 +55,14 @@ object BlockCreator {
             val encodedInvalidBlockHash = Base16.encode(invalidBlockHash.toByteArray)
             val deploy = ConstructDeploy.sourceDeploy(
               s"""
-                 |new rl(`rho:registry:lookup`), posCh in {
-                 |  rl!(`rho:rchain:pos`, *posCh) |
-                 |  for(@(_, PoS) <- posCh) {
-                 |    @PoS!("slash", "$encodedInvalidBlockHash".hexToBytes(), "IGNOREFORNOW")
-                 |  }
-                 |}
-            """.stripMargin,
+                 #new rl(`rho:registry:lookup`), posCh in {
+                 #  rl!(`rho:rchain:pos`, *posCh) |
+                 #  for(@(_, PoS) <- posCh) {
+                 #    @PoS!("slash", "$encodedInvalidBlockHash".hexToBytes(), "IGNOREFORNOW")
+                 #  }
+                 #}
+                 #
+              """.stripMargin('#'),
               System.currentTimeMillis(),
               accounting.MAX_VALUE,
               sec = privateKey

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -12,6 +12,7 @@ import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockS
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.DeployError._
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.ConstructDeploy.{defaultSec, sourceDeploy}
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util._
 import coop.rchain.casper.util.comm.CommUtil
@@ -21,11 +22,13 @@ import coop.rchain.catscontrib.BooleanF._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.TransportLayer
+import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord
 import coop.rchain.models.Validator.Validator
+import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.shared._
 
 /**

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -380,9 +380,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
          */
         Log[F].info(
           s"Did not add block ${PrettyPrinter.buildString(block.blockHash)} as that would add an equivocation to the BlockDAG"
-        ) *> dag.pure[F]
+        ) >> dag.pure[F]
       case InvalidUnslashableBlock =>
-        handleInvalidBlockEffect(status, block)
+        Log[F].warn(
+          s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}."
+        ) >> dag.pure[F]
       case InvalidFollows =>
         handleInvalidBlockEffect(status, block)
       case InvalidBlockNumber =>

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -488,6 +488,7 @@ object Validate {
       } yield Left(InvalidShardId)
     }
 
+  // TODO: Double check this validation isn't shadowed by the blockSignature validation
   def blockHash[F[_]: Applicative: Log](b: BlockMessage): F[Either[InvalidBlock, ValidBlock]] = {
     val blockHashComputed = ProtoUtil.hashSignedBlock(
       b.header.get,

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -98,11 +98,7 @@ object ProtoUtil {
       }
 
   def creatorJustification(block: BlockMetadata): Option[Justification] =
-    block.justifications
-      .find {
-        case Justification(validator: Validator, _) =>
-          validator == block.sender
-      }
+    block.justifications.find(justification => justification.validator == block.sender)
 
   /**
     * Since the creator justification is unique

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -154,7 +154,10 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
             Expr.ExprInstance.EMapBody(
               ParMap(SortedParMap(invalidBlocks.map {
                 case (validator, blockHash) =>
-                  (byteStringToPar(validator), byteStringToPar(blockHash))
+                  (
+                    RhoType.ByteArray(validator.toByteArray),
+                    RhoType.ByteArray(blockHash.toByteArray)
+                  )
               }))
             )
           )
@@ -162,9 +165,6 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
       )
     runtime.invalidBlocks.setParams(invalidBlocksPar)
   }
-
-  private def byteStringToPar(b: ByteString): Par =
-    Par(exprs = Seq(Expr(Expr.ExprInstance.GByteArray(b))))
 
   def computeBonds(hash: StateHash): F[Seq[Bond]] =
     captureResults(hash, ConstructDeploy.sourceDeployNow(bondsQuerySource()))

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -14,6 +14,8 @@ import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.comm.rp.ProtocolHelper.packet
 import coop.rchain.comm.transport
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -545,6 +547,30 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
           _    = v3.logEff.warns shouldBe empty
         } yield ()
       }
+  }
+
+  // TODO: Enable when we switch to new PoS contract
+  it should "succeed at slashing" ignore effectTest {
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      for {
+        deployData            <- ConstructDeploy.basicDeployData[Effect](0)
+        createBlockResult     <- nodes(0).casperEff.deploy(deployData) >> nodes(0).casperEff.createBlock
+        Created(signedBlock)  = createBlockResult
+        invalidBlock          = signedBlock.withSeqNum(47)
+        _                     <- nodes(1).casperEff.addBlock(invalidBlock, ignoreDoppelgangerCheck[Effect])
+        _                     <- nodes(2).casperEff.addBlock(invalidBlock, ignoreDoppelgangerCheck[Effect])
+        createBlockResult2    <- nodes(1).casperEff.createBlock
+        Created(signedBlock2) = createBlockResult2
+        _                     <- nodes(1).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
+        bonds                 <- nodes(1).runtimeManager.computeBonds(ProtoUtil.postStateHash(signedBlock2))
+        _                     = bonds.map(_.stake).min should be(0) // Slashed validator has 0 stake
+        _                     <- nodes(2).receive()
+        createBlockResult3    <- nodes(2).casperEff.createBlock
+        Created(signedBlock3) = createBlockResult3
+        _                     <- nodes(2).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
+        // assert no effect as already slashed
+      } yield ()
+    }
   }
 
   private def buildBlockWithInvalidJustification(

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -549,8 +549,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
       }
   }
 
-  // TODO: Enable when we switch to new PoS contract
-  it should "succeed at slashing" ignore effectTest {
+  it should "succeed at slashing" in effectTest {
     HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
       for {
         deployData            <- ConstructDeploy.basicDeployData[Effect](0)
@@ -568,7 +567,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
         createBlockResult3    <- nodes(2).casperEff.createBlock
         Created(signedBlock3) = createBlockResult3
         _                     <- nodes(2).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
-        // assert no effect as already slashed
+        // TODO: assert no effect as already slashed
       } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
@@ -9,5 +9,5 @@ class AuthKeySpec
     extends RhoSpec(
       CompiledRholangSource("AuthKeyTest.rho"),
       Seq.empty,
-      20.seconds
+      60.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
@@ -3,11 +3,9 @@ package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
 
-import scala.concurrent.duration._
-
 class AuthKeySpec
     extends RhoSpec(
       CompiledRholangSource("AuthKeyTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
@@ -4,4 +4,8 @@ import coop.rchain.rholang.build.CompiledRholangSource
 import scala.concurrent.duration._
 
 class DeployDataContractSpec
-    extends RhoSpec(CompiledRholangSource("DeployDataContractTest.rho"), Seq.empty, 30.seconds)
+    extends RhoSpec(
+      CompiledRholangSource("DeployDataContractTest.rho"),
+      Seq.empty,
+      GENESIS_TEST_TIMEOUT
+    )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -8,5 +8,5 @@ class EitherSpec
     extends RhoSpec(
       CompiledRholangSource("EitherTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -8,5 +8,5 @@ class EitherSpec
     extends RhoSpec(
       CompiledRholangSource("EitherTest.rho"),
       Seq.empty,
-      20.seconds
+      60.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
@@ -7,5 +7,5 @@ class LockboxSpec
     extends RhoSpec(
       CompiledRholangSource("LockboxTest.rho"),
       Seq.empty,
-      20.seconds
+      60.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
@@ -7,5 +7,5 @@ class LockboxSpec
     extends RhoSpec(
       CompiledRholangSource("LockboxTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -9,5 +9,5 @@ class MakeMintSpec
     extends RhoSpec(
       CompiledRholangSource("MakeMintTest.rho"),
       Seq.empty,
-      20.seconds
+      60.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -9,5 +9,5 @@ class MakeMintSpec
     extends RhoSpec(
       CompiledRholangSource("MakeMintTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -8,5 +8,5 @@ class NonNegativeNumberSpec
     extends RhoSpec(
       CompiledRholangSource("NonNegativeNumberTest.rho"),
       Seq.empty,
-      20.seconds
+      60.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -8,5 +8,5 @@ class NonNegativeNumberSpec
     extends RhoSpec(
       CompiledRholangSource("NonNegativeNumberTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -9,5 +9,5 @@ class PoSSpec
     extends RhoSpec(
       CompiledRholangSource("PoSTest.rho"),
       Seq.empty,
-      60.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -5,4 +5,4 @@ import coop.rchain.rholang.build.CompiledRholangSource
 import scala.concurrent.duration._
 
 class RevAddressSpec
-    extends RhoSpec(CompiledRholangSource("RevAddressTest.rho"), Seq.empty, 60.seconds)
+    extends RhoSpec(CompiledRholangSource("RevAddressTest.rho"), Seq.empty, GENESIS_TEST_TIMEOUT)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -5,4 +5,4 @@ import coop.rchain.rholang.build.CompiledRholangSource
 import scala.concurrent.duration._
 
 class RevAddressSpec
-    extends RhoSpec(CompiledRholangSource("RevAddressTest.rho"), Seq.empty, 20.seconds)
+    extends RhoSpec(CompiledRholangSource("RevAddressTest.rho"), Seq.empty, 60.seconds)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -9,5 +9,5 @@ class RevVaultSpec
     extends RhoSpec(
       CompiledRholangSource("RevVaultTest.rho"),
       Seq.empty,
-      30.seconds
+      GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
@@ -5,4 +5,4 @@ import coop.rchain.rholang.build.CompiledRholangSource
 import scala.concurrent.duration._
 
 class RhoSpecContractSpec
-    extends RhoSpec(CompiledRholangSource("RhoSpecContractTest.rho"), Seq.empty, 20.seconds)
+    extends RhoSpec(CompiledRholangSource("RhoSpecContractTest.rho"), Seq.empty, 60.seconds)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
@@ -5,4 +5,8 @@ import coop.rchain.rholang.build.CompiledRholangSource
 import scala.concurrent.duration._
 
 class RhoSpecContractSpec
-    extends RhoSpec(CompiledRholangSource("RhoSpecContractTest.rho"), Seq.empty, 60.seconds)
+    extends RhoSpec(
+      CompiledRholangSource("RhoSpecContractTest.rho"),
+      Seq.empty,
+      GENESIS_TEST_TIMEOUT
+    )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/package.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/package.scala
@@ -1,0 +1,7 @@
+package coop.rchain.casper.genesis
+
+import scala.concurrent.duration._
+
+package object contracts {
+  val GENESIS_TEST_TIMEOUT = 60.seconds
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -25,7 +25,7 @@ object RhoSpec {
       testResultCollector: TestResultCollector[F]
   ): Seq[SystemProcess.Definition[F]] = {
     val testResultCollectorService =
-      Seq((5, "assertAck", 25), (1, "testSuiteCompleted", 26))
+      Seq((5, "assertAck", 26), (1, "testSuiteCompleted", 27))
         .map {
           case (arity, name, n) =>
             SystemProcess.Definition[F](
@@ -38,16 +38,16 @@ object RhoSpec {
         } ++ Seq(
         SystemProcess.Definition[F](
           "rho:io:stdlog",
-          Runtime.byteName(27),
+          Runtime.byteName(28),
           2,
-          27L,
+          28L,
           ctx => RhoLoggerContract.handleMessage(ctx)(_, _)
         ),
         SystemProcess.Definition[F](
           "rho:test:deploy:set",
-          Runtime.byteName(28),
+          Runtime.byteName(29),
           3,
-          28L,
+          29L,
           ctx => DeployDataContract.set(ctx)(_, _)
         )
       )

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -25,7 +25,7 @@ object RhoSpec {
       testResultCollector: TestResultCollector[F]
   ): Seq[SystemProcess.Definition[F]] = {
     val testResultCollectorService =
-      Seq((5, "assertAck", 26), (1, "testSuiteCompleted", 27))
+      Seq((5, "assertAck", 101), (1, "testSuiteCompleted", 102))
         .map {
           case (arity, name, n) =>
             SystemProcess.Definition[F](
@@ -38,16 +38,16 @@ object RhoSpec {
         } ++ Seq(
         SystemProcess.Definition[F](
           "rho:io:stdlog",
-          Runtime.byteName(28),
+          Runtime.byteName(103),
           2,
-          28L,
+          103L,
           ctx => RhoLoggerContract.handleMessage(ctx)(_, _)
         ),
         SystemProcess.Definition[F](
           "rho:test:deploy:set",
-          Runtime.byteName(29),
+          Runtime.byteName(104),
           3,
-          29L,
+          104L,
           ctx => DeployDataContract.set(ctx)(_, _)
         )
       )

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -1,14 +1,17 @@
 package coop.rchain.casper.util
 
-import com.google.protobuf.ByteString
+import cats.implicits._
+import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper._
-import coop.rchain.casper.protocol._
+import coop.rchain.casper.helper.HashSetCasperTestNode
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.models.blockImplicits._
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen.listOfN
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import monix.execution.Scheduler.Implicits.global
 
 class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
 
@@ -22,6 +25,61 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
       result should contain allElementsOf (justificationsHashes)
       result should contain allElementsOf (parentsHashes)
       result should contain theSameElementsAs ((justificationsHashes ++ parentsHashes).toSet)
+    }
+  }
+
+  import MultiParentCasperTestUtil._
+
+  implicit val timeEff = new LogicalTime[Effect]
+
+  private val (validatorKeys, validatorPks) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
+  private val genesis = buildGenesis(
+    buildGenesisParameters(4, createBonds(validatorPks))
+  )
+
+  "unseenBlockHashes" should "return empty for a single block dag" in effectTest {
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
+
+      for {
+        deploy               <- ConstructDeploy.basicDeployData[Effect](0)
+        casper               = node.casperEff
+        _                    <- casper.deploy(deploy)
+        createBlockResult    <- casper.createBlock
+        Created(signedBlock) = createBlockResult
+        _                    <- casper.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        dag                  <- casper.blockDag
+        unseenBlockHashes    <- ProtoUtil.unseenBlockHashes[Effect](dag, signedBlock)
+        _                    = unseenBlockHashes should be(Set.empty[BlockHash])
+      } yield ()
+    }
+  }
+
+  it should "return all but the first block when passed the first block in a chain" in effectTest {
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
+
+      for {
+        deploy            <- ConstructDeploy.basicDeployData[Effect](0)
+        casper            = node.casperEff
+        _                 <- casper.deploy(deploy)
+        createBlockResult <- casper.createBlock
+        Created(block0)   = createBlockResult
+        _                 <- casper.addBlock(block0, ignoreDoppelgangerCheck[Effect])
+        _ <- (1 to 8).toList.traverse_[Effect, Unit] { i =>
+              for {
+                deploy            <- ConstructDeploy.basicDeployData[Effect](i)
+                createBlockResult <- casper.deploy(deploy) *> casper.createBlock
+                Created(block)    = createBlockResult
+                _                 <- casper.addBlock(block, ignoreDoppelgangerCheck[Effect])
+              } yield ()
+            }
+        dag               <- casper.blockDag
+        unseenBlockHashes <- ProtoUtil.unseenBlockHashes[Effect](dag, block0)
+        _                 = unseenBlockHashes.size should be(8)
+      } yield ()
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -9,7 +9,8 @@ import coop.rchain.models.blockImplicits._
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import coop.rchain.casper.scalatestcontrib._
-import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import monix.execution.Scheduler.Implicits.global
 
@@ -32,7 +33,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
 
   implicit val timeEff = new LogicalTime[Effect]
 
-  private val (validatorKeys, validatorPks) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
+  private val (validatorKeys, validatorPks) = (1 to 4).map(_ => Secp256k1.newKeyPair).unzip
   private val genesis = buildGenesis(
     buildGenesisParameters(validatorKeys.length, createBonds(validatorPks))
   )

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -68,17 +68,13 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
         createBlockResult <- casper.createBlock
         Created(block0)   = createBlockResult
         _                 <- casper.addBlock(block0, ignoreDoppelgangerCheck[Effect])
-        _ <- (1 to 8).toList.traverse_[Effect, Unit] { i =>
-              for {
-                deploy            <- ConstructDeploy.basicDeployData[Effect](i)
-                createBlockResult <- casper.deploy(deploy) *> casper.createBlock
-                Created(block)    = createBlockResult
-                _                 <- casper.addBlock(block, ignoreDoppelgangerCheck[Effect])
-              } yield ()
-            }
+        deploy            <- ConstructDeploy.basicDeployData[Effect](1)
+        createBlockResult <- casper.deploy(deploy) >> casper.createBlock
+        Created(block1)   = createBlockResult
+        _                 <- casper.addBlock(block1, ignoreDoppelgangerCheck[Effect])
         dag               <- casper.blockDag
         unseenBlockHashes <- ProtoUtil.unseenBlockHashes[Effect](dag, block0)
-        _                 = unseenBlockHashes.size should be(8)
+        _                 = unseenBlockHashes should be(Set(block1.blockHash))
       } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -34,7 +34,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
 
   private val (validatorKeys, validatorPks) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
   private val genesis = buildGenesis(
-    buildGenesisParameters(4, createBonds(validatorPks))
+    buildGenesisParameters(validatorKeys.length, createBonds(validatorPks))
   )
 
   "unseenBlockHashes" should "return empty for a single block dag" in effectTest {


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Add "slash" method in PoS and `rho:casper:invalidBlocks`

In the block creator, we queue up a slashing deploy
that calls the "slash" method in the new PoS contract.
Note this doesn't actually do anything yet as our source
of truth for bonds right now is still the old PoS contract

`ProtoUtil.unseenBlockHashes` (used in rho:casper:invalidBlocks)

When we pass the list of slashable blocks to Rholang,
we need to exclude all the blocks that the slasher
hasn't justified as seen yet.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-2381

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
