### PR TITLE
Rchain 3465: add PoS.withdraw method

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -57,7 +57,8 @@ new  PoS,
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
             // activeValidators : List[PublicKey] - the active validators
-            // withdrawers : Map[PublicKey, Int] - the validators willing to withdraw and the blocknumber for their withdrawal
+            // withdrawers : Map[PublicKey, Int] - the validators willing to withdraw and the blocknumber when their quarantine ends
+            //                                     This is the beggining of the next epoch after their withdrawal + quarantineLength
             // allBonds : Map[PublickKey, Int] - each validator stake
             stateCh!({
               "pendingRewards":{},
@@ -138,9 +139,12 @@ new  PoS,
                     @userPk <- userCh;
                     _, @blockNumber <- blockDataCh) {
                   if (state.get("allBonds").contains(userPk)) {
+                    // the withdwal is in effect starting from the next epoch
                     resultCh!(
                       state.set("withdrawers",
-                                state.get("withdrawers").set(userPk, blockNumber)),
+                                state.get("withdrawers")
+                                     .set(userPk,
+                                       $$quarantineLength$$ + $$epochLength$$ * (1 + blockNumber / $$epochLength$$))),
                       (true, Nil))
                   } else {
                     resultCh!(state, (false, "User is not bonded"))
@@ -333,7 +337,7 @@ new  PoS,
                     } |
 
                     contract isQuarantineFinished(@(_, blockNumber), resultCh) = {
-                      resultCh!(blockNumber + $$quarantineLength$$ >= currentBlockNumber)
+                      resultCh!(blockNumber >= currentBlockNumber)
                     }
                   }
                 }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -3,6 +3,7 @@
 // maximumBond - the maximum bond allowed by PoS
 // initialBonds - the initial bonds map
 // epochLength - the length of the validation epoch in blocks
+// quarantineLength - the length of the quarantine time in blocks
 
 /*
  The table below describes the required computations and their dependencies
@@ -185,7 +186,8 @@ new  PoS,
             contract PoS(@"closeBlock", ackCh) = {
               new blockDataCh, mvarProcessCh,
                   getBlockData(`rho:block:data`),
-                  commitReward, rewardsCh, newValidatorsCh in {
+                  commitReward, rewardsCh, newValidatorsCh,
+                  newWithdrawersCh, newBondsCh in {
                 getBlockData!(*blockDataCh) |
 
                 runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
@@ -198,6 +200,53 @@ new  PoS,
                     newValidatorsCh!(activeValidators)
                   } |
 
+                  new quarantinedValidatorsCh,
+                      validatorsToWithdrawListCh,
+                      validatorsToWithdrawSetCh,
+                      isQuarantineFinished,
+                      isWithdrawn,
+                      accumulateToSet,
+                      accumulateToMap,
+                      newBondsListCh,
+                      newWithdrawersListCh,
+                      test1ch, test2ch
+                  in {
+                    @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
+                    for (@quarantinedValidators <- quarantinedValidatorsCh) {
+
+                      @ListOps!("map", quarantinedValidators, *fst, *validatorsToWithdrawListCh) |
+                      for (@validatorsToWithdrawList <- validatorsToWithdrawListCh) {
+                        @ListOps!("fold", validatorsToWithdrawList, Set(), *accumulateToSet, *validatorsToWithdrawSetCh) |
+
+                        for (@validatorsToWithdrawSet <- validatorsToWithdrawSetCh) {
+                          @ListOps!("filter", allBonds.toList(), *isWithdrawn, *newBondsListCh) |
+
+                          for (@newBondsList <- newBondsListCh) {
+                            @ListOps!("fold", newBondsList, {}, *accumulateToMap, *newBondsCh)
+                          } |
+
+                          @ListOps!("filter", withdrawers.toList(), *isWithdrawn, *newWithdrawersListCh) |
+                          contract isWithdrawn(@(pk, _), resultCh) = {
+                            resultCh!(not validatorsToWithdrawSet.contains(pk))
+                          } |
+
+                          for (@newWithdrawersList <- newWithdrawersListCh) {
+                            @ListOps!("fold", newWithdrawersList, {}, *accumulateToMap, *newWithdrawersCh)
+                          } |
+
+                          contract isWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
+                        }
+                      }
+                    } |
+
+                    contract isQuarantineFinished(@(_, blockTime), resultCh) = {
+                      resultCh!(blockTime >= $$quarantineLength$$)
+                    } |
+
+                    contract accumulateToSet(@x, @acc, resultCh) = {resultCh! (acc.union(Set(x)))} |
+
+                    contract accumulateToMap(@(k, v), @acc, resultCh) = {resultCh!(acc.set(k, v))}
+                  } |
 
                   @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *rewardsCh) |
                   contract commitReward(@(pk, pending), @acc, resultCh) = {
@@ -205,8 +254,10 @@ new  PoS,
                   } |
 
                   for (@rewards <- rewardsCh;
-                       @newValidators <- newValidatorsCh) {
-                    mvarResultCh!(({}, rewards, newValidators, withdrawers, allBonds), Nil)
+                       @newValidators <- newValidatorsCh;
+                       @newWithdrawers <- newWithdrawersCh ;
+                       @newBonds <- newBondsCh) {
+                    mvarResultCh!(({}, rewards, newValidators, newWithdrawers, newBonds), Nil)
                   }
                 }
               }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -263,7 +263,7 @@ new  PoS,
 
                 contract payValidators(@payments, ackCh) = {
                   new payValidator in {
-                    @ListOps!("foreach", payments, *payValidator, *ackCh) |
+                    @ListOps!("unorderedParMap", payments, *payValidator, *ackCh) |
 
                     contract payValidator (@(pk, amount), returnCh) = {
                       new vaultCh,

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -219,41 +219,43 @@ new  PoS,
                   for(_, @blockNumber <- blockDataCh;
                       @state, mvarResultCh <- mvarProcessCh) {
 
+                    changeEpoch!(
+                      blockNumber,
+                      state.get("allBonds"),
+                      state.get("activeValidators"),
+                      state.get("withdrawers"),
+                      *newValidatorsCh)|
+
                     commitRewards!(
                       state.get("pendingRewards"),
                       state.get("committedRewards"),
                       *commitRewardsCh) |
 
                     for (@committedRewards <- commitRewardsCh) {
-                      changeEpoch!(
-                        blockNumber,
-                        state.get("allBonds"),
-                        state.get("activeValidators"),
-                        state.get("withdrawers"),
-                        *newValidatorsCh)|
 
                       removeQuarantinedWithdrawers!(
                         blockNumber,
                         state.get("allBonds"),
                         state.get("withdrawers"),
                         committedRewards,
-                        *removeQuarantinedCh) |
+                        *removeQuarantinedCh)
+                    } |
 
-                      for(@newValidators <- newValidatorsCh;
-                          @(payments, newBonds, newWithdrawers, newRewards) <- removeQuarantinedCh) {
-                        payValidators!(payments, *paymentDoneCh) |
+                    for(@newValidators <- newValidatorsCh;
+                        @(payments, newBonds, newWithdrawers, newRewards) <- removeQuarantinedCh) {
 
-                        for (_ <- paymentDoneCh) {
-                          mvarResultCh!(
-                            {
-                              "pendingRewards":{},
-                              "committedRewards":newRewards,
-                              "activeValidators":newValidators,
-                              "withdrawers":newWithdrawers,
-                              "allBonds":newBonds
-                            },
-                            Nil)
-                        }
+                      payValidators!(payments, *paymentDoneCh) |
+
+                      for (_ <- paymentDoneCh) {
+                        mvarResultCh!(
+                          {
+                            "pendingRewards":{},
+                            "committedRewards":newRewards,
+                            "activeValidators":newValidators,
+                            "withdrawers":newWithdrawers,
+                            "allBonds":newBonds
+                          },
+                          Nil)
                       }
                     }
                   }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -57,13 +57,19 @@ new  PoS,
             // activeValidators : List[PublicKey] - the active validators
             // withdrawers : Map[PublicKey, Int] - the validators willing to withdraw and the blocknumber for their withdrawal
             // allBonds : Map[PublickKey, Int] - each validator stake
-            stateCh!(({}, {}, initialActive, {}, $$initialBonds$$)) |
+            stateCh!({
+              "pendingRewards":{},
+              "committedRewards":{},
+              "activeValidators":initialActive,
+              "withdrawers":{},
+              "allBonds":$$initialBonds$$
+            }) |
 
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, _, _, _, allBonds) <- tmpCh) {
-                  returnCh!(allBonds)
+                for (@state <- tmpCh) {
+                  returnCh!(state.get("allBonds"))
                 }
               }
             } |
@@ -75,8 +81,8 @@ new  PoS,
             contract PoS (@"getRewards", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, rewards, _, _, _) <- tmpCh) {
-                  returnCh!(rewards)
+                for (@state <- tmpCh) {
+                  returnCh!(state.get("committedRewards"))
                 }
               }
             } |
@@ -86,27 +92,29 @@ new  PoS,
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
                 getUser!(*userCh) |
-                for(@(pending, rewards, activeValidators, withdrawers, allBonds), resultCh <- processCh;
+                for(@state, resultCh <- processCh;
                     @userPk <- userCh) {
-                  if (allBonds.contains(userPk)) {
-                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Public key is already bonded."))
+                  if (state.get("allBonds").contains(userPk)) {
+                    resultCh!(state, (false, "Public key is already bonded."))
                   } else if (amount < $$minimumBond$$) {
-                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond is less than minimum!"))
+                    resultCh!(state, (false, "Bond is less than minimum!"))
                   } else if (amount > $$maximumBond$$) {
-                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond is greater than maximum!"))
+                    resultCh!(state, (false, "Bond is greater than maximum!"))
                   } else {
                     deposit!(userPk, amount, *depositCh) |
                     for(@depositResult <- depositCh) {
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (pending, rewards, activeValidators, withdrawers, allBonds.set(userPk,amount)),
+                            state.set(
+                              "allBonds",
+                              state.get("allBonds").set(userPk,amount)),
                             depositResult
                           )
                         }
 
                         (false, errorMsg) => {
-                          resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
+                          resultCh!(state, (false, "Bond deposit failed: " ++ errorMsg))
                         }
                       }
                     }
@@ -124,13 +132,16 @@ new  PoS,
 
                 getBlockData!(*blockDataCh) |
                 getUser!(*userCh) |
-                for(@(pending, rewards, activeValidators, withdrawers, allBonds), resultCh <- processCh;
+                for(@state, resultCh <- processCh;
                     @userPk <- userCh;
                     _, @blockNumber <- blockDataCh) {
-                  if (allBonds.contains(userPk)) {
-                    resultCh!((pending, rewards, activeValidators, withdrawers.set(userPk, blockNumber), allBonds), (true, Nil))
+                  if (state.get("allBonds").contains(userPk)) {
+                    resultCh!(
+                      state.set("withdrawers",
+                                state.get("withdrawers").set(userPk, blockNumber)),
+                      (true, Nil))
                   } else {
-                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "User is not bonded"))
+                    resultCh!(state, (false, "User is not bonded"))
                   }
                 }
               }
@@ -142,15 +153,20 @@ new  PoS,
                   newPendingCh in {
                 getUser!(*userCh) |
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
-                for(@(pending, rewards, activeValidators, withdrawers, allBonds), payResultCh <- processPayCh;
+                for(@state, payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
-                  distributeRewards!(amount, activeValidators, allBonds, pending, *newPendingCh) |
+                  distributeRewards!(
+                    amount,
+                    state.get("activeValidators"),
+                    state.get("allBonds"),
+                    state.get("pendingRewards"),
+                    *newPendingCh) |
 
                   for(@depositResult <- depositCh;
                       @newPending <- newPendingCh) {
-                    payResultCh!((newPending, rewards, activeValidators, withdrawers, allBonds), depositResult)
+                    payResultCh!(state.set("pendingRewards", newPending), depositResult)
                   }
                 }
               }
@@ -165,17 +181,18 @@ new  PoS,
                 runMVar!(*stateCh, *doSlashCh, *returnCh) |
                 for (@invalidBlocks <- invalidBlocksCh;
                      @userPk <- userCh;
-                     @(pending, rewards, activeValidators, withdrawers, allBonds), slashResultCh <- doSlashCh) {
+                     @state, slashResultCh <- doSlashCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
                       // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
                       slashResultCh!(
-                        (pending.set(validator, 0),
-                         rewards.set(validator, 0),
-                         activeValidators,
-                         withdrawers,
-                         allBonds.set(validator, 0)),
+                        state.set("pendingRewards",
+                                  state.get("pendingRewards").set(validator, 0))
+                             .set("committedRewards",
+                                  state.get("committedRewards").set(validator, 0))
+                             .set("allBonds",
+                                  state.get("allBonds").set(validator, 0)),
                         true)
                     }
                   }
@@ -197,19 +214,39 @@ new  PoS,
 
                   runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                   for(_, @blockNumber <- blockDataCh;
-                      @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
+                      @state, mvarResultCh <- mvarProcessCh) {
+                    changeEpoch!(
+                      blockNumber,
+                      state.get("allBonds"),
+                      state.get("activeValidators"),
+                      state.get("withdrawers"),
+                      *newValidatorsCh)|
 
-                    changeEpoch!(blockNumber, allBonds, activeValidators, withdrawers, *newValidatorsCh)|
+                    removeQuarantinedWithdrawers!(
+                      blockNumber,
+                      state.get("allBonds"),
+                      state.get("withdrawers"),
+                      *newWithdrawersCh,
+                      *newBondsCh) |
 
-                    removeQuarantinedWithdrawers!(blockNumber, allBonds, withdrawers, *newWithdrawersCh, *newBondsCh) |
-
-                    commitRewards!(pendingRewards, rewards, *newRewardsCh) |
+                    commitRewards!(
+                      state.get("pendingRewards"),
+                      state.get("committedRewards"),
+                      *newRewardsCh) |
 
                     for (@newRewards <- newRewardsCh;
                          @newValidators <- newValidatorsCh;
                          @newWithdrawers <- newWithdrawersCh ;
                          @newBonds <- newBondsCh) {
-                      mvarResultCh!(({}, newRewards, newValidators, newWithdrawers, newBonds), Nil)
+                      mvarResultCh!(
+                        {
+                          "pendingRewards":{},
+                          "committedRewards":newRewards,
+                          "activeValidators":newValidators,
+                          "withdrawers":newWithdrawers,
+                          "allBonds":newBonds
+                        },
+                        Nil)
                     }
                   }
                 } |

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -113,6 +113,22 @@ new  PoS,
               }
             } |
 
+            contract PoS (@"withdraw", returnCh) = {
+              new userCh, depositCh, processCh in {
+                runMVar!(*stateCh, *processCh, *returnCh) |
+
+                getUser!(*userCh) |
+                for(@(pending, rewards, activeValidators, allBonds), resultCh <- processCh;
+                    @userPk <- userCh) {
+                  if (allBonds.contains(userPk)) {
+                    resultCh!((pending, rewards, activeValidators, allBonds), (true, Nil))
+                  } else {
+                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "User is not bonded"))
+                  }
+                }
+              }
+            } |
+
             contract PoS (@"pay", @amount, returnCh) = {
               new vaultCh, transferCh, userCh, processPayCh,
                   depositCh,

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -44,7 +44,7 @@ new  PoS,
       getCurrentUserAddress!(*posRevAddressCh) |
       for(@posRevAddress <- posRevAddressCh) {
         new stateCh, posVaultCh, initialActiveCh in {
-          pickActiveValidators!($$initialBonds$$, *initialActiveCh) |
+          pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
 
           @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
           for (@(true, _) <- posVaultCh;
@@ -193,7 +193,7 @@ new  PoS,
                     @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
 
                   if (blockNumber % $$epochLength$$ == 0) {
-                    pickActiveValidators!(allBonds, *newValidatorsCh)
+                    pickActiveValidators!(allBonds, withdrawers, *newValidatorsCh)
                   } else {
                     newValidatorsCh!(activeValidators)
                   } |
@@ -298,9 +298,16 @@ new  PoS,
         }
       } |
 
-      contract pickActiveValidators(@allBonds, returnCh) = {
-        //TODO choose only a limited number of validators
-        @ListOps!("map", allBonds.toList(), *fst, *returnCh)
+      contract pickActiveValidators(@allBonds, @withdrawers, returnCh) = {
+        new availableValidatorsCh, isAvailable in {
+          @ListOps!("filter", allBonds.toList(), *isAvailable, *availableValidatorsCh) |
+          contract isAvailable(@(pk, _), resultCh) = { resultCh!(not withdrawers.contains(pk))} |
+
+          for (@availableValidators <- availableValidatorsCh) {
+            //TODO choose only a limited number of validators
+            @ListOps!("map", availableValidators, *fst, *returnCh)
+          }
+        }
       } |
 
       contract getCurrentUserVault(returnCh) = {

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -184,41 +184,47 @@ new  PoS,
             } |
 
             contract PoS(@"closeBlock", ackCh) = {
-              new blockDataCh, mvarProcessCh,
-                  getBlockData(`rho:block:data`),
-                  commitReward, newRewardsCh, newValidatorsCh,
-                  newWithdrawersCh, newBondsCh,
-                  changeEpoch, removeQuarantinedWithdrawers, commitRewards
+              new commitRewards,
+                  changeEpoch,
+                  removeQuarantinedWithdrawers
               in {
-                getBlockData!(*blockDataCh) |
+                new blockDataCh, mvarProcessCh,
+                    getBlockData(`rho:block:data`),
+                    newRewardsCh, newValidatorsCh,
+                    newWithdrawersCh, newBondsCh
+                in {
+                  getBlockData!(*blockDataCh) |
 
-                runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
-                for(_, @blockNumber <- blockDataCh;
-                    @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
+                  runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
+                  for(_, @blockNumber <- blockDataCh;
+                      @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
 
-                  changeEpoch!(blockNumber, allBonds, activeValidators, withdrawers, *newValidatorsCh)|
+                    changeEpoch!(blockNumber, allBonds, activeValidators, withdrawers, *newValidatorsCh)|
 
-                  removeQuarantinedWithdrawers!(blockNumber, allBonds, withdrawers, *newWithdrawersCh, *newBondsCh) |
+                    removeQuarantinedWithdrawers!(blockNumber, allBonds, withdrawers, *newWithdrawersCh, *newBondsCh) |
 
-                  commitRewards!(pendingRewards, rewards, *newRewardsCh) |
+                    commitRewards!(pendingRewards, rewards, *newRewardsCh) |
 
-                  for (@newRewards <- newRewardsCh;
-                       @newValidators <- newValidatorsCh;
-                       @newWithdrawers <- newWithdrawersCh ;
-                       @newBonds <- newBondsCh) {
-                    mvarResultCh!(({}, newRewards, newValidators, newWithdrawers, newBonds), Nil)
+                    for (@newRewards <- newRewardsCh;
+                         @newValidators <- newValidatorsCh;
+                         @newWithdrawers <- newWithdrawersCh ;
+                         @newBonds <- newBondsCh) {
+                      mvarResultCh!(({}, newRewards, newValidators, newWithdrawers, newBonds), Nil)
+                    }
                   }
                 } |
 
                 contract commitRewards(@pendingRewards, @rewards, newRewardsCh) = {
-                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *newRewardsCh) |
-                  contract commitReward(@(pk, pending), @acc, resultCh) = {
-                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                  new commitReward in {
+                    @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *newRewardsCh) |
+                    contract commitReward(@(pk, pending), @acc, resultCh) = {
+                      resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                    }
                   }
                 }|
 
-                contract changeEpoch(@blockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
-                  if (blockNumber % $$epochLength$$ == 0) {
+                contract changeEpoch(@currentBlockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
+                  if (currentBlockNumber % $$epochLength$$ == 0) {
                     pickActiveValidators!(allBonds, withdrawers, *resultCh)
                   } else {
                     resultCh!(activeValidators)

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -271,49 +271,42 @@ new  PoS,
                 contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, newWithdrawersCh, newBondsCh) = {
                   new quarantinedValidatorsCh,
                       validatorsToWithdrawListCh,
-                      validatorsToWithdrawSetCh,
                       isQuarantineFinished,
                       isWithdrawn,
-                      accumulateToSet,
-                      accumulateToMap,
                       newBondsListCh,
                       newWithdrawersListCh
                   in {
                     @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
                     for (@quarantinedValidators <- quarantinedValidatorsCh) {
-
                       @ListOps!("map", quarantinedValidators, *fst, *validatorsToWithdrawListCh) |
                       for (@validatorsToWithdrawList <- validatorsToWithdrawListCh) {
-                        @ListOps!("fold", validatorsToWithdrawList, Set(), *accumulateToSet, *validatorsToWithdrawSetCh) |
 
-                        for (@validatorsToWithdrawSet <- validatorsToWithdrawSetCh) {
-                          @ListOps!("filter", allBonds.toList(), *isWithdrawn, *newBondsListCh) |
+                        match validatorsToWithdrawList.toSet() {
+                          validatorsToWithdrawSet => {
+                            @ListOps!("filter", allBonds.toList(), *isWithdrawn, *newBondsListCh) |
 
-                          for (@newBondsList <- newBondsListCh) {
-                            @ListOps!("fold", newBondsList, {}, *accumulateToMap, *newBondsCh)
-                          } |
+                            for (@newBondsList <- newBondsListCh) {
+                              newBondsCh!(newBondsList.toMap())
+                            } |
 
-                          @ListOps!("filter", withdrawers.toList(), *isWithdrawn, *newWithdrawersListCh) |
-                          contract isWithdrawn(@(pk, _), resultCh) = {
-                            resultCh!(not validatorsToWithdrawSet.contains(pk))
-                          } |
+                            @ListOps!("filter", withdrawers.toList(), *isWithdrawn, *newWithdrawersListCh) |
+                            contract isWithdrawn(@(pk, _), resultCh) = {
+                              resultCh!(not validatorsToWithdrawSet.contains(pk))
+                            } |
 
-                          for (@newWithdrawersList <- newWithdrawersListCh) {
-                            @ListOps!("fold", newWithdrawersList, {}, *accumulateToMap, *newWithdrawersCh)
-                          } |
+                            for (@newWithdrawersList <- newWithdrawersListCh) {
+                              newWithdrawersCh!(newWithdrawersList.toMap())
+                            } |
 
-                          contract isWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
+                            contract isWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
+                          }
                         }
                       }
                     } |
 
                     contract isQuarantineFinished(@(_, blockNumber), resultCh) = {
                       resultCh!(blockNumber + $$quarantineLength$$ >= currentBlockNumber)
-                    } |
-
-                    contract accumulateToSet(@x, @acc, resultCh) = {resultCh! (acc.union(Set(x)))} |
-
-                    contract accumulateToMap(@(k, v), @acc, resultCh) = {resultCh!(acc.set(k, v))}
+                    }
                   }
                 }
               }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -187,18 +187,16 @@ new  PoS,
               new blockDataCh, mvarProcessCh,
                   getBlockData(`rho:block:data`),
                   commitReward, rewardsCh, newValidatorsCh,
-                  newWithdrawersCh, newBondsCh in {
+                  newWithdrawersCh, newBondsCh,
+                  changeEpoch
+              in {
                 getBlockData!(*blockDataCh) |
 
                 runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                 for(_, @blockNumber <- blockDataCh;
                     @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
 
-                  if (blockNumber % $$epochLength$$ == 0) {
-                    pickActiveValidators!(allBonds, withdrawers, *newValidatorsCh)
-                  } else {
-                    newValidatorsCh!(activeValidators)
-                  } |
+                  changeEpoch!(blockNumber, allBonds, activeValidators, withdrawers, *newValidatorsCh)|
 
                   new quarantinedValidatorsCh,
                       validatorsToWithdrawListCh,
@@ -258,6 +256,14 @@ new  PoS,
                        @newWithdrawers <- newWithdrawersCh ;
                        @newBonds <- newBondsCh) {
                     mvarResultCh!(({}, rewards, newValidators, newWithdrawers, newBonds), Nil)
+                  }
+                } |
+
+                contract changeEpoch(@blockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
+                  if (blockNumber % $$epochLength$$ == 0) {
+                    pickActiveValidators!(allBonds, withdrawers, *resultCh)
+                  } else {
+                    resultCh!(activeValidators)
                   }
                 }
               }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -186,9 +186,9 @@ new  PoS,
             contract PoS(@"closeBlock", ackCh) = {
               new blockDataCh, mvarProcessCh,
                   getBlockData(`rho:block:data`),
-                  commitReward, rewardsCh, newValidatorsCh,
+                  commitReward, newRewardsCh, newValidatorsCh,
                   newWithdrawersCh, newBondsCh,
-                  changeEpoch, removeQuarantinedWithdrawers
+                  changeEpoch, removeQuarantinedWithdrawers, commitRewards
               in {
                 getBlockData!(*blockDataCh) |
 
@@ -200,18 +200,22 @@ new  PoS,
 
                   removeQuarantinedWithdrawers!(blockNumber, allBonds, withdrawers, *newWithdrawersCh, *newBondsCh) |
 
-                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *rewardsCh) |
-                  contract commitReward(@(pk, pending), @acc, resultCh) = {
-                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
-                  } |
+                  commitRewards!(pendingRewards, rewards, *newRewardsCh) |
 
-                  for (@rewards <- rewardsCh;
+                  for (@newRewards <- newRewardsCh;
                        @newValidators <- newValidatorsCh;
                        @newWithdrawers <- newWithdrawersCh ;
                        @newBonds <- newBondsCh) {
-                    mvarResultCh!(({}, rewards, newValidators, newWithdrawers, newBonds), Nil)
+                    mvarResultCh!(({}, newRewards, newValidators, newWithdrawers, newBonds), Nil)
                   }
                 } |
+
+                contract commitRewards(@pendingRewards, @rewards, newRewardsCh) = {
+                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *newRewardsCh) |
+                  contract commitReward(@(pk, pending), @acc, resultCh) = {
+                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                  }
+                }|
 
                 contract changeEpoch(@blockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
                   if (blockNumber % $$epochLength$$ == 0) {

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -40,17 +40,19 @@ new  PoS,
 
   for(@(_, RevVault) <- revVaultCh;
       @(_, ListOps) <- listOpsCh) {
-    new posRevAddressCh in {
+    new posRevAddressCh, posAuthKeyCh, posVaultCh, initialActiveCh in {
 
+      @RevVault!("deployerAuthKey", *posAuthKeyCh) |
       getCurrentUserAddress!(*posRevAddressCh) |
-      for(@posRevAddress <- posRevAddressCh) {
-        new stateCh, posVaultCh, initialActiveCh in {
-          pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
 
-          @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
-          for (@(true, _) <- posVaultCh;
-               @initialActive <- initialActiveCh) {
+      for(@posRevAddress <- posRevAddressCh;
+          @posAuthKey <- posAuthKeyCh) {
+        @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
+        pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
 
+        for (@(true, posVault) <- posVaultCh;
+             @initialActive <- initialActiveCh) {
+          new stateCh in {
             // State structure:
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
@@ -124,7 +126,7 @@ new  PoS,
             } |
 
             contract PoS (@"withdraw", returnCh) = {
-              new userCh, depositCh, processCh,
+              new userCh, processCh,
                   getBlockData(`rho:block:data`),
                   blockDataCh
               in {
@@ -203,50 +205,72 @@ new  PoS,
             contract PoS(@"closeBlock", ackCh) = {
               new commitRewards,
                   changeEpoch,
-                  removeQuarantinedWithdrawers
+                  removeQuarantinedWithdrawers,
+                  payValidators
               in {
                 new blockDataCh, mvarProcessCh,
                     getBlockData(`rho:block:data`),
-                    newRewardsCh, newValidatorsCh,
-                    newWithdrawersCh, newBondsCh
+                    commitRewardsCh,
+                    newValidatorsCh, removeQuarantinedCh, paymentDoneCh
                 in {
                   getBlockData!(*blockDataCh) |
 
                   runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                   for(_, @blockNumber <- blockDataCh;
                       @state, mvarResultCh <- mvarProcessCh) {
-                    changeEpoch!(
-                      blockNumber,
-                      state.get("allBonds"),
-                      state.get("activeValidators"),
-                      state.get("withdrawers"),
-                      *newValidatorsCh)|
-
-                    removeQuarantinedWithdrawers!(
-                      blockNumber,
-                      state.get("allBonds"),
-                      state.get("withdrawers"),
-                      *newWithdrawersCh,
-                      *newBondsCh) |
 
                     commitRewards!(
                       state.get("pendingRewards"),
                       state.get("committedRewards"),
-                      *newRewardsCh) |
+                      *commitRewardsCh) |
 
-                    for (@newRewards <- newRewardsCh;
-                         @newValidators <- newValidatorsCh;
-                         @newWithdrawers <- newWithdrawersCh ;
-                         @newBonds <- newBondsCh) {
-                      mvarResultCh!(
-                        {
-                          "pendingRewards":{},
-                          "committedRewards":newRewards,
-                          "activeValidators":newValidators,
-                          "withdrawers":newWithdrawers,
-                          "allBonds":newBonds
-                        },
-                        Nil)
+                    for (@committedRewards <- commitRewardsCh) {
+                      changeEpoch!(
+                        blockNumber,
+                        state.get("allBonds"),
+                        state.get("activeValidators"),
+                        state.get("withdrawers"),
+                        *newValidatorsCh)|
+
+                      removeQuarantinedWithdrawers!(
+                        blockNumber,
+                        state.get("allBonds"),
+                        state.get("withdrawers"),
+                        committedRewards,
+                        *removeQuarantinedCh) |
+
+                      for(@newValidators <- newValidatorsCh;
+                          @(payments, newBonds, newWithdrawers, newRewards) <- removeQuarantinedCh) {
+                        payValidators!(payments, *paymentDoneCh) |
+
+                        for (_ <- paymentDoneCh) {
+                          mvarResultCh!(
+                            {
+                              "pendingRewards":{},
+                              "committedRewards":newRewards,
+                              "activeValidators":newValidators,
+                              "withdrawers":newWithdrawers,
+                              "allBonds":newBonds
+                            },
+                            Nil)
+                        }
+                      }
+                    }
+                  }
+                } |
+
+                contract payValidators(@payments, ackCh) = {
+                  new payValidator in {
+                    @ListOps!("foreach", payments, *payValidator, *ackCh) |
+
+                    contract payValidator (@(pk, amount), returnCh) = {
+                      new vaultCh,
+                          revAddressCh in {
+                        revAddressOps!("fromPublicKey", pk, *revAddressCh) |
+                        for (@toRevAddress <- revAddressCh) {
+                          @posVault!("transfer", toRevAddress, amount, posAuthKey, *returnCh)
+                        }
+                      }
                     }
                   }
                 } |
@@ -268,37 +292,39 @@ new  PoS,
                   }
                 } |
 
-                contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, newWithdrawersCh, newBondsCh) = {
+                contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, @rewards, returnCh) = {
                   new quarantinedValidatorsCh,
                       validatorsToWithdrawListCh,
                       isQuarantineFinished,
-                      isWithdrawn,
+                      notWithdrawn,
                       newBondsListCh,
-                      newWithdrawersListCh
+                      newWithdrawersListCh,
+                      newRewardsListCh,
+                      paymentsCh, computePay
                   in {
                     @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
                     for (@quarantinedValidators <- quarantinedValidatorsCh) {
                       @ListOps!("map", quarantinedValidators, *fst, *validatorsToWithdrawListCh) |
                       for (@validatorsToWithdrawList <- validatorsToWithdrawListCh) {
+                        @ListOps!("map", validatorsToWithdrawList, *computePay, *paymentsCh) |
+                        contract computePay(@pk, resultCh) = {
+                          resultCh!((pk, allBonds.get(pk) + rewards.getOrElse(pk, 0)))
+                        } |
 
                         match validatorsToWithdrawList.toSet() {
                           validatorsToWithdrawSet => {
-                            @ListOps!("filter", allBonds.toList(), *isWithdrawn, *newBondsListCh) |
+                            @ListOps!("filter", allBonds.toList(), *notWithdrawn, *newBondsListCh) |
+                            @ListOps!("filter", withdrawers.toList(), *notWithdrawn, *newWithdrawersListCh) |
+                            @ListOps!("filter", rewards.toList(), *notWithdrawn, *newRewardsListCh) |
 
-                            for (@newBondsList <- newBondsListCh) {
-                              newBondsCh!(newBondsList.toMap())
+                            for (@newWithdrawersList <- newWithdrawersListCh;
+                                 @newBondsList <- newBondsListCh;
+                                 @newRewardsList <- newRewardsListCh;
+                                 @payments <- paymentsCh) {
+                              returnCh!((payments, newBondsList.toMap(), newWithdrawersList.toMap(), newRewardsList.toMap()))
                             } |
 
-                            @ListOps!("filter", withdrawers.toList(), *isWithdrawn, *newWithdrawersListCh) |
-                            contract isWithdrawn(@(pk, _), resultCh) = {
-                              resultCh!(not validatorsToWithdrawSet.contains(pk))
-                            } |
-
-                            for (@newWithdrawersList <- newWithdrawersListCh) {
-                              newWithdrawersCh!(newWithdrawersList.toMap())
-                            } |
-
-                            contract isWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
+                            contract notWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
                           }
                         }
                       }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -188,7 +188,7 @@ new  PoS,
                   getBlockData(`rho:block:data`),
                   commitReward, rewardsCh, newValidatorsCh,
                   newWithdrawersCh, newBondsCh,
-                  changeEpoch
+                  changeEpoch, removeQuarantinedWithdrawers
               in {
                 getBlockData!(*blockDataCh) |
 
@@ -198,6 +198,30 @@ new  PoS,
 
                   changeEpoch!(blockNumber, allBonds, activeValidators, withdrawers, *newValidatorsCh)|
 
+                  removeQuarantinedWithdrawers!(blockNumber, allBonds, withdrawers, *newWithdrawersCh, *newBondsCh) |
+
+                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *rewardsCh) |
+                  contract commitReward(@(pk, pending), @acc, resultCh) = {
+                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                  } |
+
+                  for (@rewards <- rewardsCh;
+                       @newValidators <- newValidatorsCh;
+                       @newWithdrawers <- newWithdrawersCh ;
+                       @newBonds <- newBondsCh) {
+                    mvarResultCh!(({}, rewards, newValidators, newWithdrawers, newBonds), Nil)
+                  }
+                } |
+
+                contract changeEpoch(@blockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
+                  if (blockNumber % $$epochLength$$ == 0) {
+                    pickActiveValidators!(allBonds, withdrawers, *resultCh)
+                  } else {
+                    resultCh!(activeValidators)
+                  }
+                } |
+
+                contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, newWithdrawersCh, newBondsCh) = {
                   new quarantinedValidatorsCh,
                       validatorsToWithdrawListCh,
                       validatorsToWithdrawSetCh,
@@ -206,8 +230,7 @@ new  PoS,
                       accumulateToSet,
                       accumulateToMap,
                       newBondsListCh,
-                      newWithdrawersListCh,
-                      test1ch, test2ch
+                      newWithdrawersListCh
                   in {
                     @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
                     for (@quarantinedValidators <- quarantinedValidatorsCh) {
@@ -237,33 +260,13 @@ new  PoS,
                       }
                     } |
 
-                    contract isQuarantineFinished(@(_, blockTime), resultCh) = {
-                      resultCh!(blockTime >= $$quarantineLength$$)
+                    contract isQuarantineFinished(@(_, blockNumber), resultCh) = {
+                      resultCh!(blockNumber + $$quarantineLength$$ >= currentBlockNumber)
                     } |
 
                     contract accumulateToSet(@x, @acc, resultCh) = {resultCh! (acc.union(Set(x)))} |
 
                     contract accumulateToMap(@(k, v), @acc, resultCh) = {resultCh!(acc.set(k, v))}
-                  } |
-
-                  @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *rewardsCh) |
-                  contract commitReward(@(pk, pending), @acc, resultCh) = {
-                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
-                  } |
-
-                  for (@rewards <- rewardsCh;
-                       @newValidators <- newValidatorsCh;
-                       @newWithdrawers <- newWithdrawersCh ;
-                       @newBonds <- newBondsCh) {
-                    mvarResultCh!(({}, rewards, newValidators, newWithdrawers, newBonds), Nil)
-                  }
-                } |
-
-                contract changeEpoch(@blockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
-                  if (blockNumber % $$epochLength$$ == 0) {
-                    pickActiveValidators!(allBonds, withdrawers, *resultCh)
-                  } else {
-                    resultCh!(activeValidators)
                   }
                 }
               }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -53,14 +53,15 @@ new  PoS,
             // State structure:
             // pendingRewards : Map[PublickKey, Int] - are accummulated by calling "pay"
             // committedRewards : Map[PublickKey, Int] - are moved from pendingRewards at each closeBlock
-            // activeBonds : List[PublickKey] - the active validators
-            // allbonds : Map[PublickKey, Int] - each validator stake
-            stateCh!(({}, {}, initialActive, $$initialBonds$$)) |
+            // activeValidators : List[PublicKey] - the active validators
+            // withdrawers : Map[PublicKey, Int] - the validators willing to withdraw and the blocknumber for their withdrawal
+            // allBonds : Map[PublickKey, Int] - each validator stake
+            stateCh!(({}, {}, initialActive, {}, $$initialBonds$$)) |
 
             contract PoS (@"getBonds", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, _, _, allBonds) <- tmpCh) {
+                for (@(_, _, _, _, allBonds) <- tmpCh) {
                   returnCh!(allBonds)
                 }
               }
@@ -73,7 +74,7 @@ new  PoS,
             contract PoS (@"getRewards", returnCh) = {
               new tmpCh in {
                 getMVar!(*stateCh, *tmpCh) |
-                for (@(_, rewards, _, _) <- tmpCh) {
+                for (@(_, rewards, _, _, _) <- tmpCh) {
                   returnCh!(rewards)
                 }
               }
@@ -84,27 +85,27 @@ new  PoS,
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
                 getUser!(*userCh) |
-                for(@(pending, rewards, activeValidators, allBonds), resultCh <- processCh;
+                for(@(pending, rewards, activeValidators, withdrawers, allBonds), resultCh <- processCh;
                     @userPk <- userCh) {
                   if (allBonds.contains(userPk)) {
-                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Public key is already bonded."))
+                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Public key is already bonded."))
                   } else if (amount < $$minimumBond$$) {
-                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond is less than minimum!"))
+                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond is less than minimum!"))
                   } else if (amount > $$maximumBond$$) {
-                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond is greater than maximum!"))
+                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond is greater than maximum!"))
                   } else {
                     deposit!(userPk, amount, *depositCh) |
                     for(@depositResult <- depositCh) {
                       match depositResult {
                         (true, _) => {
                           resultCh!(
-                            (pending, rewards, activeValidators, allBonds.set(userPk,amount)),
+                            (pending, rewards, activeValidators, withdrawers, allBonds.set(userPk,amount)),
                             depositResult
                           )
                         }
 
                         (false, errorMsg) => {
-                          resultCh!((pending, rewards, activeValidators, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
+                          resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "Bond deposit failed: " ++ errorMsg))
                         }
                       }
                     }
@@ -114,16 +115,21 @@ new  PoS,
             } |
 
             contract PoS (@"withdraw", returnCh) = {
-              new userCh, depositCh, processCh in {
+              new userCh, depositCh, processCh,
+                  getBlockData(`rho:block:data`),
+                  blockDataCh
+              in {
                 runMVar!(*stateCh, *processCh, *returnCh) |
 
+                getBlockData!(*blockDataCh) |
                 getUser!(*userCh) |
-                for(@(pending, rewards, activeValidators, allBonds), resultCh <- processCh;
-                    @userPk <- userCh) {
+                for(@(pending, rewards, activeValidators, withdrawers, allBonds), resultCh <- processCh;
+                    @userPk <- userCh;
+                    _, @blockNumber <- blockDataCh) {
                   if (allBonds.contains(userPk)) {
-                    resultCh!((pending, rewards, activeValidators, allBonds), (true, Nil))
+                    resultCh!((pending, rewards, activeValidators, withdrawers.set(userPk, blockNumber), allBonds), (true, Nil))
                   } else {
-                    resultCh!((pending, rewards, activeValidators, allBonds), (false, "User is not bonded"))
+                    resultCh!((pending, rewards, activeValidators, withdrawers, allBonds), (false, "User is not bonded"))
                   }
                 }
               }
@@ -135,7 +141,7 @@ new  PoS,
                   newPendingCh in {
                 getUser!(*userCh) |
                 runMVar!(*stateCh, *processPayCh, *returnCh) |
-                for(@(pending, rewards, activeValidators, allBonds), payResultCh <- processPayCh;
+                for(@(pending, rewards, activeValidators, withdrawers, allBonds), payResultCh <- processPayCh;
                     @userPk <- userCh) {
                   deposit!(userPk, amount, *depositCh) |
 
@@ -143,7 +149,7 @@ new  PoS,
 
                   for(@depositResult <- depositCh;
                       @newPending <- newPendingCh) {
-                    payResultCh!((newPending, rewards, activeValidators, allBonds), depositResult)
+                    payResultCh!((newPending, rewards, activeValidators, withdrawers, allBonds), depositResult)
                   }
                 }
               }
@@ -158,7 +164,7 @@ new  PoS,
                 runMVar!(*stateCh, *doSlashCh, *returnCh) |
                 for (@invalidBlocks <- invalidBlocksCh;
                      @userPk <- userCh;
-                     @(pending, rewards, activeValidators, allBonds), slashResultCh <- doSlashCh) {
+                     @(pending, rewards, activeValidators, withdrawers, allBonds), slashResultCh <- doSlashCh) {
                   new toBeSlashed in {
                     toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
                     for (@validator <- toBeSlashed) {
@@ -167,6 +173,7 @@ new  PoS,
                         (pending.set(validator, 0),
                          rewards.set(validator, 0),
                          activeValidators,
+                         withdrawers,
                          allBonds.set(validator, 0)),
                         true)
                     }
@@ -183,7 +190,7 @@ new  PoS,
 
                 runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
                 for(_, @blockNumber <- blockDataCh;
-                    @(pendingRewards, rewards, activeValidators, allBonds), mvarResultCh <- mvarProcessCh) {
+                    @(pendingRewards, rewards, activeValidators, withdrawers, allBonds), mvarResultCh <- mvarProcessCh) {
 
                   if (blockNumber % $$epochLength$$ == 0) {
                     pickActiveValidators!(allBonds, *newValidatorsCh)
@@ -199,7 +206,7 @@ new  PoS,
 
                   for (@rewards <- rewardsCh;
                        @newValidators <- newValidatorsCh) {
-                    mvarResultCh!(({}, rewards, newValidators, allBonds), Nil)
+                    mvarResultCh!(({}, rewards, newValidators, withdrawers, allBonds), Nil)
                   }
                 }
               }

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -10,14 +10,16 @@ final case class ProofOfStake(
     minimumBond: Long,
     maximumBond: Long,
     validators: Seq[Validator],
-    epochLength: Int = 10000
+    epochLength: Int = 10000,
+    quarantineLength: Int = 50000
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
       NormalizerEnv.Empty,
-      "minimumBond"  -> minimumBond,
-      "maximumBond"  -> maximumBond,
-      "initialBonds" -> ProofOfStake.initialBonds(validators),
-      "epochLength"  -> epochLength
+      "minimumBond"      -> minimumBond,
+      "maximumBond"      -> maximumBond,
+      "initialBonds"     -> ProofOfStake.initialBonds(validators),
+      "epochLength"      -> epochLength,
+      "quarantineLength" -> quarantineLength
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -13,7 +13,9 @@ match (
       posRevAddressCh, posVaultCh,
       RhoSpecCh, PoSCh, RevVaultCh, ListOpsCh,
       setup, prepareUser,
-      test_make_pos_succeeds, test_bonding_succeeds,
+      test_make_pos_succeeds,
+      test_close_block_finishes,
+      test_bonding_succeeds,
       test_multiple_bonding_succeeds,
       test_bonding_fails_if_deposit_fails,
       test_bonding_fails_if_already_bonded,
@@ -39,6 +41,7 @@ match (
           @RhoSpec!("testSuite", *setup,
             [
               ("PoS is created with empty bonds", *test_make_pos_succeeds),
+              ("closeBlock finishes successfully", *test_close_block_finishes),
               ("bonding success", *test_bonding_succeeds),
               ("bonding fails if deposit fails", *test_bonding_fails_if_deposit_fails),
               ("multiple bondings work", *test_multiple_bonding_succeeds),
@@ -88,6 +91,20 @@ match (
             }
           } |
 
+
+          contract test_close_block_finishes(rhoSpec, _, ackCh) = {
+            new resultCh in {
+              @PoS!("closeBlock", *resultCh) |
+              for ( _ <- resultCh) {
+                rhoSpec!("assertMany",
+                  [
+                    (true, "all good here")
+                  ],
+                  *ackCh
+                )
+              }
+            }
+          } |
           contract test_bonding_succeeds(rhoSpec, _, ackCh) = {
             new setupCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
                 initialUserBalanceCh, finalUserBalanceCh,

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -17,6 +17,7 @@ match (
       test_close_block_finishes,
       test_bonding_succeeds,
       test_withdraw_succeeds,
+      test_validator_is_paid_after_withdraw,
       test_multiple_bonding_succeeds,
       test_bonding_fails_if_deposit_fails,
       test_bonding_fails_if_already_bonded,
@@ -45,6 +46,7 @@ match (
               ("closeBlock finishes successfully", *test_close_block_finishes),
               ("bonding success", *test_bonding_succeeds),
               ("withdraw succeeds", *test_withdraw_succeeds),
+              ("validator is paid after withdraw", *test_validator_is_paid_after_withdraw),
               ("bonding fails if deposit fails", *test_bonding_fails_if_deposit_fails),
               ("multiple bondings work", *test_multiple_bonding_succeeds),
               ("payment works", *test_pay_succeeds),
@@ -195,6 +197,58 @@ match (
             }
           } |
 
+          contract test_validator_is_paid_after_withdraw(rhoSpec, _, ackCh) = {
+            new setupCh, retCh,
+                initialValidatorBalanceCh, finalValidatorBalanceCh,
+                initialBondsCh, finalBondsCh,
+                withdrawCh, closeBlockCh,
+                setDeployData(`rho:test:deploy:set`), identitySet in {
+              prepareUser!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 10000, *setupCh) |
+              for (@validatorPubKey, _, @validatorVault <- setupCh) {
+                @validatorVault!("balance", *initialValidatorBalanceCh) |
+                @PoS!("getBonds", *initialBondsCh) |
+                for(@initialValidatorBalance <- initialValidatorBalanceCh;
+                    @initialBonds <- initialBondsCh) {
+                  @PoS!("bond", 100, *retCh) |
+                  for ( @(true, _) <- retCh) {
+                    @PoS!("closeBlock", *closeBlockCh) |
+                    for (_ <- closeBlockCh) {
+                      prepareUser!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", 10000, *setupCh) |
+                      for (@userPubKey, _, @userVault <- setupCh) {
+                        @PoS!("pay", 100, *retCh) |
+                        for ( @(true, _) <- retCh) {
+                          @PoS!("closeBlock", *closeBlockCh) |
+                          for (_ <- closeBlockCh) {
+                            setDeployData!("userId", validatorPubKey, *identitySet) |
+                            for(_ <- identitySet) {
+                              @PoS!("withdraw", *withdrawCh) |
+                              for (_ <- withdrawCh) {
+                                @PoS!("closeBlock", *closeBlockCh) |
+                                for (_ <- closeBlockCh) {
+                                  @validatorVault!("balance", *finalValidatorBalanceCh) |
+                                  @PoS!("getBonds", *finalBondsCh) |
+                                  for(@finalBonds <- finalBondsCh;
+                                      @finalValidatorBalance <- finalValidatorBalanceCh) {
+                                    rhoSpec!("assertMany",
+                                      [
+                                        ((finalBonds, "==", initialBonds), "bonds don't change"),
+                                        ((46, "==", finalValidatorBalance-initialValidatorBalance ), "user balance changes accordingly")
+                                      ],
+                                      *ackCh
+                                    )
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          } |
           contract test_multiple_bonding_succeeds(rhoSpec, _, ackCh) = {
             new setupCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
                 initialUser1BalanceCh, finalUser1BalanceCh,

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -16,6 +16,7 @@ match (
       test_make_pos_succeeds,
       test_close_block_finishes,
       test_bonding_succeeds,
+      test_withdraw_succeeds,
       test_multiple_bonding_succeeds,
       test_bonding_fails_if_deposit_fails,
       test_bonding_fails_if_already_bonded,
@@ -43,6 +44,7 @@ match (
               ("PoS is created with empty bonds", *test_make_pos_succeeds),
               ("closeBlock finishes successfully", *test_close_block_finishes),
               ("bonding success", *test_bonding_succeeds),
+              ("withdraw succeeds", *test_withdraw_succeeds),
               ("bonding fails if deposit fails", *test_bonding_fails_if_deposit_fails),
               ("multiple bondings work", *test_multiple_bonding_succeeds),
               ("payment works", *test_pay_succeeds),
@@ -133,6 +135,54 @@ match (
                               ((100, "==", initialUserBalance - finalUserBalance), "the user account decreases"),
                               ((100, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
                               ((Nil, "==", rewards.get(user1PubKey)), "new validator reward should be zero")
+                            ],
+                            *ackCh
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          } |
+          contract test_withdraw_succeeds(rhoSpec, _, ackCh) = {
+            new setupCh, retCh,
+                initialPosBalanceCh, finalPosBalanceCh,
+                initialUserBalanceCh, finalUserBalanceCh,
+                initialRewardsCh, finalRewardsCh,
+                initialBondsCh, finalBondsCh,
+                withdrawCh, closeBlockCh in {
+              prepareUser!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 10000, *setupCh) |
+              for (@user1PubKey, _, @user1Vault <- setupCh) {
+                @posVault!("balance", *initialPosBalanceCh) |
+                @user1Vault!("balance", *initialUserBalanceCh) |
+                @PoS!("getBonds", *initialBondsCh) |
+                @PoS!("getRewards", *initialRewardsCh) |
+                for(@initialPosBalance <- initialPosBalanceCh;
+                    @initialUserBalance <- initialUserBalanceCh;
+                    @initialBonds <- initialBondsCh;
+                    @initialRewards <- initialRewardsCh) {
+                  @PoS!("bond", 100, *retCh) |
+                  for ( @(true, _) <- retCh) {
+                    @PoS!("withdraw", *withdrawCh) |
+                    for (_ <- withdrawCh) {
+                      @PoS!("closeBlock", *closeBlockCh) |
+                      for (_ <- closeBlockCh) {
+                        @PoS!("getBonds", *finalBondsCh) |
+                        @posVault!("balance", *finalPosBalanceCh) |
+                        @user1Vault!("balance", *finalUserBalanceCh) |
+                        @PoS!("getRewards", *finalRewardsCh) |
+                        for(@finalPosBalance <- finalPosBalanceCh;
+                            @finalUserBalance <- finalUserBalanceCh;
+                            @finalBonds <- finalBondsCh;
+                            @finalRewards <- finalRewardsCh) {
+                          rhoSpec!("assertMany",
+                            [
+                              ((finalBonds, "==", initialBonds), "bonds don't change"),
+                              ((finalRewards, "==", initialRewards), "rewards don't change"),
+                              ((finalUserBalance, "==", initialUserBalance), "user balancs doesn't change"),
+                              ((finalPosBalance, "==", initialPosBalance), "pos balance doesn't change")
                             ],
                             *ackCh
                           )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -3,10 +3,11 @@ package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.NormalizerEnv
+import scala.concurrent.duration._
 
 class PoSSpec
     extends RhoSpec(
       CompiledRholangSource("PoSTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      GENESIS_TEST_TIMEOUT
+      120.seconds
     )


### PR DESCRIPTION
## Overview
Add logic for validator withdrawal



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3465
https://rchain.atlassian.net/browse/RCHAIN-3466



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
