### PR TITLE
Enforce strict ordering of block hashes with equal weight 

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -15,7 +15,11 @@ import coop.rchain.models.Validator.Validator
 import com.google.protobuf.ByteString
 
 object Estimator {
-  implicit val decreasingOrder = Ordering[Long].reverse
+
+  implicit val decreasingOrder = Ordering.Tuple2(
+    Ordering[Long].reverse,
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+  )
 
   private val EstimatorMetricsSource: Metrics.Source =
     Metrics.Source(CasperMetricsSource, "estimator")

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorTest.scala
@@ -1,7 +1,6 @@
 package coop.rchain.casper
 
 import scala.collection.immutable.HashMap
-
 import coop.rchain.casper.protocol.Bond
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.casper.helper.BlockGenerator._
@@ -9,14 +8,15 @@ import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
-
 import com.google.protobuf.ByteString
+import coop.rchain.shared.Log
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 
 class EstimatorTest extends FlatSpec with Matchers with BlockGenerator with BlockDagStorageFixture {
   implicit val metricsEff           = new Metrics.MetricsNOP[Task]
   implicit val noopSpan: Span[Task] = NoopSpan[Task]()
+  implicit val log                  = new Log.NOPLog[Task]()
 
   "Estimator on empty latestMessages" should "return the genesis regardless of DAG" in withStorage {
     implicit blockStore => implicit blockDagStorage =>

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -10,6 +10,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.LogStub
+import coop.rchain.shared.Log
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -28,6 +29,7 @@ class BlocksResponseAPITest
   val v3Bond                       = Bond(v3, 15)
   val bonds                        = Seq(v1Bond, v2Bond, v3Bond)
   implicit val spanEff: Span[Task] = Span.noop
+  implicit val log                 = new Log.NOPLog[Task]()
 
   "showMainChain" should "return only blocks in the main chain" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
@@ -84,7 +86,7 @@ class BlocksResponseAPITest
              )
         dag        <- blockDagStorage.getRepresentation
         metricsEff = new Metrics.MetricsNOP[Task]
-        tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], metricsEff, spanEff)
+        tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], log, metricsEff, spanEff)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
@@ -159,7 +161,7 @@ class BlocksResponseAPITest
              )
         dag        <- blockDagStorage.getRepresentation
         metricsEff = new Metrics.MetricsNOP[Task]
-        tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], metricsEff, spanEff)
+        tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], log, metricsEff, spanEff)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
                          tips
@@ -233,7 +235,7 @@ class BlocksResponseAPITest
            )
       dag        <- blockDagStorage.getRepresentation
       metricsEff = new Metrics.MetricsNOP[Task]
-      tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], metricsEff, spanEff)
+      tips       <- Estimator.tips[Task](dag, genesis)(Sync[Task], log, metricsEff, spanEff)
       casperEffect <- NoOpsCasperEffect[Task](
                        HashMap.empty[BlockHash, BlockMessage],
                        tips

--- a/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/listOps.scala
@@ -5,9 +5,9 @@ import scala.math.Ordering
 
 object ListContrib {
   def sortBy[A, K: Monoid](list: List[A], map: collection.Map[A, K])(
-      implicit ord: Ordering[K]
+      implicit ord: Ordering[(K, A)]
   ): List[A] =
-    list.sortBy(map.getOrElse(_, Monoid[K].empty))(ord)
+    list.sortBy(e => (map.getOrElse(e, Monoid[K].empty), e))(ord)
 
   // From https://hygt.github.io/2018/08/05/Cats-findM-collectFirstM.html
   def findM[G[_], A](list: List[A], p: A => G[Boolean])(implicit G: Monad[G]): G[Option[A]] =


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Also adds debug log for scores map

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

https://rchain.atlassian.net/browse/RCHAIN-3695

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
