### PR TITLE
Make admissible equivocation an invalid block

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -369,11 +369,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Sync: ConnectionsCell: Trans
                       }
                 } yield ()
               }
-          updatedDag <- BlockDagStorage[F].insert(block, genesis, invalid = false)
+          // We can only treat admissible equivocations as invalid blocks if
+          // casper is single threaded.
+          updatedDag <- handleInvalidBlockEffect(status, block)
           _          <- CommUtil.sendBlock[F](block)
-          _ <- Log[F].info(
-                s"Added admissible equivocation child block ${PrettyPrinter.buildString(block.blockHash)}"
-              )
         } yield updatedDag
       case IgnorableEquivocation =>
         /*

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -340,9 +340,11 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
         _ <- nodes(1).casperEff
               .contains(signedBlock4) shouldBeF true // However, marked as invalid
 
-        _ = nodes(1).logEff.infos.count(_ startsWith "Added admissible equivocation") should be(1)
+        _ = nodes(1).logEff.warns.exists(
+          _.matches("Recording invalid block .* for AdmissibleEquivocation.")
+        ) should be(true)
         _ = nodes(2).logEff.warns.size should be(0)
-        _ = nodes(1).logEff.warns.size should be(1)
+        _ = nodes(1).logEff.warns.size should be(3)
         _ = nodes(0).logEff.warns.size should be(0)
 
         _ <- nodes(1).casperEff


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This means we don't need a separate slashing path for equivocations. The DOS vector for not eagerly slashing equivocations in my opinion isn't much of a concern but maybe we should discuss.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3570



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
