### PR TITLE
Remove uninformative exception message when logging uncaught exceptions

### DIFF
--- a/shared/src/main/scala/coop/rchain/shared/UncaughtExceptionLogger.scala
+++ b/shared/src/main/scala/coop/rchain/shared/UncaughtExceptionLogger.scala
@@ -9,5 +9,5 @@ object UncaughtExceptionLogger extends UncaughtExceptionReporter {
   private val log: Log[Id]                  = Log.logId
 
   def reportFailure(ex: scala.Throwable): Unit =
-    log.error(s"Uncaught Exception : ${ex.getMessage}", ex)
+    log.error("Uncaught Exception", ex)
 }


### PR DESCRIPTION
## Overview
We should not log uncaught exception message since we print full exception stack trace anyway. This is especially misleading when there is no exception message and `UncaughtExceptionLogger` prints "Uncaught Exception: null"


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3476


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
