### PR TITLE
Uncaught FileNotFoundException when deleting bts file

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -88,11 +88,8 @@ object StreamHandler {
       .map(_.leftMap(StreamError.unexpected).flatten)
 
   private def init(folder: Path): Task[Streamed] =
-    for {
-      packetFile <- createPacketFile[Task](folder, "_packet_streamed.bts")
-      file       = packetFile.file
-      fos        = packetFile.fos
-    } yield Streamed(fos = fos, path = file)
+    createPacketFile[Task](folder, "_packet_streamed.bts")
+      .map { case (file, fos) => Streamed(fos = fos, path = file) }
 
   private def collect(
       networkId: String,


### PR DESCRIPTION
## Overview
This problem is very mysterious. The logs show that the file has been streamed to a peer and then deleted. And then 4 seconds later node tries to stream and delete the same file again. The only explanation that comes to my mind it that the file has been enqueued twice to the stream queue.

For now, I did:
1. Improved the code so it anticipates the case when the file is missing and don’t throws an exception.
2. Added a debug message each time a packet file gets enqueued. Next time we can check if a packet got enqueued twice for streaming.

Caveat:
Since there will be no exception thrown anymore we need to monitor the logs for stream errors.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3443

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
