### PR TITLE
Rspace/introduce flag for new rspace

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/Context.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Context.scala
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import cats.effect.Sync
 import coop.rchain.rspace.history.{Branch, ITrieStore, InMemoryTrieStore, LMDBTrieStore}
 import coop.rchain.rspace.internal.GNAT
+import coop.rchain.rspace.nextgenrspace.history.HistoryRepository
 import org.lmdbjava.{Env, EnvFlags, Txn}
 import scodec.Codec
 
@@ -79,6 +80,19 @@ private[rspace] class MixedContext[F[_], C, P, A, K] private[rspace] (
     trieStore.close()
     env.close()
   }
+}
+
+class RSpace2Context[F[_], C, P, A, K](historyRepository: HistoryRepository[F, C, P, A, K])
+    extends Context[F, C, P, A, K] {
+  override def close(): Unit = ()
+
+  override def createStore(branch: Branch)(
+      implicit sc: Serialize[C],
+      sp: Serialize[P],
+      sa: Serialize[A],
+      sk: Serialize[K],
+      syncF: Sync[F]
+  ): IStore[F, C, P, A, K] = ???
 }
 
 object Context {

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/SpaceMatcher.scala
@@ -23,10 +23,6 @@ import scala.concurrent.SyncVar
   */
 private[rspace] trait SpaceMatcher[F[_], C, P, A, R, K] extends ISpace[F, C, P, A, R, K] {
 
-  val store: HotStore[F, C, P, A, K]
-
-  val branch: Branch
-
   protected[this] val eventLog: SyncVar[Log] =
     SyncVarOps.create[Log](Seq.empty)
 
@@ -65,12 +61,6 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, R, K] extends ISpace[F, C, P, 
         }
       case _ => none[MatchingDataCandidate].pure[F]
     }
-
-  def getData(channel: C): F[Seq[Datum[A]]] =
-    store.getData(channel)
-
-  def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
-    store.getContinuations(channels)
 
   /** Iterates through (channel, pattern) pairs looking for matching data.
     *

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepository.scala
@@ -3,7 +3,6 @@ package coop.rchain.rspace.nextgenrspace.history
 import cats.implicits._
 import cats.effect.Sync
 import coop.rchain.rspace.{Blake2b256Hash, HistoryReader, HotStoreAction}
-import org.lmdbjava.EnvFlags
 import scodec.Codec
 
 trait HistoryRepository[F[_], C, P, A, K] extends HistoryReader[F, C, P, A, K] {
@@ -16,14 +15,6 @@ trait HistoryRepository[F[_], C, P, A, K] extends HistoryReader[F, C, P, A, K] {
   def close(): F[Unit]
 }
 
-final case class LMDBStorageConfig(
-    path: String,
-    mapSize: Long,
-    maxReaders: Int = 2048,
-    maxDbs: Int = 2,
-    flags: List[EnvFlags] = Nil,
-    dbNamePrefix: String = "db"
-)
 final case class LMDBRSpaceStorageConfig(
     coldStore: StoreConfig,
     historyStore: StoreConfig,

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/Store.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/Store.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rspace.nextgenrspace.history
 
 import java.nio.ByteBuffer
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 
 import cats.implicits._
 import cats.effect.Sync
@@ -22,11 +22,11 @@ trait Store[F[_]] {
 }
 
 final case class StoreConfig(
-    path: String,
+    path: Path,
     mapSize: Long,
-    maxDbs: Int,
-    maxReaders: Int,
-    flags: List[EnvFlags]
+    maxDbs: Int = 2,
+    maxReaders: Int = 2048,
+    flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
 )
 
 object StoreInstances {
@@ -36,7 +36,7 @@ object StoreInstances {
       .setMapSize(config.mapSize)
       .setMaxDbs(config.maxDbs)
       .setMaxReaders(config.maxReaders)
-      .open(Paths.get(config.path).toFile, config.flags: _*)
+      .open(config.path.toFile, config.flags: _*)
     val dbi = env.openDbi("db", MDB_CREATE)
     LMDBStore(env, dbi)
   }

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
@@ -13,6 +13,7 @@ import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.history._
 import coop.rchain.rspace.nextgenrspace.history.{
+  HistoryRepository,
   HistoryRepositoryInstances,
   LMDBRSpaceStorageConfig,
   StoreConfig
@@ -27,11 +28,14 @@ import scodec.Codec
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import monix.eval.Task
+import monix.execution.atomic.AtomicAny
 import org.lmdbjava.EnvFlags
 
 trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with OptionValues {
-  type T  = ISpace[F, C, P, A, A, K]
-  type ST = HotStore[F, C, P, A, K]
+  type T    = ISpace[F, C, P, A, A, K]
+  type ST   = HotStore[F, C, P, A, K]
+  type HR   = HistoryRepository[F, C, P, A, K]
+  type AtST = AtomicAny[ST]
 
   implicit def concurrentF: Concurrent[F]
   implicit def logF: Log[F]
@@ -48,9 +52,11 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
 
   /** A fixture for creating and running a test with a fresh instance of the test store.
     */
-  def withTestSpace[R](f: (ST, T) => F[R]): R
-  def withTestSpaceNonF[R](f: (ST, T) => R): R =
-    withTestSpace((st: ST, t: T) => concurrentF.delay(f(st, t)))
+  def fixture[R](f: (ST, AtST, T) => F[R]): R
+
+  def fixtureNonF[R](f: (ST, AtST, T) => R): R =
+    fixture((st: ST, ast: AtST, t: T) => concurrentF.delay(f(st, ast, t)))
+
   def run[S](f: F[S]): S
 
   import scala.reflect.ClassTag
@@ -60,6 +66,44 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
       .collect {
         case e: HA if clazz.isInstance(e) => e
       }
+  }
+
+  protected def setupTestingSpace[S, STORE](
+      createISpace: (HR, ST, Branch) => F[(ST, AtST, T)],
+      f: (ST, AtST, T) => F[S]
+  )(implicit codecC: Codec[C], codecP: Codec[P], codecA: Codec[A], codecK: Codec[K]): S = {
+    val branch = Branch("inmem")
+
+    val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
+    val mapSize: Long = 1024L * 1024L * 1024L
+
+    def storeConfig(name: String): StoreConfig =
+      StoreConfig(
+        Files.createDirectories(dbDir.resolve(name)).toString,
+        mapSize,
+        2,
+        2048,
+        List(EnvFlags.MDB_NOTLS)
+      )
+
+    val config = LMDBRSpaceStorageConfig(
+      storeConfig("cold"),
+      storeConfig("history"),
+      storeConfig("pointers"),
+      storeConfig("roots")
+    )
+
+    run(for {
+      historyRepository    <- HistoryRepositoryInstances.lmdbRepository[F, C, P, A, K](config)
+      cache                <- Cell.refCell[F, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      testStore            = HotStore.inMem[F, C, P, A, K](Sync[F], cache, historyRepository)
+      spaceAndStore        <- createISpace(historyRepository, testStore, branch)
+      (store, atom, space) = spaceAndStore
+      res                  <- f(store, atom, space)
+      _                    <- Sync[F].delay(dbDir.recursivelyDelete())
+    } yield {
+      res
+    })
   }
 }
 
@@ -96,55 +140,20 @@ abstract class InMemoryHotStoreTestsBase[F[_]]
     extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with BeforeAndAfterAll {
 
-  override def withTestSpace[S](f: (ST, T) => F[S]): S = {
-    val branch = Branch("inmem")
+  implicit val patternCodec: Codec[Pattern] = StringExamples.implicits.patternSerialize.toCodec
+  implicit val stringCodec: Codec[String]   = StringExamples.implicits.stringSerialize.toCodec
+  implicit val stringCaptorCodec: Codec[StringsCaptor] =
+    StringExamples.implicits.stringClosureSerialize.toCodec
 
-    implicit val patternCodec: Codec[Pattern] = StringExamples.implicits.patternSerialize.toCodec
-    implicit val stringCodec: Codec[String]   = StringExamples.implicits.stringSerialize.toCodec
-    implicit val stringCaptorCodec: Codec[StringsCaptor] =
-      StringExamples.implicits.stringClosureSerialize.toCodec
-
-    val dbDir: Path   = Files.createTempDirectory("rchain-storage-test-")
-    val mapSize: Long = 1024L * 1024L * 1024L
-
-    def storeConfig(name: String): StoreConfig =
-      StoreConfig(
-        Files.createDirectories(dbDir.resolve(name)).toString,
-        mapSize,
-        2,
-        2048,
-        List(EnvFlags.MDB_NOTLS)
-      )
-
-    val config = LMDBRSpaceStorageConfig(
-      storeConfig("cold"),
-      storeConfig("history"),
-      storeConfig("pointers"),
-      storeConfig("roots")
-    )
-
-    run(for {
-      historyRepository <- HistoryRepositoryInstances
-                            .lmdbRepository[F, String, Pattern, String, StringsCaptor](config)
-      cache <- Cell.refCell[F, Cache[String, Pattern, String, StringsCaptor]](
-                Cache[String, Pattern, String, StringsCaptor]()
-              )
-      testStore = {
-        implicit val hr: HistoryReader[F, String, Pattern, String, StringsCaptor] =
-          historyRepository
-        implicit val c = cache
-        HotStore.inMem[F, String, Pattern, String, StringsCaptor]
+  override def fixture[S](f: (ST, AtST, T) => F[S]): S = {
+    val creator: (HR, ST, Branch) => F[(ST, AtST, T)] =
+      (hr, ts, b) => {
+        val atomicStore = AtomicAny(ts)
+        val space =
+          new RSpace[F, String, Pattern, String, String, StringsCaptor](hr, atomicStore, b)
+        Applicative[F].pure((ts, atomicStore, space))
       }
-      testSpace <- RSpace.create[F, String, Pattern, String, String, StringsCaptor](
-                    historyRepository,
-                    testStore,
-                    branch
-                  )
-      res <- f(testStore, testSpace)
-    } yield {
-      dbDir.recursivelyDelete()
-      res
-    })
+    setupTestingSpace(creator, f)
   }
 
   override def afterAll(): Unit =

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/StorageTestsBase.scala
@@ -79,7 +79,7 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
 
     def storeConfig(name: String): StoreConfig =
       StoreConfig(
-        Files.createDirectories(dbDir.resolve(name)).toString,
+        Files.createDirectories(dbDir.resolve(name)),
         mapSize,
         2,
         2048,

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -39,7 +39,7 @@ class LMDBHistoryRepositoryGenerativeSpec extends HistoryRepositoryGenerativeDef
   def lmdbConfig = {
     val dbDir: Path = Files.createTempDirectory("rchain-storage-test-")
     StoreConfig(
-      dbDir.toAbsolutePath.toString,
+      dbDir,
       1024L * 1024L * 4096L,
       2,
       2048,

--- a/shared/src/main/scala/coop/rchain/shared/StoreType.scala
+++ b/shared/src/main/scala/coop/rchain/shared/StoreType.scala
@@ -2,22 +2,25 @@ package coop.rchain.shared
 
 sealed trait StoreType
 object StoreType {
-  case object Mixed extends StoreType
-  case object LMDB  extends StoreType
-  case object InMem extends StoreType
+  case object Mixed   extends StoreType
+  case object LMDB    extends StoreType
+  case object InMem   extends StoreType
+  case object RSpace2 extends StoreType
 
   def from(s: String): Option[StoreType] =
     s match {
       case "mixed" => Some(Mixed)
       case "inmem" => Some(InMem)
       case "lmdb"  => Some(LMDB)
+      case "v2"    => Some(RSpace2)
       case _       => None
     }
 
   def toConfig(s: StoreType): String =
     s match {
-      case Mixed => "mixed"
-      case LMDB  => "lmdb"
-      case InMem => "inmem"
+      case Mixed   => "mixed"
+      case LMDB    => "lmdb"
+      case InMem   => "inmem"
+      case RSpace2 => "v2"
     }
 }


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Introduces a new value for flag store type that directs node to instrument Runtime with RSpaceV2.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RCHAIN-3296


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
