### PR TITLE
RCHAIN-3504: Implement readers-writer lock

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/LockReleaseException.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/LockReleaseException.scala
@@ -1,0 +1,3 @@
+package coop.rchain.rholang.interpreter.error
+
+final case class LockReleaseException(message: String) extends Throwable

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/MLock.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/MLock.scala
@@ -1,0 +1,41 @@
+package coop.rchain.rholang.interpreter.error
+
+import cats.effect.{Bracket, Concurrent}
+import cats.implicits._
+import cats.effect.concurrent.MVar
+
+final class MLock[F[_]](lock: MVar[F, Unit])(implicit bracketF: Bracket[F, Throwable]) {
+
+  def acquire: F[Unit] = lock.take
+
+  /**
+    * Attempts to release lock.
+    *
+    * Throws an error if lock is already released.
+    *
+    */
+  def release: F[Unit] =
+    lock
+      .tryPut(())
+      .ifM(
+        ().pure[F],
+        LockReleaseException("attempted to release released lock").raiseError[F, Unit]
+      )
+
+  def withLock[A](fa: F[A]): F[A] = bracketF.bracket[Unit, A](acquire)(_ => fa)(_ => release)
+
+  /**
+    * Blocks asynchronously until lock is released.
+    *
+    * The next call to release will unblock all readers simultaneously.
+    *
+    */
+  def waitForLock: F[Unit] = lock.read
+
+}
+
+object MLock {
+
+  def apply[F[_]: Concurrent]: F[MLock[F]] = MVar.of[F, Unit](()).map(new MLock[F](_))
+
+}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/RWLock.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/error/RWLock.scala
@@ -1,0 +1,166 @@
+package coop.rchain.rholang.interpreter.error
+
+import cats.effect.concurrent.MVar
+import cats.effect.{Bracket, Concurrent}
+import cats.implicits._
+
+/**
+  * [[Free]]: Read or write lock can be acquired without blocking.
+  *
+  * [[Write]]: Read and write locks block until lock is released.
+  *
+  * [[Read]]: Write locks block until all read locks are released.
+  *
+  * @note Nesting the monadic combinators is not advised as each
+  *       combination either dead-locks or throws an error.
+  *
+  */
+sealed trait State
+case object Write                 extends State
+case object Free                  extends State
+final case class Read(count: Int) extends State
+
+final class RWLock[F[_]](stateRef: MVar[F, State], readLock: MLock[F], writeLock: MLock[F])(
+    implicit bracketF: Bracket[F, Throwable]
+) {
+
+  /**
+    * Acquires read lock.
+    *
+    * Blocks (asynchronously) if another thread has write lock.
+    *
+    */
+  def acquireRead: F[Unit] =
+    stateRef.take >>= {
+      case Free        => readLock.acquire >> stateRef.put(Read(1))
+      case Write       => stateRef.put(Write) >> writeLock.waitForLock >> acquireRead
+      case Read(count) => stateRef.put(Read(count + 1))
+    }
+
+  /**
+    * Attempts to acquire read lock.
+    *
+    * Non-blocking.
+    *
+    * @return True if read lock was acquired. False otherwise.
+    *
+    */
+  def tryAcquireRead: F[Boolean] =
+    stateRef.take >>= {
+      case Free        => readLock.acquire >> stateRef.put(Read(1)) >> true.pure[F]
+      case Write       => stateRef.put(Write) >> false.pure[F]
+      case Read(count) => stateRef.put(Read(count - 1)) >> true.pure[F]
+    }
+
+  /**
+    * Releases read lock.
+    *
+    */
+  def releaseRead: F[Unit] =
+    stateRef.take >>= {
+      case Read(1)     => readLock.release >> stateRef.put(Free)
+      case Read(count) => readLock.release >> stateRef.put(Read(count - 1))
+      case state =>
+        stateRef.put(state) >> LockReleaseException("attempted to release released read lock")
+          .raiseError[F, Unit]
+    }
+
+  /**
+    * Performs a computation with read lock acquired.
+    *
+    * Blocks (asynchronously) if another thread has write lock.
+    *
+    * Read lock is guaranteed to be released whether or not computation succeeds.
+    *
+    */
+  def withReadLock[A](fa: F[A]): F[A] = bracketF.bracket(acquireRead)(_ => fa)(_ => releaseRead)
+
+  /**
+    * Attempts to perform a computation with read lock acquired.
+    *
+    * Non-blocking.
+    *
+    * Read lock is guaranteed to be released whether or not computation succeeds.
+    *
+    */
+  def tryWithRead[A](fa: F[A]): F[Option[A]] =
+    tryAcquireRead >>= {
+      case true  => bracketF.guarantee(fa)(releaseRead).map(_.some)
+      case false => none[A].pure[F]
+    }
+
+  /**
+    * Acquires write lock.
+    *
+    * Blocks (asynchronously) if other threads have read or write locks.
+    *
+    */
+  def acquireWrite: F[Unit] =
+    stateRef.take >>= {
+      case Free            => writeLock.acquire >> stateRef.put(Write)
+      case Write           => stateRef.put(Write) >> writeLock.waitForLock >> acquireWrite
+      case state @ Read(_) => stateRef.put(state) >> readLock.waitForLock >> acquireWrite
+    }
+
+  /**
+    * Attempts to acquire write lock.
+    *
+    * Non-blocking.
+    *
+    * @return True if write lock was acquired. False otherwise.
+    *
+    */
+  def tryAcquireWrite: F[Boolean] =
+    stateRef.take >>= {
+      case Free  => writeLock.acquire >> stateRef.put(Write) >> true.pure[F]
+      case state => stateRef.put(state) >> false.pure[F]
+    }
+
+  /**
+    * Releases write lock.
+    *
+    */
+  def releaseWrite: F[Unit] =
+    stateRef.take >>= {
+      case Write =>
+        writeLock.release >> stateRef.put(Free)
+      case state =>
+        stateRef.put(state) >> LockReleaseException("attempted to release released write lock")
+          .raiseError[F, Unit]
+    }
+
+  /**
+    * Performs a computation with write lock acquired.
+    *
+    * Blocks (asynchronously) if other threads have read or write locks.
+    *
+    * Write lock is guaranteed to be released whether or not computation succeeds.
+    *
+    */
+  def withWriteLock[A](fa: F[A]): F[A] = bracketF.bracket(acquireWrite)(_ => fa)(_ => releaseWrite)
+
+  /**
+    * Attempts to perform a computation with write lock acquired.
+    *
+    * Non-blocking.
+    *
+    * Write lock is guaranteed to be released whether or not computation succeeds.
+    *
+    */
+  def tryWithWrite[A](fa: F[A]): F[Option[A]] =
+    tryAcquireWrite >>= {
+      case true  => bracketF.guarantee(fa)(releaseWrite).map(_.some)
+      case false => none[A].pure[F]
+    }
+}
+
+object RWLock {
+
+  def apply[F[_]: Concurrent]: F[RWLock[F]] =
+    for {
+      stateRef  <- MVar.of[F, State](Free)
+      readLock  <- MLock[F]
+      writeLock <- MLock[F]
+    } yield new RWLock(stateRef, readLock, writeLock)
+
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/error/MLockSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/error/MLockSpec.scala
@@ -1,0 +1,85 @@
+package coop.rchain.rholang.interpreter.error
+
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import org.scalatest.FlatSpec
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class MLockSpec extends FlatSpec {
+
+  implicit val scheduler: TestScheduler = TestScheduler()
+
+  private val MAX_DURATION = 5.seconds
+
+  def withFixture[A](f: MLock[Task] => A): A = f(MLock[Task].runSyncUnsafe(MAX_DURATION))
+
+  behavior of "MLock"
+
+  "release" should "throw error when released lock is released" in withFixture { lock =>
+    val a = lock.release.runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Failure(LockReleaseException("attempted to release released lock"))))
+  }
+
+  "release" should "unblock lock acquisitions in FIFO order" in withFixture { lock =>
+    val a = lock.acquire.runToFuture
+    val b = lock.acquire.delayExecution(1.second).runToFuture
+    val c = lock.acquire.delayExecution(2.second).runToFuture
+    val d = lock.release.delayExecution(3.second).runToFuture
+    val e = lock.release.delayExecution(4.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(c.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(d.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(e.value.contains(Success(())))
+    assert(c.value.contains(Success(())))
+  }
+
+  "withLock" should "block lock acquisitions while lock is held" in withFixture { lock =>
+    val a = lock.withLock(Task.unit.delayExecution(2.second)).runToFuture
+    val b = lock.acquire.delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(b.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(a.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+  }
+
+  "release" should "unblock all waiting threads simultaneously" in withFixture { lock =>
+    val a = lock.acquire.runToFuture
+    val b = lock.waitForLock.delayExecution(1.second).runToFuture
+    val c = lock.waitForLock.delayExecution(1.second).runToFuture
+    val d = lock.release.delayExecution(2.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.isEmpty)
+    assert(c.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(d.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+    assert(c.value.contains(Success(())))
+  }
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/error/RWLockSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/error/RWLockSpec.scala
@@ -1,0 +1,193 @@
+package coop.rchain.rholang.interpreter.error
+
+import monix.eval.Task
+import monix.execution.schedulers.TestScheduler
+import org.scalatest.FlatSpec
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class RWLockSpec extends FlatSpec {
+
+  implicit val scheduler: TestScheduler = TestScheduler()
+
+  val MAX_DURATION: FiniteDuration = 5.seconds
+
+  def withFixture[A](f: RWLock[Task] => A): A = f(RWLock[Task].runSyncUnsafe(MAX_DURATION))
+
+  behavior of "RWLock"
+
+  "release write, release read" should "throw error when released lock is released" in withFixture {
+    rwLock =>
+      val a = rwLock.releaseRead.runToFuture
+      val b = rwLock.releaseWrite.runToFuture
+
+      scheduler.tick()
+      assert(
+        a.value.contains(Failure(LockReleaseException("attempted to release released read lock")))
+      )
+      assert(
+        b.value.contains(Failure(LockReleaseException("attempted to release released write lock")))
+      )
+  }
+
+  // TODO: How to assert that rwLock.stateRef has correct value w/o making stateRef public?
+  "acquire read; acquire read" should "not block" in withFixture { rwLock =>
+    val a = rwLock.acquireRead.runToFuture
+    val b = rwLock.acquireRead.delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.contains(Success(())))
+  }
+
+  "acquire read; acquire write" should "block until release read" in withFixture { rwLock =>
+    val a = rwLock.acquireRead.runToFuture
+    val b = rwLock.acquireWrite.delayExecution(1.second).runToFuture
+    val c = rwLock.releaseRead.delayExecution(2.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.seconds)
+    assert(b.value.isEmpty)
+
+    scheduler.tick(1.seconds)
+    assert(c.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+  }
+
+  "acquire write; acquire read" should "block until release write" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.acquireRead.delayExecution(1.second).runToFuture
+    val c = rwLock.releaseWrite.delayExecution(2.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(c.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+  }
+
+  "acquire write; acquire write" should "block until release write" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.acquireWrite.delayExecution(1.second).runToFuture
+    val c = rwLock.releaseWrite.delayExecution(2.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.isEmpty)
+
+    scheduler.tick(1.second)
+    assert(c.value.contains(Success(())))
+    assert(b.value.contains(Success(())))
+  }
+
+  "withReadLock(withReadLock(fa))" should "throw error" in withFixture { rwLock =>
+    val a = rwLock.withReadLock(rwLock.withReadLock(Task.unit)).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Failure(LockReleaseException("attempted to release released lock"))))
+  }
+
+  "withReadLock(withWriteLock(fa))" should "block" in withFixture { rwLock =>
+    val a = rwLock.withReadLock(rwLock.withWriteLock(Task.unit)).runToFuture
+
+    scheduler.tick()
+    assert(a.value.isEmpty)
+  }
+
+  "withWriteLock(withReadLock(fa))" should "block" in withFixture { rwLock =>
+    val a = rwLock.withWriteLock(rwLock.withReadLock(Task.unit)).runToFuture
+
+    scheduler.tick()
+    assert(a.value.isEmpty)
+  }
+
+  "withWriteLock(withWriteLock(fa))" should "block" in withFixture { rwLock =>
+    val a = rwLock.withWriteLock(rwLock.withWriteLock(Task.unit)).runToFuture
+
+    scheduler.tick()
+    assert(a.value.isEmpty)
+  }
+
+  "tryAcquireRead" should "return true when read lock is free" in withFixture { rwLock =>
+    val a = rwLock.tryAcquireRead.runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(true)))
+  }
+
+  "tryAcquireRead" should "return false when read lock is not free" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.tryAcquireRead.delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.contains(Success(false)))
+  }
+
+  "tryAcquireWrite" should "return true when write lock is free" in withFixture { rwLock =>
+    val a = rwLock.tryAcquireWrite.runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(true)))
+  }
+
+  "tryAcquireWrite" should "return false when write lock is not free" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.tryAcquireWrite.delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.contains(Success(false)))
+  }
+
+  "tryWithRead" should "return Some when read lock is free" in withFixture { rwLock =>
+    val a = rwLock.tryWithRead(Task.unit).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(Some(()))))
+  }
+
+  "tryWithRead" should "return None when read lock is not free" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.tryWithRead(Task.unit).delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.contains(Success(None)))
+  }
+
+  "tryWithWrite" should "return Some when write lock is free" in withFixture { rwLock =>
+    val a = rwLock.tryWithWrite(Task.unit).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(Some(()))))
+  }
+
+  "tryWithWrite" should "return None when write lock is not free" in withFixture { rwLock =>
+    val a = rwLock.acquireWrite.runToFuture
+    val b = rwLock.tryWithWrite(Task.unit).delayExecution(1.second).runToFuture
+
+    scheduler.tick()
+    assert(a.value.contains(Success(())))
+
+    scheduler.tick(1.second)
+    assert(b.value.contains(Success(None)))
+  }
+}


### PR DESCRIPTION
### JIRA ticket:

The RWLock will be used to guard access to a single `Option[InterpreterError]` resource. We want error reporting to be such that any number of threads can see if there has been an error, but only one thread at a time can report such an error. 

A subsequent PR should modify the reducer such that each thread checks the error resource before executing. If an error has been reported, it doesn't execute. Otherwise, it does. This usage implies that the error resource will only be modified once for a given term evaluation. The first error is the last.

https://rchain.atlassian.net/browse/RCHAIN-3504