### PR TITLE
Enable -Xfatal-warning for all subprojects

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -112,10 +112,6 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.modify(s => s.copy(topoSort = v))
   private[this] def setEquviocationsTracker(v: Set[EquivocationRecord]): F[Unit] =
     state.modify(s => s.copy(equivocationsTracker = v))
-  private[this] def setSortOffset(v: Long): F[Unit] =
-    state.modify(s => s.copy(sortOffset = v))
-  private[this] def setCheckpoints(v: List[Checkpoint]): F[Unit] =
-    state.modify(s => s.copy(checkpoints = v))
   private[this] def setLatestMessagesLogOutputStream(v: FileOutputStreamIO[F]): F[Unit] =
     state.modify(s => s.copy(latestMessagesLogOutputStream = v))
   private[this] def setLatestMessagesLogSize(v: Int): F[Unit] =
@@ -127,10 +123,6 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
   private[this] def setBlockMetadataCrc(v: Crc32[F]): F[Unit] =
     state.modify(s => s.copy(blockMetadataCrc = v))
   private[this] def setEquivocationsTrackerLogOutputStream(v: FileOutputStreamIO[F]): F[Unit] =
-    state.modify(s => s.copy(equivocationsTrackerLogOutputStream = v))
-  private[this] def setEquivocationsTrackerCrc(v: Crc32[F]): F[Unit] =
-    state.modify(s => s.copy(equivocationsTrackerCrc = v))
-  private[this] def setInvalidBlocksLogOutputStream(v: FileOutputStreamIO[F]): F[Unit] =
     state.modify(s => s.copy(equivocationsTrackerLogOutputStream = v))
 
   private[this] def modifyLatestMessages(
@@ -157,24 +149,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       f: Set[BlockMetadata] => Set[BlockMetadata]
   ): F[Unit] =
     state.modify(s => s.copy(invalidBlocks = f(s.invalidBlocks)))
-  private[this] def modifySortOffset(f: Long => Long): F[Unit] =
-    state.modify(s => s.copy(sortOffset = f(s.sortOffset)))
   private[this] def modifyCheckpoints(f: List[Checkpoint] => List[Checkpoint]): F[Unit] =
     state.modify(s => s.copy(checkpoints = f(s.checkpoints)))
-  private[this] def modifyLatestMessagesLogOutputStream(
-      f: FileOutputStreamIO[F] => FileOutputStreamIO[F]
-  ): F[Unit] =
-    state.modify(s => s.copy(latestMessagesLogOutputStream = f(s.latestMessagesLogOutputStream)))
   private[this] def modifyLatestMessagesLogSize(f: Int => Int): F[Unit] =
     state.modify(s => s.copy(latestMessagesLogSize = f(s.latestMessagesLogSize)))
-  private[this] def modifyLatestMessagesCrc(f: Crc32[F] => Crc32[F]): F[Unit] =
-    state.modify(s => s.copy(latestMessagesCrc = f(s.latestMessagesCrc)))
-  private[this] def modifyBlockMetadataLogOutputStream(
-      f: FileOutputStreamIO[F] => FileOutputStreamIO[F]
-  ): F[Unit] =
-    state.modify(s => s.copy(blockMetadataLogOutputStream = f(s.blockMetadataLogOutputStream)))
-  private[this] def modifyBlockMetadataCrc(f: Crc32[F] => Crc32[F]): F[Unit] =
-    state.modify(s => s.copy(blockMetadataCrc = f(s.blockMetadataCrc)))
 
   private[this] def getBlockNumber(blockHash: BlockHash): F[Option[Long]] =
     blockNumberIndex.withReadTxn { txn =>

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -26,7 +26,7 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
     equivocationsTrackerRef: Ref[F, Set[EquivocationRecord]],
     invalidBlocksRef: Ref[F, Set[BlockMetadata]]
 ) extends BlockDagStorage[F] {
-  final case class InMemBlockDagRepresentation(
+  private case class InMemBlockDagRepresentation(
       latestMessagesMap: Map[Validator, BlockHash],
       childMap: Map[BlockHash, Set[BlockHash]],
       dataLookup: Map[BlockHash, BlockMetadata],

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -141,19 +141,11 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
   private def defaultBlockNumberIndex(dagDataDir: Path): Path =
     dagDataDir.resolve("block-number-index")
 
-  private def createBlockStore(blockStoreDataDir: Path): Task[BlockStore[Task]] = {
-    implicit val metrics = new MetricsNOP[Task]()
-    implicit val log     = new Log.NOPLog[Task]()
-    val env              = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
-    FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir).map(_.right.get)
-  }
-
   private def createAtDefaultLocation(
       dagDataDir: Path,
       maxSizeFactor: Int = 10
   ): Task[BlockDagFileStorage[Task]] = {
-    implicit val log     = new shared.Log.NOPLog[Task]()
-    implicit val metrics = new MetricsNOP[Task]()
+    implicit val log = new shared.Log.NOPLog[Task]()
     BlockDagFileStorage.create[Task](
       BlockDagFileStorage.Config(
         defaultLatestMessagesLog(dagDataDir),

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -135,10 +135,9 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
   private[this] val mapSize: Long    = 100L * 1024L * 1024L * 4096L
 
   override def withStore[R](f: BlockStore[Task] => Task[R]): R = {
-    val dbDir                           = mkTmpDir()
-    implicit val metrics: Metrics[Task] = new MetricsNOP[Task]()
-    implicit val log: Log[Task]         = new Log.NOPLog[Task]()
-    val env                             = Context.env(dbDir, mapSize)
+    val dbDir                   = mkTmpDir()
+    implicit val log: Log[Task] = new Log.NOPLog[Task]()
+    val env                     = Context.env(dbDir, mapSize)
     val test = for {
       store  <- FileLMDBIndexBlockStore.create[Task](env, dbDir).map(_.right.get)
       _      <- store.find(_ => true).map(map => assert(map.isEmpty))
@@ -153,9 +152,8 @@ class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
   }
 
   private def createBlockStore(blockStoreDataDir: Path): Task[BlockStore[Task]] = {
-    implicit val metrics = new MetricsNOP[Task]()
-    implicit val log     = new Log.NOPLog[Task]()
-    val env              = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
+    implicit val log = new Log.NOPLog[Task]()
+    val env          = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
     FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir).map(_.right.get)
   }
 

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
@@ -37,7 +37,7 @@ final class IndexedBlockDagStorage[F[_]: Monad](
       body              = block.body.get
       header            = block.header.get
       currentId         <- currentIdRef.get
-      nextId            = if (block.seqNum == 0) currentId + 1L else block.seqNum
+      nextId            = if (block.seqNum == 0) currentId + 1L else block.seqNum.toLong
       dag               <- underlying.getRepresentation
       nextCreatorSeqNum <- dag.latestMessage(block.sender).map(_.fold(-1)(_.seqNum) + 1)
       newPostState      = body.getState.withBlockNumber(nextId)
@@ -54,7 +54,7 @@ final class IndexedBlockDagStorage[F[_]: Monad](
   def inject(index: Int, block: BlockMessage, genesis: BlockMessage, invalid: Boolean): F[Unit] =
     for {
       _ <- lock.acquire
-      _ <- idToBlocksRef.update(_.updated(index, block))
+      _ <- idToBlocksRef.update(_.updated(index.toLong, block))
       _ <- underlying.insert(block, genesis, invalid)
       _ <- lock.release
     } yield ()
@@ -76,11 +76,11 @@ final class IndexedBlockDagStorage[F[_]: Monad](
   def lookupById(id: Int): F[Option[BlockMessage]] =
     for {
       idToBlocks <- idToBlocksRef.get
-    } yield idToBlocks.get(id)
+    } yield idToBlocks.get(id.toLong)
   def lookupByIdUnsafe(id: Int): F[BlockMessage] =
     for {
       idToBlocks <- idToBlocksRef.get
-    } yield idToBlocks(id)
+    } yield idToBlocks(id.toLong)
 }
 
 object IndexedBlockDagStorage {

--- a/build.sbt
+++ b/build.sbt
@@ -104,14 +104,6 @@ lazy val compilerSettings = CompilerSettings.options ++ Seq(
   crossScalaVersions := Seq("2.11.12", scalaVersion.value)
 )
 
-// TOOD will become compilerSettings once this is turned on for blockstore
-lazy val almostCompilerSettings = Seq(
-  "-Xfatal-warnings",
-  "-unchecked",
-  "-deprecation",
-  "-feature"
-)
-
 // Before starting sbt export YOURKIT_AGENT set to the profiling agent appropriate
 // for your OS (https://www.yourkit.com/docs/java/help/agent.jsp)
 lazy val profilerSettings = Seq(
@@ -128,7 +120,6 @@ lazy val shared = (project in file("shared"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
-    scalacOptions ++= almostCompilerSettings,
     libraryDependencies ++= commonDependencies ++ Seq(
       catsCore,
       catsEffect,
@@ -148,7 +139,6 @@ lazy val graphz = (project in file("graphz"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
-    scalacOptions ++= almostCompilerSettings,
     libraryDependencies ++= commonDependencies ++ Seq(
       catsCore,
       catsEffect,
@@ -165,7 +155,6 @@ lazy val casper = (project in file("casper"))
   .settings(inConfig(SlowcookerTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings))
   .settings(
     name := "casper",
-    scalacOptions ++= almostCompilerSettings,
     libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
       catsCore,
       catsMtl,
@@ -188,7 +177,6 @@ lazy val comm = (project in file("comm"))
   .settings(commonSettings: _*)
   .settings(
     version := "0.1",
-    scalacOptions ++= almostCompilerSettings,
     dependencyOverrides += "org.slf4j" % "slf4j-api" % "1.7.25",
     libraryDependencies ++= commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
       grpcNetty,
@@ -214,7 +202,6 @@ lazy val crypto = (project in file("crypto"))
   .settings(commonSettings: _*)
   .settings(
     name := "crypto",
-    scalacOptions ++= almostCompilerSettings,
     libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
       guava,
       bouncyCastle,
@@ -254,7 +241,6 @@ lazy val node = (project in file("node"))
   .settings(
     version := "0.9.4" + git.gitHeadCommit.value.map(".git" + _.take(8)).getOrElse(""),
     name := "rnode",
-    scalacOptions ++= almostCompilerSettings,
     maintainer := "RChain Cooperative https://www.rchain.coop/",
     packageSummary := "RChain Node",
     packageDescription := "RChain Node - the RChain blockchain node server software.",

--- a/models/src/main/scala/coop/rchain/models/ProtoM.scala
+++ b/models/src/main/scala/coop/rchain/models/ProtoM.scala
@@ -37,8 +37,8 @@ object ProtoM extends DescriptorPimps {
             .sortBy(_.getNumber)
             .toList
             .traverse[Coeval, Unit](f => {
-              val fieldValue = message.getField(f)
-              val default    = defaultInstance.getField(f)
+              val fieldValue = message.getFieldByNumber(f.getNumber)
+              val default    = defaultInstance.getFieldByNumber(f.getNumber)
               if (fieldValue != default)
                 writeField(out, fieldValue, f)
               else Monad[Coeval].pure(())
@@ -127,7 +127,9 @@ object ProtoM extends DescriptorPimps {
         case FIXED32  => out.writeFixed32   (field.getNumber, value.asInstanceOf[Int])
         case BOOL     => out.writeBool      (field.getNumber, value.asInstanceOf[Boolean])
         case STRING   => out.writeString    (field.getNumber, value.asInstanceOf[String])
-        case GROUP    => out.writeGroup     (field.getNumber, value.asInstanceOf[MessageLite])
+        case GROUP    => throw new UnsupportedOperationException(
+          "Groups are not supported, because they're deprecated in protobuf"
+        )
         case MESSAGE  => out.writeMessage   (field.getNumber, value.asInstanceOf[MessageLite])
         case BYTES    => out.writeBytes     (field.getNumber, value.asInstanceOf[ByteString])
         case UINT32   => out.writeUInt32    (field.getNumber, value.asInstanceOf[Int])
@@ -154,8 +156,8 @@ object ProtoM extends DescriptorPimps {
             "Unknown fields are not supported"
           )
       fieldSizes <- descriptor.fields.toList.traverse[Coeval, Int](f => {
-                     val fieldValue = message.getField(f)
-                     val default    = defaultInstance.getField(f)
+                     val fieldValue = message.getFieldByNumber(f.getNumber)
+                     val default    = defaultInstance.getFieldByNumber(f.getNumber)
                      if (fieldValue != default)
                        fieldSize(fieldValue, f)
                      else Monad[Coeval].pure(0)
@@ -228,7 +230,9 @@ object ProtoM extends DescriptorPimps {
         case FIXED32  => computeFixed32Size    (field.getNumber, value.asInstanceOf[Int])
         case BOOL     => computeBoolSize       (field.getNumber, value.asInstanceOf[Boolean])
         case STRING   => computeStringSize     (field.getNumber, value.asInstanceOf[String])
-        case GROUP    => computeGroupSize      (field.getNumber, value.asInstanceOf[MessageLite])
+        case GROUP    => throw new UnsupportedOperationException(
+          "Groups are not supported, because they're deprecated in protobuf"
+        )
         case MESSAGE  => computeMessageSize    (field.getNumber, value.asInstanceOf[MessageLite])
         case BYTES    => computeBytesSize      (field.getNumber, value.asInstanceOf[ByteString])
         case UINT32   => computeUInt32Size     (field.getNumber, value.asInstanceOf[Int])

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
@@ -31,7 +31,8 @@ private[sorter] object ConnectiveSortMatcher extends Sortable[Connective] {
           Node(Score.CONNECTIVE_NOT, scoredPar.score)
         )
       case v @ VarRefBody(VarRef(index, depth)) =>
-        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_VARREF, index, depth)).pure[F]
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_VARREF, index.toLong, depth.toLong))
+          .pure[F]
       case v @ ConnBool(b) =>
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_BOOL, if (b) 1 else 0)).pure[F]
       case v @ ConnInt(b) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -13,7 +13,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
     def constructExpr(exprInstance: ExprInstance, score: Tree[ScoreAtom]) =
       ScoredTerm(Expr(exprInstance = exprInstance), score)
 
-    def remainderScore[F[_]: Sync](remainder: Option[Var]): F[Tree[ScoreAtom]] =
+    def remainderScore(remainder: Option[Var]): F[Tree[ScoreAtom]] =
       remainder match {
         case Some(_var) => Sortable[Var].sortMatch[F](_var).map(_.score)
         case None       => Sync[F].pure(Leaf(-1))
@@ -171,7 +171,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
         for {
           sortedPars          <- parMap.ps.sortedList.traverse(kv => sortKeyValuePair(kv._1, kv._2))
           remainderScore      <- remainderScore(parMap.remainder)
-          connectiveUsedScore = if (parMap.connectiveUsed) 1 else 0
+          connectiveUsedScore = if (parMap.connectiveUsed) 1L else 0L
         } yield constructExpr(
           EMapBody(
             ParMap(
@@ -191,7 +191,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
         for {
           sortedPars          <- parSet.ps.sortedPars.traverse(Sortable[Par].sortMatch[F])
           remainderScore      <- remainderScore(parSet.remainder)
-          connectiveUsedScore = if (parSet.connectiveUsed) 1 else 0
+          connectiveUsedScore = if (parSet.connectiveUsed) 1L else 0L
         } yield constructExpr(
           ESetBody(
             ParSet(
@@ -210,7 +210,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
         for {
           pars                <- list.ps.toList.traverse(Sortable[Par].sortMatch[F])
           remainderScore      <- remainderScore(list.remainder)
-          connectiveUsedScore = if (list.connectiveUsed) 1 else 0
+          connectiveUsedScore = if (list.connectiveUsed) 1L else 0L
         } yield constructExpr(
           EListBody(
             EList(pars.map(_.term), list.locallyFree, list.connectiveUsed, list.remainder)
@@ -224,7 +224,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
       case ETupleBody(tuple) =>
         for {
           sortedPars          <- tuple.ps.toList.traverse(Sortable[Par].sortMatch[F])
-          connectiveUsedScore = if (tuple.connectiveUsed) 1 else 0
+          connectiveUsedScore = if (tuple.connectiveUsed) 1L else 0L
         } yield ScoredTerm(
           ETupleBody(tuple.withPs(sortedPars.map(_.term))),
           Node(
@@ -235,7 +235,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
         for {
           args                <- em.arguments.toList.traverse(Sortable[Par].sortMatch[F])
           sortedTarget        <- Sortable.sortMatch(em.target)
-          connectiveUsedScore = if (em.connectiveUsed) 1 else 0
+          connectiveUsedScore = if (em.connectiveUsed) 1L else 0L
         } yield constructExpr(
           EMethodBody(em.withArguments(args.map(_.term)).withTarget(sortedTarget.term)),
           Node(

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
@@ -18,7 +18,7 @@ private[sorter] object MatchSortMatcher extends Sortable[Match] {
     for {
       sortedValue         <- Sortable.sortMatch(m.target)
       scoredCases         <- m.cases.toList.traverse(sortCase)
-      connectiveUsedScore = if (m.connectiveUsed) 1 else 0
+      connectiveUsedScore = if (m.connectiveUsed) 1L else 0L
     } yield ScoredTerm(
       Match(sortedValue.term, scoredCases.map(_.term), m.locallyFree, m.connectiveUsed),
       Node(

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
@@ -10,6 +10,8 @@ private[sorter] object NewSortMatcher extends Sortable[New] {
       sortedPar <- Sortable.sortMatch(n.p)
     } yield ScoredTerm(
       New(bindCount = n.bindCount, p = sortedPar.term, uri = n.uri, locallyFree = n.locallyFree),
-      new Node(Leaf(Score.NEW) +: (Leaf(n.bindCount) +: n.uri.map(Leaf.apply) :+ sortedPar.score))
+      new Node(
+        Leaf(Score.NEW) +: (Leaf(n.bindCount.toLong) +: n.uri.map(Leaf.apply) :+ sortedPar.score)
+      )
     )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ParSortMatcher.scala
@@ -29,7 +29,7 @@ private[sorter] object ParSortMatcher extends Sortable[Par] {
         locallyFree = par.locallyFree,
         connectiveUsed = par.connectiveUsed
       )
-      connectiveUsedScore = if (par.connectiveUsed) 1 else 0
+      connectiveUsedScore = if (par.connectiveUsed) 1L else 0L
       parScore = Node(
         Score.PAR,
         sends.map(_.score) ++

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -30,8 +30,8 @@ object ReceiveSortMatcher extends Sortable[Receive] {
   def sortMatch[F[_]: Sync](r: Receive): F[ScoredTerm[Receive]] =
     for {
       sortedBinds         <- r.binds.toList.traverse(sortBind[F])
-      persistentScore     = if (r.persistent) 1 else 0
-      connectiveUsedScore = if (r.connectiveUsed) 1 else 0
+      persistentScore     = if (r.persistent) 1L else 0L
+      connectiveUsedScore = if (r.connectiveUsed) 1L else 0L
       sortedBody          <- Sortable.sortMatch(r.body)
     } yield ScoredTerm(
       Receive(
@@ -45,7 +45,7 @@ object ReceiveSortMatcher extends Sortable[Receive] {
       Node(
         Score.RECEIVE,
         Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score)
-          ++ Seq(Leaf(r.bindCount)) ++ Seq(Leaf(connectiveUsedScore)): _*
+          ++ Seq(Leaf(r.bindCount.toLong)) ++ Seq(Leaf(connectiveUsedScore)): _*
       )
     )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
@@ -84,7 +84,7 @@ trait ScoreTree {
   object Node {
     // Shortcut to write Node(1, Leaf(1)) instead of Node(Seq(Leaf(ScoreAtom(1)), Leaf(ScoreAtom(1))))
     def apply(left: Int, right: Tree[ScoreAtom]*): Tree[ScoreAtom] =
-      new Node(Seq(Leaf(left)) ++ right)
+      new Node(Seq(Leaf(left.toLong)) ++ right)
   }
 
   object ScoredTerm {

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/SendSortMatcher.scala
@@ -17,8 +17,8 @@ private[sorter] object SendSortMatcher extends Sortable[Send] {
         locallyFree = s.locallyFree,
         connectiveUsed = s.connectiveUsed
       )
-      persistentScore     = if (s.persistent) 1 else 0
-      connectiveUsedScore = if (s.connectiveUsed) 1 else 0
+      persistentScore     = if (s.persistent) 1L else 0L
+      connectiveUsedScore = if (s.connectiveUsed) 1L else 0L
       sendScore = Node(
         Score.SEND,
         Seq(Leaf(persistentScore)) ++ Seq(sortedChan.score) ++ sortedData.map(_.score) ++ Seq(

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/VarSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/VarSortMatcher.scala
@@ -9,8 +9,8 @@ import cats.syntax._
 private[sorter] object VarSortMatcher extends Sortable[Var] {
   def sortMatch[F[_]: Sync](v: Var): F[ScoredTerm[Var]] =
     v.varInstance match {
-      case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level)).pure[F]
-      case FreeVar(level)  => ScoredTerm(v, Leaves(Score.FREE_VAR, level)).pure[F]
+      case BoundVar(level) => ScoredTerm(v, Leaves(Score.BOUND_VAR, level.toLong)).pure[F]
+      case FreeVar(level)  => ScoredTerm(v, Leaves(Score.FREE_VAR, level.toLong)).pure[F]
       case Wildcard(_)     => ScoredTerm(v, Leaves(Score.WILDCARD)).pure[F]
       case Empty           => ScoredTerm(Var(Empty), Leaf(Score.ABSENT)).pure[F]
     }

--- a/models/src/test/scala/coop/rchain/models/Assertions.scala
+++ b/models/src/test/scala/coop/rchain/models/Assertions.scala
@@ -1,7 +1,7 @@
 package coop.rchain.models
-import org.scalatest.{Assertion, Assertions}
+import org.scalatest.{Assertion, Assertions => ScalaTestAssertions}
 
-object Assertions extends Assertions {
+object Assertions extends ScalaTestAssertions {
 
   def assertEqual[A: Pretty](result: A, expected: A): Assertion =
     assert(

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -17,7 +17,7 @@ import scala.runtime.ScalaRunTime
 class HashMSpec extends FlatSpec with PropertyChecks with Matchers {
 
   implicit override val generatorDrivenConfig =
-    PropertyCheckConfig(maxSize = 100, minSuccessful = 50)
+    PropertyCheckConfiguration(sizeRange = 100, minSuccessful = 50)
 
   behavior of "HashM"
 

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -26,6 +26,7 @@ object CompilerSettings {
       "-feature",
       "-language:_",
       "-unchecked",
+      "-Xfatal-warnings",
       //With > 16: [error] invalid setting for -Ybackend-parallelism must be between 1 and 16
       //https://github.com/scala/scala/blob/v2.12.6/src/compiler/scala/tools/nsc/settings/ScalaSettings.scala#L240
       "-Ybackend-parallelism", getRuntime.availableProcessors().min(16).toString

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -161,7 +161,7 @@ object BasicBench {
       Arbitrary(
         for {
           v <- Gen.posNum[Int]
-        } yield GInt(v)
+        } yield GInt(v.toLong)
       )
 
     def onePar(i: GInt) = List(


### PR DESCRIPTION
## Overview
- Resolves all warnings in `models` and `blockstorage`
- Incorporates `almostCompilerSettings` into `compilerSettings`


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3432


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
