### PR TITLE
Forward InternalServerError messages in SslSessionClientInterceptor

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -75,8 +75,9 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
               }
             }
           } else {
-            log.warn(s"Wrong network id '$nid'. Closing connection")
-            close(Status.PERMISSION_DENIED.withDescription(s"Wrong network id '$nid'"))
+            val nidStr = if (nid.isEmpty) "<empty>" else nid
+            log.warn(s"Wrong network id '$nidStr'. Closing connection")
+            close(Status.PERMISSION_DENIED.withDescription(s"Wrong network id '$nidStr'"))
           }
 
         case TLResponse(Payload.InternalServerError(_)) =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -78,6 +78,10 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
             log.warn(s"Wrong network id '$nid'. Closing connection")
             close(Status.PERMISSION_DENIED.withDescription(s"Wrong network id '$nid'"))
           }
+
+        case TLResponse(Payload.InternalServerError(_)) =>
+          next.onMessage(message)
+
         case TLResponse(_) =>
           log.warn(s"Malformed response $message")
           close(Status.INVALID_ARGUMENT.withDescription("Malformed message"))

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -67,10 +67,13 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
               }
             }
           } else {
-            log.warn(s"Wrong network id '$nid'. Closing connection")
+            val nidStr = if (nid.isEmpty) "<empty>" else nid
+            log.warn(s"Wrong network id '$nidStr'. Closing connection")
             close(
               Status.PERMISSION_DENIED
-                .withDescription(s"Wrong network id '$nid'. This node runs on network '$networkID'")
+                .withDescription(
+                  s"Wrong network id '$nidStr'. This node runs on network '$networkID'"
+                )
             )
           }
         case TLRequest(_) =>


### PR DESCRIPTION
## Overview
Forward `InternalServerError` messages in `SslSessionClientInterceptor`

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3328

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
