### PR TITLE
Add PeerTableSpec

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/discovery/PeerTableSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/PeerTableSpec.scala
@@ -1,0 +1,42 @@
+package coop.rchain.comm.discovery
+
+import scala.util.Random
+
+import cats.{Id, catsInstancesForId => _}
+
+import coop.rchain.catscontrib.effect.implicits._
+import coop.rchain.comm._
+
+import org.scalatest._
+
+class PeerTableSpec extends FlatSpec with Matchers with Inside {
+  val addressWidth = 8
+  val endpoint     = Endpoint("", 0, 0)
+  val home         = PeerNode(NodeIdentifier(randBytes(addressWidth)), endpoint)
+
+  private def randBytes(nbytes: Int): Array[Byte] = {
+    val arr = Array.fill(nbytes)(0.toByte)
+    Random.nextBytes(arr)
+    arr
+  }
+
+  implicit val ping: KademliaRPC[Id] = new KademliaRPC[Id] {
+    def ping(node: PeerNode): Boolean                         = true
+    def lookup(key: Seq[Byte], peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
+  }
+
+  "Peer that is already in the table" should "get updated" in {
+    val id    = randBytes(addressWidth)
+    val peer0 = PeerNode(NodeIdentifier(id), Endpoint("new", 0, 0))
+    val peer1 = PeerNode(NodeIdentifier(id), Endpoint("changed", 0, 0))
+    val table = PeerTable[PeerNode, Id](home.key)
+    table.updateLastSeen(peer0)
+    inside(table.peers) {
+      case p +: Nil => p should equal(peer0)
+    }
+    table.updateLastSeen(peer1)
+    inside(table.peers) {
+      case p +: Nil => p should equal(peer1)
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Add a unit test that checks if the Kademlia `PeerTable` updates known peer with address A with the same peer but a new address B.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2052

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).
