### PR TITLE
Rchain 3461: distribute rewards to active validators

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -2,6 +2,7 @@
 // minimumBond - the minimum bond allowed by the PoS
 // maximumBond - the maximum bond allowed by PoS
 // initialBonds - the initial bonds map
+// epochLength - the length of the validation epoch in blocks
 
 /*
  The table below describes the required computations and their dependencies
@@ -168,7 +169,7 @@ new  PoS,
                 for(_, @blockNumber <- blockDataCh;
                     @(pendingRewards, rewards, activeValidators, allBonds), mvarResultCh <- mvarProcessCh) {
 
-                  if (blockNumber % 1000 == 0) {
+                  if (blockNumber % $$epochLength$$ == 0) {
                     pickActiveValidators!(allBonds, *newValidatorsCh)
                   } else {
                     newValidatorsCh!(activeValidators)

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -48,14 +48,14 @@ new  PoS,
             // State structure:
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
-            // bonds : Map[PublickKey, Int] - each validator stake
+            // allbonds : Map[PublickKey, Int] - each validator stake
             stateCh!(({}, {}, $$initialBonds$$)) |
 
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, _, bonds) <- tmpCh) {
-                  returnCh!(bonds)
+                for (@(_, _, allBonds) <- tmpCh) {
+                  returnCh!(allBonds)
                 }
               }
             } |
@@ -78,27 +78,27 @@ new  PoS,
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
                 getUser!(*userCh) |
-                for(@(pending, rewards, bonds), resultCh <- processCh;
+                for(@(pending, rewards, allBonds), resultCh <- processCh;
                     @userPk <- userCh) {
-                  if (bonds.contains(userPk)) {
-                    resultCh!((pending, rewards, bonds), (false, "Public key is already bonded."))
+                  if (allBonds.contains(userPk)) {
+                    resultCh!((pending, rewards, allBonds), (false, "Public key is already bonded."))
                   } else if (amount < $$minimumBond$$) {
-                    resultCh!((pending, rewards, bonds), (false, "Bond is less than minimum!"))
+                    resultCh!((pending, rewards, allBonds), (false, "Bond is less than minimum!"))
                   } else if (amount > $$maximumBond$$) {
-                    resultCh!((pending, rewards, bonds), (false, "Bond is greater than maximum!"))
+                    resultCh!((pending, rewards, allBonds), (false, "Bond is greater than maximum!"))
                   } else {
                     deposit!(userPk, amount, *depositCh) |
                     for(@depositResult <- depositCh) {
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (pending, rewards, bonds.set(userPk,amount)),
+                            (pending, rewards, allBonds.set(userPk,amount)),
                             depositResult
                           )
                         }
 
                         (false, errorMsg) => {
-                          resultCh!((pending, rewards, bonds), (false, "Bond deposit failed: " ++ errorMsg))
+                          resultCh!((pending, rewards, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
                         }
                       }
                     }
@@ -113,15 +113,15 @@ new  PoS,
                   newPendingCh in {
                 getUser!(*userCh) |
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
-                for(@(pending, rewards, bonds), payResultCh <- processPayCh;
+                for(@(pending, rewards, allBonds), payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
-                  distributeRewards!(amount, bonds, pending, *newPendingCh) |
+                  distributeRewards!(amount, allBonds, pending, *newPendingCh) |
 
                   for(@depositResult <- depositCh;
                       @newPending <- newPendingCh) {
-                    payResultCh!((newPending, rewards, bonds), depositResult)
+                    payResultCh!((newPending, rewards, allBonds), depositResult)
                   }
                 }
               }
@@ -132,14 +132,14 @@ new  PoS,
                   getInvalidBlocks(`rho:casper:invalidBlocks`) in {
                 getInvalidBlocks!(*invalidBlocksCh) |
                 getUser!(*userCh) |
-                for (@invalidBlocks <- invalidBlocksCh; @(pending, rewards, bonds) <- stateCh; @userPk <- userCh) {
+                for (@invalidBlocks <- invalidBlocksCh; @(pending, rewards, allBonds) <- stateCh; @userPk <- userCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
                       // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
                       stateCh!((pending.set(validator, 0),
                                 rewards.set(validator, 0),
-                                bonds.set(validator, 0))) |
+                                allBonds.set(validator, 0))) |
                       return!(true)
                     }
                   }
@@ -155,7 +155,7 @@ new  PoS,
 
                 runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                 for(_, @blockNumber <- blockDataCh;
-                    @(pendingRewards, rewards, bonds), mvarResultCh <- mvarProcessCh) {
+                    @(pendingRewards, rewards, allBonds), mvarResultCh <- mvarProcessCh) {
 
                   if (blockNumber % 1000 == 0) {
                     new stdout(`rho:io:stdout`) in {
@@ -170,7 +170,7 @@ new  PoS,
                   } |
 
                   for (@rewards <- rewardsCh) {
-                    mvarResultCh!(({}, rewards, bonds), Nil)
+                    mvarResultCh!(({}, rewards, allBonds), Nil)
                   }
                 }
               }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -208,18 +208,18 @@ new  PoS,
         } |
 
         contract distributeRewards(@amount, @activeValidators, @bonds, @originalRewards, returnCh) = {
-          new computeSum, totalStakeCh,
+          new computeSum, totalActiveStakeCh,
               computeDelta, rewardsDeltaCh,
               computeMergeMap in {
-            @ListOps!("fold", bonds.toList(), 0, *computeSum, *totalStakeCh) |
-            contract computeSum(@(pk, stake), @acc, resultCh) = {
-              resultCh!(acc + stake)
+            @ListOps!("fold", activeValidators, 0, *computeSum, *totalActiveStakeCh) |
+            contract computeSum(@pk, @acc, resultCh) = {
+              resultCh!(acc + bonds.get(pk))
             } |
 
-            for(@totalStake <- totalStakeCh) {
-              @ListOps!("fold", bonds.toList(), {}, *computeDelta, *rewardsDeltaCh) |
-              contract computeDelta(@(pk, currentValidatorStake), @acc, resultCh) = {
-                resultCh!(acc.set(pk, (amount * currentValidatorStake) / totalStake))
+            for(@totalActiveStake <- totalActiveStakeCh) {
+              @ListOps!("fold", activeValidators, {}, *computeDelta, *rewardsDeltaCh) |
+              contract computeDelta(@pk, @acc, resultCh) = {
+                resultCh!(acc.set(pk, (amount * bonds.get(pk)) / totalActiveStake))
               }
             } |
 

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -127,20 +127,25 @@ new  PoS,
               }
             } |
 
-            contract PoS(@"slash", @blockHash, return) = {
-              new userCh, invalidBlocksCh,
+            contract PoS(@"slash", @blockHash, returnCh) = {
+              new userCh, invalidBlocksCh, doSlashCh,
                   getInvalidBlocks(`rho:casper:invalidBlocks`) in {
                 getInvalidBlocks!(*invalidBlocksCh) |
                 getUser!(*userCh) |
-                for (@invalidBlocks <- invalidBlocksCh; @(pending, rewards, allBonds) <- stateCh; @userPk <- userCh) {
+
+                runMVar!(*stateCh, *doSlashCh, *returnCh) |
+                for (@invalidBlocks <- invalidBlocksCh;
+                     @userPk <- userCh;
+                     @(pending, rewards, allBonds), slashResultCh <- doSlashCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
                       // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
-                      stateCh!((pending.set(validator, 0),
-                                rewards.set(validator, 0),
-                                allBonds.set(validator, 0))) |
-                      return!(true)
+                      slashResultCh!(
+                        (pending.set(validator, 0),
+                         rewards.set(validator, 0),
+                         allBonds.set(validator, 0)),
+                        true)
                     }
                   }
                 }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -26,8 +26,10 @@ new  PoS,
     getUser,
     getCurrentUserAddress,
     getCurrentUserVault,
+    pickActiveValidators,
     getMVar,
     runMVar,
+    fst,
     deposit, distributeRewards,
     rs(`rho:registry:insertSigned:secp256k1`),
     uriOut in {
@@ -40,21 +42,24 @@ new  PoS,
 
       getCurrentUserAddress!(*posRevAddressCh) |
       for(@posRevAddress <- posRevAddressCh) {
-        new stateCh, posVaultCh in {
+        new stateCh, posVaultCh, initialActiveCh in {
+          pickActiveValidators!($$initialBonds$$, *initialActiveCh) |
 
           @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
-          for (@(true, _) <- posVaultCh ) {
+          for (@(true, _) <- posVaultCh;
+               @initialActive <- initialActiveCh) {
 
             // State structure:
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
+            // activeBonds : List[PublickKey] - the active validators
             // allbonds : Map[PublickKey, Int] - each validator stake
-            stateCh!(({}, {}, $$initialBonds$$)) |
+            stateCh!(({}, {}, initialActive, $$initialBonds$$)) |
 
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, _, allBonds) <- tmpCh) {
+                for (@(_, _, _, allBonds) <- tmpCh) {
                   returnCh!(allBonds)
                 }
               }
@@ -67,7 +72,7 @@ new  PoS,
             contract PoS (@"getRewards", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, rewards, _) <- tmpCh) {
+                for (@(_, rewards, _, _) <- tmpCh) {
                   returnCh!(rewards)
                 }
               }
@@ -78,27 +83,27 @@ new  PoS,
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
                 getUser!(*userCh) |
-                for(@(pending, rewards, allBonds), resultCh <- processCh;
+                for(@(pending, rewards, activeValidators, allBonds), resultCh <- processCh;
                     @userPk <- userCh) {
                   if (allBonds.contains(userPk)) {
-                    resultCh!((pending, rewards, allBonds), (false, "Public key is already bonded."))
+                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Public key is already bonded."))
                   } else if (amount < $$minimumBond$$) {
-                    resultCh!((pending, rewards, allBonds), (false, "Bond is less than minimum!"))
+                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond is less than minimum!"))
                   } else if (amount > $$maximumBond$$) {
-                    resultCh!((pending, rewards, allBonds), (false, "Bond is greater than maximum!"))
+                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond is greater than maximum!"))
                   } else {
                     deposit!(userPk, amount, *depositCh) |
                     for(@depositResult <- depositCh) {
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (pending, rewards, allBonds.set(userPk,amount)),
+                            (pending, rewards, activeValidators, allBonds.set(userPk,amount)),
                             depositResult
                           )
                         }
 
                         (false, errorMsg) => {
-                          resultCh!((pending, rewards, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
+                          resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
                         }
                       }
                     }
@@ -113,15 +118,15 @@ new  PoS,
                   newPendingCh in {
                 getUser!(*userCh) |
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
-                for(@(pending, rewards, allBonds), payResultCh <- processPayCh;
+                for(@(pending, rewards, activeValidators, allBonds), payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
-                  distributeRewards!(amount, allBonds, pending, *newPendingCh) |
+                  distributeRewards!(amount, activeValidators, allBonds, pending, *newPendingCh) |
 
                   for(@depositResult <- depositCh;
                       @newPending <- newPendingCh) {
-                    payResultCh!((newPending, rewards, allBonds), depositResult)
+                    payResultCh!((newPending, rewards, activeValidators, allBonds), depositResult)
                   }
                 }
               }
@@ -136,7 +141,7 @@ new  PoS,
                 runMVar!(*stateCh, *doSlashCh, *returnCh) |
                 for (@invalidBlocks <- invalidBlocksCh;
                      @userPk <- userCh;
-                     @(pending, rewards, allBonds), slashResultCh <- doSlashCh) {
+                     @(pending, rewards, activeValidators, allBonds), slashResultCh <- doSlashCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
@@ -144,6 +149,7 @@ new  PoS,
                       slashResultCh!(
                         (pending.set(validator, 0),
                          rewards.set(validator, 0),
+                         activeValidators,
                          allBonds.set(validator, 0)),
                         true)
                     }
@@ -155,17 +161,17 @@ new  PoS,
             contract PoS(@"closeBlock", ackCh) = {
               new blockDataCh, mvarProcessCh,
                   getBlockData(`rho:block:data`),
-                  commitReward, rewardsCh in {
+                  commitReward, rewardsCh, newValidatorsCh in {
                 getBlockData!(*blockDataCh) |
 
                 runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                 for(_, @blockNumber <- blockDataCh;
-                    @(pendingRewards, rewards, allBonds), mvarResultCh <- mvarProcessCh) {
+                    @(pendingRewards, rewards, activeValidators, allBonds), mvarResultCh <- mvarProcessCh) {
 
                   if (blockNumber % 1000 == 0) {
-                    new stdout(`rho:io:stdout`) in {
-                      stdout!("TODO: a validator change should happen")
-                    }
+                    pickActiveValidators!(allBonds, *newValidatorsCh)
+                  } else {
+                    newValidatorsCh!(activeValidators)
                   } |
 
 
@@ -174,8 +180,9 @@ new  PoS,
                     resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
                   } |
 
-                  for (@rewards <- rewardsCh) {
-                    mvarResultCh!(({}, rewards, allBonds), Nil)
+                  for (@rewards <- rewardsCh;
+                       @newValidators <- newValidatorsCh) {
+                    mvarResultCh!(({}, rewards, newValidators, allBonds), Nil)
                   }
                 }
               }
@@ -200,7 +207,7 @@ new  PoS,
           }
         } |
 
-        contract distributeRewards(@amount, @bonds, @originalRewards, returnCh) = {
+        contract distributeRewards(@amount, @activeValidators, @bonds, @originalRewards, returnCh) = {
           new computeSum, totalStakeCh,
               computeDelta, rewardsDeltaCh,
               computeMergeMap in {
@@ -245,6 +252,10 @@ new  PoS,
         }
       } |
 
+      contract fst(@(first, _), resultCh) = {
+        resultCh!(first)
+      } |
+
       contract getUser (returnCh) = {
         new parametersCh, getParameters(`rho:deploy:params`) in {
           getParameters!(*parametersCh) |
@@ -261,6 +272,11 @@ new  PoS,
             revAddressOps!("fromPublicKey", userPk, *returnCh)
           }
         }
+      } |
+
+      contract pickActiveValidators(@allBonds, returnCh) = {
+        //TODO choose only a limited number of validators
+        @ListOps!("map", allBonds.toList(), *fst, *returnCh)
       } |
 
       contract getCurrentUserVault(returnCh) = {

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -9,12 +9,18 @@ import monix.eval.Coeval
 import scala.io.Source
 
 // TODO: Eliminate validators argument if unnecessary.
-final case class ProofOfStake(minimumBond: Long, maximumBond: Long, validators: Seq[Validator])
-    extends CompiledRholangTemplate(
+// TODO: eliminate the default for epochLength. Now it is used in order to minimise the impact of adding this parameter
+final case class ProofOfStake(
+    minimumBond: Long,
+    maximumBond: Long,
+    validators: Seq[Validator],
+    epochLength: Int = 10000
+) extends CompiledRholangTemplate(
       "PoS.rhox",
       "minimumBond"  -> minimumBond,
       "maximumBond"  -> maximumBond,
-      "initialBonds" -> ProofOfStake.initialBonds(validators)
+      "initialBonds" -> ProofOfStake.initialBonds(validators),
+      "epochLength"  -> epochLength
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -19,6 +19,7 @@ match (
       test_bonding_fails_if_already_bonded,
       test_bonding_fails_if_bond_too_small,
       test_pay_succeeds,
+      test_dont_pay_inactive_validators,
       test_bonding_failure
     in {
       revAddressOps!("fromPublicKey", posPubKey, *posRevAddressCh) |
@@ -43,7 +44,8 @@ match (
               ("multiple bondings work", *test_multiple_bonding_succeeds),
               ("payment works", *test_pay_succeeds),
               ("bonding fails if already bonded", *test_bonding_fails_if_already_bonded),
-              ("bonding fails is bond is too small", *test_bonding_fails_if_bond_too_small)
+              ("bonding fails is bond is too small", *test_bonding_fails_if_bond_too_small),
+              ("payment is not distributed to inactive validators", *test_dont_pay_inactive_validators)
             ]) |
 
           contract setup(retCh) = {
@@ -51,6 +53,7 @@ match (
           } |
 
           contract prepareUser(@pk, @vaultAmount, retCh) = {
+            stdlog!("info", ("preparing user ", pk)) |
             new setDeployData(`rho:test:deploy:set`), identitySet, revAddrCh, vaultCh in {
               setDeployData!("userId", pk.hexToBytes(), *identitySet) |
               revAddressOps!("fromPublicKey", pk.hexToBytes(), *revAddrCh) |
@@ -307,6 +310,37 @@ match (
                       ],
                       *ackCh
                     )
+                  }
+                }
+              }
+            }
+          } |
+
+          contract test_dont_pay_inactive_validators(rhoSpec, _, ackCh) = {
+            new setupCh, closeBlockCh, retCh,
+                finalRewardsCh
+            in {
+              prepareUser!("9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 10000, *setupCh) |
+              for (@validatorPubKey, _, _ <- setupCh) {
+                @PoS!("bond", 100, *setupCh) |
+                for (@(true, _) <- setupCh) {
+                  prepareUser!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 10000, *setupCh) |
+                  for (@user1PubKey, _, @user1Vault <- setupCh) {
+                    @PoS!("pay", 100, *retCh) |
+                    for ( @(true, _) <- retCh) {
+                      @PoS!("closeBlock", *closeBlockCh) |
+                      for (_ <- closeBlockCh) {
+                        @PoS!("getRewards", *finalRewardsCh) |
+                        for(@finalRewards <- finalRewardsCh) {
+                          rhoSpec!("assertMany",
+                            [
+                              ((Nil, "==", finalRewards.get(validatorPubKey)), "the new validator should have no reward")
+                            ],
+                            *ackCh
+                          )
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -110,8 +110,8 @@ match (
                           rhoSpec!("assertMany",
                             [
                               ((100, "==", bondAmount), "the new bond is expected in the final map"),
-                              ((initialUserBalance - finalUserBalance, "==", 100), "the user account decreases"),
-                              ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
+                              ((100, "==", initialUserBalance - finalUserBalance), "the user account decreases"),
+                              ((100, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
                               ((Nil, "==", rewards.get(user1PubKey)), "new validator reward should be zero")
                             ],
                             *ackCh
@@ -159,9 +159,9 @@ match (
                                   [
                                     ((100, "==", bondAmount1), "the user1 bond is expected in the final map"),
                                     ((200, "==", bondAmount2), "the user2 bond is expected in the final map"),
-                                    ((initialUser1Balance - finalUser1Balance, "==", 100), "the user1 account decreases"),
-                                    ((initialUser2Balance - finalUser2Balance, "==", 200), "the user2 account decreases"),
-                                    ((finalPosBalance - initialPosBalance, "==", 300), "the pos account increases"),
+                                    ((100, "==", initialUser1Balance - finalUser1Balance), "the user1 account decreases"),
+                                    ((200, "==", initialUser2Balance - finalUser2Balance), "the user2 account decreases"),
+                                    ((300, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
                                   ],
                                   *ackCh
                                 )
@@ -223,9 +223,9 @@ match (
 
                               rhoSpec!("assertMany",
                                 [
-                                  ((initialUser1Balance - finalUser1Balance, "==", 100), "the user account decreases"),
-                                  ((finalPosBalance - initialPosBalance, "==", 100), "the pos account increases"),
-                                  ((finalRewards.get(validatorPubKey), "==", 19), "the validator's finalRewards is as expected"),
+                                  ((100, "==", initialUser1Balance - finalUser1Balance), "the user account decreases"),
+                                  ((100, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
+                                  ((19, "==", finalRewards.get(validatorPubKey)), "the validator's finalRewards is as expected"),
                                   //TODO use arbitrary precision numbers instead of long ints
                                   ((96, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
                                   ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")
@@ -268,9 +268,9 @@ match (
                       @PoS!("getRewards", *finalRewardsCh) |
                       rhoSpec!("assertMany",
                         [
-                          ((result1, "==", true), "the first bond should succeed"),
-                          ((result2, "==", false), "the second bond should fail"),
-                          ((msg2, "==", "Public key is already bonded."), "the message should be as expected"),
+                          ((true, "==", result1), "the first bond should succeed"),
+                          ((false, "==", result2), "the second bond should fail"),
+                          (("Public key is already bonded.", "==", msg2), "the message should be as expected"),
                           ((initialBonds, "== <-", *bondsCh), "the bonds map remains unchanged"),
                           ((initialRewards, "== <-", *finalRewardsCh), "the rewards map should not change")
                         ],
@@ -300,8 +300,8 @@ match (
                     @PoS!("getRewards", *finalRewardsCh) |
                     rhoSpec!("assertMany",
                       [
-                        ((msg, "==", expectedMsg), "the message should be as epected"),
-                        ((result, "==", false), "the bond should fail"),
+                        ((expectedMsg, "==", msg), "the message should be as epected"),
+                        ((false, "==", result), "the bond should fail"),
                         ((initialBonds, "== <-", *bondsCh), "the bonds map remains unchanged"),
                         ((initialRewards, "== <-", *finalRewardsCh), "the rewards map should not change")
                       ],

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -178,7 +178,7 @@ match (
           } |
 
           contract test_pay_succeeds(rhoSpec, _, ackCh) = {
-            new setupCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
+            new setupCh, closeBlockCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
                 initialUser1BalanceCh, finalUser1BalanceCh,
                 initialRewardsCh, finalRewardsCh,
                 computeDelta, deltaRewardsCh, deltaSumCh, sumDelta,
@@ -188,8 +188,10 @@ match (
               for (@validatorPubKey, _, _ <- setupCh) {
                 @PoS!("bond", 100, *setupCh) |
                 for (@(true, _) <- setupCh) {
+                  @PoS!("closeBlock", *closeBlockCh) |
                   prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", 10000, *setupCh) |
-                  for (@user1PubKey, _, @user1Vault <- setupCh) {
+                  for (@user1PubKey, _, @user1Vault <- setupCh;
+                       _ <- closeBlockCh) {
                     @posVault!("balance", *initialPosBalanceCh) |
                     @user1Vault!("balance", *initialUser1BalanceCh) |
                     @PoS!("getRewards", *initialRewardsCh) |
@@ -198,8 +200,8 @@ match (
                         @initialRewards <- initialRewardsCh) {
                       @PoS!("pay", 100, *retCh) |
                       for ( @(true, _) <- retCh) {
-                        @PoS!("closeBlock", *ackCh) |
-                        for (_ <- ackCh) {
+                        @PoS!("closeBlock", *closeBlockCh) |
+                        for (_ <- closeBlockCh) {
                           @posVault!("balance", *finalPosBalanceCh) |
                           @user1Vault!("balance", *finalUser1BalanceCh) |
                           @PoS!("getRewards", *finalRewardsCh) |

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TestUtil.scala
@@ -45,7 +45,9 @@ object TestUtil {
     } yield (runtime)
 
   // TODO: Have this function take an additional "Genesis" argument.
-  def defaultGenesisSetup[F[_]: Concurrent](runtimeManager: RuntimeManager[F]): F[BlockMessage] = {
+  def defaultGenesisSetup[F[_]: Concurrent](
+      epochLength: Int
+  )(runtimeManager: RuntimeManager[F]): F[BlockMessage] = {
 
     val (_, validatorPks) = (1 to 4).map(_ => Secp256k1.newKeyPair).unzip
     val bonds             = createBonds(validatorPks)
@@ -58,6 +60,7 @@ object TestUtil {
         proofOfStake = ProofOfStake(
           minimumBond = 0L,
           maximumBond = Long.MaxValue,
+          epochLength = epochLength,
           validators = bonds.map(Validator.tupled).toSeq
         ),
         genesisPk = Secp256k1.newKeyPair._2,

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -71,7 +71,7 @@ object RhoSpec {
           _ <- Runtime.injectEmptyRegistryRoot[Task](runtime.space, runtime.replaySpace)
           _ <- TestUtil.setupRuntime[Task, Task.Par](
                 runtime,
-                TestUtil.defaultGenesisSetup,
+                TestUtil.defaultGenesisSetup(1),
                 otherLibs
               )
           rand = Blake2b512Random(128)


### PR DESCRIPTION
## Overview
At bond time the validator is added to the bonds map without becoming active. At epoch change it has the chance to become an active validator. Only the active validators are the ones who actually do validation work.

For now, all the validators become active but in the future some percentage will change at each epoch.

Note that, at first look, this implementation might seem different than what was discussed originally but, in fact, it behaves the same.

Also note that, for the moment, for testing purposes the epoch length is set to 1.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3461



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
