### PR TITLE
RCHAIN-3250 fix the bug

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -167,14 +167,12 @@ object CasperLaunch {
     for {
       validators  <- CasperConf.parseValidatorsFile[F](init.conf.knownValidatorsFile)
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
-      _ <- EngineCell[F].set(
-            new Initializing(
-              init.runtimeManager,
-              init.conf.shardId,
-              validatorId,
-              validators,
-              CommUtil.requestApprovedBlock[F]
-            )
+      _ <- Engine.tranistionToInitializing(
+            init.runtimeManager,
+            init.conf.shardId,
+            validatorId,
+            validators,
+            CommUtil.requestApprovedBlock[F]
           )
     } yield ()
 }


### PR DESCRIPTION
## Overview

This PR fixes the RCHAIN-3250 bug. Bug existed because genesis validator was continuously responding to ALL UnapprovedBlocks.
Fix is straightforward, once genesis validator validated UnapprovedBlock, it immediately jumps to `Initializing` state, ignoring all other `UnapprovedBlock` messages

<img width="1421" alt="Screenshot 2019-05-14 at 16 47 46" src="https://user-images.githubusercontent.com/6287558/57724980-4bc1c580-768c-11e9-9ed8-af4c73482a88.png">


Because it no longer validates each Unapproved Block message, the whole process is a lot faster. Here output from tests

Before `test_successful_genesis_ceremony` took:

```
1 passed, 27 deselected in 1087.99 seconds
```

Now it takes:

```
1 passed, 29 deselected in 449.71 second
```

### JIRA ticket:
RCHAIN-3250