### PR TITLE
Replace block hash size and validator size magic numbers with constants

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -10,8 +10,6 @@ import cats.effect.concurrent.Semaphore
 import cats.mtl.MonadState
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagFileStorage.{Checkpoint, CheckpointedDagInfo}
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.blockstorage.util.BlockMessageUtil.{blockNumber, bonds, parentHashes}
 import coop.rchain.blockstorage.util.{BlockMessageUtil, Crc32, TopologicalSortUtil}
 import coop.rchain.blockstorage.util.byteOps._
@@ -20,6 +18,8 @@ import coop.rchain.blockstorage.util.io._
 import coop.rchain.blockstorage.util.io.IOError
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.shared.{AtomicMonadState, Log, LogSource}
 import coop.rchain.shared.ByteStringOps._

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -1,9 +1,8 @@
 package coop.rchain.blockstorage
 
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 
 trait BlockDagStorage[F[_]] {
@@ -35,10 +34,6 @@ trait BlockDagRepresentation[F[_]] {
   def latestMessageHashes: F[Map[Validator, BlockHash]]
   def latestMessages: F[Map[Validator, BlockMetadata]]
   def invalidBlocks: F[Set[BlockMetadata]]
-}
-
-object BlockDagRepresentation {
-  type Validator = ByteString
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -2,14 +2,12 @@ package coop.rchain.blockstorage
 
 import cats.Applicative
 import cats.implicits._
-import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
+import coop.rchain.models.BlockHash.BlockHash
 
 import scala.language.higherKinds
 
 trait BlockStore[F[_]] {
-  import BlockStore.BlockHash
-
   def put(blockMessage: BlockMessage): F[Unit] =
     put((blockMessage.blockHash, blockMessage))
 
@@ -42,7 +40,4 @@ trait BlockStore[F[_]] {
 object BlockStore {
 
   def apply[F[_]](implicit ev: BlockStore[F]): BlockStore[F] = ev
-
-  type BlockHash = ByteString
-
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import cats.effect.concurrent.Semaphore
 import cats.mtl.MonadState
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.blockstorage.FileLMDBIndexBlockStore.Checkpoint
 import coop.rchain.blockstorage.StorageError.StorageErr
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
@@ -18,6 +17,7 @@ import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
 import coop.rchain.blockstorage.util.io.IOError
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.{AtomicMonadState, Log}
 import coop.rchain.shared.ByteStringOps._
 import coop.rchain.shared.Language.ignore

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -4,15 +4,15 @@ import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.blockstorage.StorageError.StorageErr
 import coop.rchain.blockstorage.util.BlockMessageUtil.{bonds, parentHashes}
 import coop.rchain.blockstorage.util.{BlockMessageUtil, TopologicalSortUtil}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.models.EquivocationRecord.SequenceNumber
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.Log
 
 import scala.collection.immutable.HashSet

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -10,6 +10,7 @@ import coop.rchain.blockstorage.util.{BlockMessageUtil, TopologicalSortUtil}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockHash
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.models.Validator.Validator
@@ -127,7 +128,7 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
                                                 Log[F].warn(
                                                   s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
                                                 ) *> newValidatorsLatestMessages.pure[F]
-                                              } else if (block.sender.size() == 32) {
+                                              } else if (block.sender.size() == BlockHash.Length) {
                                                 (newValidatorsLatestMessages + (
                                                   (
                                                     block.sender,

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -4,9 +4,9 @@ import cats._
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
 
 import scala.language.higherKinds
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/TopologicalSortUtil.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/TopologicalSortUtil.scala
@@ -1,7 +1,7 @@
 package coop.rchain.blockstorage.util
 
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
 
 object TopologicalSortUtil {
   type BlockSort = Vector[Vector[BlockHash]]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
@@ -2,9 +2,9 @@ package coop.rchain.blockstorage.util
 import java.nio.ByteBuffer
 
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
-import coop.rchain.blockstorage.BlockStore.BlockHash
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.Language.ignore
 
 object byteOps {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
@@ -3,19 +3,25 @@ import java.nio.ByteBuffer
 
 import com.google.protobuf.ByteString
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockHash
 import coop.rchain.models.EquivocationRecord
 import coop.rchain.models.Validator.Validator
+import coop.rchain.models.Validator
 import coop.rchain.shared.Language.ignore
 
 object byteOps {
   implicit class ByteBufferRich(val byteBuffer: ByteBuffer) extends AnyVal {
     def getBlockHash(): BlockHash = {
-      val blockHashBytes = Array.ofDim[Byte](32)
+      val blockHashBytes = Array.ofDim[Byte](BlockHash.Length)
       ignore { byteBuffer.get(blockHashBytes) }
       ByteString.copyFrom(blockHashBytes)
     }
 
-    def getValidator(): Validator = getBlockHash()
+    def getValidator(): Validator = {
+      val validatorBytes = Array.ofDim[Byte](Validator.Length)
+      ignore { byteBuffer.get(validatorBytes) }
+      ByteString.copyFrom(validatorBytes)
+    }
   }
 
   implicit class IntRich(val value: Int) extends AnyVal {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -5,16 +5,15 @@ import java.nio.file.StandardOpenOption
 import cats.implicits._
 import coop.rchain.shared.PathOps._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
-
 import cats.effect.Sync
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.models.blockImplicits._
 import coop.rchain.rspace.Context

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -6,7 +6,6 @@ import scala.language.higherKinds
 import cats._
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper.protocol._
 import coop.rchain.rspace.Context
 import coop.rchain.shared.PathOps._
@@ -17,6 +16,7 @@ import coop.rchain.blockstorage.InMemBlockStore.emptyMapRef
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -1,7 +1,9 @@
 package coop.rchain.casper
 
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
-import cats._, cats.data._, cats.implicits._
+import cats._
+import cats.data._
+import cats.implicits._
 import cats.effect.{Concurrent, Sync}
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol._
@@ -11,11 +13,12 @@ import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.shared._
 import cats.effect.concurrent.Semaphore
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.ski.kp2
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 
 sealed trait DeployError
 final case class ParsingError(details: String)          extends DeployError

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -9,7 +9,6 @@ import coop.rchain.blockstorage.{
   BlockStore,
   EquivocationsTracker
 }
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.casper.util.{DagOperations, DoublyLinkedDag, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.{
@@ -17,7 +16,9 @@ import coop.rchain.casper.util.ProtoUtil.{
   getCreatorJustificationAsListUntilGoalInMemory,
   toLatestMessageHashes
 }
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord.SequenceNumber
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models._
 import coop.rchain.shared.{Cell, Log, LogSource}
 

--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -1,10 +1,8 @@
 package coop.rchain.casper
 
 import scala.collection.immutable.{Map, Set}
-
 import cats.Monad
 import cats.implicits._
-
 import coop.rchain.blockstorage.BlockDagRepresentation
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.DagOperations
@@ -12,13 +10,10 @@ import coop.rchain.casper.util.ProtoUtil.weightFromValidatorByDag
 import coop.rchain.catscontrib.ListContrib
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockMetadata
-
-import com.google.protobuf.ByteString
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 
 object Estimator {
-  type BlockHash = ByteString
-  type Validator = ByteString
-
   implicit val decreasingOrder = Ordering[Long].reverse
 
   private val EstimatorMetricsSource: Metrics.Source =

--- a/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
@@ -7,6 +7,7 @@ import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.protocol.Event.EventInstance.{Comm, Consume, Produce}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockMetadata
 import coop.rchain.shared.Log
 

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -7,6 +7,7 @@ import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockS
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.shared.{Cell, Log}
 import coop.rchain.catscontrib.ListContrib
+import coop.rchain.models.BlockHash.BlockHash
 
 object LastFinalizedBlockCalculator {
   // TODO: Extract hardcoded fault tolerance threshold

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -22,7 +22,9 @@ import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared._
 
 /**
@@ -49,8 +51,6 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
     extends MultiParentCasper[F] {
 
   implicit private val logSource: LogSource = LogSource(this.getClass)
-
-  type Validator = ByteString
 
   //TODO: Extract hardcoded version and expirationThreshold
   private val version             = 1L

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -8,12 +8,13 @@ import Catscontrib._
 import cats.data.OptionT
 
 import coop.rchain.blockstorage.BlockDagRepresentation
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.protocol.Justification
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, DagOperations, ProtoUtil}
 import coop.rchain.models.BlockMetadata
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.{Log, StreamT}
 
 /*

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.catscontrib._
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
@@ -17,7 +16,9 @@ import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockMetadata
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared._
 import scala.util.{Failure, Success, Try}
 

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
 import coop.rchain.casper.DeployError._
-import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper._
@@ -17,6 +16,7 @@ import coop.rchain.casper.util.{EventConverter, ProtoUtil}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.graphz._
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Par
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.api
 
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
-import coop.rchain.casper._, Estimator.BlockHash, MultiParentCasperRef.MultiParentCasperRef
+import coop.rchain.casper._, MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.graphz._
 import coop.rchain.shared.Log
@@ -13,6 +13,7 @@ import cats.mtl._
 import cats.mtl.implicits._
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.catscontrib.ski._
+import coop.rchain.models.BlockHash.BlockHash
 
 final case class ValidatorBlock(
     blockHash: String,

--- a/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/MachineVerifiableDag.scala
@@ -4,6 +4,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.models.BlockHash.BlockHash
 import cats._, cats.data._, cats.implicits._
 
 final case class VerifiableEdge(from: String, to: String)

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper._
@@ -23,6 +22,7 @@ import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.{Blob, TransportLayer}
 import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.{Log, LogSource, Time}
 import monix.eval.Task
 import monix.execution.Scheduler

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -1,12 +1,10 @@
 package coop.rchain
 
-import com.google.protobuf.ByteString
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
 
 package object casper {
-
-  type BlockHash = ByteString
-  type TopoSort  = Vector[Vector[BlockHash]]
+  type TopoSort = Vector[Vector[BlockHash]]
 
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DoublyLinkedDagOperations.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.util
 
-import coop.rchain.casper.Estimator.BlockHash
+import coop.rchain.models.BlockHash.BlockHash
 
 import scala.collection.immutable.{HashMap, HashSet}
 

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -8,13 +8,14 @@ import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
-import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.{DeployData, _}
 import coop.rchain.casper.util.implicits._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.DeployParameters
 

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -4,12 +4,12 @@ import scala.collection.immutable.HashMap
 import scala.collection.mutable
 
 import coop.rchain.blockstorage.{BlockStore, IndexedBlockDagStorage}
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.metrics.Metrics
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
+import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import com.google.protobuf.ByteString
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
@@ -4,10 +4,11 @@ import scala.collection.immutable.HashMap
 
 import coop.rchain.casper.protocol.Bond
 import coop.rchain.metrics.Metrics
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 
 import com.google.protobuf.ByteString
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -9,6 +9,7 @@ import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.shared.{Log, Time}
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -7,12 +7,13 @@ import cats.implicits._
 
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockStore, IndexedBlockDagStorage}
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -4,13 +4,13 @@ import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
-import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.signatures.Ed25519
 import coop.rchain.p2p.EffectsTestInstances.{LogStub, LogicalTime}

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -5,12 +5,12 @@ import scala.collection.immutable.HashMap
 import cats.effect.Sync
 
 import coop.rchain.casper._
-import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.helper._
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.protocol._
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 
 import com.google.protobuf.ByteString

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -14,12 +14,13 @@ import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util._
 import coop.rchain.casper.util.rholang._
-import coop.rchain.casper.Estimator.Validator
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.MultiParentCasperRef.MultiParentCasperRef
 import coop.rchain.casper.api.BlockAPI.ApiErr
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.shared.Time

--- a/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
@@ -2,6 +2,7 @@ package coop.rchain.casper.api
 
 import coop.rchain.casper._
 import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.models.BlockHash.BlockHash
 
 import coop.rchain.shared.ByteStringOps._
 import cats._, cats.data._, cats.implicits._

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -6,7 +6,6 @@ import cats.effect.concurrent.Ref
 import cats.implicits._
 
 import coop.rchain.blockstorage._
-import coop.rchain.blockstorage.BlockStore.BlockHash
 import coop.rchain.casper._
 import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
 import coop.rchain.casper.genesis.Genesis
@@ -20,6 +19,7 @@ import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.comm._
 import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.crypto.signatures.Ed25519
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.rholang.interpreter.Runtime

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -7,13 +7,13 @@ import java.util.zip.CRC32
 import cats.effect.{Concurrent, Resource, Sync}
 import cats.syntax.functor._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation.Validator
 import coop.rchain.blockstorage._
 import coop.rchain.casper.protocol.BlockMessage
 
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.models.Validator.Validator
 import coop.rchain.rspace.Context
 import coop.rchain.shared.Log
 import org.scalatest.{BeforeAndAfter, Suite}

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -5,13 +5,14 @@ import cats.effect._
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
-import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.InterpreterUtil.computeDeploysCheckpoint
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang.{InternalProcessedDeploy, RuntimeManager}
 import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.Time
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockUtil.scala
@@ -1,11 +1,11 @@
 package coop.rchain.casper.helper
 
 import com.google.protobuf.ByteString
-import coop.rchain.casper.Estimator.BlockHash
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.ProtoUtil.hashSignedBlock
 import coop.rchain.casper.util.implicits._
 import coop.rchain.crypto.PrivateKey
+import coop.rchain.models.BlockHash.BlockHash
 
 import scala.util.Random
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -5,10 +5,11 @@ import cats.implicits._
 import cats.{Applicative, Monad}
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import coop.rchain.casper.DeployError
-import coop.rchain.casper.Estimator.{BlockHash, Validator}
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import monix.eval.Task
 
 import scala.collection.mutable.{Map => MutableMap}

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -1,12 +1,13 @@
 package coop.rchain.casper.util
 
 import cats.{Id, Monad}
-import coop.rchain.casper.BlockHash
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.models.BlockMetadata
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models
+
+import com.google.protobuf.ByteString
+
+object BlockHash {
+  type BlockHash = ByteString
+}

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -4,4 +4,6 @@ import com.google.protobuf.ByteString
 
 object BlockHash {
   type BlockHash = ByteString
+
+  val Length = 32
 }

--- a/models/src/main/scala/coop/rchain/models/EquivocationRecord.scala
+++ b/models/src/main/scala/coop/rchain/models/EquivocationRecord.scala
@@ -1,7 +1,8 @@
 package coop.rchain.models
 
-import com.google.protobuf.ByteString
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord._
+import coop.rchain.models.Validator.Validator
 
 /**
   * A summary of the neglected equivocation algorithm is as follows.
@@ -44,6 +45,4 @@ final case class EquivocationRecord(
 
 object EquivocationRecord {
   type SequenceNumber = Int
-  type Validator      = ByteString
-  type BlockHash      = ByteString
 }

--- a/models/src/main/scala/coop/rchain/models/Validator.scala
+++ b/models/src/main/scala/coop/rchain/models/Validator.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models
+
+import com.google.protobuf.ByteString
+
+object Validator {
+  type Validator = ByteString
+}

--- a/models/src/main/scala/coop/rchain/models/Validator.scala
+++ b/models/src/main/scala/coop/rchain/models/Validator.scala
@@ -4,4 +4,6 @@ import com.google.protobuf.ByteString
 
 object Validator {
   type Validator = ByteString
+
+  val Length = 32
 }


### PR DESCRIPTION
## Overview
- Unifies `BlockHash` and `Validator` type aliases in all projects
- Adds constants `BlockHashLength` and `ValidatorLength`
- Refactors `blockImplicits` to generate validator and block hash separately

I have tested it by changing `BlockHashLength` to 65 and the blockstorage tests were still passing

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3489


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
