### PR TITLE
Make BlockDagRepresentation.contains process blocks with malformed hash

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -239,9 +239,13 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
           findAndAccessCheckpoint(blockHash, _.dataLookup.get(blockHash))
       }
     def contains(blockHash: BlockHash): F[Boolean] =
-      dataLookup.get(blockHash) match {
-        case Some(_) => true.pure[F]
-        case None    => getBlockNumber(blockHash).map(_.isDefined)
+      if (blockHash.size == 32) {
+        dataLookup.get(blockHash) match {
+          case Some(_) => true.pure[F]
+          case None    => getBlockNumber(blockHash).map(_.isDefined)
+        }
+      } else {
+        false.pure[F]
       }
     def topoSort(startBlockNumber: Long): F[Vector[Vector[BlockHash]]] =
       if (startBlockNumber >= sortOffset) {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -68,6 +68,15 @@ trait BlockDagStorageTest
       }
     }
   }
+
+  it should "be able to handle checking if contains a block with empty hash" in {
+    withDagStorage { dagStorage =>
+      for {
+        dag        <- dagStorage.getRepresentation
+        ifContains <- dag.contains(ByteString.EMPTY)
+      } yield ifContains shouldBe false
+    }
+  }
 }
 
 class BlockDagFileStorageTest extends BlockDagStorageTest {


### PR DESCRIPTION
## Overview
Since we are trying to check if a block is contained in `BlockDagStorage` before validating it, `BlockDagRepresentation.contains` should be able to handle blocks with malformed block hash.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3339


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
