### PR TITLE
Metric: received, enqueued or dropped messages

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -13,6 +13,7 @@ import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.transport.buffer.LimitedBuffer
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared._
+import coop.rchain.shared.PathOps.PathDelete
 
 import io.grpc.netty.NettyServerBuilder
 import io.netty.handler.ssl.SslContext
@@ -85,7 +86,8 @@ object GrpcTransportReceiver {
                     ).sequence,
                     List(
                       logger.debug(s"Dropped packet ${msg.path}"),
-                      metrics.incrementCounter("dropped.packets")
+                      metrics.incrementCounter("dropped.packets"),
+                      msg.path.deleteSingleFile[Task]
                     ).sequence
                   )
           }).as(ChunkResponse())

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -121,7 +121,7 @@ class NodeRuntime private[node] (
                               conf.server.maxStreamMessageSize,
                               conf.server.dataDir.resolve("tmp").resolve("comm"),
                               conf.server.messageConsumers
-                            )(grpcScheduler, rPConfAsk, log)
+                            )(grpcScheduler, rPConfAsk, log, metrics)
                           )
 
       externalApiServer <- api


### PR DESCRIPTION
## Overview
Add metrics how many incoming messages/packets have been received, enqueued or dropped. Also, add a counter of how many messages/packets have been dispatched.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3579

### Notes
Bug fixed:
When a packet gets dropped because the message queue is full then delete the packet file.
