### PR TITLE
Rchain 3502: split blessed contracts into lang and rchain

### DIFF
--- a/casper/src/main/resources/BasicWalletFaucet.rho
+++ b/casper/src/main/resources/BasicWalletFaucet.rho
@@ -18,7 +18,7 @@ new
   BasicWalletFaucet, rs(`rho:registry:insertSigned:secp256k1`), uriOut,
   rl(`rho:registry:lookup`), BasicWalletCh
 in {
-  rl!(`rho:lang:basicWallet`, *BasicWalletCh) |
+  rl!(`rho:rchain:basicWallet`, *BasicWalletCh) |
   for(@(_, BasicWallet) <- BasicWalletCh) {
     contract BasicWalletFaucet(mint, return) = {
       new this in {

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -23,7 +23,7 @@ new
   _getOrCreate,
   _revVault
 in {
-  rl!(`rho:lang:makeMint`, *MakeMintCh) |
+  rl!(`rho:rchain:makeMint`, *MakeMintCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
   rl!(`rho:lang:either`, *EitherCh) |
   for(@(_, MakeMint) <- MakeMintCh; @(_, AuthKey) <- AuthKeyCh; @(_, Either) <- EitherCh) {

--- a/casper/src/main/resources/WalletCheck.rho
+++ b/casper/src/main/resources/WalletCheck.rho
@@ -19,7 +19,7 @@ new
   rl(`rho:registry:lookup`), BasicWalletCh, claimContractStore,
   walletStore
 in {
-  rl!(`rho:lang:basicWallet`, *BasicWalletCh) |
+  rl!(`rho:rchain:basicWallet`, *BasicWalletCh) |
   for(@(_, BasicWallet) <- BasicWalletCh) {
     claimContractStore!({}) |
     walletStore!({}) |

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Faucet.scala
@@ -11,7 +11,7 @@ object Faucet {
   //TODO: use registry instead of public names
   def basicWalletFaucet(mintName: String): String =
     s"""new rl(`rho:registry:lookup`), BasicWalletFaucetCh, faucetCh in {
-       |  rl!(`rho:lang:basicWalletFaucet`, *BasicWalletFaucetCh) |
+       |  rl!(`rho:rchain:basicWalletFaucet`, *BasicWalletFaucetCh) |
        |  for(@(_, BasicWalletFaucet) <- BasicWalletFaucetCh) {
        |    @BasicWalletFaucet!($mintName, *faucetCh) |
        |    for(@faucet <- faucetCh){

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Rev.scala
@@ -25,11 +25,11 @@ class Rev[A](
     |  rl(`rho:registry:lookup`), MakeMintCh, WalletCheckCh, BasicWalletCh,
     |  MakePoSCh, SystemInstancesCh, revMintCh, posPurseCh, rev, posCh
     |in {
-    |  rl!(`rho:lang:makeMint`, *MakeMintCh) |
-    |  rl!(`rho:lang:walletCheck`, *WalletCheckCh) |
-    |  rl!(`rho:lang:basicWallet`, *BasicWalletCh) |
-    |  rl!(`rho:lang:makePos`, *MakePoSCh) |
-    |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+    |  rl!(`rho:rchain:makeMint`, *MakeMintCh) |
+    |  rl!(`rho:rchain:walletCheck`, *WalletCheckCh) |
+    |  rl!(`rho:rchain:basicWallet`, *BasicWalletCh) |
+    |  rl!(`rho:rchain:makePos`, *MakePoSCh) |
+    |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
     |  for(
     |    @(_, MakeMint) <- MakeMintCh; @(_, WalletCheck) <- WalletCheckCh;
     |    @(_, BasicWallet) <- BasicWalletCh; @(_, MakePoS) <- MakePoSCh;

--- a/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/BondingUtil.scala
@@ -27,7 +27,7 @@ object BondingUtil {
 
   def bondingForwarderDeploy(bondKey: String, ethAddress: String): String =
     s"""new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
-       |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+       |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
        |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
        |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
        |    for(@purse <- @"${bondingForwarderAddress(ethAddress)}"; pos <- posCh){
@@ -103,7 +103,7 @@ object BondingUtil {
       _             = assert(Secp256k1.verify(unlockSigData, unlockSig, Base16.unsafeDecode("04" + pubKey)))
       sigString     = Base16.encode(unlockSig)
     } yield s"""new rl(`rho:registry:lookup`), WalletCheckCh in {
-           |  rl!(`rho:lang:walletCheck`, *WalletCheckCh) |
+           |  rl!(`rho:rchain:walletCheck`, *WalletCheckCh) |
            |  for(@(_, WalletCheck) <- WalletCheckCh) {
            |    @WalletCheck!("claim", "$ethAddress", "$pubKey", "$sigString", "$statusOut")
            |  }
@@ -142,7 +142,7 @@ object BondingUtil {
       transferSigData <- walletTransferSigData[F](nonce, amount, destination)
       transferSig     = Secp256k1.sign(transferSigData, secKey)
     } yield s"""new rl(`rho:registry:lookup`), WalletCheckCh, result in {
-               |  rl!(`rho:lang:walletCheck`, *WalletCheckCh) |
+               |  rl!(`rho:rchain:walletCheck`, *WalletCheckCh) |
                |  for(@(_, WalletCheck) <- WalletCheckCh) {
                |    @WalletCheck!("access", "$pubKey", *result) |
                |    for(@(true, wallet) <- result) {
@@ -170,7 +170,7 @@ object BondingUtil {
       transferSigData <- walletTransferSigData(nonce, amount, destination)
       transferSig     = sigFunc(transferSigData)
     } yield s"""new rl(`rho:registry:lookup`), SystemInstancesCh, walletCh, faucetCh in {
-               |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+               |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
                |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
                |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
                |    for(faucet <- faucetCh){ faucet!($amount, "secp256k1", "$pubKey", *walletCh) } |

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -158,7 +158,7 @@ class RuntimeManagerImpl[F[_]: Concurrent] private[rholang] (
   private def bondsQuerySource(name: String = "__SCALA__"): String =
     s"""
        | new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
-       |   rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+       |   rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
        |   for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
        |     @SystemInstancesRegistry!("lookup", "pos", *posCh) |
        |     for(pos <- posCh){ pos!("getBonds", "$name") }

--- a/casper/src/test/resources/LockboxTest.rho
+++ b/casper/src/test/resources/LockboxTest.rho
@@ -23,7 +23,7 @@ match (
     in {
       stdlog!("info", "Starting Lockbox test") |
       rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
-      rl!(`rho:lang:lockbox`, *LockboxCh) |
+      rl!(`rho:rchain:lockbox`, *LockboxCh) |
       for(@(_, RhoSpec) <- RhoSpecCh; @(_, Lockbox) <- LockboxCh) {
         stdlog!("info", "RhoSpec and Lockbox found") |
         @RhoSpec!("testSuite", *setup,

--- a/casper/src/test/resources/MakeMintTest.rho
+++ b/casper/src/test/resources/MakeMintTest.rho
@@ -25,7 +25,7 @@ in {
   
   contract setup(retCh) = {
     new MakeMintCh, mintACh, mintBCh in {
-      rl!(`rho:lang:makeMint`, *MakeMintCh) |
+      rl!(`rho:rchain:makeMint`, *MakeMintCh) |
       for(@(_, MakeMint) <- MakeMintCh) {
         @MakeMint!(*mintACh) | @MakeMint!(*mintBCh) |
         for(mintA <- mintACh; mintB <- mintBCh) {

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperBondingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperBondingSpec.scala
@@ -135,7 +135,7 @@ class MultiParentCasperBondingSpec extends FlatSpec with Matchers with Inspector
 
           rankedValidatorQuery = ConstructDeploy.sourceDeploy(
             """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
-            |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+            |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
             |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
             |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
             |    for(pos <- posCh){

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
@@ -185,7 +185,7 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
            |  paymentForward, walletCh, rl(`rho:registry:lookup`),
            |  SystemInstancesCh, faucetCh, posCh
            |in {
-           |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+           |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
            |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
            |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
            |    @SystemInstancesRegistry!("lookup", "faucet", *faucetCh) |
@@ -210,7 +210,7 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
         paymentQuery = ConstructDeploy
           .sourceDeploy(
             """new rl(`rho:registry:lookup`), SystemInstancesCh, posCh in {
-              |  rl!(`rho:lang:systemInstancesRegistry`, *SystemInstancesCh) |
+              |  rl!(`rho:rchain:systemInstancesRegistry`, *SystemInstancesCh) |
               |  for(@(_, SystemInstancesRegistry) <- SystemInstancesCh) {
               |    @SystemInstancesRegistry!("lookup", "pos", *posCh) |
               |    for(pos <- posCh){ pos!("lastPayment", "__SCALA__") }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Registry.scala
@@ -15,6 +15,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.BodyRefs
 import coop.rchain.rholang.interpreter.storage.implicits._
 import coop.rchain.rspace.util._
+import coop.rchain.shared.Matcher.WithPrefix
 import org.lightningj.util.ZBase32
 
 import scala.annotation.tailrec
@@ -876,13 +877,6 @@ class RegistryImpl[F[_]](
       "walletCheck"             -> "5ssrgy91wskd46gjjo6qamxhg88t1fymb5ekgzfksgyeubgq3nucc9"
     )
   )
-
-  case class WithPrefix(prefix: String) {
-    def unapply(s: String): Option[String] =
-      if (s.startsWith(prefix))
-        Some(s.substring(prefix.length))
-      else None
-  }
 
   def publicLookup(args: RootSeq[ListParWithRandom], sequenceNumber: Int): F[Unit] =
     args match {

--- a/shared/src/main/scala/coop/rchain/shared/Matcher.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Matcher.scala
@@ -1,0 +1,3 @@
+package coop.rchain.shared object Matcher {
+
+}

--- a/shared/src/main/scala/coop/rchain/shared/Matcher.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Matcher.scala
@@ -1,3 +1,10 @@
-package coop.rchain.shared object Matcher {
+package coop.rchain.shared
 
+object Matcher {
+  final case class WithPrefix(prefix: String) {
+    def unapply(s: String): Option[String] =
+      if (s.startsWith(prefix))
+        Some(s.substring(prefix.length))
+      else None
+  }
 }


### PR DESCRIPTION
## Overview
All the blessed contracts can be referred either via rho:lang or rho:rchain which is confusing for the users.

This PR splits them and allow only one location for these blessed contracts

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3502

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
