### PR TITLE
Remove ChunkResponse from the streaming API

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -29,7 +29,6 @@ final case class MalformedMessage(pm: Protocol)                     extends Comm
 final case object CouldNotConnectToBootstrap                        extends CommError
 final case class InternalCommunicationError(msg: String)            extends CommError
 final case object TimeOut                                           extends CommError
-final case object NoResponseForRequest                              extends CommError
 final case object UpstreamNotAvailable                              extends CommError
 final case class UnexpectedMessage(msgStr: String)                  extends CommError
 final case object SenderNotAvailable                                extends CommError
@@ -56,7 +55,6 @@ object CommError {
   def couldNotConnectToBootstrap: CommError                = CouldNotConnectToBootstrap
   def internalCommunicationError(msg: String): CommError   = InternalCommunicationError(msg)
   def malformedMessage(pm: Protocol): CommError            = MalformedMessage(pm)
-  def noResponseForRequest: CommError                      = NoResponseForRequest
   def upstreamNotAvailable: CommError                      = UpstreamNotAvailable
   def unexpectedMessage(msgStr: String): CommError         = UnexpectedMessage(msgStr)
   def senderNotAvailable: CommError                        = SenderNotAvailable

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
@@ -27,7 +27,7 @@ object GrpcTransport {
       peer: PeerNode
   )(
       request: RoutingGrpcMonix.TransportLayer => Task[TLResponse]
-  ): Request[Option[Protocol]] =
+  ): Request[Unit] =
     ReaderT(stub => request(stub).attempt.map(processResponse(peer, _)))
 
   private object PeerUnavailable {
@@ -71,12 +71,12 @@ object GrpcTransport {
   private def processResponse(
       peer: PeerNode,
       response: Either[Throwable, TLResponse]
-  ): CommErr[Option[Protocol]] =
+  ): CommErr[Unit] =
     processError(peer, response)
       .flatMap(
         tlr =>
           tlr.payload match {
-            case p if p.isNoResponse => Right(None)
+            case p if p.isNoResponse => Right(())
             case TLResponse.Payload.InternalServerError(ise) =>
               Left(internalCommunicationError("Got response: " + ise.error.toStringUtf8))
           }
@@ -97,15 +97,8 @@ object GrpcTransport {
 
   def send(peer: PeerNode, msg: Protocol)(implicit metrics: Metrics[Task]): Request[Unit] =
     for {
-      _ <- ReaderT.liftF(metrics.incrementCounter("send"))
-      result <- transport(peer)(
-                 _.send(TLRequest(msg.some))
-                   .timer("send-time")
-               ).map(_.flatMap {
-                 case Some(p) =>
-                   Left(internalCommunicationError(s"Was expecting no message. Response: $p"))
-                 case _ => Right(())
-               })
+      _      <- ReaderT.liftF(metrics.incrementCounter("send"))
+      result <- transport(peer)(_.send(TLRequest(msg.some)).timer("send-time"))
     } yield result
 
   def stream(networkId: String, peer: PeerNode, blob: Blob, packetChunkSize: Int): Request[Unit] =

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
@@ -104,6 +104,6 @@ object GrpcTransport {
   def stream(networkId: String, peer: PeerNode, blob: Blob, packetChunkSize: Int): Request[Unit] =
     ReaderT(
       _.stream(Observable.fromIterator(Chunker.chunkIt(networkId, blob, packetChunkSize))).attempt
-        .map(r => processError(peer, r.map(kp(()))))
+        .map(r => processResponse(peer, r))
     )
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
@@ -76,7 +76,7 @@ object GrpcTransport {
       .flatMap(
         tlr =>
           tlr.payload match {
-            case p if p.isNoResponse => Right(())
+            case p if p.isAck => Right(())
             case TLResponse.Payload.InternalServerError(ise) =>
               Left(internalCommunicationError("Got response: " + ise.error.toStringUtf8))
           }

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -139,14 +139,14 @@ class GrpcTransportClient(
             withClient(peer, timeout(packet))(
               GrpcTransport.stream(networkId, peer, Blob(sender, packet), packetChunkSize)
             ).flatMap {
-              case Left(error @ PeerUnavailable(_)) =>
+              case Left(error @ TimeOut) =>
                 log.debug(
                   s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
-                )
+                ) >> delay(handle(retryCount - 1))
               case Left(error) =>
                 log.error(
                   s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
-                ) >> delay(handle(retryCount - 1))
+                )
               case Right(_) => log.info(s"Streamed packet $path to $peer")
             }
           case Left(error) =>

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -54,7 +54,7 @@ object GrpcTransportReceiver {
                       .delay(tellBuffer.pushNext(Send(protocol)))
                       .ifM(
                         metrics.incrementCounter("enqueued.messages") >> Task
-                          .delay(noResponse(src)),
+                          .delay(ack(src)),
                         metrics.incrementCounter("dropped.messages") >> Task
                           .delay(internalServerError("message dropped"))
                       )
@@ -91,7 +91,7 @@ object GrpcTransportReceiver {
                       metrics.incrementCounter("dropped.packets"),
                       msg.path.deleteSingleFile[Task]
                     ).sequence
-                  ) >> rPConfAsk.reader(c => noResponse(c.local))
+                  ) >> rPConfAsk.reader(c => ack(c.local))
           }
         }
 
@@ -102,9 +102,9 @@ object GrpcTransportReceiver {
               .InternalServerError(InternalServerError(ProtocolHelper.toProtocolBytes(msg)))
           )
 
-        private def noResponse(src: PeerNode): TLResponse =
+        private def ack(src: PeerNode): TLResponse =
           TLResponse(
-            TLResponse.Payload.NoResponse(NoResponse(Some(ProtocolHelper.header(src, networkId))))
+            TLResponse.Payload.Ack(Ack(Some(ProtocolHelper.header(src, networkId))))
           )
       }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -53,7 +53,7 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.NoResponse(NoResponse(Some(RHeader(Some(sender), nid))))) =>
+        case TLResponse(Payload.Ack(Ack(Some(RHeader(Some(sender), nid))))) =>
           if (nid == networkID) {
             val sslSession: Option[SSLSession] = Option(
               self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)

--- a/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
@@ -32,8 +32,8 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
     PeerNode.from(id, "host", 0, 0)
   }
 
-  private val noResponse: TLResponse =
-    TLResponse(TLResponse.Payload.NoResponse(NoResponse()))
+  private val ack: TLResponse =
+    TLResponse(TLResponse.Payload.Ack(Ack()))
 
   private def internalServerError(msg: String): TLResponse =
     TLResponse(
@@ -59,7 +59,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
     def stream(input: Observable[Chunk]): Task[TLResponse] =
       input.toListL.map { l =>
         streamMessages += l
-        noResponse
+        ack
       }
 
     val sendMessages: mutable.MutableList[TLRequest]     = mutable.MutableList.empty[TLRequest]
@@ -69,7 +69,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
   "sending a message to a remote peer" when {
     "everything is fine" should {
       "send and receive Unit" in {
-        val response   = noResponse
+        val response   = ack
         val stub       = new TestTransportLayer(Task.now(response))
         val result     = GrpcTransport.send(peerRemote, msg).run(stub).attempt.runSyncUnsafe()
         val unit: Unit = ()

--- a/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
@@ -56,10 +56,10 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
       sendMessages += request
       response
     }
-    def stream(input: Observable[Chunk]): Task[ChunkResponse] =
+    def stream(input: Observable[Chunk]): Task[TLResponse] =
       input.toListL.map { l =>
         streamMessages += l
-        ChunkResponse()
+        noResponse
       }
 
     val sendMessages: mutable.MutableList[TLRequest]     = mutable.MutableList.empty[TLRequest]

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -67,13 +67,13 @@ message InternalServerError {
   bytes error = 1;
 }
 
-message NoResponse {
-    Header header      = 1;
+message Ack {
+    Header header = 1;
 }
 
 message TLResponse {
   oneof payload {
-    NoResponse noResponse                   = 1;
+    Ack ack                                 = 1;
     InternalServerError internalServerError = 2;
   }
 }

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -56,7 +56,7 @@ message Protocol {
 
 service TransportLayer {
   rpc Send (TLRequest) returns (TLResponse) {}
-  rpc Stream (stream Chunk) returns (ChunkResponse) {}
+  rpc Stream (stream Chunk) returns (TLResponse) {}
 }
 
 message TLRequest {
@@ -95,8 +95,4 @@ message Chunk {
     ChunkHeader header = 1;
     ChunkData   data   = 2;
   }
-}
-
-message ChunkResponse {
-
 }


### PR DESCRIPTION
## Overview
Remove ChunkResponse from the streaming API because it's misleading. Instead, use `TLResponse` and respond with `NoResponse` when the streaming was successful and with `InternalCommunicationError` otherwise.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3605

## Note
This is a breaking change in the node to node protocol.
