### PR TITLE
Rchain 3430 remove error handler and effect

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -7,7 +7,6 @@ import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang._
 import coop.rchain.catscontrib._
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.shared._
 import cats.effect.concurrent.Semaphore
@@ -89,7 +88,7 @@ sealed abstract class MultiParentCasperInstances {
     Metrics.Source(CasperMetricsSource, "casper")
   private[this] val genesisLabel = Metrics.Source(MetricsSource, "genesis")
 
-  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
+  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: Time: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
       runtimeManager: RuntimeManager[F],
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -18,7 +18,6 @@ import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang._
 import coop.rchain.catscontrib.BooleanF._
 import coop.rchain.catscontrib.ski._
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.crypto.codec.Base16
@@ -39,7 +38,7 @@ final case class CasperState(
     dependencyDag: DoublyLinkedDag[BlockHash] = BlockDependencyDag.empty
 )
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: TransportLayer: Log: Time: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage](
     runtimeManager: RuntimeManager[F],
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -15,7 +15,6 @@ import coop.rchain.casper.util.rholang.{
   RuntimeManager
 }
 import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.RPConfAsk
 import coop.rchain.comm.transport.{Blob, TransportLayer}
@@ -45,7 +44,7 @@ class BlockApproverProtocol(
   implicit private val logSource: LogSource = LogSource(this.getClass)
   private val _bonds                        = bonds.map(e => ByteString.copyFrom(e._1.bytes) -> e._2)
 
-  def unapprovedBlockPacketHandler[F[_]: Concurrent: TransportLayer: Log: Time: ErrorHandler: RPConfAsk](
+  def unapprovedBlockPacketHandler[F[_]: Concurrent: TransportLayer: Log: Time: RPConfAsk](
       peer: PeerNode,
       u: UnapprovedBlock,
       runtimeManager: RuntimeManager[F]

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -19,7 +19,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
+
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -39,7 +39,7 @@ object CasperLaunch {
       val conf: CasperConf,
       val runtimeManager: RuntimeManager[F]
   )
-  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell: RaiseIOError](
+  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: Sync: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =
@@ -65,7 +65,7 @@ object CasperLaunch {
       case (msg, action) => Log[F].info(msg) >> action
     }
 
-  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: ErrorHandler: RPConfAsk: SafetyOracle: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell](
+  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: Concurrent: Time: Log: MultiParentCasperRef: BlockDagStorage: EngineCell](
       approvedBlock: ApprovedBlock,
       init: CasperInit[F]
   ): F[Unit] =
@@ -77,7 +77,7 @@ object CasperLaunch {
       _ <- Engine.transitionToRunning[F](casper, approvedBlock)
     } yield ()
 
-  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: ErrorHandler: Time: Concurrent: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
+  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: Time: Concurrent: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F]
   ): F[Unit] =
     for {
@@ -108,7 +108,7 @@ object CasperLaunch {
           )
     } yield ()
 
-  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: ErrorHandler: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
+  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: BlockDagStorage: EngineCell: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =
@@ -153,7 +153,7 @@ object CasperLaunch {
       _ <- EngineCell[F].set(new GenesisCeremonyMaster[F](abp))
     } yield ()
 
-  def connectAndQueryApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: ErrorHandler: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Metrics: Concurrent: SafetyOracle: BlockDagStorage: EngineCell](
+  def connectAndQueryApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Metrics: Concurrent: SafetyOracle: BlockDagStorage: EngineCell](
       init: CasperInit[F]
   ): F[Unit] =
     for {

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -18,7 +18,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
+
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -54,7 +54,7 @@ object Engine {
    * Note the ordering of the insertions is important.
    * We always want the block dag store to be a subset of the block store.
    */
-  def insertIntoBlockAndDagStore[F[_]: Sync: Concurrent: ErrorHandler: TransportLayer: ConnectionsCell: Log: BlockStore: BlockDagStorage](
+  def insertIntoBlockAndDagStore[F[_]: Sync: Concurrent: TransportLayer: ConnectionsCell: Log: BlockStore: BlockDagStorage](
       genesis: BlockMessage,
       approvedBlock: ApprovedBlock
   ): F[Unit] =
@@ -80,7 +80,7 @@ object Engine {
       _   <- TransportLayer[F].stream(peer, msg)
     } yield ()
 
-  def transitionToRunning[F[_]: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: ErrorHandler](
+  def transitionToRunning[F[_]: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time](
       casper: MultiParentCasper[F],
       approvedBlock: ApprovedBlock
   ): F[Unit] =
@@ -92,7 +92,7 @@ object Engine {
 
     } yield ()
 
-  def tranistionToInitializing[F[_]: Concurrent: Metrics: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: ErrorHandler: SafetyOracle: LastApprovedBlock: BlockDagStorage](
+  def tranistionToInitializing[F[_]: Concurrent: Metrics: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastApprovedBlock: BlockDagStorage](
       rm: RuntimeManager[F],
       shardId: String,
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -18,7 +18,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
+
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -31,7 +31,7 @@ import monix.execution.Scheduler
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
-class GenesisCeremonyMaster[F[_]: Sync: ConnectionsCell: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock](
+class GenesisCeremonyMaster[F[_]: Sync: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock](
     approveProtocol: ApproveBlockProtocol[F]
 ) extends Engine[F] {
   import Engine._
@@ -49,7 +49,7 @@ class GenesisCeremonyMaster[F[_]: Sync: ConnectionsCell: BlockStore: TransportLa
 
 object GenesisCeremonyMaster {
   import Engine._
-  def approveBlockInterval[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: EngineCell](
+  def approveBlockInterval[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: EngineCell](
       interval: FiniteDuration,
       shardId: String,
       runtimeManager: RuntimeManager[F],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -18,7 +18,6 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -32,7 +31,7 @@ import monix.execution.Scheduler
 import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
-class GenesisValidator[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: MultiParentCasperRef](
+class GenesisValidator[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: MultiParentCasperRef](
     rm: RuntimeManager[F],
     validatorId: ValidatorIdentity,
     shardId: String,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -18,7 +18,6 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -36,7 +35,7 @@ import scala.util.Try
   * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
   * `F[None]` to all other message types.
     **/
-class Initializing[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: MultiParentCasperRef: EngineCell](
+class Initializing[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: MultiParentCasperRef: EngineCell](
     runtimeManager: RuntimeManager[F],
     shardId: String,
     validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -17,7 +17,6 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -36,7 +35,7 @@ import scala.util.Try
   *
   * In the future it will be possible to create checkpoint with new [[ApprovedBlock]].
     **/
-class Running[F[_]: RPConfAsk: BlockStore: Monad: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler](
+class Running[F[_]: RPConfAsk: BlockStore: Monad: ConnectionsCell: TransportLayer: Log: Time](
     private val casper: MultiParentCasper[F],
     approvedBlock: ApprovedBlock
 ) extends Engine[F] {

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -9,7 +9,6 @@ import com.google.protobuf.ByteString
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
-import coop.rchain.comm.CommError.ErrorHandler
 import coop.rchain.comm.discovery._
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.RPConfAsk
@@ -28,7 +27,7 @@ object CommUtil {
 
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
-  def sendBlock[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: RPConfAsk](
+  def sendBlock[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk](
       b: BlockMessage
   ): F[Unit] = {
     val serializedBlock = b.toByteString
@@ -38,7 +37,7 @@ object CommUtil {
     } yield ()
   }
 
-  def sendBlockRequest[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: RPConfAsk](
+  def sendBlockRequest[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk](
       r: BlockRequest
   ): F[Unit] = {
     val serialized = r.toByteString
@@ -80,7 +79,7 @@ object CommUtil {
       _     <- TransportLayer[F].stream(peers, msg)
     } yield ()
 
-  def requestApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Log: Time: Metrics: TransportLayer: ConnectionsCell: ErrorHandler: RPConfAsk]
+  def requestApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Log: Time: Metrics: TransportLayer: ConnectionsCell: RPConfAsk]
       : F[Unit] = {
     val request = ApprovedBlockRequest("PleaseSendMeAnApprovedBlock").toByteString
     for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -21,7 +21,7 @@ import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.catscontrib.ski._
-import coop.rchain.comm.CommError.ErrorHandler
+
 import coop.rchain.comm._
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.comm.rp.Connect
@@ -52,7 +52,6 @@ class HashSetCasperTestNode[F[_]](
     val genesis: BlockMessage,
     sk: PrivateKey,
     logicalTime: LogicalTime[F],
-    implicit val errorHandlerEff: ErrorHandler[F],
     val blockDagDir: Path,
     val blockStoreDir: Path,
     blockProcessingLock: Semaphore[F],
@@ -162,8 +161,7 @@ object HashSetCasperTestNode {
       storageSize: Long,
       createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]]
   )(
-      implicit errorHandler: ErrorHandler[F],
-      concurrentF: Concurrent[F],
+      implicit concurrentF: Concurrent[F],
       testNetworkF: TestNetwork[F]
   ): Resource[F, HashSetCasperTestNode[F]] = {
     val name                        = "standalone"
@@ -217,7 +215,6 @@ object HashSetCasperTestNode {
                    genesis,
                    sk,
                    logicalTime,
-                   errorHandler,
                    blockDagDir,
                    blockStoreDir,
                    blockProcessingLock,
@@ -253,7 +250,6 @@ object HashSetCasperTestNode {
           storageSize,
           createRuntime
         )(
-          ApplicativeError_[Effect, CommError],
           Concurrent[Effect],
           testNetwork
         )
@@ -265,8 +261,7 @@ object HashSetCasperTestNode {
       storageSize: Long,
       createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]]
   )(
-      implicit errorHandler: ErrorHandler[F],
-      concurrentF: Concurrent[F],
+      implicit concurrentF: Concurrent[F],
       testNetworkF: TestNetwork[F]
   ): Resource[F, IndexedSeq[HashSetCasperTestNode[F]]] = {
     val n                           = sks.length
@@ -333,7 +328,6 @@ object HashSetCasperTestNode {
                            genesis,
                            sk,
                            logicalTime,
-                           errorHandler,
                            blockDagDir,
                            blockStoreDir,
                            semaphore,
@@ -388,7 +382,6 @@ object HashSetCasperTestNode {
       storageSize,
       createRuntime
     )(
-      ApplicativeError_[Effect, CommError],
       Concurrent[Effect],
       testNetwork
     )

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -41,13 +41,6 @@ final case class UnableToRestorePacket(path: Path, th: Throwable)   extends Comm
 
 object CommError {
 
-  type ErrorHandler[F[_]] = ApplicativeError_[F, CommError]
-
-  object ErrorHandler {
-    def apply[F[_]](implicit ev: ApplicativeError_[F, CommError]): ApplicativeError_[F, CommError] =
-      ev
-  }
-
   type CommErrT[F[_], A] = EitherT[F, CommError, A]
   type CommErr[A]        = Either[CommError, A]
 

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -10,7 +10,6 @@ import coop.rchain.comm.protocol.routing._
 // TODO we need lower level errors and general error, for now all in one place
 // TODO cleanup unused errors (UDP trash)
 sealed trait CommError
-final case class InitializationError(msg: String)                   extends CommError
 final case class UnknownCommError(msg: String)                      extends CommError
 final case class DatagramSizeError(size: Int)                       extends CommError
 final case class DatagramFramingError(ex: Exception)                extends CommError

--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -22,7 +22,7 @@ object HandleMessages {
   implicit private val metricsSource: Metrics.Source =
     Metrics.Source(CommMetricsSource, "rp.handle")
 
-  def handle[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: ErrorHandler: PacketHandler: ConnectionsCell: RPConfAsk](
+  def handle[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: PacketHandler: ConnectionsCell: RPConfAsk](
       protocol: Protocol
   ): F[CommunicationResponse] =
     ProtocolHelper.sender(protocol) match {
@@ -31,7 +31,7 @@ object HandleMessages {
       case Some(sender) => handle_[F](protocol, sender)
     }
 
-  private def handle_[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: ErrorHandler: PacketHandler: ConnectionsCell: RPConfAsk](
+  private def handle_[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: PacketHandler: ConnectionsCell: RPConfAsk](
       proto: Protocol,
       sender: PeerNode
   ): F[CommunicationResponse] =
@@ -58,7 +58,7 @@ object HandleMessages {
       _ <- Metrics[F].incrementCounter("disconnect")
     } yield handledWithoutMessage
 
-  def handlePacket[F[_]: Monad: Time: TransportLayer: ErrorHandler: Log: PacketHandler: RPConfAsk](
+  def handlePacket[F[_]: Monad: Time: TransportLayer: Log: PacketHandler: RPConfAsk](
       remote: PeerNode,
       packet: Packet
   ): F[CommunicationResponse] =

--- a/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
@@ -49,7 +49,7 @@ class ConnectSpec
         // given
         transportLayerEff.setResponses(kp(alwaysSuccess))
         // when
-        Connect.connect[Effect](remote, defaultTimeout)
+        Connect.connect[Effect](remote)
         // then
         transportLayerEff.requests.size should be(1)
         val Protocol(_, Protocol.Message.ProtocolHandshake(_)) = transportLayerEff.requests(0).msg

--- a/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
@@ -37,10 +37,10 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
     connectCalled = List.empty[PeerNode]
   }
 
-  val connect: (PeerNode, FiniteDuration) => Effect[Unit] = (peer, to) => {
+  val connect: PeerNode => Effect[CommErr[Unit]] = (peer) => {
     connectCalled = connectCalled :+ peer
-    if (willConnectSuccessfully.contains(peer)) ().pure[Effect]
-    else EitherT[Id, CommError, Unit](Left(timeout))
+    if (willConnectSuccessfully.contains(peer)) ().asRight[CommError].pure[Effect]
+    else CommError.timeout.asLeft[Unit].pure[Effect]
   }
 
   describe("Node when called to find and connect") {
@@ -62,7 +62,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
         implicit val connections = mkConnections()
         willConnectSuccessfully = List(peer("A"), peer("C"))
         // when
-        val result = Connect.findAndConnect[Effect](connect).value.right.get
+        val result = Connect.findAndConnect[Effect](connect)
         // then
         result.size shouldBe (2)
         result should contain(peer("A"))
@@ -90,7 +90,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
         implicit val connections = mkConnections(peer("B"))
         willConnectSuccessfully = List(peer("A"))
         // when
-        val result = Connect.findAndConnect[Effect](connect).value.right.get
+        val result = Connect.findAndConnect[Effect](connect)
         // then
         result.size shouldBe (1)
         result should contain(peer("A"))

--- a/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
@@ -18,7 +18,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
 
   import ScalaTestCats._
 
-  type Effect[A] = EitherT[Id, CommError, A]
+  type Effect[A] = Id[A]
 
   val src: PeerNode              = peer("src")
   val deftimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS)
@@ -125,8 +125,4 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
         maxNumOfConnections = maxNumOfConnections
       )
     )
-
-  implicit def eiterTrpConfAsk: RPConfAsk[Effect] =
-    new EitherTApplicativeAsk[Id, RPConf, CommError]
-
 }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -129,26 +129,12 @@ object Main {
     // https://www.slf4j.org/legacy.html#jul-to-slf4j
     SLF4JBridgeHandler.removeHandlersForRootLogger()
     SLF4JBridgeHandler.install()
-
-    val node =
-      for {
-        _       <- log.info(VersionInfo.get).toEffect
-        _       <- logConfiguration(conf).toEffect
-        runtime <- NodeRuntime(conf)
-        _       <- runtime.main
-      } yield ()
-
-    node.value >>= {
-      case Right(_) =>
-        Task.unit
-      case Left(CouldNotConnectToBootstrap) =>
-        log.error("Node could not connect to bootstrap node.")
-      case Left(InitializationError(msg)) =>
-        log.error(msg) >>
-          Task.delay(System.exit(-1))
-      case Left(error) =>
-        log.error(s"Failed! Reason: '$error")
-    }
+    for {
+      _       <- log.info(VersionInfo.get).toEffect
+      _       <- logConfiguration(conf).toEffect
+      runtime <- NodeRuntime(conf)
+      _       <- runtime.main
+    } yield ()
   }
 
   private def logConfiguration(conf: Configuration): Task[Unit] =

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -130,8 +130,8 @@ object Main {
     SLF4JBridgeHandler.removeHandlersForRootLogger()
     SLF4JBridgeHandler.install()
     for {
-      _       <- log.info(VersionInfo.get).toEffect
-      _       <- logConfiguration(conf).toEffect
+      _       <- log.info(VersionInfo.get)
+      _       <- logConfiguration(conf)
       runtime <- NodeRuntime(conf)
       _       <- runtime.main
     } yield ()

--- a/node/src/main/scala/coop/rchain/node/NodeEnvironment.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeEnvironment.scala
@@ -20,24 +20,24 @@ object NodeEnvironment {
 
   class InitializationException(msg: String) extends RuntimeException
 
-  def create(conf: Configuration)(implicit log: Log[Task]): Effect[NodeIdentifier] =
+  def create(conf: Configuration)(implicit log: Log[Task]): Task[NodeIdentifier] =
     for {
-      dataDir <- Task.delay(conf.server.dataDir.toFile).toEffect
+      dataDir <- Task.delay(conf.server.dataDir.toFile)
       _       <- canCreateDataDir(dataDir)
       _       <- haveAccessToDataDir(dataDir)
-      _       <- log.info(s"Using data dir: ${dataDir.getAbsolutePath}").toEffect
-      _       <- transport.generateCertificateIfAbsent[Effect].apply(conf.tls)
+      _       <- log.info(s"Using data dir: ${dataDir.getAbsolutePath}")
+      _       <- transport.generateCertificateIfAbsent[Task].apply(conf.tls)
       _       <- hasCertificate(conf)
       _       <- hasKey(conf)
       name    <- name(conf)
     } yield NodeIdentifier(name)
 
-  private def isValid(pred: Boolean, msg: String): Effect[Unit] =
+  private def isValid(pred: Boolean, msg: String): Task[Unit] =
     if (pred) Task.raiseError(new RuntimeException(msg))
     else Task.unit
 
-  private def name(conf: Configuration): Effect[String] = {
-    val certificate: Effect[X509Certificate] =
+  private def name(conf: Configuration): Task[String] = {
+    val certificate: Task[X509Certificate] =
       Task
         .delay(CertificateHelper.fromFile(conf.tls.certificate.toFile))
         .attempt
@@ -56,9 +56,9 @@ object NodeEnvironment {
     } yield name
   }
 
-  private def certBase16(maybePubAddr: Option[Array[Byte]]): Effect[String] =
+  private def certBase16(maybePubAddr: Option[Array[Byte]]): Task[String] =
     maybePubAddr match {
-      case Some(bytes) => Base16.encode(bytes).pure[Effect]
+      case Some(bytes) => Base16.encode(bytes).pure[Task]
       case None =>
         Task.fromEither(
           new InitializationException(
@@ -67,22 +67,22 @@ object NodeEnvironment {
         )
     }
 
-  private def canCreateDataDir(dataDir: File): Effect[Unit] = isValid(
+  private def canCreateDataDir(dataDir: File): Task[Unit] = isValid(
     !dataDir.exists() && !dataDir.mkdir(),
     s"The data dir must be a directory and have read and write permissions:\\n${dataDir.getAbsolutePath}"
   )
 
-  private def haveAccessToDataDir(dataDir: File): Effect[Unit] = isValid(
+  private def haveAccessToDataDir(dataDir: File): Task[Unit] = isValid(
     !dataDir.isDirectory || !dataDir.canRead || !dataDir.canWrite,
     s"The data dir must be a directory and have read and write permissions:\n${dataDir.getAbsolutePath}"
   )
 
-  private def hasCertificate(conf: Configuration): Effect[Unit] = isValid(
+  private def hasCertificate(conf: Configuration): Task[Unit] = isValid(
     !conf.tls.certificate.toFile.exists(),
     s"Certificate file ${conf.tls.certificate} not found"
   )
 
-  private def hasKey(conf: Configuration): Effect[Unit] = isValid(
+  private def hasKey(conf: Configuration): Task[Unit] = isValid(
     !conf.tls.key.toFile.exists(),
     s"Secret key file ${conf.tls.certificate} not found"
   )

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -83,25 +83,25 @@ class NodeRuntime private[node] (
   case class Servers(
       kademliaRPCServer: Server[Task],
       transportServer: TransportServer,
-      externalApiServer: Server[Effect],
+      externalApiServer: Server[Task],
       internalApiServer: Server[Task],
       httpServer: Fiber[Task, Unit]
   )
 
-  def acquireServers(runtime: Runtime[Task], blockApiLock: Semaphore[Effect])(
+  def acquireServers(runtime: Runtime[Task], blockApiLock: Semaphore[Task])(
       implicit
       kademliaStore: KademliaStore[Task],
       nodeDiscovery: NodeDiscovery[Task],
-      blockStore: BlockStore[Effect],
-      oracle: SafetyOracle[Effect],
-      multiParentCasperRef: MultiParentCasperRef[Effect],
+      blockStore: BlockStore[Task],
+      oracle: SafetyOracle[Task],
+      multiParentCasperRef: MultiParentCasperRef[Task],
       nodeCoreMetrics: NodeMetrics[Task],
       jvmMetrics: JvmMetrics[Task],
       connectionsCell: ConnectionsCell[Task],
-      concurrent: Concurrent[Effect],
+      concurrent: Concurrent[Task],
       metrics: Metrics[Task],
       rPConfAsk: RPConfAsk[Task]
-  ): Effect[Servers] = {
+  ): Task[Servers] = {
     implicit val s: Scheduler = scheduler
     for {
       kademliaRPCServer <- discovery
@@ -111,7 +111,7 @@ class NodeRuntime private[node] (
                               KademliaHandleRPC.handlePing[Task],
                               KademliaHandleRPC.handleLookup[Task]
                             )(grpcScheduler)
-                            .toEffect
+
       transportServer <- Task
                           .delay(
                             GrpcTransportServer.acquireServer(
@@ -124,9 +124,9 @@ class NodeRuntime private[node] (
                               conf.server.messageConsumers
                             )(grpcScheduler, rPConfAsk, log)
                           )
-                          .toEffect
+
       externalApiServer <- api
-                            .acquireExternalServer[Effect](
+                            .acquireExternalServer[Task](
                               conf.grpcServer.portExternal,
                               grpcScheduler,
                               blockApiLock
@@ -137,7 +137,6 @@ class NodeRuntime private[node] (
                               runtime,
                               grpcScheduler
                             )
-                            .toEffect
 
       prometheusReporter = new NewPrometheusReporter()
       prometheusService  = NewPrometheusReporter.service[Task](prometheusReporter)
@@ -150,7 +149,6 @@ class NodeRuntime private[node] (
                           .resource
                           .use(_ => Task.never[Unit])
                           .start
-                          .toEffect
 
       _ <- Task.delay {
             Kamon.reconfigure(conf.underlying.withFallback(Kamon.config()))
@@ -160,7 +158,7 @@ class NodeRuntime private[node] (
             if (conf.kamon.zipkin) Kamon.addReporter(new ZipkinReporter())
             Kamon.addReporter(new JmxReporter())
             if (conf.kamon.sigar) SystemMetrics.startCollecting()
-          }.toEffect
+          }
     } yield Servers(
       kademliaRPCServer,
       transportServer,
@@ -172,8 +170,8 @@ class NodeRuntime private[node] (
 
   def clearResources(servers: Servers, runtime: Runtime[Task], casperRuntime: Runtime[Task])(
       implicit
-      blockStore: BlockStore[Effect],
-      blockDagStorage: BlockDagStorage[Effect]
+      blockStore: BlockStore[Task],
+      blockDagStorage: BlockDagStorage[Task]
   ): Unit =
     (for {
       _ <- log.info("Shutting down API servers...")
@@ -198,8 +196,8 @@ class NodeRuntime private[node] (
     } yield ()).unsafeRunSync(scheduler)
 
   def addShutdownHook(servers: Servers, runtime: Runtime[Task], casperRuntime: Runtime[Task])(
-      implicit blockStore: BlockStore[Effect],
-      blockDagStorage: BlockDagStorage[Effect]
+      implicit blockStore: BlockStore[Task],
+      blockDagStorage: BlockDagStorage[Task]
   ): Task[Unit] =
     Task.delay(sys.addShutdownHook(clearResources(servers, runtime, casperRuntime)))
 
@@ -219,19 +217,19 @@ class NodeRuntime private[node] (
       kademliaStore: KademliaStore[Task],
       nodeDiscovery: NodeDiscovery[Task],
       rpConnectons: ConnectionsCell[Task],
-      blockDagStorage: BlockDagStorage[Effect],
-      blockStore: BlockStore[Effect],
-      oracle: SafetyOracle[Effect],
-      packetHandler: PacketHandler[Effect],
-      casperConstructor: MultiParentCasperRef[Effect],
+      blockDagStorage: BlockDagStorage[Task],
+      blockStore: BlockStore[Task],
+      oracle: SafetyOracle[Task],
+      packetHandler: PacketHandler[Task],
+      casperConstructor: MultiParentCasperRef[Task],
       nodeCoreMetrics: NodeMetrics[Task],
       jvmMetrics: JvmMetrics[Task],
-      engineCell: EngineCell[Effect]
-  ): Effect[Unit] = {
+      engineCell: EngineCell[Task]
+  ): Task[Unit] = {
 
-    val info: Effect[Unit] =
-      if (conf.server.standalone) Log[Effect].info(s"Starting stand-alone node.")
-      else Log[Effect].info(s"Starting node that will bootstrap from ${conf.server.bootstrap}")
+    val info: Task[Unit] =
+      if (conf.server.standalone) Log[Task].info(s"Starting stand-alone node.")
+      else Log[Task].info(s"Starting node that will bootstrap from ${conf.server.bootstrap}")
 
     val dynamicIpCheck: Task[Unit] =
       if (conf.server.dynamicHostAddress)
@@ -245,57 +243,57 @@ class NodeRuntime private[node] (
         } yield ()
       else Task.unit
 
-    val loop: Effect[Unit] =
+    val loop: Task[Unit] =
       for {
-        _ <- dynamicIpCheck.toEffect
-        _ <- NodeDiscovery[Effect].discover
-        _ <- Connect.clearConnections[Effect]
-        _ <- Connect.findAndConnect[Effect](Connect.connect[Effect])
-        _ <- time.sleep(20.seconds).toEffect
+        _ <- dynamicIpCheck
+        _ <- NodeDiscovery[Task].discover
+        _ <- Connect.clearConnections[Task]
+        _ <- Connect.findAndConnect[Task](Connect.connect[Task])
+        _ <- time.sleep(20.seconds)
       } yield ()
 
-    def waitForFirstConnetion: Effect[Unit] =
+    def waitForFirstConnetion: Task[Unit] =
       for {
-        _ <- time.sleep(10.second).toEffect
-        _ <- ConnectionsCell[Effect].read.map(_.isEmpty).ifM(waitForFirstConnetion, ().pure[Effect])
+        _ <- time.sleep(10.second)
+        _ <- ConnectionsCell[Task].read.map(_.isEmpty).ifM(waitForFirstConnetion, ().pure[Task])
       } yield ()
 
-    val casperLoop: Effect[Unit] =
+    val casperLoop: Task[Unit] =
       for {
         casper <- casperConstructor.get
-        _      <- casper.fold(().pure[Effect])(_.fetchDependencies)
-        _      <- time.sleep(30.seconds).toEffect
+        _      <- casper.fold(().pure[Task])(_.fetchDependencies)
+        _      <- time.sleep(30.seconds)
       } yield ()
 
     for {
-      blockApiLock <- Semaphore[Effect](1)
+      blockApiLock <- Semaphore[Task](1)
       _            <- info
-      local        <- peerNodeAsk.ask.toEffect
+      local        <- peerNodeAsk.ask
       host         = local.endpoint.host
       servers      <- acquireServers(runtime, blockApiLock)
-      _            <- addShutdownHook(servers, runtime, casperRuntime).toEffect
+      _            <- addShutdownHook(servers, runtime, casperRuntime)
       _            <- servers.externalApiServer.start
-      _ <- Log[Effect].info(
+      _ <- Log[Task].info(
             s"External API server started at $host:${servers.externalApiServer.port}"
           )
-      _ <- servers.internalApiServer.start.toEffect
-      _ <- Log[Effect].info(
+      _ <- servers.internalApiServer.start
+      _ <- Log[Task].info(
             s"Internal API server started at $host:${servers.internalApiServer.port}"
           )
-      _ <- servers.kademliaRPCServer.start.toEffect
-      _ <- Log[Effect].info(
+      _ <- servers.kademliaRPCServer.start
+      _ <- Log[Task].info(
             s"Kademlia RPC server started at $host:${servers.kademliaRPCServer.port}"
           )
       _ <- servers.transportServer.start(
-            pm => HandleMessages.handle[Effect](pm),
+            pm => HandleMessages.handle[Task](pm),
             blob => packetHandler.handlePacket(blob.sender, blob.packet)
           )
       address = s"rnode://$id@$host?protocol=$port&discovery=$kademliaPort"
-      _       <- Log[Effect].info(s"Listening for traffic on $address.")
+      _       <- Log[Task].info(s"Listening for traffic on $address.")
       _       <- Task.defer(loop.forever).executeOn(loopScheduler).start
-      _ <- if (conf.server.standalone) ().pure[Effect]
-          else Log[Effect].info(s"Waiting for first connection.") >> waitForFirstConnetion
-      _ <- Concurrent[Effect].start(EngineCell[Effect].read >>= (_.init))
+      _ <- if (conf.server.standalone) ().pure[Task]
+          else Log[Task].info(s"Waiting for first connection.") >> waitForFirstConnetion
+      _ <- Concurrent[Task].start(EngineCell[Task].read >>= (_.init))
       _ <- Task.defer(casperLoop.forever).executeOn(loopScheduler)
     } yield ()
   }
@@ -304,7 +302,7 @@ class NodeRuntime private[node] (
     * Handles unrecoverable errors in program. Those are errors that should not happen in properly
     * configured enviornment and they mean immediate termination of the program
     */
-  private def handleUnrecoverableErrors(prog: Effect[Unit]): Effect[Unit] =
+  private def handleUnrecoverableErrors(prog: Task[Unit]): Task[Unit] =
     prog
       .onErrorHandleWith { th =>
         log.error("Caught unhandable error. Exiting. Stacktrace below.") *> Task.delay {
@@ -327,8 +325,8 @@ class NodeRuntime private[node] (
     )
 
   // TODO this should use existing algebra
-  private def mkDirs(path: Path): Effect[Unit] =
-    Sync[Effect].delay(Files.createDirectories(path))
+  private def mkDirs(path: Path): Task[Unit] =
+    Sync[Task].delay(Files.createDirectories(path))
 
   /**
     * Main node entry. It will:
@@ -337,7 +335,7 @@ class NodeRuntime private[node] (
     * 3. run the node program.
     */
   // TODO: Resolve scheduler chaos in Runtime, RuntimeManager and CasperPacketHandler
-  val main: Effect[Unit] = for {
+  val main: Task[Unit] = for {
     // 1. fetch local peer node
     local <- WhoAmI
               .fetchLocalPeerNode[Task](
@@ -347,7 +345,6 @@ class NodeRuntime private[node] (
                 conf.server.noUpnp,
                 id
               )
-              .toEffect
 
     // 2. set up configurations
     defaultTimeout = conf.server.defaultTimeout
@@ -357,18 +354,18 @@ class NodeRuntime private[node] (
     rpConfState          = effects.rpConfState(rpConf(local, initPeer))
     rpConfAsk            = effects.rpConfAsk(rpConfState)
     peerNodeAsk          = effects.peerNodeAsk(rpConfState)
-    rpConnections        <- effects.rpConnections.toEffect
+    rpConnections        <- effects.rpConnections
     metrics              = diagnostics.effects.metrics[Task]
     time                 = effects.time
     timerTask            = Task.timer
-    multiParentCasperRef <- MultiParentCasperRef.of[Effect]
-    lab                  <- LastApprovedBlock.of[Task].toEffect
+    multiParentCasperRef <- MultiParentCasperRef.of[Task]
+    lab                  <- LastApprovedBlock.of[Task]
     commTmpFolder        = conf.server.dataDir.resolve("tmp").resolve("comm")
     _ <- commTmpFolder.toFile
           .exists()
           .fold(
-            commTmpFolder.deleteDirectory[Task]().toEffect,
-            Task.unit.toEffect
+            commTmpFolder.deleteDirectory[Task](),
+            Task.unit
           )
     transport <- effects
                   .transportClient(
@@ -379,14 +376,14 @@ class NodeRuntime private[node] (
                     conf.server.packetChunkSize,
                     commTmpFolder
                   )(grpcScheduler, log, metrics)
-                  .toEffect
+
     kademliaRPC = effects.kademliaRPC(conf.server.networkId, defaultTimeout)(
       grpcScheduler,
       peerNodeAsk,
       metrics
     )
     kademliaStore = effects.kademliaStore(id)(kademliaRPC, metrics)
-    _             <- initPeer.fold(Task.unit.toEffect)(p => kademliaStore.updateLastSeen(p).toEffect)
+    _             <- initPeer.fold(Task.unit)(p => kademliaStore.updateLastSeen(p))
     nodeDiscovery = effects.nodeDiscovery(id)(kademliaStore, kademliaRPC)
 
     /**
@@ -399,9 +396,9 @@ class NodeRuntime private[node] (
     _             <- mkDirs(dagStoragePath)
     blockstoreEnv = Context.env(blockstorePath, 8L * 1024L * 1024L * 1024L)
     blockStore <- FileLMDBIndexBlockStore
-                   .create[Effect](blockstoreEnv, blockstorePath)(
-                     Concurrent[Effect],
-                     Sync[Effect],
+                   .create[Task](blockstoreEnv, blockstorePath)(
+                     Concurrent[Task],
+                     Sync[Task],
                      log
                    )
                    .map(_.right.get) // TODO handle errors
@@ -419,14 +416,14 @@ class NodeRuntime private[node] (
       mapSize = 8L * 1024L * 1024L * 1024L,
       latestMessagesLogMaxSizeFactor = 10
     )
-    blockDagStorage <- BlockDagFileStorage.create[Effect](dagConfig)(
-                        Concurrent[Effect],
-                        Sync[Effect],
+    blockDagStorage <- BlockDagFileStorage.create[Task](dagConfig)(
+                        Concurrent[Task],
+                        Sync[Task],
                         log
                       )
     oracle = SafetyOracle
-      .cliqueOracle[Effect](
-        Monad[Effect],
+      .cliqueOracle[Task](
+        Monad[Task],
         log,
         metrics
       )
@@ -435,11 +432,11 @@ class NodeRuntime private[node] (
       implicit val m: Metrics[Task] = metrics
       Runtime
         .createWithEmptyCost[Task, Task.Par](storagePath, storageSize, storeType, Seq.empty)
-        .toEffect
+
     }
     _ <- Runtime
           .injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)
-          .toEffect
+
     casperRuntime <- {
       implicit val s                = rspaceScheduler
       implicit val m: Metrics[Task] = metrics
@@ -450,12 +447,12 @@ class NodeRuntime private[node] (
           storeType,
           Seq.empty
         )
-        .toEffect
+
     }
-    runtimeManager <- RuntimeManager.fromRuntime[Task](casperRuntime).toEffect
-    engineCell     <- EngineCell.init[Effect]
-    raiseIOError   = IOError.raiseIOErrorThroughSync[Effect]
-    casperInit = new CasperInit[Effect](
+    runtimeManager <- RuntimeManager.fromRuntime[Task](casperRuntime)
+    engineCell     <- EngineCell.init[Task]
+    raiseIOError   = IOError.raiseIOErrorThroughSync[Task]
+    casperInit = new CasperInit[Task](
       conf.casper,
       runtimeManager
     )
@@ -468,8 +465,8 @@ class NodeRuntime private[node] (
           transport,
           rpConfAsk,
           oracle,
-          Sync[Effect],
-          Concurrent[Effect],
+          Sync[Task],
+          Concurrent[Task],
           time,
           log,
           multiParentCasperRef,
@@ -479,8 +476,8 @@ class NodeRuntime private[node] (
           scheduler
         )
     packetHandler = {
-      implicit val ev: EngineCell[Effect] = engineCell
-      CasperPacketHandler[Effect]
+      implicit val ev: EngineCell[Task] = engineCell
+      CasperPacketHandler[Task]
     }
     nodeCoreMetrics = diagnostics.effects.nodeCoreMetrics[Task]
     jvmMetrics      = diagnostics.effects.jvmMetrics[Task]
@@ -513,9 +510,9 @@ class NodeRuntime private[node] (
 object NodeRuntime {
   def apply(
       conf: Configuration
-  )(implicit scheduler: Scheduler, log: Log[Task]): Effect[NodeRuntime] =
+  )(implicit scheduler: Scheduler, log: Log[Task]): Task[NodeRuntime] =
     for {
       id      <- NodeEnvironment.create(conf)
-      runtime <- Task.delay(new NodeRuntime(conf, id, scheduler)).toEffect
+      runtime <- Task.delay(new NodeRuntime(conf, id, scheduler))
     } yield runtime
 }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -22,7 +22,7 @@ import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm._
-import coop.rchain.comm.CommError.ErrorHandler
+
 import coop.rchain.comm.discovery._
 import coop.rchain.comm.rp._
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk, RPConfState}
@@ -472,7 +472,6 @@ class NodeRuntime private[node] (
           Cell.eitherTCell(Monad[Task], rpConnections),
           NodeDiscovery.eitherTNodeDiscovery(Monad[Task], nodeDiscovery),
           TransportLayer.eitherTTransportLayer(Monad[Task], log, transport),
-          ErrorHandler[Effect],
           eiterTrpConfAsk(rpConfAsk),
           oracle,
           Sync[Effect],

--- a/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/client/Runtime.scala
@@ -14,8 +14,8 @@ object Runtime {
 
   type ErrorHandler[F[_]] = ApplicativeError_[F, Throwable]
 
-  def diagnosticsProgram[F[_]: Monad: ErrorHandler: ConsoleIO: DiagnosticsService]: F[Unit] = {
-    val program = for {
+  def diagnosticsProgram[F[_]: Monad: ConsoleIO: DiagnosticsService]: F[Unit] =
+    for {
       peersRP <- DiagnosticsService[F].listPeers
       _       <- ConsoleIO[F].println(showPeers(peersRP, "connected"))
       peersND <- DiagnosticsService[F].listDiscoveredPeers
@@ -34,18 +34,6 @@ object Runtime {
       _       <- ConsoleIO[F].println(showThreads(threads))
       _       <- ConsoleIO[F].close
     } yield ()
-
-    for {
-      result <- program.attempt
-      _ <- result match {
-            case Left(ex) => ConsoleIO[F].println(s"Error: ${processError(ex).getMessage}")
-            case _        => ().pure[F]
-          }
-    } yield ()
-  }
-
-  private def processError(t: Throwable): Throwable =
-    Option(t.getCause).getOrElse(t)
 
   def showPeers(peers: Seq[PeerNode], peerType: String): String =
     List(

--- a/node/src/main/scala/coop/rchain/node/package.scala
+++ b/node/src/main/scala/coop/rchain/node/package.scala
@@ -10,11 +10,5 @@ import coop.rchain.comm.CommError
 import monix.eval.Task
 
 package object node {
-
   type CommErrT[F[_], A] = EitherT[F, CommError, A]
-  type Effect[A]         = Task[A]
-
-  implicit class TaskEffectOps[A](t: Task[A]) {
-    def toEffect: Effect[A] = t
-  }
 }

--- a/node/src/main/scala/coop/rchain/node/package.scala
+++ b/node/src/main/scala/coop/rchain/node/package.scala
@@ -11,14 +11,10 @@ import monix.eval.Task
 
 package object node {
 
-  /** Final Effect + helper methods */
   type CommErrT[F[_], A] = EitherT[F, CommError, A]
-  type Effect[A]         = CommErrT[Task, A]
+  type Effect[A]         = Task[A]
 
-  implicit class EitherEffectOps[A](e: Either[CommError, A]) {
-    def toEffect: Effect[A] = EitherT[Task, CommError, A](e.pure[Task])
-  }
   implicit class TaskEffectOps[A](t: Task[A]) {
-    def toEffect: Effect[A] = t.liftM[CommErrT]
+    def toEffect: Effect[A] = t
   }
 }


### PR DESCRIPTION
## Overview
ErrorHandler is mostly not used in comm (or used poorly), but that constraint pushes a lot complexity to other layers that use comm. Once ErrorHandler is removed, a lot of that complexity will be removed

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3430
