### PR TITLE
Change Kademlia node discovery strategy. Shuffle peers before lookup

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/KademliaNodeDiscovery.scala
@@ -1,6 +1,7 @@
 package coop.rchain.comm.discovery
 
 import scala.collection.mutable
+import scala.util.Random
 
 import cats._
 import cats.implicits._
@@ -23,7 +24,7 @@ object KademliaNodeDiscovery {
     def find(
         limit: Int,
         dists: Array[Int],
-        peerSet: Set[PeerNode],
+        peerSet: List[PeerNode],
         potentials: Set[PeerNode],
         i: Int
     ): F[List[PeerNode]] =
@@ -54,7 +55,7 @@ object KademliaNodeDiscovery {
     for {
       peers  <- KademliaStore[F].peers
       dists  <- KademliaStore[F].sparseness
-      result <- find(10, dists.toArray, peers.toSet, Set(), 0)
+      result <- find(10, dists.toArray, Random.shuffle(peers.toList), Set(), 0)
       _      <- result.traverse(KademliaStore[F].updateLastSeen)
     } yield ()
   }


### PR DESCRIPTION
## Overview
Change Kademlia node discovery strategy. Shuffle peers before lookup.
This change is a result of the simulation of P2P networks with 100, 1000 and 10000 nodes. The shuffling of peers before performing a lookup makes the network more homogenous.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3305

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
