### PR TITLE
Align hashing with 'canonical' implementation for GNAT

### DIFF
--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/EncodingSpec.scala
@@ -22,8 +22,10 @@ class EncodingSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyCh
   implicit val codecDatumString: Codec[Datum[String]] = codecDatum(stringCodec)
 
   implicit val codecContinuation: Codec[WaitingContinuation[Pattern, StringsCaptor]] =
-    codecWaitingContinuation(implicits.patternSerialize.toCodec,
-                             implicits.stringClosureSerialize.toCodec)
+    codecWaitingContinuation(
+      implicits.patternSerialize.toCodec,
+      implicits.stringClosureSerialize.toCodec
+    )
 
   "Datum list encode" should "return same hash for different orderings of each datum" in forAll {
     (datum1: Datum[String], datum2: Datum[String]) =>

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/EncodingSpec.scala
@@ -1,0 +1,54 @@
+package coop.rchain.rspace.nextgenrspace.history
+
+import coop.rchain.rspace.Blake2b256Hash
+import coop.rchain.rspace.examples.StringExamples.{Pattern, StringsCaptor}
+import coop.rchain.rspace.internal.Datum
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import coop.rchain.rspace.util.stringCodec
+import scodec.Codec
+import coop.rchain.rspace.examples.StringExamples._
+import coop.rchain.rspace.examples.StringExamples.implicits._
+import coop.rchain.rspace.internal._
+import coop.rchain.rspace.test.ArbitraryInstances._
+
+class EncodingSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  type Continuation = WaitingContinuation[Pattern, StringsCaptor]
+  type Join         = Seq[String]
+
+  implicit val codecChannel: Codec[String] = stringCodec
+
+  implicit val codecDatumString: Codec[Datum[String]] = codecDatum(stringCodec)
+
+  implicit val codecContinuation: Codec[WaitingContinuation[Pattern, StringsCaptor]] =
+    codecWaitingContinuation(implicits.patternSerialize.toCodec,
+                             implicits.stringClosureSerialize.toCodec)
+
+  "Datum list encode" should "return same hash for different orderings of each datum" in forAll {
+    (datum1: Datum[String], datum2: Datum[String]) =>
+      val bytes1 = HistoryRepositoryImpl.encodeData(datum1 :: datum2 :: Nil)
+      val bytes2 = HistoryRepositoryImpl.encodeData(datum2 :: datum1 :: Nil)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes2)
+  }
+
+  "WaitingContinuation list encode" should "return same hash for different orderings of each continuation" in forAll {
+    (c1: Continuation, c2: Continuation, c3: Continuation) =>
+      val bytes1 = HistoryRepositoryImpl.encodeContinuations(c1 :: c2 :: c3 :: Nil)
+      val bytes2 = HistoryRepositoryImpl.encodeContinuations(c3 :: c2 :: c1 :: Nil)
+      val bytes3 = HistoryRepositoryImpl.encodeContinuations(c2 :: c3 :: c1 :: Nil)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes2)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes3)
+  }
+
+  "Joins list encode" should "return same hash for different orderings of each channel list" in forAll {
+    (j1: Join, j2: Join, j3: Join) =>
+      val bytes1 = HistoryRepositoryImpl.encodeJoins(j1 :: j2 :: j3 :: Nil)
+      val bytes2 = HistoryRepositoryImpl.encodeJoins(j3 :: j2 :: j1 :: Nil)
+      val bytes3 = HistoryRepositoryImpl.encodeJoins(j2 :: j3 :: j1 :: Nil)
+      val bytes4 = HistoryRepositoryImpl.encodeJoins(j1 :: j3 :: j2 :: Nil)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes2)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes3)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes4)
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositorySpec.scala
@@ -68,16 +68,18 @@ class HistoryRepositorySpec
       fetchedContinuations <- conts.traverse(d => nextRepo.getContinuations(d.channels))
       _                    = fetchedContinuations shouldBe conts.map(_.continuations)
       fetchedJoins         <- joins.traverse(d => nextRepo.getJoins(d.channel))
-      _                    = fetchedJoins shouldBe joins.map(_.joins)
-
-      deletedRepo <- nextRepo.checkpoint(deleteElements.toList)
+      allJoins             = fetchedJoins.toSet.flatten.flatten
+      expectedJoins        = joins.toSet.flatMap((j: InsertJoins[String]) => j.joins).flatten
+      _                    = allJoins should contain theSameElementsAs expectedJoins
+      deletedRepo          <- nextRepo.checkpoint(deleteElements.toList)
 
       fetchedData          <- data.traverse(d => nextRepo.getData(d.channel))
       _                    = fetchedData shouldBe data.map(_.data)
       fetchedContinuations <- conts.traverse(d => nextRepo.getContinuations(d.channels))
       _                    = fetchedContinuations shouldBe conts.map(_.continuations)
       fetchedJoins         <- joins.traverse(d => nextRepo.getJoins(d.channel))
-      _                    = fetchedJoins shouldBe joins.map(_.joins)
+      allJoins             = fetchedJoins.toSet.flatten.flatten
+      _                    = allJoins should contain theSameElementsAs expectedJoins
 
       fetchedData          <- data.traverse(d => deletedRepo.getData(d.channel))
       _                    = fetchedData.flatten shouldBe empty


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
The previous implementation had a 'canonical' representation for GNAT.
This change aligns the new implementation with the previous assumptions.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RCHAIN-3309


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
