### PR TITLE
Makes bors a bit more patient

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -8,7 +8,7 @@ status = [
 required_approvals = 2
 
 # Number of seconds from when a merge commit is created to when its statuses must pass.
-timeout_sec = 10800 #3h
+timeout_sec = 14400 #4h
 
 # A marker in the PR description that indicates boilerplate that does not belong in the merge-commit message.
 cut_body_after = "## Overview"


### PR DESCRIPTION
## Overview
See title

### JIRA ticket:
N/A


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
