### PR TITLE
RCHAIN-3517: change rho:block:timestamp to rho:block:data

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -16,6 +16,7 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.rholang.interpreter.accounting
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.shared.{Cell, Log, Time}
 
 object BlockCreator {
@@ -196,7 +197,7 @@ object BlockCreator {
         deploys,
         dag,
         runtimeManager,
-        now,
+        BlockData(now, maxBlockNumber + 1),
         span,
         invalidBlocks
       )

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -159,7 +159,7 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics] private[rholang] (
       runtime: Runtime[F]
   ): F[Unit] = {
     val timestamp: Par = Par(exprs = Seq(Expr(Expr.ExprInstance.GInt(blockTime))))
-    runtime.blockTime.setParams(timestamp)
+    runtime.blockData.setParams(timestamp)
   }
 
   private def setInvalidBlocks(

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
@@ -230,9 +230,9 @@ class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors 
       """.stripMargin
     val timeRho =
       """
-        |new timestamp(`rho:block:timestamp`), stdout(`rho:io:stdout`), tCh in {
-        |  timestamp!(*tCh) |
-        |  for(@t <- tCh) {
+        |new getBlockData(`rho:block:data`), stdout(`rho:io:stdout`), tCh in {
+        |  getBlockData!(*tCh) |
+        |  for(@_, @t <- tCh) {
         |    match t {
         |      Nil => { stdout!("no block time; no blocks yet? Not connected to Casper network?") }
         |      _ => { stdout!({"block time": t}) }

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -26,14 +26,14 @@ class RholangBuildTest extends FlatSpec with Matchers {
         implicit val rm = node.runtimeManager
 
         val code =
-          """new double, rl(`rho:registry:lookup`), ListOpsCh, time(`rho:block:timestamp`), timeRtn, stdout(`rho:io:stdout`), doubleRet ,timestampRet in {
+          """new double, rl(`rho:registry:lookup`), ListOpsCh, getBlockData(`rho:block:data`), timeRtn, stdout(`rho:io:stdout`), doubleRet ,timestampRet in {
           |  contract double(@x, ret) = { ret!(2 * x) } |
           |  rl!(`rho:lang:listOps`, *ListOpsCh) |
           |  for(@(_, ListOps) <- ListOpsCh) {
           |    @ListOps!("map", [2, 3, 5, 7], *double, *doubleRet)
           |  } |
-          |  time!(*timeRtn) |
-          |  for (@timestamp <- timeRtn) {
+          |  getBlockData!(*timeRtn) |
+          |  for (@_, @timestamp <- timeRtn) {
           |    timestampRet!("The timestamp is ${timestamp}" %% {"timestamp" : timestamp})
           |  }
           |}""".stripMargin

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -16,6 +16,7 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.models._
 import coop.rchain.rholang.Resources._
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.accounting
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.Log
@@ -97,18 +98,24 @@ class RevIssuanceTest extends FlatSpec with Matchers {
         .unsafeRunSync
       val (postGenHash, _) =
         runtimeManager
-          .computeState(emptyHash)(genesisDeploys, System.currentTimeMillis())
+          .computeState(emptyHash)(genesisDeploys, BlockData(System.currentTimeMillis(), 0))
           .runSyncUnsafe(20.seconds)
       val (postUnlockHash, _) =
         runtimeManager
-          .computeState(postGenHash)(unlockDeployData :: Nil, System.currentTimeMillis())
+          .computeState(postGenHash)(
+            unlockDeployData :: Nil,
+            BlockData(System.currentTimeMillis(), 0)
+          )
           .runSyncUnsafe(10.seconds)
       val unlockResult = getDataUnsafe(runtimeManager, postUnlockHash, statusOut)
       assert(unlockResult.head.exprs.head.getETupleBody.ps.head.exprs.head.getGBool) //assert unlock success
 
       val (postTransferHash, _) =
         runtimeManager
-          .computeState(postUnlockHash)(transferDeployData :: Nil, System.currentTimeMillis())
+          .computeState(postUnlockHash)(
+            transferDeployData :: Nil,
+            BlockData(System.currentTimeMillis(), 0)
+          )
           .runSyncUnsafe(10.seconds)
       val transferSuccess = getDataUnsafe(runtimeManager, postTransferHash, transferStatusOut)
       val transferResult  = getDataUnsafe(runtimeManager, postTransferHash, destination)

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.helper
 import cats._
 import cats.effect._
 import cats.implicits._
-
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
 import coop.rchain.casper.protocol._
@@ -16,13 +15,13 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.Time
-
 import monix.eval.Task
+
 import scala.collection.immutable.HashMap
 import scala.language.higherKinds
-
 import coop.rchain.casper.CasperMetricsSource
 import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 
 object BlockGenerator {
   implicit val timeEff = new LogicalTime[Task]
@@ -97,7 +96,7 @@ object BlockGenerator {
                  deploys,
                  dag,
                  runtimeManager,
-                 now,
+                 BlockData(now, b.body.get.state.get.blockNumber),
                  span
                )
     } yield result

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/DeployerAuthTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/DeployerAuthTest.scala
@@ -11,6 +11,7 @@ import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.Expr.ExprInstance.GBool
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{GDeployerAuth, Par}
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.accounting
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -82,7 +83,7 @@ class DeployerAuthTest extends FlatSpec with Matchers {
         runtimeManager
           .use { mgr =>
             mgr
-              .computeState(mgr.emptyStateHash)(Seq(contract), 0L)
+              .computeState(mgr.emptyStateHash)(Seq(contract), BlockData(0L, 0L))
               .flatMap { result =>
                 val hash = result._1
                 mgr

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -24,6 +24,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.PCost
 import coop.rchain.p2p.EffectsTestInstances.LogStub
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.{accounting, Runtime}
 import coop.rchain.shared.{StoreType, Time}
 import monix.eval.Task
@@ -59,7 +60,7 @@ class InterpreterUtilTest
       deploys,
       dag,
       runtimeManager,
-      System.currentTimeMillis(),
+      BlockData(System.currentTimeMillis(), 0),
       span0
     )
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -13,6 +13,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.{accounting, ParBuilder}
 import coop.rchain.shared.Log
@@ -32,7 +33,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       startHash: StateHash,
       terms: List[Id[DeployData]]
   ): F[(StateHash, Seq[InternalProcessedDeploy])] =
-    runtimeManager.computeState(startHash)(terms, System.currentTimeMillis())
+    runtimeManager.computeState(startHash)(terms, BlockData(System.currentTimeMillis(), 0))
 
   "computeState" should "capture rholang errors" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) } | @"x"!(1) | @"y"!("hi") """
@@ -117,7 +118,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
           mgr
             .computeState(mgr.emptyStateHash)(
               Seq(StandardDeploys.nonNegativeNumber, deployData),
-              System.currentTimeMillis()
+              BlockData(System.currentTimeMillis(), 0)
             )
             .flatMap { result =>
               val hash = result._1

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -39,6 +39,8 @@ object RhoType {
       p.singleExpr().collect {
         case Expr(GInt(v)) => v
       }
+
+    def apply(i: Long): Par = Expr(GInt(i))
   }
 
   object Tuple2 {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -134,7 +134,7 @@ object Runtime {
     val REG_PUBLIC_REGISTER_SIGNED: Long   = 20L
     val REG_NONCE_INSERT_CALLBACK: Long    = 21L
     val GET_DEPLOY_PARAMS: Long            = 22L
-    val GET_TIMESTAMP: Long                = 23L
+    val GET_BLOCK_DATA: Long               = 23L
     val GET_INVALID_BLOCKS: Long           = 24L
     val REV_ADDRESS: Long                  = 25L
   }
@@ -155,7 +155,7 @@ object Runtime {
     val REG_INSERT_RANDOM: Par  = byteName(10)
     val REG_INSERT_SIGNED: Par  = byteName(11)
     val GET_DEPLOY_PARAMS: Par  = byteName(12)
-    val GET_TIMESTAMP: Par      = byteName(13)
+    val GET_BLOCK_DATA: Par     = byteName(13)
     val GET_INVALID_BLOCKS: Par = byteName(14)
     val REV_ADDRESS: Par        = byteName(15)
   }
@@ -261,11 +261,11 @@ object Runtime {
       }
     ),
     SystemProcess.Definition[F](
-      "rho:block:timestamp",
-      FixedChannels.GET_TIMESTAMP,
+      "rho:block:data",
+      FixedChannels.GET_BLOCK_DATA,
       1,
-      BodyRefs.GET_TIMESTAMP, { ctx =>
-        ctx.systemProcesses.blockTime(ctx.blockTime)
+      BodyRefs.GET_BLOCK_DATA, { ctx =>
+        ctx.systemProcesses.getBlockData(ctx.blockTime)
       }
     ),
     SystemProcess.Definition[F](

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
+import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.Runtime.{BlockTime, InvalidBlocks, RhoISpace}
@@ -30,7 +31,7 @@ trait SystemProcesses[F[_]] {
   def keccak256Hash: Contract[F]
   def blake2b256Hash: Contract[F]
   def getDeployParams(runtimeParametersRef: Ref[F, DeployParameters]): Contract[F]
-  def blockTime(timestamp: BlockTime[F]): Contract[F]
+  def getBlockData(timestamp: BlockTime[F]): Contract[F]
   def invalidBlocks(invalidBlocks: InvalidBlocks[F]): Contract[F]
   def validateRevAddress: Contract[F]
 }
@@ -174,13 +175,14 @@ object SystemProcesses {
           illegalArgumentException("deployParameters expects only a return channel")
       }
 
-      def blockTime(
+      def getBlockData(
           blocktime: Runtime.BlockTime[F]
       ): Contract[F] = {
         case isContractCall(produce, Seq(ack)) =>
           for {
-            time <- blocktime.timestamp.get
-            _    <- produce(Seq(time), ack)
+            time   <- blocktime.timestamp.get
+            number <- 1L.pure[F] // TODO figure out how to compute the block number
+            _      <- produce(Seq(GInt(number), time), ack)
           } yield ()
         case _ =>
           illegalArgumentException("blockTime expects only a return channel")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -9,7 +9,7 @@ import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.rholang.interpreter.Runtime.{BlockTime, InvalidBlocks, RhoISpace}
+import coop.rchain.rholang.interpreter.Runtime.{BlockDataStorage, InvalidBlocks, RhoISpace}
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.rspace.{ContResult, Result}
 
@@ -31,7 +31,7 @@ trait SystemProcesses[F[_]] {
   def keccak256Hash: Contract[F]
   def blake2b256Hash: Contract[F]
   def getDeployParams(runtimeParametersRef: Ref[F, DeployParameters]): Contract[F]
-  def getBlockData(timestamp: BlockTime[F]): Contract[F]
+  def getBlockData(timestamp: BlockDataStorage[F]): Contract[F]
   def invalidBlocks(invalidBlocks: InvalidBlocks[F]): Contract[F]
   def validateRevAddress: Contract[F]
 }
@@ -176,7 +176,7 @@ object SystemProcesses {
       }
 
       def getBlockData(
-          blocktime: Runtime.BlockTime[F]
+          blocktime: Runtime.BlockDataStorage[F]
       ): Contract[F] = {
         case isContractCall(produce, Seq(ack)) =>
           for {


### PR DESCRIPTION
## Overview
Change rho:block:timestamp to rho:block:data which returns both timestamp and blocknum



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3517



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
