### PR TITLE
Remove tuplespace dump

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -67,7 +67,6 @@ trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {
   // this initial fault weight combined with our fault tolerance threshold t.
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float]
   def lastFinalizedBlock: F[BlockMessage]
-  def storageContents(hash: ByteString): F[String]
   // TODO: Refactor hashSetCasper to take a RuntimeManager[F] just like BlockStore[F]
   def getRuntimeManager: F[Option[RuntimeManager[F]]]
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -247,11 +247,6 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
   def blockDag: F[BlockDagRepresentation[F]] =
     BlockDagStorage[F].getRepresentation
 
-  def storageContents(hash: StateHash): F[String] =
-    runtimeManager
-      .storageRepr(hash)
-      .map(_.getOrElse(s"Tuplespace hash ${Base16.encode(hash.toByteArray)} not found!"))
-
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =
     BlockDagStorage[F].accessEquivocationsTracker { tracker =>
       tracker.equivocationRecords.map { equivocations =>

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -505,16 +505,13 @@ object BlockAPI {
       bondsValidatorList: Seq[Bond],
       processedDeploys: Seq[ProcessedDeploy]
   ): F[BlockInfo] =
-    for {
-      tsDesc <- MultiParentCasper[F].storageContents(tsHash)
-    } yield BlockInfo(
+    BlockInfo(
       blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
       blockSize = block.serializedSize.toString,
       blockNumber = ProtoUtil.blockNumber(block),
       version = version,
       deployCount = deployCount,
       tupleSpaceHash = PrettyPrinter.buildStringNoLimit(tsHash),
-      tupleSpaceDump = tsDesc,
       timestamp = timestamp,
       faultTolerance = normalizedFaultTolerance - initialFault, // TODO: Fix
       mainParentHash = PrettyPrinter.buildStringNoLimit(mainParent),
@@ -523,7 +520,7 @@ object BlockAPI {
       shardId = block.shardId,
       bondsValidatorList = bondsValidatorList.map(PrettyPrinter.buildString),
       deployCost = processedDeploys.map(PrettyPrinter.buildString)
-    )
+    ).pure[F]
 
   private def constructBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -185,7 +185,7 @@ object BlockAPI {
         ProtoUtil.tuplespace(block).get
       for {
         data      <- runtimeManager.getData(stateHash)(sortedListeningName)
-        blockInfo <- getBlockInfoWithoutTuplespace[F](block)
+        blockInfo <- getLightBlockInfo[F](block)
       } yield Option[DataWithBlockInfo](DataWithBlockInfo(data, Some(blockInfo)))
     } else {
       none[DataWithBlockInfo].pure[F]
@@ -204,7 +204,7 @@ object BlockAPI {
         continuationInfos = continuations.map(
           continuation => WaitingContinuationInfo(continuation._1, Some(continuation._2))
         )
-        blockInfo <- getBlockInfoWithoutTuplespace[F](block)
+        blockInfo <- getLightBlockInfo[F](block)
       } yield Option[ContinuationsWithBlockInfo](
         ContinuationsWithBlockInfo(continuationInfos, Some(blockInfo))
       )
@@ -297,17 +297,17 @@ object BlockAPI {
 
   def getBlocks[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Option[Int]
-  ): Effect[F, List[BlockInfoWithoutTuplespace]] =
-    toposortDag[F, List[BlockInfoWithoutTuplespace]](depth) {
+  ): Effect[F, List[LightBlockInfo]] =
+    toposortDag[F, List[LightBlockInfo]](depth) {
       case (casper, topoSort) =>
         implicit val ev: MultiParentCasper[F] = casper
         topoSort
-          .foldM(List.empty[BlockInfoWithoutTuplespace]) {
+          .foldM(List.empty[LightBlockInfo]) {
             case (blockInfosAtHeightAcc, blockHashesAtHeight) =>
               for {
                 blocksAtHeight <- blockHashesAtHeight.traverse(ProtoUtil.unsafeGetBlock[F])
                 blockInfosAtHeight <- blocksAtHeight.traverse(
-                                       getBlockInfoWithoutTuplespace[F]
+                                       getLightBlockInfo[F]
                                      )
               } yield blockInfosAtHeightAcc ++ blockInfosAtHeight
           }
@@ -316,7 +316,7 @@ object BlockAPI {
 
   def showMainChain[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
-  ): F[List[BlockInfoWithoutTuplespace]] = {
+  ): F[List[LightBlockInfo]] = {
 
     val errorMessage =
       "Could not show main chain, casper instance was not available yet."
@@ -328,12 +328,12 @@ object BlockAPI {
         tipHash    = tipHashes.head
         tip        <- ProtoUtil.unsafeGetBlock[F](tipHash)
         mainChain  <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[BlockMessage], depth)
-        blockInfos <- mainChain.toList.traverse(getBlockInfoWithoutTuplespace[F])
+        blockInfos <- mainChain.toList.traverse(getLightBlockInfo[F])
       } yield blockInfos
 
-    MultiParentCasperRef.withCasper[F, List[BlockInfoWithoutTuplespace]](
+    MultiParentCasperRef.withCasper[F, List[LightBlockInfo]](
       casperResponse(_),
-      Log[F].warn(errorMessage).as(List.empty[BlockInfoWithoutTuplespace])
+      Log[F].warn(errorMessage).as(List.empty[LightBlockInfo])
     )
   }
 
@@ -348,7 +348,7 @@ object BlockAPI {
           maybeBlock <- allBlocksTopoSort.flatten.reverse.toStream
                          .traverse(ProtoUtil.unsafeGetBlock[F])
                          .map(_.find(ProtoUtil.containsDeploy(_, ByteString.copyFrom(id))))
-          response <- maybeBlock.traverse(getBlockInfoWithoutTuplespace[F])
+          response <- maybeBlock.traverse(getLightBlockInfo[F])
         } yield response.fold(
           s"Couldn't find block containing deploy with id: ${PrettyPrinter
             .buildStringNoLimit(id)}".asLeft[LightBlockQueryResponse]
@@ -487,10 +487,10 @@ object BlockAPI {
   private def getFullBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage
   ): F[BlockInfo] = getBlockInfo[BlockInfo, F](block, constructBlockInfo[F])
-  private def getBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
+  private def getLightBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage
-  ): F[BlockInfoWithoutTuplespace] =
-    getBlockInfo[BlockInfoWithoutTuplespace, F](block, constructBlockInfoWithoutTuplespace[F])
+  ): F[LightBlockInfo] =
+    getBlockInfo[LightBlockInfo, F](block, constructLightBlockInfo[F])
 
   private def constructBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage,
@@ -522,7 +522,7 @@ object BlockAPI {
       deployCost = processedDeploys.map(PrettyPrinter.buildString)
     ).pure[F]
 
-  private def constructBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
+  private def constructLightBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: BlockMessage,
       version: Long,
       deployCount: Int,
@@ -534,8 +534,8 @@ object BlockAPI {
       initialFault: Float,
       bondsValidatorList: Seq[Bond],
       processedDeploys: Seq[ProcessedDeploy]
-  ): F[BlockInfoWithoutTuplespace] =
-    BlockInfoWithoutTuplespace(
+  ): F[LightBlockInfo] =
+    LightBlockInfo(
       blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
       blockSize = block.serializedSize.toString,
       blockNumber = ProtoUtil.blockNumber(block),

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -73,7 +73,7 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
   def getBlocks(q: BlocksQuery): Task[Either[Seq[String], String]] =
     stub
       .getBlocks(q)
-      .map(_.toEither[BlockInfoWithoutTuplespace].map { bi =>
+      .map(_.toEither[LightBlockInfo].map { bi =>
         s"""
          |------------- block ${bi.blockNumber} ---------------
          |${bi.toProtoString}

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -116,7 +116,6 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =
     underlying.normalizedInitialFault(weights)
   def lastFinalizedBlock: F[BlockMessage]             = underlying.lastFinalizedBlock
-  def storageContents(hash: ByteString): F[String]    = underlying.storageContents(hash)
   def getRuntimeManager: F[Option[RuntimeManager[F]]] = underlying.getRuntimeManager
   def fetchDependencies: F[Unit]                      = underlying.fetchDependencies
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -40,7 +40,6 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def blockDag: F[BlockDagRepresentation[F]]                          = BlockDagStorage[F].getRepresentation
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[BlockMessage]                             = BlockMessage().pure[F]
-  def storageContents(hash: BlockHash): F[String]                     = "".pure[F]
   def getRuntimeManager: F[Option[RuntimeManager[F]]]                 = none[RuntimeManager[F]].pure[F]
   def fetchDependencies: F[Unit]                                      = ().pure[F]
 }

--- a/docs/rnode-api/index.md
+++ b/docs/rnode-api/index.md
@@ -9,7 +9,7 @@
     - [ApprovedBlockRequest](#coop.rchain.casper.protocol.ApprovedBlockRequest)
     - [BlockApproval](#coop.rchain.casper.protocol.BlockApproval)
     - [BlockInfo](#coop.rchain.casper.protocol.BlockInfo)
-    - [BlockInfoWithoutTuplespace](#coop.rchain.casper.protocol.BlockInfoWithoutTuplespace)
+    - [LightBlockInfo](#coop.rchain.casper.protocol.LightBlockInfo)
     - [BlockMessage](#coop.rchain.casper.protocol.BlockMessage)
     - [BlockQuery](#coop.rchain.casper.protocol.BlockQuery)
     - [BlockQueryResponse](#coop.rchain.casper.protocol.BlockQueryResponse)
@@ -42,11 +42,11 @@
     - [Signature](#coop.rchain.casper.protocol.Signature)
     - [UnapprovedBlock](#coop.rchain.casper.protocol.UnapprovedBlock)
     - [WaitingContinuationInfo](#coop.rchain.casper.protocol.WaitingContinuationInfo)
-  
-  
-  
+
+
+
     - [DeployService](#coop.rchain.casper.protocol.DeployService)
-  
+
 
 - [RhoTypes.proto](#RhoTypes.proto)
     - [BindPattern](#.BindPattern)
@@ -95,10 +95,10 @@
     - [Var](#.Var)
     - [Var.WildcardMsg](#.Var.WildcardMsg)
     - [VarRef](#.VarRef)
-  
-  
-  
-  
+
+
+
+
 
 - [diagnostics.proto](#diagnostics.proto)
     - [GarbageCollector](#coop.rchain.node.model.GarbageCollector)
@@ -112,11 +112,11 @@
     - [Peers](#coop.rchain.node.model.Peers)
     - [ProcessCpu](#coop.rchain.node.model.ProcessCpu)
     - [Threads](#coop.rchain.node.model.Threads)
-  
-  
-  
+
+
+
     - [Diagnostics](#coop.rchain.node.model.Diagnostics)
-  
+
 
 - [Scalar Value Types](#scalar-value-types)
 
@@ -219,9 +219,9 @@ For node clients, see BlockMessage for actual Casper protocol Block representati
 
 
 
-<a name="coop.rchain.casper.protocol.BlockInfoWithoutTuplespace"/>
+<a name="coop.rchain.casper.protocol.LightBlockInfo"/>
 
-### BlockInfoWithoutTuplespace
+### LightBlockInfo
 
 
 
@@ -421,7 +421,7 @@ For node clients, see BlockMessage for actual Casper protocol Block representati
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | postBlockContinuations | [WaitingContinuationInfo](#coop.rchain.casper.protocol.WaitingContinuationInfo) | repeated |  |
-| block | [BlockInfoWithoutTuplespace](#coop.rchain.casper.protocol.BlockInfoWithoutTuplespace) |  |  |
+| block | [LightBlockInfo](#coop.rchain.casper.protocol.LightBlockInfo) |  |  |
 
 
 
@@ -453,7 +453,7 @@ For node clients, see BlockMessage for actual Casper protocol Block representati
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | postBlockData | [Par](#Par) | repeated |  |
-| block | [BlockInfoWithoutTuplespace](#coop.rchain.casper.protocol.BlockInfoWithoutTuplespace) |  |  |
+| block | [LightBlockInfo](#coop.rchain.casper.protocol.LightBlockInfo) |  |  |
 
 
 
@@ -786,11 +786,11 @@ Note: deploys are uniquely keyed by `user`, `timestamp`.
 
 
 
- 
 
- 
 
- 
+
+
+
 
 
 <a name="coop.rchain.casper.protocol.DeployService"/>
@@ -807,14 +807,14 @@ To get results back, use `listenForDataAtName`.
 | DoDeploy | [DeployData](#coop.rchain.casper.protocol.DeployData) | [DeployServiceResponse](#coop.rchain.casper.protocol.DeployData) | Queue deployment of Rholang code (or fail to parse). |
 | createBlock | [.google.protobuf.Empty](#google.protobuf.Empty) | [DeployServiceResponse](#google.protobuf.Empty) | Add a block including all pending deploys. |
 | getBlock | [BlockQuery](#coop.rchain.casper.protocol.BlockQuery) | [BlockQueryResponse](#coop.rchain.casper.protocol.BlockQuery) | Get details about a particular block. |
-| showMainChain | [BlocksQuery](#coop.rchain.casper.protocol.BlocksQuery) | [BlockInfoWithoutTuplespace](#coop.rchain.casper.protocol.BlocksQuery) |  |
-| getBlocks | [BlocksQuery](#coop.rchain.casper.protocol.BlocksQuery) | [BlockInfoWithoutTuplespace](#coop.rchain.casper.protocol.BlocksQuery) | Get a summary of blocks on the blockchain. |
+| showMainChain | [BlocksQuery](#coop.rchain.casper.protocol.BlocksQuery) | [LightBlockInfo](#coop.rchain.casper.protocol.BlocksQuery) |  |
+| getBlocks | [BlocksQuery](#coop.rchain.casper.protocol.BlocksQuery) | [LightBlockInfo](#coop.rchain.casper.protocol.BlocksQuery) | Get a summary of blocks on the blockchain. |
 | listenForDataAtName | [DataAtNameQuery](#coop.rchain.casper.protocol.DataAtNameQuery) | [ListeningNameDataResponse](#coop.rchain.casper.protocol.DataAtNameQuery) | Find data sent to a name. |
 | listenForContinuationAtName | [ContinuationAtNameQuery](#coop.rchain.casper.protocol.ContinuationAtNameQuery) | [ListeningNameContinuationResponse](#coop.rchain.casper.protocol.ContinuationAtNameQuery) | Find processes receiving on a name. |
 | findBlockWithDeploy | [FindDeployInBlockQuery](#coop.rchain.casper.protocol.FindDeployInBlockQuery) | [BlockQueryResponse](#coop.rchain.casper.protocol.FindDeployInBlockQuery) | Find block from a deploy. |
 | previewPrivateNames | [PrivateNamePreviewQuery](#coop.rchain.casper.protocol.PrivateNamePreviewQuery) | [PrivateNamePreviewResponse](#coop.rchain.casper.protocol.PrivateNamePreviewQuery) | Preview new top-level unforgeable names (for example, to compute signatures over them). |
 
- 
+
 
 
 
@@ -1645,13 +1645,13 @@ These are DeBruijn levels
 
 
 
- 
 
- 
 
- 
 
- 
+
+
+
+
 
 
 
@@ -1852,11 +1852,11 @@ These are DeBruijn levels
 
 
 
- 
 
- 
 
- 
+
+
+
 
 
 <a name="coop.rchain.node.model.Diagnostics"/>
@@ -1875,7 +1875,7 @@ These are DeBruijn levels
 | GetThreads | [.google.protobuf.Empty](#google.protobuf.Empty) | [Threads](#google.protobuf.Empty) |  |
 | GetNodeCoreMetrics | [.google.protobuf.Empty](#google.protobuf.Empty) | [NodeCoreMetrics](#google.protobuf.Empty) |  |
 
- 
+
 
 
 
@@ -1898,4 +1898,3 @@ These are DeBruijn levels
 | <a name="bool" /> bool |  | bool | boolean | boolean |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str |
-

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -172,15 +172,14 @@ message BlockInfo {
   int64 version = 4;
   int32 deployCount = 5;
   string tupleSpaceHash = 6; // Same as postStateHash of BlockMessage
-  string tupleSpaceDump = 7;
-  int64 timestamp = 8;
-  float faultTolerance = 9;
-  string mainParentHash = 10;
-  repeated string parentsHashList = 11;
-  string sender = 12;
-  string shardId = 13;
-  repeated string bondsValidatorList = 14;
-  repeated string deployCost = 15;
+  int64 timestamp = 7;
+  float faultTolerance = 8;
+  string mainParentHash = 9;
+  repeated string parentsHashList = 10;
+  string sender = 11;
+  string shardId = 12;
+  repeated string bondsValidatorList = 13;
+  repeated string deployCost = 14;
 }
 
 message DataWithBlockInfo {

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -41,10 +41,10 @@ service DeployService {
   // Returns on success VisualizeBlocksResponse
   rpc visualizeDag(VisualizeDagQuery) returns (stream Either) {}
   rpc machineVerifiableDag(MachineVerifyQuery) returns (Either) {}
-  // Returns on success BlockInfoWithoutTuplespace
+  // Returns on success LightBlockInfo
   rpc showMainChain(BlocksQuery) returns (stream Either) {}
   // Get a summary of blocks on the blockchain.
-  // Returns on success BlockInfoWithoutTuplespace
+  // Returns on success LightBlockInfo
   rpc getBlocks(BlocksQuery) returns (stream Either) {}
   // Find data sent to a name.
   // Returns on success ListeningNameDataResponse
@@ -102,7 +102,7 @@ message BlockQueryResponse {
 }
 
 message LightBlockQueryResponse {
-  BlockInfoWithoutTuplespace blockInfo = 1;
+  LightBlockInfo blockInfo = 1;
 }
 
 message VisualizeDagQuery {
@@ -143,14 +143,14 @@ message PrivateNamePreviewResponse {
 }
 
 message LastFinalizedBlockQuery {
-  
+
 }
 
 message LastFinalizedBlockResponse {
   BlockInfo blockInfo = 1;
 }
 
-message BlockInfoWithoutTuplespace {
+message LightBlockInfo {
   string blockHash = 1;
   string blockSize = 2;
   int64 blockNumber = 3;
@@ -184,12 +184,12 @@ message BlockInfo {
 
 message DataWithBlockInfo {
   repeated Par postBlockData = 1;
-  BlockInfoWithoutTuplespace block = 2;
+  LightBlockInfo block = 2;
 }
 
 message ContinuationsWithBlockInfo {
   repeated WaitingContinuationInfo postBlockContinuations = 1;
-  BlockInfoWithoutTuplespace block = 2;
+  LightBlockInfo block = 2;
 }
 
 message WaitingContinuationInfo {

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -98,7 +98,7 @@ object EqualM extends EqualMDerivation {
   implicit val ParMapEqual: EqualM[ParMap] = by(x => (x.ps, x.remainder, x.connectiveUsed))
 
   implicit val BlockInfoHash                  = gen[BlockInfo]
-  implicit val BlockInfoWithoutTuplespaceHash = gen[BlockInfoWithoutTuplespace]
+  implicit val LightBlockInfoHash             = gen[LightBlockInfo]
   implicit val BlockQueryResponseHash         = gen[BlockQueryResponse]
   implicit val ContinuationsWithBlockInfoHash = gen[ContinuationsWithBlockInfo]
   implicit val DataWithBlockInfoHash          = gen[DataWithBlockInfo]

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -127,7 +127,7 @@ object HashM extends HashMDerivation {
   }
 
   implicit val BlockInfoHash                  = gen[BlockInfo]
-  implicit val BlockInfoWithoutTuplespaceHash = gen[BlockInfoWithoutTuplespace]
+  implicit val LightBlockInfoHash             = gen[LightBlockInfo]
   implicit val BlockQueryResponseHash         = gen[BlockQueryResponse]
   implicit val ContinuationsWithBlockInfoHash = gen[ContinuationsWithBlockInfo]
   implicit val DataWithBlockInfoHash          = gen[DataWithBlockInfo]

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -91,9 +91,9 @@ private[api] object DeployGrpcService {
       override def getBlocks(request: BlocksQuery): Observable[GrpcEither] =
         Observable
           .fromTask(
-            deferList[BlockInfoWithoutTuplespace](
+            deferList[LightBlockInfo](
               Functor[F].map(BlockAPI.getBlocks[F](Some(request.depth)))(
-                _.getOrElse(List.empty[BlockInfoWithoutTuplespace])
+                _.getOrElse(List.empty[LightBlockInfo])
               )
             )
           )


### PR DESCRIPTION
## Overview
Removes the tuplespace dump from BlockInfo

### JIRA ticket:
Clean-up after:
https://rchain.atlassian.net/browse/RCHAIN-3456


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
