### PR TITLE
Add invalid blocks storage

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -37,6 +37,7 @@ private final case class BlockDagFileStorageState[F[_]: Sync](
     dataLookup: Map[BlockHash, BlockMetadata],
     topoSort: Vector[Vector[BlockHash]],
     equivocationsTracker: Set[EquivocationRecord],
+    invalidBlocks: Set[BlockMetadata],
     sortOffset: Long,
     checkpoints: List[Checkpoint],
     latestMessagesLogOutputStream: FileOutputStreamIO[F],
@@ -45,7 +46,9 @@ private final case class BlockDagFileStorageState[F[_]: Sync](
     blockMetadataLogOutputStream: FileOutputStreamIO[F],
     blockMetadataCrc: Crc32[F],
     equivocationsTrackerLogOutputStream: FileOutputStreamIO[F],
-    equivocationsTrackerCrc: Crc32[F]
+    equivocationsTrackerCrc: Crc32[F],
+    invalidBlocksLogOutputStream: FileOutputStreamIO[F],
+    invalidBlocksCrc: Crc32[F]
 )
 
 final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] private (
@@ -58,6 +61,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     blockMetadataCrcPath: Path,
     equivocationTrackerLogPath: Path,
     equivocationTrackerCrcPath: Path,
+    invalidBlocksLogPath: Path,
+    invalidBlocksCrcPath: Path,
     state: MonadState[F, BlockDagFileStorageState[F]]
 ) extends BlockDagStorage[F] {
   implicit private val logSource = LogSource(BlockDagFileStorage.getClass)
@@ -74,6 +79,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.get.map(_.sortOffset)
   private[this] def getEquviocationsTracker: F[Set[EquivocationRecord]] =
     state.get.map(_.equivocationsTracker)
+  private[this] def getInvalidBlocks: F[Set[BlockMetadata]] =
+    state.get.map(_.invalidBlocks)
   private[this] def getCheckpoints: F[List[Checkpoint]] =
     state.get.map(_.checkpoints)
   private[this] def getLatestMessagesLogOutputStream: F[FileOutputStreamIO[F]] =
@@ -90,6 +97,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.get.map(_.equivocationsTrackerLogOutputStream)
   private[this] def getEquivocationsTrackerCrc: F[Crc32[F]] =
     state.get.map(_.equivocationsTrackerCrc)
+  private[this] def getInvalidBlocksLogOutputStream: F[FileOutputStreamIO[F]] =
+    state.get.map(_.invalidBlocksLogOutputStream)
+  private[this] def getInvalidBlocksCrc: F[Crc32[F]] =
+    state.get.map(_.invalidBlocksCrc)
 
   private[this] def setLatestMessages(v: Map[Validator, BlockHash]): F[Unit] =
     state.modify(s => s.copy(latestMessages = v))
@@ -119,6 +130,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.modify(s => s.copy(equivocationsTrackerLogOutputStream = v))
   private[this] def setEquivocationsTrackerCrc(v: Crc32[F]): F[Unit] =
     state.modify(s => s.copy(equivocationsTrackerCrc = v))
+  private[this] def setInvalidBlocksLogOutputStream(v: FileOutputStreamIO[F]): F[Unit] =
+    state.modify(s => s.copy(equivocationsTrackerLogOutputStream = v))
 
   private[this] def modifyLatestMessages(
       f: Map[Validator, BlockHash] => Map[Validator, BlockHash]
@@ -140,6 +153,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       f: Set[EquivocationRecord] => Set[EquivocationRecord]
   ): F[Unit] =
     state.modify(s => s.copy(equivocationsTracker = f(s.equivocationsTracker)))
+  private[this] def modifyInvalidBlocks(
+      f: Set[BlockMetadata] => Set[BlockMetadata]
+  ): F[Unit] =
+    state.modify(s => s.copy(invalidBlocks = f(s.invalidBlocks)))
   private[this] def modifySortOffset(f: Long => Long): F[Unit] =
     state.modify(s => s.copy(sortOffset = f(s.sortOffset)))
   private[this] def modifyCheckpoints(f: List[Checkpoint] => List[Checkpoint]): F[Unit] =
@@ -182,6 +199,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       childMap: Map[BlockHash, Set[BlockHash]],
       dataLookup: Map[BlockHash, BlockMetadata],
       topoSortVector: Vector[Vector[BlockHash]],
+      invalidBlocksSet: Set[BlockMetadata],
       sortOffset: Long
   ) extends BlockDagRepresentation[F] {
     private def findAndAccessCheckpoint[R](
@@ -275,6 +293,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
           case (validator, hash) => lookup(hash).map(validator -> _.get)
         }
         .map(_.toMap)
+    def invalidBlocks: F[Set[BlockMetadata]] =
+      invalidBlocksSet.pure[F]
   }
 
   private object FileEquivocationsTracker extends EquivocationsTracker[F] {
@@ -430,12 +450,16 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       _                                   <- updateCrcFile(equivocationsTrackerCrc, equivocationTrackerCrcPath)
     } yield ()
 
-  private def updateEquivocationsTrackerCrcFile(newCrc: Crc32[F]): F[Unit] =
+  private def updateInvalidBlocksFile(newBlockMetadata: BlockMetadata): F[Unit] =
     for {
-      newCrcBytes <- newCrc.bytes
-      tmpCrc      <- createSameDirectoryTemporaryFile(equivocationTrackerCrcPath)
-      _           <- writeToFile[F](tmpCrc, newCrcBytes)
-      _           <- replaceFile(tmpCrc, equivocationTrackerCrcPath)
+      invalidBlocksCrc             <- getInvalidBlocksCrc
+      invalidBlocksLogOutputStream <- getInvalidBlocksLogOutputStream
+      blockBytes                   = newBlockMetadata.toByteString
+      toAppend                     = blockBytes.size.toByteString.concat(blockBytes).toByteArray
+      _                            <- invalidBlocksLogOutputStream.write(toAppend)
+      _                            <- invalidBlocksLogOutputStream.flush
+      _                            <- invalidBlocksCrc.update(toAppend)
+      _                            <- updateCrcFile(invalidBlocksCrc, invalidBlocksCrcPath)
     } yield ()
 
   private def representation: F[BlockDagRepresentation[F]] =
@@ -444,8 +468,16 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       childMap       <- getChildMap
       dataLookup     <- getDataLookup
       topoSort       <- getTopoSort
+      invalidBlocks  <- getInvalidBlocks
       sortOffset     <- getSortOffset
-    } yield FileDagRepresentation(latestMessages, childMap, dataLookup, topoSort, sortOffset)
+    } yield FileDagRepresentation(
+      latestMessages,
+      childMap,
+      dataLookup,
+      topoSort,
+      invalidBlocks,
+      sortOffset
+    )
 
   def getRepresentation: F[BlockDagRepresentation[F]] =
     lock.withPermit(representation)
@@ -465,6 +497,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
                 _             <- squashLatestMessagesDataFileIfNeeded()
                 blockMetadata = BlockMetadata.fromBlock(block, invalid)
                 _             = assert(block.blockHash.size == 32)
+                _             <- if (invalid) modifyInvalidBlocks(_ + blockMetadata) else ().pure[F]
                 _             <- modifyDataLookup(_.updated(block.blockHash, blockMetadata))
                 _ <- modifyChildMap(
                       childMap =>
@@ -513,6 +546,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
                 _ <- putBlockNumber(block.blockHash, blockNumber(block))
                 _ <- updateLatestMessagesFile(newValidatorsWithSenderLatestMessages.toList)
                 _ <- updateDataLookupFile(blockMetadata)
+                _ <- updateInvalidBlocksFile(blockMetadata)
               } yield ()
             }
         dag <- representation
@@ -589,6 +623,8 @@ object BlockDagFileStorage {
       blockMetadataCrcPath: Path,
       equivocationsTrackerLogPath: Path,
       equivocationsTrackerCrcPath: Path,
+      invalidBlocksLogPath: Path,
+      invalidBlocksCrcPath: Path,
       checkpointsDirPath: Path,
       blockNumberIndexPath: Path,
       mapSize: Long,
@@ -871,6 +907,76 @@ object BlockDagFileStorage {
       }
       .toSet
 
+  private def calculateInvalidBlocksCrc[F[_]: Monad](
+      invalidBlocks: List[BlockMetadata]
+  ): Crc32[F] =
+    Crc32[F](
+      invalidBlocks
+        .foldLeft(ByteString.EMPTY) {
+          case (byteString, blockMetadata) =>
+            val blockBytes = blockMetadata.toByteString
+            byteString.concat(blockBytes.size().toByteString.concat(blockBytes))
+        }
+        .toByteArray
+    )
+
+  private def readInvalidBlocksLog[F[_]: Sync](
+      randomAccessIO: RandomAccessIO[F]
+  ): F[List[BlockMetadata]] = {
+    def readRec(
+        result: List[BlockMetadata]
+    ): F[List[BlockMetadata]] =
+      for {
+        blockSizeOpt <- randomAccessIO.readInt
+        result <- blockSizeOpt match {
+                   case Some(blockSize) =>
+                     val blockMetaBytes = Array.ofDim[Byte](blockSize)
+                     for {
+                       _             <- randomAccessIO.readFully(blockMetaBytes)
+                       blockMetadata <- Sync[F].delay { BlockMetadata.fromBytes(blockMetaBytes) }
+                       result        <- readRec(blockMetadata :: result)
+                     } yield result
+                   case None =>
+                     result.reverse.pure[F]
+                 }
+      } yield result
+    readRec(List.empty)
+  }
+
+  private def validateInvalidBlocks[F[_]: Sync](
+      randomAccessIO: RandomAccessIO[F],
+      readInvalidBlocksCrc: Long,
+      invalidBlocks: List[BlockMetadata]
+  ): F[(List[BlockMetadata], Crc32[F])] = {
+    val fullCalculatedCrc = calculateInvalidBlocksCrc[F](invalidBlocks)
+    fullCalculatedCrc.value.flatMap { fullCalculatedCrcValue =>
+      if (fullCalculatedCrcValue == readInvalidBlocksCrc) {
+        (invalidBlocks, fullCalculatedCrc).pure[F]
+      } else if (invalidBlocks.nonEmpty) {
+        val withoutLastCalculatedCrc =
+          calculateInvalidBlocksCrc[F](invalidBlocks.init)
+        withoutLastCalculatedCrc.value.flatMap { withoutLastCalculatedCrcValue =>
+          if (withoutLastCalculatedCrcValue == readInvalidBlocksCrc) {
+            val lastRecord           = invalidBlocks.last
+            val lastRecordSize: Long = 4L + lastRecord.toByteString.size
+            for {
+              length <- randomAccessIO.length
+              _      <- randomAccessIO.setLength(length - lastRecordSize)
+            } yield (invalidBlocks.init, withoutLastCalculatedCrc)
+          } else {
+            Sync[F].raiseError[(List[BlockMetadata], Crc32[F])](
+              InvalidBlocksIsCorrupted
+            )
+          }
+        }
+      } else {
+        Sync[F].raiseError[(List[BlockMetadata], Crc32[F])](
+          InvalidBlocksIsCorrupted
+        )
+      }
+    }
+  }
+
   private def extractChildMap(
       dataLookup: List[(BlockHash, BlockMetadata)]
   ): Map[BlockHash, Set[BlockHash]] =
@@ -1010,7 +1116,24 @@ object BlockDagFileStorage {
                                    }
       (equivocationsTrackerList, calculatedEquivocationsTrackerCrc) = equivocationsTrackerResult
       equivocationsTracker                                          = squashEquivocationsTracker(equivocationsTrackerList)
-      sortedCheckpoints                                             <- loadCheckpoints(config.checkpointsDirPath)
+      invalidBlocksFileResource = Resource.make(
+        RandomAccessIO.open[F](config.invalidBlocksLogPath, RandomAccessIO.ReadWrite)
+      )(_.close)
+      readInvalidBlocksCrc <- readCrc[F](config.invalidBlocksCrcPath)
+      invalidBlocksResult <- invalidBlocksFileResource.use { invalidBlocksFile =>
+                              for {
+                                invalidBlocksList <- readInvalidBlocksLog(
+                                                      invalidBlocksFile
+                                                    )
+                                result <- validateInvalidBlocks(
+                                           invalidBlocksFile,
+                                           readInvalidBlocksCrc,
+                                           invalidBlocksList
+                                         )
+                              } yield result
+                            }
+      (invalidBlocksList, calculatedInvalidBlocksCrc) = invalidBlocksResult
+      sortedCheckpoints                               <- loadCheckpoints(config.checkpointsDirPath)
       latestMessagesLogOutputStream <- FileOutputStreamIO.open[F](
                                         config.latestMessagesLogPath,
                                         true
@@ -1023,12 +1146,17 @@ object BlockDagFileStorage {
                                               config.equivocationsTrackerLogPath,
                                               true
                                             )
+      invalidBlocksLogOutputStream <- FileOutputStreamIO.open[F](
+                                       config.invalidBlocksLogPath,
+                                       true
+                                     )
       state = BlockDagFileStorageState(
         latestMessages = latestMessagesMap,
         childMap = childMap,
         dataLookup = dataLookupList.toMap,
         topoSort = topoSort,
         equivocationsTracker = equivocationsTracker,
+        invalidBlocks = invalidBlocksList.toSet,
         sortOffset = sortedCheckpoints.lastOption.map(_.end).getOrElse(0L),
         checkpoints = sortedCheckpoints,
         latestMessagesLogOutputStream = latestMessagesLogOutputStream,
@@ -1037,7 +1165,9 @@ object BlockDagFileStorage {
         blockMetadataLogOutputStream = blockMetadataLogOutputStream,
         blockMetadataCrc = calculatedDataLookupCrc,
         equivocationsTrackerLogOutputStream = equivocationsTrackerLogOutputStream,
-        equivocationsTrackerCrc = calculatedEquivocationsTrackerCrc
+        equivocationsTrackerCrc = calculatedEquivocationsTrackerCrc,
+        invalidBlocksLogOutputStream = invalidBlocksLogOutputStream,
+        invalidBlocksCrc = calculatedInvalidBlocksCrc
       )
     } yield new BlockDagFileStorage[F](
       lock,
@@ -1049,6 +1179,8 @@ object BlockDagFileStorage {
       config.blockMetadataCrcPath,
       config.equivocationsTrackerLogPath,
       config.equivocationsTrackerCrcPath,
+      config.invalidBlocksLogPath,
+      config.invalidBlocksCrcPath,
       new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
     )
   }
@@ -1098,13 +1230,19 @@ object BlockDagFileStorage {
                                               config.equivocationsTrackerLogPath,
                                               true
                                             )
+      invalidBlocksLogOutputStream <- FileOutputStreamIO.open[F](
+                                       config.invalidBlocksLogPath,
+                                       true
+                                     )
       equivocationsTrackerCrc = Crc32.empty[F]()
+      invalidBlocksCrc        = Crc32.empty[F]()
       state = BlockDagFileStorageState(
         latestMessages = initialLatestMessages,
         childMap = Map(genesis.blockHash   -> Set.empty[BlockHash]),
         dataLookup = Map(genesis.blockHash -> BlockMetadata.fromBlock(genesis, false)),
         topoSort = Vector(Vector(genesis.blockHash)),
         equivocationsTracker = Set.empty,
+        invalidBlocks = Set.empty,
         sortOffset = 0L,
         checkpoints = List.empty,
         latestMessagesLogOutputStream = latestMessagesLogOutputStream,
@@ -1113,7 +1251,9 @@ object BlockDagFileStorage {
         blockMetadataLogOutputStream = blockMetadataLogOutputStream,
         blockMetadataCrc = blockMetadataCrc,
         equivocationsTrackerLogOutputStream = equivocationsTrackerLogOutputStream,
-        equivocationsTrackerCrc = equivocationsTrackerCrc
+        equivocationsTrackerCrc = equivocationsTrackerCrc,
+        invalidBlocksLogOutputStream = invalidBlocksLogOutputStream,
+        invalidBlocksCrc = invalidBlocksCrc
       )
     } yield new BlockDagFileStorage[F](
       lock,
@@ -1125,6 +1265,8 @@ object BlockDagFileStorage {
       config.blockMetadataCrcPath,
       config.equivocationsTrackerLogPath,
       config.equivocationsTrackerCrcPath,
+      config.invalidBlocksLogPath,
+      config.invalidBlocksCrcPath,
       new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
     )
   }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -34,6 +34,7 @@ trait BlockDagRepresentation[F[_]] {
   def latestMessage(validator: Validator): F[Option[BlockMetadata]]
   def latestMessageHashes: F[Map[Validator, BlockHash]]
   def latestMessages: F[Map[Validator, BlockMetadata]]
+  def invalidBlocks: F[Set[BlockMetadata]]
 }
 
 object BlockDagRepresentation {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -17,6 +17,7 @@ final case object LatestMessagesLogIsMalformed                                ex
 final case object EquivocationsTrackerLogIsMalformed                          extends StorageError
 final case object LatestMessagesLogIsCorrupted                                extends StorageError
 final case object DataLookupIsCorrupted                                       extends StorageError
+final case object InvalidBlocksIsCorrupted                                    extends StorageError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
@@ -42,6 +43,8 @@ object StorageError {
         "Latest messages log is corrupted"
       case DataLookupIsCorrupted =>
         "Data lookup log is corrupted"
+      case InvalidBlocksIsCorrupted =>
+        "Invalid blocks log is corrupted"
     }
 
   implicit class StorageErrorToMessage(storageError: StorageError) {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -120,6 +120,12 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
   private def defaultEquivocationsTrackerCrc(dagDataDir: Path): Path =
     dagDataDir.resolve("equivocations-tracker-checksum")
 
+  private def defaultInvalidBlocksLog(dagDataDir: Path): Path =
+    dagDataDir.resolve("invalid-blocks-data")
+
+  private def defaultInvalidBlocksCrc(dagDataDir: Path): Path =
+    dagDataDir.resolve("invalid-blocks-checksum")
+
   private def defaultCheckpointsDir(dagDataDir: Path): Path =
     dagDataDir.resolve("checkpoints")
 
@@ -147,6 +153,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         defaultBlockMetadataCrc(dagDataDir),
         defaultEquivocationsTrackerLog(dagDataDir),
         defaultEquivocationsTrackerCrc(dagDataDir),
+        defaultInvalidBlocksLog(dagDataDir),
+        defaultInvalidBlocksCrc(dagDataDir),
         defaultCheckpointsDir(dagDataDir),
         defaultBlockNumberIndex(dagDataDir),
         100L * 1024L * 1024L * 4096L,

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -110,6 +110,8 @@ object BlockDagStorageTestFixture {
         blockDagStorageDir.resolve("block-metadata-crc"),
         blockDagStorageDir.resolve("equivocations-tracker-data"),
         blockDagStorageDir.resolve("equivocations-tracker-crc"),
+        blockDagStorageDir.resolve("invalid-blocks-data"),
+        blockDagStorageDir.resolve("invalid-blocks-crc"),
         blockDagStorageDir.resolve("checkpoints"),
         blockDagStorageDir.resolve("block-number-index"),
         mapSize

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -215,6 +215,8 @@ object HashSetCasperTestNode {
                             blockDagDir.resolve("block-metadata-crc"),
                             blockDagDir.resolve("equivocations-tracker-data"),
                             blockDagDir.resolve("equivocations-tracker-crc"),
+                            blockDagDir.resolve("invalid-blocks-data"),
+                            blockDagDir.resolve("invalid-blocks-crc"),
                             blockDagDir.resolve("checkpoints"),
                             blockDagDir.resolve("block-number-index"),
                             mapSize
@@ -301,8 +303,10 @@ object HashSetCasperTestNode {
                                     blockDagDir.resolve("latest-messages-crc"),
                                     blockDagDir.resolve("block-metadata-data"),
                                     blockDagDir.resolve("block-metadata-crc"),
+                                    blockDagDir.resolve("equivocations-tracker-data"),
                                     blockDagDir.resolve("equivocations-tracker-crc"),
-                                    blockDagDir.resolve("equivocations-tracker-crc"),
+                                    blockDagDir.resolve("invalid-blocks-data"),
+                                    blockDagDir.resolve("invalid-blocks-crc"),
                                     blockDagDir.resolve("checkpoints"),
                                     blockDagDir.resolve("block-number-index"),
                                     mapSize

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -416,6 +416,8 @@ class NodeRuntime private[node] (
       blockMetadataCrcPath = dagStoragePath.resolve("blockMetadataCrcPath"),
       equivocationsTrackerLogPath = dagStoragePath.resolve("equivocationsTrackerLogPath"),
       equivocationsTrackerCrcPath = dagStoragePath.resolve("equivocationsTrackerCrcPath"),
+      invalidBlocksLogPath = dagStoragePath.resolve("invalidBlocksLogPath"),
+      invalidBlocksCrcPath = dagStoragePath.resolve("invalidBlocksCrcPath"),
       checkpointsDirPath = dagStoragePath.resolve("checkpointsDirPath"),
       blockNumberIndexPath = dagStoragePath.resolve("blockNumberIndexPath"),
       mapSize = 8L * 1024L * 1024L * 1024L,

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -136,6 +136,8 @@ object Configuration {
       dataDir.resolve("casper-block-dag-file-storage-block-metadata-crc"),
       dataDir.resolve("casper-block-dag-file-storage-equivocation-tracker-log"),
       dataDir.resolve("casper-block-dag-file-storage-equivocation-tracker-crc"),
+      dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-log"),
+      dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-crc"),
       dataDir.resolve("casper-block-dag-file-storage-checkpoints"),
       dataDir.resolve("casper-block-dag-file-storage-block-number-index"),
       server.dagStorageSize


### PR DESCRIPTION
## Overview
Introduces a storage for invalid blocks to provide a fast way to fetch all invalid blocks. I decided to leave the  (somewhat redundant) `BlockMetadata.invalid` field in but am open for a discussion.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3266


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
