### PR TITLE
Rchain 3464: distribute rewards at closeBlock

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -26,7 +26,6 @@ new  PoS,
     getUser,
     getCurrentUserAddress,
     getCurrentUserVault,
-    initialRewardsCh, computeInitialRewards,
     getMVar,
     runMVar,
     deposit, distributeRewards,
@@ -43,20 +42,14 @@ new  PoS,
       for(@posRevAddress <- posRevAddressCh) {
         new stateCh, posVaultCh in {
 
-          @ListOps!("fold", $$initialBonds$$.toList(), {}, *computeInitialRewards, *initialRewardsCh) |
-          contract computeInitialRewards(@(pk, _), @acc, resultCh) = {
-            resultCh!(acc.set(pk, 0))
-          } |
-
           @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
-          for (@(true, _) <- posVaultCh;
-               @initialRewards <- initialRewardsCh ) {
+          for (@(true, _) <- posVaultCh ) {
 
             // State structure:
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
             // bonds : Map[PublickKey, Int] - each validator stake
-            stateCh!(({}, initialRewards, $$initialBonds$$)) |
+            stateCh!(({}, {}, $$initialBonds$$)) |
 
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
@@ -99,7 +92,7 @@ new  PoS,
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (pending, rewards.set(userPk, 0), bonds.set(userPk,amount)),
+                            (pending, rewards, bonds.set(userPk,amount)),
                             depositResult
                           )
                         }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -67,6 +67,10 @@ new  PoS,
               }
             } |
 
+            /**
+             * Returns a Map[PublidKey, Int] containing the rewards accumulated for each validator.
+             * The returned map contains only the committed rewards after the last closeBlock
+             */
             contract PoS (@"getRewards", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
@@ -113,21 +117,18 @@ new  PoS,
             contract PoS (@"pay", @amount, returnCh) = {
               new vaultCh, transferCh, userCh, processPayCh,
                   depositCh,
-                  computeSum, totalStakeCh,
-                  computeDelta, rewardsDeltaCh,
-                  computeMergeMap, newRewardsCh in {
+                  newPendingCh in {
                 getUser!(*userCh) |
-
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
                 for(@(pending, rewards, bonds), payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
-                  distributeRewards!(amount, bonds, rewards, *newRewardsCh) |
+                  distributeRewards!(amount, bonds, pending, *newPendingCh) |
 
                   for(@depositResult <- depositCh;
-                      @newRewards <- newRewardsCh) {
-                    payResultCh!((pending, newRewards, bonds), depositResult)
+                      @newPending <- newPendingCh) {
+                    payResultCh!((newPending, rewards, bonds), depositResult)
                   }
                 }
               }
@@ -154,15 +155,30 @@ new  PoS,
             } |
 
             contract PoS(@"closeBlock", ackCh) = {
-              new blockDataCh,
+              new blockDataCh, mvarProcessCh,
                   getBlockData(`rho:block:data`),
-                  stdout(`rho:io:stdout`) in {
+                  commitReward, rewardsCh in {
                 getBlockData!(*blockDataCh) |
-                for (_, @blockNumber <- blockDataCh) {
+
+                runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
+                for(_, @blockNumber <- blockDataCh;
+                    @(pendingRewards, rewards, bonds), mvarResultCh <- mvarProcessCh) {
+
                   if (blockNumber % 1000 == 0) {
-                    stdout!("TODO: a validator change should happen")
+                    new stdout(`rho:io:stdout`) in {
+                      stdout!("TODO: a validator change should happen")
+                    }
                   } |
-                  ackCh!(Nil)
+
+
+                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *rewardsCh) |
+                  contract commitReward(@(pk, pending), @acc, resultCh) = {
+                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                  } |
+
+                  for (@rewards <- rewardsCh) {
+                    mvarResultCh!(({}, rewards, bonds), Nil)
+                  }
                 }
               }
             }
@@ -203,9 +219,10 @@ new  PoS,
             } |
 
             for (@rewardsDelta <- rewardsDeltaCh) {
+
               @ListOps!("fold", rewardsDelta.toList(), originalRewards, *computeMergeMap, *returnCh) |
-              contract computeMergeMap(@(pk, rewardDelta), @newRewards, resultCh) = {
-                resultCh!(newRewards.set(pk, newRewards.get(pk) + rewardDelta))
+              contract computeMergeMap(@(pk, rewardDelta), @acc, resultCh) = {
+                resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + rewardDelta))
               }
             }
           }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -52,11 +52,16 @@ new  PoS,
           for (@(true, _) <- posVaultCh;
                @initialRewards <- initialRewardsCh ) {
 
-            stateCh!((initialRewards, $$initialBonds$$)) |
+            // State structure:
+            // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
+            // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
+            // bonds : Map[PublickKey, Int] - each validator stake
+            stateCh!(({}, initialRewards, $$initialBonds$$)) |
+
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, bonds) <- tmpCh) {
+                for (@(_, _, bonds) <- tmpCh) {
                   returnCh!(bonds)
                 }
               }
@@ -65,7 +70,7 @@ new  PoS,
             contract PoS (@"getRewards", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(rewards, _) <- tmpCh) {
+                for (@(_, rewards, _) <- tmpCh) {
                   returnCh!(rewards)
                 }
               }
@@ -76,27 +81,27 @@ new  PoS,
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
                 getUser!(*userCh) |
-                for(@(rewards, bonds), resultCh <- processCh;
+                for(@(pending, rewards, bonds), resultCh <- processCh;
                     @userPk <- userCh) {
                   if (bonds.contains(userPk)) {
-                    resultCh!((rewards, bonds), (false, "Public key is already bonded."))
+                    resultCh!((pending, rewards, bonds), (false, "Public key is already bonded."))
                   } else if (amount < $$minimumBond$$) {
-                    resultCh!((rewards, bonds), (false, "Bond is less than minimum!"))
+                    resultCh!((pending, rewards, bonds), (false, "Bond is less than minimum!"))
                   } else if (amount > $$maximumBond$$) {
-                    resultCh!((rewards, bonds), (false, "Bond is greater than maximum!"))
+                    resultCh!((pending, rewards, bonds), (false, "Bond is greater than maximum!"))
                   } else {
                     deposit!(userPk, amount, *depositCh) |
                     for(@depositResult <- depositCh) {
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (rewards.set(userPk, 0), bonds.set(userPk,amount)),
+                            (pending, rewards.set(userPk, 0), bonds.set(userPk,amount)),
                             depositResult
                           )
                         }
 
                         (false, errorMsg) => {
-                          resultCh!((rewards, bonds), (false, "Bond deposit failed: " ++ errorMsg))
+                          resultCh!((pending, rewards, bonds), (false, "Bond deposit failed: " ++ errorMsg))
                         }
                       }
                     }
@@ -114,7 +119,7 @@ new  PoS,
                 getUser!(*userCh) |
 
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
-                for(@(rewards, bonds), payResultCh <- processPayCh;
+                for(@(pending, rewards, bonds), payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
@@ -122,7 +127,7 @@ new  PoS,
 
                   for(@depositResult <- depositCh;
                       @newRewards <- newRewardsCh) {
-                    payResultCh!((newRewards, bonds), depositResult)
+                    payResultCh!((pending, newRewards, bonds), depositResult)
                   }
                 }
               }
@@ -133,12 +138,14 @@ new  PoS,
                   getInvalidBlocks(`rho:casper:invalidBlocks`) in {
                 getInvalidBlocks!(*invalidBlocksCh) |
                 getUser!(*userCh) |
-                for (@invalidBlocks <- invalidBlocksCh; @(rewards, bonds) <- stateCh; @userPk <- userCh) {
+                for (@invalidBlocks <- invalidBlocksCh; @(pending, rewards, bonds) <- stateCh; @userPk <- userCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
                       // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
-                      stateCh!((rewards.set(validator, 0), bonds.set(validator, 0))) |
+                      stateCh!((pending.set(validator, 0),
+                                rewards.set(validator, 0),
+                                bonds.set(validator, 0))) |
                       return!(true)
                     }
                   }

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -182,48 +182,58 @@ match (
                 initialUser1BalanceCh, finalUser1BalanceCh,
                 initialRewardsCh, finalRewardsCh,
                 computeDelta, deltaRewardsCh, deltaSumCh, sumDelta,
-                isPositive, allRewardsPositiveCh in {
+                isPositive, allRewardsPositiveCh
+            in {
               prepareUser!("4444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444", 10000, *setupCh) |
-              for (@user1PubKey, _, @user1Vault <- setupCh) {
-                @posVault!("balance", *initialPosBalanceCh) |
-                @user1Vault!("balance", *initialUser1BalanceCh) |
-                @PoS!("getRewards", *initialRewardsCh) |
-                for(@initialPosBalance <- initialPosBalanceCh;
-                    @initialUser1Balance <- initialUser1BalanceCh;
-                    @initialRewards <- initialRewardsCh) {
-                  @PoS!("pay", 100, *retCh) |
-                  for ( @(true, _) <- retCh) {
+              for (@validatorPubKey, _, _ <- setupCh) {
+                @PoS!("bond", 100, *setupCh) |
+                for (@(true, _) <- setupCh) {
+                  prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", 10000, *setupCh) |
+                  for (@user1PubKey, _, @user1Vault <- setupCh) {
+                    @posVault!("balance", *initialPosBalanceCh) |
+                    @user1Vault!("balance", *initialUser1BalanceCh) |
+                    @PoS!("getRewards", *initialRewardsCh) |
+                    for(@initialPosBalance <- initialPosBalanceCh;
+                        @initialUser1Balance <- initialUser1BalanceCh;
+                        @initialRewards <- initialRewardsCh) {
+                      @PoS!("pay", 100, *retCh) |
+                      for ( @(true, _) <- retCh) {
+                        @PoS!("closeBlock", *ackCh) |
+                        for (_ <- ackCh) {
+                          @posVault!("balance", *finalPosBalanceCh) |
+                          @user1Vault!("balance", *finalUser1BalanceCh) |
+                          @PoS!("getRewards", *finalRewardsCh) |
+                          for(@finalPosBalance <- finalPosBalanceCh;
+                              @finalUser1Balance <- finalUser1BalanceCh;
+                              @finalRewards <- finalRewardsCh) {
+                            @ListOps!("fold", finalRewards.toList(), {}, *computeDelta, *deltaRewardsCh) |
+                            contract computeDelta(@(pk, finalReward), @acc, resultCh) = {
+                              resultCh!(acc.set(pk, finalReward - initialRewards.get(pk)))
+                            } |
+                            for (@deltaRewards <- deltaRewardsCh) {
+                              @ListOps!("forall", deltaRewards, *isPositive, *allRewardsPositiveCh) |
+                              contract isPositive(@n, resultCh) = { resultCh!(n > 0)} |
 
-                    @posVault!("balance", *finalPosBalanceCh) |
-                    @user1Vault!("balance", *finalUser1BalanceCh) |
-                    @PoS!("getRewards", *finalRewardsCh) |
-                    for(@finalPosBalance <- finalPosBalanceCh;
-                        @finalUser1Balance <- finalUser1BalanceCh;
-                        @finalRewards <- finalRewardsCh) {
-                      @ListOps!("fold", finalRewards.toList(), {}, *computeDelta, *deltaRewardsCh) |
-                      contract computeDelta(@(pk, finalReward), @acc, resultCh) = {
-                        resultCh!(acc.set(pk, finalReward - initialRewards.get(pk)))
-                      } |
-                      for (@deltaRewards <- deltaRewardsCh) {
-                        @ListOps!("forall", deltaRewards, *isPositive, *allRewardsPositiveCh) |
-                        contract isPositive(@n, resultCh) = { resultCh!(n > 0)} |
+                              @ListOps!("fold", deltaRewards.toList(), 0, *sumDelta, *deltaSumCh) |
+                              contract sumDelta(@(_, delta), @acc, resultCh) = {
+                                resultCh!(acc + delta)
+                              } |
 
-                        @ListOps!("fold", deltaRewards.toList(), 0, *sumDelta, *deltaSumCh) |
-                        contract sumDelta(@(_, delta), @acc, resultCh) = {
-                          resultCh!(acc + delta)
-                        } |
-
-                        rhoSpec!("assertMany",
-                          [
-                            ((initialUser1Balance - finalUser1Balance, "==", 100), "the user account decreases"),
-                            ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
-                            ((finalRewards.size(), "==", initialRewards.size()), "rewards map size doesn't change"),
-                            //TODO use arbitrary precision numbers instead of long ints
-                            ((98, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
-                            ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")
-                          ],
-                          *ackCh
-                        )
+                              rhoSpec!("assertMany",
+                                [
+                                  ((initialUser1Balance - finalUser1Balance, "==", 100), "the user account decreases"),
+                                  ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
+                                  ((finalRewards.get(validatorPubKey), "==", 19), "the validator's finalRewards is as expected"),
+                                  ((finalRewards.size(), "==", initialRewards.size()), "rewards map size doesn't change"),
+                                  //TODO use arbitrary precision numbers instead of long ints
+                                  ((96, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
+                                  ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")
+                                ],
+                                *ackCh
+                              )
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -233,17 +243,17 @@ match (
           } |
 
           contract test_bonding_fails_if_deposit_fails(rhoSpec, _, ackCh) = {
-            test_bonding_failure!(*rhoSpec, "5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", 10000, 20000, "Bond deposit failed: Insufficient funds", *ackCh)
+            test_bonding_failure!(*rhoSpec, "6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666", 10000, 20000, "Bond deposit failed: Insufficient funds", *ackCh)
           } |
 
           contract test_bonding_fails_if_bond_too_small(rhoSpec, _, ackCh) = {
-            test_bonding_failure!(*rhoSpec, "6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666", 10000, -1, "Bond is less than minimum!", *ackCh)
+            test_bonding_failure!(*rhoSpec, "7777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777", 10000, -1, "Bond is less than minimum!", *ackCh)
           } |
 
           contract test_bonding_fails_if_already_bonded(rhoSpec, _, ackCh) = {
             new setupCh, initialBondsCh, bond1Ch, bond2Ch, bondsCh,
                 finalRewardsCh, initialRewardsCh in {
-              prepareUser!("7777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777", 10000, *setupCh) |
+              prepareUser!("8888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888", 10000, *setupCh) |
               for (@user1PubKey, _, _ <- setupCh) {
                 @PoS!("bond", 150, *bond1Ch) |
                 for ( @(result1, _) <- bond1Ch) {

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -76,7 +76,7 @@ match (
                 rhoSpec!("assertMany",
                   [
                     (bonds.size() >= 0, "some bonds map should be received"),
-                    ((bonds.size(), "==", rewards.size()), "each validator should have a bond and a reward"),
+                    ((0, "==", rewards.size()), "the rewards map is initially empty"),
                     ((true, "== <-", *rewardsZeroCh), "no rewards yet")
                   ],
                   *ackCh
@@ -112,7 +112,7 @@ match (
                               ((100, "==", bondAmount), "the new bond is expected in the final map"),
                               ((initialUserBalance - finalUserBalance, "==", 100), "the user account decreases"),
                               ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
-                              ((rewards.get(user1PubKey), "==", 0), "new validator reward should be zero")
+                              ((Nil, "==", rewards.get(user1PubKey)), "new validator reward should be zero")
                             ],
                             *ackCh
                           )
@@ -208,7 +208,7 @@ match (
                               @finalRewards <- finalRewardsCh) {
                             @ListOps!("fold", finalRewards.toList(), {}, *computeDelta, *deltaRewardsCh) |
                             contract computeDelta(@(pk, finalReward), @acc, resultCh) = {
-                              resultCh!(acc.set(pk, finalReward - initialRewards.get(pk)))
+                              resultCh!(acc.set(pk, finalReward - initialRewards.getOrElse(pk, 0)))
                             } |
                             for (@deltaRewards <- deltaRewardsCh) {
                               @ListOps!("forall", deltaRewards, *isPositive, *allRewardsPositiveCh) |
@@ -224,7 +224,6 @@ match (
                                   ((initialUser1Balance - finalUser1Balance, "==", 100), "the user account decreases"),
                                   ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
                                   ((finalRewards.get(validatorPubKey), "==", 19), "the validator's finalRewards is as expected"),
-                                  ((finalRewards.size(), "==", initialRewards.size()), "rewards map size doesn't change"),
                                   //TODO use arbitrary precision numbers instead of long ints
                                   ((96, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
                                   ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")


### PR DESCRIPTION
## Overview
With this PR the rewards are kept in a separate data structure. Only when the block is closed they are moved to the rewards map and become visible from the outside



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3464



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
