### PR TITLE
Do not assert on "tuplespace as string" contents

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
@@ -5,7 +5,7 @@ import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.scalatestcontrib._
-import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
+import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.accounting
@@ -15,6 +15,7 @@ import org.scalatest.{FlatSpec, Inspectors, Matchers}
 class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors {
 
   import MultiParentCasperTestUtil._
+  import RSpaceUtil._
 
   implicit val timeEff = new LogicalTime[Effect]
 
@@ -25,6 +26,7 @@ class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors 
 
   "HashSetCasper" should "handle multi-parent blocks correctly" in effectTest {
     HashSetCasperTestNode.networkEff(validatorKeys.take(2), genesis).use { nodes =>
+      implicit val rm = nodes(1).runtimeManager
       for {
         deployData0 <- ConstructDeploy.basicDeployData[Effect](0)
         deployData2 <- ConstructDeploy.basicDeployData[Effect](2)
@@ -62,13 +64,10 @@ class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors 
         _ = multiparentBlock.header.get.parentsHashList.size shouldBe 2
         _ = nodes(0).casperEff.contains(multiparentBlock) shouldBeF true
         _ = nodes(1).casperEff.contains(multiparentBlock) shouldBeF true
-
-        finalTuplespace <- nodes(0).casperEff
-                            .storageContents(ProtoUtil.postStateHash(multiparentBlock))
-        _      = finalTuplespace.contains("@{0}!(0)") shouldBe true
-        _      = finalTuplespace.contains("@{1}!(1)") shouldBe true
-        result = finalTuplespace.contains("@{2}!(2)") shouldBe true
-      } yield result
+        _ <- getDataAtPublicChannel[Effect](multiparentBlock, 0).map(_ shouldBe Seq("0"))
+        _ <- getDataAtPublicChannel[Effect](multiparentBlock, 1).map(_ shouldBe Seq("1"))
+        _ <- getDataAtPublicChannel[Effect](multiparentBlock, 2).map(_ shouldBe Seq("2"))
+      } yield ()
     }
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
@@ -39,6 +39,7 @@ object MultiParentCasperTestUtil {
       _      <- bs.close()
     } yield result
 
+  // TODO: remove
   def blockTuplespaceContents(
       block: BlockMessage
   )(implicit casper: MultiParentCasper[Effect]): Effect[String] = {

--- a/casper/src/test/scala/coop/rchain/casper/util/RSpaceUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/RSpaceUtil.scala
@@ -1,0 +1,44 @@
+package coop.rchain.casper.util
+
+import com.google.protobuf.ByteString
+
+import cats._
+import cats.implicits._
+
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.models.{Expr, GPrivate, Par}
+import coop.rchain.models.Expr.ExprInstance.GInt
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.interpreter.{PrettyPrinter => RholangPrettyPrinter}
+
+object RSpaceUtil {
+
+  def getDataAtPublicChannel[F[_]: FlatMap](hash: ByteString, channel: Long)(
+      implicit runtimeManager: RuntimeManager[F]
+  ): F[Seq[String]] = getDataAt[F](hash, GInt(channel))
+
+  def getDataAtPublicChannel[F[_]: FlatMap](block: BlockMessage, channel: Long)(
+      implicit runtimeManager: RuntimeManager[F]
+  ): F[Seq[String]] = getDataAtPublicChannel[F](ProtoUtil.postStateHash(block), channel)
+
+  def getDataAtPrivateChannel[F[_]: FlatMap](block: BlockMessage, channel: String)(
+      implicit runtimeManager: RuntimeManager[F]
+  ) = {
+    val name = ByteString.copyFrom(
+      Base16
+        .unsafeDecode(channel)
+    )
+    getDataAt[F](ProtoUtil.postStateHash(block), GPrivate().withId(name))
+  }
+
+  def getDataAt[F[_]: FlatMap](hash: ByteString, channel: Par)(
+      implicit runtimeManager: RuntimeManager[F]
+  ) =
+    for {
+      data <- runtimeManager.getData(hash)(channel)
+      res  = data.map(_.exprs.map(RholangPrettyPrinter().buildString)).flatten
+    } yield (res)
+
+}


### PR DESCRIPTION
## Overview
Gets rid of assertions done on the contents of the tuplespace presented as string. This change will be necessary after switching to the new RSpace. It should also allow to get rid of `runtimeManager.storageRepr` and `casper.storageContents` functions

### JIRA ticket:
N/A. It's a fragment of https://github.com/rchain/rchain/pull/2419 which can already go to dev.


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
