### PR TITLE
Charging for deploy 4.5

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperTestUtil.scala
@@ -96,7 +96,7 @@ object MultiParentCasperTestUtil {
                         .createWithEmptyCost[Task, Task.Par](
                           storageDirectory,
                           storageSize,
-                          StoreType.LMDB
+                          StoreType.InMem
                         )
       runtimeManager <- RuntimeManager.fromRuntime[Task](activeRuntime)
       genesis <- Genesis.createGenesisBlock(

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -39,7 +39,7 @@ object Setup {
     val runtimeDir            = BlockDagStorageTestFixture.blockStorageDir
     val activeRuntime =
       Runtime
-        .createWithEmptyCost[Task, Task.Par](runtimeDir, 3024L * 1024, StoreType.LMDB)(
+        .createWithEmptyCost[Task, Task.Par](runtimeDir, 3024L * 1024, StoreType.InMem)(
           ContextShift[Task],
           Concurrent[Task],
           log,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -286,7 +286,7 @@ object GenesisTest {
       runtime <- Runtime.createWithEmptyCost[Task, Task.Par](
                   storePath,
                   storageSize,
-                  StoreType.LMDB
+                  StoreType.InMem
                 )
       result <- body(runtime, genesisPath, log, time)
       _      <- runtime.close()

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -41,7 +41,7 @@ class RevIssuanceTest extends FlatSpec with Matchers {
   }
 
   "Rev" should "be issued and accessible based on inputs from Ethereum" in {
-    mkRuntime[Task, Task.Par]("rev-issuance-test").use { activeRuntime =>
+    mkRuntime[Task]("rev-issuance-test").use { activeRuntime =>
       val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
       val emptyHash      = runtimeManager.emptyStateHash
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -129,7 +129,7 @@ object HashSetCasperTestNode {
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     val activeRuntime =
       Runtime
-        .createWithEmptyCost[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB)
+        .createWithEmptyCost[Task, Task.Par](storageDirectory, storageSize, StoreType.InMem)
         .unsafeRunSync
     val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync
     Resource.make[Effect, RuntimeManager[Effect]](

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -15,7 +15,7 @@ import coop.rchain.rholang.Resources._
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
-import coop.rchain.shared.Log
+import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
@@ -70,6 +70,7 @@ object RhoSpec {
       mkRuntime[Task, Task.Par](
         s"rhoSpec-${testObject.path}",
         10 * 1024 * 1024,
+        StoreType.LMDB,
         testFrameworkContracts(testResultCollector)
       ).use { runtime =>
         for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -1,19 +1,13 @@
 package coop.rchain.casper.helper
 
 import cats.effect.Concurrent
-import coop.rchain.casper.MultiParentCasperTestUtil.createBonds
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts.{Faucet, PreWallet, ProofOfStake, TestUtil, Validator}
-import coop.rchain.casper.protocol.{BlockMessage, DeployData}
-import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.casper.genesis.contracts.TestUtil
 import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.Resources._
 import coop.rchain.rholang.build.CompiledRholangSource
-import coop.rchain.rholang.interpreter.Runtime
+import coop.rchain.rholang.interpreter.{PrettyPrinter, Runtime}
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
@@ -21,7 +15,6 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import coop.rchain.rholang.interpreter.PrettyPrinter
 
 object RhoSpec {
 
@@ -67,7 +60,7 @@ object RhoSpec {
       timeout: FiniteDuration
   ): Task[TestResult] =
     TestResultCollector[Task].flatMap { testResultCollector =>
-      mkRuntime[Task, Task.Par](
+      mkRuntime[Task](
         s"rhoSpec-${testObject.path}",
         10 * 1024 * 1024,
         StoreType.LMDB,

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -63,7 +63,7 @@ object RhoSpec {
       mkRuntime[Task](
         s"rhoSpec-${testObject.path}",
         10 * 1024 * 1024,
-        StoreType.LMDB,
+        StoreType.InMem,
         testFrameworkContracts(testResultCollector)
       ).use { runtime =>
         for {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -37,7 +37,7 @@ class InterpreterUtilTest
   val storageDirectory                   = Files.createTempDirectory("casper-interp-util-test")
   val activeRuntime =
     Runtime
-      .createWithEmptyCost[Task, Task.Par](storageDirectory, storageSize, StoreType.LMDB)
+      .createWithEmptyCost[Task, Task.Par](storageDirectory, storageSize, StoreType.InMem)
       .unsafeRunSync
 
   val runtimeManager = RuntimeManager.fromRuntime(activeRuntime).unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -13,7 +13,7 @@ object Resources {
   def mkRuntimeManager(
       prefix: String,
       storageSize: Long = 1024 * 1024L,
-      storeType: StoreType = StoreType.LMDB
+      storeType: StoreType = StoreType.InMem
   )(implicit scheduler: Scheduler): Resource[Task, RuntimeManager[Task]] = {
     implicit val log: Log[Task]            = Log.log[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -4,7 +4,6 @@ import cats.effect.Resource
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.Resources.mkRuntime
-import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -19,7 +18,7 @@ object Resources {
     implicit val log: Log[Task]            = Log.log[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-    mkRuntime[Task, Task.Par](prefix, storageSize.toLong, storeType)
+    mkRuntime[Task](prefix, storageSize.toLong, storeType)
       .flatMap { runtime =>
         Resource.liftF(RuntimeManager.fromRuntime[Task](runtime))
       }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -1,13 +1,10 @@
 package coop.rchain.casper.util.rholang
 
-import cats.implicits._
 import cats.effect.Resource
-import cats.effect.implicits._
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
-import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared.{Log, StoreType}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -35,7 +32,7 @@ object Resources {
     implicit val log: Log[Task]            = Log.log[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-    mkRuntime[Task, Task.Par](prefix, storageSize)
+    mkRuntime[Task, Task.Par](prefix, storageSize.toLong, storeType)
       .flatMap { runtime =>
         Resource.liftF(RuntimeManager.fromRuntime[Task](runtime))
       }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -11,19 +11,6 @@ import monix.execution.Scheduler
 
 object Resources {
 
-  def mkRuntimeAndManager(
-      prefix: String,
-      storageSize: Int = 1024 * 1024,
-      storeType: StoreType = StoreType.LMDB
-  )(implicit scheduler: Scheduler): Resource[Task, (Runtime[Task], RuntimeManager[Task])] = {
-    implicit val log: Log[Task]            = Log.log[Task]
-    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
-    for {
-      runtime        <- mkRuntime[Task, Task.Par](prefix)
-      runtimeManager <- Resource.liftF(RuntimeManager.fromRuntime[Task](runtime))
-    } yield ((runtime, runtimeManager))
-  }
-
   def mkRuntimeManager(
       prefix: String,
       storageSize: Long = 1024 * 1024L,

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -29,13 +29,13 @@ object Resources {
 
   def mkRuntimeManager(
       prefix: String,
-      storageSize: Int = 1024 * 1024,
+      storageSize: Long = 1024 * 1024L,
       storeType: StoreType = StoreType.LMDB
   )(implicit scheduler: Scheduler): Resource[Task, RuntimeManager[Task]] = {
     implicit val log: Log[Task]            = Log.log[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
-    mkRuntime[Task, Task.Par](prefix)
+    mkRuntime[Task, Task.Par](prefix, storageSize)
       .flatMap { runtime =>
         Resource.liftF(RuntimeManager.fromRuntime[Task](runtime))
       }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -2,17 +2,13 @@ package coop.rchain.casper.util.rholang
 
 import cats.Id
 import cats.effect.Resource
-import com.google.protobuf.ByteString
-import coop.rchain.casper.genesis.contracts.{ProofOfStake, StandardDeploys, Validator, Vault}
+import coop.rchain.casper.genesis.contracts.StandardDeploys
 import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.util.rholang.Resources._
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
 import coop.rchain.catscontrib.effect.implicits._
-import coop.rchain.crypto.PublicKey
-import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -69,7 +65,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     (for {
-      reductionCost <- mkRuntime[Task, Task.Par]("casper-runtime")
+      reductionCost <- mkRuntime[Task]("casper-runtime")
                         .use { runtime =>
                           implicit val rand: Blake2b512Random = Blake2b512Random(
                             DeployData.toByteArray(ProtoUtil.stripDeployData(deploy))

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -12,7 +12,7 @@ import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace, SystemProcess}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Context, RSpace}
-import coop.rchain.shared.StoreType.LMDB
+import coop.rchain.shared.StoreType.InMem
 import coop.rchain.shared.{Log, StoreType}
 import monix.execution.Scheduler
 
@@ -75,7 +75,7 @@ object Resources {
     def apply[M[_]: Parallel[F, ?[_]]](
         prefix: String,
         storageSize: Long = 1024 * 1024,
-        storeType: StoreType = LMDB,
+        storeType: StoreType = InMem,
         additionalSystemProcesses: Seq[SystemProcess.Definition[F]] = Seq.empty
     )(
         implicit scheduler: Scheduler,

--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -12,6 +12,7 @@ import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace, SystemProcess}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace.{Context, RSpace}
+import coop.rchain.shared.StoreType.LMDB
 import coop.rchain.shared.{Log, StoreType}
 import monix.execution.Scheduler
 
@@ -64,12 +65,13 @@ object Resources {
   def mkRuntime[F[_]: ContextShift: Concurrent: Log: Metrics, M[_]: Parallel[F, ?[_]]](
       prefix: String,
       storageSize: Long = 1024 * 1024,
+      storeType: StoreType = LMDB,
       additionalSystemProcesses: Seq[SystemProcess.Definition[F]] = Seq.empty
   )(implicit scheduler: Scheduler): Resource[F, Runtime[F]] =
     mkTempDir[F](prefix).flatMap { tmpDir =>
       Resource.make[F, Runtime[F]](
         Runtime
-          .createWithEmptyCost[F, M](tmpDir, storageSize, StoreType.LMDB, additionalSystemProcesses)
+          .createWithEmptyCost[F, M](tmpDir, storageSize, storeType, additionalSystemProcesses)
       )(_.close())
     }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -190,7 +190,7 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
       val ast = ParBuilder[Coeval].buildNormalizedTerm(rho).value()
       PrettyPrinter().buildString(ast)
       checkSuccess(rho) {
-        mkRuntime[Task, Task.Par](tmpPrefix, mapSize).use { runtime =>
+        mkRuntime[Task](tmpPrefix, mapSize).use { runtime =>
           implicit val c = runtime.cost
           Interpreter[Task].evaluate(runtime, rho)
         }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -220,7 +220,7 @@ class CryptoChannelsSpec
     implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     val runtime = (for {
-      runtime <- Runtime.createWithEmptyCost[Task, Task.Par](dbDir, size, StoreType.LMDB)
+      runtime <- Runtime.createWithEmptyCost[Task, Task.Par](dbDir, size, StoreType.InMem)
       _       <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
     } yield (runtime)).unsafeRunSync
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/DeployParamsSpec.scala
@@ -30,7 +30,7 @@ class DeployParamsSpec extends fixture.FlatSpec with Matchers {
     val dbDir     = Files.createTempDirectory(s"rchain-storage-test-$randomInt")
     val size      = 1024L * 1024 * 10
     (for {
-      runtime <- Runtime.createWithEmptyCost[Task, Task.Par](dbDir, size, StoreType.LMDB)
+      runtime <- Runtime.createWithEmptyCost[Task, Task.Par](dbDir, size, StoreType.InMem)
       _       <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
       outcome = try {
         test(runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -1,13 +1,11 @@
 package coop.rchain.rholang.interpreter
-import java.io.StringReader
-
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers}
-import coop.rchain.shared.Log
 
 import scala.concurrent.duration._
 
@@ -51,7 +49,7 @@ class RuntimeSpec extends FlatSpec with Matchers {
     assert(execute(rho).errors.nonEmpty, s"Expected $rho to fail - it didn't.")
 
   private def execute(source: String): EvaluateResult =
-    mkRuntime[Task, Task.Par](tmpPrefix, mapSize)
+    mkRuntime[Task](tmpPrefix, mapSize)
       .use { runtime =>
         implicit val c = runtime.cost
         Interpreter[Task].evaluate(runtime, source)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -1,29 +1,21 @@
 package coop.rchain.rholang.interpreter.accounting
 
-import java.nio.file.Files
-
 import cats._
 import cats.effect._
 import cats.implicits._
-import coop.rchain.catscontrib.mtl.implicits._
-import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.rholang.Resources._
-import coop.rchain.rholang.interpreter.Runtime.{RhoContext, RhoISpace}
 import coop.rchain.rholang.interpreter.{PrettyPrinter => PP, _}
-import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{PPar, Proc}
 import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.{GenTools, ProcGen}
-import coop.rchain.rspace.history.Branch
-import coop.rchain.rspace.{Context, RSpace}
 import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Test.Parameters
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -109,7 +101,7 @@ object CostAccountingPropertyTest {
     implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
 
     val prefix = "cost-accounting-property-test"
-    mkRuntime[Task, Task.Par](prefix, 1024 * 1024).use { runtime =>
+    mkRuntime[Task](prefix, 1024 * 1024).use { runtime =>
       for {
         _    <- runtime.reducer.setPhlo(Cost.UNSAFE_MAX)
         _    <- Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -45,7 +45,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
           implicit val c = cost
           for {
             runtime <- Runtime
-                        .create[Task, Task.Par](dbDir, size, StoreType.LMDB)
+                        .create[Task, Task.Par](dbDir, size, StoreType.InMem)
             res <- Interpreter[Task]
                     .evaluate(runtime, contract, Cost(initialPhlo.toLong))
             _ <- Task.delay(runtime.close())

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -1,18 +1,15 @@
 package rholang.rosette
 
-import java.io.FileReader
 import java.nio.file.{Files, Path, Paths}
 
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
-import coop.rchain.rholang.interpreter.{EvaluateResult, Interpreter, Runtime}
-import coop.rchain.shared.Resources
-import monix.execution.Scheduler.Implicits.global
 import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.{EvaluateResult, Interpreter}
+import coop.rchain.shared.{Log, Resources}
 import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FunSuite, Matchers}
-import coop.rchain.shared.Log
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -46,7 +43,7 @@ class CompilerTests extends FunSuite with Matchers {
   }
 
   private def execute(file: Path): EvaluateResult =
-    mkRuntime[Task, Task.Par](tmpPrefix, mapSize)
+    mkRuntime[Task](tmpPrefix, mapSize)
       .use { runtime =>
         Resources.withResource(Source.fromFile(file.toString))(
           fileContents => {


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

While working on tests for charging for deploy, I've found a couple omissions, which previously made switching to InMem rspace uneffective. So I went ahead and ran our tests with in-mem rspace, and the build only took [32 minutes](https://drone.rchain-dev.tk/rchain/rchain/3875) (!).

Given the recent clogging up of drone, and the achieved speedup, I'd like to switch to InMem rspace in the places included in the last commit.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
