### PR TITLE
Make `LastFinalizedBlockCalculator` to be initialized by configuration

### DIFF
--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -430,7 +430,9 @@ class NodeRuntime private[node] (
         log,
         metrics
       )
-    lastFinalizedBlockCalculator = LastFinalizedBlockCalculator[Task](0f)(
+    lastFinalizedBlockCalculator = LastFinalizedBlockCalculator[Task](
+      conf.server.faultToleranceThreshold
+    )(
       Sync[Task],
       log,
       Concurrent[Task],


### PR DESCRIPTION
## Overview
Fixes https://github.com/rchain/rchain/pull/2445


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3373


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
