### PR TITLE
Make node fail on invalid path to bonds/wallets files

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/SourceIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/SourceIO.scala
@@ -1,0 +1,30 @@
+package coop.rchain.blockstorage.util.io
+
+import java.io.FileNotFoundException
+import java.nio.file.Path
+
+import cats.effect.{Resource, Sync}
+import cats.syntax.functor._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+
+import scala.io.Source
+
+final case class SourceIO[F[_]: Sync: RaiseIOError] private (
+    private val source: Source
+) {
+  def getLines: F[List[String]] =
+    handleIo(source.getLines.toList, UnexpectedIOError.apply)
+
+  def close: F[Unit] =
+    handleIo(source.close(), ClosingFailed.apply)
+}
+
+object SourceIO {
+  def open[F[_]: Sync: RaiseIOError](path: Path): Resource[F, SourceIO[F]] =
+    Resource.make(
+      handleIo(Source.fromFile(path.toFile), {
+        case e: FileNotFoundException => FileNotFound(e)
+        case e                        => UnexpectedIOError(e)
+      }).map(SourceIO.apply[F])
+    )(_.close)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -66,6 +66,9 @@ package object io {
   def notExists[F[_]: Sync: RaiseIOError](path: Path): F[Boolean] =
     handleIo(Files.notExists(path), UnexpectedIOError.apply)
 
+  def exists[F[_]: Sync: RaiseIOError](path: Path): F[Boolean] =
+    handleIo(Files.exists(path), UnexpectedIOError.apply)
+
   def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Path] =
     handleIo(Files.createDirectories(dirPath), UnexpectedIOError.apply)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -80,11 +80,10 @@ object CasperLaunch {
       init: CasperInit[F]
   ): F[Unit] =
     for {
-      walletsFile <- Genesis.toFile[F](
-                      init.conf.walletsFile,
-                      init.conf.genesisPath.resolve("wallets.txt")
-                    )
-      wallets   <- Genesis.getWallets[F](walletsFile, init.conf.walletsFile)
+      wallets <- Genesis.getWallets[F](
+                  init.conf.walletsFile,
+                  init.conf.genesisPath.resolve("wallets.txt")
+                )
       timestamp <- init.conf.deployTimestamp.fold(Time[F].currentMillis)(_.pure[F])
       bonds <- Genesis.getBonds[F](
                 init.conf.bondsFile,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -86,10 +86,12 @@ object CasperLaunch {
                     )
       wallets   <- Genesis.getWallets[F](walletsFile, init.conf.walletsFile)
       timestamp <- init.conf.deployTimestamp.fold(Time[F].currentMillis)(_.pure[F])
-      bondsFile <- Genesis
-                    .toFile[F](init.conf.bondsFile, init.conf.genesisPath.resolve("bonds.txt"))
-      bonds <- Genesis
-                .getBonds[F](bondsFile, init.conf.numValidators, init.conf.genesisPath)
+      bonds <- Genesis.getBonds[F](
+                init.conf.bondsFile,
+                init.conf.genesisPath.resolve("bonds.txt"),
+                init.conf.numValidators,
+                init.conf.genesisPath
+              )
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
       bap = new BlockApproverProtocol(
         validatorId.get,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -13,6 +13,7 @@ import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper._
 import coop.rchain.casper.util.comm._
 import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -38,7 +39,7 @@ object CasperLaunch {
       val conf: CasperConf,
       val runtimeManager: RuntimeManager[F]
   )
-  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell](
+  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =
@@ -76,7 +77,7 @@ object CasperLaunch {
       _ <- Engine.transitionToRunning[F](casper, approvedBlock)
     } yield ()
 
-  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: ErrorHandler: Time: Concurrent: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: BlockDagStorage: EngineCell](
+  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: ErrorHandler: Time: Concurrent: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F]
   ): F[Unit] =
     for {
@@ -107,7 +108,7 @@ object CasperLaunch {
           )
     } yield ()
 
-  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: ErrorHandler: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: BlockDagStorage: EngineCell](
+  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: ErrorHandler: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -222,28 +222,6 @@ object Genesis {
     unsignedBlockProto(body, header, List.empty[Justification], shardId)
   }
 
-  //FIXME delay and simplify this
-  def toFile[F[_]: Applicative: Log](
-      maybePath: Option[String],
-      defaultPath: Path
-  ): F[Option[File]] =
-    maybePath match {
-      case Some(path) =>
-        val f = new File(path)
-        if (f.exists) f.some.pure[F]
-        else {
-          none[File].pure[F]
-        }
-
-      case None =>
-        val default = defaultPath.toFile
-        if (default.exists) {
-          Log[F].info(
-            s"Found default file ${default.getPath}."
-          ) *> default.some.pure[F]
-        } else none[File].pure[F]
-    }
-
   def getWallets[F[_]: Monad: Sync: Log](
       maybeWalletsPath: Option[String],
       defaultWalletPath: Path

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -18,6 +18,7 @@ import coop.rchain.shared.PathOps.RichPath
 import coop.rchain.shared.StoreType
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import java.nio.file.Path
+import coop.rchain.blockstorage.util.io.IOError
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan}
 import monix.eval.Task
@@ -216,6 +217,8 @@ object GenesisTest {
   def genesisPath     = Files.createTempDirectory(s"casper-genesis-test")
   val numValidators   = 5
   val rchainShardId   = "rchain"
+
+  implicit val raiseIOError = IOError.raiseIOErrorThroughSync[Task]
 
   def fromInputFiles(
       maybeBondsPath: Option[String] = None,

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -13,6 +13,7 @@ import cats.implicits._
 import coop.rchain.blockstorage._
 import coop.rchain.casper._
 import coop.rchain.casper.engine._, EngineCell._, CasperLaunch.CasperInit
+import coop.rchain.blockstorage.util.io.IOError
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.util.comm.CasperPacketHandler
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -459,6 +460,7 @@ class NodeRuntime private[node] (
     }
     runtimeManager <- RuntimeManager.fromRuntime[Task](casperRuntime).toEffect
     engineCell     <- EngineCell.init[Effect]
+    raiseIOError   = IOError.raiseIOErrorThroughSync[Effect]
     casperInit = new CasperInit[Effect](
       conf.casper,
       RuntimeManager.eitherTRuntimeManager(runtimeManager)
@@ -480,6 +482,7 @@ class NodeRuntime private[node] (
           multiParentCasperRef,
           blockDagStorage,
           engineCell,
+          raiseIOError,
           scheduler
         )
     packetHandler = {


### PR DESCRIPTION
## Overview
What title says and enables GenesisTest tests as they were apparently disabled


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-937


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
