### PR TITLE
Remove trie delete action optimisation

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IStore.scala
@@ -126,9 +126,8 @@ trait IStore[F[_], C, P, A, K] {
           value
             .sorted(Ordering.by((tu: TrieUpdate[C, P, A, K]) => tu.count).reverse)
             .headOption match {
-            case Some(TrieUpdate(_, Delete, _, _))          => List.empty
-            case Some(insert @ TrieUpdate(_, Insert, _, _)) => List(insert)
-            case _                                          => value
+            case Some(v) => List(v)
+            case _       => value
           }
       }
       .toList

--- a/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/package.scala
@@ -496,9 +496,9 @@ package object history {
             case Node(_) =>
               logger.debug(s"workingRootHash: $currentRootHash")
               false
-            // If the "tip" is equal to a leaf containing the given key and value, commence
+            // If the "tip" is equal to a leaf containing the given key, commence
             // with the deletion process.
-            case leaf @ Leaf(_, _) if leaf == Leaf(key, value) =>
+            case Leaf(leafKey, _) if key == leafKey =>
               val (hd, nodesToRehash, newNodes) = deleteLeaf(store, txn, parents)
               val rehashedNodes                 = rehash[K, V](hd, nodesToRehash)
               val nodesToInsert                 = newNodes ++ rehashedNodes
@@ -506,6 +506,10 @@ package object history {
               store.putRoot(txn, branch, newRootHash)
               logger.debug(s"workingRootHash: $newRootHash")
               true
+            // A Skip means that the value does not exist in the trie
+            case Skip(_, _) =>
+              logger.debug(s"workingRootHash: $currentRootHash")
+              false
             // The entry is not in the trie
             case Leaf(_, _) =>
               logger.debug(s"workingRootHash: $currentRootHash")


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Revert an optimisation in RSpace that is too aggressive. 

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
create ticket.


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
