### PR TITLE
Fixed a bug in data generated to test RSpace Next History (#RCHAIN-3544)

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/History.scala
@@ -7,7 +7,6 @@ import scodec.codecs.{discriminated, provide, uint, uint2, vectorOfN}
 import coop.rchain.rspace.internal.codecByteVector
 import coop.rchain.shared.AttemptOps._
 import History._
-import coop.rchain.rspace.nextgenrspace.history.Trie.codecSkip
 
 trait History[F[_]] {
   def process(actions: List[HistoryAction]): F[History[F]]

--- a/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/HistoryInstances.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/nextgenrspace/history/HistoryInstances.scala
@@ -332,6 +332,12 @@ object HistoryInstances {
         )
 
       for {
+        _ <- Sync[F].ifM((actions.map(_.key).toSet.size == actions.size).pure[F])(
+              ifTrue = Applicative[F].unit,
+              ifFalse = Sync[F].raiseError(
+                new RuntimeException("Cannot process duplicate actions on one key")
+              )
+            )
         result <- sorted.foldLeftM(start) {
                    case (
                        (currentRoot, previousModificationOpt),


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
The keys passed to History process should not be duplicated. The generated data did not honour this assumption.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
RCHAIN-3544

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
