### PR TITLE
Update RevIssuanceTest to use RevVaults

### DIFF
--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -57,8 +57,7 @@ in {
           }
         } |
 
-        //FIXME remove this, create standard vaults instead and do a `_deposit` to them somehow
-        contract RevVault(@"findOrCreateGenesisVault", @ownerRevAddress, @initialAmount, ret) = {
+        for (@"findOrCreateGenesisVault", @ownerRevAddress, @initialAmount, ret <- RevVault) {
           new findOrCreateGenesisVault in {
             _getOrCreate!(ownerRevAddress, *findOrCreateGenesisVault, *ret) |
             for (retCh <- findOrCreateGenesisVault) {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/AddressTools.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/AddressTools.scala
@@ -28,9 +28,7 @@ class AddressTools(prefix: Array[Byte], keyLength: Int, checksumLength: Int) {
   def fromPublicKey(pk: PublicKey): Option[Address] =
     if (keyLength == pk.bytes.length || pk.bytes.length == 65) { // TODO: Clean up for secp256k1
       val ethAddress = Base16.encode(Keccak256.hash(pk.bytes.drop(1))).takeRight(40)
-      val keyHash    = Keccak256.hash(Base16.unsafeDecode(ethAddress))
-      val payload    = prefix ++ keyHash
-      Some(Address(prefix, keyHash, computeChecksum(payload)))
+      Some(fromEthAddress(ethAddress))
     } else None
 
   def fromEthAddress(ethAddress: String): Address = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rholang.interpreter.util
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.hash.Keccak256
 
 final case class RevAddress(address: Address) {
 
@@ -14,6 +15,9 @@ object RevAddress {
   private val prefix  = Base16.unsafeDecode(coinId + version)
 
   private val tools = new AddressTools(prefix, keyLength = 32, checksumLength = 4)
+
+  def fromEthAddress(ethAddress: String): RevAddress =
+    RevAddress(tools.fromEthAddress(ethAddress))
 
   def fromPublicKey(pk: PublicKey): Option[RevAddress] =
     tools.fromPublicKey(pk).map(RevAddress(_))


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Assumes RevAddress = hash(EthAddress)

`preWalletUnlockDeploy` which uses the old wallet
system is moved out of RevIssuanceTest. Note we can't
delete it just yet as other tests that still are using
the old wallet system still need to be updated.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3422

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>

- Invalid auth key was resolved by changing the implementation of fromPubKey 
- If RevVault isn't created yet, sending to that RevAddress and trying to check balance will silently fail

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
