### PR TITLE
Manage HashSetCasperTestNode with Resource

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParenCasperFinalizationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParenCasperFinalizationSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import cats.implicits._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.signatures.Ed25519
@@ -25,82 +25,81 @@ class MultiParentCasperFinalizationSpec extends FlatSpec with Matchers with Insp
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "MultiParentCasper" should "increment last finalized block as appropriate in round robin" in effectTest {
-    for {
-      nodes       <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deployDatas <- (0 to 7).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      for {
+        deployDatas <- (0 to 7).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
 
-      createBlock1Result <- nodes(0).casperEff
-                             .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
-      Created(block1) = createBlock1Result
-      _               <- nodes(0).casperEff.addBlock(block1, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(1).receive()
-      _               <- nodes(2).receive()
+        createBlock1Result <- nodes(0).casperEff
+                               .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
+        Created(block1) = createBlock1Result
+        _               <- nodes(0).casperEff.addBlock(block1, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(1).receive()
+        _               <- nodes(2).receive()
 
-      createBlock2Result <- nodes(1).casperEff
-                             .deploy(deployDatas(1)) *> nodes(1).casperEff.createBlock
-      Created(block2) = createBlock2Result
-      _               <- nodes(1).casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(0).receive()
-      _               <- nodes(2).receive()
+        createBlock2Result <- nodes(1).casperEff
+                               .deploy(deployDatas(1)) *> nodes(1).casperEff.createBlock
+        Created(block2) = createBlock2Result
+        _               <- nodes(1).casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(0).receive()
+        _               <- nodes(2).receive()
 
-      createBlock3Result <- nodes(2).casperEff
-                             .deploy(deployDatas(2)) *> nodes(2).casperEff.createBlock
-      Created(block3) = createBlock3Result
-      _               <- nodes(2).casperEff.addBlock(block3, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(0).receive()
-      _               <- nodes(1).receive()
+        createBlock3Result <- nodes(2).casperEff
+                               .deploy(deployDatas(2)) *> nodes(2).casperEff.createBlock
+        Created(block3) = createBlock3Result
+        _               <- nodes(2).casperEff.addBlock(block3, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(0).receive()
+        _               <- nodes(1).receive()
 
-      createBlock4Result <- nodes(0).casperEff
-                             .deploy(deployDatas(3)) *> nodes(0).casperEff.createBlock
-      Created(block4) = createBlock4Result
-      _               <- nodes(0).casperEff.addBlock(block4, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(1).receive()
-      _               <- nodes(2).receive()
+        createBlock4Result <- nodes(0).casperEff
+                               .deploy(deployDatas(3)) *> nodes(0).casperEff.createBlock
+        Created(block4) = createBlock4Result
+        _               <- nodes(0).casperEff.addBlock(block4, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(1).receive()
+        _               <- nodes(2).receive()
 
-      createBlock5Result <- nodes(1).casperEff
-                             .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
-      Created(block5) = createBlock5Result
-      _               <- nodes(1).casperEff.addBlock(block5, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(0).receive()
-      _               <- nodes(2).receive()
+        createBlock5Result <- nodes(1).casperEff
+                               .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
+        Created(block5) = createBlock5Result
+        _               <- nodes(1).casperEff.addBlock(block5, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(0).receive()
+        _               <- nodes(2).receive()
 
-      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block1
-      state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
+        _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block1
+        state <- nodes(0).casperState.read
+        _     = state.deployHistory.size should be(1)
 
-      createBlock6Result <- nodes(2).casperEff
-                             .deploy(deployDatas(5)) *> nodes(2).casperEff.createBlock
-      Created(block6) = createBlock6Result
-      _               <- nodes(2).casperEff.addBlock(block6, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(0).receive()
-      _               <- nodes(1).receive()
+        createBlock6Result <- nodes(2).casperEff
+                               .deploy(deployDatas(5)) *> nodes(2).casperEff.createBlock
+        Created(block6) = createBlock6Result
+        _               <- nodes(2).casperEff.addBlock(block6, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(0).receive()
+        _               <- nodes(1).receive()
 
-      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block2
-      state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
+        _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block2
+        state <- nodes(0).casperState.read
+        _     = state.deployHistory.size should be(1)
 
-      createBlock7Result <- nodes(0).casperEff
-                             .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
-      Created(block7) = createBlock7Result
-      _               <- nodes(0).casperEff.addBlock(block7, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(1).receive()
-      _               <- nodes(2).receive()
+        createBlock7Result <- nodes(0).casperEff
+                               .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
+        Created(block7) = createBlock7Result
+        _               <- nodes(0).casperEff.addBlock(block7, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(1).receive()
+        _               <- nodes(2).receive()
 
-      _ <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
-      _ = state.deployHistory.size should be(1)
+        _ <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
+        _ = state.deployHistory.size should be(1)
 
-      createBlock8Result <- nodes(1).casperEff
-                             .deploy(deployDatas(7)) *> nodes(1).casperEff.createBlock
-      Created(block8) = createBlock8Result
-      _               <- nodes(1).casperEff.addBlock(block8, ignoreDoppelgangerCheck[Effect])
-      _               <- nodes(0).receive()
-      _               <- nodes(2).receive()
+        createBlock8Result <- nodes(1).casperEff
+                               .deploy(deployDatas(7)) *> nodes(1).casperEff.createBlock
+        Created(block8) = createBlock8Result
+        _               <- nodes(1).casperEff.addBlock(block8, ignoreDoppelgangerCheck[Effect])
+        _               <- nodes(0).receive()
+        _               <- nodes(2).receive()
 
-      _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block4
-      state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
-
-      _ <- nodes.map(_.tearDown()).toList.sequence
-    } yield ()
+        _     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block4
+        state <- nodes(0).casperState.read
+        _     = state.deployHistory.size should be(1)
+      } yield ()
+    }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -5,7 +5,7 @@ import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.helper.{BlockUtil, HashSetCasperTestNode}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.scalatestcontrib._
@@ -40,442 +40,440 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
   //test since we cannot reset it
   "MultiParentCasper" should "not allow multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
-    val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler)
-    val casper    = node.casperEff
+    val testProgram =
+      HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)(scheduler).use { node =>
+        val casper = node.casperEff
+        for {
+          deploy <- ConstructDeploy.basicDeployData[Effect](0)
+          _      <- casper.deploy(deploy)
+          block <- casper.createBlock.map {
+                    case Created(block) => block
+                    case _              => throw new RuntimeException()
+                  }
+          result <- EitherT(
+                     Task
+                       .racePair(
+                         casper.addBlock(block, ignoreDoppelgangerCheck[Effect]).value,
+                         casper.addBlock(block, ignoreDoppelgangerCheck[Effect]).value
+                       )
+                       .flatMap {
+                         case Left((statusA, running)) =>
+                           running.join.map((statusA, _).tupled)
 
-    val testProgram = for {
-      deploy <- ConstructDeploy.basicDeployData[Effect](0)
-      _      <- casper.deploy(deploy)
-      block <- casper.createBlock.map {
-                case Created(block) => block
-                case _              => throw new RuntimeException()
-              }
-      result <- EitherT(
-                 Task
-                   .racePair(
-                     casper.addBlock(block, ignoreDoppelgangerCheck[Effect]).value,
-                     casper.addBlock(block, ignoreDoppelgangerCheck[Effect]).value
+                         case Right((running, statusB)) =>
+                           running.join.map((_, statusB).tupled)
+                       }
                    )
-                   .flatMap {
-                     case Left((statusA, running)) =>
-                       running.join.map((statusA, _).tupled)
-
-                     case Right((running, statusB)) =>
-                       running.join.map((_, statusB).tupled)
-                   }
-               )
-    } yield result
+        } yield result
+      }
     val threadStatuses: (BlockStatus, BlockStatus) =
       testProgram.value.unsafeRunSync(scheduler).right.get
 
     threadStatuses should matchPattern { case (Processing, Valid) | (Valid, Processing) => }
-    node.tearDown().value.unsafeRunSync
   }
 
   it should "accept signed blocks" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      deploy               <- ConstructDeploy.basicDeployData[Effect](0)
-      _                    <- MultiParentCasper[Effect].deploy(deploy)
-      createBlockResult    <- MultiParentCasper[Effect].createBlock
-      Created(signedBlock) = createBlockResult
-      _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-      _                    = logEff.warns.isEmpty should be(true)
-      dag                  <- MultiParentCasper[Effect].blockDag
-      estimate             <- MultiParentCasper[Effect].estimator(dag)
-      _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
-      _                    <- node.tearDown()
-    } yield ()
+      for {
+        deploy               <- ConstructDeploy.basicDeployData[Effect](0)
+        _                    <- MultiParentCasper[Effect].deploy(deploy)
+        createBlockResult    <- MultiParentCasper[Effect].createBlock
+        Created(signedBlock) = createBlockResult
+        _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        _                    = logEff.warns.isEmpty should be(true)
+        dag                  <- MultiParentCasper[Effect].blockDag
+        estimate             <- MultiParentCasper[Effect].estimator(dag)
+        _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
+      } yield ()
+    }
   }
 
   it should "be able to create a chain of blocks from different deploys" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
 
-    val start = System.currentTimeMillis()
+      val start = System.currentTimeMillis()
 
-    val deployDatas = Vector(
-      "contract @\"add\"(@x, @y, ret) = { ret!(x + y) }",
-      "new unforgable in { @\"add\"!(5, 7, *unforgable) }"
-    ).zipWithIndex.map(s => ConstructDeploy.sourceDeploy(s._1, start + s._2, accounting.MAX_VALUE))
+      val deployDatas = Vector(
+        "contract @\"add\"(@x, @y, ret) = { ret!(x + y) }",
+        "new unforgable in { @\"add\"!(5, 7, *unforgable) }"
+      ).zipWithIndex
+        .map(s => ConstructDeploy.sourceDeploy(s._1, start + s._2, accounting.MAX_VALUE))
 
-    for {
-      createBlockResult1 <- MultiParentCasper[Effect].deploy(deployDatas.head) *> MultiParentCasper[
-                             Effect
-                           ].createBlock
-      Created(signedBlock1) = createBlockResult1
-      _                     <- MultiParentCasper[Effect].addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
-      createBlockResult2 <- MultiParentCasper[Effect].deploy(deployDatas(1)) *> MultiParentCasper[
-                             Effect
-                           ].createBlock
-      Created(signedBlock2) = createBlockResult2
-      _                     <- MultiParentCasper[Effect].addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
-      storage               <- blockTuplespaceContents(signedBlock2)
+      for {
+        createBlockResult1 <- MultiParentCasper[Effect]
+                               .deploy(deployDatas.head) *> MultiParentCasper[
+                               Effect
+                             ].createBlock
+        Created(signedBlock1) = createBlockResult1
+        _                     <- MultiParentCasper[Effect].addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
+        createBlockResult2 <- MultiParentCasper[Effect].deploy(deployDatas(1)) *> MultiParentCasper[
+                               Effect
+                             ].createBlock
+        Created(signedBlock2) = createBlockResult2
+        _                     <- MultiParentCasper[Effect].addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
+        storage               <- blockTuplespaceContents(signedBlock2)
 
-      _        = logEff.warns should be(Nil)
-      _        = ProtoUtil.parentHashes(signedBlock2) should be(Seq(signedBlock1.blockHash))
-      dag      <- MultiParentCasper[Effect].blockDag
-      estimate <- MultiParentCasper[Effect].estimator(dag)
-      _        = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
-      result   = storage.contains("!(12)") should be(true)
-      _        <- node.tearDown()
-    } yield result
+        _        = logEff.warns should be(Nil)
+        _        = ProtoUtil.parentHashes(signedBlock2) should be(Seq(signedBlock1.blockHash))
+        dag      <- MultiParentCasper[Effect].blockDag
+        estimate <- MultiParentCasper[Effect].estimator(dag)
+        _        = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
+        result   = storage.contains("!(12)") should be(true)
+      } yield result
+    }
   }
 
   it should "allow multiple deploys in a single block" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
 
-    val startTime = System.currentTimeMillis()
-    val source    = " for(@x <- @0){ @0!(x) } | @0!(0) "
-    val deploys = (source #:: source #:: Stream.empty[String]).zipWithIndex
-      .map(s => ConstructDeploy.sourceDeploy(s._1, startTime + s._2, accounting.MAX_VALUE))
-    for {
-      _                 <- deploys.traverse_(MultiParentCasper[Effect].deploy(_))
-      createBlockResult <- MultiParentCasper[Effect].createBlock
-      Created(block)    = createBlockResult
-      _                 <- MultiParentCasper[Effect].addBlock(block, ignoreDoppelgangerCheck[Effect])
-      result            <- MultiParentCasper[Effect].contains(block) shouldBeF true
-      _                 <- node.tearDown()
-    } yield result
+      val startTime = System.currentTimeMillis()
+      val source    = " for(@x <- @0){ @0!(x) } | @0!(0) "
+      val deploys = (source #:: source #:: Stream.empty[String]).zipWithIndex
+        .map(s => ConstructDeploy.sourceDeploy(s._1, startTime + s._2, accounting.MAX_VALUE))
+      for {
+        _                 <- deploys.traverse_(MultiParentCasper[Effect].deploy(_))
+        createBlockResult <- MultiParentCasper[Effect].createBlock
+        Created(block)    = createBlockResult
+        _                 <- MultiParentCasper[Effect].addBlock(block, ignoreDoppelgangerCheck[Effect])
+        result            <- MultiParentCasper[Effect].contains(block) shouldBeF true
+      } yield result
+    }
   }
 
   it should "reject unsigned blocks" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
-      createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
-                            Effect
-                          ].createBlock
-      Created(block) = createBlockResult
-      invalidBlock   = block.withSig(ByteString.EMPTY)
-      status         <- MultiParentCasper[Effect].addBlock(invalidBlock, ignoreDoppelgangerCheck[Effect])
-      _              = status shouldBe InvalidUnslashableBlock
-      _              <- node.casperEff.contains(invalidBlock) shouldBeF false
-      _              = logEff.warns.head.contains("Ignoring block") should be(true)
-      _              <- node.tearDownNode()
-    } yield ()
+      for {
+        basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
+        createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
+                              Effect
+                            ].createBlock
+        Created(block) = createBlockResult
+        invalidBlock   = block.withSig(ByteString.EMPTY)
+        status         <- MultiParentCasper[Effect].addBlock(invalidBlock, ignoreDoppelgangerCheck[Effect])
+        _              = status shouldBe InvalidUnslashableBlock
+        _              <- node.casperEff.contains(invalidBlock) shouldBeF false
+        _              = logEff.warns.head.contains("Ignoring block") should be(true)
+      } yield ()
+    }
   }
 
   it should "not request invalid blocks from peers" in effectTest {
-
     val List(data0, data1) =
       (0 to 1)
         .map(i => ConstructDeploy.sourceDeploy(s"@$i!($i)", i.toLong, accounting.MAX_VALUE))
         .toList
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      val List(node0, node1) = nodes.toList
+      for {
+        unsignedBlock <- (node0.casperEff.deploy(data0) *> node0.casperEff.createBlock)
+                          .map {
+                            case Created(block) =>
+                              block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
+                            case _ => throw new RuntimeException()
+                          }
 
-    for {
-      nodes              <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      List(node0, node1) = nodes.toList
+        _ <- node0.casperEff.addBlock(unsignedBlock, ignoreDoppelgangerCheck[Effect])
+        _ <- node1.transportLayerEff.clear(node1.local) //node1 misses this block
 
-      unsignedBlock <- (node0.casperEff.deploy(data0) *> node0.casperEff.createBlock)
+        signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
                         .map {
-                          case Created(block) =>
-                            block.copy(sigAlgorithm = "invalid", sig = ByteString.EMPTY)
-                          case _ => throw new RuntimeException()
+                          case Created(block) => block
+                          case _              => throw new RuntimeException()
                         }
 
-      _ <- node0.casperEff.addBlock(unsignedBlock, ignoreDoppelgangerCheck[Effect])
-      _ <- node1.transportLayerEff.clear(node1.local) //node1 misses this block
+        _ <- node0.casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        _ <- node1.receive() //receives block1; should not ask for block0
 
-      signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
-                      .map {
-                        case Created(block) => block
-                        case _              => throw new RuntimeException()
-                      }
-
-      _ <- node0.casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-      _ <- node1.receive() //receives block1; should not ask for block0
-
-      _ <- node0.casperEff.contains(unsignedBlock) shouldBeF false
-      _ <- node1.casperEff.contains(unsignedBlock) shouldBeF false
-
-    } yield ()
+        _ <- node0.casperEff.contains(unsignedBlock) shouldBeF false
+        _ <- node1.casperEff.contains(unsignedBlock) shouldBeF false
+      } yield ()
+    }
   }
 
   it should "reject blocks not from bonded validators" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, Ed25519.newKeyPair._1)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, Ed25519.newKeyPair._1).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
-      createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
-                            Effect
-                          ].createBlock
-      Created(signedBlock) = createBlockResult
-      _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-      _                    = logEff.warns.head.contains("Ignoring block") should be(true)
-      _                    <- node.tearDownNode()
-    } yield ()
+      for {
+        basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
+        createBlockResult <- MultiParentCasper[Effect].deploy(basicDeployData) *> MultiParentCasper[
+                              Effect
+                            ].createBlock
+        Created(signedBlock) = createBlockResult
+        _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        _                    = logEff.warns.head.contains("Ignoring block") should be(true)
+      } yield ()
+    }
   }
 
   it should "propose blocks it adds to peers" in effectTest {
-    for {
-      nodes                <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData           <- ConstructDeploy.basicDeployData[Effect](0)
-      createBlockResult    <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
-      Created(signedBlock) = createBlockResult
-      _                    <- nodes(0).casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-      _                    <- nodes(1).receive()
-      result               <- nodes(1).casperEff.contains(signedBlock) shouldBeF true
-      _                    <- nodes.map(_.tearDownNode()).toList.sequence
-      _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
-            validateBlockStore(node) { blockStore =>
-              blockStore.get(signedBlock.blockHash) shouldBeF Some(signedBlock)
-            }(nodes(0).metricEff, nodes(0).logEff)
-          }
-    } yield result
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      for {
+        deployData           <- ConstructDeploy.basicDeployData[Effect](0)
+        createBlockResult    <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
+        Created(signedBlock) = createBlockResult
+        _                    <- nodes(0).casperEff.addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        _                    <- nodes(1).receive()
+        result               <- nodes(1).casperEff.contains(signedBlock) shouldBeF true
+        _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
+              validateBlockStore(node) { blockStore =>
+                blockStore.get(signedBlock.blockHash) shouldBeF Some(signedBlock)
+              }(nodes(0).metricEff, nodes(0).logEff)
+            }
+      } yield result
+    }
   }
 
   it should "add a valid block from peer" in effectTest {
-    for {
-      nodes                      <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployData                 <- ConstructDeploy.basicDeployData[Effect](1)
-      createBlockResult          <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1Prime) = createBlockResult
-      _                          <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
-      _                          <- nodes(1).receive()
-      _                          = nodes(1).logEff.infos.count(_ startsWith "Added") should be(1)
-      result                     = nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(0)
-      _                          <- nodes.map(_.tearDownNode()).toList.sequence
-      _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
-            validateBlockStore(node) { blockStore =>
-              blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(signedBlock1Prime)
-            }(nodes(0).metricEff, nodes(0).logEff)
-          }
-    } yield result
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      for {
+        deployData                 <- ConstructDeploy.basicDeployData[Effect](1)
+        createBlockResult          <- nodes(0).casperEff.deploy(deployData) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1Prime) = createBlockResult
+        _                          <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
+        _                          <- nodes(1).receive()
+        _                          = nodes(1).logEff.infos.count(_ startsWith "Added") should be(1)
+        result                     = nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(0)
+        _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
+              validateBlockStore(node) { blockStore =>
+                blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(signedBlock1Prime)
+              }(nodes(0).metricEff, nodes(0).logEff)
+            }
+      } yield result
+    }
   }
 
   it should "reject addBlock when there exist deploy by the same (user, millisecond timestamp) in the chain" in effectTest {
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      deployDatas <- (0 to 2).toList
-                      .traverse[Effect, DeployData](i => ConstructDeploy.basicDeployData[Effect](i))
-      deployPrim0 = ConstructDeploy.sign(
-        deployDatas(1)
-          .withTimestamp(deployDatas(0).timestamp)
-          .withDeployer(deployDatas(0).deployer)
-      ) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
-      createBlockResult1 <- nodes(0).casperEff
-                             .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1) = createBlockResult1
-      _                     <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
-      _                     <- nodes(1).receive() // receive block1
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      for {
+        deployDatas <- (0 to 2).toList
+                        .traverse[Effect, DeployData](
+                          i => ConstructDeploy.basicDeployData[Effect](i)
+                        )
+        deployPrim0 = ConstructDeploy.sign(
+          deployDatas(1)
+            .withTimestamp(deployDatas(0).timestamp)
+            .withDeployer(deployDatas(0).deployer)
+        ) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
+        createBlockResult1 <- nodes(0).casperEff
+                               .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1) = createBlockResult1
+        _                     <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
+        _                     <- nodes(1).receive() // receive block1
 
-      createBlockResult2 <- nodes(0).casperEff
-                             .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock2) = createBlockResult2
-      _                     <- nodes(0).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
-      _                     <- nodes(1).receive() // receive block2
+        createBlockResult2 <- nodes(0).casperEff
+                               .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock2) = createBlockResult2
+        _                     <- nodes(0).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
+        _                     <- nodes(1).receive() // receive block2
 
-      createBlockResult3 <- nodes(0).casperEff
-                             .deploy(deployDatas(2)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock3) = createBlockResult3
-      _                     <- nodes(0).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
-      _                     <- nodes(1).receive() // receive block3
+        createBlockResult3 <- nodes(0).casperEff
+                               .deploy(deployDatas(2)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock3) = createBlockResult3
+        _                     <- nodes(0).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
+        _                     <- nodes(1).receive() // receive block3
 
-      _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true
+        _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true
 
-      createBlockResult4 <- nodes(1).casperEff
-                             .deploy(deployPrim0) *> nodes(1).casperEff.createBlock
-      Created(signedBlock4) = createBlockResult4
-      _ <- nodes(1).casperEff
-            .addBlock(signedBlock4, ignoreDoppelgangerCheck[Effect]) // should succeed
-      _ <- nodes(0).receive() // still receive signedBlock4
+        createBlockResult4 <- nodes(1).casperEff
+                               .deploy(deployPrim0) *> nodes(1).casperEff.createBlock
+        Created(signedBlock4) = createBlockResult4
+        _ <- nodes(1).casperEff
+              .addBlock(signedBlock4, ignoreDoppelgangerCheck[Effect]) // should succeed
+        _ <- nodes(0).receive() // still receive signedBlock4
 
-      result <- nodes(1).casperEff
-                 .contains(signedBlock4) shouldBeF true // Invalid blocks are still added
-      // TODO: Fix with https://rchain.atlassian.net/browse/RHOL-1048
-      // nodes(0).casperEff.contains(signedBlock4) should be(false)
-      //
-      // nodes(0).logEff.warns
-      //   .count(_ contains "found deploy by the same (user, millisecond timestamp) produced") should be(
-      //   1
-      // )
-      _ <- nodes.map(_.tearDownNode()).toList.sequence
-
-      _ = nodes.toList.traverse_[Effect, Assertion] { node =>
-        validateBlockStore(node) { blockStore =>
-          for {
-            _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
-            _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
-            result <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
-          } yield result
-        }(nodes(0).metricEff, nodes(0).logEff)
-      }
-    } yield result
+        result <- nodes(1).casperEff
+                   .contains(signedBlock4) shouldBeF true // Invalid blocks are still added
+        // TODO: Fix with https://rchain.atlassian.net/browse/RHOL-1048
+        // nodes(0).casperEff.contains(signedBlock4) should be(false)
+        //
+        // nodes(0).logEff.warns
+        //   .count(_ contains "found deploy by the same (user, millisecond timestamp) produced") should be(
+        //   1
+        // )
+        _ = nodes.toList.traverse_[Effect, Assertion] { node =>
+          validateBlockStore(node) { blockStore =>
+            for {
+              _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
+              _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
+              result <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
+            } yield result
+          }(nodes(0).metricEff, nodes(0).logEff)
+        }
+      } yield result
+    }
   }
 
   it should "ignore adding equivocation blocks" in effectTest {
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      for {
+        // Creates a pair that constitutes equivocation blocks
+        basicDeployData0 <- ConstructDeploy.basicDeployData[Effect](0)
+        createBlockResult1 <- nodes(0).casperEff
+                               .deploy(basicDeployData0) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1) = createBlockResult1
+        basicDeployData1      <- ConstructDeploy.basicDeployData[Effect](1)
+        createBlockResult1Prime <- nodes(0).casperEff
+                                    .deploy(basicDeployData1) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1Prime) = createBlockResult1Prime
 
-      // Creates a pair that constitutes equivocation blocks
-      basicDeployData0 <- ConstructDeploy.basicDeployData[Effect](0)
-      createBlockResult1 <- nodes(0).casperEff
-                             .deploy(basicDeployData0) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1) = createBlockResult1
-      basicDeployData1      <- ConstructDeploy.basicDeployData[Effect](1)
-      createBlockResult1Prime <- nodes(0).casperEff
-                                  .deploy(basicDeployData1) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1Prime) = createBlockResult1Prime
+        _ <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(1).receive()
+        _ <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(1).receive()
 
-      _ <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(1).receive()
-      _ <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(1).receive()
-
-      _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
-      result <- nodes(1).casperEff
-                 .contains(signedBlock1Prime) shouldBeF false // we still add the equivocation pair
-
-      _ <- nodes(0).tearDownNode()
-      _ <- nodes(1).tearDownNode()
-      _ <- validateBlockStore(nodes(1)) { blockStore =>
-            for {
-              _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
-              result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF None
-            } yield result
-          }(nodes(0).metricEff, nodes(0).logEff)
-    } yield result
+        _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
+        result <- nodes(1).casperEff
+                   .contains(signedBlock1Prime) shouldBeF false // we still add the equivocation pair
+        _ <- validateBlockStore(nodes(1)) { blockStore =>
+              for {
+                _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
+                result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF None
+              } yield result
+            }(nodes(0).metricEff, nodes(0).logEff)
+      } yield result
+    }
   }
 
   // See [[/docs/casper/images/minimal_equivocation_neglect.png]] but cross out genesis block
   it should "not ignore equivocation blocks that are required for parents of proper nodes" in effectTest {
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deployDatas <- (0 to 5).toList
-                      .traverse[Effect, DeployData](i => ConstructDeploy.basicDeployData[Effect](i))
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      for {
+        deployDatas <- (0 to 5).toList
+                        .traverse[Effect, DeployData](
+                          i => ConstructDeploy.basicDeployData[Effect](i)
+                        )
 
-      // Creates a pair that constitutes equivocation blocks
-      createBlockResult1 <- nodes(0).casperEff
-                             .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1) = createBlockResult1
-      createBlockResult1Prime <- nodes(0).casperEff
-                                  .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1Prime) = createBlockResult1Prime
+        // Creates a pair that constitutes equivocation blocks
+        createBlockResult1 <- nodes(0).casperEff
+                               .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1) = createBlockResult1
+        createBlockResult1Prime <- nodes(0).casperEff
+                                    .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1Prime) = createBlockResult1Prime
 
-      _ <- nodes(1).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(0).transportLayerEff.clear(nodes(0).local) //nodes(0) misses this block
-      _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
+        _ <- nodes(1).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(0).transportLayerEff.clear(nodes(0).local) //nodes(0) misses this block
+        _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
 
-      _ <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(2).receive()
-      _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
+        _ <- nodes(0).casperEff.addBlock(signedBlock1Prime, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(2).receive()
+        _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
 
-      _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
-      _ <- nodes(2).casperEff.contains(signedBlock1) shouldBeF false
+        _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
+        _ <- nodes(2).casperEff.contains(signedBlock1) shouldBeF false
 
-      _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF false
-      _ <- nodes(2).casperEff.contains(signedBlock1Prime) shouldBeF true
+        _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF false
+        _ <- nodes(2).casperEff.contains(signedBlock1Prime) shouldBeF true
 
-      createBlockResult2 <- nodes(1).casperEff
-                             .deploy(deployDatas(2)) *> nodes(1).casperEff.createBlock
-      Created(signedBlock2) = createBlockResult2
-      createBlockResult3 <- nodes(2).casperEff
-                             .deploy(deployDatas(3)) *> nodes(2).casperEff.createBlock
-      Created(signedBlock3) = createBlockResult3
+        createBlockResult2 <- nodes(1).casperEff
+                               .deploy(deployDatas(2)) *> nodes(1).casperEff.createBlock
+        Created(signedBlock2) = createBlockResult2
+        createBlockResult3 <- nodes(2).casperEff
+                               .deploy(deployDatas(3)) *> nodes(2).casperEff.createBlock
+        Created(signedBlock3) = createBlockResult3
 
-      _ <- nodes(2).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(1).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) ignores block2
-      _ <- nodes(1).receive() // receives block3; asks for block1'
-      _ <- nodes(2).receive() // receives request for block1'; sends block1'
-      _ <- nodes(1).receive() // receives block1'; adds both block3 and block1'
+        _ <- nodes(2).casperEff.addBlock(signedBlock3, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(1).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) ignores block2
+        _ <- nodes(1).receive() // receives block3; asks for block1'
+        _ <- nodes(2).receive() // receives request for block1'; sends block1'
+        _ <- nodes(1).receive() // receives block1'; adds both block3 and block1'
 
-      _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true
-      _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF true
+        _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true
+        _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF true
 
-      createBlockResult4 <- nodes(1).casperEff
-                             .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
-      Created(signedBlock4) = createBlockResult4
-      _                     <- nodes(1).casperEff.addBlock(signedBlock4, ignoreDoppelgangerCheck[Effect])
+        createBlockResult4 <- nodes(1).casperEff
+                               .deploy(deployDatas(4)) *> nodes(1).casperEff.createBlock
+        Created(signedBlock4) = createBlockResult4
+        _                     <- nodes(1).casperEff.addBlock(signedBlock4, ignoreDoppelgangerCheck[Effect])
 
-      // Node 1 should contain both blocks constituting the equivocation
-      _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
-      _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF true
+        // Node 1 should contain both blocks constituting the equivocation
+        _ <- nodes(1).casperEff.contains(signedBlock1) shouldBeF true
+        _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF true
 
-      _ <- nodes(1).casperEff
-            .contains(signedBlock4) shouldBeF true // However, marked as invalid
+        _ <- nodes(1).casperEff
+              .contains(signedBlock4) shouldBeF true // However, marked as invalid
 
-      _ = nodes(1).logEff.infos.count(_ startsWith "Added admissible equivocation") should be(1)
-      _ = nodes(2).logEff.warns.size should be(0)
-      _ = nodes(1).logEff.warns.size should be(1)
-      _ = nodes(0).logEff.warns.size should be(0)
+        _ = nodes(1).logEff.infos.count(_ startsWith "Added admissible equivocation") should be(1)
+        _ = nodes(2).logEff.warns.size should be(0)
+        _ = nodes(1).logEff.warns.size should be(1)
+        _ = nodes(0).logEff.warns.size should be(0)
 
-      _ <- nodes(1).casperEff
-            .normalizedInitialFault(ProtoUtil.weightMap(genesis)) shouldBeF 1f / (1f + 3f + 5f + 7f)
-      _ <- nodes.map(_.tearDownNode()).toList.sequence
-
-      _ <- validateBlockStore(nodes(0)) { blockStore =>
-            for {
-              _ <- blockStore.get(signedBlock1.blockHash) shouldBeF None
-              result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(
-                         signedBlock1Prime
-                       )
-            } yield result
-          }(nodes(0).metricEff, nodes(0).logEff)
-      _ <- validateBlockStore(nodes(1)) { blockStore =>
-            for {
-              _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
-              result <- blockStore.get(signedBlock4.blockHash) shouldBeF Some(signedBlock4)
-            } yield result
-          }(nodes(1).metricEff, nodes(1).logEff)
-      result <- validateBlockStore(nodes(2)) { blockStore =>
-                 for {
-                   _ <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
-                   result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(
-                              signedBlock1Prime
-                            )
-                 } yield result
-               }(nodes(2).metricEff, nodes(2).logEff)
-    } yield result
+        _ <- nodes(1).casperEff
+              .normalizedInitialFault(ProtoUtil.weightMap(genesis)) shouldBeF 1f / (1f + 3f + 5f + 7f)
+        _ <- validateBlockStore(nodes(0)) { blockStore =>
+              for {
+                _ <- blockStore.get(signedBlock1.blockHash) shouldBeF None
+                result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(
+                           signedBlock1Prime
+                         )
+              } yield result
+            }(nodes(0).metricEff, nodes(0).logEff)
+        _ <- validateBlockStore(nodes(1)) { blockStore =>
+              for {
+                _      <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
+                result <- blockStore.get(signedBlock4.blockHash) shouldBeF Some(signedBlock4)
+              } yield result
+            }(nodes(1).metricEff, nodes(1).logEff)
+        result <- validateBlockStore(nodes(2)) { blockStore =>
+                   for {
+                     _ <- blockStore.get(signedBlock3.blockHash) shouldBeF Some(signedBlock3)
+                     result <- blockStore.get(signedBlock1Prime.blockHash) shouldBeF Some(
+                                signedBlock1Prime
+                              )
+                   } yield result
+                 }(nodes(2).metricEff, nodes(2).logEff)
+      } yield result
+    }
   }
 
   it should "prepare to slash an block that includes a invalid block pointer" in effectTest {
-    for {
-      nodes           <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deploys         <- (0 to 5).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
-      deploysWithCost = deploys.map(d => ProcessedDeploy(deploy = Some(d))).toIndexedSeq
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      for {
+        deploys         <- (0 to 5).toList.traverse(i => ConstructDeploy.basicDeployData[Effect](i))
+        deploysWithCost = deploys.map(d => ProcessedDeploy(deploy = Some(d))).toIndexedSeq
 
-      createBlockResult <- nodes(0).casperEff
-                            .deploy(deploys(0)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock) = createBlockResult
-      signedInvalidBlock = BlockUtil.resignBlock(
-        signedBlock.withSeqNum(-2),
-        nodes(0).validatorId.privateKey
-      ) // Invalid seq num
+        createBlockResult <- nodes(0).casperEff
+                              .deploy(deploys(0)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock) = createBlockResult
+        signedInvalidBlock = BlockUtil.resignBlock(
+          signedBlock.withSeqNum(-2),
+          nodes(0).validatorId.privateKey
+        ) // Invalid seq num
 
-      blockWithInvalidJustification <- buildBlockWithInvalidJustification(
-                                        nodes,
-                                        deploysWithCost,
-                                        signedInvalidBlock
-                                      )
+        blockWithInvalidJustification <- buildBlockWithInvalidJustification(
+                                          nodes,
+                                          deploysWithCost,
+                                          signedInvalidBlock
+                                        )
 
-      _ <- nodes(1).casperEff
-            .addBlock(blockWithInvalidJustification, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(0).transportLayerEff
-            .clear(nodes(0).local) // nodes(0) rejects normal adding process for blockThatPointsToInvalidBlock
+        _ <- nodes(1).casperEff
+              .addBlock(blockWithInvalidJustification, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(0).transportLayerEff
+              .clear(nodes(0).local) // nodes(0) rejects normal adding process for blockThatPointsToInvalidBlock
 
-      signedInvalidBlockPacketMessage = packet(
-        nodes(0).local,
-        "test",
-        transport.BlockMessage,
-        signedInvalidBlock.toByteString
-      )
-      _ <- nodes(0).transportLayerEff.send(nodes(1).local, signedInvalidBlockPacketMessage)
-      _ <- nodes(1).receive() // receives signedInvalidBlock; attempts to add both blocks
+        signedInvalidBlockPacketMessage = packet(
+          nodes(0).local,
+          "test",
+          transport.BlockMessage,
+          signedInvalidBlock.toByteString
+        )
+        _ <- nodes(0).transportLayerEff.send(nodes(1).local, signedInvalidBlockPacketMessage)
+        _ <- nodes(1).receive() // receives signedInvalidBlock; attempts to add both blocks
 
-      result = nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(1)
-      _      <- nodes.map(_.tearDown()).toList.sequence
-    } yield result
+        result = nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(1)
+      } yield result
+    }
   }
 
   it should "estimate parent properly" in effectTest {
@@ -504,45 +502,44 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
       )
 
     val network = TestNetwork.empty[Effect]
-
-    for {
-      nodes <- HashSetCasperTestNode
-                .networkEff(
-                  validatorKeys.take(3),
-                  buildGenesis(
-                    buildGenesisParameters(
-                      5,
-                      Map(
-                        validatorPks(0) -> 3L,
-                        validatorPks(1) -> 1L,
-                        validatorPks(2) -> 5L,
-                        validatorPks(3) -> 2L,
-                        validatorPks(4) -> 4L
-                      )
-                    )
-                  ),
-                  testNetwork = network
-                )
-                .map(_.toList)
-      v1   = nodes(0)
-      v2   = nodes(1)
-      v3   = nodes(2)
-      _    <- deploy(v1, deployment(0, 1)) >> create(v1) >>= (v1c1 => add(v1, v1c1)) //V1#1
-      v2c1 <- deploy(v2, deployment(0, 2)) >> create(v2) //V2#1
-      _    <- v2.receive()
-      _    <- v3.receive()
-      _    <- deploy(v1, deployment(0, 4)) >> create(v1) >>= (v1c2 => add(v1, v1c2)) //V1#2
-      v3c2 <- deploy(v3, deployment(0, 5)) >> create(v3) //V3#2
-      _    <- v3.receive()
-      _    <- add(v3, v3c2) //V3#2
-      _    <- add(v2, v2c1) //V2#1
-      _    <- v3.receive()
-      r    <- deploy(v3, deployment(0, 6)) >> create(v3) >>= (b => add(v3, b))
-      _    = r shouldBe Right(Valid)
-      _    = v3.logEff.warns shouldBe empty
-
-      _ <- nodes.map(_.tearDown()).sequence
-    } yield ()
+    HashSetCasperTestNode
+      .networkEff(
+        validatorKeys.take(3),
+        buildGenesis(
+          buildGenesisParameters(
+            5,
+            Map(
+              validatorPks(0) -> 3L,
+              validatorPks(1) -> 1L,
+              validatorPks(2) -> 5L,
+              validatorPks(3) -> 2L,
+              validatorPks(4) -> 4L
+            )
+          )
+        ),
+        testNetwork = network
+      )
+      .map(_.toList)
+      .use { nodes =>
+        val v1 = nodes(0)
+        val v2 = nodes(1)
+        val v3 = nodes(2)
+        for {
+          _    <- deploy(v1, deployment(0, 1)) >> create(v1) >>= (v1c1 => add(v1, v1c1)) //V1#1
+          v2c1 <- deploy(v2, deployment(0, 2)) >> create(v2) //V2#1
+          _    <- v2.receive()
+          _    <- v3.receive()
+          _    <- deploy(v1, deployment(0, 4)) >> create(v1) >>= (v1c2 => add(v1, v1c2)) //V1#2
+          v3c2 <- deploy(v3, deployment(0, 5)) >> create(v3) //V3#2
+          _    <- v3.receive()
+          _    <- add(v3, v3c2) //V3#2
+          _    <- add(v2, v2c1) //V2#1
+          _    <- v3.receive()
+          r    <- deploy(v3, deployment(0, 6)) >> create(v3) >>= (b => add(v3, b))
+          _    = r shouldBe Right(Valid)
+          _    = v3.logEff.warns shouldBe empty
+        } yield ()
+      }
   }
 
   private def buildBlockWithInvalidJustification(

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperCommunicationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperCommunicationSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import cats.implicits._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
@@ -27,9 +27,8 @@ class MultiParentCasperCommunicationSpec extends FlatSpec with Matchers with Ins
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "MultiParentCasper" should "ask peers for blocks it is missing" in effectTest {
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
-      deployDatas = Vector(
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      val deployDatas = Vector(
         "for(_ <- @1){ Nil } | @1!(1)",
         "@2!(2)"
       ).zipWithIndex
@@ -38,44 +37,43 @@ class MultiParentCasperCommunicationSpec extends FlatSpec with Matchers with Ins
             ConstructDeploy
               .sourceDeploy(d._1, System.currentTimeMillis() + d._2, accounting.MAX_VALUE)
         )
+      for {
+        createBlockResult1 <- nodes(0).casperEff
+                               .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock1) = createBlockResult1
 
-      createBlockResult1 <- nodes(0).casperEff
-                             .deploy(deployDatas(0)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock1) = createBlockResult1
+        _ <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(1).receive()
+        _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
 
-      _ <- nodes(0).casperEff.addBlock(signedBlock1, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(1).receive()
-      _ <- nodes(2).transportLayerEff.clear(nodes(2).local) //nodes(2) misses this block
+        createBlockResult2 <- nodes(0).casperEff
+                               .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
+        Created(signedBlock2) = createBlockResult2
 
-      createBlockResult2 <- nodes(0).casperEff
-                             .deploy(deployDatas(1)) *> nodes(0).casperEff.createBlock
-      Created(signedBlock2) = createBlockResult2
+        _ <- nodes(0).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
+        _ <- nodes(1).receive() //receives block2
+        _ <- nodes(2).receive() //receives block2; asks for block1
+        _ <- nodes(1).receive() //receives request for block1; sends block1
+        _ <- nodes(2).receive() //receives block1; adds both block1 and block2
 
-      _ <- nodes(0).casperEff.addBlock(signedBlock2, ignoreDoppelgangerCheck[Effect])
-      _ <- nodes(1).receive() //receives block2
-      _ <- nodes(2).receive() //receives block2; asks for block1
-      _ <- nodes(1).receive() //receives request for block1; sends block1
-      _ <- nodes(2).receive() //receives block1; adds both block1 and block2
+        _ <- nodes(2).casperEff.contains(signedBlock1) shouldBeF true
+        _ <- nodes(2).casperEff.contains(signedBlock2) shouldBeF true
 
-      _ <- nodes(2).casperEff.contains(signedBlock1) shouldBeF true
-      _ <- nodes(2).casperEff.contains(signedBlock2) shouldBeF true
-
-      _ = nodes(2).logEff.infos
-        .count(_ startsWith "Requested missing block") should be(1)
-      result = nodes(1).logEff.infos.count(
-        s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
-      ) should be(1)
-
-      _ <- nodes.map(_.tearDownNode()).toList.sequence
-      _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
-            validateBlockStore(node) { blockStore =>
-              for {
-                _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
-                result <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
-              } yield result
-            }(nodes(0).metricEff, nodes(0).logEff)
-          }
-    } yield result
+        _ = nodes(2).logEff.infos
+          .count(_ startsWith "Requested missing block") should be(1)
+        result = nodes(1).logEff.infos.count(
+          s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
+        ) should be(1)
+        _ <- nodes.toList.traverse_[Effect, Assertion] { node =>
+              validateBlockStore(node) { blockStore =>
+                for {
+                  _      <- blockStore.get(signedBlock1.blockHash) shouldBeF Some(signedBlock1)
+                  result <- blockStore.get(signedBlock2.blockHash) shouldBeF Some(signedBlock2)
+                } yield result
+              }(nodes(0).metricEff, nodes(0).logEff)
+            }
+      } yield result
+    }
   }
 
   /*
@@ -147,76 +145,75 @@ class MultiParentCasperCommunicationSpec extends FlatSpec with Matchers with Ins
         _ <- nodes(2).receive()
       } yield ()
 
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis)
+    HashSetCasperTestNode.networkEff(validatorKeys.take(3), genesis).use { nodes =>
+      for {
+        _ <- stepSplit(nodes) // blocks a1 a2
+        _ <- stepSplit(nodes) // blocks b1 b2
+        _ <- stepSplit(nodes) // blocks c1 c2
 
-      _ <- stepSplit(nodes) // blocks a1 a2
-      _ <- stepSplit(nodes) // blocks b1 b2
-      _ <- stepSplit(nodes) // blocks c1 c2
+        _ <- stepSingle(nodes) // block d1
+        _ <- stepSingle(nodes) // block e1
 
-      _ <- stepSingle(nodes) // block d1
-      _ <- stepSingle(nodes) // block e1
+        _ <- stepSplit(nodes) // blocks f1 f2
+        _ <- stepSplit(nodes) // blocks g1 g2
 
-      _ <- stepSplit(nodes) // blocks f1 f2
-      _ <- stepSplit(nodes) // blocks g1 g2
+        // this block will be propagated to all nodes and force nodes(2) to ask for missing blocks.
+        br <- deploy(nodes(0), deployDatasFs(0).apply()) // block h1
 
-      // this block will be propagated to all nodes and force nodes(2) to ask for missing blocks.
-      br <- deploy(nodes(0), deployDatasFs(0).apply()) // block h1
+        _ <- List.fill(22)(propagate(nodes)).sequence // force the network to communicate
 
-      _ <- List.fill(22)(propagate(nodes)).toList.sequence // force the network to communicate
+        _ <- nodes(2).casperEff.contains(br) shouldBeF true
 
-      _ <- nodes(2).casperEff.contains(br) shouldBeF true
-
-      nr <- deploy(nodes(2), deployDatasFs(0).apply())
-      _  = nr.header.get.parentsHashList shouldBe Seq(br.blockHash)
-      _  <- nodes.map(_.tearDownNode()).toList.sequence
-    } yield ()
+        nr <- deploy(nodes(2), deployDatasFs(0).apply())
+        _  = nr.header.get.parentsHashList shouldBe Seq(br.blockHash)
+      } yield ()
+    }
   }
 
   it should "handle a long chain of block requests appropriately" in effectTest {
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(
-                validatorKeys.take(2),
-                genesis,
-                storageSize = 1024L * 1024 * 10
-              )
+    HashSetCasperTestNode
+      .networkEff(
+        validatorKeys.take(2),
+        genesis,
+        storageSize = 1024L * 1024 * 10
+      )
+      .use { nodes =>
+        for {
+          _ <- (0 to 9).toList.traverse_[Effect, Unit] { i =>
+                for {
+                  deploy <- ConstructDeploy.basicDeployData[Effect](i)
+                  createBlockResult <- nodes(0).casperEff
+                                        .deploy(deploy) *> nodes(0).casperEff.createBlock
+                  Created(block) = createBlockResult
 
-      _ <- (0 to 9).toList.traverse_[Effect, Unit] { i =>
-            for {
-              deploy <- ConstructDeploy.basicDeployData[Effect](i)
-              createBlockResult <- nodes(0).casperEff
-                                    .deploy(deploy) *> nodes(0).casperEff.createBlock
-              Created(block) = createBlockResult
+                  _ <- nodes(0).casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
+                  _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
+                } yield ()
+              }
+          deployData10 <- ConstructDeploy.basicDeployData[Effect](10)
+          createBlock11Result <- nodes(0).casperEff.deploy(deployData10) *> nodes(
+                                  0
+                                ).casperEff.createBlock
+          Created(block11) = createBlock11Result
+          _                <- nodes(0).casperEff.addBlock(block11, ignoreDoppelgangerCheck[Effect])
 
-              _ <- nodes(0).casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
-              _ <- nodes(1).transportLayerEff.clear(nodes(1).local) //nodes(1) misses this block
-            } yield ()
-          }
-      deployData10 <- ConstructDeploy.basicDeployData[Effect](10)
-      createBlock11Result <- nodes(0).casperEff.deploy(deployData10) *> nodes(
-                              0
-                            ).casperEff.createBlock
-      Created(block11) = createBlock11Result
-      _                <- nodes(0).casperEff.addBlock(block11, ignoreDoppelgangerCheck[Effect])
+          // Cycle of requesting and passing blocks until block #3 from nodes(0) to nodes(1)
+          _ <- (0 to 8).toList.traverse_[Effect, Unit] { i =>
+                nodes(1).receive() *> nodes(0).receive()
+              }
 
-      // Cycle of requesting and passing blocks until block #3 from nodes(0) to nodes(1)
-      _ <- (0 to 8).toList.traverse_[Effect, Unit] { i =>
-            nodes(1).receive() *> nodes(0).receive()
-          }
+          // We simulate a network failure here by not allowing block #2 to get passed to nodes(1)
 
-      // We simulate a network failure here by not allowing block #2 to get passed to nodes(1)
+          // And then we assume fetchDependencies eventually gets called
+          _ <- nodes(1).casperEff.fetchDependencies
+          _ <- nodes(0).receive()
 
-      // And then we assume fetchDependencies eventually gets called
-      _ <- nodes(1).casperEff.fetchDependencies
-      _ <- nodes(0).receive()
-
-      _ = nodes(1).logEff.infos.count(_ startsWith "Requested missing block") should be(10)
-      result = nodes(0).logEff.infos.count(
-        s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
-      ) should be(10)
-
-      _ <- nodes.map(_.tearDown()).toList.sequence
-    } yield result
+          _ = nodes(1).logEff.infos.count(_ startsWith "Requested missing block") should be(10)
+          result = nodes(0).logEff.infos.count(
+            s => (s startsWith "Received request for block") && (s endsWith "Response sent.")
+          ) should be(10)
+        } yield result
+      }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
@@ -4,7 +4,7 @@ import com.google.protobuf.ByteString
 import cats.implicits._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
 import coop.rchain.crypto.codec.Base16
@@ -27,224 +27,225 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
   )
 
   "MultiParentCasper" should "accept deploys" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      deploy <- ConstructDeploy.basicDeployData[Effect](0)
-      _      <- MultiParentCasper[Effect].deploy(deploy)
+      for {
+        deploy <- ConstructDeploy.basicDeployData[Effect](0)
+        _      <- MultiParentCasper[Effect].deploy(deploy)
 
-      _      = logEff.infos.size should be(2)
-      result = logEff.infos(1).contains("Received Deploy") should be(true)
-      _      <- node.tearDown()
-    } yield result
+        _      = logEff.infos.size should be(2)
+        result = logEff.infos(1).contains("Received Deploy") should be(true)
+      } yield result
+    }
   }
 
   it should "not allow deploy if deploy is missing signature" in effectTest {
-    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val casper           = node.casperEff
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val casper           = node.casperEff
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withSig(ByteString.EMPTY)
-      deployResult    <- casper.deploy(incorrectDeploy)
-      _               <- node.tearDown()
-    } yield deployResult should be(Left(MissingSignature))
+      for {
+        correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
+        incorrectDeploy = correctDeploy.withSig(ByteString.EMPTY)
+        deployResult    <- casper.deploy(incorrectDeploy)
+      } yield deployResult should be(Left(MissingSignature))
+    }
   }
 
   it should "not allow deploy if deploy is missing signature algorithm" in effectTest {
-    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val casper           = node.casperEff
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val casper           = node.casperEff
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withSigAlgorithm("")
-      deployResult    <- casper.deploy(incorrectDeploy)
-      _               <- node.tearDown()
-    } yield deployResult should be(Left(MissingSignatureAlgorithm))
+      for {
+        correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
+        incorrectDeploy = correctDeploy.withSigAlgorithm("")
+        deployResult    <- casper.deploy(incorrectDeploy)
+      } yield deployResult should be(Left(MissingSignatureAlgorithm))
+    }
   }
 
   it should "not allow deploy if deploy is missing user" in effectTest {
-    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val casper           = node.casperEff
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val casper           = node.casperEff
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withDeployer(ByteString.EMPTY)
-      deployResult    <- casper.deploy(incorrectDeploy)
-      _               <- node.tearDown()
-    } yield deployResult should be(Left(MissingUser))
+      for {
+        correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
+        incorrectDeploy = correctDeploy.withDeployer(ByteString.EMPTY)
+        deployResult    <- casper.deploy(incorrectDeploy)
+      } yield deployResult should be(Left(MissingUser))
+    }
   }
 
   it should "not allow deploy if deploy is holding non-existing algorithm" in effectTest {
-    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val casper           = node.casperEff
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val casper           = node.casperEff
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withSigAlgorithm("SOME_RANDOME_STUFF")
-      deployResult    <- casper.deploy(incorrectDeploy)
-      _               <- node.tearDown()
-    } yield deployResult should be(Left(UnknownSignatureAlgorithm("SOME_RANDOME_STUFF")))
+      for {
+        correctDeploy   <- ConstructDeploy.basicDeployData[Effect](0)
+        incorrectDeploy = correctDeploy.withSigAlgorithm("SOME_RANDOME_STUFF")
+        deployResult    <- casper.deploy(incorrectDeploy)
+      } yield deployResult should be(Left(UnknownSignatureAlgorithm("SOME_RANDOME_STUFF")))
+    }
   }
 
   it should "not allow deploy if deploy is incorrectly signed" in effectTest {
-    val node             = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val casper           = node.casperEff
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val casper           = node.casperEff
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      correctDeploy <- ConstructDeploy.basicDeployData[Effect](0)
-      incorrectDeploy = correctDeploy.withSig(
-        ByteString.copyFrom(correctDeploy.sig.toByteArray.reverse)
-      )
-      deployResult <- casper.deploy(incorrectDeploy)
-      _            <- node.tearDown()
-    } yield deployResult should be(Left(SignatureVerificationFailed))
+      for {
+        correctDeploy <- ConstructDeploy.basicDeployData[Effect](0)
+        incorrectDeploy = correctDeploy.withSig(
+          ByteString.copyFrom(correctDeploy.sig.toByteArray.reverse)
+        )
+        deployResult <- casper.deploy(incorrectDeploy)
+      } yield deployResult should be(Left(SignatureVerificationFailed))
+    }
   }
 
   it should "not create a block with a repeated deploy" in effectTest {
     implicit val timeEff = new LogicalTime[Effect]
-
-    for {
-      nodes              <- HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis)
-      List(node0, node1) = nodes.toList
-      casper0            = node0.casperEff
-      deploy             <- ConstructDeploy.basicDeployData[Effect](0)
-      _                  <- casper0.deploy(deploy)
-      createBlockResult  <- casper0.createBlock
-      Created(block)     = createBlockResult
-      _                  <- casper0.addBlock(block, ignoreDoppelgangerCheck[Effect])
-      _                  <- node1.receive()
-      casper1            = node1.casperEff
-      _                  <- casper1.deploy(deploy)
-      createBlockResult2 <- casper1.createBlock
-      _                  = createBlockResult2 should be(NoNewDeploys)
-      _                  <- nodes.toList.traverse(_.tearDownNode())
-    } yield ()
+    HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      val List(node0, node1) = nodes.toList
+      val casper0            = node0.casperEff
+      for {
+        deploy             <- ConstructDeploy.basicDeployData[Effect](0)
+        _                  <- casper0.deploy(deploy)
+        createBlockResult  <- casper0.createBlock
+        Created(block)     = createBlockResult
+        _                  <- casper0.addBlock(block, ignoreDoppelgangerCheck[Effect])
+        _                  <- node1.receive()
+        casper1            = node1.casperEff
+        _                  <- casper1.deploy(deploy)
+        createBlockResult2 <- casper1.createBlock
+        _                  = createBlockResult2 should be(NoNewDeploys)
+      } yield ()
+    }
   }
 
   it should "fail when deploying with insufficient phlos" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      deployData        <- ConstructDeploy.basicDeployData[Effect](0, phlos = 1)
-      _                 <- node.casperEff.deploy(deployData)
-      createBlockResult <- MultiParentCasper[Effect].createBlock
-      Created(block)    = createBlockResult
-    } yield assert(block.body.get.deploys.head.errored)
+      for {
+        deployData        <- ConstructDeploy.basicDeployData[Effect](0, phlos = 1)
+        _                 <- node.casperEff.deploy(deployData)
+        createBlockResult <- MultiParentCasper[Effect].createBlock
+        Created(block)    = createBlockResult
+      } yield assert(block.body.get.deploys.head.errored)
+    }
   }
 
   it should "succeed if given enough phlos for deploy" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Effect]
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node._
+      implicit val timeEff = new LogicalTime[Effect]
 
-    for {
-      deployData <- ConstructDeploy.basicDeployData[Effect](0, phlos = 100)
-      _          <- node.casperEff.deploy(deployData)
+      for {
+        deployData <- ConstructDeploy.basicDeployData[Effect](0, phlos = 100)
+        _          <- node.casperEff.deploy(deployData)
 
-      createBlockResult <- MultiParentCasper[Effect].createBlock
-      Created(block)    = createBlockResult
-    } yield assert(!block.body.get.deploys.head.errored)
+        createBlockResult <- MultiParentCasper[Effect].createBlock
+        Created(block)    = createBlockResult
+      } yield assert(!block.body.get.deploys.head.errored)
+    }
   }
 
   it should "allow paying for deploys" in effectTest {
-    val node      = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    val (sk, pk)  = Ed25519.newKeyPair
-    val timestamp = System.currentTimeMillis()
-    val phloPrice = 1L
-    val amount    = 847L
-    val sigDeployData = ConstructDeploy
-      .sourceDeploy(
-        s"""new retCh in { @"blake2b256Hash"!([0, $amount, *retCh].toByteArray(), "__SCALA__") }""",
-        timestamp,
-        accounting.MAX_VALUE,
-        sec = sk
-      )
-
-    for {
-      capturedResults <- node.runtimeManager
-                          .captureResults(
-                            ProtoUtil.postStateHash(genesis),
-                            sigDeployData
-                          )
-      sigData     = capturedResults.head.exprs.head.getGByteArray
-      sig         = Base16.encode(Ed25519.sign(sigData.toByteArray, sk))
-      pkStr       = Base16.encode(pk.bytes)
-      paymentCode = s"""new
-         |  paymentForward, walletCh, rl(`rho:registry:lookup`),
-         |  SystemInstancesCh, faucetCh, posCh
-         |in {
-         |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
-         |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-         |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
-         |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
-         |    for(faucet <- faucetCh; pos <- posCh){
-         |      faucet!($amount, "ed25519", "$pkStr", *walletCh) |
-         |      for(@[wallet] <- walletCh) {
-         |        @wallet!("transfer", $amount, 0, "$sig", *paymentForward, Nil) |
-         |        for(@purse <- paymentForward){ pos!("pay", purse, Nil) }
-         |      }
-         |    }
-         |  }
-         |}""".stripMargin
-      paymentDeployData = ConstructDeploy
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      val (sk, pk)  = Ed25519.newKeyPair
+      val timestamp = System.currentTimeMillis()
+      val phloPrice = 1L
+      val amount    = 847L
+      val sigDeployData = ConstructDeploy
         .sourceDeploy(
-          paymentCode,
+          s"""new retCh in { @"blake2b256Hash"!([0, $amount, *retCh].toByteArray(), "__SCALA__") }""",
           timestamp,
           accounting.MAX_VALUE,
-          phloPrice = phloPrice,
           sec = sk
         )
 
-      paymentQuery = ConstructDeploy
-        .sourceDeploy(
-          """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
-        |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
-        |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-        |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
-        |    for(pos <- posCh){ pos!("lastPayment", "__SCALA__") }
-        |  }
-        |}""".stripMargin,
-          0L,
-          accounting.MAX_VALUE,
-          sec = sk
-        )
+      for {
+        capturedResults <- node.runtimeManager
+                            .captureResults(
+                              ProtoUtil.postStateHash(genesis),
+                              sigDeployData
+                            )
+        sigData     = capturedResults.head.exprs.head.getGByteArray
+        sig         = Base16.encode(Ed25519.sign(sigData.toByteArray, sk))
+        pkStr       = Base16.encode(pk.bytes)
+        paymentCode = s"""new
+           |  paymentForward, walletCh, rl(`rho:registry:lookup`),
+           |  SystemInstancesCh, faucetCh, posCh
+           |in {
+           |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
+           |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
+           |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
+           |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
+           |    for(faucet <- faucetCh; pos <- posCh){
+           |      faucet!($amount, "ed25519", "$pkStr", *walletCh) |
+           |      for(@[wallet] <- walletCh) {
+           |        @wallet!("transfer", $amount, 0, "$sig", *paymentForward, Nil) |
+           |        for(@purse <- paymentForward){ pos!("pay", purse, Nil) }
+           |      }
+           |    }
+           |  }
+           |}""".stripMargin
+        paymentDeployData = ConstructDeploy
+          .sourceDeploy(
+            paymentCode,
+            timestamp,
+            accounting.MAX_VALUE,
+            phloPrice = phloPrice,
+            sec = sk
+          )
 
-      deployQueryResult <- deployAndQuery(
-                            node,
-                            paymentDeployData,
-                            paymentQuery
-                          )
-      (blockStatus, queryResult) = deployQueryResult
-      DeployParameters(codeHashPar, _, userIdPar, timestampPar) = ProtoUtil.getRholangDeployParams(
-        paymentDeployData
-      )
-      phloPurchasedPar = Par(exprs = Seq(Expr(Expr.ExprInstance.GInt(phloPrice * amount))))
+        paymentQuery = ConstructDeploy
+          .sourceDeploy(
+            """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
+              |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
+              |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
+              |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
+              |    for(pos <- posCh){ pos!("lastPayment", "__SCALA__") }
+              |  }
+              |}""".stripMargin,
+            0L,
+            accounting.MAX_VALUE,
+            sec = sk
+          )
 
-      _ <- node.tearDown()
-    } yield {
-      blockStatus shouldBe Valid
+        deployQueryResult <- deployAndQuery(
+                              node,
+                              paymentDeployData,
+                              paymentQuery
+                            )
+        (blockStatus, queryResult) = deployQueryResult
+        DeployParameters(codeHashPar, _, userIdPar, timestampPar) = ProtoUtil
+          .getRholangDeployParams(
+            paymentDeployData
+          )
+        phloPurchasedPar = Par(exprs = Seq(Expr(Expr.ExprInstance.GInt(phloPrice * amount))))
+      } yield {
+        blockStatus shouldBe Valid
 
-      queryResult.head.exprs.head.getETupleBody.ps match {
-        case Seq(
-            actualCodeHashPar,
-            actualUserIdPar,
-            actualTimestampPar,
-            actualPhloPurchasedPar
-            ) =>
-          actualCodeHashPar should be(codeHashPar)
-          actualUserIdPar should be(userIdPar)
-          actualTimestampPar should be(timestampPar)
-          actualPhloPurchasedPar should be(phloPurchasedPar)
+        queryResult.head.exprs.head.getETupleBody.ps match {
+          case Seq(
+              actualCodeHashPar,
+              actualUserIdPar,
+              actualTimestampPar,
+              actualPhloPurchasedPar
+              ) =>
+            actualCodeHashPar should be(codeHashPar)
+            actualUserIdPar should be(userIdPar)
+            actualTimestampPar should be(timestampPar)
+            actualPhloPurchasedPar should be(phloPurchasedPar)
+        }
       }
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperRholangSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperRholangSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import cats.implicits._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
 import coop.rchain.crypto.PrivateKey
@@ -28,151 +28,150 @@ class MultiParentCasperRholangSpec extends FlatSpec with Matchers with Inspector
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "MultiParentCasper" should "create blocks based on deploys" in effectTest {
-    val node            = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    implicit val casper = node.casperEff
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      implicit val casper = node.casperEff
 
-    for {
-      deploy <- ConstructDeploy.basicDeployData[Effect](0)
-      _      <- MultiParentCasper[Effect].deploy(deploy)
+      for {
+        deploy <- ConstructDeploy.basicDeployData[Effect](0)
+        _      <- MultiParentCasper[Effect].deploy(deploy)
 
-      createBlockResult <- MultiParentCasper[Effect].createBlock
-      Created(block)    = createBlockResult
-      deploys           = block.body.get.deploys.flatMap(_.deploy)
-      parents           = ProtoUtil.parentHashes(block)
-      storage           <- blockTuplespaceContents(block)
+        createBlockResult <- MultiParentCasper[Effect].createBlock
+        Created(block)    = createBlockResult
+        deploys           = block.body.get.deploys.flatMap(_.deploy)
+        parents           = ProtoUtil.parentHashes(block)
+        storage           <- blockTuplespaceContents(block)
 
-      _      = parents.size should be(1)
-      _      = parents.head should be(genesis.blockHash)
-      _      = deploys.size should be(1)
-      _      = deploys.head should be(deploy)
-      result = storage.contains("@{0}!(0)") should be(true)
-      _      <- node.tearDown()
-    } yield result
+        _      = parents.size should be(1)
+        _      = parents.head should be(genesis.blockHash)
+        _      = deploys.size should be(1)
+        _      = deploys.head should be(deploy)
+        result = storage.contains("@{0}!(0)") should be(true)
+      } yield result
+    }
   }
 
   it should "be able to use the registry" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node.casperEff
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node.casperEff
 
-    def now = System.currentTimeMillis()
-    val registerDeploy = ConstructDeploy.sourceDeploy(
-      """new uriCh, rr(`rho:registry:insertArbitrary`), hello in {
-        |  contract hello(@name, return) = { return!("Hello, ${name}!" %% {"name" : name}) } |
-        |  rr!(bundle+{*hello}, *uriCh)
-        |}
-      """.stripMargin,
-      1539788365118L, //fix the timestamp so that `uriCh` is known
-      accounting.MAX_VALUE
-    )
+      def now = System.currentTimeMillis()
 
-    for {
-      _                 <- casperEff.deploy(registerDeploy)
-      createBlockResult <- casperEff.createBlock
-      Created(block)    = createBlockResult
-      blockStatus       <- casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
-      id <- casperEff
-             .storageContents(ProtoUtil.postStateHash(block))
-             .map(
-               _.split('|')
-                 .find(
-                   _.contains(
-                     //based on the timestamp of registerDeploy, this is uriCh
-                     "@{Unforgeable(0xe2615f3fd74c2b83230a3bfc44001d38aded3d2ade5e9b15ffd20e8566d3426f)}!"
-                   )
-                 )
-                 .get
-                 .split('`')(1)
-             )
-      callDeploy = ConstructDeploy.sourceDeploy(
-        s"""new rl(`rho:registry:lookup`), helloCh, out in {
-           |  rl!(`$id`, *helloCh) |
-           |  for(hello <- helloCh){ hello!("World", *out) }
-           |}
-      """.stripMargin,
-        now,
+      val registerDeploy = ConstructDeploy.sourceDeploy(
+        """new uriCh, rr(`rho:registry:insertArbitrary`), hello in {
+          |  contract hello(@name, return) = { return!("Hello, ${name}!" %% {"name" : name}) } |
+          |  rr!(bundle+{*hello}, *uriCh)
+          |}
+        """.stripMargin,
+        1539788365118L, //fix the timestamp so that `uriCh` is known
         accounting.MAX_VALUE
       )
-      _                  <- casperEff.deploy(callDeploy)
-      createBlockResult2 <- casperEff.createBlock
-      Created(block2)    = createBlockResult2
-      block2Status       <- casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
-      _                  = blockStatus shouldBe Valid
-      _                  = block2Status shouldBe Valid
-      result <- casperEff
-                 .storageContents(ProtoUtil.postStateHash(block2))
-                 .map(_.contains("Hello, World!")) shouldBeF true
 
-      _ <- node.tearDown()
-    } yield result
+      for {
+        _                 <- casperEff.deploy(registerDeploy)
+        createBlockResult <- casperEff.createBlock
+        Created(block)    = createBlockResult
+        blockStatus       <- casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
+        id <- casperEff
+               .storageContents(ProtoUtil.postStateHash(block))
+               .map(
+                 _.split('|')
+                   .find(
+                     _.contains(
+                       //based on the timestamp of registerDeploy, this is uriCh
+                       "@{Unforgeable(0xe2615f3fd74c2b83230a3bfc44001d38aded3d2ade5e9b15ffd20e8566d3426f)}!"
+                     )
+                   )
+                   .get
+                   .split('`')(1)
+               )
+        callDeploy = ConstructDeploy.sourceDeploy(
+          s"""new rl(`rho:registry:lookup`), helloCh, out in {
+             |  rl!(`$id`, *helloCh) |
+             |  for(hello <- helloCh){ hello!("World", *out) }
+             |}
+      """.stripMargin,
+          now,
+          accounting.MAX_VALUE
+        )
+        _                  <- casperEff.deploy(callDeploy)
+        createBlockResult2 <- casperEff.createBlock
+        Created(block2)    = createBlockResult2
+        block2Status       <- casperEff.addBlock(block2, ignoreDoppelgangerCheck[Effect])
+        _                  = blockStatus shouldBe Valid
+        _                  = block2Status shouldBe Valid
+        result <- casperEff
+                   .storageContents(ProtoUtil.postStateHash(block2))
+                   .map(_.contains("Hello, World!")) shouldBeF true
+      } yield result
+    }
   }
 
   it should "have a working faucet (in testnet)" in effectTest {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head)
-    import node.casperEff
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.head).use { node =>
+      import node.casperEff
 
-    //val skStr = "6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14"
-    val pkStr = "16989775f3f207a717134216816d3c9d97b0bfb8d560b29485f23f6ead435f09"
-    val sigStr = "51c2b091559745d51c7270189911d9d894d538f76150ed67d164705dcf0af52" +
-      "e101fa06396db2b2ac21a4bfbe3461567b5f8b3d2e666c377cb92d96bc38e2c08"
-    val amount = 157L
-    val createWalletCode =
-      s"""new
-         |  walletCh, rl(`rho:registry:lookup`), SystemInstancesCh, faucetCh,
-         |  rs(`rho:registry:insertSigned:ed25519`), uriOut
-         |in {
-         |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
-         |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
-         |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
-         |    for(faucet <- faucetCh){ faucet!($amount, "ed25519", "$pkStr", *walletCh) } |
-         |    for(@[wallet] <- walletCh){ walletCh!!(wallet) }
-         |  } |
-         |  rs!(
-         |    "$pkStr".hexToBytes(),
-         |    (9223372036854775807, bundle-{*walletCh}),
-         |    "$sigStr".hexToBytes(),
-         |    *uriOut
-         |  )
-         |}""".stripMargin
-
-    //with the fixed user+timestamp we know that walletCh is registered at `rho:id:mrs88izurkgki71dpjqamzg6tgcjd6sk476c9msks7tumw4a6e39or`
-    val createWalletDeploy = ConstructDeploy.sourceDeploy(
-      source = createWalletCode,
-      timestamp = 1540570144121L,
-      phlos = accounting.MAX_VALUE,
-      sec = PrivateKey(
-        Base16.unsafeDecode("6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14")
-      )
-    )
-
-    for {
-      createBlockResult <- casperEff.deploy(createWalletDeploy) *> casperEff.createBlock
-      Created(block)    = createBlockResult
-      blockStatus       <- casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
-      balanceQuery = ConstructDeploy.sourceDeploy(
+      //val skStr = "6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14"
+      val pkStr = "16989775f3f207a717134216816d3c9d97b0bfb8d560b29485f23f6ead435f09"
+      val sigStr = "51c2b091559745d51c7270189911d9d894d538f76150ed67d164705dcf0af52" +
+        "e101fa06396db2b2ac21a4bfbe3461567b5f8b3d2e666c377cb92d96bc38e2c08"
+      val amount = 157L
+      val createWalletCode =
         s"""new
-           |  rl(`rho:registry:lookup`), walletFeedCh
+           |  walletCh, rl(`rho:registry:lookup`), SystemInstancesCh, faucetCh,
+           |  rs(`rho:registry:insertSigned:ed25519`), uriOut
            |in {
-           |  rl!(`rho:id:mrs88izurkgki71dpjqamzg6tgcjd6sk476c9msks7tumw4a6e39or`, *walletFeedCh) |
-           |  for(@(_, walletFeed) <- walletFeedCh) {
-           |    for(wallet <- @walletFeed) { wallet!("getBalance", "__SCALA__") }
-           |  }
-           |}""".stripMargin,
-        0L,
-        accounting.MAX_VALUE,
+           |  rl!(`rho:id:wdwc36f4ixa6xacck3ddepmgueum7zueuczgthcqp6771kdu8jogm8`, *SystemInstancesCh) |
+           |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
+           |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
+           |    for(faucet <- faucetCh){ faucet!($amount, "ed25519", "$pkStr", *walletCh) } |
+           |    for(@[wallet] <- walletCh){ walletCh!!(wallet) }
+           |  } |
+           |  rs!(
+           |    "$pkStr".hexToBytes(),
+           |    (9223372036854775807, bundle-{*walletCh}),
+           |    "$sigStr".hexToBytes(),
+           |    *uriOut
+           |  )
+           |}""".stripMargin
+
+      //with the fixed user+timestamp we know that walletCh is registered at `rho:id:mrs88izurkgki71dpjqamzg6tgcjd6sk476c9msks7tumw4a6e39or`
+      val createWalletDeploy = ConstructDeploy.sourceDeploy(
+        source = createWalletCode,
+        timestamp = 1540570144121L,
+        phlos = accounting.MAX_VALUE,
         sec = PrivateKey(
           Base16.unsafeDecode("6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14")
         )
       )
-      newWalletBalance <- node.runtimeManager
-                           .captureResults(
-                             ProtoUtil.postStateHash(block),
-                             balanceQuery
-                           )
-      _      = blockStatus shouldBe Valid
-      result = newWalletBalance.head.exprs.head.getGInt shouldBe amount
 
-      _ <- node.tearDown()
-    } yield result
+      for {
+        createBlockResult <- casperEff.deploy(createWalletDeploy) *> casperEff.createBlock
+        Created(block)    = createBlockResult
+        blockStatus       <- casperEff.addBlock(block, ignoreDoppelgangerCheck[Effect])
+        balanceQuery = ConstructDeploy.sourceDeploy(
+          s"""new
+             |  rl(`rho:registry:lookup`), walletFeedCh
+             |in {
+             |  rl!(`rho:id:mrs88izurkgki71dpjqamzg6tgcjd6sk476c9msks7tumw4a6e39or`, *walletFeedCh) |
+             |  for(@(_, walletFeed) <- walletFeedCh) {
+             |    for(wallet <- @walletFeed) { wallet!("getBalance", "__SCALA__") }
+             |  }
+             |}""".stripMargin,
+          0L,
+          accounting.MAX_VALUE,
+          sec = PrivateKey(
+            Base16.unsafeDecode("6061f3ea36d0419d1e9e23c33bba88ed1435427fa2a8f7300ff210b4e9f18a14")
+          )
+        )
+        newWalletBalance <- node.runtimeManager
+                             .captureResults(
+                               ProtoUtil.postStateHash(block),
+                               balanceQuery
+                             )
+        _      = blockStatus shouldBe Valid
+        result = newWalletBalance.head.exprs.head.getGInt shouldBe amount
+      } yield result
+    }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
@@ -37,7 +37,6 @@ object MultiParentCasperTestUtil {
       bs     <- BlockDagStorageTestFixture.createBlockStorage[Effect](node.blockStoreDir)
       result <- f(bs)
       _      <- bs.close()
-      _      <- Sync[Effect].delay { node.blockStoreDir.recursivelyDelete() }
     } yield result
 
   def blockTuplespaceContents(

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import cats.implicits._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.rholang.interpreter.accounting
@@ -19,32 +19,33 @@ class RholangBuildTest extends FlatSpec with Matchers {
   //put a new casper instance at the start of each
   //test since we cannot reset it
   "Our build system" should "allow import of rholang sources into scala code" in {
-    val node = HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.last)
-    import node._
+    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.last).use { node =>
+      import node._
 
-    val code =
-      """new double, dprimes, rl(`rho:registry:lookup`), ListOpsCh, time(`rho:block:timestamp`), timeRtn, timeStore, stdout(`rho:io:stdout`) in {
-        |  contract double(@x, ret) = { ret!(2 * x) } |
-        |  rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
-        |  for(@(_, ListOps) <- ListOpsCh) {
-        |    @ListOps!("map", [2, 3, 5, 7], *double, *dprimes)
-        |  } |
-        |  time!(*timeRtn) |
-        |  for (@timestamp <- timeRtn) {
-        |    timeStore!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
-        |  }
-        |}""".stripMargin
-    val deploy = ConstructDeploy.sourceDeploy(code, 1L, accounting.MAX_VALUE)
-    for {
-      createBlockResult    <- MultiParentCasper[Effect].deploy(deploy) *> MultiParentCasper[Effect].createBlock
-      Created(signedBlock) = createBlockResult
-      _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-      storage              <- MultiParentCasperTestUtil.blockTuplespaceContents(signedBlock)
-      _                    = logEff.warns should be(Nil)
-      _                    = storage.contains("!([4, 6, 10, 14])") should be(true)
-      result               = storage.contains("!(\"The timestamp is 1\")") should be(true)
-      _                    = node.tearDown()
-    } yield result
+      val code =
+        """new double, dprimes, rl(`rho:registry:lookup`), ListOpsCh, time(`rho:block:timestamp`), timeRtn, timeStore, stdout(`rho:io:stdout`) in {
+          |  contract double(@x, ret) = { ret!(2 * x) } |
+          |  rl!(`rho:id:dputnspi15oxxnyymjrpu7rkaok3bjkiwq84z7cqcrx4ktqfpyapn4`, *ListOpsCh) |
+          |  for(@(_, ListOps) <- ListOpsCh) {
+          |    @ListOps!("map", [2, 3, 5, 7], *double, *dprimes)
+          |  } |
+          |  time!(*timeRtn) |
+          |  for (@timestamp <- timeRtn) {
+          |    timeStore!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
+          |  }
+          |}""".stripMargin
+      val deploy = ConstructDeploy.sourceDeploy(code, 1L, accounting.MAX_VALUE)
+      for {
+        createBlockResult <- MultiParentCasper[Effect]
+                              .deploy(deploy) *> MultiParentCasper[Effect].createBlock
+        Created(signedBlock) = createBlockResult
+        _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+        storage              <- MultiParentCasperTestUtil.blockTuplespaceContents(signedBlock)
+        _                    = logEff.warns should be(Nil)
+        _                    = storage.contains("!([4, 6, 10, 14])") should be(true)
+        result               = storage.contains("!(\"The timestamp is 1\")") should be(true)
+      } yield result
+    }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -4,13 +4,12 @@ import java.nio.file.{Files, Path}
 
 import cats.data.EitherT
 import cats.effect.concurrent.{Ref, Semaphore}
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, Resource, Sync}
 import cats.implicits._
 import cats.{Applicative, ApplicativeError, Id, Monad}
 import coop.rchain.blockstorage._
 import coop.rchain.casper._
 import coop.rchain.casper.helper.BlockDagStorageTestFixture.mapSize
-import coop.rchain.casper.helper.HashSetCasperTestNode.Close
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.comm.CasperPacketHandler.{
@@ -57,12 +56,11 @@ class HashSetCasperTestNode[F[_]](
     sk: PrivateKey,
     logicalTime: LogicalTime[F],
     implicit val errorHandlerEff: ErrorHandler[F],
-    storageSize: Long,
     val blockDagDir: Path,
     val blockStoreDir: Path,
     blockProcessingLock: Semaphore[F],
     shardId: String = "rchain",
-    createRuntime: (Path, Long) => (RuntimeManager[F], Close[F])
+    val runtimeManager: RuntimeManager[F]
 )(
     implicit concurrentF: Concurrent[F],
     val blockStore: BlockStore[F],
@@ -71,17 +69,12 @@ class HashSetCasperTestNode[F[_]](
     val casperState: Cell[F, CasperState]
 ) {
 
-  private val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-$name")
-
   implicit val logEff             = new LogStub[F]
   implicit val timeEff            = logicalTime
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
   implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
   implicit val rpConfAsk          = createRPConfAsk[F](local)
-
-  val (runtimeManager, closeRuntime) =
-    createRuntime(storageDirectory, storageSize)
 
   val defaultTimeout: FiniteDuration = FiniteDuration(1000, MILLISECONDS)
 
@@ -127,24 +120,9 @@ class HashSetCasperTestNode[F[_]](
       }
 
   def receive(): F[Unit] = tls.receive(p => handle[F](p), kp(().pure[F])).void
-
-  def tearDown(): F[Unit] =
-    tearDownNode().map { _ =>
-      blockStoreDir.recursivelyDelete()
-      blockDagDir.recursivelyDelete()
-    }
-
-  def tearDownNode(): F[Unit] =
-    for {
-      _ <- blockStore.close()
-      _ <- blockDagStorage.close()
-      _ <- closeRuntime.apply()
-    } yield ()
 }
 
 object HashSetCasperTestNode {
-  type Close[F[_]] = () => F[Unit] //TODO replace with Resource
-
   type CommErrT[F[_], A] = EitherT[F, CommError, A]
   type Effect[A]         = CommErrT[Task, A]
 
@@ -152,7 +130,7 @@ object HashSetCasperTestNode {
 
   def createRuntime(storageDirectory: Path, storageSize: Long)(
       implicit scheduler: Scheduler
-  ): (RuntimeManager[Effect], Close[Effect]) = {
+  ): Resource[Effect, RuntimeManager[Effect]] = {
     implicit val log                       = new Log.NOPLog[Task]()
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     val activeRuntime =
@@ -160,10 +138,9 @@ object HashSetCasperTestNode {
         .createWithEmptyCost[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB)
         .unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
-    (
-      RuntimeManager.eitherTRuntimeManager(runtimeManager),
-      () => activeRuntime.close().liftM[CommErrT]
-    )
+    Resource.make[Effect, RuntimeManager[Effect]](
+      RuntimeManager.eitherTRuntimeManager[CommError, Task](runtimeManager).pure[Effect]
+    )(_ => activeRuntime.close().liftM[CommErrT])
   }
 
   def rigConnectionsF[F[_]: Monad](
@@ -186,13 +163,15 @@ object HashSetCasperTestNode {
   def standaloneF[F[_]](
       genesis: BlockMessage,
       sk: PrivateKey,
-      storageSize: Long = 1024L * 1024 * 10,
-      createRuntime: (Path, Long) => (RuntimeManager[F], Close[F])
+      blockDagDir: Path,
+      blockStoreDir: Path,
+      storageSize: Long,
+      createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]]
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
       testNetworkF: TestNetwork[F]
-  ): F[HashSetCasperTestNode[F]] = {
+  ): Resource[F, HashSetCasperTestNode[F]] = {
     val name                        = "standalone"
     val identity                    = peerNode(name, 40400)
     val tle                         = new TransportLayerTestImpl[F]()
@@ -200,55 +179,67 @@ object HashSetCasperTestNode {
     val logicalTime: LogicalTime[F] = new LogicalTime[F]
     implicit val log                = new Log.NOPLog[F]()
     implicit val metricEff          = new Metrics.MetricsNOP[F]
-
-    val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
-    val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
-    val env           = Context.env(blockStoreDir, mapSize)
+    val env                         = Context.env(blockStoreDir, mapSize)
     for {
-      _          <- TestNetwork.addPeer(identity)
-      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
-      blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
-                          BlockDagFileStorage.Config(
-                            blockDagDir.resolve("latest-messages-data"),
-                            blockDagDir.resolve("latest-messages-crc"),
-                            blockDagDir.resolve("block-metadata-data"),
-                            blockDagDir.resolve("block-metadata-crc"),
-                            blockDagDir.resolve("equivocations-tracker-data"),
-                            blockDagDir.resolve("equivocations-tracker-crc"),
-                            blockDagDir.resolve("invalid-blocks-data"),
-                            blockDagDir.resolve("invalid-blocks-crc"),
-                            blockDagDir.resolve("checkpoints"),
-                            blockDagDir.resolve("block-number-index"),
-                            mapSize
-                          ),
-                          genesis
-                        )(Concurrent[F], Sync[F], Log[F])
-      blockProcessingLock <- Semaphore[F](1)
-      casperState         <- Cell.mvarCell[F, CasperState](CasperState())
-      node = new HashSetCasperTestNode[F](
-        name,
-        identity,
-        tle,
-        tls,
-        genesis,
-        sk,
-        logicalTime,
-        errorHandler,
-        storageSize,
-        blockDagDir,
-        blockStoreDir,
-        blockProcessingLock,
-        "rchain",
-        createRuntime
-      )(
-        concurrentF,
-        blockStore,
-        blockDagStorage,
-        metricEff,
-        casperState
-      )
-      result <- node.initialize.map(_ => node)
-    } yield result
+      blockStore <- Resource.make[F, BlockStore[F]](
+                     FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
+                   )(_.close())
+      blockDagStorage <- Resource.make[F, BlockDagStorage[F]](
+                          BlockDagFileStorage
+                            .createEmptyFromGenesis[F](
+                              BlockDagFileStorage.Config(
+                                blockDagDir.resolve("latest-messages-data"),
+                                blockDagDir.resolve("latest-messages-crc"),
+                                blockDagDir.resolve("block-metadata-data"),
+                                blockDagDir.resolve("block-metadata-crc"),
+                                blockDagDir.resolve("equivocations-tracker-data"),
+                                blockDagDir.resolve("equivocations-tracker-crc"),
+                                blockDagDir.resolve("invalid-blocks-data"),
+                                blockDagDir.resolve("invalid-blocks-crc"),
+                                blockDagDir.resolve("checkpoints"),
+                                blockDagDir.resolve("block-number-index"),
+                                mapSize
+                              ),
+                              genesis
+                            )(Concurrent[F], Sync[F], Log[F])
+                            .widen[BlockDagStorage[F]]
+                        )(_.close())
+      storageDirectory <- Resource.make[F, Path](
+                           Sync[F].delay {
+                             Files.createTempDirectory(s"hash-set-casper-test-$name")
+                           }
+                         )(dir => Sync[F].delay { dir.recursivelyDelete() })
+      runtimeManager <- createRuntime(storageDirectory, storageSize)
+      node <- Resource.make[F, HashSetCasperTestNode[F]] {
+               for {
+                 _                   <- TestNetwork.addPeer(identity)
+                 blockProcessingLock <- Semaphore[F](1)
+                 casperState         <- Cell.mvarCell[F, CasperState](CasperState())
+                 node = new HashSetCasperTestNode[F](
+                   name,
+                   identity,
+                   tle,
+                   tls,
+                   genesis,
+                   sk,
+                   logicalTime,
+                   errorHandler,
+                   blockDagDir,
+                   blockStoreDir,
+                   blockProcessingLock,
+                   "rchain",
+                   runtimeManager
+                 )(
+                   concurrentF,
+                   blockStore,
+                   blockDagStorage,
+                   metricEff,
+                   casperState
+                 )
+                 result <- node.initialize().map(_ => node)
+               } yield result
+             }(_ => ().pure[F])
+    } yield node
   }
   def standaloneEff(
       genesis: BlockMessage,
@@ -257,23 +248,33 @@ object HashSetCasperTestNode {
       testNetwork: TestNetwork[Effect] = TestNetwork.empty
   )(
       implicit scheduler: Scheduler
-  ): HashSetCasperTestNode[Effect] =
-    standaloneF[Effect](genesis, sk, storageSize, createRuntime)(
-      ApplicativeError_[Effect, CommError],
-      Concurrent[Effect],
-      testNetwork
-    ).value.unsafeRunSync.right.get
+  ): Resource[Effect, HashSetCasperTestNode[Effect]] =
+    BlockDagStorageTestFixture.createDirectories[Effect].flatMap {
+      case (blockStoreDir, blockDagDir) =>
+        standaloneF[Effect](
+          genesis,
+          sk,
+          blockDagDir,
+          blockStoreDir,
+          storageSize,
+          createRuntime
+        )(
+          ApplicativeError_[Effect, CommError],
+          Concurrent[Effect],
+          testNetwork
+        )
+    }
 
   def networkF[F[_]](
       sks: IndexedSeq[PrivateKey],
       genesis: BlockMessage,
-      storageSize: Long = 1024L * 1024 * 10,
-      createRuntime: (Path, Long) => (RuntimeManager[F], Close[F])
+      storageSize: Long,
+      createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]]
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
       testNetworkF: TestNetwork[F]
-  ): F[IndexedSeq[HashSetCasperTestNode[F]]] = {
+  ): Resource[F, IndexedSeq[HashSetCasperTestNode[F]]] = {
     val n                           = sks.length
     val names                       = (1 to n).map(i => s"node-$i")
     val peers                       = names.map(peerNode(_, 40400))
@@ -290,87 +291,109 @@ object HashSetCasperTestNode {
             val tls                = new TransportLayerServerTestImpl[F](p)
             implicit val log       = new Log.NOPLog[F]()
             implicit val metricEff = new Metrics.MetricsNOP[F]
-
-            val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
-            val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
-            val env           = Context.env(blockStoreDir, mapSize)
             for {
-              _          <- TestNetwork.addPeer(p)
-              blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
-              blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
-                                  BlockDagFileStorage.Config(
-                                    blockDagDir.resolve("latest-messages-data"),
-                                    blockDagDir.resolve("latest-messages-crc"),
-                                    blockDagDir.resolve("block-metadata-data"),
-                                    blockDagDir.resolve("block-metadata-crc"),
-                                    blockDagDir.resolve("equivocations-tracker-data"),
-                                    blockDagDir.resolve("equivocations-tracker-crc"),
-                                    blockDagDir.resolve("invalid-blocks-data"),
-                                    blockDagDir.resolve("invalid-blocks-crc"),
-                                    blockDagDir.resolve("checkpoints"),
-                                    blockDagDir.resolve("block-number-index"),
-                                    mapSize
-                                  ),
-                                  genesis
-                                )(Concurrent[F], Sync[F], Log[F])
-              semaphore <- Semaphore[F](1)
-              casperState <- Cell.mvarCell[F, CasperState](
-                              CasperState()
-                            )
-              node = new HashSetCasperTestNode[F](
-                n,
-                p,
-                tle,
-                tls,
-                genesis,
-                sk,
-                logicalTime,
-                errorHandler,
-                storageSize,
-                blockDagDir,
-                blockStoreDir,
-                semaphore,
-                "rchain",
-                createRuntime
-              )(
-                concurrentF,
-                blockStore,
-                blockDagStorage,
-                metricEff,
-                casperState
-              )
+              storageDirectories           <- BlockDagStorageTestFixture.createDirectories[F]
+              (blockStoreDir, blockDagDir) = storageDirectories
+              env                          = Context.env(blockStoreDir, mapSize)
+              blockStore <- Resource.make[F, BlockStore[F]](
+                             FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
+                           )(_.close())
+              blockDagStorage <- Resource.make[F, BlockDagStorage[F]](
+                                  BlockDagFileStorage
+                                    .createEmptyFromGenesis[F](
+                                      BlockDagFileStorage.Config(
+                                        blockDagDir.resolve("latest-messages-data"),
+                                        blockDagDir.resolve("latest-messages-crc"),
+                                        blockDagDir.resolve("block-metadata-data"),
+                                        blockDagDir.resolve("block-metadata-crc"),
+                                        blockDagDir.resolve("equivocations-tracker-data"),
+                                        blockDagDir.resolve("equivocations-tracker-crc"),
+                                        blockDagDir.resolve("invalid-blocks-data"),
+                                        blockDagDir.resolve("invalid-blocks-crc"),
+                                        blockDagDir.resolve("checkpoints"),
+                                        blockDagDir.resolve("block-number-index"),
+                                        mapSize
+                                      ),
+                                      genesis
+                                    )(Concurrent[F], Sync[F], Log[F])
+                                    .widen
+                                )(_.close())
+              storageDirectory <- Resource.make[F, Path](
+                                   Sync[F].delay {
+                                     Files.createTempDirectory(s"hash-set-casper-test-$n")
+                                   }
+                                 )(dir => Sync[F].delay { dir.recursivelyDelete() })
+              runtimeManager <- createRuntime(storageDirectory, storageSize)
+              node <- Resource.make[F, HashSetCasperTestNode[F]](
+                       for {
+                         _         <- TestNetwork.addPeer(p)
+                         semaphore <- Semaphore[F](1)
+                         casperState <- Cell.mvarCell[F, CasperState](
+                                         CasperState()
+                                       )
+                         node = new HashSetCasperTestNode[F](
+                           n,
+                           p,
+                           tle,
+                           tls,
+                           genesis,
+                           sk,
+                           logicalTime,
+                           errorHandler,
+                           blockDagDir,
+                           blockStoreDir,
+                           semaphore,
+                           "rchain",
+                           runtimeManager
+                         )(
+                           concurrentF,
+                           blockStore,
+                           blockDagStorage,
+                           metricEff,
+                           casperState
+                         )
+                       } yield node
+                     )(_ => ().pure[F])
             } yield node
         }
         .map(_.toVector)
 
-    import Connections._
-    //make sure all nodes know about each other
-    for {
-      nodes <- nodesF
-      pairs = for {
-        n <- nodes
-        m <- nodes
-        if n.local != m.local
-      } yield (n, m)
-      _ <- nodes.traverse(_.initialize).void
-      _ <- pairs.foldLeft(().pure[F]) {
-            case (f, (n, m)) =>
-              f.flatMap(
-                _ =>
-                  n.connectionsCell.flatModify(
-                    _.addConn[F](m.local)
+    nodesF.flatMap { nodes =>
+      import Connections._
+      //make sure all nodes know about each other
+      Resource.liftF(
+        for {
+          _ <- nodes.traverse_[F, Unit](_.initialize())
+          pairs = for {
+            n <- nodes
+            m <- nodes
+            if n.local != m.local
+          } yield (n, m)
+          _ <- pairs.foldLeft(().pure[F]) {
+                case (f, (n, m)) =>
+                  f.flatMap(
+                    _ =>
+                      n.connectionsCell.flatModify(
+                        _.addConn[F](m.local)
+                      )
                   )
-              )
-          }
-    } yield nodes
+              }
+        } yield nodes
+      )
+    }
   }
   def networkEff(
       sks: IndexedSeq[PrivateKey],
       genesis: BlockMessage,
       storageSize: Long = 1024L * 1024 * 10,
       testNetwork: TestNetwork[Effect] = TestNetwork.empty
-  )(implicit scheduler: Scheduler): Effect[IndexedSeq[HashSetCasperTestNode[Effect]]] =
-    networkF[Effect](sks, genesis, storageSize, createRuntime)(
+  )(implicit scheduler: Scheduler): Resource[Effect, IndexedSeq[HashSetCasperTestNode[Effect]]] =
+    networkF[Effect](
+      sks,
+      genesis,
+      storageSize,
+      createRuntime
+    )(
       ApplicativeError_[Effect, CommError],
       Concurrent[Effect],
       testNetwork

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/BlockApproverProtocolTest.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import coop.rchain.casper.MultiParentCasperTestUtil
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts._
-import coop.rchain.casper.helper.HashSetCasperTestNode.Effect
+import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.helper.{BlockDagStorageTestFixture, HashSetCasperTestNode}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.scalatestcontrib._
@@ -122,20 +122,19 @@ object BlockApproverProtocolTest {
           supply = Long.MaxValue
         )
       )
-
-    for {
-      nodes <- HashSetCasperTestNode.networkEff(Vector(sk), genesis)
-      node  = nodes.head
-    } yield new BlockApproverProtocol(
-      node.validatorId,
-      deployTimestamp,
-      bonds,
-      wallets,
-      1L,
-      Long.MaxValue,
-      false,
-      requiredSigs
-    ) -> node
+    HashSetCasperTestNode.networkEff(Vector(sk), genesis).use { nodes =>
+      val node = nodes.head
+      (new BlockApproverProtocol(
+        node.validatorId,
+        deployTimestamp,
+        bonds,
+        wallets,
+        1L,
+        Long.MaxValue,
+        false,
+        requiredSigs
+      ) -> node).pure[Effect]
+    }
   }
 
 }


### PR DESCRIPTION
## Overview
Makes `HashSetCasperTestNode` a Resource by:

- Making `RuntimeManager` a Resource
- Making block/DAG storage directories Resources
- Making block/DAG storages Resources
- Getting rid of `tearDown` methods in `HashSetCasperTestNode`

Most of the meaningful changes are located in `HashSetCasperTestNode.scala`. Other test files were adapted to use the new resource properly.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3325

### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
