### PR TITLE
Re-enable cost accounting test

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -65,6 +65,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
     ("""@0!(2) | @1!(1)""", 69L),
     ("""for(x <- @0){ Nil }""", 64L),
     ("""for(x <- @0){ Nil } | @0!(2)""", 76L),
+    /*
     ("""new loop in {
          contract loop(@n) = {
            match n {
@@ -74,6 +75,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
          } |
          loop!(10)
        }""".stripMargin, 1936L),
+     */
     ("""42 | @0!(2) | for (x <- @0) { Nil }""", 83L),
     ("""@1!(1) |
         for(x <- @1) { Nil } |
@@ -85,7 +87,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
      """.stripMargin, 634L)
   )
 
-  "Total cost of evaluation" should "be equal to the sum of all costs in the log" in pendingUntilFixed {
+  "Total cost of evaluation" should "be equal to the sum of all costs in the log" in {
     forAll(
       contracts
     ) { (contract: String, expectedTotalCost: Long) =>
@@ -94,7 +96,6 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
         val (result, costLog) = evaluateWithCostLog(initialPhlo, contract)
         result shouldBe EvaluateResult(Cost(expectedTotalCost), Vector.empty)
         costLog.map(_.value).toList.sum shouldEqual expectedTotalCost
-        fail("removed once test fixed")
       }
     }
   }


### PR DESCRIPTION
## Overview
Do not  make the whole test pending, just comment out the problematic contract

### JIRA ticket:
Ad hoc



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
