### PR TITLE
RCHAIN-3530 drop if message notneeded

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -54,7 +54,9 @@ object GrpcTransportReceiver {
           import StreamHandler._
           import StreamError.StreamErrorToMessage
 
-          val circuitBreaker: StreamHandler.CircuitBreaker = _ > maxStreamMessageSize
+          val circuitBreaker: StreamHandler.CircuitBreaker = {
+            case streamed => streamed.readSoFar > maxStreamMessageSize
+          }
 
           (handleStream(networkId, tempFolder, observable, circuitBreaker) >>= {
             case Left(error @ StreamError.Unexpected(t)) => logger.error(error.message, t)

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -56,7 +56,7 @@ object GrpcTransportReceiver {
 
           val circuitBreaker: StreamHandler.CircuitBreaker = {
             case streamed =>
-              streamed.networkId.map(_ != networkId).getOrElse(false) ||
+              streamed.header.map(_.networkId != networkId).getOrElse(false) ||
                 streamed.readSoFar > maxStreamMessageSize
           }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -1,6 +1,6 @@
 package coop.rchain.comm.transport
 
-import coop.rchain.comm.protocol.routing._
+import coop.rchain.comm.protocol.routing.{Header => RHeader, _}
 import coop.rchain.comm.protocol.routing.TLResponse.Payload
 import coop.rchain.crypto.util.CertificateHelper
 import coop.rchain.shared.{Log, LogSource}
@@ -53,7 +53,7 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.NoResponse(NoResponse(Some(Header(Some(sender), nid))))) =>
+        case TLResponse(Payload.NoResponse(NoResponse(Some(RHeader(Some(sender), nid))))) =>
           if (nid == networkID) {
             val sslSession: Option[SSLSession] = Option(
               self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -1,6 +1,6 @@
 package coop.rchain.comm.transport
 
-import coop.rchain.comm.protocol.routing._
+import coop.rchain.comm.protocol.routing.{Header => RHeader, _}
 import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.crypto.util.CertificateHelper
 import coop.rchain.shared.{Log, LogSource}
@@ -40,7 +40,7 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
 
     override def onMessage(message: ReqT): Unit =
       message match {
-        case TLRequest(Some(Protocol(Some(Header(Some(sender), nid)), msg))) =>
+        case TLRequest(Some(Protocol(Some(RHeader(Some(sender), nid)), msg))) =>
           if (nid == networkID) {
             if (log.isTraceEnabled) {
               val peerNode = ProtocolHelper.toPeerNode(sender)

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -53,19 +53,19 @@ object StreamHandler {
     type StreamErr[A] = Either[StreamError, A]
 
     case object WrongNetworkId                        extends StreamError
-    case object CircuitBroken                         extends StreamError // TODO rename to MaxSizeReached
+    case object MaxSizeReached                        extends StreamError
     final case class NotFullMessage(streamed: String) extends StreamError
     final case class Unexpected(error: Throwable)     extends StreamError
 
     val wrongNetworkId: StreamError                   = WrongNetworkId
-    val circuitBroken: StreamError                    = CircuitBroken
+    val circuitBroken: StreamError                    = MaxSizeReached
     def notFullMessage(streamed: String): StreamError = NotFullMessage(streamed)
     def unexpected(error: Throwable): StreamError     = Unexpected(error)
 
     def errorMessage(error: StreamError): String =
       error match {
         case WrongNetworkId => "Could not receive stream! Wrong network id."
-        case CircuitBroken  => "Could not receive stream! Circuit was broken."
+        case MaxSizeReached => "Max message size was reached."
         case NotFullMessage(streamed) =>
           s"Received not full stream message, will not process. $streamed"
         case Unexpected(t) => s"Could not receive stream! ${t.getMessage}"

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -83,7 +83,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
     it("should stop receiving a stream if will not fit in memory") {
       // given
       val messageSize                     = 10 * 1024
-      val breakOnSndChunk: CircuitBreaker = read => read > messageSize
+      val breakOnSndChunk: CircuitBreaker = streamed => streamed.readSoFar > messageSize
       val stream                          = createStream(messageSize = messageSize)
       // when
       val err: StreamHandler.StreamError = handleStreamErr(stream, circuitBreaker = breakOnSndChunk)

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -83,7 +83,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
     it("should stop receiving a stream if circuit broken") {
       // given
       val breakOnSndChunk: CircuitBreaker =
-        streamed => Broken(StreamHandler.StreamError.circuitBroken)
+        streamed => Opened(StreamHandler.StreamError.circuitOpened)
       val stream = createStream()
       // when
       val err: StreamHandler.StreamError = handleStreamErr(stream, circuitBreaker = breakOnSndChunk)

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -150,7 +150,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
 
   private def handleStream(stream: Observable[Chunk], folder: Path = tempFolder): StreamMessage =
     StreamHandler
-      .handleStream(networkId, folder, stream, circuitBreaker = neverBreak)
+      .handleStream(folder, stream, circuitBreaker = neverBreak)
       .unsafeRunSync
       .right
       .get
@@ -161,7 +161,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
       circuitBreaker: StreamHandler.CircuitBreaker = neverBreak
   ): StreamHandler.StreamError =
     StreamHandler
-      .handleStream(networkId, folder, stream, circuitBreaker = circuitBreaker)
+      .handleStream(folder, stream, circuitBreaker = circuitBreaker)
       .unsafeRunSync
       .left
       .get

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -89,7 +89,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
       val err: StreamHandler.StreamError = handleStreamErr(stream, circuitBreaker = breakOnSndChunk)
       // then
       inside(err) {
-        case StreamHandler.StreamError.CircuitBroken => ()
+        case StreamHandler.StreamError.MaxSizeReached => ()
       }
       tempFolder.toFile.list() should be(empty)
     }

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -110,7 +110,7 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside with BeforeAnd
       val err: StreamHandler.StreamError = handleStreamErr(streamWithIncompleteHeader)
       // then
       inside(err) {
-        case StreamHandler.StreamError.NotFullMessage(_) =>
+        case StreamHandler.StreamError.CircuitBroken =>
       }
       tempFolder.toFile.list() should be(empty)
     }


### PR DESCRIPTION
## Overview
We are dropping changes that we were hoping to provide with RCHAIN-3530 and will apply ideas that were discussed on two last sprints (RCHAIN-3582), but the refactorings I did for RCHAIN-3530 are still worth having in dev.

In this PR we are modifing the `CircuitBreaker`. Instead of returning `Boolean` it returns ADT `Closed` or `Open(error)`. This way all functionality that was breaking streams before was now moved to the `CircuitBreaker`. 
Additional some classes were extracted (like `Header`) and few other minor improvements


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3530
