### PR TITLE
RCHAIN-3424: Make RevVault use the on-chain deployer ID

### DIFF
--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -33,6 +33,17 @@ in {
       @MakeMint!(*mintCh) |
       for (mint <- mintCh) {
 
+        contract RevVault(@"deployerAuthKey", deployerId, ret) = {
+
+          new RevAddress(`rho:rev:address`), revAddrCh in {
+            RevAddress!("fromDeployerId", *deployerId, *revAddrCh)|
+            for (@deployerRevAddress <- revAddrCh) {
+
+              @AuthKey!("make", (*_revVault, deployerRevAddress), *ret)
+            }
+          }
+        } |
+
         contract RevVault(@"deployerAuthKey", ret) = {
 
           new deployerPubKeyBytesCh in {

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -35,11 +35,15 @@ in {
 
         contract RevVault(@"deployerAuthKey", deployerId, ret) = {
 
-          new RevAddress(`rho:rev:address`), revAddrCh in {
-            RevAddress!("fromDeployerId", *deployerId, *revAddrCh)|
-            for (@deployerRevAddress <- revAddrCh) {
+          new RevAddress(`rho:rev:address`), DeployerIdOps(`rho:rchain:deployerId:ops`), revAddrCh, deployerPubKeyBytesCh in {
+            DeployerIdOps!("pubKeyBytes", *deployerId, *deployerPubKeyBytesCh) |
+            for (@deployerPubKeyBytes <- deployerPubKeyBytesCh) {
 
-              @AuthKey!("make", (*_revVault, deployerRevAddress), *ret)
+              RevAddress!("fromPublicKey", deployerPubKeyBytes, *revAddrCh)|
+              for (@deployerRevAddress <- revAddrCh) {
+
+                @AuthKey!("make", (*_revVault, deployerRevAddress), *ret)
+              }
             }
           }
         } |

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -44,6 +44,8 @@ in {
           }
         } |
 
+        // Deprecated version of `deployerAuthKey`
+        // Please use the version above where a deployer id has to be passed
         contract RevVault(@"deployerAuthKey", ret) = {
 
           new deployerPubKeyBytesCh in {

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -1,12 +1,10 @@
 package coop.rchain.casper.genesis.contracts
 
+import cats.implicits._
 import coop.rchain.crypto.codec.Base16
-import coop.rchain.models.Par
-import coop.rchain.rholang.build.{CompiledRholangSource, CompiledRholangTemplate}
-import coop.rchain.rholang.interpreter.ParBuilder
-import monix.eval.Coeval
-
-import scala.io.Source
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.rholang.build.CompiledRholangTemplate
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 // TODO: Eliminate validators argument if unnecessary.
 // TODO: eliminate the default for epochLength. Now it is used in order to minimise the impact of adding this parameter
@@ -17,6 +15,7 @@ final case class ProofOfStake(
     epochLength: Int = 10000
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
+      NormalizerEnv(none, ProofOfStake.pk.some),
       "minimumBond"  -> minimumBond,
       "maximumBond"  -> maximumBond,
       "initialBonds" -> ProofOfStake.initialBonds(validators),
@@ -30,6 +29,7 @@ final case class ProofOfStake(
 }
 
 object ProofOfStake {
+  val (_, pk) = Secp256k1.newKeyPair
 
   // TODO: Determine how the "intial bonds" map can simulate transferring stake into the PoS contract
   //       when this must be done during genesis, under the authority of the genesisPk, which calls the

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -1,8 +1,6 @@
 package coop.rchain.casper.genesis.contracts
 
-import cats.implicits._
 import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.build.CompiledRholangTemplate
 import coop.rchain.rholang.interpreter.NormalizerEnv
 
@@ -15,7 +13,7 @@ final case class ProofOfStake(
     epochLength: Int = 10000
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
-      NormalizerEnv(none, ProofOfStake.pk.some),
+      NormalizerEnv.Empty,
       "minimumBond"  -> minimumBond,
       "maximumBond"  -> maximumBond,
       "initialBonds" -> ProofOfStake.initialBonds(validators),
@@ -29,8 +27,6 @@ final case class ProofOfStake(
 }
 
 object ProofOfStake {
-  val (_, pk) = Secp256k1.newKeyPair
-
   // TODO: Determine how the "intial bonds" map can simulate transferring stake into the PoS contract
   //       when this must be done during genesis, under the authority of the genesisPk, which calls the
   //       linear receive in PoS.rho

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
@@ -42,7 +42,11 @@ final case class RevGenerator(
        # }
      """.stripMargin('#')
 
-  val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, NormalizerEnv(deployId = None, deployerPk = genesisPk.some)).value()
+  val normalizerEnv: NormalizerEnv = NormalizerEnv(deployId = none, deployerPk = genesisPk.some)
+
+  val term: Par = ParBuilder[Coeval]
+    .buildNormalizedTerm(code, normalizerEnv)
+    .value()
 
   private def findOrCreate(userVault: Vault): String =
     s""" 

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
@@ -1,14 +1,19 @@
 package coop.rchain.casper.genesis.contracts
 
+import cats.implicits._
+import coop.rchain.crypto.PublicKey
 import coop.rchain.models.Par
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.{NormalizerEnv, ParBuilder}
 import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.rholang.interpreter.util.codec.Base58
 import monix.eval.Coeval
 
-final case class RevGenerator(genesisAddress: RevAddress, userVaults: Seq[Vault], supply: Long)
-    extends CompiledRholangSource {
+final case class RevGenerator(
+    genesisPk: PublicKey,
+    genesisAddress: RevAddress,
+    userVaults: Seq[Vault],
+    supply: Long
+) extends CompiledRholangSource {
 
   val path: String = "<synthetic in Rev.scala>"
 
@@ -24,8 +29,8 @@ final case class RevGenerator(genesisAddress: RevAddress, userVaults: Seq[Vault]
        #         *genesisVaultCh
        #       )
        #       | for (@(true, genesisVault) <- genesisVaultCh) {
-       #         new genesisAuthKeyCh in {
-       #           @RevVault!("deployerAuthKey", *genesisAuthKeyCh)
+       #         new genesisAuthKeyCh, deployerId(`rho:rchain:deployerId`) in {
+       #           @RevVault!("deployerAuthKey", *deployerId, *genesisAuthKeyCh)
        #           | for (genesisVaultAuthKey <- genesisAuthKeyCh) {
        #             ${concatenate(findOrCreate)} |
        #             ${concatenate(transfer)}
@@ -37,7 +42,7 @@ final case class RevGenerator(genesisAddress: RevAddress, userVaults: Seq[Vault]
        # }
      """.stripMargin('#')
 
-  val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, NormalizerEnv.Empty).value()
+  val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, NormalizerEnv(deployId = None, deployerPk = genesisPk.some)).value()
 
   private def findOrCreate(userVault: Vault): String =
     s""" 

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -5,7 +5,7 @@ import coop.rchain.casper.util.ProtoUtil.stringToByteString
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.rholang.build.CompiledRholangSource
-import coop.rchain.rholang.interpreter.accounting
+import coop.rchain.rholang.interpreter.{accounting, NormalizerEnv}
 import coop.rchain.rholang.interpreter.util.RevAddress
 
 object StandardDeploys {
@@ -25,46 +25,46 @@ object StandardDeploys {
   }
 
   def listOps: DeployData = toDeploy(
-    CompiledRholangSource("ListOps.rho"),
+    CompiledRholangSource("ListOps.rho", NormalizerEnv.Empty),
     "040126690519dc9b0f52876cb13458e15697794dd87d7c6477707c7efa4cce8a36b634eab5056bd4e3ba385ab14a638e4ac7d3b3e4968da3d66933fc04bc7038b5",
     1559156082324L
   )
   def either: DeployData =
     toDeploy(
-      CompiledRholangSource("Either.rho"),
+      CompiledRholangSource("Either.rho", NormalizerEnv.Empty),
       "04c71f6c7b87edf4bec14f16f715ee49c6fea918549abdf06c734d384b60ba922990317cc4bf68da8c85b455a65595cf7007f1e54bfd6be26ffee53d1ea6d7406b",
       1559156217509L
     )
   def nonNegativeNumber: DeployData =
     toDeploy(
-      CompiledRholangSource("NonNegativeNumber.rho"),
+      CompiledRholangSource("NonNegativeNumber.rho", NormalizerEnv.Empty),
       "04e1559d809924e564dce57e34646e155b144d2a504ce7ee519d7a5108fd42f1038d08d745e5ea21cb53d6aa7c7174a768fa373207a83bc947a20c6a02ece7a60e",
       1559156251792L
     )
   def makeMint: DeployData =
     toDeploy(
-      CompiledRholangSource("MakeMint.rho"),
+      CompiledRholangSource("MakeMint.rho", NormalizerEnv.Empty),
       "0470256c078e105d2958b9cf66f2161d83368f483c0219790277fb726a459be7f56a9a48bbecf72bcaed6a3515bd0a144faf6a6a8de8f6c9b3b7dff297eb371f28",
       1559156452968L
     )
 
   def authKey: DeployData =
     toDeploy(
-      CompiledRholangSource("AuthKey.rho"),
+      CompiledRholangSource("AuthKey.rho", NormalizerEnv.Empty),
       "04f4b4417f930e6fab5765ac0defcf9fce169982acfd046e7c27f9b14c0804014623c0439e5c8035e9607599a549303b5b6b90cd9685e6965278bddca65dac7510",
       1559156356769L
     )
 
   def lockbox: DeployData =
     toDeploy(
-      CompiledRholangSource("Lockbox.rho"),
+      CompiledRholangSource("Lockbox.rho", NormalizerEnv.Empty),
       "04c1a88afc0810d0b7e4dea817f458c9d0a1913ec3459fb91bb9acdf0d867873d5144366275c5a63b0225a5167c6a838bb02285072d7177dc9f6407aaba87bca93",
       1559156146649L
     )
 
   def revVault: DeployData =
     toDeploy(
-      CompiledRholangSource("RevVault.rho"),
+      CompiledRholangSource("RevVault.rho", NormalizerEnv.Empty),
       "040f035630a5d2199184890b4b6b83440c842da0b6becca539f788f7b35d6e873561f673cd6ebe2e32236398a86f29dad992e8fba32534734300fcc5104bcfea0e",
       1559156183943L
     )

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -78,7 +78,7 @@ object StandardDeploys {
 
   def revGenerator(genesisPk: PublicKey, vaults: Seq[Vault], supply: Long): DeployData =
     toDeploy(
-      RevGenerator(RevAddress.fromPublicKey(genesisPk).get, vaults, supply),
+      RevGenerator(genesisPk, RevAddress.fromPublicKey(genesisPk).get, vaults, supply),
       Base16.encode(genesisPk.bytes),
       System.currentTimeMillis()
     )

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Validator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/Validator.scala
@@ -21,6 +21,8 @@ final case class Validator(pk: PublicKey, stake: Long) extends CompiledRholangSo
        | }
      """.stripMargin
 
-  lazy val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, NormalizerEnv.Empty).value()
+  val normalizerEnv: NormalizerEnv = NormalizerEnv.Empty
+
+  lazy val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, normalizerEnv).value()
 
 }

--- a/casper/src/test/resources/RevAddressTest.rho
+++ b/casper/src/test/resources/RevAddressTest.rho
@@ -6,7 +6,7 @@ new
   revAddress(`rho:rev:address`),
   stdlog(`rho:io:stdlog`),
   setup,
-  test_valid_address, test_invalid_address, test_fromPublicKey, test_fromPublicKey_invalid, test_fromDeployerId, test_fromDeployerId_invalid
+  test_valid_address, test_invalid_address, test_fromPublicKey, test_fromPublicKey_invalid
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
@@ -16,8 +16,6 @@ in {
         ("Validating a invalid address returns a non-Nil value", *test_invalid_address),
         ("Convert a public key into a RevAddress", *test_fromPublicKey),
         ("Reject an invalid public key", *test_fromPublicKey_invalid),
-        ("Convert a deployer id into a RevAddress", *test_fromDeployerId),
-        ("Reject an invalid deployer id", *test_fromDeployerId_invalid),
       ])
   } |
 
@@ -68,58 +66,6 @@ in {
     new retCh in {
       revAddress!("fromPublicKey", "F0F0".hexToBytes(), *retCh) |
       rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
-    }
-  } |
-
-  contract test_fromDeployerId(rhoSpec, _, ackCh) = {
-    new r1, r2, r3, getDeployerId(`rho:test:deployerId:get`), deployerIdCh1, deployerIdCh2, deployerIdCh3 in {
-      getDeployerId!(
-        "deployerId",
-        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".hexToBytes(),
-        *deployerIdCh1
-      ) |
-      getDeployerId!(
-        "deployerId",
-        "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".hexToBytes(),
-        *deployerIdCh2
-      ) |
-      getDeployerId!(
-        "deployerId",
-        "2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222".hexToBytes(),
-        *deployerIdCh3
-      ) |
-      for(@deployerId1 <- deployerIdCh1; @deployerId2 <- deployerIdCh2; @deployerId3 <- deployerIdCh3) {
-        revAddress!(
-          "fromDeployerId",
-          deployerId1,
-          *r1
-        ) |
-        revAddress!(
-          "fromDeployerId",
-          deployerId2,
-          *r2
-        ) |
-        revAddress!(
-          "fromDeployerId",
-          deployerId3,
-          *r3
-        ) |
-        rhoSpec!("assertMany", [
-          (("11112c4Z48VufA19YCWdUoXrXKKVza16dix2xUa5q3TpnRLcZAQg7d", "== <-", *r1), "correct RevAddress"),
-          (("1111vQiDiLGjHgjV1D7j6EbXHyStToU3iQ3eWA394p3rzYFocXGtv", "== <-", *r2), "correct RevAddress"),
-          (("11112nT39uWFt9J3CT7hi87JRmnWsQuMh1oDjfhkyfcGnjV54Umn1n", "== <-", *r3), "correct RevAddress"),
-        ], *ackCh)
-      }
-    }
-  } |
-
-  contract test_fromDeployerId_invalid(rhoSpec, _, ackCh) = {
-    new retCh, getDeployerId(`rho:test:deployerId:get`), deployerIdCh in {
-      getDeployerId!("deployerId", "F0F0".hexToBytes(), *deployerIdCh) |
-      for(@deployerId <- deployerIdCh) {
-        revAddress!("fromDeployerId", deployerId, *retCh) |
-        rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
-      }
     }
   }
 }

--- a/casper/src/test/resources/RevAddressTest.rho
+++ b/casper/src/test/resources/RevAddressTest.rho
@@ -6,7 +6,7 @@ new
   revAddress(`rho:rev:address`),
   stdlog(`rho:io:stdlog`),
   setup,
-  test_valid_address, test_invalid_address, test_fromPublicKey, test_fromPublicKey_invalid
+  test_valid_address, test_invalid_address, test_fromPublicKey, test_fromPublicKey_invalid, test_fromDeployerId, test_fromDeployerId_invalid
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
@@ -16,6 +16,8 @@ in {
         ("Validating a invalid address returns a non-Nil value", *test_invalid_address),
         ("Convert a public key into a RevAddress", *test_fromPublicKey),
         ("Reject an invalid public key", *test_fromPublicKey_invalid),
+        ("Convert a deployer id into a RevAddress", *test_fromDeployerId),
+        ("Reject an invalid deployer id", *test_fromDeployerId_invalid),
       ])
   } |
 
@@ -66,6 +68,58 @@ in {
     new retCh in {
       revAddress!("fromPublicKey", "F0F0".hexToBytes(), *retCh) |
       rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
+    }
+  } |
+
+  contract test_fromDeployerId(rhoSpec, _, ackCh) = {
+    new r1, r2, r3, getDeployerId(`rho:test:deployerId:get`), deployerIdCh1, deployerIdCh2, deployerIdCh3 in {
+      getDeployerId!(
+        "deployerId",
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".hexToBytes(),
+        *deployerIdCh1
+      ) |
+      getDeployerId!(
+        "deployerId",
+        "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".hexToBytes(),
+        *deployerIdCh2
+      ) |
+      getDeployerId!(
+        "deployerId",
+        "2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222".hexToBytes(),
+        *deployerIdCh3
+      ) |
+      for(@deployerId1 <- deployerIdCh1; @deployerId2 <- deployerIdCh2; @deployerId3 <- deployerIdCh3) {
+        revAddress!(
+          "fromDeployerId",
+          deployerId1,
+          *r1
+        ) |
+        revAddress!(
+          "fromDeployerId",
+          deployerId2,
+          *r2
+        ) |
+        revAddress!(
+          "fromDeployerId",
+          deployerId3,
+          *r3
+        ) |
+        rhoSpec!("assertMany", [
+          (("11112c4Z48VufA19YCWdUoXrXKKVza16dix2xUa5q3TpnRLcZAQg7d", "== <-", *r1), "correct RevAddress"),
+          (("1111vQiDiLGjHgjV1D7j6EbXHyStToU3iQ3eWA394p3rzYFocXGtv", "== <-", *r2), "correct RevAddress"),
+          (("11112nT39uWFt9J3CT7hi87JRmnWsQuMh1oDjfhkyfcGnjV54Umn1n", "== <-", *r3), "correct RevAddress"),
+        ], *ackCh)
+      }
+    }
+  } |
+
+  contract test_fromDeployerId_invalid(rhoSpec, _, ackCh) = {
+    new retCh, getDeployerId(`rho:test:deployerId:get`), deployerIdCh in {
+      getDeployerId!("deployerId", "F0F0".hexToBytes(), *deployerIdCh) |
+      for(@deployerId <- deployerIdCh) {
+        revAddress!("fromDeployerId", deployerId, *retCh) |
+        rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
+      }
     }
   }
 }

--- a/casper/src/test/resources/RevVaultTest.rho
+++ b/casper/src/test/resources/RevVaultTest.rho
@@ -22,6 +22,7 @@ match (
       ListOpsCh,
       stdout(`rho:io:stdout`),
       setDeployData(`rho:test:deploy:set`),
+      getDeployerId(`rho:test:deployerId:get`),
       setup,
       testFindOrCreateGenesisVault,
       testCreateVaultFail,
@@ -85,10 +86,10 @@ match (
       } |
 
       contract testCreateVault(rhoSpec, RevVault, ackCh) = {
-        new aliceVaultCh, genesisAuthKeyCh, balanceCh, transferCh in {
+        new aliceVaultCh, deployerId(`rho:rchain:deployerId`), genesisAuthKeyCh, balanceCh, transferCh in {
           RevVault!("findOrCreate", aliceRevAddress, *aliceVaultCh) |
           //as per `setup`, the deployer is `genesis` and shouldn't be able to access the vault
-          RevVault!("deployerAuthKey", *genesisAuthKeyCh) |
+          RevVault!("deployerAuthKey", *deployerId, *genesisAuthKeyCh) |
           for (@(true, aliceVault) <- aliceVaultCh; genesisAuthKey <- genesisAuthKeyCh) {
             @aliceVault!("balance", *balanceCh) |
             @aliceVault!("transfer", genesisRevAddress, 0, *genesisAuthKey, *transferCh) |
@@ -179,13 +180,14 @@ match (
         for (@(_, RevVault) <- RevVaultCh) {
 
           contract withVaultAndIdentityOf(@pubKey, ret) = {
-            new RevAddress(`rho:rev:address`), revAddrCh, vaultCh, identityChanged, authKeyCh in {
+            new RevAddress(`rho:rev:address`), revAddrCh, vaultCh, identityChanged, deployerIdCh, authKeyCh in {
               setDeployData!("userId", pubKey, *identityChanged) |
+              getDeployerId!("deployerId", pubKey, *deployerIdCh) |
               RevAddress!("fromPublicKey", pubKey, *revAddrCh) |
               for (@revAddr <- revAddrCh) {
                 @RevVault!("findOrCreate", revAddr, *vaultCh) |
-                for (@(true, vault) <- vaultCh; _ <- identityChanged) {
-                  @RevVault!("deployerAuthKey", *authKeyCh) |
+                for (@(true, vault) <- vaultCh; _ <- identityChanged; deployerId <- deployerIdCh) {
+                  @RevVault!("deployerAuthKey", *deployerId, *authKeyCh) |
                   for (@authKey <- authKeyCh) {
                     ret!(vault, authKey)
                   }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
@@ -2,10 +2,12 @@ package coop.rchain.casper.genesis.contracts
 
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class AuthKeySpec
     extends RhoSpec(
-      CompiledRholangSource("AuthKeyTest.rho"),
+      CompiledRholangSource("AuthKeyTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/AuthKeySpec.scala
@@ -8,6 +8,5 @@ class AuthKeySpec
     extends RhoSpec(
       CompiledRholangSource("AuthKeyTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
@@ -9,6 +9,5 @@ class BlockDataContractSpec
     extends RhoSpec(
       CompiledRholangSource("BlockDataContractTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       30.seconds
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/BlockDataContractSpec.scala
@@ -1,7 +1,14 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.NormalizerEnv
+
 import scala.concurrent.duration._
 
 class BlockDataContractSpec
-    extends RhoSpec(CompiledRholangSource("BlockDataContractTest.rho"), Seq.empty, 30.seconds)
+    extends RhoSpec(
+      CompiledRholangSource("BlockDataContractTest.rho", NormalizerEnv.Empty),
+      Seq.empty,
+      NormalizerEnv.Empty,
+      30.seconds
+    )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
@@ -1,11 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class DeployDataContractSpec
     extends RhoSpec(
-      CompiledRholangSource("DeployDataContractTest.rho"),
+      CompiledRholangSource("DeployDataContractTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/DeployDataContractSpec.scala
@@ -7,6 +7,5 @@ class DeployDataContractSpec
     extends RhoSpec(
       CompiledRholangSource("DeployDataContractTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -7,6 +7,5 @@ class EitherSpec
     extends RhoSpec(
       CompiledRholangSource("EitherTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/EitherSpec.scala
@@ -1,12 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class EitherSpec
     extends RhoSpec(
-      CompiledRholangSource("EitherTest.rho"),
+      CompiledRholangSource("EitherTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -30,7 +30,6 @@ class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matche
       .getResults(
         CompiledRholangSource("FailingResultCollectorTest.rho", NormalizerEnv.Empty),
         Seq.empty,
-        NormalizerEnv.Empty,
         10.seconds
       )
       .runSyncUnsafe(Duration.Inf)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -1,5 +1,6 @@
 import coop.rchain.casper.helper.{RhoAssertEquals, RhoAssertTrue, RhoSpec, RhoTestAssertion}
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.NormalizerEnv
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
@@ -26,7 +27,12 @@ class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matche
 
   val result =
     RhoSpec
-      .getResults(CompiledRholangSource("FailingResultCollectorTest.rho"), Seq.empty, 10.seconds)
+      .getResults(
+        CompiledRholangSource("FailingResultCollectorTest.rho", NormalizerEnv.Empty),
+        Seq.empty,
+        NormalizerEnv.Empty,
+        10.seconds
+      )
       .runSyncUnsafe(Duration.Inf)
 
   result.assertions

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/ListOpsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/ListOpsSpec.scala
@@ -9,6 +9,5 @@ class ListOpsSpec
     extends RhoSpec(
       CompiledRholangSource("ListOpsTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/ListOpsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/ListOpsSpec.scala
@@ -1,12 +1,14 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 import scala.concurrent.duration._
 
 class ListOpsSpec
     extends RhoSpec(
-      CompiledRholangSource("ListOpsTest.rho"),
+      CompiledRholangSource("ListOpsTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
@@ -7,6 +7,5 @@ class LockboxSpec
     extends RhoSpec(
       CompiledRholangSource("LockboxTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/LockboxSpec.scala
@@ -1,11 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class LockboxSpec
     extends RhoSpec(
-      CompiledRholangSource("LockboxTest.rho"),
+      CompiledRholangSource("LockboxTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -2,12 +2,12 @@ package coop.rchain.casper.genesis.contracts
 
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class MakeMintSpec
     extends RhoSpec(
-      CompiledRholangSource("MakeMintTest.rho"),
+      CompiledRholangSource("MakeMintTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/MakeMintSpec.scala
@@ -8,6 +8,5 @@ class MakeMintSpec
     extends RhoSpec(
       CompiledRholangSource("MakeMintTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -7,6 +7,5 @@ class NonNegativeNumberSpec
     extends RhoSpec(
       CompiledRholangSource("NonNegativeNumberTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/NonNegativeNumberSpec.scala
@@ -1,12 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class NonNegativeNumberSpec
     extends RhoSpec(
-      CompiledRholangSource("NonNegativeNumberTest.rho"),
+      CompiledRholangSource("NonNegativeNumberTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -2,12 +2,12 @@ package coop.rchain.casper.genesis.contracts
 
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class PoSSpec
     extends RhoSpec(
-      CompiledRholangSource("PoSTest.rho"),
+      CompiledRholangSource("PoSTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -8,6 +8,5 @@ class PoSSpec
     extends RhoSpec(
       CompiledRholangSource("PoSTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -1,8 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class RevAddressSpec
-    extends RhoSpec(CompiledRholangSource("RevAddressTest.rho"), Seq.empty, GENESIS_TEST_TIMEOUT)
+    extends RhoSpec(
+      CompiledRholangSource("RevAddressTest.rho", NormalizerEnv.Empty),
+      Seq.empty,
+      NormalizerEnv.Empty,
+      GENESIS_TEST_TIMEOUT
+    )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -7,6 +7,5 @@ class RevAddressSpec
     extends RhoSpec(
       CompiledRholangSource("RevAddressTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -1,13 +1,25 @@
 package coop.rchain.casper.genesis.contracts
 
+import cats.implicits._
 import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class RevVaultSpec
     extends RhoSpec(
-      CompiledRholangSource("RevVaultTest.rho"),
+      CompiledRholangSource("RevVaultTest.rho", RevVaultSpec.normalizerEnv),
       Seq.empty,
+      RevVaultSpec.normalizerEnv,
       GENESIS_TEST_TIMEOUT
     )
+
+object RevVaultSpec {
+  val genesisPk = PublicKey(
+    Base16.unsafeDecode(
+      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    )
+  )
+  val normalizerEnv = NormalizerEnv(none, genesisPk.some)
+}

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -11,7 +11,6 @@ class RevVaultSpec
     extends RhoSpec(
       CompiledRholangSource("RevVaultTest.rho", RevVaultSpec.normalizerEnv),
       Seq.empty,
-      RevVaultSpec.normalizerEnv,
       GENESIS_TEST_TIMEOUT
     )
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
@@ -7,6 +7,5 @@ class RhoSpecContractSpec
     extends RhoSpec(
       CompiledRholangSource("RhoSpecContractTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RhoSpecContractSpec.scala
@@ -1,12 +1,12 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
-
-import scala.concurrent.duration._
+import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class RhoSpecContractSpec
     extends RhoSpec(
-      CompiledRholangSource("RhoSpecContractTest.rho"),
+      CompiledRholangSource("RhoSpecContractTest.rho", NormalizerEnv.Empty),
       Seq.empty,
+      NormalizerEnv.Empty,
       GENESIS_TEST_TIMEOUT
     )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -8,7 +8,6 @@ import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics.Metrics

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -39,7 +39,7 @@ object TestUtil {
       runtimeManager <- RuntimeManager.fromRuntime(runtime)
       _              <- genesisSetup(runtimeManager)
       _              <- evalDeploy(rhoSpecDeploy, runtime, normalizerEnv)
-      _              <- otherLibs.toList.traverse(evalDeploy(_, runtime, normalizerEnv))
+      _              <- otherLibs.toList.traverse(d => evalDeploy(d, runtime, NormalizerEnv(d)))
       // reset the deployParams.userId before executing the test
       // otherwise it'd execute as the deployer of last deployed contract
       _ <- runtime.deployParametersRef.update(_.copy(userId = Par()))

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -38,8 +38,8 @@ object TestUtil {
     for {
       runtimeManager <- RuntimeManager.fromRuntime(runtime)
       _              <- genesisSetup(runtimeManager)
-      _              <- evalDeploy(rhoSpecDeploy, runtime, normalizerEnv)
-      _              <- otherLibs.toList.traverse(d => evalDeploy(d, runtime, NormalizerEnv(d)))
+      _              <- evalDeploy(rhoSpecDeploy, runtime)
+      _              <- otherLibs.toList.traverse(d => evalDeploy(d, runtime))
       // reset the deployParams.userId before executing the test
       // otherwise it'd execute as the deployer of last deployed contract
       _ <- runtime.deployParametersRef.update(_.copy(userId = Par()))
@@ -79,13 +79,12 @@ object TestUtil {
 
   private def evalDeploy[F[_]: Sync](
       deploy: DeployData,
-      runtime: Runtime[F],
-      normalizerEnv: NormalizerEnv
+      runtime: Runtime[F]
   ): F[Unit] = {
     val rand: Blake2b512Random = Blake2b512Random(
       DeployData.toByteArray(ProtoUtil.stripDeployData(deploy))
     )
-    eval(deploy.term, runtime, normalizerEnv)(implicitly, rand)
+    eval(deploy.term, runtime, NormalizerEnv(deploy))(implicitly, rand)
   }
 
   def eval[F[_]: Sync](

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
@@ -1,6 +1,7 @@
 package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
+import coop.rchain.rholang.interpreter.NormalizerEnv
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
@@ -9,7 +10,12 @@ import monix.execution.Scheduler.Implicits.global
 class TimeoutResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
   it should "testFinished should be false if execution hasn't finished within timeout" in {
     RhoSpec
-      .getResults(CompiledRholangSource("TimeoutResultCollectorTest.rho"), Seq.empty, 10.seconds)
+      .getResults(
+        CompiledRholangSource("TimeoutResultCollectorTest.rho", NormalizerEnv.Empty),
+        Seq.empty,
+        NormalizerEnv.Empty,
+        10.seconds
+      )
       .runSyncUnsafe(Duration.Inf)
       .hasFinished should be(false)
   }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
@@ -13,7 +13,6 @@ class TimeoutResultCollectorSpec extends FlatSpec with AppendedClues with Matche
       .getResults(
         CompiledRholangSource("TimeoutResultCollectorTest.rho", NormalizerEnv.Empty),
         Seq.empty,
-        NormalizerEnv.Empty,
         10.seconds
       )
       .runSyncUnsafe(Duration.Inf)

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
@@ -1,10 +1,8 @@
 package coop.rchain.casper.helper
 import cats.effect.Concurrent
-import coop.rchain.models.rholang.implicits._
-import coop.rchain.models.{GDeployerId, ListParWithRandom, Par}
+import coop.rchain.models.ListParWithRandom
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
-import coop.rchain.shared.ByteStringOps._
 
 /**
   * Warning: This should under no circumstances be available in production
@@ -23,7 +21,7 @@ object DeployerIdContract {
           Seq(RhoType.String("deployerId"), RhoType.ByteArray(pk), ackCh)
           ) =>
         for {
-          _ <- produce(Seq(GDeployerId(pk.toByteString): Par), ackCh)
+          _ <- produce(Seq(RhoType.DeployerId(pk)), ackCh)
         } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
@@ -6,6 +6,9 @@ import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
 import coop.rchain.shared.ByteStringOps._
 
+/**
+  * Warning: This should under no circumstances be available in production
+  */
 object DeployerIdContract {
   import cats.implicits._
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
@@ -1,0 +1,27 @@
+package coop.rchain.casper.helper
+import cats.effect.Concurrent
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.{GDeployerId, ListParWithRandom, Par}
+import coop.rchain.rholang.interpreter.Runtime.SystemProcess
+import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
+import coop.rchain.shared.ByteStringOps._
+
+object DeployerIdContract {
+  import cats.implicits._
+
+  def get[F[_]: Concurrent](
+      ctx: SystemProcess.Context[F]
+  )(message: (Seq[ListParWithRandom], Int)): F[Unit] = {
+
+    val isContractCall = new ContractCall(ctx.space, ctx.dispatcher)
+    message match {
+      case isContractCall(
+          produce,
+          Seq(RhoType.String("deployerId"), RhoType.ByteArray(pk), ackCh)
+          ) =>
+        for {
+          _ <- produce(Seq(GDeployerId(pk.toByteString): Par), ackCh)
+        } yield ()
+    }
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -50,6 +50,13 @@ object RhoSpec {
           3,
           104L,
           ctx => DeployDataContract.set(ctx)(_, _)
+        ),
+        SystemProcess.Definition[F](
+          "rho:test:deployerId:get",
+          Runtime.byteName(105),
+          3,
+          105L,
+          ctx => DeployerIdContract.get(ctx)(_, _)
         )
       )
     testResultCollectorService

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.helper
 import cats.effect.Concurrent
 import coop.rchain.casper.genesis.contracts.TestUtil
 import coop.rchain.casper.protocol.DeployData
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Metrics
 import coop.rchain.rholang.Resources._
@@ -98,7 +97,6 @@ object RhoSpec {
 class RhoSpec(
     testObject: CompiledRholangSource,
     extraNonGenesisDeploys: Seq[DeployData],
-    normalizerEnv: NormalizerEnv,
     executionTimeout: FiniteDuration
 ) extends FlatSpec
     with AppendedClues
@@ -138,7 +136,7 @@ class RhoSpec(
   def hasFailures(assertions: List[RhoTestAssertion]) = assertions.find(_.isSuccess).isDefined
 
   private val result = RhoSpec
-    .getResults(testObject, extraNonGenesisDeploys, normalizerEnv, executionTimeout)
+    .getResults(testObject, extraNonGenesisDeploys, testObject.normalizerEnv, executionTimeout)
     .runSyncUnsafe(Duration.Inf)
 
   it should "finish execution within timeout" in {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Interactive.scala
@@ -6,18 +6,19 @@ import monix.execution.Scheduler
 import monix.eval.Task
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.rholang.interpreter.accounting.{CostAccounting}
+import coop.rchain.rholang.interpreter.accounting.CostAccounting
 import coop.rchain.shared.PathOps.RichPath
 import java.nio.file.{Files, Path, Paths}
-import coop.rchain.rholang.interpreter.{PrettyPrinter, Runtime}
+
+import coop.rchain.rholang.interpreter.{NormalizerEnv, PrettyPrinter, Runtime}
 import coop.rchain.rspace.Checkpoint
 import coop.rchain.shared.Log
 import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
 import coop.rchain.catscontrib.TaskContrib._
-import scala.collection.mutable
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 /**
@@ -53,7 +54,7 @@ class Interactive private (runtime: Runtime[Task])(implicit scheduler: Scheduler
   def checkpointNames: List[String] = checkpoints.keys.toList
 
   def eval(code: String): Unit = {
-    TestUtil.eval(code, runtime).runSyncUnsafe(Duration.Inf)
+    TestUtil.eval(code, runtime, NormalizerEnv.Empty).runSyncUnsafe(Duration.Inf)
     val errors = runtime.errorLog.readAndClearErrorVector().unsafeRunSync
     if (errors.nonEmpty) {
       println("Errors during execution:")

--- a/integration-tests/resources/wallets/transfer_funds.rho
+++ b/integration-tests/resources/wallets/transfer_funds.rho
@@ -16,9 +16,9 @@ in {
     ) {
       (from, to, amount) => {
 
-        new vaultCh, revVaultkeyCh in {
+        new vaultCh, revVaultkeyCh, deployerId(`rho:rchain:deployerId`) in {
           @RevVault!("findOrCreate", from, *vaultCh) |
-          @RevVault!("deployerAuthKey", *revVaultkeyCh) |
+          @RevVault!("deployerAuthKey", *deployerId, *revVaultkeyCh) |
           for (@(true, vault) <- vaultCh; key <- revVaultkeyCh) {
 
             log!(("Beginning transfer of ", amount, "REV from", from, "to", to)) |

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -294,6 +294,16 @@ object implicits {
         None
       }
 
+    def singleUnforgeable(): Option[GUnforgeable] =
+      if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.bundles.isEmpty && p.connectives.isEmpty) {
+        p.unforgeables.toList match {
+          case Seq(single) => Some(single)
+          case _           => None
+        }
+      } else {
+        None
+      }
+
     def singleConnective(): Option[Connective] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.bundles.isEmpty && p.connectives.size == 1) {
         Some(p.connectives.head)

--- a/rholang/examples/vault_demo/3.transfer_funds.rho
+++ b/rholang/examples/vault_demo/3.transfer_funds.rho
@@ -16,9 +16,9 @@ in {
     ) {
       (from, to, amount) => {
 
-        new vaultCh, revVaultkeyCh in {
+        new vaultCh, revVaultkeyCh, deployerId(`rho:rchain:deployerId`) in {
           @RevVault!("findOrCreate", from, *vaultCh) |
-          @RevVault!("deployerAuthKey", *revVaultkeyCh) |
+          @RevVault!("deployerAuthKey", *deployerId, *revVaultkeyCh) |
           for (@(true, vault) <- vaultCh; key <- revVaultkeyCh) {
 
             stdout!(("Beginning transfer of ", amount, "REV from", from, "to", to)) |

--- a/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/build/CompiledRholangSource.scala
@@ -1,5 +1,4 @@
 package coop.rchain.rholang.build
-import coop.rchain.crypto.PublicKey
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.{NormalizerEnv, ParBuilder}
 import monix.eval.Coeval
@@ -10,11 +9,12 @@ trait CompiledRholangSource {
   val path: String
   val term: Par
   val code: String
+  val normalizerEnv: NormalizerEnv
 }
 
 object CompiledRholangSource {
 
-  def apply(classpath: String, normalizerEnv: NormalizerEnv): CompiledRholangSource =
+  def apply(classpath: String, env: NormalizerEnv): CompiledRholangSource =
     new CompiledRholangSource {
       override val path: String = classpath
       override val code: String = {
@@ -25,7 +25,8 @@ object CompiledRholangSource {
          #""".stripMargin('#')
       }
       override val term: Par =
-        ParBuilder[Coeval].buildNormalizedTerm(code, normalizerEnv).value()
+        ParBuilder[Coeval].buildNormalizedTerm(code, env).value()
+      override val normalizerEnv: NormalizerEnv = env
     }
 }
 
@@ -38,7 +39,7 @@ object CompiledRholangSource {
   */
 abstract class CompiledRholangTemplate(
     classpath: String,
-    normalizerEnv: NormalizerEnv,
+    normalizerEnv0: NormalizerEnv,
     env: (String, Any)*
 ) extends CompiledRholangSource {
 
@@ -54,5 +55,6 @@ abstract class CompiledRholangTemplate(
         #$finalContent
         #""".stripMargin('#')
 
-  override val term: Par = ParBuilder[Coeval].buildNormalizedTerm(code, normalizerEnv).value()
+  override val term: Par                    = ParBuilder[Coeval].buildNormalizedTerm(code, normalizerEnv0).value()
+  override val normalizerEnv: NormalizerEnv = normalizerEnv0
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -2,7 +2,8 @@ package coop.rchain.rholang.interpreter
 import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.GUnforgeable.UnfInstance.GDeployerIdBody
-import coop.rchain.models.{ETuple, Expr, GUnforgeable, Par}
+import coop.rchain.models.{ETuple, Expr, GDeployerId, GUnforgeable, Par}
+import coop.rchain.shared.ByteStringOps._
 
 object RhoType {
   import coop.rchain.models.rholang.implicits._
@@ -62,12 +63,12 @@ object RhoType {
     def apply(s: String): Par = GUri(s)
   }
 
-  object GDeployerId {
+  object DeployerId {
     def unapply(p: Par): Option[Array[Byte]] =
       p.singleUnforgeable().collect {
         case GUnforgeable(GDeployerIdBody(id)) => id.publicKey.toByteArray
       }
 
-    def apply(bytes: Array[Byte]): Par = GDeployerId(bytes)
+    def apply(bytes: Array[Byte]): Par = GDeployerId(bytes.toByteString)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -1,7 +1,8 @@
 package coop.rchain.rholang.interpreter
 import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.{ETuple, Expr, Par}
+import coop.rchain.models.GUnforgeable.UnfInstance.GDeployerIdBody
+import coop.rchain.models.{ETuple, Expr, GUnforgeable, Par}
 
 object RhoType {
   import coop.rchain.models.rholang.implicits._
@@ -59,5 +60,14 @@ object RhoType {
       }
 
     def apply(s: String): Par = GUri(s)
+  }
+
+  object GDeployerId {
+    def unapply(p: Par): Option[Array[Byte]] =
+      p.singleUnforgeable().collect {
+        case GUnforgeable(GDeployerIdBody(id)) => id.publicKey.toByteArray
+      }
+
+    def apply(bytes: Array[Byte]): Par = GDeployerId(bytes)
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -120,6 +120,7 @@ object Runtime {
     val GET_BLOCK_DATA: Long               = 23L
     val GET_INVALID_BLOCKS: Long           = 24L
     val REV_ADDRESS: Long                  = 25L
+    val DEPLOYER_ID_OPS: Long              = 26L
   }
 
   def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
@@ -141,6 +142,7 @@ object Runtime {
     val GET_BLOCK_DATA: Par     = byteName(13)
     val GET_INVALID_BLOCKS: Par = byteName(14)
     val REV_ADDRESS: Par        = byteName(15)
+    val DEPLOYER_ID_OPS: Par    = byteName(16)
   }
 
   private def introduceSystemProcesses[F[_]: Sync: _cost](
@@ -265,6 +267,14 @@ object Runtime {
       3,
       BodyRefs.REV_ADDRESS, { ctx =>
         ctx.systemProcesses.validateRevAddress
+      }
+    ),
+    SystemProcess.Definition[F](
+      "rho:rchain:deployerId:ops",
+      FixedChannels.DEPLOYER_ID_OPS,
+      3,
+      BodyRefs.DEPLOYER_ID_OPS, { ctx =>
+        ctx.systemProcesses.deployerIdOps
       }
     )
   )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -33,6 +33,7 @@ trait SystemProcesses[F[_]] {
   def getBlockData(blockData: Ref[F, BlockData]): Contract[F]
   def invalidBlocks(invalidBlocks: InvalidBlocks[F]): Contract[F]
   def validateRevAddress: Contract[F]
+  def deployerIdOps: Contract[F]
 }
 
 object SystemProcesses {
@@ -169,6 +170,14 @@ object SystemProcesses {
               .getOrElse(Par())
 
           produce(Seq(response), ack)
+      }
+
+      def deployerIdOps: Contract[F] = {
+        case isContractCall(
+            produce,
+            Seq(RhoType.String("pubKeyBytes"), RhoType.GDeployerId(publicKey), ack)
+            ) =>
+          produce(Seq(RhoType.ByteArray(publicKey)), ack)
       }
 
       def secp256k1Verify: Contract[F] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -161,7 +161,7 @@ object SystemProcesses {
 
         case isContractCall(
             produce,
-            Seq(RhoType.String("fromDeployerId"), RhoType.GDeployerId(publicKey), ack)
+            Seq(RhoType.String("fromDeployerId"), RhoType.DeployerId(publicKey), ack)
             ) =>
           val response =
             RevAddress
@@ -175,7 +175,7 @@ object SystemProcesses {
       def deployerIdOps: Contract[F] = {
         case isContractCall(
             produce,
-            Seq(RhoType.String("pubKeyBytes"), RhoType.GDeployerId(publicKey), ack)
+            Seq(RhoType.String("pubKeyBytes"), RhoType.DeployerId(publicKey), ack)
             ) =>
           produce(Seq(RhoType.ByteArray(publicKey)), ack)
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -158,18 +158,6 @@ object SystemProcesses {
               .getOrElse(Par())
 
           produce(Seq(response), ack)
-
-        case isContractCall(
-            produce,
-            Seq(RhoType.String("fromDeployerId"), RhoType.DeployerId(publicKey), ack)
-            ) =>
-          val response =
-            RevAddress
-              .fromPublicKey(PublicKey(publicKey))
-              .map(ra => RhoType.String(ra.toBase58))
-              .getOrElse(Par())
-
-          produce(Seq(response), ack)
       }
 
       def deployerIdOps: Contract[F] = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -157,6 +157,18 @@ object SystemProcesses {
               .getOrElse(Par())
 
           produce(Seq(response), ack)
+
+        case isContractCall(
+            produce,
+            Seq(RhoType.String("fromDeployerId"), RhoType.GDeployerId(publicKey), ack)
+            ) =>
+          val response =
+            RevAddress
+              .fromPublicKey(PublicKey(publicKey))
+              .map(ra => RhoType.String(ra.toBase58))
+              .getOrElse(Par())
+
+          produce(Seq(response), ack)
       }
 
       def secp256k1Verify: Contract[F] =


### PR DESCRIPTION
## Overview
Not removing the old version of `deployerAuthKey` yet since it is still needed for the PoS contract and removing it from the PoS contract is another ticket.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3424



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
