### PR TITLE
Optimize storage of Produce/Consume.

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/Resources.scala
@@ -10,8 +10,7 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.Runtime.{RhoISpace, SystemProcess}
-import coop.rchain.rspace._
-import coop.rchain.rspace.{RSpace, ReplayRSpace}
+import coop.rchain.rspace.{RSpace}
 import coop.rchain.rspace.history.Branch
 import coop.rchain.shared.Log
 import monix.execution.Scheduler

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/Checkpoint.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/Checkpoint.scala
@@ -1,0 +1,9 @@
+package coop.rchain.rspace
+package experiment
+
+final case class SoftCheckpoint[C, P, A, K](
+    cacheSnapshot: Snapshot[C, P, A, K],
+    log: trace.Log,
+    maybeRoot: Option[Blake2b256Hash] = None
+) //TODO: remove maybeRoot along with old RSpace
+final case class Checkpoint(root: Blake2b256Hash, log: trace.Log)

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/HistoryReader.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/HistoryReader.scala
@@ -1,0 +1,10 @@
+package coop.rchain.rspace
+package experiment
+
+import internal.{Datum, WaitingContinuation}
+
+trait HistoryReader[F[_], C, P, A, K] {
+  def getJoins(channel: C): F[Seq[Seq[C]]]
+  def getData(channel: C): F[Seq[Datum[A]]]
+  def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/HotStore.scala
@@ -1,0 +1,300 @@
+package coop.rchain.rspace
+package experiment
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.implicits._
+import coop.rchain.catscontrib.mtl.implicits._
+import coop.rchain.catscontrib.seq._
+import coop.rchain.shared.Cell
+import coop.rchain.shared.MapOps._
+import coop.rchain.rspace.Serialize._
+import internal.{Datum, Row, WaitingContinuation}
+import scodec.Codec
+
+import scala.collection.concurrent.TrieMap
+
+final case class Snapshot[C, P, A, K](private[rspace] val cache: Cache[C, P, A, K])
+
+trait HotStore[F[_], C, P, A, K] {
+  def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]]
+  def putContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit]
+  def installContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit]
+  def removeContinuation(channels: Seq[C], index: Int): F[Unit]
+
+  def getData(channel: C): F[Seq[Datum[A]]]
+  def putDatum(channel: C, d: Datum[A]): F[Unit]
+  def removeDatum(channel: C, index: Int): F[Unit]
+
+  def getJoins(channel: C): F[Seq[Seq[C]]]
+  def putJoin(channel: C, join: Seq[C]): F[Unit]
+  def installJoin(channel: C, join: Seq[C]): F[Unit]
+  def removeJoin(channel: C, join: Seq[C]): F[Unit]
+
+  def changes(): F[Seq[HotStoreAction]]
+  def toMap: F[Map[Seq[C], Row[P, A, K]]]
+  def snapshot(): F[Snapshot[C, P, A, K]]
+}
+
+final case class Cache[C, P, A, K](
+    continuations: TrieMap[Seq[C], Seq[WaitingContinuation[P, K]]] =
+      TrieMap.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
+    installedContinuations: TrieMap[Seq[C], WaitingContinuation[P, K]] =
+      TrieMap.empty[Seq[C], WaitingContinuation[P, K]],
+    data: TrieMap[C, Seq[Datum[A]]] = TrieMap.empty[C, Seq[Datum[A]]],
+    joins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]],
+    installedJoins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]]
+) {
+  def snapshot(): Snapshot[C, P, A, K] =
+    Snapshot(
+      this.copy(
+        continuations = this.continuations.snapshot(),
+        installedContinuations = this.installedContinuations.snapshot(),
+        data = this.data.snapshot(),
+        joins = this.joins.snapshot(),
+        installedJoins = this.installedJoins.snapshot()
+      )
+    )
+}
+
+private class InMemHotStore[F[_]: Sync, C, P, A, K](
+    implicit S: Cell[F, Cache[C, P, A, K]],
+    HR: HistoryReader[F, C, P, A, K],
+    ck: Codec[K]
+) extends HotStore[F, C, P, A, K] {
+
+  implicit val codec = fromCodec(ck)
+
+  def snapshot(): F[Snapshot[C, P, A, K]] = S.read.map(_.snapshot())
+
+  def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+    for {
+      cached <- internalGetContinuations(channels)
+      state  <- S.read
+      result = state.installedContinuations.get(channels) ++: cached
+      res <- result
+              .map(
+                wk =>
+                  roundTrip[F, K](wk.continuation).map { copied =>
+                    wk.copy(continuation = copied)
+                  }
+              )
+              .sequence
+    } yield res
+
+  private[this] def internalGetContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+    for {
+      state <- S.read
+      res <- state.continuations.get(channels) match {
+              case None =>
+                for {
+                  historyContinuations <- HR.getContinuations(channels)
+                  _ <- S.flatModify { cache =>
+                        Sync[F]
+                          .delay(cache.continuations.putIfAbsent(channels, historyContinuations))
+                          .as(cache)
+                      }
+                } yield (historyContinuations)
+              case Some(continuations) => Applicative[F].pure(continuations)
+            }
+    } yield (res)
+
+  def putContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] =
+    for {
+      continuations <- internalGetContinuations(channels)
+      _ <- S.flatModify { cache =>
+            Sync[F].delay(cache.continuations.put(channels, wc +: continuations)).as(cache)
+          }
+    } yield ()
+
+  def installContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] = S.flatModify {
+    cache =>
+      Sync[F].delay(cache.installedContinuations.put(channels, wc)).map(_ => cache)
+  }
+
+  def removeContinuation(channels: Seq[C], index: Int): F[Unit] =
+    for {
+      continuations <- getContinuations(channels)
+      cache         <- S.read
+      installed     = cache.installedContinuations.get(channels)
+      _ <- if (installed.isDefined && index == 0)
+            Sync[F].raiseError {
+              new IllegalArgumentException("Attempted to remove an installed continuation")
+            } else
+            S.flatModify { cache =>
+              removeIndex(
+                continuations,
+                index
+              ) >>= { updated =>
+                Sync[F]
+                  .delay {
+                    installed match {
+                      case Some(_) => cache.continuations.put(channels, updated tail)
+                      case None    => cache.continuations.put(channels, updated)
+                    }
+                  }
+                  .as(cache)
+              }
+            }
+    } yield ()
+
+  def getData(channel: C): F[Seq[Datum[A]]] =
+    for {
+      state <- S.read
+      res <- state.data.get(channel) match {
+              case None =>
+                for {
+                  historyData <- HR.getData(channel)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.data.putIfAbsent(channel, historyData)).as(cache)
+                      }
+                } yield (historyData)
+              case Some(data) => Applicative[F].pure(data)
+            }
+    } yield (res)
+
+  def putDatum(channel: C, datum: Datum[A]): F[Unit] =
+    for {
+      data <- getData(channel)
+      _ <- S.flatModify { cache =>
+            Sync[F].delay(cache.data.put(channel, datum +: data)).as(cache)
+          }
+    } yield ()
+
+  def removeDatum(channel: C, index: Int): F[Unit] =
+    for {
+      data <- getData(channel)
+      _ <- S.flatModify { cache =>
+            removeIndex(cache.data(channel), index) >>= { updated =>
+              Sync[F]
+                .delay {
+                  cache.data.put(channel, updated)
+                }
+                .as(cache)
+            }
+          }
+    } yield ()
+
+  def getJoins(channel: C): F[Seq[Seq[C]]] =
+    for {
+      cached <- internalGetJoins(channel)
+      state  <- S.read
+    } yield (state.installedJoins.get(channel).getOrElse(Seq.empty) ++: cached)
+
+  private[this] def internalGetJoins(channel: C): F[Seq[Seq[C]]] =
+    for {
+      state <- S.read
+      res <- state.joins.get(channel) match {
+              case None =>
+                for {
+                  historyJoins <- HR.getJoins(channel)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.joins.putIfAbsent(channel, historyJoins)).as(cache)
+                      }
+                } yield (historyJoins)
+              case Some(joins) => Applicative[F].pure(joins)
+            }
+    } yield (res)
+
+  def putJoin(channel: C, join: Seq[C]): F[Unit] =
+    for {
+      joins <- getJoins(channel)
+      _ <- if (!joins.contains(join)) S.flatModify { cache =>
+            Sync[F].delay(cache.joins.put(channel, join +: joins)).as(cache)
+          } else Applicative[F].unit
+    } yield ()
+
+  def installJoin(channel: C, join: Seq[C]): F[Unit] = S.flatModify { cache =>
+    Sync[F]
+      .delay {
+        val installed = cache.installedJoins.get(channel).getOrElse(Seq.empty)
+
+        if (!installed.contains(join))
+          cache.installedJoins
+            .put(channel, join +: installed)
+      }
+      .map(_ => cache)
+  }
+
+  def removeJoin(channel: C, join: Seq[C]): F[Unit] =
+    for {
+      joins         <- internalGetJoins(channel)
+      continuations <- getContinuations(join)
+      _ <- if (continuations.isEmpty) S.flatModify { cache =>
+            val index = cache.joins(channel).indexOf(join)
+            if (index != -1) removeIndex(cache.joins(channel), index) >>= { updated =>
+              Sync[F]
+                .delay {
+                  cache.joins.put(channel, updated)
+                }
+                .as(cache)
+            } else cache.pure[F]
+          } else Applicative[F].unit
+    } yield ()
+
+  def changes(): F[Seq[HotStoreAction]] =
+    for {
+      cache <- S.read
+      continuations = (cache.continuations
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteContinuations(k)
+          case (k, v)                => InsertContinuations(k, v)
+        })
+        .toVector
+      data = (cache.data
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteData(k)
+          case (k, v)                => InsertData(k, v)
+        })
+        .toVector
+      joins = (cache.joins
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteJoins(k)
+          case (k, v)                => InsertJoins(k, v)
+        })
+        .toVector
+    } yield (continuations ++ data ++ joins)
+
+  private def removeIndex[E](col: Seq[E], index: Int): F[Seq[E]] =
+    if (col.isDefinedAt(index)) {
+      val (l1, l2) = col splitAt index
+      (l1 ++ (l2 tail)).pure[F]
+    } else
+      Sync[F].raiseError(
+        new IndexOutOfBoundsException(
+          s"Tried to remove index ${index} from a Vector of size ${col.size}"
+        )
+      )
+
+  def toMap: F[Map[Seq[C], Row[P, A, K]]] =
+    for {
+      cache         <- S.read
+      data          = cache.data.readOnlySnapshot().map(_.leftMap(Seq(_))).toMap
+      continuations = (cache.continuations ++ cache.installedContinuations.mapValues(Seq(_))).toMap
+      zipped        = zip(data, continuations, Seq.empty[Datum[A]], Seq.empty[WaitingContinuation[P, K]])
+      mapped        = zipped.mapValues { case (d, k) => Row(d, k) }
+    } yield mapped.filter { case (_, v) => !(v.data.isEmpty && v.wks.isEmpty) }
+}
+
+object HotStore {
+
+  def inMem[F[_]: Sync, C, P, A, K](
+      implicit S: Cell[F, Cache[C, P, A, K]],
+      HR: HistoryReader[F, C, P, A, K],
+      ck: Codec[K]
+  ): HotStore[F, C, P, A, K] =
+    new InMemHotStore[F, C, P, A, K]
+
+  def from[F[_], C, P, A, K](
+      cache: Cache[C, P, A, K],
+      historyReader: HistoryReader[F, C, P, A, K]
+  )(implicit ck: Codec[K], sync: Sync[F]) =
+    for {
+      cache <- Cell.refCell[F, Cache[C, P, A, K]](cache)
+      store = HotStore.inMem(Sync[F], cache, historyReader, ck)
+    } yield store
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/HotStoreAction.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/HotStoreAction.scala
@@ -1,0 +1,21 @@
+package coop.rchain.rspace
+package experiment
+
+import internal.{Datum, WaitingContinuation}
+
+sealed trait HotStoreAction
+
+sealed trait InsertAction                                          extends HotStoreAction
+final case class InsertData[C, A](channel: C, data: Seq[Datum[A]]) extends InsertAction
+final case class InsertJoins[C](channel: C, joins: Seq[Seq[C]])    extends InsertAction
+final case class InsertContinuations[C, P, K](
+    channels: Seq[C],
+    continuations: Seq[WaitingContinuation[P, K]]
+) extends InsertAction
+
+sealed trait DeleteAction                   extends HotStoreAction
+final case class DeleteData[C](channel: C)  extends DeleteAction
+final case class DeleteJoins[C](channel: C) extends DeleteAction
+final case class DeleteContinuations[C](
+    channels: Seq[C]
+) extends DeleteAction

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/ISpace.scala
@@ -1,0 +1,148 @@
+package coop.rchain.rspace
+package experiment
+
+import cats.Id
+import internal._
+
+import scala.collection.SortedSet
+
+final case class Result[R](value: R, persistent: Boolean)
+final case class ContResult[C, P, R](
+    value: R,
+    persistent: Boolean,
+    channels: Seq[C],
+    patterns: Seq[P],
+    sequenceNumber: Int,
+    peek: Boolean = false
+)
+
+/** The interface for RSpace
+  *
+  * @tparam C a type representing a channel
+  * @tparam P a type representing a pattern
+  * @tparam A a type representing an arbitrary piece of data
+  * @tparam R a type representing a match result
+  * @tparam K a type representing a continuation
+  */
+trait ISpace[F[_], C, P, A, R, K] {
+
+  /** Searches the store for data matching all the given patterns at the given channels.
+    *
+    * If no match is found, then the continuation and patterns are put in the store at the given
+    * channels.
+    *
+    * If a match is found, then the continuation is returned along with the matching data.
+    *
+    * Matching data stored with the `persist` flag set to `true` will not be removed when it is
+    * retrieved. See below for more information about using the `persist` flag.
+    *
+    * '''NOTE''':
+    *
+    * A call to [[consume]] that is made with the persist flag set to `true` only persists when
+    * there is no matching data.
+    *
+    * This means that in order to make a continuation "stick" in the store, the user will have to
+    * continue to call [[consume]] until a `None` is received.
+    *
+    * @param channels A Seq of channels on which to search for matching data
+    * @param patterns A Seq of patterns with which to search for matching data
+    * @param continuation A continuation
+    * @param persist Whether or not to attempt to persist the data
+    */
+  def consume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      sequenceNumber: Int = 0,
+      peeks: SortedSet[Int] = SortedSet.empty
+  )(
+      implicit m: Match[F, P, A, R]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+
+  def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
+      implicit m: Match[F, P, A, R]
+  ): F[Option[(K, Seq[R])]]
+
+  /** Searches the store for a continuation that has patterns that match the given data at the
+    * given channel.
+    *
+    * If no match is found, then the data is put in the store at the given channel.
+    *
+    * If a match is found, then the continuation is returned along with the matching data.
+    *
+    * Matching data or continuations stored with the `persist` flag set to `true` will not be
+    * removed when they are retrieved. See below for more information about using the `persist`
+    * flag.
+    *
+    * '''NOTE''':
+    *
+    * A call to [[produce]] that is made with the persist flag set to `true` only persists when
+    * there are no matching continuations.
+    *
+    * This means that in order to make a piece of data "stick" in the store, the user will have to
+    * continue to call [[produce]] until a `None` is received.
+    *
+    * @param channel A channel on which to search for matching continuations and/or store data
+    * @param data A piece of data
+    * @param persist Whether or not to attempt to persist the data
+    */
+  def produce(channel: C, data: A, persist: Boolean, sequenceNumber: Int = 0)(
+      implicit m: Match[F, P, A, R]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+
+  /** Creates a checkpoint.
+    *
+    * @return A [[coop.rchain.rspace.Checkpoint]]
+    */
+  def createCheckpoint(): F[Checkpoint]
+
+  /** Resets the store to the given root.
+    *
+    * @param root A BLAKE2b256 Hash representing the checkpoint
+    */
+  def reset(root: Blake2b256Hash): F[Unit]
+
+  /**
+    * Retrieves a GNAT from the history trie at a particular checkpoint and channels hash.
+    */
+  def retrieve(root: Blake2b256Hash, channelsHash: Blake2b256Hash): F[Option[GNAT[C, P, A, K]]]
+
+  def getData(channel: C): F[Seq[Datum[A]]]
+
+  def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]]
+
+  /** Clears the store.  Does not affect the history trie.
+    */
+  def clear(): F[Unit]
+
+  /** Closes
+    */
+  def close(): F[Unit]
+
+  /**
+    * checks it the internal state is consistent with the passed root hash
+    *
+    * @param root to verify the state against
+    */
+  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
+
+  // TODO: this should not be exposed
+  def toMap: F[Map[Seq[C], Row[P, A, K]]]
+
+  /**
+    Allows to create a "soft" checkpoint which doesn't persist the checkpointed data into history.
+    This operation is significantly faster than {@link #createCheckpoint()} because the computationally
+    expensive operation of creating the history trie is avoided.
+    */
+  def createSoftCheckpoint(): F[SoftCheckpoint[C, P, A, K]]
+
+  /**
+    Reverts the ISpace to the state checkpointed using {@link #createSoftCheckpoint()}
+    */
+  def revertToSoftCheckpoint(checkpoint: SoftCheckpoint[C, P, A, K]): F[Unit]
+}
+
+object ISpace {
+  type IdISpace[C, P, A, R, K] = ISpace[Id, C, P, A, R, K]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/ISpace.scala
@@ -12,7 +12,6 @@ final case class ContResult[C, P, R](
     persistent: Boolean,
     channels: Seq[C],
     patterns: Seq[P],
-    sequenceNumber: Int,
     peek: Boolean = false
 )
 

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/RSpaceOps.scala
@@ -1,0 +1,222 @@
+// package coop.rchain.rspace
+// package experiment
+
+// import cats.effect.{Concurrent, Sync}
+// import cats.implicits._
+// import com.typesafe.scalalogging.Logger
+// import coop.rchain.catscontrib._
+// import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
+// import coop.rchain.rspace.history.{Branch, History, HistoryRepository}
+// import internal._
+// import trace.{Consume, Log => EventLog}
+// import coop.rchain.shared.SyncVarOps._
+// import coop.rchain.shared.{Cell, Log}
+// import monix.execution.atomic.AtomicAny
+// import scodec.Codec
+
+// import scala.collection.SortedSet
+// import scala.concurrent.SyncVar
+// import scala.util.Random
+
+// abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
+//     historyRepository: HistoryRepository[F, C, P, A, K],
+//     val storeAtom: AtomicAny[HotStore[F, C, P, A, K]],
+//     val branch: Branch
+// )(
+//     implicit
+//     serializeC: Serialize[C],
+//     serializeP: Serialize[P],
+//     serializeK: Serialize[K],
+//     logF: Log[F]
+// ) extends SpaceMatcher[F, C, P, A, R, K] {
+
+//   protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Seq.empty)
+
+//   //TODO close in some F state abstraction
+//   protected val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
+//     historyRepository
+//   )
+
+//   def store: HotStore[F, C, P, A, K]
+
+//   def getData(channel: C): F[Seq[Datum[A]]] =
+//     store.getData(channel)
+
+//   def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+//     store.getContinuations(channels)
+
+//   implicit val codecC = serializeC.toCodec
+
+//   val syncF: Sync[F] = Concurrent[F]
+
+//   private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF()
+
+//   type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[R]])]
+
+//   protected[this] def consumeLockF(
+//       channels: Seq[C]
+//   )(
+//       thunk: => F[MaybeActionResult]
+//   ): F[MaybeActionResult] = {
+//     val hashes = channels.map(ch => StableHashProvider.hash(ch))
+//     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
+//   }
+
+//   protected[this] def installLockF(
+//       channels: Seq[C]
+//   )(
+//       thunk: => F[Option[(K, Seq[R])]]
+//   ): F[Option[(K, Seq[R])]] = {
+//     val hashes = channels.map(ch => StableHashProvider.hash(ch))
+//     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
+//   }
+
+//   protected[this] def produceLockF(
+//       channel: C
+//   )(
+//       thunk: => F[MaybeActionResult]
+//   ): F[MaybeActionResult] =
+//     lockF.acquire(Seq(StableHashProvider.hash(channel)))(
+//       () =>
+//         for {
+//           groupedChannels <- store.getJoins(channel)
+//         } yield (groupedChannels.flatten.map(StableHashProvider.hash(_)))
+//     )(thunk)
+
+//   protected[this] val logger: Logger
+
+//   private[this] val installs: SyncVar[Installs[F, C, P, A, R, K]] = {
+//     val installs = new SyncVar[Installs[F, C, P, A, R, K]]()
+//     installs.put(Map.empty)
+//     installs
+//   }
+
+//   protected[this] def restoreInstalls(): F[Unit] =
+//     installs.get.toList
+//       .traverse {
+//         case (channels, Install(patterns, continuation, _match)) =>
+//           install(channels, patterns, continuation)(_match)
+//       }
+//       .as(())
+
+//   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+//   // TODO stop throwing exceptions
+//   private[this] def lockedInstall(
+//       channels: Seq[C],
+//       patterns: Seq[P],
+//       continuation: K
+//   )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] =
+//     if (channels.length =!= patterns.length) {
+//       val msg = "channels.length must equal patterns.length"
+//       logger.error(msg)
+//       throw new IllegalArgumentException(msg)
+//     } else {
+//       /*
+//        * Here, we create a cache of the data at each channel as `channelToIndexedData`
+//        * which is used for finding matches.  When a speculative match is found, we can
+//        * remove the matching datum from the remaining data candidates in the cache.
+//        *
+//        * Put another way, this allows us to speculatively remove matching data without
+//        * affecting the actual store contents.
+//        */
+
+//       for {
+//         _          <- logF.debug(s"""|install: searching for data matching <patterns: $patterns>
+//                                   |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+//         consumeRef = Consume.create(channels, patterns, continuation, true)
+//         channelToIndexedData <- channels
+//                                  .traverse { c =>
+//                                    for {
+//                                      data <- store.getData(c)
+//                                    } yield c -> Random.shuffle(data.zipWithIndex)
+//                                  }
+//         options <- extractDataCandidates(channels.zip(patterns), channelToIndexedData.toMap, Nil)
+//                     .map(_.sequence)
+//         result <- options match {
+//                    case None =>
+//                      for {
+//                        _ <- syncF.delay {
+//                              installs.update(
+//                                _.updated(channels, Install(patterns, continuation, m))
+//                              )
+//                            }
+//                        _ <- store.installContinuation(
+//                              channels,
+//                              WaitingContinuation(
+//                                patterns,
+//                                continuation,
+//                                persist = true,
+//                                SortedSet.empty
+//                              )
+//                            )
+//                        _ <- channels.traverse { channel =>
+//                              store.installJoin(channel, channels)
+//                            }
+//                        _ <- logF.debug(
+//                              s"""|storing <(patterns, continuation): ($patterns, $continuation)>
+//                               |at <channels: $channels>""".stripMargin.replace('\n', ' ')
+//                            )
+//                      } yield None
+//                    case Some(_) =>
+//                      throw new RuntimeException("Installing can be done only on startup")
+//                  }
+//       } yield result
+//     }
+
+//   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
+//       implicit m: Match[F, P, A, R]
+//   ): F[Option[(K, Seq[R])]] =
+//     installLockF(channels) {
+//       lockedInstall(channels, patterns, continuation)
+//     }
+
+//   override def retrieve(
+//       root: Blake2b256Hash,
+//       channelsHash: Blake2b256Hash
+//   ): F[Option[GNAT[C, P, A, K]]] = ???
+
+//   protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
+
+//   def toMap: F[Map[Seq[C], Row[P, A, K]]] = storeAtom.get().toMap
+
+//   override def reset(root: Blake2b256Hash): F[Unit] =
+//     for {
+//       nextHistory <- historyRepositoryAtom.get().reset(root)
+//       _           = historyRepositoryAtom.set(nextHistory)
+//       _           = eventLog.take()
+//       _           = eventLog.put(Seq.empty)
+//       _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+//       _           <- restoreInstalls()
+//     } yield ()
+
+//   override def clear(): F[Unit] = reset(History.emptyRootHash)
+
+//   protected def createCache: F[Cell[F, Cache[C, P, A, K]]] =
+//     Cell.refCell[F, Cache[C, P, A, K]](Cache())
+
+//   protected def createNewHotStore(
+//       historyReader: HistoryReader[F, C, P, A, K]
+//   )(implicit ck: Codec[K]): F[Unit] =
+//     for {
+//       cache        <- createCache
+//       nextHotStore = HotStore.inMem(Sync[F], cache, historyReader, ck)
+//       _            = storeAtom.set(nextHotStore)
+//     } yield ()
+
+//   override def createSoftCheckpoint(): F[SoftCheckpoint[C, P, A, K]] =
+//     for {
+//       cache <- storeAtom.get().snapshot()
+//       log   = eventLog.take()
+//       _     = eventLog.put(Seq.empty)
+//     } yield SoftCheckpoint[C, P, A, K](cache, log)
+
+//   override def revertToSoftCheckpoint(checkpoint: SoftCheckpoint[C, P, A, K]): F[Unit] = {
+//     implicit val ck: Codec[K] = serializeK.toCodec
+//     for {
+//       hotStore <- HotStore.from(checkpoint.cacheSnapshot.cache, historyRepository)
+//       _        = storeAtom.set(hotStore)
+//       _        = eventLog.take()
+//       _        = eventLog.put(checkpoint.log)
+//     } yield ()
+//   }
+// }

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/RSpaceOps.scala
@@ -1,222 +1,223 @@
-// package coop.rchain.rspace
-// package experiment
+package coop.rchain.rspace
+package experiment
 
-// import cats.effect.{Concurrent, Sync}
-// import cats.implicits._
-// import com.typesafe.scalalogging.Logger
-// import coop.rchain.catscontrib._
-// import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
-// import coop.rchain.rspace.history.{Branch, History, HistoryRepository}
-// import internal._
-// import trace.{Consume, Log => EventLog}
-// import coop.rchain.shared.SyncVarOps._
-// import coop.rchain.shared.{Cell, Log}
-// import monix.execution.atomic.AtomicAny
-// import scodec.Codec
+import cats.effect.{Concurrent, Sync}
+import cats.implicits._
+import com.typesafe.scalalogging.Logger
+import coop.rchain.catscontrib._
+import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
+import coop.rchain.rspace.history.Branch
+import history.{History, HistoryRepository}
+import internal._
+import trace.{Consume, Log => EventLog}
+import coop.rchain.shared.SyncVarOps._
+import coop.rchain.shared.{Cell, Log}
+import monix.execution.atomic.AtomicAny
+import scodec.Codec
 
-// import scala.collection.SortedSet
-// import scala.concurrent.SyncVar
-// import scala.util.Random
+import scala.collection.SortedSet
+import scala.concurrent.SyncVar
+import scala.util.Random
 
-// abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
-//     historyRepository: HistoryRepository[F, C, P, A, K],
-//     val storeAtom: AtomicAny[HotStore[F, C, P, A, K]],
-//     val branch: Branch
-// )(
-//     implicit
-//     serializeC: Serialize[C],
-//     serializeP: Serialize[P],
-//     serializeK: Serialize[K],
-//     logF: Log[F]
-// ) extends SpaceMatcher[F, C, P, A, R, K] {
+abstract class RSpaceOps[F[_]: Concurrent, C, P, A, R, K](
+    historyRepository: HistoryRepository[F, C, P, A, K],
+    val storeAtom: AtomicAny[HotStore[F, C, P, A, K]],
+    val branch: Branch
+)(
+    implicit
+    serializeC: Serialize[C],
+    serializeP: Serialize[P],
+    serializeK: Serialize[K],
+    logF: Log[F]
+) extends SpaceMatcher[F, C, P, A, R, K] {
 
-//   protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Seq.empty)
+  protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Seq.empty)
 
-//   //TODO close in some F state abstraction
-//   protected val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
-//     historyRepository
-//   )
+  //TODO close in some F state abstraction
+  protected val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
+    historyRepository
+  )
 
-//   def store: HotStore[F, C, P, A, K]
+  def store: HotStore[F, C, P, A, K]
 
-//   def getData(channel: C): F[Seq[Datum[A]]] =
-//     store.getData(channel)
+  def getData(channel: C): F[Seq[Datum[A]]] =
+    store.getData(channel)
 
-//   def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
-//     store.getContinuations(channels)
+  def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+    store.getContinuations(channels)
 
-//   implicit val codecC = serializeC.toCodec
+  implicit val codecC = serializeC.toCodec
 
-//   val syncF: Sync[F] = Concurrent[F]
+  val syncF: Sync[F] = Concurrent[F]
 
-//   private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF()
+  private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF()
 
-//   type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[R]])]
+  type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[R]])]
 
-//   protected[this] def consumeLockF(
-//       channels: Seq[C]
-//   )(
-//       thunk: => F[MaybeActionResult]
-//   ): F[MaybeActionResult] = {
-//     val hashes = channels.map(ch => StableHashProvider.hash(ch))
-//     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
-//   }
+  protected[this] def consumeLockF(
+      channels: Seq[C]
+  )(
+      thunk: => F[MaybeActionResult]
+  ): F[MaybeActionResult] = {
+    val hashes = channels.map(ch => StableHashProvider.hash(ch))
+    lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
+  }
 
-//   protected[this] def installLockF(
-//       channels: Seq[C]
-//   )(
-//       thunk: => F[Option[(K, Seq[R])]]
-//   ): F[Option[(K, Seq[R])]] = {
-//     val hashes = channels.map(ch => StableHashProvider.hash(ch))
-//     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
-//   }
+  protected[this] def installLockF(
+      channels: Seq[C]
+  )(
+      thunk: => F[Option[(K, Seq[R])]]
+  ): F[Option[(K, Seq[R])]] = {
+    val hashes = channels.map(ch => StableHashProvider.hash(ch))
+    lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
+  }
 
-//   protected[this] def produceLockF(
-//       channel: C
-//   )(
-//       thunk: => F[MaybeActionResult]
-//   ): F[MaybeActionResult] =
-//     lockF.acquire(Seq(StableHashProvider.hash(channel)))(
-//       () =>
-//         for {
-//           groupedChannels <- store.getJoins(channel)
-//         } yield (groupedChannels.flatten.map(StableHashProvider.hash(_)))
-//     )(thunk)
+  protected[this] def produceLockF(
+      channel: C
+  )(
+      thunk: => F[MaybeActionResult]
+  ): F[MaybeActionResult] =
+    lockF.acquire(Seq(StableHashProvider.hash(channel)))(
+      () =>
+        for {
+          groupedChannels <- store.getJoins(channel)
+        } yield (groupedChannels.flatten.map(StableHashProvider.hash(_)))
+    )(thunk)
 
-//   protected[this] val logger: Logger
+  protected[this] val logger: Logger
 
-//   private[this] val installs: SyncVar[Installs[F, C, P, A, R, K]] = {
-//     val installs = new SyncVar[Installs[F, C, P, A, R, K]]()
-//     installs.put(Map.empty)
-//     installs
-//   }
+  private[this] val installs: SyncVar[Installs[F, C, P, A, R, K]] = {
+    val installs = new SyncVar[Installs[F, C, P, A, R, K]]()
+    installs.put(Map.empty)
+    installs
+  }
 
-//   protected[this] def restoreInstalls(): F[Unit] =
-//     installs.get.toList
-//       .traverse {
-//         case (channels, Install(patterns, continuation, _match)) =>
-//           install(channels, patterns, continuation)(_match)
-//       }
-//       .as(())
+  protected[this] def restoreInstalls(): F[Unit] =
+    installs.get.toList
+      .traverse {
+        case (channels, Install(patterns, continuation, _match)) =>
+          install(channels, patterns, continuation)(_match)
+      }
+      .as(())
 
-//   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-//   // TODO stop throwing exceptions
-//   private[this] def lockedInstall(
-//       channels: Seq[C],
-//       patterns: Seq[P],
-//       continuation: K
-//   )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] =
-//     if (channels.length =!= patterns.length) {
-//       val msg = "channels.length must equal patterns.length"
-//       logger.error(msg)
-//       throw new IllegalArgumentException(msg)
-//     } else {
-//       /*
-//        * Here, we create a cache of the data at each channel as `channelToIndexedData`
-//        * which is used for finding matches.  When a speculative match is found, we can
-//        * remove the matching datum from the remaining data candidates in the cache.
-//        *
-//        * Put another way, this allows us to speculatively remove matching data without
-//        * affecting the actual store contents.
-//        */
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
+  private[this] def lockedInstall(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K
+  )(implicit m: Match[F, P, A, R]): F[Option[(K, Seq[R])]] =
+    if (channels.length =!= patterns.length) {
+      val msg = "channels.length must equal patterns.length"
+      logger.error(msg)
+      throw new IllegalArgumentException(msg)
+    } else {
+      /*
+       * Here, we create a cache of the data at each channel as `channelToIndexedData`
+       * which is used for finding matches.  When a speculative match is found, we can
+       * remove the matching datum from the remaining data candidates in the cache.
+       *
+       * Put another way, this allows us to speculatively remove matching data without
+       * affecting the actual store contents.
+       */
 
-//       for {
-//         _          <- logF.debug(s"""|install: searching for data matching <patterns: $patterns>
-//                                   |at <channels: $channels>""".stripMargin.replace('\n', ' '))
-//         consumeRef = Consume.create(channels, patterns, continuation, true)
-//         channelToIndexedData <- channels
-//                                  .traverse { c =>
-//                                    for {
-//                                      data <- store.getData(c)
-//                                    } yield c -> Random.shuffle(data.zipWithIndex)
-//                                  }
-//         options <- extractDataCandidates(channels.zip(patterns), channelToIndexedData.toMap, Nil)
-//                     .map(_.sequence)
-//         result <- options match {
-//                    case None =>
-//                      for {
-//                        _ <- syncF.delay {
-//                              installs.update(
-//                                _.updated(channels, Install(patterns, continuation, m))
-//                              )
-//                            }
-//                        _ <- store.installContinuation(
-//                              channels,
-//                              WaitingContinuation(
-//                                patterns,
-//                                continuation,
-//                                persist = true,
-//                                SortedSet.empty
-//                              )
-//                            )
-//                        _ <- channels.traverse { channel =>
-//                              store.installJoin(channel, channels)
-//                            }
-//                        _ <- logF.debug(
-//                              s"""|storing <(patterns, continuation): ($patterns, $continuation)>
-//                               |at <channels: $channels>""".stripMargin.replace('\n', ' ')
-//                            )
-//                      } yield None
-//                    case Some(_) =>
-//                      throw new RuntimeException("Installing can be done only on startup")
-//                  }
-//       } yield result
-//     }
+      for {
+        _          <- logF.debug(s"""|install: searching for data matching <patterns: $patterns>
+                                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+        consumeRef = Consume.create(channels, patterns, continuation, true)
+        channelToIndexedData <- channels
+                                 .traverse { c =>
+                                   for {
+                                     data <- store.getData(c)
+                                   } yield c -> Random.shuffle(data.zipWithIndex)
+                                 }
+        options <- extractDataCandidates(channels.zip(patterns), channelToIndexedData.toMap, Nil)
+                    .map(_.sequence)
+        result <- options match {
+                   case None =>
+                     for {
+                       _ <- syncF.delay {
+                             installs.update(
+                               _.updated(channels, Install(patterns, continuation, m))
+                             )
+                           }
+                       _ <- store.installContinuation(
+                             channels,
+                             WaitingContinuation(
+                               patterns,
+                               continuation,
+                               persist = true,
+                               SortedSet.empty
+                             )
+                           )
+                       _ <- channels.traverse { channel =>
+                             store.installJoin(channel, channels)
+                           }
+                       _ <- logF.debug(
+                             s"""|storing <(patterns, continuation): ($patterns, $continuation)>
+                              |at <channels: $channels>""".stripMargin.replace('\n', ' ')
+                           )
+                     } yield None
+                   case Some(_) =>
+                     throw new RuntimeException("Installing can be done only on startup")
+                 }
+      } yield result
+    }
 
-//   override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
-//       implicit m: Match[F, P, A, R]
-//   ): F[Option[(K, Seq[R])]] =
-//     installLockF(channels) {
-//       lockedInstall(channels, patterns, continuation)
-//     }
+  override def install(channels: Seq[C], patterns: Seq[P], continuation: K)(
+      implicit m: Match[F, P, A, R]
+  ): F[Option[(K, Seq[R])]] =
+    installLockF(channels) {
+      lockedInstall(channels, patterns, continuation)
+    }
 
-//   override def retrieve(
-//       root: Blake2b256Hash,
-//       channelsHash: Blake2b256Hash
-//   ): F[Option[GNAT[C, P, A, K]]] = ???
+  override def retrieve(
+      root: Blake2b256Hash,
+      channelsHash: Blake2b256Hash
+  ): F[Option[GNAT[C, P, A, K]]] = ???
 
-//   protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
+  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean]
 
-//   def toMap: F[Map[Seq[C], Row[P, A, K]]] = storeAtom.get().toMap
+  def toMap: F[Map[Seq[C], Row[P, A, K]]] = storeAtom.get().toMap
 
-//   override def reset(root: Blake2b256Hash): F[Unit] =
-//     for {
-//       nextHistory <- historyRepositoryAtom.get().reset(root)
-//       _           = historyRepositoryAtom.set(nextHistory)
-//       _           = eventLog.take()
-//       _           = eventLog.put(Seq.empty)
-//       _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
-//       _           <- restoreInstalls()
-//     } yield ()
+  override def reset(root: Blake2b256Hash): F[Unit] =
+    for {
+      nextHistory <- historyRepositoryAtom.get().reset(root)
+      _           = historyRepositoryAtom.set(nextHistory)
+      _           = eventLog.take()
+      _           = eventLog.put(Seq.empty)
+      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+      _           <- restoreInstalls()
+    } yield ()
 
-//   override def clear(): F[Unit] = reset(History.emptyRootHash)
+  override def clear(): F[Unit] = reset(History.emptyRootHash)
 
-//   protected def createCache: F[Cell[F, Cache[C, P, A, K]]] =
-//     Cell.refCell[F, Cache[C, P, A, K]](Cache())
+  protected def createCache: F[Cell[F, Cache[C, P, A, K]]] =
+    Cell.refCell[F, Cache[C, P, A, K]](Cache())
 
-//   protected def createNewHotStore(
-//       historyReader: HistoryReader[F, C, P, A, K]
-//   )(implicit ck: Codec[K]): F[Unit] =
-//     for {
-//       cache        <- createCache
-//       nextHotStore = HotStore.inMem(Sync[F], cache, historyReader, ck)
-//       _            = storeAtom.set(nextHotStore)
-//     } yield ()
+  protected def createNewHotStore(
+      historyReader: HistoryReader[F, C, P, A, K]
+  )(implicit ck: Codec[K]): F[Unit] =
+    for {
+      cache        <- createCache
+      nextHotStore = HotStore.inMem(Sync[F], cache, historyReader, ck)
+      _            = storeAtom.set(nextHotStore)
+    } yield ()
 
-//   override def createSoftCheckpoint(): F[SoftCheckpoint[C, P, A, K]] =
-//     for {
-//       cache <- storeAtom.get().snapshot()
-//       log   = eventLog.take()
-//       _     = eventLog.put(Seq.empty)
-//     } yield SoftCheckpoint[C, P, A, K](cache, log)
+  override def createSoftCheckpoint(): F[SoftCheckpoint[C, P, A, K]] =
+    for {
+      cache <- storeAtom.get().snapshot()
+      log   = eventLog.take()
+      _     = eventLog.put(Seq.empty)
+    } yield SoftCheckpoint[C, P, A, K](cache, log)
 
-//   override def revertToSoftCheckpoint(checkpoint: SoftCheckpoint[C, P, A, K]): F[Unit] = {
-//     implicit val ck: Codec[K] = serializeK.toCodec
-//     for {
-//       hotStore <- HotStore.from(checkpoint.cacheSnapshot.cache, historyRepository)
-//       _        = storeAtom.set(hotStore)
-//       _        = eventLog.take()
-//       _        = eventLog.put(checkpoint.log)
-//     } yield ()
-//   }
-// }
+  override def revertToSoftCheckpoint(checkpoint: SoftCheckpoint[C, P, A, K]): F[Unit] = {
+    implicit val ck: Codec[K] = serializeK.toCodec
+    for {
+      hotStore <- HotStore.from(checkpoint.cacheSnapshot.cache, historyRepository)
+      _        = storeAtom.set(hotStore)
+      _        = eventLog.take()
+      _        = eventLog.put(checkpoint.log)
+    } yield ()
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/SpaceMatcher.scala
@@ -1,0 +1,117 @@
+package coop.rchain.rspace
+package experiment
+
+import cats.effect.Sync
+import cats.implicits._
+import coop.rchain.catscontrib._
+import internal._
+
+/** The interface for RSpace
+  *
+  * @tparam C a type representing a channel
+  * @tparam P a type representing a pattern
+  * @tparam A a type representing an arbitrary piece of data
+  * @tparam R a type representing a match result
+  * @tparam K a type representing a continuation
+  */
+private[rspace] trait SpaceMatcher[F[_], C, P, A, R, K] extends ISpace[F, C, P, A, R, K] {
+
+  implicit val syncF: Sync[F]
+
+  /* Consume */
+
+  type MatchingDataCandidate = (DataCandidate[C, R], Seq[(Datum[A], Int)])
+
+  /** Searches through data, looking for a match with a given pattern.
+    *
+    * If there is a match, we return the matching [[DataCandidate]],
+    * along with the remaining unmatched data. If an illegal state is reached
+    * during searching for a match we short circuit and return the state.
+    */
+  private[rspace] final def findMatchingDataCandidate(
+      channel: C,
+      data: Seq[(Datum[A], Int)],
+      pattern: P,
+      prefix: Seq[(Datum[A], Int)]
+  )(
+      implicit m: Match[F, P, A, R]
+  ): F[Option[MatchingDataCandidate]] =
+    data match {
+      case (indexedDatum @ (Datum(matchCandidate, persist), dataIndex)) +: remaining =>
+        m.get(pattern, matchCandidate).flatMap {
+          case None =>
+            findMatchingDataCandidate(channel, remaining, pattern, indexedDatum +: prefix)
+          case Some(mat) if persist =>
+            (DataCandidate(channel, Datum(mat, persist), dataIndex), data).some.pure[F]
+          case Some(mat) =>
+            (
+              DataCandidate(channel, Datum(mat, persist), dataIndex),
+              prefix ++ remaining
+            ).some.pure[F]
+        }
+      case _ => none[MatchingDataCandidate].pure[F]
+    }
+
+  /** Iterates through (channel, pattern) pairs looking for matching data.
+    *
+    * Potential match candidates are supplied by the `channelToIndexedData` cache.
+    *
+    * After a match is found, we remove the matching datum from the candidate cache for
+    * remaining matches. If an illegal state is reached when searching a matching candidate
+    * we treat it as if no match was found and append the illegal state to result list.
+    */
+  private[rspace] final def extractDataCandidates(
+      channelPatternPairs: Seq[(C, P)],
+      channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
+      acc: Seq[Option[DataCandidate[C, R]]]
+  )(implicit m: Match[F, P, A, R]): F[Seq[Option[DataCandidate[C, R]]]] =
+    channelPatternPairs match {
+      case (channel, pattern) +: tail =>
+        for {
+          maybeTuple <- channelToIndexedData.get(channel) match {
+                         case Some(indexedData) =>
+                           findMatchingDataCandidate(channel, indexedData, pattern, Nil)
+                         case None =>
+                           none[(DataCandidate[C, R], Seq[(Datum[A], Int)])].pure[F]
+                       }
+          dataCandidates <- maybeTuple match {
+                             case Some((cand, rem)) =>
+                               extractDataCandidates(
+                                 tail,
+                                 channelToIndexedData.updated(channel, rem),
+                                 Some(cand) +: acc
+                               )
+                             case None =>
+                               extractDataCandidates(tail, channelToIndexedData, None +: acc)
+                           }
+        } yield dataCandidates
+      case _ => acc.reverse.pure[F]
+    }
+
+  /* Produce */
+
+  private[rspace] final def extractFirstMatch(
+      channels: Seq[C],
+      matchCandidates: Seq[(WaitingContinuation[P, K], Int)],
+      channelToIndexedData: Map[C, Seq[(Datum[A], Int)]]
+  )(implicit m: Match[F, P, A, R]): F[Option[ProduceCandidate[C, P, R, K]]] =
+    matchCandidates match {
+      case (p @ WaitingContinuation(patterns, _, _, _), index) +: remaining =>
+        for {
+          maybeDataCandidates <- extractDataCandidates(
+                                  channels.zip(patterns),
+                                  channelToIndexedData,
+                                  Nil
+                                ).map(_.sequence)
+          produceCandidates <- maybeDataCandidates match {
+                                case None =>
+                                  extractFirstMatch(channels, remaining, channelToIndexedData)
+                                case Some(dataCandidates) =>
+                                  ProduceCandidate(channels, p, index, dataCandidates).some.pure[F]
+                              }
+        } yield produceCandidates
+      case _ => none[ProduceCandidate[C, P, R, K]].pure[F]
+    }
+
+  override def close(): F[Unit] = ().pure[F]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/ColdStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/ColdStore.scala
@@ -1,0 +1,60 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats.implicits._
+import cats.effect.Sync
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs.{discriminated, uint2}
+import coop.rchain.rspace.internal.codecByteVector
+import coop.rchain.shared.AttemptOpsF.RichAttempt
+
+trait ColdStore[F[_]] {
+  def put(hash: Blake2b256Hash, data: PersistedData): F[Unit]
+
+  def get(hash: Blake2b256Hash): F[Option[PersistedData]]
+
+  def close(): F[Unit]
+}
+
+object ColdStoreInstances {
+  private[history] def codecPersistedData: Codec[PersistedData] =
+    discriminated[PersistedData]
+      .by(uint2)
+      .subcaseP(0) {
+        case n: JoinsLeaf => n
+      }(codecByteVector.as[JoinsLeaf])
+      .subcaseP(1) {
+        case s: DataLeaf => s
+      }(codecByteVector.as[DataLeaf])
+      .subcaseP(2) {
+        case c: ContinuationsLeaf => c
+      }(codecByteVector.as[ContinuationsLeaf])
+
+  def coldStore[F[_]: Sync](store: Store[F]): ColdStore[F] = new ColdStore[F] {
+    private val codec = codecPersistedData
+
+    override def put(key: Blake2b256Hash, d: PersistedData): F[Unit] =
+      for {
+        encoded <- codec.encode(d).get
+        data    <- store.put(key, encoded)
+      } yield data
+
+    override def get(key: Blake2b256Hash): F[Option[PersistedData]] =
+      for {
+        maybeBytes   <- store.get(key)
+        maybeDecoded <- maybeBytes.map(bytes => codec.decode(bytes).get).sequence
+      } yield (maybeDecoded.map(_.value))
+
+    override def close(): F[Unit] = store.close()
+  }
+}
+
+sealed trait PersistedData {
+  def bytes: ByteVector
+}
+
+final case class JoinsLeaf(bytes: ByteVector)         extends PersistedData
+final case class DataLeaf(bytes: ByteVector)          extends PersistedData
+final case class ContinuationsLeaf(bytes: ByteVector) extends PersistedData

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/History.scala
@@ -1,0 +1,172 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import scodec.{Attempt, Codec}
+import scodec.bits.{BitVector, ByteVector}
+import scodec.codecs.{discriminated, provide, uint, uint2, vectorOfN}
+import internal.codecByteVector
+import coop.rchain.shared.AttemptOps._
+import History._
+
+trait History[F[_]] {
+  def process(actions: List[HistoryAction]): F[History[F]]
+  def root: Blake2b256Hash
+  def find(key: KeyPath): F[(TriePointer, Vector[Trie])]
+  def close(): F[Unit]
+  def reset(root: Blake2b256Hash): History[F]
+}
+
+object History {
+
+  val emptyRoot: Trie               = EmptyTrie
+  private[this] def encodeEmptyRoot = Trie.codecTrie.encode(emptyRoot).get.toByteVector
+  val emptyRootHash: Blake2b256Hash = Blake2b256Hash.create(encodeEmptyRoot)
+
+  // this mapping is kept explicit on purpose
+  @inline
+  private[history] def toInt(b: Byte): Int =
+    java.lang.Byte.toUnsignedInt(b)
+
+  // this mapping is kept explicit on purpose
+  @inline
+  private[history] def toByte(i: Int): Byte =
+    i.toByte
+
+  def commonPrefix(l: KeyPath, r: KeyPath): KeyPath =
+    (l.view, r.view).zipped.takeWhile { case (ll, rr) => ll == rr }.map(_._1).toSeq
+
+  def skip(pb: PointerBlock, affix: KeyPath): Trie =
+    Skip(ByteVector(affix), NodePointer(pb.hash))
+
+  type KeyPath = Seq[Byte]
+}
+
+sealed trait Trie
+sealed trait NonEmptyTrie extends Trie
+case object EmptyTrie     extends Trie
+final case class Skip(affix: ByteVector, ptr: ValuePointer) extends NonEmptyTrie {
+  lazy val encoded: BitVector = Trie.codecSkip.encode(this).get
+
+  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
+}
+
+final case class PointerBlock private (toVector: Vector[TriePointer]) extends NonEmptyTrie {
+  def updated(tuples: List[(Int, TriePointer)]): PointerBlock =
+    new PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
+      vec.updated(curr._1, curr._2)
+    })
+
+  def countNonEmpty: Int = toVector.count(_ != EmptyPointer)
+
+  lazy val encoded: BitVector = PointerBlock.codecPointerBlock.encode(this).get
+
+  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
+
+  override def toString: String = {
+    val pbs =
+      toVector.zipWithIndex.filter { case (v, _) => v != EmptyPointer }.map(_.swap).mkString(";")
+    s"PB($hash: $pbs)"
+  }
+}
+
+sealed trait TriePointer
+sealed trait NonEmptyTriePointer extends TriePointer {
+  def hash: Blake2b256Hash
+}
+case object EmptyPointer  extends TriePointer
+sealed trait ValuePointer extends NonEmptyTriePointer
+
+final case class LeafPointer(hash: Blake2b256Hash) extends ValuePointer
+final case class SkipPointer(hash: Blake2b256Hash) extends NonEmptyTriePointer
+final case class NodePointer(hash: Blake2b256Hash) extends ValuePointer
+
+object Trie {
+  def hash(trie: Trie): Blake2b256Hash =
+    trie match {
+      case pb: PointerBlock  => pb.hash
+      case s: Skip           => s.hash
+      case _: EmptyTrie.type => History.emptyRootHash
+    }
+
+  val codecSkip: Codec[Skip] = (codecByteVector :: codecTrieValuePointer).as[Skip]
+
+  val memoizingSkipCodec: Codec[Skip] =
+    Codec.apply((s: Skip) => Attempt.successful(s.encoded), codecSkip.decode)
+
+  val memoizingPointerBlockCodec: Codec[PointerBlock] =
+    Codec.apply(
+      (s: PointerBlock) => Attempt.successful(s.encoded),
+      PointerBlock.codecPointerBlock.decode
+    )
+
+  val codecTrie: Codec[Trie] =
+    discriminated[Trie]
+      .by(uint2)
+      .subcaseP(0) {
+        case e: EmptyTrie.type => e
+      }(provide(EmptyTrie))
+      .subcaseP(1) {
+        case s: Skip => s
+      }(memoizingSkipCodec)
+      .subcaseP(2) {
+        case pb: PointerBlock => pb
+      }(memoizingPointerBlockCodec)
+
+  implicit def codecTriePointer: Codec[TriePointer] =
+    discriminated[TriePointer]
+      .by(uint2)
+      .subcaseP(0) {
+        case p: EmptyPointer.type => p
+      }(provide(EmptyPointer))
+      .subcaseP(1) {
+        case p: LeafPointer => p
+      }(Blake2b256Hash.codecBlake2b256Hash.as[LeafPointer])
+      .subcaseP(2) {
+        case p: SkipPointer => p
+      }(Blake2b256Hash.codecBlake2b256Hash.as[SkipPointer])
+      .subcaseP(3) {
+        case p: NodePointer => p
+      }(Blake2b256Hash.codecBlake2b256Hash.as[NodePointer])
+
+  implicit def codecTrieValuePointer: Codec[ValuePointer] =
+    discriminated[ValuePointer]
+      .by(uint(1))
+      .subcaseP(0) {
+        case p: LeafPointer => p
+      }(Blake2b256Hash.codecBlake2b256Hash.as[LeafPointer])
+      .subcaseP(1) {
+        case p: NodePointer => p
+      }(Blake2b256Hash.codecBlake2b256Hash.as[NodePointer])
+
+}
+
+object PointerBlock {
+  val length = 256
+
+  def create(): PointerBlock = new PointerBlock(Vector.fill(length)(EmptyPointer))
+
+  def create(first: (Int, TriePointer)): PointerBlock =
+    PointerBlock.create().updated(List(first))
+
+  def create(first: (Int, TriePointer), second: (Int, TriePointer)): PointerBlock =
+    PointerBlock.create().updated(List(first, second))
+
+  // consider using zlib
+  implicit val codecPointerBlock: Codec[PointerBlock] =
+    vectorOfN(
+      provide(length),
+      Trie.codecTriePointer
+    ).as[PointerBlock]
+
+  def unapply(arg: PointerBlock): Option[Vector[TriePointer]] = Option(arg.toVector)
+}
+
+final case class TriePath(nodes: Vector[Trie], conflicting: Option[Trie], edges: KeyPath) {
+  def append(affix: KeyPath, t: Trie): TriePath =
+    this.copy(nodes = this.nodes :+ t, edges = this.edges ++ affix)
+}
+
+object TriePath {
+  def empty: TriePath = TriePath(Vector(), None, Nil)
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryAction.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryAction.scala
@@ -1,0 +1,12 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import coop.rchain.rspace.history.History.KeyPath
+
+sealed trait HistoryAction {
+  def key: KeyPath
+}
+
+final case class InsertAction(key: KeyPath, hash: Blake2b256Hash) extends HistoryAction
+final case class DeleteAction(key: KeyPath)                       extends HistoryAction

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryInstances.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryInstances.scala
@@ -1,0 +1,481 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats.effect.Sync
+import cats.implicits._
+import cats.{Applicative, FlatMap}
+import History._
+import scodec.bits.ByteVector
+
+import scala.Ordering.Implicits.seqDerivedOrdering
+import scala.collection.concurrent.TrieMap
+
+object HistoryInstances {
+
+  def MalformedTrieError = new RuntimeException("malformed trie")
+
+  final case class MergingHistory[F[_]: Sync](
+      root: Blake2b256Hash,
+      historyStore: CachingHistoryStore[F]
+  ) extends History[F] {
+
+    def skip(path: History.KeyPath, ptr: ValuePointer): (TriePointer, Option[Trie]) =
+      if (path.isEmpty) {
+        (ptr, None)
+      } else {
+        val s = Skip(ByteVector(path), ptr)
+        (SkipPointer(Trie.hash(s)), Some(s))
+      }
+
+    def pointer(trie: Trie): TriePointer =
+      trie match {
+        case EmptyTrie        => EmptyPointer
+        case pb: PointerBlock => NodePointer(pb.hash)
+        case s: Skip          => SkipPointer(s.hash)
+      }
+
+    private def divideSkip(
+        incomingPath: KeyPath,
+        affix: ByteVector,
+        incomingPointer: ValuePointer,
+        existingPointer: ValuePointer
+    ): (List[Trie], TriePointer) = {
+      val affixBytes                                 = affix.toSeq.toList
+      val prefixPath                                 = commonPrefix(incomingPath, affixBytes)
+      val incomingIdx :: incomingTail                = incomingPath.drop(prefixPath.size)
+      val existingIdx :: existingTail                = affixBytes.drop(prefixPath.size)
+      val (newExistingPointer, maybeNewExistingSkip) = skip(existingTail, existingPointer)
+      val (newIncomingPointer, maybeIncomingSkip)    = skip(incomingTail, incomingPointer)
+      val pointerBlock = PointerBlock.create(
+        (toInt(incomingIdx), newIncomingPointer),
+        (toInt(existingIdx), newExistingPointer)
+      )
+      val pbPtr                            = NodePointer(pointerBlock.hash)
+      val (topLevelPtr, maybeTopLevelSkip) = skip(prefixPath, pbPtr)
+      val res                              = maybeNewExistingSkip ++ maybeIncomingSkip ++ Some(pointerBlock) ++ maybeTopLevelSkip
+      (res.toList, topLevelPtr)
+    }
+
+    // TODO consider an indexedseq
+    private def rebalanceInsert(
+        newLeaf: LeafPointer,
+        remainingPath: KeyPath,
+        partialTrie: TriePath
+    ): F[List[Trie]] =
+      partialTrie match {
+        case TriePath(Vector(), None, Nil) => // kickstart a trie
+          Applicative[F].pure(Skip(ByteVector(remainingPath), newLeaf) :: Nil)
+
+        case TriePath(Vector(Skip(skippedPath, LeafPointer(_))), None, common)
+            if common == skippedPath.toSeq.toList => // update 1 element trie
+          Applicative[F].pure(Skip(ByteVector(common), newLeaf) :: Nil)
+
+        case TriePath(Vector(), Some(Skip(affix, existingPointer)), Nil) => // split skip at root
+          val (dividedElems, _) = divideSkip(
+            remainingPath,
+            affix,
+            newLeaf,
+            existingPointer
+          )
+          Applicative[F].pure(dividedElems)
+
+        case TriePath(
+            elems :+ (pointerBlock: PointerBlock),
+            Some(Skip(affix, existingPointer)),
+            common
+            ) => // split existing skip
+          val incomingPath = remainingPath.drop(common.size)
+          val (dividedElems, dividedTopPtr) = divideSkip(
+            incomingPath,
+            affix,
+            newLeaf,
+            existingPointer
+          )
+          val updatedPointerBlock = pointerBlock.updated((toInt(common.last), dividedTopPtr) :: Nil)
+          rehash(common.init, elems, updatedPointerBlock, dividedElems)
+
+        case TriePath(elems :+ (pastPb: PointerBlock), None, common) => // add to existing node
+          val key          = remainingPath.drop(common.size)
+          val (ptr, nodes) = skip(key, newLeaf)
+          val updatedPb    = pastPb.updated((toInt(common.last), ptr) :: Nil)
+          rehash(common.init, elems, updatedPb, nodes.toList)
+
+        case TriePath(elems :+ Skip(affix, LeafPointer(_)), _, path) => // update value
+          rehash(path.dropRight(affix.size.toInt), elems, Skip(affix, newLeaf), Nil)
+        case _ => Sync[F].raiseError(MalformedTrieError)
+      }
+
+    private def rehash(
+        path: KeyPath,
+        rest: Vector[Trie],
+        lastSeen: Trie,
+        initialElements: List[Trie]
+    ): F[List[Trie]] = {
+      type Params = (KeyPath, Vector[Trie], Trie, List[Trie])
+      def go(params: Params): F[Either[Params, List[Trie]]] =
+        params match {
+          case (
+              remainingPath: KeyPath,
+              remainingPrefixNodes: Vector[Trie],
+              nextLastSeen: Trie,
+              currentAcc: List[Trie]
+              ) =>
+            (remainingPrefixNodes, nextLastSeen) match {
+              case (head :+ (pointerBlock: PointerBlock), other) =>
+                val ptr     = pointer(other)
+                val updated = pointerBlock.updated((toInt(remainingPath.last), ptr) :: Nil)
+                Applicative[F].pure(
+                  (remainingPath.init, head, updated, currentAcc :+ nextLastSeen).asLeft
+                )
+
+              case (head :+ Skip(affix, _), pb: PointerBlock) =>
+                Applicative[F]
+                  .pure(
+                    (
+                      remainingPath.dropRight(affix.size.toInt),
+                      head,
+                      Skip(affix, NodePointer(pb.hash)),
+                      currentAcc :+ nextLastSeen
+                    )
+                  )
+                  .map(_.asLeft)
+
+              case (Vector(), _) => Applicative[F].pure(currentAcc :+ nextLastSeen).map(_.asRight)
+              case _             => Sync[F].raiseError(MalformedTrieError)
+
+            }
+        }
+      FlatMap[F].tailRecM((path, rest, lastSeen, initialElements))(go)
+    }
+
+    private def rebalanceDelete(fullPath: KeyPath, trieNodesOnPath: Vector[Trie]): F[List[Trie]] = {
+      type Params = (KeyPath, Vector[Trie], Option[Trie])
+      def go(params: Params): F[Either[Params, List[Trie]]] =
+        params match {
+          case (currentKey, init :+ Skip(affix, _), None) => // remove empty skip
+            Applicative[F]
+              .pure((currentKey.dropRight(affix.size.toInt), init, None))
+              .map(_.asLeft)
+
+          case (currentKey, init :+ Skip(affix, _), Some(Skip(eaffix, ep))) => // merge skips
+            rehash(currentKey.dropRight(affix.size.toInt), init, Skip(affix ++ eaffix, ep), Nil)
+              .map(_.asRight)
+
+          case (keyInit :+ keyLast, init :+ (pointerBlock: PointerBlock), None) => // handle pointer block
+            pointerBlock match {
+              case _ if pointerBlock.countNonEmpty == 2 =>
+                // pointerBlock contains 1 more element, find it, wrap in skip and re-balance
+                val (other, idx) = pointerBlock
+                  .updated((toInt(keyLast), EmptyPointer) :: Nil)
+                  .toVector
+                  .zipWithIndex
+                  .filter(v => v._1 != EmptyPointer)
+                  .head
+                val r: F[Trie] = other match {
+                  case sp: SkipPointer =>
+                    historyStore.get(sp.hash).flatMap {
+                      case Skip(affix, ptr) => Applicative[F].pure(Skip(toByte(idx) +: affix, ptr))
+                      case _                => Sync[F].raiseError[Trie](MalformedTrieError)
+                    }
+                  case n: NodePointer =>
+                    Applicative[F].pure(Skip(ByteVector(toByte(idx)), n))
+                  case l: LeafPointer =>
+                    Applicative[F].pure(Skip(ByteVector(toByte(idx)), l))
+                  case _ =>
+                    Sync[F].raiseError[Trie](MalformedTrieError)
+                }
+                r.map { nv =>
+                  (keyInit, init, Some(nv)).asLeft
+                }
+              case _ => // pb contains 3+ elements, drop one, rehash
+                val updated = pointerBlock.updated((toInt(keyLast), EmptyPointer) :: Nil)
+                rehash(keyInit, init, updated, Nil).map(_.asRight)
+            }
+
+          case (key, rest @ _ :+ (_: PointerBlock), Some(s: Skip)) =>
+            rehash(key, rest, s, Nil).map(_.asRight)
+
+          case (Nil, Vector(), Some(t)) =>
+            Applicative[F].pure(t :: Nil).map(_.asRight) // collapse to one element in trie
+
+          case (Nil, Vector(), None) =>
+            Applicative[F].pure(EmptyTrie :: Nil).map(_.asRight) // collapse to empty trie
+        }
+      FlatMap[F].tailRecM((fullPath, trieNodesOnPath, none[Trie]))(go)
+    }
+
+    def findUncommonNode(
+        currentPath: KeyPath,
+        previousPath: KeyPath,
+        previousRoot: Trie
+    ): F[Option[Blake2b256Hash]] = {
+      def commonPrefixWithLastDiverging(path: KeyPath, affix: ByteVector): Boolean =
+        affix.toSeq.startsWith(path.dropRight(1))
+
+      def extractPointerToPointerBlock(ptr: ValuePointer): Option[Blake2b256Hash] =
+        ptr match {
+          case _: LeafPointer    => none      // ignore leaf
+          case NodePointer(hash) => hash.some // pick pointerBlock
+        }
+
+      def pathTerminatesInAffix(path: KeyPath, affix: KeyPath): Boolean =
+        affix == path || affix.startsWith(path)
+
+      type PathToTrie = (KeyPath, Trie)
+      def go(params: PathToTrie): F[Either[(KeyPath, Trie), Option[Blake2b256Hash]]] =
+        params match {
+          // whatever lives beneath the skip can be persisted
+          case (path, Skip(affix, ptr)) if pathTerminatesInAffix(path, affix.toSeq) =>
+            Applicative[F].pure(extractPointerToPointerBlock(ptr).asRight)
+
+          // traverse non-terminal skip
+          case (path, Skip(affix, ptr)) if path.startsWith(affix.toSeq) =>
+            ptr match {
+              case _: LeafPointer => Sync[F].raiseError(MalformedTrieError)
+              case NodePointer(hash) =>
+                historyStore
+                  .get(hash)
+                  .map(v => (path.drop(affix.size.toInt), v).asLeft)
+            }
+
+          // the path does not exist but some other skip lives near it == a node was removed
+          case (path, Skip(affix, _)) if commonPrefixWithLastDiverging(path, affix) =>
+            Applicative[F].pure(None.asRight) // removed path
+
+          case (b :: Nil, PointerBlock(pointers)) => // interpret terminal pointer block
+            (pointers(toInt(b)) match {
+              case SkipPointer(hash) => hash.some
+              case NodePointer(hash) => hash.some
+              case _: LeafPointer    => none[Blake2b256Hash] // ignore leaf
+              case EmptyPointer      => none[Blake2b256Hash] // removed path
+            }).asRight[PathToTrie].pure[F]
+
+          case (b :: rest, PointerBlock(pointers)) => // traverse non-terminal pointer block
+            pointers(toInt(b)) match {
+              case SkipPointer(hash) => historyStore.get(hash).map(v => (rest, v).asLeft)
+              case NodePointer(hash) => historyStore.get(hash).map(v => (rest, v).asLeft)
+              case _: LeafPointer    => Sync[F].raiseError(MalformedTrieError)
+              case EmptyPointer      => Applicative[F].pure(None.asRight) // removed path
+            }
+
+          case _ => Sync[F].raiseError(MalformedTrieError)
+        }
+
+      val common = commonPrefix(previousPath, currentPath)
+      if (common == currentPath) Applicative[F].pure(none[Blake2b256Hash])
+      else {
+        val withFirstUncommon = previousPath.take(common.size + 1)
+        Sync[F].tailRecM((withFirstUncommon, previousRoot))(go)
+      }
+    }
+
+    def commitUncommonLeftSubtrie(
+        currentPath: KeyPath,
+        previousPath: KeyPath,
+        previousRoot: Trie
+    ): F[Unit] =
+      for {
+        hashOpt <- findUncommonNode(currentPath, previousPath, previousRoot)
+        _ <- hashOpt match {
+              case None       => Applicative[F].unit
+              case Some(hash) => historyStore.commit(hash)
+            }
+      } yield ()
+
+    def commitPreviousModification(
+        currentPath: KeyPath,
+        previousModificationOpt: Option[(KeyPath, Trie)]
+    ): F[Unit] =
+      previousModificationOpt match {
+        case None => Applicative[F].unit
+        case Some((previousPath, previousRoot)) =>
+          commitUncommonLeftSubtrie(currentPath, previousPath, previousRoot)
+      }
+
+    def process(actions: List[HistoryAction]): F[History[F]] = {
+      type LastModification = (KeyPath, Trie)
+      val start: (Blake2b256Hash, Option[LastModification]) = (this.root, None)
+      val sorted                                            = actions.sortBy(_.key)
+      def insert(
+          currentRoot: Blake2b256Hash,
+          previousModificationOpt: Option[LastModification],
+          remainingPath: KeyPath,
+          value: Blake2b256Hash
+      ): F[(Blake2b256Hash, Option[LastModification])] =
+        for {
+          _              <- commitPreviousModification(remainingPath, previousModificationOpt)
+          traverseResult <- findPath(remainingPath, currentRoot)
+          (_, triePath)  = traverseResult
+          elements       <- rebalanceInsert(LeafPointer(value), remainingPath, triePath)
+          _              <- historyStore.put(elements)
+        } yield (Trie.hash(elements.last), (remainingPath, elements.last).some)
+
+      def delete(
+          currentRoot: Blake2b256Hash,
+          previousModificationOpt: Option[LastModification],
+          remainingPath: KeyPath
+      ): F[(Blake2b256Hash, Option[LastModification])] =
+        for {
+          _              <- commitPreviousModification(remainingPath, previousModificationOpt)
+          traverseResult <- findPath(remainingPath, currentRoot)
+          (_, triePath)  = traverseResult
+          elements <- triePath match {
+                       case TriePath(elems, None, path) if remainingPath == path =>
+                         rebalanceDelete(remainingPath, elems)
+                       case _ =>
+                         Applicative[F].pure[List[Trie]](Nil)
+                     }
+          _ <- historyStore.put(elements)
+        } yield (
+          elements.lastOption.map(Trie.hash).getOrElse(currentRoot),
+          elements.lastOption.map(t => (remainingPath, t))
+        )
+
+      for {
+        _ <- Sync[F].ifM((actions.map(_.key).toSet.size == actions.size).pure[F])(
+              ifTrue = Applicative[F].unit,
+              ifFalse = Sync[F].raiseError(
+                new RuntimeException("Cannot process duplicate actions on one key")
+              )
+            )
+        result <- sorted.foldLeftM(start) {
+                   case (
+                       (currentRoot, previousModificationOpt),
+                       InsertAction(remainingPath, value)
+                       ) =>
+                     insert(currentRoot, previousModificationOpt, remainingPath, value)
+
+                   case ((currentRoot, previousModificationOpt), DeleteAction(remainingPath)) =>
+                     delete(currentRoot, previousModificationOpt, remainingPath)
+                 }
+        (newRoot, _) = result
+        _            <- historyStore.commit(newRoot)
+        _            <- historyStore.clear()
+      } yield this.copy(root = newRoot)
+    }
+
+    private[history] def findPath(
+        key: KeyPath,
+        start: Blake2b256Hash
+    ): F[(TriePointer, TriePath)] = {
+      type Params = (Trie, KeyPath, TriePath)
+      def traverse(params: Params): F[Either[Params, (TriePointer, TriePath)]] =
+        params match {
+          case (EmptyTrie, _, path) => Applicative[F].pure((EmptyPointer, path)).map(_.asRight)
+          case (s @ Skip(affix, p), remainingPath, path) if remainingPath.startsWith(affix.toSeq) =>
+            p match {
+              case _: LeafPointer if remainingPath == affix.toSeq =>
+                Applicative[F].pure((p, path.append(affix.toSeq, s)).asRight)
+              case _: LeafPointer =>
+                Sync[F].raiseError(MalformedTrieError)
+              case _: NodePointer =>
+                historyStore
+                  .get(p.hash)
+                  .map(
+                    trie =>
+                      (
+                        trie,
+                        remainingPath.drop(affix.size.toInt),
+                        path.append(affix.toSeq.toList, s)
+                      ).asLeft
+                  )
+            }
+          case (s: Skip, _, path) => //not a prefix
+            Applicative[F].pure((EmptyPointer, path.copy(conflicting = Some(s)))).map(_.asRight)
+          case (pb: PointerBlock, h :: tail, path) =>
+            pb.toVector(toInt(h)) match {
+              case e: EmptyPointer.type =>
+                Applicative[F].pure((e, path.append(h :: Nil, pb)).asRight)
+              case n: NodePointer =>
+                historyStore.get(n.hash).map(t => (t, tail, path.append(h :: Nil, pb)).asLeft)
+              case s: SkipPointer =>
+                historyStore.get(s.hash).map(t => (t, tail, path.append(h :: Nil, pb)).asLeft)
+              case l: LeafPointer if tail.isEmpty =>
+                Applicative[F].pure((l, path.append(h :: Nil, pb)).asRight)
+              case _: LeafPointer => Sync[F].raiseError(MalformedTrieError)
+            }
+          case _ => Sync[F].raiseError(MalformedTrieError)
+        }
+      for {
+        node   <- historyStore.get(start)
+        result <- FlatMap[F].tailRecM((node, key, TriePath.empty))(traverse)
+      } yield result
+
+    }
+
+    private[history] def findPath(key: KeyPath): F[(TriePointer, TriePath)] =
+      findPath(key, root)
+
+    def find(key: KeyPath): F[(TriePointer, Vector[Trie])] = findPath(key).map {
+      case (trie, path) => (trie, path.nodes)
+    }
+
+    override def close(): F[Unit] = historyStore.close()
+
+    override def reset(root: Blake2b256Hash): History[F] = this.copy(root = root)
+
+  }
+
+  def merging[F[_]: Sync](root: Blake2b256Hash, historyStore: HistoryStore[F]): History[F] =
+    new MergingHistory[F](root, CachingHistoryStore(historyStore))
+
+  final case class CachingHistoryStore[F[_]: Sync](historyStore: HistoryStore[F])
+      extends HistoryStore[F] {
+    private[this] val cache: TrieMap[Blake2b256Hash, Trie] = TrieMap.empty
+
+    override def put(tries: List[Trie]): F[Unit] =
+      Sync[F].delay {
+        tries.foreach { t =>
+          cache.put(Trie.hash(t), t)
+        }
+      }
+
+    override def get(key: Blake2b256Hash): F[Trie] =
+      for {
+        maybeValue <- Sync[F].delay { cache.get(key) }
+        result <- maybeValue match {
+                   case None    => historyStore.get(key)
+                   case Some(v) => Applicative[F].pure(v)
+                 }
+      } yield result
+
+    override def close(): F[Unit] = historyStore.close()
+
+    def clear(): F[Unit] = Sync[F].delay {
+      cache.clear()
+    }
+
+    def commit(key: Blake2b256Hash): F[Unit] = {
+      def getValue(key: Blake2b256Hash): List[Trie] =
+        cache.get(key).toList // if a key exists in cache - we want to process it
+
+      def extractRefs(t: Trie): Seq[Blake2b256Hash] =
+        t match {
+          case pb: PointerBlock =>
+            pb.toVector.toList.filter(_ != EmptyPointer).flatMap {
+              case v: SkipPointer => v.hash :: Nil
+              case v: NodePointer => v.hash :: Nil
+              case _              => Nil
+            }
+          case Skip(_, LeafPointer(_))    => Nil
+          case Skip(_, NodePointer(hash)) => hash :: Nil
+          case EmptyTrie                  => Nil
+        }
+
+      def go(keys: List[Blake2b256Hash]): F[Either[List[Blake2b256Hash], Unit]] =
+        if (keys.isEmpty) Sync[F].pure(().asRight)
+        else {
+          val head :: rest = keys
+          for {
+            ts   <- Sync[F].delay { getValue(head) }
+            _    <- historyStore.put(ts)
+            _    <- Sync[F].delay { cache.remove(head) }
+            refs = ts.flatMap(extractRefs)
+          } yield (refs ++ rest).asLeft
+        }
+      Sync[F].tailRecM(key :: Nil)(go)
+    }
+
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryRepository.scala
@@ -1,0 +1,56 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats.implicits._
+import cats.effect.Sync
+import org.lmdbjava.EnvFlags
+import scodec.Codec
+
+trait HistoryRepository[F[_], C, P, A, K] extends HistoryReader[F, C, P, A, K] {
+  def checkpoint(actions: List[HotStoreAction]): F[HistoryRepository[F, C, P, A, K]]
+
+  def reset(root: Blake2b256Hash): F[HistoryRepository[F, C, P, A, K]]
+
+  def history: History[F]
+
+  def close(): F[Unit]
+}
+
+final case class LMDBStorageConfig(
+    path: String,
+    mapSize: Long,
+    maxReaders: Int = 2048,
+    maxDbs: Int = 2,
+    flags: List[EnvFlags] = Nil,
+    dbNamePrefix: String = "db"
+)
+final case class LMDBRSpaceStorageConfig(
+    coldStore: StoreConfig,
+    historyStore: StoreConfig,
+    rootsStore: StoreConfig
+)
+
+object HistoryRepositoryInstances {
+
+  def lmdbRepository[F[_]: Sync, C, P, A, K](
+      config: LMDBRSpaceStorageConfig
+  )(
+      implicit codecC: Codec[C],
+      codecP: Codec[P],
+      codecA: Codec[A],
+      codecK: Codec[K]
+  ): F[HistoryRepository[F, C, P, A, K]] = {
+    val rootsLMDBStore  = StoreInstances.lmdbStore[F](config.rootsStore)
+    val rootsRepository = new RootRepository[F](RootsStoreInstances.rootsStore[F](rootsLMDBStore))
+
+    for {
+      currentRoot      <- rootsRepository.currentRoot()
+      coldLMDBStore    = StoreInstances.lmdbStore[F](config.coldStore)
+      coldStore        = ColdStoreInstances.coldStore[F](coldLMDBStore)
+      historyLMDBStore = StoreInstances.lmdbStore[F](config.historyStore)
+      historyStore     = HistoryStoreInstances.historyStore[F](historyLMDBStore)
+      history          = HistoryInstances.merging(currentRoot, historyStore)
+    } yield HistoryRepositoryImpl[F, C, P, A, K](history, rootsRepository, coldStore)
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryRepositoryImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryRepositoryImpl.scala
@@ -1,0 +1,258 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import java.nio.charset.StandardCharsets
+
+import cats.Applicative
+import cats.effect.{IO, Sync}
+import cats.implicits._
+import internal._
+import scodec.Codec
+import scodec.bits.{BitVector, ByteVector}
+import HistoryRepositoryImpl._
+import com.typesafe.scalalogging.Logger
+import monix.execution.schedulers.TestScheduler.Task
+
+final case class HistoryRepositoryImpl[F[_]: Sync, C, P, A, K](
+    history: History[F],
+    rootsRepository: RootRepository[F],
+    leafStore: ColdStore[F]
+)(implicit codecC: Codec[C], codecP: Codec[P], codecA: Codec[A], codecK: Codec[K])
+    extends HistoryRepository[F, C, P, A, K] {
+  val joinSuffixBits                = BitVector("-joins".getBytes(StandardCharsets.UTF_8))
+  val dataSuffixBits                = BitVector("-data".getBytes(StandardCharsets.UTF_8))
+  val continuationSuffixBits        = BitVector("-continuation".getBytes(StandardCharsets.UTF_8))
+  val codecJoin: Codec[Seq[Seq[C]]] = codecSeq(codecSeq(codecC))
+
+  implicit val serializeC: Serialize[C] = Serialize.fromCodec(codecC)
+
+  private def fetchData(key: Blake2b256Hash): F[Option[PersistedData]] =
+    history.find(key.bytes.toSeq.toList).flatMap {
+      case (trie, _) =>
+        trie match {
+          case LeafPointer(dataHash) => leafStore.get(dataHash)
+          case EmptyPointer          => Applicative[F].pure(None)
+          case _ =>
+            Sync[F].raiseError(new RuntimeException(s"unexpected data at key $key, data: $trie"))
+
+        }
+    }
+
+  private def hashWithSuffix(bits: BitVector, suffix: BitVector): Blake2b256Hash = {
+    val suffixed = bits ++ suffix
+    Blake2b256Hash.create(suffixed.toByteVector)
+  }
+
+  private def hashJoinsChannel(channel: C): Blake2b256Hash =
+    hashWithSuffix(codecC.encode(channel).get, joinSuffixBits)
+
+  private def hashContinuationsChannels(channels: Seq[C]): Blake2b256Hash = {
+    val chs = channels
+      .map(c => serializeC.encode(c))
+      .sorted(util.ordByteVector)
+    val channelsBits = codecSeq(codecByteVector).encode(chs).get
+    hashWithSuffix(channelsBits, continuationSuffixBits)
+  }
+
+  private def hashDataChannel(channel: C): Blake2b256Hash =
+    hashWithSuffix(codecC.encode(channel).get, dataSuffixBits)
+
+  def decode[R](bv: ByteVector)(implicit codecR: Codec[R]): Seq[R] =
+    Codec.decode[Seq[R]](bv.bits).get.value
+
+  override def getJoins(channel: C): F[Seq[Seq[C]]] =
+    fetchData(hashJoinsChannel(channel)).flatMap {
+      case Some(JoinsLeaf(bytes)) =>
+        decodeJoins[C](bytes).pure[F]
+      case Some(p) =>
+        Sync[F].raiseError[Seq[Seq[C]]](
+          new RuntimeException(
+            s"Found unexpected leaf while looking for joins at key $channel, data: $p"
+          )
+        )
+      case None => Seq.empty[Seq[C]].pure[F]
+    }
+
+  override def getData(channel: C): F[Seq[internal.Datum[A]]] =
+    fetchData(hashDataChannel(channel)).flatMap {
+      case Some(DataLeaf(bytes)) =>
+        decodeSorted[internal.Datum[A]](bytes).pure[F]
+      case Some(p) =>
+        Sync[F].raiseError[Seq[internal.Datum[A]]](
+          new RuntimeException(
+            s"Found unexpected leaf while looking for data at key $channel, data: $p"
+          )
+        )
+      case None => Seq.empty[internal.Datum[A]].pure[F]
+    }
+
+  override def getContinuations(channels: Seq[C]): F[Seq[internal.WaitingContinuation[P, K]]] =
+    fetchData(hashContinuationsChannels(channels)).flatMap {
+      case Some(ContinuationsLeaf(bytes)) =>
+        decodeSorted[internal.WaitingContinuation[P, K]](bytes).pure[F]
+      case Some(p) =>
+        Sync[F].raiseError[Seq[internal.WaitingContinuation[P, K]]](
+          new RuntimeException(
+            s"Found unexpected leaf while looking for continuations at key $channels, data: $p"
+          )
+        )
+      case None => Seq.empty[internal.WaitingContinuation[P, K]].pure[F]
+    }
+
+  type Result = (Blake2b256Hash, Option[PersistedData], HistoryAction)
+
+  protected[this] val dataLogger: Logger =
+    Logger("coop.rchain.rspace.datametrics")
+
+  private def measure(actions: List[HotStoreAction]): F[Unit] =
+    Sync[F].delay(
+      dataLogger.whenDebugEnabled {
+        computeMeasure(actions).foreach(p => dataLogger.debug(p))
+      }
+    )
+
+  private def computeMeasure(actions: List[HotStoreAction]): List[String] =
+    actions.map {
+      case i: InsertData[C, A] =>
+        val key  = hashDataChannel(i.channel).bytes
+        val data = encodeData(i.data)
+        s"${key.toHex};insert-data;${data.length};${i.data.length}"
+      case i: InsertContinuations[C, P, K] =>
+        val key  = hashContinuationsChannels(i.channels).bytes
+        val data = encodeContinuations(i.continuations)
+        s"${key.toHex};insert-continuation;${data.length};${i.continuations.length}"
+      case i: InsertJoins[C] =>
+        val key  = hashJoinsChannel(i.channel).bytes
+        val data = encodeJoins(i.joins)
+        s"${key.toHex};insert-join;${data.length}"
+      case d: DeleteData[C] =>
+        val key = hashDataChannel(d.channel).bytes
+        s"${key.toHex};delete-data;0"
+      case d: DeleteContinuations[C] =>
+        val key = hashContinuationsChannels(d.channels).bytes
+        s"${key.toHex};delete-continuation;0"
+      case d: DeleteJoins[C] =>
+        val key = hashJoinsChannel(d.channel).bytes
+        s"${key.toHex};delete-join;0"
+    }
+
+  private def transform(actions: List[HotStoreAction]): List[Result] =
+    actions.map {
+      case i: InsertData[C, A] =>
+        val key      = hashDataChannel(i.channel)
+        val data     = encodeData(i.data)
+        val dataLeaf = DataLeaf(data)
+        val dataHash = Blake2b256Hash.create(data)
+        (dataHash, Some(dataLeaf), InsertAction(key.bytes.toSeq.toList, dataHash))
+      case i: InsertContinuations[C, P, K] =>
+        val key               = hashContinuationsChannels(i.channels)
+        val data              = encodeContinuations(i.continuations)
+        val continuationsLeaf = ContinuationsLeaf(data)
+        val continuationsHash = Blake2b256Hash.create(data)
+        (
+          continuationsHash,
+          Some(continuationsLeaf),
+          InsertAction(key.bytes.toSeq.toList, continuationsHash)
+        )
+      case i: InsertJoins[C] =>
+        val key       = hashJoinsChannel(i.channel)
+        val data      = encodeJoins(i.joins)
+        val joinsLeaf = JoinsLeaf(data)
+        val joinsHash = Blake2b256Hash.create(data)
+        (joinsHash, Some(joinsLeaf), InsertAction(key.bytes.toSeq.toList, joinsHash))
+      case d: DeleteData[C] =>
+        val key = hashDataChannel(d.channel)
+        (key, None, DeleteAction(key.bytes.toSeq.toList))
+      case d: DeleteContinuations[C] =>
+        val key = hashContinuationsChannels(d.channels)
+        (key, None, DeleteAction(key.bytes.toSeq.toList))
+      case d: DeleteJoins[C] =>
+        val key = hashJoinsChannel(d.channel)
+        (key, None, DeleteAction(key.bytes.toSeq.toList))
+    }
+
+  private def storeLeaves(leafs: List[Result]): F[List[HistoryAction]] =
+    leafs.traverse {
+      case (key, Some(data), historyAction) =>
+        leafStore.put(key, data).map(_ => historyAction)
+      case (_, None, historyAction) =>
+        Applicative[F].pure(historyAction)
+    }
+
+  override def checkpoint(actions: List[HotStoreAction]): F[HistoryRepository[F, C, P, A, K]] =
+    for {
+      trieActions    <- Applicative[F].pure(transform(actions))
+      historyActions <- storeLeaves(trieActions)
+      next           <- history.process(historyActions)
+      _              <- rootsRepository.commit(next.root)
+      _              <- measure(actions)
+    } yield this.copy(history = next)
+
+  override def reset(root: Blake2b256Hash): F[HistoryRepository[F, C, P, A, K]] =
+    for {
+      _    <- rootsRepository.validateRoot(root)
+      next = history.reset(root = root)
+    } yield this.copy(history = next)
+
+  override def close(): F[Unit] =
+    for {
+      _ <- leafStore.close()
+      _ <- rootsRepository.close()
+      _ <- history.close()
+    } yield ()
+}
+
+object HistoryRepositoryImpl {
+  val codecSeqByteVector: Codec[Seq[ByteVector]] = codecSeq(codecByteVector)
+
+  private def decodeSorted[D](data: ByteVector)(implicit codec: Codec[D]): Seq[D] =
+    codecSeqByteVector.decode(data.bits).get.value.map(bv => codec.decode(bv.bits).get.value)
+
+  private def encodeSorted[D](data: Seq[D])(implicit codec: Codec[D]): ByteVector =
+    codecSeqByteVector
+      .encode(
+        data
+          .map(d => Codec.encode[D](d).get.toByteVector)
+          .sorted(util.ordByteVector)
+      )
+      .get
+      .toByteVector
+
+  private def encodeUnsorted[D](data: Seq[D])(implicit codec: Codec[D]): ByteVector =
+    codecSeqByteVector
+      .encode(
+        data
+          .map(d => Codec.encode[D](d).get.toByteVector)
+      )
+      .get
+      .toByteVector
+
+  def encodeData[A](data: Seq[internal.Datum[A]])(implicit codec: Codec[Datum[A]]): ByteVector =
+    encodeSorted(data)
+
+  def encodeContinuations[P, K](
+      continuations: Seq[internal.WaitingContinuation[P, K]]
+  )(implicit codec: Codec[WaitingContinuation[P, K]]): ByteVector =
+    encodeSorted(continuations)
+
+  def decodeJoins[C](data: ByteVector)(implicit codec: Codec[C]): Seq[Seq[C]] =
+    codecSeqByteVector
+      .decode(data.bits)
+      .get
+      .value
+      .map(
+        bv => codecSeqByteVector.decode(bv.bits).get.value.map(v => codec.decode(v.bits).get.value)
+      )
+
+  def encodeJoins[C](joins: Seq[Seq[C]])(implicit codec: Codec[C]): ByteVector =
+    codecSeqByteVector
+      .encode(
+        joins
+          .map(
+            channels => encodeUnsorted(channels)
+          )
+      )
+      .get
+      .toByteVector
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HistoryStore.scala
@@ -1,0 +1,44 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.shared.AttemptOpsF.RichAttempt
+import scodec.bits.BitVector
+
+trait HistoryStore[F[_]] {
+  def put(tries: List[Trie]): F[Unit]
+
+  def get(key: Blake2b256Hash): F[Trie]
+
+  def close(): F[Unit]
+}
+
+object HistoryStoreInstances {
+  type KVData = (Blake2b256Hash, BitVector)
+  def historyStore[F[_]: Sync](store: Store[F]): HistoryStore[F] = new HistoryStore[F] {
+    // TODO put list
+    override def put(tries: List[Trie]): F[Unit] = {
+
+      def asEncoded(t: Trie): F[KVData] =
+        for {
+          b <- Trie.codecTrie.encode(t).get
+          k = Trie.hash(t)
+        } yield (k, b)
+
+      for {
+        asKeyValue <- tries traverse asEncoded
+        storeRes   <- store.put(asKeyValue)
+      } yield (storeRes)
+    }
+
+    override def get(key: Blake2b256Hash): F[Trie] =
+      for {
+        maybeBytes <- store.get(key)
+        result     <- maybeBytes.traverse(bytes => Trie.codecTrie.decode(bytes).get)
+      } yield (result.map(_.value).getOrElse(EmptyTrie))
+
+    override def close(): F[Unit] = store.close()
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/HotStore.scala
@@ -1,0 +1,300 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats._
+import cats.effect._
+import cats.implicits._
+import coop.rchain.catscontrib.mtl.implicits._
+import coop.rchain.catscontrib.seq._
+import coop.rchain.rspace.Serialize._
+import internal._
+import coop.rchain.shared.Cell
+import coop.rchain.shared.MapOps._
+import scodec.Codec
+
+import scala.collection.concurrent.TrieMap
+
+final case class Snapshot[C, P, A, K](private[rspace] val cache: Cache[C, P, A, K])
+
+trait HotStore[F[_], C, P, A, K] {
+  def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]]
+  def putContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit]
+  def installContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit]
+  def removeContinuation(channels: Seq[C], index: Int): F[Unit]
+
+  def getData(channel: C): F[Seq[Datum[A]]]
+  def putDatum(channel: C, d: Datum[A]): F[Unit]
+  def removeDatum(channel: C, index: Int): F[Unit]
+
+  def getJoins(channel: C): F[Seq[Seq[C]]]
+  def putJoin(channel: C, join: Seq[C]): F[Unit]
+  def installJoin(channel: C, join: Seq[C]): F[Unit]
+  def removeJoin(channel: C, join: Seq[C]): F[Unit]
+
+  def changes(): F[Seq[HotStoreAction]]
+  def toMap: F[Map[Seq[C], Row[P, A, K]]]
+  def snapshot(): F[Snapshot[C, P, A, K]]
+}
+
+final case class Cache[C, P, A, K](
+    continuations: TrieMap[Seq[C], Seq[WaitingContinuation[P, K]]] =
+      TrieMap.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
+    installedContinuations: TrieMap[Seq[C], WaitingContinuation[P, K]] =
+      TrieMap.empty[Seq[C], WaitingContinuation[P, K]],
+    data: TrieMap[C, Seq[Datum[A]]] = TrieMap.empty[C, Seq[Datum[A]]],
+    joins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]],
+    installedJoins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]]
+) {
+  def snapshot(): Snapshot[C, P, A, K] =
+    Snapshot(
+      this.copy(
+        continuations = this.continuations.snapshot(),
+        installedContinuations = this.installedContinuations.snapshot(),
+        data = this.data.snapshot(),
+        joins = this.joins.snapshot(),
+        installedJoins = this.installedJoins.snapshot()
+      )
+    )
+}
+
+private class InMemHotStore[F[_]: Sync, C, P, A, K](
+    implicit S: Cell[F, Cache[C, P, A, K]],
+    HR: HistoryReader[F, C, P, A, K],
+    ck: Codec[K]
+) extends HotStore[F, C, P, A, K] {
+
+  implicit val codec = fromCodec(ck)
+
+  def snapshot(): F[Snapshot[C, P, A, K]] = S.read.map(_.snapshot())
+
+  def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+    for {
+      cached <- internalGetContinuations(channels)
+      state  <- S.read
+      result = state.installedContinuations.get(channels) ++: cached
+      res <- result
+              .map(
+                wk =>
+                  roundTrip[F, K](wk.continuation).map { copied =>
+                    wk.copy(continuation = copied)
+                  }
+              )
+              .sequence
+    } yield res
+
+  private[this] def internalGetContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
+    for {
+      state <- S.read
+      res <- state.continuations.get(channels) match {
+              case None =>
+                for {
+                  historyContinuations <- HR.getContinuations(channels)
+                  _ <- S.flatModify { cache =>
+                        Sync[F]
+                          .delay(cache.continuations.putIfAbsent(channels, historyContinuations))
+                          .as(cache)
+                      }
+                } yield (historyContinuations)
+              case Some(continuations) => Applicative[F].pure(continuations)
+            }
+    } yield (res)
+
+  def putContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] =
+    for {
+      continuations <- internalGetContinuations(channels)
+      _ <- S.flatModify { cache =>
+            Sync[F].delay(cache.continuations.put(channels, wc +: continuations)).as(cache)
+          }
+    } yield ()
+
+  def installContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] = S.flatModify {
+    cache =>
+      Sync[F].delay(cache.installedContinuations.put(channels, wc)).map(_ => cache)
+  }
+
+  def removeContinuation(channels: Seq[C], index: Int): F[Unit] =
+    for {
+      continuations <- getContinuations(channels)
+      cache         <- S.read
+      installed     = cache.installedContinuations.get(channels)
+      _ <- if (installed.isDefined && index == 0)
+            Sync[F].raiseError {
+              new IllegalArgumentException("Attempted to remove an installed continuation")
+            } else
+            S.flatModify { cache =>
+              removeIndex(
+                continuations,
+                index
+              ) >>= { updated =>
+                Sync[F]
+                  .delay {
+                    installed match {
+                      case Some(_) => cache.continuations.put(channels, updated tail)
+                      case None    => cache.continuations.put(channels, updated)
+                    }
+                  }
+                  .as(cache)
+              }
+            }
+    } yield ()
+
+  def getData(channel: C): F[Seq[Datum[A]]] =
+    for {
+      state <- S.read
+      res <- state.data.get(channel) match {
+              case None =>
+                for {
+                  historyData <- HR.getData(channel)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.data.putIfAbsent(channel, historyData)).as(cache)
+                      }
+                } yield (historyData)
+              case Some(data) => Applicative[F].pure(data)
+            }
+    } yield (res)
+
+  def putDatum(channel: C, datum: Datum[A]): F[Unit] =
+    for {
+      data <- getData(channel)
+      _ <- S.flatModify { cache =>
+            Sync[F].delay(cache.data.put(channel, datum +: data)).as(cache)
+          }
+    } yield ()
+
+  def removeDatum(channel: C, index: Int): F[Unit] =
+    for {
+      data <- getData(channel)
+      _ <- S.flatModify { cache =>
+            removeIndex(cache.data(channel), index) >>= { updated =>
+              Sync[F]
+                .delay {
+                  cache.data.put(channel, updated)
+                }
+                .as(cache)
+            }
+          }
+    } yield ()
+
+  def getJoins(channel: C): F[Seq[Seq[C]]] =
+    for {
+      cached <- internalGetJoins(channel)
+      state  <- S.read
+    } yield (state.installedJoins.get(channel).getOrElse(Seq.empty) ++: cached)
+
+  private[this] def internalGetJoins(channel: C): F[Seq[Seq[C]]] =
+    for {
+      state <- S.read
+      res <- state.joins.get(channel) match {
+              case None =>
+                for {
+                  historyJoins <- HR.getJoins(channel)
+                  _ <- S.flatModify { cache =>
+                        Sync[F].delay(cache.joins.putIfAbsent(channel, historyJoins)).as(cache)
+                      }
+                } yield (historyJoins)
+              case Some(joins) => Applicative[F].pure(joins)
+            }
+    } yield (res)
+
+  def putJoin(channel: C, join: Seq[C]): F[Unit] =
+    for {
+      joins <- getJoins(channel)
+      _ <- if (!joins.contains(join)) S.flatModify { cache =>
+            Sync[F].delay(cache.joins.put(channel, join +: joins)).as(cache)
+          } else Applicative[F].unit
+    } yield ()
+
+  def installJoin(channel: C, join: Seq[C]): F[Unit] = S.flatModify { cache =>
+    Sync[F]
+      .delay {
+        val installed = cache.installedJoins.get(channel).getOrElse(Seq.empty)
+
+        if (!installed.contains(join))
+          cache.installedJoins
+            .put(channel, join +: installed)
+      }
+      .map(_ => cache)
+  }
+
+  def removeJoin(channel: C, join: Seq[C]): F[Unit] =
+    for {
+      joins         <- internalGetJoins(channel)
+      continuations <- getContinuations(join)
+      _ <- if (continuations.isEmpty) S.flatModify { cache =>
+            val index = cache.joins(channel).indexOf(join)
+            if (index != -1) removeIndex(cache.joins(channel), index) >>= { updated =>
+              Sync[F]
+                .delay {
+                  cache.joins.put(channel, updated)
+                }
+                .as(cache)
+            } else cache.pure[F]
+          } else Applicative[F].unit
+    } yield ()
+
+  def changes(): F[Seq[HotStoreAction]] =
+    for {
+      cache <- S.read
+      continuations = (cache.continuations
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteContinuations(k)
+          case (k, v)                => InsertContinuations(k, v)
+        })
+        .toVector
+      data = (cache.data
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteData(k)
+          case (k, v)                => InsertData(k, v)
+        })
+        .toVector
+      joins = (cache.joins
+        .readOnlySnapshot()
+        .map {
+          case (k, v) if (v.isEmpty) => DeleteJoins(k)
+          case (k, v)                => InsertJoins(k, v)
+        })
+        .toVector
+    } yield (continuations ++ data ++ joins)
+
+  private def removeIndex[E](col: Seq[E], index: Int): F[Seq[E]] =
+    if (col.isDefinedAt(index)) {
+      val (l1, l2) = col splitAt index
+      (l1 ++ (l2 tail)).pure[F]
+    } else
+      Sync[F].raiseError(
+        new IndexOutOfBoundsException(
+          s"Tried to remove index ${index} from a Vector of size ${col.size}"
+        )
+      )
+
+  def toMap: F[Map[Seq[C], Row[P, A, K]]] =
+    for {
+      cache         <- S.read
+      data          = cache.data.readOnlySnapshot().map(_.leftMap(Seq(_))).toMap
+      continuations = (cache.continuations ++ cache.installedContinuations.mapValues(Seq(_))).toMap
+      zipped        = zip(data, continuations, Seq.empty[Datum[A]], Seq.empty[WaitingContinuation[P, K]])
+      mapped        = zipped.mapValues { case (d, k) => Row(d, k) }
+    } yield mapped.filter { case (_, v) => !(v.data.isEmpty && v.wks.isEmpty) }
+}
+
+object HotStore {
+
+  def inMem[F[_]: Sync, C, P, A, K](
+      implicit S: Cell[F, Cache[C, P, A, K]],
+      HR: HistoryReader[F, C, P, A, K],
+      ck: Codec[K]
+  ): HotStore[F, C, P, A, K] =
+    new InMemHotStore[F, C, P, A, K]
+
+  def from[F[_], C, P, A, K](
+      cache: Cache[C, P, A, K],
+      historyReader: HistoryReader[F, C, P, A, K]
+  )(implicit ck: Codec[K], sync: Sync[F]) =
+    for {
+      cache <- Cell.refCell[F, Cache[C, P, A, K]](cache)
+      store = HotStore.inMem(Sync[F], cache, historyReader, ck)
+    } yield store
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/RootRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/RootRepository.scala
@@ -1,0 +1,33 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import cats.Applicative
+import cats.effect.Sync
+import cats.implicits._
+import History.emptyRootHash
+
+import scala.Function._
+
+class RootRepository[F[_]: Sync](
+    rootsStore: RootsStore[F]
+) {
+  val unknownRoot = new RuntimeException("unknown root")
+
+  def commit(root: Blake2b256Hash): F[Unit] =
+    rootsStore.recordRoot(root)
+
+  def currentRoot(): F[Blake2b256Hash] =
+    rootsStore.currentRoot().flatMap {
+      case None       => rootsStore.recordRoot(emptyRootHash).map(const(emptyRootHash))
+      case Some(root) => Applicative[F].pure(root)
+    }
+
+  def validateRoot(root: Blake2b256Hash): F[Unit] =
+    rootsStore.validateRoot(root).flatMap {
+      case None    => Sync[F].raiseError[Unit](unknownRoot)
+      case Some(_) => Applicative[F].pure(())
+    }
+
+  def close(): F[Unit] = rootsStore.close()
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/RootsStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/RootsStore.scala
@@ -1,0 +1,60 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.shared.AttemptOpsF.RichAttempt
+import coop.rchain.shared.ByteVectorOps._
+import scodec.bits.{BitVector, ByteVector}
+
+trait RootsStore[F[_]] {
+  def currentRoot(): F[Option[Blake2b256Hash]]
+  def validateRoot(key: Blake2b256Hash): F[Option[Blake2b256Hash]]
+  def recordRoot(key: Blake2b256Hash): F[Unit]
+
+  def close(): F[Unit]
+}
+
+object RootsStoreInstances {
+  def rootsStore[F[_]: Sync](store: Store[F]): RootsStore[F] = new RootsStore[F] {
+    val tag: ByteBuffer = ByteVector("root".getBytes(StandardCharsets.UTF_8)).toDirectByteBuffer
+    val currentRootName: ByteBuffer =
+      ByteVector("current-root".getBytes(StandardCharsets.UTF_8)).toDirectByteBuffer
+
+    override def currentRoot(): F[Option[Blake2b256Hash]] =
+      for {
+        byteBuf <- store.get(currentRootName)
+        maybeDecoded <- byteBuf
+                         .map(
+                           bytes =>
+                             Blake2b256Hash.codecBlake2b256Hash
+                               .decode(BitVector(bytes))
+                               .get
+                         )
+                         .sequence
+        maybeHash = maybeDecoded.map(_.value)
+      } yield (maybeHash)
+
+    override def validateRoot(key: Blake2b256Hash): F[Option[Blake2b256Hash]] =
+      for {
+        bits    <- Blake2b256Hash.codecBlake2b256Hash.encode(key).get
+        bytes   = bits.toByteVector.toDirectByteBuffer
+        byteBuf <- store.get(bytes)
+        result  <- byteBuf.traverse(_ => store.put(currentRootName, bytes).as(key))
+      } yield result
+
+    override def recordRoot(key: Blake2b256Hash): F[Unit] =
+      for {
+        bits  <- Blake2b256Hash.codecBlake2b256Hash.encode(key).get
+        bytes = bits.toByteVector.toDirectByteBuffer
+        _     <- store.put(bytes, tag)
+        _     <- store.put(currentRootName, bytes)
+      } yield ()
+
+    override def close(): F[Unit] = store.close()
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/history/Store.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/history/Store.scala
@@ -1,0 +1,129 @@
+package coop.rchain.rspace
+package experiment
+package history
+
+import java.nio.ByteBuffer
+import java.nio.file.{Path, Paths}
+
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.shared.ByteVectorOps.RichByteVector
+import org.lmdbjava.DbiFlags.MDB_CREATE
+import org.lmdbjava.{Dbi, Env, EnvFlags, Txn}
+import scodec.bits.BitVector
+
+import scala.util.control.NonFatal
+
+trait Store[F[_]] {
+  def get(key: Blake2b256Hash): F[Option[BitVector]]
+  def put(key: Blake2b256Hash, value: BitVector): F[Unit]
+  def get(key: ByteBuffer): F[Option[ByteBuffer]]
+  def put(key: ByteBuffer, value: ByteBuffer): F[Unit]
+  def put(data: Seq[(Blake2b256Hash, BitVector)]): F[Unit]
+  def close(): F[Unit]
+}
+
+final case class StoreConfig(
+    path: Path,
+    mapSize: Long,
+    maxDbs: Int = 2,
+    maxReaders: Int = 2048,
+    flags: List[EnvFlags] = List(EnvFlags.MDB_NOTLS)
+)
+
+object StoreInstances {
+  def lmdbStore[F[_]: Sync](config: StoreConfig): Store[F] = {
+    val env = Env
+      .create()
+      .setMapSize(config.mapSize)
+      .setMaxDbs(config.maxDbs)
+      .setMaxReaders(config.maxReaders)
+      .open(config.path.toFile, config.flags: _*)
+    val dbi = env.openDbi("db", MDB_CREATE)
+    LMDBStore(env, dbi)
+  }
+}
+
+final case class LMDBStore[F[_]: Sync] private[history] (
+    env: Env[ByteBuffer],
+    dbi: Dbi[ByteBuffer]
+) extends Store[F] {
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  // TODO stop throwing exceptions
+  private def withTxn[R](txn: Txn[ByteBuffer])(f: Txn[ByteBuffer] => R): R =
+    try {
+      val ret: R = f(txn)
+      txn.commit()
+      ret
+    } catch {
+      case NonFatal(ex) =>
+        ex.printStackTrace()
+        throw ex
+    } finally {
+      txn.close()
+    }
+
+  private def withReadTxnF[R](f: Txn[ByteBuffer] => R): F[R] =
+    Sync[F].delay {
+      withTxn(env.txnRead)(f)
+    }
+
+  private def withWriteTxnF[R](f: Txn[ByteBuffer] => R): F[R] =
+    Sync[F].delay {
+      withTxn(env.txnWrite)(f)
+    }
+
+  def get(key: Blake2b256Hash): F[Option[BitVector]] = {
+    val directKey = key.bytes.toDirectByteBuffer
+    get(directKey).map(v => v.map(BitVector(_)))
+  }
+
+  override def get(key: ByteBuffer): F[Option[ByteBuffer]] =
+    withReadTxnF { txn =>
+      dbi.get(txn, key)
+    }.map(v => Option(v))
+
+  def put(key: Blake2b256Hash, value: BitVector): F[Unit] = {
+    val directKey   = key.bytes.toDirectByteBuffer
+    val directValue = value.toByteVector.toDirectByteBuffer
+    put(directKey, directValue)
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  override def put(key: ByteBuffer, value: ByteBuffer): F[Unit] =
+    withWriteTxnF { txn =>
+      if (dbi.put(txn, key, value)) {
+        ()
+      } else {
+        throw new RuntimeException("was not able to put data")
+      }
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  private[this] def putIfAbsent(txn: Txn[ByteBuffer], key: ByteBuffer, value: ByteBuffer): Unit =
+    Option(dbi.get(txn, key)) match {
+      case None =>
+        if (dbi.put(txn, key, value)) {
+          ()
+        } else {
+          throw new RuntimeException("was not able to put data")
+        }
+      case _: Some[ByteBuffer] => ()
+    }
+
+  def close(): F[Unit] =
+    Sync[F].delay {
+      env.close()
+    }
+
+  override def put(data: Seq[(Blake2b256Hash, BitVector)]): F[Unit] = {
+    val byteBuffers = data.map {
+      case (key, bytes) =>
+        (key.bytes.toDirectByteBuffer, bytes.toByteVector.toDirectByteBuffer)
+    }
+    withWriteTxnF { txn =>
+      byteBuffers.foreach { case (key, value) => putIfAbsent(txn, key, value) }
+    }
+  }
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/internal.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace
 package experiment
 
 import com.google.common.collect.{HashMultiset, Multiset}
-import trace.{Consume, Produce}
 import coop.rchain.scodec.codecs.seqOfN
 import scodec.Codec
 import scodec.bits.ByteVector
@@ -36,8 +35,7 @@ object internal {
         patterns: Seq[P],
         continuation: K,
         persist: Boolean,
-        peek: SortedSet[Int],
-        sequenceNumber: Int = 0
+        peek: SortedSet[Int]
     )(
         ): WaitingContinuation[P, K] =
       WaitingContinuation(patterns, continuation, persist, peek)

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/internal.scala
@@ -1,0 +1,164 @@
+package coop.rchain.rspace
+package experiment
+
+import com.google.common.collect.{HashMultiset, Multiset}
+import trace.{Consume, Produce}
+import coop.rchain.scodec.codecs.seqOfN
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs.{bool, bytes, int32, int64, uint8, variableSizeBytesLong}
+
+import scala.collection.SortedSet
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+object internal {
+
+  final case class Datum[A](a: A, persist: Boolean)
+
+  object Datum {
+    def create[C, A](channel: C, a: A, persist: Boolean)(
+        ): Datum[A] =
+      Datum(a, persist)
+  }
+
+  final case class DataCandidate[C, A](channel: C, datum: Datum[A], datumIndex: Int)
+
+  final case class WaitingContinuation[P, K](
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int]
+  )
+
+  object WaitingContinuation {
+    def create[C, P, K](
+        channels: Seq[C],
+        patterns: Seq[P],
+        continuation: K,
+        persist: Boolean,
+        peek: SortedSet[Int],
+        sequenceNumber: Int = 0
+    )(
+        ): WaitingContinuation[P, K] =
+      WaitingContinuation(patterns, continuation, persist, peek)
+  }
+
+  final case class ProduceCandidate[C, P, A, K](
+      channels: Seq[C],
+      continuation: WaitingContinuation[P, K],
+      continuationIndex: Int,
+      dataCandidates: Seq[DataCandidate[C, A]]
+  )
+
+  final case class Row[P, A, K](data: Seq[Datum[A]], wks: Seq[WaitingContinuation[P, K]])
+
+  /** [[GNAT]] is not a `Tuple3`
+    */
+  final case class GNAT[C, P, A, K](
+      channels: Seq[C],
+      data: Seq[Datum[A]],
+      wks: Seq[WaitingContinuation[P, K]]
+  )
+
+  sealed trait Operation extends Product with Serializable
+  case object Insert     extends Operation
+  case object Delete     extends Operation
+
+  final case class TrieUpdate[C, P, A, K](
+      count: Long,
+      operation: Operation,
+      channelsHash: Blake2b256Hash,
+      gnat: GNAT[C, P, A, K]
+  )
+
+  implicit val codecByteVector: Codec[ByteVector] =
+    variableSizeBytesLong(int64, bytes)
+
+  implicit def codecSeq[A](implicit codecA: Codec[A]): Codec[Seq[A]] =
+    seqOfN(int32, codecA)
+
+  implicit def codecDatum[A](implicit codecA: Codec[A]): Codec[Datum[A]] =
+    (codecA :: bool).as[Datum[A]]
+
+  def sortedSet[A](codecA: Codec[A])(implicit O: Ordering[A]): Codec[SortedSet[A]] =
+    codecSeq[A](codecA).xmap[SortedSet[A]](s => SortedSet(s: _*), _.toSeq)
+
+  implicit def codecWaitingContinuation[P, K](
+      implicit
+      codecP: Codec[P],
+      codecK: Codec[K]
+  ): Codec[WaitingContinuation[P, K]] =
+    (codecSeq(codecP) :: codecK :: bool :: sortedSet[Int](uint8))
+      .as[WaitingContinuation[P, K]]
+
+  implicit def codecGNAT[C, P, A, K](
+      implicit
+      codecC: Codec[C],
+      codecP: Codec[P],
+      codecA: Codec[A],
+      codecK: Codec[K]
+  ): Codec[GNAT[C, P, A, K]] =
+    (codecSeq(codecC) ::
+      codecSeq(codecDatum(codecA)) ::
+      codecSeq(codecWaitingContinuation(codecP, codecK))).as[GNAT[C, P, A, K]]
+
+  import scala.collection.concurrent.TrieMap
+  type MultisetMultiMap[K, V] = TrieMap[K, Multiset[V]]
+
+  object MultisetMultiMap {
+    def empty[K, V]: MultisetMultiMap[K, V] = new TrieMap[K, Multiset[V]]()
+  }
+
+  implicit class RichMultisetMultiMap[K, V](val value: MultisetMultiMap[K, V]) extends AnyVal {
+
+    def addBinding(k: K, v: V): MultisetMultiMap[K, V] =
+      value.get(k) match {
+        case Some(current) =>
+          current.add(v)
+          value
+        case None =>
+          val ms = HashMultiset.create[V]()
+          ms.add(v)
+          value.putIfAbsent(k, ms)
+          value
+      }
+
+    def removeBinding(k: K, v: V): MultisetMultiMap[K, V] =
+      value.get(k) match {
+        case Some(current) =>
+          current.remove(v)
+          if (current.isEmpty) {
+            value.remove(k, current)
+          }
+          value
+        case None =>
+          value
+      }
+  }
+
+  final case class Install[F[_], P, A, R, K](
+      patterns: Seq[P],
+      continuation: K,
+      _match: Match[F, P, A, R]
+  )
+
+  type Installs[F[_], C, P, A, R, K] = Map[Seq[C], Install[F, P, A, R, K]]
+
+  import scodec.Attempt
+
+  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
+  implicit class RichAttempt[T](a: Attempt[T]) {
+    def get: T =
+      a match {
+        case Attempt.Successful(res) => res
+        case Attempt.Failure(err) =>
+          throw new Exception("Data in RSpace is corrupted. " + err.messageWithContext)
+      }
+  }
+
+  def toOrderedByteVectors[A](elements: Seq[A])(implicit serialize: Serialize[A]): Seq[ByteVector] =
+    elements
+      .map(e => serialize.encode(e))
+      .sorted(util.ordByteVector)
+
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/Event.scala
@@ -1,0 +1,143 @@
+package coop.rchain.rspace
+package experiment
+package trace
+
+import coop.rchain.rspace.StableHashProvider._
+import internal._
+import cats.implicits._
+import coop.rchain.rspace.internal.codecSeq
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs._
+
+import scala.collection.SortedSet
+
+/**
+  * Broadly speaking, there are two kinds of events in RSpace,
+  *
+  *   1. [[IOEvent]]s, which are represented as [[Produce]] and [[Consume]]s
+  *   2. [[COMM]] Events, which consist of a single [[Consume]] and one or more [[Produce]]s
+  */
+sealed trait Event
+
+object Event {
+
+  implicit def codecEvent: Codec[Event] =
+    discriminated[Event]
+      .by(uint2)
+      .subcaseP(0) {
+        case (comm: COMM) => comm
+      }(Codec[COMM])
+      .subcaseP(1) {
+        case produce: Produce => produce
+      }(Codec[Produce])
+      .subcaseP(2) {
+        case consume: Consume => consume
+      }(Codec[Consume])
+
+  implicit def codecLog: Codec[Seq[Event]] = codecSeq[Event](codecEvent)
+}
+
+final case class COMM(
+    consume: Consume,
+    produces: Seq[Produce],
+    peeks: SortedSet[Int] = SortedSet.empty
+) extends Event
+
+object COMM {
+  implicit val codecCOMM: Codec[COMM] =
+    (Codec[Consume] :: Codec[Seq[Produce]] :: sortedSet(uint8)).as[COMM]
+}
+
+sealed trait IOEvent extends Event
+
+final case class Produce private (
+    channelsHash: Blake2b256Hash,
+    hash: Blake2b256Hash,
+    sequenceNumber: Int
+) extends IOEvent {
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case produce: Produce => produce.hash == hash && produce.sequenceNumber == sequenceNumber
+    case _                => false
+  }
+
+  override def hashCode(): Int = hash.hashCode() * 47 + sequenceNumber.hashCode()
+
+  override def toString: String =
+    s"Produce(channels: ${channelsHash.toString}, hash: ${hash.toString})"
+
+}
+
+object Produce {
+
+  def unapply(arg: Produce): Option[(Blake2b256Hash, Blake2b256Hash, Int)] =
+    Some((arg.channelsHash, arg.hash, arg.sequenceNumber))
+
+  def create[C, A](channel: C, datum: A, persist: Boolean, sequenceNumber: Int = 0)(
+      implicit
+      serializeC: Serialize[C],
+      serializeA: Serialize[A]
+  ): Produce =
+    new Produce(
+      hash(channel)(serializeC),
+      hash(channel, datum, persist),
+      sequenceNumber
+    )
+
+  def fromHash(channelsHash: Blake2b256Hash, hash: Blake2b256Hash, sequenceNumber: Int): Produce =
+    new Produce(channelsHash, hash, sequenceNumber)
+
+  implicit val codecProduce: Codec[Produce] =
+    (Codec[Blake2b256Hash] :: Codec[Blake2b256Hash] :: int32).as[Produce]
+}
+
+final case class Consume private (
+    channelsHashes: Seq[Blake2b256Hash],
+    hash: Blake2b256Hash
+) extends IOEvent {
+
+  override def equals(obj: scala.Any): Boolean = obj match {
+    case consume: Consume => consume.hash == hash
+    case _                => false
+  }
+
+  override def hashCode(): Int = hash.hashCode() * 47
+
+  override def toString: String =
+    s"Consume(channels: ${channelsHashes.toString}, hash: ${hash.toString})"
+}
+
+object Consume {
+
+  def unapply(arg: Consume): Option[(Seq[Blake2b256Hash], Blake2b256Hash)] =
+    Some((arg.channelsHashes, arg.hash))
+
+  def create[C, P, K](
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean
+  )(
+      implicit
+      serializeC: Serialize[C],
+      serializeP: Serialize[P],
+      serializeK: Serialize[K]
+  ): Consume = {
+    val channelsByteVectors: Seq[ByteVector] = toOrderedByteVectors(channels)
+    new Consume(
+      channelsByteVectors.map(Blake2b256Hash.create),
+      hash(channelsByteVectors, patterns, continuation, persist)
+    )
+  }
+
+  def fromHash(
+      channelsHashes: Seq[Blake2b256Hash],
+      hash: Blake2b256Hash,
+      sequenceNumber: Int
+  ): Consume =
+    new Consume(channelsHashes, hash)
+
+  implicit val codecConsume: Codec[Consume] =
+    (Codec[Seq[Blake2b256Hash]] :: Codec[Blake2b256Hash]).as[Consume]
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/Event.scala
@@ -53,16 +53,15 @@ sealed trait IOEvent extends Event
 
 final case class Produce private (
     channelsHash: Blake2b256Hash,
-    hash: Blake2b256Hash,
-    sequenceNumber: Int
+    hash: Blake2b256Hash
 ) extends IOEvent {
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case produce: Produce => produce.hash == hash && produce.sequenceNumber == sequenceNumber
+    case produce: Produce => produce.hash == hash
     case _                => false
   }
 
-  override def hashCode(): Int = hash.hashCode() * 47 + sequenceNumber.hashCode()
+  override def hashCode(): Int = hash.hashCode() * 47
 
   override def toString: String =
     s"Produce(channels: ${channelsHash.toString}, hash: ${hash.toString})"
@@ -71,25 +70,24 @@ final case class Produce private (
 
 object Produce {
 
-  def unapply(arg: Produce): Option[(Blake2b256Hash, Blake2b256Hash, Int)] =
-    Some((arg.channelsHash, arg.hash, arg.sequenceNumber))
+  def unapply(arg: Produce): Option[(Blake2b256Hash, Blake2b256Hash)] =
+    Some((arg.channelsHash, arg.hash))
 
-  def create[C, A](channel: C, datum: A, persist: Boolean, sequenceNumber: Int = 0)(
+  def create[C, A](channel: C, datum: A, persist: Boolean)(
       implicit
       serializeC: Serialize[C],
       serializeA: Serialize[A]
   ): Produce =
     new Produce(
       hash(channel)(serializeC),
-      hash(channel, datum, persist),
-      sequenceNumber
+      hash(channel, datum, persist)
     )
 
   def fromHash(channelsHash: Blake2b256Hash, hash: Blake2b256Hash, sequenceNumber: Int): Produce =
-    new Produce(channelsHash, hash, sequenceNumber)
+    new Produce(channelsHash, hash)
 
   implicit val codecProduce: Codec[Produce] =
-    (Codec[Blake2b256Hash] :: Codec[Blake2b256Hash] :: int32).as[Produce]
+    (Codec[Blake2b256Hash] :: Codec[Blake2b256Hash]).as[Produce]
 }
 
 final case class Consume private (

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/ReplayData.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/ReplayData.scala
@@ -1,0 +1,10 @@
+package coop.rchain.rspace
+package experiment
+package trace
+
+import internal.MultisetMultiMap
+
+object ReplayData {
+
+  def empty: ReplayData = MultisetMultiMap.empty
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/trace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/experiment/trace/trace.scala
@@ -1,0 +1,11 @@
+package coop.rchain.rspace
+package experiment
+
+import internal.MultisetMultiMap
+
+package object trace {
+
+  type Log = Seq[Event]
+
+  type ReplayData = MultisetMultiMap[IOEvent, COMM]
+}


### PR DESCRIPTION
Consume and Produce contain source related data. Source data may be computed at
runtime as required, see ReceiveBind in Rhotypes.proto.
This is a refactoring effort to remove Source from Datum and Continuation.

## Overview
<sup>Optimize how source for Produce and Consume is stored.</sup>



### JIRA ticket:
<sup>https://rchain.atlassian.net/browse/RCHAIN-3446</sup>



### Notes
<sup>The current implementation of Datum and Continuation store source that created them. This can be computed and removed from lmdb.</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
