### PR TITLE
Fix RCHAIN-3575

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -1204,7 +1204,7 @@ object BlockDagFileStorage {
       _                      <- writeToFile[F](config.latestMessagesLogPath, latestMessagesData)
       _                      <- writeToFile[F](config.latestMessagesCrcPath, latestMessagesCrcBytes)
       blockMetadataCrc       = Crc32.empty[F]()
-      genesisByteString      = genesis.toByteString
+      genesisByteString      = BlockMetadata.fromBlock(genesis, invalid = false).toByteString
       genesisData            = genesisByteString.size.toByteString.concat(genesisByteString).toByteArray
       _                      <- blockMetadataCrc.update(genesisData)
       blockMetadataCrcBytes  <- blockMetadataCrc.bytes

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperRestartSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperRestartSpec.scala
@@ -1,0 +1,70 @@
+package coop.rchain.casper
+
+import java.nio.file.{Files, Path}
+
+import cats.effect._
+import coop.rchain.casper.helper.BlockDagStorageTestFixture
+import coop.rchain.casper.helper.HashSetCasperTestNode
+import coop.rchain.casper.helper.HashSetCasperTestNode.{Effect, _}
+import coop.rchain.casper.scalatestcontrib._
+import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.PathOps.RichPath
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
+
+class MultiParentCasperRestartSpec extends FlatSpec with Matchers with Inspectors {
+
+  import BlockDagStorageTestFixture._
+  import MultiParentCasperTestUtil._
+
+  implicit val timeEff: LogicalTime[Effect] = new LogicalTime[Effect]
+
+  private val (validatorKey, validatorPk) = Secp256k1.newKeyPair
+  private val genesis = buildGenesis(
+    buildGenesisParameters(1, createBonds(Seq(validatorPk)))
+  )
+
+  "MultiParentCasper" should "load block data after restart" in effectTest {
+    createDirectories[Effect].use {
+      case (blockStoreDir, blockDagDir) =>
+        Resource
+          .make[Effect, Path](
+            Sync[Effect].delay {
+              Files.createTempDirectory(s"casper-restart-spec-storage-")
+            }
+          )(dir => Sync[Effect].delay { dir.recursivelyDelete() })
+          .use { storageDir =>
+            def startAndCreateBlock(restart: Boolean) =
+              HashSetCasperTestNode
+                .standaloneEffFromDirs(
+                  genesis,
+                  blockStoreDir,
+                  blockDagDir,
+                  storageDir,
+                  validatorKey,
+                  createEmptyDagStorage = !restart
+                )
+                .use { node =>
+                  for {
+                    deployData    <- ConstructDeploy.basicDeployData[Effect](1)
+                    block         <- node.addBlock(deployData)
+                    dagRepr       <- node.blockDagStorage.getRepresentation
+                    invalidBlocks <- dagRepr.invalidBlocks
+                    _             = invalidBlocks shouldBe empty
+                  } yield (block)
+                }
+
+            for {
+              block1     <- startAndCreateBlock(restart = false)
+              blockHash1 = PrettyPrinter.buildStringNoLimit(block1.blockHash)
+              block2     <- startAndCreateBlock(restart = true)
+              block2parentHashes = ProtoUtil
+                .parentHashes(block2)
+                .map(PrettyPrinter.buildStringNoLimit)
+            } yield (block2parentHashes should contain only (blockHash1))
+          }
+    }
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -180,8 +180,10 @@ object HashSetCasperTestNode {
       sk: PrivateKey,
       blockDagDir: Path,
       blockStoreDir: Path,
+      storageDir: Path,
       storageSize: Long,
-      createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]]
+      createRuntime: (Path, Long) => Resource[F, RuntimeManager[F]],
+      createEmptyDagStorage: Boolean = true
   )(
       implicit concurrentF: Concurrent[F],
       testNetworkF: TestNetwork[F]
@@ -198,32 +200,35 @@ object HashSetCasperTestNode {
       blockStore <- Resource.make[F, BlockStore[F]](
                      FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
                    )(_.close())
+      config = BlockDagFileStorage.Config(
+        blockDagDir.resolve("latest-messages-data"),
+        blockDagDir.resolve("latest-messages-crc"),
+        blockDagDir.resolve("block-metadata-data"),
+        blockDagDir.resolve("block-metadata-crc"),
+        blockDagDir.resolve("equivocations-tracker-data"),
+        blockDagDir.resolve("equivocations-tracker-crc"),
+        blockDagDir.resolve("invalid-blocks-data"),
+        blockDagDir.resolve("invalid-blocks-crc"),
+        blockDagDir.resolve("checkpoints"),
+        blockDagDir.resolve("block-number-index"),
+        mapSize
+      )
       blockDagStorage <- Resource.make[F, BlockDagStorage[F]](
-                          BlockDagFileStorage
-                            .createEmptyFromGenesis[F](
-                              BlockDagFileStorage.Config(
-                                blockDagDir.resolve("latest-messages-data"),
-                                blockDagDir.resolve("latest-messages-crc"),
-                                blockDagDir.resolve("block-metadata-data"),
-                                blockDagDir.resolve("block-metadata-crc"),
-                                blockDagDir.resolve("equivocations-tracker-data"),
-                                blockDagDir.resolve("equivocations-tracker-crc"),
-                                blockDagDir.resolve("invalid-blocks-data"),
-                                blockDagDir.resolve("invalid-blocks-crc"),
-                                blockDagDir.resolve("checkpoints"),
-                                blockDagDir.resolve("block-number-index"),
-                                mapSize
-                              ),
-                              genesis
-                            )(Concurrent[F], Sync[F], Log[F])
+                          (if (createEmptyDagStorage)
+                             BlockDagFileStorage
+                               .createEmptyFromGenesis[F](
+                                 config,
+                                 genesis
+                               )(Concurrent[F], Sync[F], Log[F])
+                           else
+                             BlockDagFileStorage
+                               .create[F](
+                                 config
+                               ))
                             .widen[BlockDagStorage[F]]
                         )(_.close())
-      storageDirectory <- Resource.make[F, Path](
-                           Sync[F].delay {
-                             Files.createTempDirectory(s"hash-set-casper-test-$name")
-                           }
-                         )(dir => Sync[F].delay { dir.recursivelyDelete() })
-      runtimeManager <- createRuntime(storageDirectory, storageSize)
+
+      runtimeManager <- createRuntime(storageDir, storageSize)
       node <- Resource.make[F, HashSetCasperTestNode[F]] {
                for {
                  _                   <- TestNetwork.addPeer(identity)
@@ -254,6 +259,33 @@ object HashSetCasperTestNode {
              }(_ => ().pure[F])
     } yield node
   }
+
+  def standaloneEffFromDirs(
+      genesis: BlockMessage,
+      blockStoreDir: Path,
+      blockDagDir: Path,
+      storageDir: Path,
+      sk: PrivateKey,
+      createEmptyDagStorage: Boolean,
+      storageSize: Long = 1024L * 1024 * 10,
+      testNetwork: TestNetwork[Effect] = TestNetwork.empty
+  )(
+      implicit scheduler: Scheduler
+  ): Resource[Effect, HashSetCasperTestNode[Effect]] =
+    standaloneF[Effect](
+      genesis,
+      sk,
+      blockDagDir,
+      blockStoreDir,
+      storageDir,
+      storageSize,
+      createRuntime,
+      createEmptyDagStorage
+    )(
+      Concurrent[Effect],
+      testNetwork
+    )
+
   def standaloneEff(
       genesis: BlockMessage,
       sk: PrivateKey,
@@ -264,17 +296,25 @@ object HashSetCasperTestNode {
   ): Resource[Effect, HashSetCasperTestNode[Effect]] =
     BlockDagStorageTestFixture.createDirectories[Effect].flatMap {
       case (blockStoreDir, blockDagDir) =>
-        standaloneF[Effect](
-          genesis,
-          sk,
-          blockDagDir,
-          blockStoreDir,
-          storageSize,
-          createRuntime
-        )(
-          Concurrent[Effect],
-          testNetwork
-        )
+        for {
+          storageDir <- Resource.make[Effect, Path](
+                         Sync[Effect].delay {
+                           Files.createTempDirectory(s"hash-set-casper-test-")
+                         }
+                       )(dir => Sync[Effect].delay { dir.recursivelyDelete() })
+          res <- standaloneF[Effect](
+                  genesis,
+                  sk,
+                  blockDagDir,
+                  blockStoreDir,
+                  storageDir,
+                  storageSize,
+                  createRuntime
+                )(
+                  Concurrent[Effect],
+                  testNetwork
+                )
+        } yield res
     }
 
   def networkF[F[_]](
@@ -392,6 +432,7 @@ object HashSetCasperTestNode {
       )
     }
   }
+
   def networkEff(
       sks: IndexedSeq[PrivateKey],
       genesis: BlockMessage,


### PR DESCRIPTION
## Overview
Makes sure that after restarting Casper can see the blocks it created before it was brought down


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3575

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
