### PR TITLE
Remove MultiParentCasperTestUtil.blockTuplespaceContents

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
@@ -39,14 +39,6 @@ object MultiParentCasperTestUtil {
       _      <- bs.close()
     } yield result
 
-  // TODO: remove
-  def blockTuplespaceContents(
-      block: BlockMessage
-  )(implicit casper: MultiParentCasper[Effect]): Effect[String] = {
-    val tsHash = ProtoUtil.postStateHash(block)
-    MultiParentCasper[Effect].storageContents(tsHash)
-  }
-
   def deployAndQuery(
       node: HashSetCasperTestNode[Effect],
       dd: DeployData,

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -46,11 +46,11 @@ class RholangBuildTest extends FlatSpec with Matchers {
           _                    = logEff.warns should be(Nil)
           _ <- getDataAtPrivateChannel[Effect](
                 signedBlock,
-                "512d1953abf723978ac70213b6c2cf26b066e508b0e54013d04e9e85974c5760"
+                "cc7214cc9a111bfa8af931f001ce129ec5d7c7d641b4cb6b5c3166444a47c5ec"
               ).map(_ shouldBe Seq("[4, 6, 10, 14]"))
           _ <- getDataAtPrivateChannel[Effect](
                 signedBlock,
-                "cb4ce87e153bb97d7022d5fe971cfecd7d8be729180d54596afba31a6326c92d"
+                "870decec96bb14dd556d56320de0338be14d5eb82c44be43cb225f870cdd239c"
               ).map(_ shouldBe Seq("\"The timestamp is 1\""))
         } yield ()
       }

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -6,6 +6,7 @@ import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.rholang.interpreter.accounting
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
@@ -18,12 +19,14 @@ class RholangBuildTest extends FlatSpec with Matchers {
 
   //put a new casper instance at the start of each
   //test since we cannot reset it
-  "Our build system" should "allow import of rholang sources into scala code" in {
-    HashSetCasperTestNode.standaloneEff(genesis, validatorKeys.last).use { node =>
-      import node._
+  "Our build system" should "allow import of rholang sources into scala code" in effectTest {
+    HashSetCasperTestNode
+      .standaloneEff(genesis, validatorKeys.last)
+      .use { node =>
+        import node._
 
-      val code =
-        """new double, dprimes, rl(`rho:registry:lookup`), ListOpsCh, time(`rho:block:timestamp`), timeRtn, timeStore, stdout(`rho:io:stdout`) in {
+        val code =
+          """new double, dprimes, rl(`rho:registry:lookup`), ListOpsCh, time(`rho:block:timestamp`), timeRtn, timeStore, stdout(`rho:io:stdout`) in {
           |  contract double(@x, ret) = { ret!(2 * x) } |
           |  rl!(`rho:lang:listOps`, *ListOpsCh) |
           |  for(@(_, ListOps) <- ListOpsCh) {
@@ -34,18 +37,18 @@ class RholangBuildTest extends FlatSpec with Matchers {
           |    timeStore!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
           |  }
           |}""".stripMargin
-      val deploy = ConstructDeploy.sourceDeploy(code, 1L, accounting.MAX_VALUE)
-      for {
-        createBlockResult <- MultiParentCasper[Effect]
-                              .deploy(deploy) *> MultiParentCasper[Effect].createBlock
-        Created(signedBlock) = createBlockResult
-        _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
-        storage              <- MultiParentCasperTestUtil.blockTuplespaceContents(signedBlock)
-        _                    = logEff.warns should be(Nil)
-        _                    = storage.contains("!([4, 6, 10, 14])") should be(true)
-        result               = storage.contains("!(\"The timestamp is 1\")") should be(true)
-      } yield result
-    }
+        val deploy = ConstructDeploy.sourceDeploy(code, 1L, accounting.MAX_VALUE)
+        for {
+          createBlockResult <- MultiParentCasper[Effect]
+                                .deploy(deploy) *> MultiParentCasper[Effect].createBlock
+          Created(signedBlock) = createBlockResult
+          _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
+          storage              <- MultiParentCasperTestUtil.blockTuplespaceContents(signedBlock)
+          _                    = logEff.warns should be(Nil)
+          _                    = storage.contains("!([4, 6, 10, 14])") should be(true)
+          result               = storage.contains("!(\"The timestamp is 1\")") should be(true)
+        } yield result
+      }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -17,8 +17,6 @@ class RholangBuildTest extends FlatSpec with Matchers {
   val bonds                       = MultiParentCasperTestUtil.createBonds(validators)
   val genesis                     = MultiParentCasperTestUtil.createGenesis(bonds)
 
-  //put a new casper instance at the start of each
-  //test since we cannot reset it
   "Our build system" should "allow import of rholang sources into scala code" in effectTest {
     HashSetCasperTestNode
       .standaloneEff(genesis, validatorKeys.last)


### PR DESCRIPTION
## Overview
Brings us one step closer towards removal of `Casper.storageContents`


### JIRA ticket:
Related to https://rchain.atlassian.net/browse/RCHAIN-3456 and https://rchain.atlassian.net/browse/RCHAIN-3327


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
