### PR TITLE
Fix DistanceSpec bugs

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -42,7 +42,7 @@ class DistanceSpec extends FlatSpec with Matchers {
         j <- 7 to 0 by -1
       } yield {
         val k1 = Array.fill(key.length)(0.toByte)
-        Array.copy(k1, 0, key, 0, key.length)
+        Array.copy(key, 0, k1, 0, k1.length)
         k1(i) = (k1(i) ^ (1 << j).toByte).toByte
         k1
       }

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -1,5 +1,7 @@
 package coop.rchain.comm.discovery
 
+import java.util
+
 import cats.{catsInstancesForId => _, _}
 
 import coop.rchain.catscontrib.effect.implicits._
@@ -104,11 +106,15 @@ class DistanceSpec extends FlatSpec with Matchers {
     }
 
     it should s"return min(k, ${8 * width}) peers on lookup" in {
-      val table = PeerTable[PeerNode, Id](kr)
-      for (k <- oneOffs(kr)) {
+      val table     = PeerTable[PeerNode, Id](kr)
+      val krOneOffs = oneOffs(kr)
+      for (k <- krOneOffs) {
         table.updateLastSeen(PeerNode(NodeIdentifier(k), endpoint))
       }
-      table.lookup(randBytes(width)).size should be(scala.math.min(table.k, 8 * width))
+      val randomKey = randBytes(width)
+      val expected =
+        if (krOneOffs.exists(util.Arrays.equals(_, randomKey))) 8 * width - 1 else 8 * width
+      table.lookup(randomKey).size should be(scala.math.min(table.k, expected))
     }
 
     it should "not return sought peer on lookup" in {


### PR DESCRIPTION
## Overview
- Refactors DistanceSpec
- Fixes a non-related bug where the random key was always being overwritten with zeros
- Fixes the actual bug where in rare cases (with a chance of 16/(256^2) I believe) a generated random key coincided with one of the "one-offs" (single bit modifications of the original key). The test expected every one of the 16 "one-offs" to be returned by `PeerTable.lookup` but `PeerTable` returned only 15 since one of them is the key which is being looked up.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3268


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
