### PR TITLE
Rchain 3462: add rholang operator % and placeholder for PoS.closeBlock

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -1,3 +1,8 @@
+// Rholang macro parameters:
+// minimumBond - the minimum bond allowed by the PoS
+// maximumBond - the maximum bond allowed by PoS
+// initialBonds - the initial bonds map
+
 /*
  The table below describes the required computations and their dependencies
 
@@ -100,6 +105,18 @@ new  PoS,
                   }
                 }
               }
+            } |
+
+            contract PoS(@"closeBlock", ackCh) = {
+              new blockDataCh, getBlockData(`rho:block:data`), stdout(`rho:io:stdout`) in {
+                getBlockData!(*blockDataCh) |
+                for (_, @blockNumber <- blockDataCh) {
+                  if (blockNumber % 1000 == 0) {
+                    stdout!("TODO: a validator change should happen")
+                  } |
+                  ackCh!(Nil)
+                }
+              }
             }
           }
         } |
@@ -173,5 +190,3 @@ new  PoS,
     *uriOut)
   }
 }
-  
-  

--- a/casper/src/test/resources/BlockDataContractTest.rho
+++ b/casper/src/test/resources/BlockDataContractTest.rho
@@ -1,0 +1,32 @@
+new
+  rl(`rho:registry:lookup`), RhoSpecCh,
+  getBlockData(`rho:block:data`),
+  stdlog(`rho:io:stdlog`),
+  setup,
+  test_get_block_data
+in {
+  rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
+  for(@(_, RhoSpec) <- RhoSpecCh) {
+    @RhoSpec!("testSuite", *setup,
+      [
+        ("rho:block:data returns", *test_get_block_data)
+      ])
+  } |
+
+  contract setup(returnCh) = {
+    returnCh!([])
+  } |
+
+  contract test_get_block_data(rhoSpec, _, ackCh) = {
+    new retCh in {
+      getBlockData!( *retCh) |
+      for (@timestamp,@blockNumber <- retCh) {
+        rhoSpec!("assertMany",
+          [
+            ((0, "==", timestamp), "timestamp is zero"),
+            ((1, "==", blockNumber), "the blocknumber is genesis + 1"),
+          ], *ackCh)
+      }
+    }
+  }
+}

--- a/casper/src/test/resources/BlockDataContractTest.rho
+++ b/casper/src/test/resources/BlockDataContractTest.rho
@@ -19,12 +19,12 @@ in {
 
   contract test_get_block_data(rhoSpec, _, ackCh) = {
     new retCh in {
-      getBlockData!( *retCh) |
-      for (@timestamp,@blockNumber <- retCh) {
+      getBlockData!(*retCh) |
+      for (@timestamp, @blockNumber <- retCh) {
         rhoSpec!("assertMany",
           [
             ((0, "==", timestamp), "timestamp is zero"),
-            ((1, "==", blockNumber), "the blocknumber is genesis + 1"),
+            ((1, "==", blockNumber), "the blocknumber is genesis + 1")
           ], *ackCh)
       }
     }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
@@ -1,0 +1,7 @@
+package coop.rchain.casper.genesis.contracts
+import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.rholang.build.CompiledRholangSource
+import scala.concurrent.duration._
+
+class BlockDataContractSpec
+    extends RhoSpec(CompiledRholangSource("BlockDataContractTest.rho"), Seq.empty, 30.seconds)

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -201,6 +201,8 @@ message Expr {
         EPercentPercent e_percent_percent_body = 28; // string interpolation
         EPlusPlus e_plus_plus_body = 29; // concatenation
         EMinusMinus e_minus_minus_body = 30;  // set difference
+
+        EMod e_mod_body = 31;
     }
 }
 
@@ -269,6 +271,11 @@ message EMult {
 }
 
 message EDiv {
+    Par p1 = 1 [(scalapb.field).no_box = true];
+    Par p2 = 2 [(scalapb.field).no_box = true];
+}
+
+message EMod {
     Par p1 = 1 [(scalapb.field).no_box = true];
     Par p2 = 2 [(scalapb.field).no_box = true];
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -66,6 +66,10 @@ object implicits {
     new Expr(exprInstance = EDivBody(e))
   implicit def fromEDiv(e: EDiv): Expr = apply(e)
 
+  def apply(e: EMod): Expr =
+    new Expr(exprInstance = EModBody(e))
+  implicit def fromEMod(e: EMod): Expr = apply(e)
+
   def apply(e: EPlus): Expr =
     new Expr(exprInstance = EPlusBody(e))
   implicit def fromEPlus(e: EPlus): Expr = apply(e)
@@ -347,6 +351,7 @@ object implicits {
         case ENegBody(ENeg(p))                            => p.connectiveUsed
         case EMultBody(EMult(p1, p2))                     => p1.connectiveUsed || p2.connectiveUsed
         case EDivBody(EDiv(p1, p2))                       => p1.connectiveUsed || p2.connectiveUsed
+        case EModBody(EMod(p1, p2))                       => p1.connectiveUsed || p2.connectiveUsed
         case EPlusBody(EPlus(p1, p2))                     => p1.connectiveUsed || p2.connectiveUsed
         case EMinusBody(EMinus(p1, p2))                   => p1.connectiveUsed || p2.connectiveUsed
         case ELtBody(ELt(p1, p2))                         => p1.connectiveUsed || p2.connectiveUsed
@@ -381,6 +386,7 @@ object implicits {
         case ENegBody(ENeg(p))                            => p.locallyFree
         case EMultBody(EMult(p1, p2))                     => p1.locallyFree | p2.locallyFree
         case EDivBody(EDiv(p1, p2))                       => p1.locallyFree | p2.locallyFree
+        case EModBody(EMod(p1, p2))                       => p1.locallyFree | p2.locallyFree
         case EPlusBody(EPlus(p1, p2))                     => p1.locallyFree | p2.locallyFree
         case EMinusBody(EMinus(p1, p2))                   => p1.locallyFree | p2.locallyFree
         case ELtBody(ELt(p1, p2))                         => p1.locallyFree | p2.locallyFree

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -48,6 +48,14 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
           EDivBody(EDiv(sortedPar1.term, sortedPar2.term)),
           Node(Score.EDIV, sortedPar1.score, sortedPar2.score)
         )
+      case EModBody(ed) =>
+        for {
+          sortedPar1 <- Sortable.sortMatch(ed.p1)
+          sortedPar2 <- Sortable.sortMatch(ed.p2)
+        } yield constructExpr(
+          EModBody(EMod(sortedPar1.term, sortedPar2.term)),
+          Node(Score.EMOD, sortedPar1.score, sortedPar2.score)
+        )
       case EPlusBody(ep) =>
         for {
           sortedPar1 <- Sortable.sortMatch(ep.p1)

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
@@ -165,6 +165,7 @@ trait ScoreTree {
     final val EPERCENT    = 119
     final val EPLUSPLUS   = 120
     final val EMINUSMINUS = 121
+    final val EMOD        = 122
 
     // Other
     final val QUOTE    = 203

--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -44,6 +44,7 @@ PNot.            Proc10 ::= "not" Proc10 ;
 PNeg.            Proc10 ::= "-" Proc10 ;
 PMult.           Proc9  ::= Proc9 "*" Proc10 ;
 PDiv.            Proc9  ::= Proc9 "/" Proc10 ;
+PMod.            Proc9  ::= Proc9 "%" Proc10 ;
 PPercentPercent. Proc9  ::= Proc9 "%%" Proc10 ;
 PAdd.            Proc8  ::= Proc8 "+" Proc9 ;
 PMinus.          Proc8  ::= Proc8 "-" Proc9 ;

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -68,6 +68,8 @@ final case class PrettyPrinter(
         (buildStringM(p1) |+| pure(" * ") |+| buildStringM(p2)).map(_.wrapWithBraces)
       case EDivBody(EDiv(p1, p2)) =>
         (buildStringM(p1) |+| pure(" / ") |+| buildStringM(p2)).map(_.wrapWithBraces)
+      case EModBody(EMod(p1, p2)) =>
+        (buildStringM(p1) |+| pure(" % ") |+| buildStringM(p2)).map(_.wrapWithBraces)
       case EPercentPercentBody(EPercentPercent(p1, p2)) =>
         (buildStringM(p1) |+| pure(" %% ") |+| buildStringM(p2)).map(_.wrapWithBraces)
       case EPlusBody(EPlus(p1, p2)) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -532,6 +532,13 @@ class DebruijnInterpreter[M[_], F[_]](
           _  <- charge[M](DIVISION_COST)
         } yield GInt(v1 / v2)
 
+      case EModBody(EMod(p1, p2)) =>
+        for {
+          v1 <- evalToLong(p1)
+          v2 <- evalToLong(p2)
+          _  <- charge[M](MODULO_COST)
+        } yield GInt(v1 % v2)
+
       case EPlusBody(EPlus(p1, p2)) =>
         for {
           v1 <- evalSingleExpr(p1)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -285,6 +285,8 @@ object Substitute {
             s2(par1, par2)(EMult(_, _))
           case EDivBody(EDiv(par1, par2)) =>
             s2(par1, par2)(EDiv(_, _))
+          case EModBody(EMod(par1, par2)) =>
+            s2(par1, par2)(EMod(_, _))
           case EPercentPercentBody(EPercentPercent(par1, par2)) =>
             s2(par1, par2)(EPercentPercent(_, _))
           case EPlusBody(EPlus(par1, par2)) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -44,6 +44,7 @@ trait Costs {
   final val COMPARISON_COST: Cost     = Cost(3, "comparison")
   final val MULTIPLICATION_COST: Cost = Cost(9, "multiplication")
   final val DIVISION_COST: Cost       = Cost(9, "division")
+  final val MODULO_COST: Cost         = Cost(9, "modulo")
 
   // operations on collections
   // source: https://docs.scala-lang.org/overviews/collections/performance-characteristics.html

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -541,6 +541,11 @@ trait SpatialMatcherInstances {
           _ <- spatialMatch(t1, p1)
           _ <- spatialMatch(t2, p2)
         } yield ()
+      case (EModBody(EMod(t1, t2)), EModBody(EMod(p1, p2))) =>
+        for {
+          _ <- spatialMatch(t1, p1)
+          _ <- spatialMatch(t2, p2)
+        } yield ()
       case (
           EPercentPercentBody(EPercentPercent(t1, t2)),
           EPercentPercentBody(EPercentPercent(p1, p2))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -596,6 +596,7 @@ object ProcNormalizeMatcher {
 
       case p: PMult           => binaryExp(p.proc_1, p.proc_2, input, EMult.apply)
       case p: PDiv            => binaryExp(p.proc_1, p.proc_2, input, EDiv.apply)
+      case p: PMod            => binaryExp(p.proc_1, p.proc_2, input, EMod.apply)
       case p: PPercentPercent => binaryExp(p.proc_1, p.proc_2, input, EPercentPercent.apply)
       case p: PAdd            => binaryExp(p.proc_1, p.proc_2, input, EPlus.apply)
       case p: PMinus          => binaryExp(p.proc_1, p.proc_2, input, EMinus.apply)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -1,6 +1,4 @@
 package coop.rchain.rholang.interpreter
-import java.io.StringReader
-
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.errors.LexerError
 import monix.eval.Coeval
@@ -24,7 +22,7 @@ class LexerTest extends FlatSpec with Matchers {
 
   it should "return LexerError for illegal character" in {
     val attempt =
-      attemptMkTerm("""("x is ${value}" % {"value" : x})""")
+      attemptMkTerm("""("x is ${value}" ^ {"value" : x})""")
     attempt.left.value shouldBe a[LexerError]
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -161,6 +161,15 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     result shouldBe target
   }
 
+  "PMod" should "Print" in {
+    val source: Par = Par(
+      exprs = Seq(EModBody(EMod(GInt(11), GInt(10))))
+    )
+    val result = PrettyPrinter().buildString(source)
+    val target = """(11 % 10)"""
+    result shouldBe target
+  }
+
   "PPercentPercent" should "Print" in {
     val source: Par = Par(
       exprs = Seq(


### PR DESCRIPTION
## Overview
Add PoS.closeBlock placeholder for epoch change
Changes in Rholang were needed to implement operator modulo operator %


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3462



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
