### PR TITLE
Make validator private key an encrypted file instead of CLI option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,7 +204,8 @@ lazy val crypto = (project in file("crypto"))
     name := "crypto",
     libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
       guava,
-      bouncyCastle,
+      bouncyPkixCastle,
+      bouncyProvCastle,
       scalacheck,
       kalium,
       jaxb,

--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -1,21 +1,17 @@
 package coop.rchain.casper
 
-import java.io.{BufferedReader, FileReader}
-import java.nio.file.Path
-
 import cats.Applicative
-import cats.effect.{Resource, Sync}
+import cats.effect.Sync
 import cats.syntax.applicative._
-import cats.syntax.either._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.Signature
 import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.signatures.SignaturesAlg
+import coop.rchain.crypto.signatures.{Secp256k1, SignaturesAlg}
 import coop.rchain.crypto.{PrivateKey, PublicKey}
-import coop.rchain.shared.{Log, LogSource}
+import coop.rchain.shared.{EnvVars, Log, LogSource}
 
 import scala.language.higherKinds
 
@@ -31,18 +27,23 @@ final case class ValidatorIdentity(
 }
 
 object ValidatorIdentity {
+  private val RNodeValidatorPasswordEnvVar  = "RNODE_VALIDATOR_PASSWORD"
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
-  private def fileContent[F[_]: Sync](path: Path): F[String] = {
-    val openFile = Sync[F].delay(new BufferedReader(new FileReader(path.toFile)))
-    Resource.fromAutoCloseable(openFile).use(br => Sync[F].delay(br.readLine()))
-  }
+  def getEnvVariablePassword[F[_]: Sync: EnvVars]: F[String] =
+    EnvVars[F].get(RNodeValidatorPasswordEnvVar).flatMap {
+      case Some(password) =>
+        password.pure[F]
+      case None =>
+        Sync[F].raiseError(
+          new Exception(s"Environment variable $RNodeValidatorPasswordEnvVar is unspecified")
+        )
+    }
 
   private def createValidatorIdentity[F[_]: Applicative](
       conf: CasperConf,
-      privateKeyBase16: String
-  ) = {
-    val privateKey     = PrivateKey(Base16.unsafeDecode(privateKeyBase16))
+      privateKey: PrivateKey
+  ): F[Option[ValidatorIdentity]] = {
     val maybePublicKey = conf.publicKeyBase16.map(pk => PublicKey(Base16.unsafeDecode(pk)))
 
     val publicKey =
@@ -51,10 +52,16 @@ object ValidatorIdentity {
     ValidatorIdentity(publicKey, privateKey, conf.sigAlgorithm).some.pure[F]
   }
 
-  def fromConfig[F[_]: Sync: Log](conf: CasperConf): F[Option[ValidatorIdentity]] =
+  def fromConfig[F[_]: Sync: EnvVars: Log](conf: CasperConf): F[Option[ValidatorIdentity]] =
     conf.privateKey match {
-      case Some(key) =>
-        key.map(fileContent[F]).leftMap(_.pure[F]).merge >>= (createValidatorIdentity(conf, _))
+      case Some(Left(privateKeyBase16)) =>
+        createValidatorIdentity(conf, PrivateKey(Base16.unsafeDecode(privateKeyBase16)))
+      case Some(Right(privateKeyPath)) =>
+        for {
+          password          <- getEnvVariablePassword
+          privateKey        <- Secp256k1.parsePemFile(privateKeyPath, password)
+          validatorIdentity <- createValidatorIdentity(conf, privateKey)
+        } yield validatorIdentity
       case None =>
         Log[F]
           .warn("No private key detected, cannot create validator identification.")

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -29,7 +29,7 @@ object CasperLaunch {
       val conf: CasperConf,
       val runtimeManager: RuntimeManager[F]
   )
-  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Sync: Concurrent: Time: Log: EventLog: MultiParentCasperRef: BlockDagStorage: EngineCell: RaiseIOError](
+  def apply[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Sync: Concurrent: Time: Log: EventLog: MultiParentCasperRef: BlockDagStorage: EngineCell: EnvVars: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =
@@ -55,7 +55,7 @@ object CasperLaunch {
       case (msg, action) => Log[F].info(msg) >> action
     }
 
-  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: MultiParentCasperRef: BlockDagStorage: EngineCell](
+  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: MultiParentCasperRef: BlockDagStorage: EngineCell: EnvVars](
       approvedBlock: ApprovedBlock,
       init: CasperInit[F]
   ): F[Unit] =
@@ -67,7 +67,7 @@ object CasperLaunch {
       _ <- Engine.transitionToRunning[F](casper, approvedBlock)
     } yield ()
 
-  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: Time: Concurrent: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EngineCell: RaiseIOError](
+  def connectAsGenesisValidator[F[_]: Monad: Sync: Metrics: LastApprovedBlock: Time: Concurrent: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EngineCell: EnvVars: RaiseIOError](
       init: CasperInit[F]
   ): F[Unit] =
     for {
@@ -98,7 +98,7 @@ object CasperLaunch {
           )
     } yield ()
 
-  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EngineCell: RaiseIOError](
+  def initBootstrap[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Concurrent: Metrics: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EngineCell: EnvVars: RaiseIOError](
       init: CasperInit[F],
       toTask: F[_] => Task[_]
   )(implicit scheduler: Scheduler): F[Unit] =
@@ -139,7 +139,7 @@ object CasperLaunch {
       _ <- EngineCell[F].set(new GenesisCeremonyMaster[F](abp))
     } yield ()
 
-  def connectAndQueryApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Metrics: Concurrent: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EngineCell](
+  def connectAndQueryApprovedBlock[F[_]: Monad: Sync: LastApprovedBlock: Time: MultiParentCasperRef: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Metrics: Concurrent: SafetyOracle: LastFinalizedBlockCalculator: BlockDagStorage: EnvVars: EngineCell](
       init: CasperInit[F]
   ): F[Unit] =
     for {

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -1,15 +1,25 @@
 package coop.rchain.crypto.signatures
 
+import java.io.FileReader
+import java.nio.file.Path
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPrivateKey
 import java.security.spec.ECGenParameterSpec
 
+import cats.effect.Sync
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.applicativeError._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.util.SecureRandomUtil
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import org.bitcoin._
 import com.google.common.base.Strings
+import org.bouncycastle.asn1.DLSequence
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openssl.bc.BcPEMDecryptorProvider
+import org.bouncycastle.openssl.{PEMEncryptedKeyPair, PEMParser}
 
 object Secp256k1 extends SignaturesAlg {
 
@@ -34,6 +44,40 @@ object Secp256k1 extends SignaturesAlg {
     val pub = Secp256k1.toPublic(sec)
 
     (PrivateKey(sec), PublicKey(pub))
+  }
+
+  def parsePemFile[F[_]: Sync](path: Path, password: String): F[PrivateKey] = {
+    import scala.collection.JavaConverters._
+
+    def handleWith[A](f: => A, message: String): F[A] =
+      Sync[F].delay(f).recoverWith { case t => Sync[F].raiseError(new Exception(message, t)) }
+
+    val parser = new PEMParser(new FileReader(path.toFile))
+    for {
+      encryptedKeyPair <- handleWith(
+                           parser.readObject().asInstanceOf[PEMEncryptedKeyPair],
+                           "PEM file is not encrypted"
+                         )
+      decryptor = new BcPEMDecryptorProvider(password.toCharArray)
+      keyPair <- handleWith(
+                  encryptedKeyPair.decryptKeyPair(decryptor),
+                  "Could not decrypt PEM file"
+                )
+      dlSequence <- handleWith(
+                     keyPair.getPrivateKeyInfo.parsePrivateKey.asInstanceOf[DLSequence],
+                     "Could not parse private key from PEM file"
+                   )
+      privateKeyOpt = dlSequence.iterator().asScala.collectFirst {
+        case octet: org.bouncycastle.asn1.DEROctetString => PrivateKey(octet.getOctets)
+      }
+      privateKey <- privateKeyOpt match {
+                     case Some(privateKey) => privateKey.pure[F]
+                     case None =>
+                       Sync[F].raiseError[PrivateKey](
+                         new Exception("PEM file does not contain private key")
+                       )
+                   }
+    } yield privateKey
   }
 
   //TODO: refactor to make use of strongly typed keys

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
@@ -5,6 +5,7 @@ trait SignaturesAlg {
   def verify(data: Array[Byte], signature: Array[Byte], pub: Array[Byte]): Boolean
   def sign(data: Array[Byte], sec: Array[Byte]): Array[Byte]
   def toPublic(sec: PrivateKey): PublicKey
+  def newKeyPair: (PrivateKey, PublicKey)
   def name: String
 
   def verify(data: Array[Byte], signature: Array[Byte], pub: PublicKey): Boolean =

--- a/crypto/src/main/scala/coop/rchain/crypto/util/KeyUtil.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/KeyUtil.scala
@@ -1,0 +1,68 @@
+package coop.rchain.crypto.util
+
+import java.io.FileWriter
+import java.math.BigInteger
+import java.nio.file.Path
+import java.security.KeyFactory
+
+import cats.effect.Resource
+import cats.implicits._
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.{Ed25519, Secp256k1, SignaturesAlg}
+import monix.eval.Task
+import org.bouncycastle.crypto.ec.CustomNamedCurves
+import org.bouncycastle.jce.ECNamedCurveTable
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.jce.spec.{ECParameterSpec, ECPrivateKeySpec}
+import org.bouncycastle.openssl.jcajce.{JcaMiscPEMGenerator, JcaPEMWriter, JcePEMEncryptorBuilder}
+
+object KeyUtil {
+
+  def writePrivateKey(
+      sk: PrivateKey,
+      sigAlgorithm: SignaturesAlg,
+      password: String,
+      privateKeyPath: Path
+  ): Task[Unit] = {
+    // Equivalent of using `openssl ec -in key.pem -out key_enc.pem -aes256`
+    val encryptor =
+      new JcePEMEncryptorBuilder("AES-256-CBC")
+        .setSecureRandom(SecureRandomUtil.secureRandomNonBlocking)
+        .setProvider(new BouncyCastleProvider())
+        .build(password.toCharArray)
+    for {
+      privateKey <- sigAlgorithm match {
+                     case Secp256k1 =>
+                       val s               = new BigInteger(Base16.encode(sk.bytes), 16)
+                       val ecParameterSpec = ECNamedCurveTable.getParameterSpec(Secp256k1.name)
+                       val privateKeySpec  = new ECPrivateKeySpec(s, ecParameterSpec)
+                       val keyFactory      = KeyFactory.getInstance("ECDSA", new BouncyCastleProvider())
+                       keyFactory.generatePrivate(privateKeySpec).pure[Task]
+                     case Ed25519 =>
+                       val s           = new BigInteger(Base16.encode(sk.bytes), 16)
+                       val ecParameter = CustomNamedCurves.getByName("Curve25519")
+                       val ecParameterSpec = new ECParameterSpec(
+                         ecParameter.getCurve,
+                         ecParameter.getG,
+                         ecParameter.getN,
+                         ecParameter.getH,
+                         ecParameter.getSeed
+                       )
+                       val privateKeySpec = new ECPrivateKeySpec(s, ecParameterSpec)
+                       val keyFactory     = KeyFactory.getInstance("ECDH", new BouncyCastleProvider())
+                       keyFactory.generatePrivate(privateKeySpec).pure[Task]
+                     case _ => Task.raiseError(new Exception("Invalid algorithm"))
+                   }
+      pemGenerator = new JcaMiscPEMGenerator(privateKey, encryptor)
+      pemObj       = pemGenerator.generate()
+      _ <- Resource
+            .make(
+              Task.delay(new JcaPEMWriter(new FileWriter(privateKeyPath.toFile)))
+            )(writer => Task.delay(writer.close()))
+            .use { writer =>
+              Task.delay(writer.writeObject(pemObj))
+            }
+    } yield ()
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -461,6 +461,7 @@ class NodeRuntime private[node] (
     }
     runtimeManager <- RuntimeManager.fromRuntime[Task](casperRuntime)
     engineCell     <- EngineCell.init[Task]
+    envVars        = EnvVars.envVars[Task]
     raiseIOError   = IOError.raiseIOErrorThroughSync[Task]
     casperInit = new CasperInit[Task](
       conf.casper,
@@ -484,6 +485,7 @@ class NodeRuntime private[node] (
           multiParentCasperRef,
           blockDagStorage,
           engineCell,
+          envVars,
           raiseIOError,
           scheduler
         )

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -194,6 +194,7 @@ object Configuration {
           phloPrice(),
           validAfterBlockNumber.getOrElse(-1L),
           privateKey.toOption,
+          privateKeyPath.toOption,
           location()
         )
       case Some(options.findDeploy) => FindDeploy(options.findDeploy.deployId())

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -208,10 +208,11 @@ object Configuration {
         VisualizeDag(depth.getOrElse(-1), showJustificationLines.getOrElse(false))
       case Some(options.machineVerifiableDag) => MachineVerifiableDag
       case Some(options.run)                  => Run
-      case Some(options.keygen)               => Keygen(options.keygen.algorithm())
-      case Some(options.lastFinalizedBlock)   => LastFinalizedBlock
-      case Some(options.dataAtName)           => DataAtName(options.dataAtName.name())
-      case Some(options.contAtName)           => ContAtName(options.contAtName.name())
+      case Some(options.keygen) =>
+        Keygen(options.keygen.algorithm(), options.keygen.privateKeyPath())
+      case Some(options.lastFinalizedBlock) => LastFinalizedBlock
+      case Some(options.dataAtName)         => DataAtName(options.dataAtName.name())
+      case Some(options.contAtName)         => ContAtName(options.contAtName.name())
       case Some(options.bondingDeployGen) =>
         import options.bondingDeployGen._
         BondingDeployGen(bondKey(), ethAddr(), amount(), privateKey(), publicKey())

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -316,7 +316,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val validatorPrivateKey = opt[String](
       descr = "Base16 encoding of the private key to use for signing a proposed blocks. " +
-        "It is not recommended to use in production since private key could be revealed through the process table"
+        "It is not recommended to use in production since private key could be revealed through the process table",
+      hidden = true
     )
 
     val validatorPrivateKeyPath = opt[Path](

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -348,6 +348,11 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       validate = (s: String) => { s == "ed25519" || s == "secp256k1" },
       required = true
     )
+
+    val privateKeyPath = opt[Path](
+      descr = "Path to the file where the encoded private key will be written to.",
+      required = true
+    )
   }
   addSubcommand(keygen)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -409,11 +409,17 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val privateKey = opt[PrivateKey](
       descr = "The deployer's ed25519 private key encoded as Base16.",
-      required = false
+      required = false,
+      hidden = true
     )(
       Base16Converter
         .flatMap(validateLength(Ed25519.keyLength))
         .map(PrivateKey)
+    )
+
+    val privateKeyPath = opt[Path](
+      descr = "The deployer's file with encrypted private key.",
+      required = false
     )
 
     val location = trailArg[String](required = true)

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -75,7 +75,7 @@ final case class ShowBlocks(depth: Int)                                    exten
 final case class VisualizeDag(depth: Int, showJustificationLines: Boolean) extends Command
 final case object MachineVerifiableDag                                     extends Command
 final case object Run                                                      extends Command
-final case class Keygen(algorithm: String)                                 extends Command
+final case class Keygen(algorithm: String, privateKeyPath: Path)           extends Command
 final case object LastFinalizedBlock                                       extends Command
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -65,6 +65,7 @@ final case class Deploy(
     phloPrice: Long,
     validAfterBlock: Long,
     privateKey: Option[PrivateKey],
+    privateKeyPath: Option[Path],
     location: String
 ) extends Command
 final case class FindDeploy(id: Array[Byte])                               extends Command

--- a/node/src/main/scala/coop/rchain/node/effects/ConsoleIO.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/ConsoleIO.scala
@@ -9,6 +9,7 @@ import coop.rchain.shared.StringOps.ColoredString
 
 trait ConsoleIO[F[_]] {
   def readLine: F[String]
+  def readPassword(prompt: String): F[String]
   def println(str: String): F[Unit]
   def println(str: ColoredString): F[Unit]
   def updateCompletion(history: Set[String]): F[Unit]
@@ -27,6 +28,7 @@ trait ConsoleIO0 {
 
 class NOPConsoleIO[F[_]: Applicative] extends ConsoleIO[F] {
   def readLine: F[String]                             = "".pure[F]
+  def readPassword(prompt: String): F[String]         = "".pure[F]
   def println(str: String): F[Unit]                   = ().pure[F]
   def updateCompletion(history: Set[String]): F[Unit] = ().pure[F]
   def close: F[Unit]                                  = ().pure[F]
@@ -36,7 +38,9 @@ class NOPConsoleIO[F[_]: Applicative] extends ConsoleIO[F] {
 object ForTrans {
   def forTrans[F[_]: Monad, T[_[_], _]: MonadTrans](implicit C: ConsoleIO[F]): ConsoleIO[T[F, ?]] =
     new ConsoleIO[T[F, ?]] {
-      def readLine: T[F, String]                  = MonadTrans[T].liftM(ConsoleIO[F].readLine)
+      def readLine: T[F, String] = MonadTrans[T].liftM(ConsoleIO[F].readLine)
+      def readPassword(prompt: String): T[F, String] =
+        MonadTrans[T].liftM(ConsoleIO[F].readPassword(prompt))
       def println(str: String): T[F, Unit]        = MonadTrans[T].liftM(ConsoleIO[F].println(str))
       def println(str: ColoredString): T[F, Unit] = MonadTrans[T].liftM(ConsoleIO[F].println(str))
       def updateCompletion(history: Set[String]): T[F, Unit] =

--- a/node/src/main/scala/coop/rchain/node/effects/JLineConsoleIO.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/JLineConsoleIO.scala
@@ -22,6 +22,9 @@ class JLineConsoleIO(console: ConsoleReader) extends ConsoleIO[Task] {
   def readLine: Task[String] = Task.delay {
     console.readLine
   }
+  def readPassword(prompt: String): Task[String] = Task.delay {
+    console.readLine(prompt, '*')
+  }
   def println(str: String): Task[Unit] = Task.delay {
     console.println(str)
     console.flush()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,8 @@ object Dependencies {
   val slf4jVersion      = "1.7.25"
 
   // format: off
-  val bouncyCastle        = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.60"
+  val bouncyProvCastle    = "org.bouncycastle"           % "bcprov-jdk15on"             % "1.61"
+  val bouncyPkixCastle    = "org.bouncycastle"           % "bcpkix-jdk15on"             % "1.61"
   val catsCore            = "org.typelevel"              %% "cats-core"                 % catsVersion
   val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
   val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"

--- a/shared/src/main/scala/coop/rchain/shared/EnvVars.scala
+++ b/shared/src/main/scala/coop/rchain/shared/EnvVars.scala
@@ -1,0 +1,13 @@
+package coop.rchain.shared
+
+import cats.effect.Sync
+
+trait EnvVars[F[_]] {
+  def get(key: String): F[Option[String]]
+}
+
+object EnvVars {
+  def apply[F[_]](implicit ev: EnvVars[F]): EnvVars[F] = ev
+
+  def envVars[F[_]: Sync]: EnvVars[F] = (key: String) => Sync[F].delay { sys.env.get(key) }
+}


### PR DESCRIPTION
## Overview
- Hides the command line option `rnode run --validator-private-key`
- The file with the validator private key should be encrypted. The node operator must provide the password in the environment variable `RNODE_VALIDATOR_PASSWORD`
- The node fails if the PK file doesn't exist, the file is not encrypted, the env var is not set or the file can't be decrypted.

Client side
- When doing `rnode keygen`, asks the user for a password and encrypts the private key with the password
- The deployers private key must be stored in an encrypted file
- Hides `rnode deploy --private-key`
- Adds a command line option `rnode deploy --private-key-path` for the encrypted file with the private key
- When a user does `rnode deploy` asks him for the password (readline) and decrypts the file which contains the private key
- Alternatively the deployer can provide the password in the environment variable RNODE_DEPLOYER_PASSWORD

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-1608


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
