### PR TITLE
Pass invalid blocks to computeState

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -18,6 +18,8 @@ import coop.rchain.comm.{transport, PeerNode}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared._
@@ -150,7 +152,8 @@ object BlockApproverProtocol {
                     runtimeManager
                       .replayComputeState(runtimeManager.emptyStateHash)(
                         blockDeploys,
-                        BlockData(time, blockNumber)
+                        BlockData(time, blockNumber),
+                        Map.empty[BlockHash, Validator]
                       )
                   ).leftMap { case (_, status) => s"Failed status during replay: $status." }
       _ <- EitherT(

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -164,7 +164,7 @@ object InterpreterUtil {
       runtimeManager: RuntimeManager[F],
       blockData: BlockData,
       span: Span[F],
-      invalidBlocks: Map[BlockHash, Validator] = Map.empty[BlockHash, Validator]
+      invalidBlocks: Map[BlockHash, Validator]
   ): F[Either[Throwable, (StateHash, StateHash, Seq[InternalProcessedDeploy])]] =
     for {
       possiblePreStateHash <- computeParentsPostState[F](parents, dag, runtimeManager, span)

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -169,7 +169,7 @@ object InterpreterUtil {
     for {
       possiblePreStateHash <- computeParentsPostState[F](parents, dag, runtimeManager, span)
       result <- possiblePreStateHash.flatTraverse { preStateHash =>
-                 runtimeManager.computeState(preStateHash)(deploys, blockData).map {
+                 runtimeManager.computeState(preStateHash)(deploys, blockData, invalidBlocks).map {
                    case (postStateHash, processedDeploys) =>
                      (preStateHash, postStateHash, processedDeploys).asRight[Throwable]
                  }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -47,12 +47,12 @@ trait RuntimeManager[F[_]] {
   def replayComputeState(startHash: StateHash)(
       terms: Seq[InternalProcessedDeploy],
       blockData: BlockData,
-      invalidBlocks: Map[BlockHash, Validator] = Map.empty[BlockHash, Validator]
+      invalidBlocks: Map[BlockHash, Validator]
   ): F[Either[(Option[DeployData], Failed), StateHash]]
   def computeState(hash: StateHash)(
       terms: Seq[DeployData],
       blockData: BlockData,
-      invalidBlocks: Map[BlockHash, Validator] = Map.empty[BlockHash, Validator]
+      invalidBlocks: Map[BlockHash, Validator]
   ): F[(StateHash, Seq[InternalProcessedDeploy])]
   def computeGenesis(
       terms: Seq[DeployData],

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -97,7 +97,8 @@ object BlockGenerator {
                  dag,
                  runtimeManager,
                  BlockData(now, b.body.get.state.get.blockNumber),
-                 span
+                 span,
+                 Map.empty[BlockHash, Validator]
                )
     } yield result
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/DeployerAuthTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/DeployerAuthTest.scala
@@ -8,7 +8,9 @@ import coop.rchain.casper.util.rholang.Resources._
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Expr.ExprInstance.GBool
+import coop.rchain.models.Validator.Validator
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{GDeployerAuth, Par}
 import coop.rchain.rholang.interpreter.Runtime.BlockData
@@ -83,7 +85,11 @@ class DeployerAuthTest extends FlatSpec with Matchers {
         runtimeManager
           .use { mgr =>
             mgr
-              .computeState(mgr.emptyStateHash)(Seq(contract), BlockData(0L, 0L))
+              .computeState(mgr.emptyStateHash)(
+                Seq(contract),
+                BlockData(0L, 0L),
+                Map.empty[BlockHash, Validator]
+              )
               .flatMap { result =>
                 val hash = result._1
                 mgr

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -22,7 +22,9 @@ import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.PCost
+import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.rholang.interpreter.{accounting, Runtime}
@@ -61,7 +63,8 @@ class InterpreterUtilTest
       dag,
       runtimeManager,
       BlockData(System.currentTimeMillis(), 0),
-      span0
+      span0,
+      Map.empty[BlockHash, Validator]
     )
 
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in withStorage {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -11,6 +11,8 @@ import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.interpreter.Runtime.BlockData
@@ -33,7 +35,11 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       startHash: StateHash,
       terms: List[Id[DeployData]]
   ): F[(StateHash, Seq[InternalProcessedDeploy])] =
-    runtimeManager.computeState(startHash)(terms, BlockData(System.currentTimeMillis(), 0))
+    runtimeManager.computeState(startHash)(
+      terms,
+      BlockData(System.currentTimeMillis(), 0),
+      Map.empty[BlockHash, Validator]
+    )
 
   "computeState" should "capture rholang errors" in {
     val badRholang = """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) } | @"x"!(1) | @"y"!("hi") """
@@ -118,7 +124,8 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
           mgr
             .computeState(mgr.emptyStateHash)(
               Seq(StandardDeploys.nonNegativeNumber, deployData),
-              BlockData(System.currentTimeMillis(), 0)
+              BlockData(System.currentTimeMillis(), 0),
+              Map.empty[BlockHash, Validator]
             )
             .flatMap { result =>
               val hash = result._1


### PR DESCRIPTION
We missed passing through invalidBlocks to computeState
because computeState had a default parameter for invalidBlocks.

The above wasn't caught by a test because in the test for slashing we also forgot to check the return status of the addBlock calls
and thus we didn't catch the fact the BlockStatus was returning
invalid.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3552


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
