### PR TITLE
Rholang peek

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -134,7 +134,8 @@ message Receive {
     repeated ReceiveBind binds = 1;
     Par body = 2 [(scalapb.field).no_box = true];
     bool persistent = 3;
-    int32 bindCount = 4;
+    bool peek = 4;
+    int32 bindCount = 5;
     bytes locallyFree = 6 [(scalapb.field).type = "coop.rchain.models.AlwaysEqual[scala.collection.immutable.BitSet]"];
     bool connective_used = 7;
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -29,8 +29,9 @@ object ReceiveSortMatcher extends Sortable[Receive] {
   // This function will then sort the insides of the preordered binds.
   def sortMatch[F[_]: Sync](r: Receive): F[ScoredTerm[Receive]] =
     for {
-      sortedBinds         <- r.binds.toList.traverse(sortBind[F])
-      persistentScore     = if (r.persistent) 1L else 0L
+      sortedBinds     <- r.binds.toList.traverse(sortBind[F])
+      persistentScore = if (r.persistent) 1L else 0L
+      // TODO: score peek
       connectiveUsedScore = if (r.connectiveUsed) 1L else 0L
       sortedBody          <- Sortable.sortMatch(r.body)
     } yield ScoredTerm(
@@ -38,6 +39,7 @@ object ReceiveSortMatcher extends Sortable[Receive] {
         sortedBinds.map(_.term),
         sortedBody.term,
         r.persistent,
+        r.peek,
         r.bindCount,
         r.locallyFree,
         r.connectiveUsed

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ReceiveSortMatcher.scala
@@ -29,9 +29,9 @@ object ReceiveSortMatcher extends Sortable[Receive] {
   // This function will then sort the insides of the preordered binds.
   def sortMatch[F[_]: Sync](r: Receive): F[ScoredTerm[Receive]] =
     for {
-      sortedBinds     <- r.binds.toList.traverse(sortBind[F])
-      persistentScore = if (r.persistent) 1L else 0L
-      // TODO: score peek
+      sortedBinds         <- r.binds.toList.traverse(sortBind[F])
+      persistentScore     = if (r.persistent) 1L else 0L
+      peekScore           = if (r.peek) 1L else 0L
       connectiveUsedScore = if (r.connectiveUsed) 1L else 0L
       sortedBody          <- Sortable.sortMatch(r.body)
     } yield ScoredTerm(
@@ -46,7 +46,9 @@ object ReceiveSortMatcher extends Sortable[Receive] {
       ),
       Node(
         Score.RECEIVE,
-        Seq(Leaf(persistentScore)) ++ sortedBinds.map(_.score) ++ Seq(sortedBody.score)
+        Seq(Leaf(persistentScore), Leaf(peekScore)) ++ sortedBinds.map(_.score) ++ Seq(
+          sortedBody.score
+        )
           ++ Seq(Leaf(r.bindCount.toLong)) ++ Seq(Leaf(connectiveUsedScore)): _*
       )
     )

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -384,7 +384,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
     result.term should be(sortedParExpr)
   }
 
-  it should "sort Receives based on persistence, channels, patterns and then body" in {
+  it should "sort Receives based on persistence, peek, channels, patterns and then body" in {
     val parExpr =
       Par(
         receives = List(
@@ -417,6 +417,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             Par(),
             true,
             false,
+            0,
+            BitSet()
+          ),
+          Receive(
+            List(ReceiveBind(List(GInt(0)), GInt(3))),
+            Par(),
+            true,
+            true,
             0,
             BitSet()
           ),
@@ -465,7 +473,15 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             0,
             BitSet()
           ),
-          Receive(List(ReceiveBind(List(GInt(0)), GInt(3))), Par(), true, false, 0, BitSet())
+          Receive(List(ReceiveBind(List(GInt(0)), GInt(3))), Par(), true, false, 0, BitSet()),
+          Receive(
+            List(ReceiveBind(List(GInt(0)), GInt(3))),
+            Par(),
+            true,
+            true,
+            0,
+            BitSet()
+          )
         )
       )
     val result = sort(parExpr)

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -392,6 +392,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(1)), GInt(3))),
             Par(),
             false,
+            false,
             0,
             BitSet()
           ),
@@ -399,12 +400,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(0)), GInt(3))),
             EVar(BoundVar(0)),
             false,
+            false,
             0,
             BitSet()
           ),
           Receive(
             List(ReceiveBind(List(GInt(0)), GInt(3))),
             Par(),
+            false,
             false,
             0,
             BitSet()
@@ -413,12 +416,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(0)), GInt(3))),
             Par(),
             true,
+            false,
             0,
             BitSet()
           ),
           Receive(
             List(ReceiveBind(List(GInt(100)), GInt(2))),
             Par(),
+            false,
             false,
             0,
             BitSet()
@@ -432,12 +437,14 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(100)), GInt(2))),
             Par(),
             false,
+            false,
             0,
             BitSet()
           ),
           Receive(
             List(ReceiveBind(List(GInt(0)), GInt(3))),
             Par(),
+            false,
             false,
             0,
             BitSet()
@@ -446,6 +453,7 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(0)), GInt(3))),
             EVar(BoundVar(0)),
             false,
+            false,
             0,
             BitSet()
           ),
@@ -453,10 +461,11 @@ class ParSortMatcherSpec extends FlatSpec with Matchers {
             List(ReceiveBind(List(GInt(1)), GInt(3))),
             Par(),
             false,
+            false,
             0,
             BitSet()
           ),
-          Receive(List(ReceiveBind(List(GInt(0)), GInt(3))), Par(), true, 0, BitSet())
+          Receive(List(ReceiveBind(List(GInt(0)), GInt(3))), Par(), true, false, 0, BitSet())
         )
       )
     val result = sort(parExpr)

--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -92,6 +92,7 @@ BundleReadWrite. Bundle ::= "bundle"  ;
 -- Receipt
 ReceiptLinear.    Receipt ::= ReceiptLinearImpl ;
 ReceiptRepeated.  Receipt ::= ReceiptRepeatedImpl ;
+ReceiptPeek.      Receipt ::= ReceiptPeekImpl ;
 
 -- Linear Receipts
 LinearSimple. ReceiptLinearImpl ::= [LinearBind] ;
@@ -108,6 +109,12 @@ RepeatedSimple. ReceiptRepeatedImpl ::= [RepeatedBind] ;
 -- Single Repeated Bind
 RepeatedBindImpl. RepeatedBind ::= [Name] NameRemainder "<=" Name ;
 separator nonempty RepeatedBind ";" ;
+
+-- Peek Receipts
+PeekSimple. ReceiptPeekImpl ::= [PeekBind] ;
+-- Single Peek
+PeekBindImpl. PeekBind ::= [Name] NameRemainder "<<-" Name ;
+separator nonempty PeekBind ";" ;
 
 -- Types of Send:
 SendSingle.   Send ::= "!" ;

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ParBuilder.scala
@@ -19,6 +19,7 @@ trait ParBuilder[F[_]] {
   def buildNormalizedTerm(reader: Reader, normalizerEnv: NormalizerEnv): F[Par]
 
   def buildPar(proc: Proc, normalizerEnv: NormalizerEnv): F[Par]
+  private[interpreter] def buildAST(reader: Reader): F[Proc]
 }
 
 object ParBuilder {
@@ -41,7 +42,7 @@ object ParBuilder {
         sortedPar <- Sortable[Par].sortMatch(par)
       } yield sortedPar.term
 
-    private def buildAST(reader: Reader): F[Proc] =
+    private[interpreter] def buildAST(reader: Reader): F[Proc] =
       for {
         lexer  <- lexer(reader)
         parser <- parser(lexer)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -194,7 +194,7 @@ final case class PrettyPrinter(
                 )
                 .buildPattern(bind.patterns)
             (bind.freeCount + previousFree, string |+| bindString |+| pure {
-              if (r.persistent) " <= " else " <- "
+              if (r.persistent) " <= " else if (r.peek) " <<- " else " <- "
             } |+| buildChannelStringM(bind.source, indent) |+| pure {
               if (i != r.binds.length - 1) " ; "
               else ""

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -229,6 +229,7 @@ object Substitute {
             binds = bindsSub,
             body = bodySub,
             persistent = term.persistent,
+            peek = term.peek,
             bindCount = term.bindCount,
             locallyFree = term.locallyFree.until(env.shift),
             connectiveUsed = term.connectiveUsed

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -747,6 +747,7 @@ object ProcNormalizeMatcher {
               ),
               body = bodyResult.par,
               persistent = true,
+              peek = false,
               bindCount = boundCount,
               locallyFree = ParLocallyFree
                 .locallyFree(nameMatchResult.chan, input.env.depth) | formalsResults._3

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -861,7 +861,10 @@ object ProcNormalizeMatcher {
                       (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
                   }
                   .map(x => (x, false, true))
+              case default =>
+                sync.raiseError(NormalizerError(s"Unknown receipt impl type $default"))
             }
+          case default => sync.raiseError(NormalizerError(s"Unknown receipt type $default"))
         }
 
         for {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -839,7 +839,7 @@ object ProcNormalizeMatcher {
                     case lbi: LinearBindImpl =>
                       (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
                   }
-                  .map(x => (x, false))
+                  .map(x => (x, false, false))
             }
           case rl: ReceiptRepeated =>
             rl.receiptrepeatedimpl_ match {
@@ -849,13 +849,23 @@ object ProcNormalizeMatcher {
                     case lbi: RepeatedBindImpl =>
                       (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
                   }
-                  .map(x => (x, true))
+                  .map(x => (x, true, false))
+            }
+          case rl: ReceiptPeek =>
+            rl.receiptpeekimpl_ match {
+              case ls: PeekSimple =>
+                ls.listpeekbind_.toList
+                  .traverse {
+                    case lbi: PeekBindImpl =>
+                      (lbi.listname_.toList, lbi.name_, lbi.nameremainder_).pure[M]
+                  }
+                  .map(x => (x, false, true))
             }
         }
 
         for {
           res                                                              <- resM
-          (bindingsRaw, persistent)                                        = res
+          (bindingsRaw, persistent, peek)                                  = res
           sourcesP                                                         <- processSources(bindingsRaw)
           (sources, thisLevelFree, sourcesLocallyFree, sourcesConnectives) = sourcesP
           bindingsProcessed                                                <- processBindings(sources)
@@ -896,6 +906,7 @@ object ProcNormalizeMatcher {
               binds,
               bodyResult.par,
               persistent,
+              peek,
               bindCount,
               sourcesLocallyFree | bindingsFree | (bodyResult.par.locallyFree
                 .from(bindCount)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -70,7 +70,7 @@ object StoragePrinter {
           patterns: Seq[BindPattern],
           continuation: TaggedContinuation,
           persist: Boolean,
-          _: SortedSet[Int],
+          peeks: SortedSet[Int],
           _: Consume
           ) =>
         val receiveBinds: Seq[ReceiveBind] = (channels zip patterns).map {
@@ -88,6 +88,7 @@ object StoragePrinter {
               receiveBinds,
               p.body,
               persist,
+              peeks.nonEmpty,
               patterns.map(_.freeCount).sum
             )
           case _ => Receive(receiveBinds, Par.defaultInstance, persist)

--- a/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration._
 class PeekSpec extends FlatSpec with Matchers {
 
   import Resources._
+  import InterpreterUtil._
 
   implicit val logF: Log[Task]            = new Log.NOPLog[Task]
   implicit val noopMetrics: Metrics[Task] = new Metrics.MetricsNOP[Task]
@@ -28,15 +29,59 @@ class PeekSpec extends FlatSpec with Matchers {
       .use { runtime =>
         implicit val c = runtime.cost
         for {
-          res1 <- InterpreterUtil.evaluate[Task](runtime, """@1!("v1") | for(_ <<- @1) { Nil }""")
+          res1 <- evaluate[Task](runtime, """@1!("v1") | for(_ <<- @1) { Nil }""")
           _    = res1.errors shouldBe empty
-          res2 <- InterpreterUtil.evaluate[Task](runtime, """for(_ <- @1) { @2!("v2") }""")
+          res2 <- evaluate[Task](runtime, """for(_ <- @1) { @2!("v2") }""")
           _    = res2.errors shouldBe empty
           data <- runtime.space.getData(GInt(2L))
           _ = withClue(
             "Continuation didn't produce expected data. Did it fire?"
           ) { data should have size 1 }
         } yield (data.head.a.pars.head.exprs.head.exprInstance shouldBe GString("v2"))
+      }
+      .runSyncUnsafe(2.seconds)
+  }
+
+  it should "not duplicate read persistent data - send is executed first" in {
+    mkRuntime[Task](tmpPrefix)
+      .use { runtime =>
+        implicit val c = runtime.cost
+        for {
+          res1       <- evaluate[Task](runtime, """@1!!("v1")""")
+          _          = res1.errors shouldBe empty
+          res1a      <- evaluate[Task](runtime, """for(_ <<- @1) { Nil }""")
+          _          = res1a.errors shouldBe empty
+          res2       <- evaluate[Task](runtime, """for(_ <- @1) { @2!("v2") }""")
+          _          = res2.errors shouldBe empty
+          v1Data     <- runtime.space.getData(GInt(1L))
+          _          = v1Data should have size 1
+          resultData <- runtime.space.getData(GInt(2L))
+          _ = withClue(
+            "Continuation didn't produce expected data. Did it fire?"
+          ) { resultData should have size 1 }
+        } yield (resultData.head.a.pars.head.exprs.head.exprInstance shouldBe GString("v2"))
+      }
+      .runSyncUnsafe(2.seconds)
+  }
+
+  it should "not duplicate read persistent data - send is executed second" in {
+    mkRuntime[Task](tmpPrefix)
+      .use { runtime =>
+        implicit val c = runtime.cost
+        for {
+          res1       <- evaluate[Task](runtime, """for(_ <<- @1) { Nil }""")
+          _          = res1.errors shouldBe empty
+          res1a      <- evaluate[Task](runtime, """@1!!("v1")""")
+          _          = res1a.errors shouldBe empty
+          res2       <- evaluate[Task](runtime, """for(_ <- @1) { @2!("v2") }""")
+          _          = res2.errors shouldBe empty
+          v1Data     <- runtime.space.getData(GInt(1L))
+          _          = v1Data should have size 1
+          resultData <- runtime.space.getData(GInt(2L))
+          _ = withClue(
+            "Continuation didn't produce expected data. Did it fire?"
+          ) { resultData should have size 1 }
+        } yield (resultData.head.a.pars.head.exprs.head.exprInstance shouldBe GString("v2"))
       }
       .runSyncUnsafe(2.seconds)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
@@ -1,0 +1,43 @@
+package coop.rchain.rholang
+
+import org.scalatest._
+
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.shared.Log
+import coop.rchain.rholang.interpreter.{EvaluateResult, InterpreterUtil, Runtime}
+
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
+import scala.concurrent.duration._
+
+class PeekSpec extends FlatSpec with Matchers {
+
+  import Resources._
+
+  implicit val logF: Log[Task]            = new Log.NOPLog[Task]
+  implicit val noopMetrics: Metrics[Task] = new Metrics.MetricsNOP[Task]
+  implicit val noopSpan: Span[Task]       = NoopSpan[Task]()
+
+  val tmpPrefix = "peek-spec-"
+
+  "peek" should "not remove read data" in {
+    mkRuntime[Task](tmpPrefix)
+      .use { runtime =>
+        implicit val c = runtime.cost
+        for {
+          res1 <- InterpreterUtil.evaluate[Task](runtime, """@1!("v1") | for(_ <<- @1) { Nil }""")
+          _    = res1.errors shouldBe empty
+          res2 <- InterpreterUtil.evaluate[Task](runtime, """for(_ <- @1) { @2!("v2") }""")
+          _    = res2.errors shouldBe empty
+          data <- runtime.space.getData(GInt(2L))
+          _ = withClue(
+            "Continuation didn't produce expected data. Did it fire?"
+          ) { data should have size 1 }
+        } yield (data.head.a.pars.head.exprs.head.exprInstance shouldBe GString("v2"))
+      }
+      .runSyncUnsafe(2.seconds)
+  }
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -651,14 +651,10 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
   }
 
   it should "handle peek" in {
-    val basicInput = ParBuilder[Coeval]
-      .buildAST(
-        new StringReader("""for ( x, y <<- @Nil ) { x!(*y) }""")
-      )
-      .value()
-
-    val result = ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs).value
-    result.par.receives.head.peek shouldBe true
+    (for {
+      basicInput <- ParBuilderUtil.buildAST[Coeval]("""for ( x, y <<- @Nil ) { x!(*y) }""")
+      result     <- ProcNormalizeMatcher.normalizeMatch[Coeval](basicInput, inputs)
+    } yield result.par.receives.head.peek shouldBe true).value()
   }
 
   "PInput" should "Handle a more complicated receive" in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.interpreter
 
-import java.io.Reader
+import java.io.{Reader, StringReader}
 
 import cats.effect.Sync
 import coop.rchain.models.Par
@@ -18,4 +18,8 @@ object ParBuilderUtil {
     ParBuilder[F].buildNormalizedTerm(reader, NormalizerEnv.Empty)
 
   def buildPar[F[_]: Sync](proc: Proc): F[Par] = ParBuilder[F].buildPar(proc, NormalizerEnv.Empty)
+
+  def buildAST[F[_]: Sync](rho: String): F[Proc] =
+    ParBuilder[F].buildAST(new StringReader(rho))
+
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -212,6 +212,14 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     result shouldBe target
   }
 
+  "Receive" should "print peek" in {
+    checkRoundTrip(
+      """for( @{x0}, @{x1} <<- @{Nil} ) {
+        |  @{x0}!(x1)
+        |}""".stripMargin
+    )
+  }
+
   "Receive" should "Print variable names consistently" in {
     // new x in { for( z <- x ) { *z } }
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
@@ -9,7 +9,6 @@ import coop.rchain.models.rholang.implicits._
 
 class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
   val emptyMap = DebruijnLevelMap[VarSort]()
-  val p        = Par()
   "Binds" should "Presort based on their channel and then pattern" in {
     val binds: List[Tuple4[List[Par], Par, Option[Var], DebruijnLevelMap[VarSort]]] =
       List(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -319,6 +319,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
             ),
             Par(),
             false,
+            false,
             3,
             BitSet()
           )
@@ -394,6 +395,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       ),
       Send(GString("result"), List(GString("Success")), false, BitSet()),
       false,
+      false,
       3,
       BitSet()
     )
@@ -444,6 +446,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           GString("channel"),
           freeCount = 1)),
       Send(GString("result"), List(GString("Success")), false, BitSet()),
+      false,
       false,
       1,
       BitSet()
@@ -498,6 +501,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       ),
       Send(GString("result"), List(GString("Success")), false, BitSet()),
       false,
+      false,
       3,
       BitSet()
     )
@@ -543,6 +547,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
       Seq(ReceiveBind(Seq(GInt(2L)), GInt(2L))),
       Par(),
       false,
+      false,
       0,
       BitSet()
     )
@@ -551,6 +556,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val receive = Receive(
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GInt(1L), freeCount = 1)),
       EVar(BoundVar(0)),
+      false,
       false,
       1,
       BitSet()
@@ -680,6 +686,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
         )
       ),
       Send(GString("result"), List(GString("Success")), false, BitSet()),
+      false,
       false,
       3,
       BitSet()
@@ -960,6 +967,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val proc = Receive(
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GString("channel"))),
       Par(),
+      false,
       false,
       1,
       BitSet()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -30,6 +30,13 @@ class SortSpec extends FlatSpec with Matchers {
     )
   }
 
+  "ReceiveSortMatcher" should "discern Receives with and without peek" in {
+    assertOrder[Receive](
+      Receive(peek = false),
+      Receive(peek = true)
+    )
+  }
+
   private def assertOrder[T: Sortable](smaller: T, bigger: T): Any = {
     val left: ScoredTerm[T]  = checkSortingAndScore(smaller)
     val right: ScoredTerm[T] = checkSortingAndScore(bigger)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -331,6 +331,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
       ),
       Send(GPrivateBuilder("unforgeable"), List(GInt(9), GInt(10)), false, BitSet()),
       false,
+      false,
       4
     )
     val pattern: Receive = Receive(
@@ -339,6 +340,7 @@ class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleE
         ReceiveBind(List(EVar(FreeVar(0)), EVar(FreeVar(1))), EVar(FreeVar(0)))
       ),
       EVar(FreeVar(1)),
+      false,
       false,
       4,
       connectiveUsed = true

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -42,6 +42,19 @@ package object util {
         (continuation, data.map(_.value), sequenceNumber)
     }
 
+  implicit def unpackOptionWithPeek[C, P, K, R](
+      v: Option[(ContResult[C, P, K], Seq[Result[R]])]
+  ): Option[(K, Seq[R], Int, Boolean)] =
+    v.map(unpackTupleWithPeek)
+
+  implicit def unpackTupleWithPeek[C, P, K, R](
+      v: (ContResult[C, P, K], Seq[Result[R]])
+  ): (K, Seq[R], Int, Boolean) =
+    v match {
+      case (ContResult(continuation, _, _, _, sequenceNumber, peek), data) =>
+        (continuation, data.map(_.value), sequenceNumber, peek)
+    }
+
   implicit def unpack[T](v: Result[T]): T                     = v.value
   implicit def unpackCont[C, P, T](v: ContResult[C, P, T]): T = v.value
 


### PR DESCRIPTION
## Overview
Adds peek semantics in binds to rholang: `for (a <<- @1) { ... }`
At present it is only possible to use binds of only the same type in a receive, so for consistency this is also the case for peek binds


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-2107


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
