### PR TITLE
Event Log for crucial events

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -74,9 +74,15 @@ object Engine {
       approvedBlock: ApprovedBlock
   ): F[Unit] =
     for {
-      _   <- MultiParentCasperRef[F].set(casper)
-      _   <- Log[F].info("Making a transition to Running state.")
-      _   <- EventLog[F].publish(shared.Event.EnteredRunningState)
+      _ <- MultiParentCasperRef[F].set(casper)
+      _ <- Log[F].info("Making a transition to Running state.")
+      _ <- EventLog[F].publish(
+            shared.Event.EnteredRunningState(
+              approvedBlock.candidate
+                .flatMap(_.block.map(b => PrettyPrinter.buildStringNoLimit(b.blockHash)))
+                .getOrElse("")
+            )
+          )
       abh = new Running[F](casper, approvedBlock)
       _   <- EngineCell[F].set(abh)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -1,36 +1,25 @@
 package coop.rchain.casper.engine
 
-import EngineCell._
-import cats.data.EitherT
-import cats.effect.concurrent.Ref
+import cats.{Applicative, Monad}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{Applicative, Monad}
-import com.google.protobuf.ByteString
+
+import EngineCell._
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
+import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper._
-import coop.rchain.casper.util.comm.CommUtil
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.MonadTrans
-
-import coop.rchain.comm.discovery.NodeDiscovery
+import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.{Blob, TransportLayer}
-import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.metrics.Metrics
-import coop.rchain.shared.{Log, LogSource, Time}
-import monix.eval.Task
-import monix.execution.Scheduler
+import coop.rchain.shared
+import coop.rchain.shared._
 
-import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
+import com.google.protobuf.ByteString
 
 trait Engine[F[_]] {
 
@@ -80,19 +69,20 @@ object Engine {
       _   <- TransportLayer[F].stream(peer, msg)
     } yield ()
 
-  def transitionToRunning[F[_]: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time](
+  def transitionToRunning[F[_]: Monad: MultiParentCasperRef: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time](
       casper: MultiParentCasper[F],
       approvedBlock: ApprovedBlock
   ): F[Unit] =
     for {
       _   <- MultiParentCasperRef[F].set(casper)
       _   <- Log[F].info("Making a transition to Running state.")
+      _   <- EventLog[F].publish(shared.Event.EnteredRunningState)
       abh = new Running[F](casper, approvedBlock)
       _   <- EngineCell[F].set(abh)
 
     } yield ()
 
-  def tranistionToInitializing[F[_]: Concurrent: Metrics: Monad: MultiParentCasperRef: EngineCell: Log: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastApprovedBlock: BlockDagStorage](
+  def tranistionToInitializing[F[_]: Concurrent: Metrics: Monad: MultiParentCasperRef: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastApprovedBlock: BlockDagStorage](
       rm: RuntimeManager[F],
       shardId: String,
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -1,35 +1,24 @@
 package coop.rchain.casper.engine
 
-import EngineCell._
-import cats.data.EitherT
-import cats.effect.concurrent.Ref
+import scala.concurrent.duration.FiniteDuration
+
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{Applicative, Monad}
-import com.google.protobuf.ByteString
+import cats.Applicative
+
+import EngineCell._
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
+import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper._
-import coop.rchain.casper.util.comm.CommUtil
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.MonadTrans
-
-import coop.rchain.comm.discovery.NodeDiscovery
-import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
-import coop.rchain.comm.transport.{Blob, TransportLayer}
-import coop.rchain.comm.{transport, PeerNode}
+import coop.rchain.comm.transport.TransportLayer
+import coop.rchain.comm.PeerNode
 import coop.rchain.metrics.Metrics
-import coop.rchain.shared.{Log, LogSource, Time}
-import monix.eval.Task
-import monix.execution.Scheduler
-import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
+import coop.rchain.shared._
 
 class GenesisCeremonyMaster[F[_]: Sync: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock](
     approveProtocol: ApproveBlockProtocol[F]
@@ -49,7 +38,7 @@ class GenesisCeremonyMaster[F[_]: Sync: ConnectionsCell: BlockStore: TransportLa
 
 object GenesisCeremonyMaster {
   import Engine._
-  def approveBlockInterval[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: EngineCell](
+  def approveBlockInterval[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: EventLog: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: MultiParentCasperRef: BlockDagStorage: EngineCell](
       interval: FiniteDuration,
       shardId: String,
       runtimeManager: RuntimeManager[F],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -1,37 +1,25 @@
 package coop.rchain.casper.engine
 
-import cats.data.EitherT
-import cats.effect.concurrent.Ref
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{Applicative, Monad}
-import com.google.protobuf.ByteString
+import cats.Applicative
+
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
+import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.util.comm.CommUtil
-import coop.rchain.casper.genesis.Genesis
+import EngineCell._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.discovery.NodeDiscovery
-import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
-import coop.rchain.comm.transport.{Blob, TransportLayer}
-import coop.rchain.comm.{transport, PeerNode}
+import coop.rchain.comm.transport.TransportLayer
+import coop.rchain.comm.PeerNode
 import coop.rchain.metrics.Metrics
-import coop.rchain.shared.{Log, LogSource, Time}
-import monix.eval.Task
-import monix.execution.Scheduler
+import coop.rchain.shared._
 
-import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
+import com.google.protobuf.ByteString
 
-class GenesisValidator[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: MultiParentCasperRef](
+class GenesisValidator[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: TransportLayer: Log: EventLog: Time: SafetyOracle: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: MultiParentCasperRef](
     rm: RuntimeManager[F],
     validatorId: ValidatorIdentity,
     shardId: String,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -1,41 +1,31 @@
 package coop.rchain.casper.engine
 
-import cats.data.EitherT
-import cats.effect.concurrent.Ref
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{Applicative, Monad}
-import com.google.protobuf.ByteString
+import cats.Applicative
+
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
+import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
-import coop.rchain.casper._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.util.comm.CommUtil
-import coop.rchain.casper.genesis.Genesis
+import EngineCell._
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.MonadTrans
-import coop.rchain.comm.discovery.NodeDiscovery
-import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
-import coop.rchain.comm.transport.{Blob, TransportLayer}
-import coop.rchain.comm.{transport, PeerNode}
+import coop.rchain.comm.transport.TransportLayer
+import coop.rchain.comm.PeerNode
 import coop.rchain.metrics.Metrics
-import coop.rchain.shared.{Log, LogSource, Time}
-import monix.eval.Task
-import monix.execution.Scheduler
+import coop.rchain.shared._
+import coop.rchain.shared
 
-import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
+import com.google.protobuf.ByteString
 
 /** Node in this state will query peers in the network with [[ApprovedBlockRequest]] message
   * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
   * `F[None]` to all other message types.
     **/
-class Initializing[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: MultiParentCasperRef: EngineCell](
+class Initializing[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore: TransportLayer: Log: EventLog: Time: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: MultiParentCasperRef: EngineCell](
     runtimeManager: RuntimeManager[F],
     shardId: String,
     validatorId: Option[ValidatorIdentity],
@@ -74,6 +64,7 @@ class Initializing[F[_]: Sync: Metrics: Concurrent: ConnectionsCell: BlockStore:
       maybeCasper <- if (isValid) {
                       for {
                         _       <- Log[F].info("Valid ApprovedBlock received!")
+                        _       <- EventLog[F].publish(shared.Event.ApprovedBlockReceived)
                         genesis = approvedBlock.candidate.flatMap(_.block).get
                         _       <- insertIntoBlockAndDagStore[F](genesis, approvedBlock)
                         _       <- LastApprovedBlock[F].set(approvedBlock)

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -1,40 +1,18 @@
 package coop.rchain.casper.engine
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift}
-import cats._, cats.data._, cats.implicits._
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.{BlockDagRepresentation, InMemBlockDagStorage, InMemBlockStore}
-import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
-import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.helper.{BlockDagStorageTestFixture, NoOpsCasperEffect}
-import coop.rchain.casper.protocol.{NoApprovedBlockAvailable, _}
-import coop.rchain.casper.util.TestTime
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.ApplicativeError_
-import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.comm.protocol.routing.Packet
-import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
-import coop.rchain.comm.rp.ProtocolHelper
-import coop.rchain.comm.rp.ProtocolHelper._
-import coop.rchain.comm.{transport, _}
-import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.hash.Blake2b256
-import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.metrics.Metrics.MetricsNOP
-import coop.rchain.p2p.EffectsTestInstances._
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Cell, StoreType}
-import monix.eval.Task
-import monix.execution.Scheduler
-import org.scalatest.WordSpec
-
 import scala.concurrent.duration._
+
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+import coop.rchain.casper._
+import coop.rchain.casper.protocol._
+import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.shared.Cell
+
+import com.google.protobuf.ByteString
+import monix.eval.Task
+import org.scalatest.WordSpec
 
 class GenesisCeremonyMasterSpec extends WordSpec {
   "GenesisCeremonyMaster" should {

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisValidatorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisValidatorSpec.scala
@@ -1,40 +1,19 @@
 package coop.rchain.casper.engine
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift}
-import cats._, cats.data._, cats.implicits._
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.{BlockDagRepresentation, InMemBlockDagStorage, InMemBlockStore}
-import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
-import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.helper.{BlockDagStorageTestFixture, NoOpsCasperEffect}
+import cats.implicits._
+
+import EngineCell._
 import coop.rchain.casper.protocol.{NoApprovedBlockAvailable, _}
-import coop.rchain.casper.util.TestTime
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.ApplicativeError_
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.comm.protocol.routing.Packet
-import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.rp.ProtocolHelper._
-import coop.rchain.comm.{transport, _}
-import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.hash.Blake2b256
-import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.metrics.Metrics.MetricsNOP
-import coop.rchain.p2p.EffectsTestInstances._
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Cell, StoreType}
+import coop.rchain.comm.transport
+import coop.rchain.shared.Cell
+
+import com.google.protobuf.ByteString
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.WordSpec
-
-import scala.concurrent.duration._
 
 class GenesisValidatorSpec extends WordSpec {
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -1,40 +1,19 @@
 package coop.rchain.casper.engine
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift}
-import cats._, cats.data._, cats.implicits._
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.{BlockDagRepresentation, InMemBlockDagStorage, InMemBlockStore}
-import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
+import cats.implicits._
+
 import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.helper.{BlockDagStorageTestFixture, NoOpsCasperEffect}
-import coop.rchain.casper.protocol.{NoApprovedBlockAvailable, _}
-import coop.rchain.casper.util.TestTime
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.ApplicativeError_
+import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.comm.protocol.routing.Packet
-import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
-import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.rp.ProtocolHelper._
-import coop.rchain.comm.{transport, _}
-import coop.rchain.crypto.codec.Base16
+import coop.rchain.comm.transport
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.metrics.Metrics.MetricsNOP
-import coop.rchain.p2p.EffectsTestInstances._
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Cell, StoreType}
-import monix.eval.Task
-import monix.execution.Scheduler
-import org.scalatest.WordSpec
+import coop.rchain.shared.Cell
 
-import scala.concurrent.duration._
+import com.google.protobuf.ByteString
+import monix.eval.Task
+import org.scalatest.WordSpec
 
 class InitializingSpec extends WordSpec {
   "Initializing state" should {

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
@@ -1,40 +1,19 @@
 package coop.rchain.casper.engine
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift}
-import cats._, cats.data._, cats.implicits._
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
-import coop.rchain.blockstorage.{BlockDagRepresentation, InMemBlockDagStorage, InMemBlockStore}
-import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
 import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts._
-import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.casper.helper.{BlockDagStorageTestFixture, NoOpsCasperEffect}
-import coop.rchain.casper.protocol.{NoApprovedBlockAvailable, _}
-import coop.rchain.casper.util.TestTime
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.catscontrib.ApplicativeError_
+import coop.rchain.casper.helper.NoOpsCasperEffect
+import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.comm.protocol.routing.Packet
-import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
-import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.rp.ProtocolHelper._
-import coop.rchain.comm.{transport, _}
+import coop.rchain.comm.transport
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.metrics.Metrics.MetricsNOP
-import coop.rchain.p2p.EffectsTestInstances._
-import coop.rchain.rholang.interpreter.Runtime
-import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Cell, StoreType}
-import monix.eval.Task
-import monix.execution.Scheduler
-import org.scalatest.WordSpec
 
-import scala.concurrent.duration._
+import com.google.protobuf.ByteString
+import monix.eval.Task
+import org.scalatest.WordSpec
 
 class RunningSpec extends WordSpec {
 

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -145,4 +145,13 @@ object EffectsTestInstances {
     }
   }
 
+  class EventLogStub[F[_]: Applicative] extends EventLog[F] {
+    var events: List[Event] = List.empty[Event]
+
+    def publish(event: Event): F[Unit] = {
+      events = events :+ event
+      ().pure[F]
+    }
+  }
+
 }

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -24,6 +24,7 @@
     </encoder>
   </appender>
 
+  <logger name="coop.rchain.shared.EventLogger" level="OFF" />
   <logger name="coop.rchain.rspace" level="warn" />
   <logger name="org.http4s" level="warn" />
   <logger name="io.netty" level="warn" />

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -8,9 +8,7 @@ import cats.implicits._
 
 import coop.rchain.casper.util.comm._
 import coop.rchain.casper.util.BondingUtil
-import coop.rchain.catscontrib._
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.comm._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.metrics
@@ -27,8 +25,9 @@ import org.slf4j.bridge.SLF4JBridgeHandler
 
 object Main {
 
-  implicit private val logSource: LogSource = LogSource(this.getClass)
-  implicit private val log: Log[Task]       = effects.log
+  implicit private val logSource: LogSource     = LogSource(this.getClass)
+  implicit private val log: Log[Task]           = effects.log
+  implicit private val eventLog: EventLog[Task] = EventLog.eventLogger
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def main(args: Array[String]): Unit = {

--- a/shared/src/main/scala/coop/rchain/shared/EventLog.scala
+++ b/shared/src/main/scala/coop/rchain/shared/EventLog.scala
@@ -1,0 +1,26 @@
+package coop.rchain.shared
+
+sealed trait Event
+object Event {
+  object NodeStarted           extends Event
+  object EnteredRunningState   extends Event
+  object ApprovedBlockReceived extends Event
+  object SentUnapprovedBlock   extends Event
+  object BlockApprovalReceived extends Event
+  object SentApprovedBlock     extends Event
+}
+
+trait EventLog[F[_]] {
+  def publish(event: Event): F[Unit]
+}
+
+object EventLog {
+  def apply[F[_]](implicit E: EventLog[F]): EventLog[F] = E
+
+  implicit val EventLoggerLogSource: LogSource = LogSource(classOf[EventLogger])
+
+  def eventLogger[F[_]: Log]: EventLog[F] =
+    (event: Event) => Log[F].info(event.getClass.getSimpleName.stripSuffix("$"))
+}
+
+class EventLogger() // Dummy class for the logger name

--- a/shared/src/main/scala/coop/rchain/shared/EventLog.scala
+++ b/shared/src/main/scala/coop/rchain/shared/EventLog.scala
@@ -2,12 +2,12 @@ package coop.rchain.shared
 
 sealed trait Event
 object Event {
-  object NodeStarted           extends Event
-  object EnteredRunningState   extends Event
-  object ApprovedBlockReceived extends Event
-  object SentUnapprovedBlock   extends Event
-  object BlockApprovalReceived extends Event
-  object SentApprovedBlock     extends Event
+  final case class NodeStarted(address: String)                             extends Event
+  final case class EnteredRunningState(blockHash: String)                   extends Event
+  final case class ApprovedBlockReceived(blockHash: String)                 extends Event
+  final case class SentUnapprovedBlock(blockHash: String)                   extends Event
+  final case class BlockApprovalReceived(blockHash: String, sender: String) extends Event
+  final case class SentApprovedBlock(blockHash: String)                     extends Event
 }
 
 trait EventLog[F[_]] {


### PR DESCRIPTION
## Overview
Introduce an Event Log by writing the events to a separate Logback logger
`coop.rchain.shared.EventLogger`

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3056

### Notes
The `EventLogger` is disabled by default in the `logback.xml` file (node project).
Currently, all events are simple strings. We can augment the events and serialize them f.e. to Json in the next step.

For the integration tests, the mapping of logs to events:

Log | Event
---- | ----- 
coop.rchain.node.NodeRuntime - Listening for traffic on rnode | `NodeStarted`
Making a transition to Running state. | `EnteredRunningState`
Valid ApprovedBlock received! | `ApprovedBlockReceived`
c.r.c.u.c.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: Sent UnapprovedBlock  | `SentUnapprovedBlock`
c.r.c.u.c.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: received block approval from | `BlockApprovalReceived`
c.r.c.u.c.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: Sent ApprovedBlock | `SentApprovedBlock`

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
