### PR TITLE
Split continuations and data namespaces in History Trie

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -22,14 +22,14 @@ import coop.rchain.rholang.interpreter.errors.BugFoundError
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.interpreter.storage.implicits.matchListPar
 import coop.rchain.rholang.interpreter.{
-    ChargingReducer,
-    ErrorLog,
-    EvaluateResult,
-    Interpreter,
-    RhoType,
-    Runtime,
-    PrettyPrinter => RholangPrinter
-  }
+  ChargingReducer,
+  ErrorLog,
+  EvaluateResult,
+  Interpreter,
+  RhoType,
+  Runtime,
+  PrettyPrinter => RholangPrinter
+}
 import coop.rchain.rspace.{trace, Blake2b256Hash, Checkpoint, ReplayException}
 
 trait RuntimeManager[F[_]] {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -165,7 +165,7 @@ object SystemProcesses {
             params                                                  <- runtimeParametersRef.get
             DeployParameters(codeHash, phloRate, userId, timestamp) = params
             _ <- produce(
-              Seq(codeHash, phloRate, userId, timestamp),
+                  Seq(codeHash, phloRate, userId, timestamp),
                   ack
                 )
           } yield ()

--- a/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/nextgenrspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -109,19 +109,20 @@ abstract class HistoryRepositoryGenerativeDefinition
 
   def repo: HistoryRepository[Task, String, Pattern, String, StringsCaptor]
 
-  "HistoryRepository" should "accept all HotStoreActions" in forAll(minSize(1),
-                                                                    sizeRange(50),
-                                                                    minSuccessful(10)) {
-    actions: List[HotStoreAction] =>
-      val repository = repo
-      actions
-        .foldLeftM(repository) { (repo, action) =>
-          for {
-            next <- repo.checkpoint(action :: Nil)
-            _    <- checkActionResult(action, next)
-          } yield next
-        }
-        .runSyncUnsafe(20.seconds)
+  "HistoryRepository" should "accept all HotStoreActions" in forAll(
+    minSize(1),
+    sizeRange(50),
+    minSuccessful(10)
+  ) { actions: List[HotStoreAction] =>
+    val repository = repo
+    actions
+      .foldLeftM(repository) { (repo, action) =>
+        for {
+          next <- repo.checkpoint(action :: Nil)
+          _    <- checkActionResult(action, next)
+        } yield next
+      }
+      .runSyncUnsafe(20.seconds)
   }
 
   def checkData(seq: Seq[Datum[String]], data: Seq[Datum[Any]]): Assertion =
@@ -129,10 +130,13 @@ abstract class HistoryRepositoryGenerativeDefinition
 
   def checkJoins(seq: Seq[Seq[String]], joins: Seq[Seq[Any]]): Assertion =
     seq.toSet.map((v: Seq[String]) => v.toSet) should contain theSameElementsAs joins.toSet.map(
-      (v: Seq[Any]) => v.toSet)
+      (v: Seq[Any]) => v.toSet
+    )
 
-  def checkContinuations(seq: Seq[WaitingContinuation[Pattern, StringsCaptor]],
-                         conts: Seq[WaitingContinuation[Any, Any]]): Assertion =
+  def checkContinuations(
+      seq: Seq[WaitingContinuation[Pattern, StringsCaptor]],
+      conts: Seq[WaitingContinuation[Any, Any]]
+  ): Assertion =
     seq should contain theSameElementsAs conts
 
   def checkActionResult(
@@ -191,8 +195,10 @@ abstract class HistoryRepositoryGenerativeDefinition
         channels <- distinctStrings
         sz       <- Gen.size
         data <- Gen
-                 .containerOfN[Set, WaitingContinuation[Pattern, StringsCaptor]](sz,
-                                                                                 genContinuation)
+                 .containerOfN[Set, WaitingContinuation[Pattern, StringsCaptor]](
+                   sz,
+                   genContinuation
+                 )
                  .map(_.toList)
       } yield InsertContinuations(channels, data)
     )


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
This allows Continuations and Data to live under the same name (if the SpatialMatcher chooses such a state).


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RCHAIN-3310


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
