### PR TITLE
Implement toSet and toMap in Scala as list methods

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1380,6 +1380,15 @@ class DebruijnInterpreter[M[_], F[_]](
       baseExpr.exprInstance match {
         case e: ESetBody =>
           (e: Par).pure[M]
+        case EMapBody(ParMap(basePs, connectiveUsed, locallyFree, remainder)) =>
+          (ESetBody(
+            ParSet(
+              basePs.toSeq.map(t => ETupleBody(ETuple(Seq(t._1, t._2))): Par),
+              connectiveUsed,
+              locallyFree,
+              remainder
+            )
+          ): Par).pure[M]
         case EListBody(EList(basePs, locallyFree, connectiveUsed, remainder)) =>
           (ESetBody(
             ParSet(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1404,7 +1404,12 @@ class DebruijnInterpreter[M[_], F[_]](
   }
 
   private[this] val toMap: Method = new Method() {
-    def makeMap(ps: Seq[Par], connectiveUsed : Boolean, locallyFree : Coeval[BitSet], remainder:Option[Var]) = {
+    def makeMap(
+        ps: Seq[Par],
+        connectiveUsed: Boolean,
+        locallyFree: Coeval[BitSet],
+        remainder: Option[Var]
+    ) = {
       val keyPairs = ps.map(RhoType.Tuple2.unapply)
       if (keyPairs.exists(_.isEmpty))
         MethodNotDefined("toMap", "types except List[(K,V)]").raiseError[M, Par]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1406,6 +1406,8 @@ class DebruijnInterpreter[M[_], F[_]](
   private[this] val toMap: Method = new Method() {
     def toMap(baseExpr: Expr): M[Par] =
       baseExpr.exprInstance match {
+        case e: EMapBody =>
+          (e: Par).pure[M]
         case EListBody(EList(basePs, locallyFree, connectiveUsed, remainder)) =>
           val keyPairs = basePs.map(RhoType.Tuple2.unapply)
           if (keyPairs.exists(_.isEmpty))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
@@ -24,8 +24,8 @@ final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Ta
 trait PersistentStoreTester {
 
   def withTestSpace[R](
-                        errorLog: ErrorLog[Task]
-                      )(f: TestFixture => R): R = {
+      errorLog: ErrorLog[Task]
+  )(f: TestFixture => R): R = {
     val dbDir                              = Files.createTempDirectory("rholang-interpreter-test-")
     implicit val logF: Log[Task]           = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
@@ -35,12 +35,12 @@ trait PersistentStoreTester {
 
     val space = (RSpace
       .create[
-      Task,
-      Par,
-      BindPattern,
-      ListParWithRandom,
-      ListParWithRandom,
-      TaggedContinuation
+        Task,
+        Par,
+        BindPattern,
+        ListParWithRandom,
+        ListParWithRandom,
+        TaggedContinuation
       ](dbDir, 1024L * 1024L * 1024L, Branch("test")))
       .unsafeRunSync
     implicit val errLog = errorLog
@@ -55,7 +55,7 @@ trait PersistentStoreTester {
   }
 
   def fixture[R](f: (RhoISpace[Task], ChargingReducer[Task]) => Task[R])(
-    implicit errorLog: ErrorLog[Task]
+      implicit errorLog: ErrorLog[Task]
   ): R = {
     implicit val logF: Log[Task]           = new Log.NOPLog[Task]
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
@@ -1,0 +1,77 @@
+package coop.rchain.rholang.interpreter
+
+import java.nio.file.Files
+
+import coop.rchain.metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.models.{BindPattern, ListParWithRandom, Par, TaggedContinuation}
+import coop.rchain.rholang.interpreter.Runtime.RhoISpace
+import coop.rchain.rholang.interpreter.accounting.{Cost, CostAccounting}
+import coop.rchain.rspace.RSpace
+import coop.rchain.rspace.history.Branch
+import coop.rchain.shared.Log
+import monix.eval.Task
+import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.rholang.Resources.mkRhoISpace
+import monix.execution.Scheduler.Implicits.global
+
+import scala.concurrent.duration._
+import coop.rchain.shared.PathOps._
+import coop.rchain.rholang.interpreter.storage.implicits._
+
+final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Task])
+
+trait PersistentStoreTester {
+
+  def withTestSpace[R](
+                        errorLog: ErrorLog[Task]
+                      )(f: TestFixture => R): R = {
+    val dbDir                              = Files.createTempDirectory("rholang-interpreter-test-")
+    implicit val logF: Log[Task]           = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+    implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
+
+    implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
+
+    val space = (RSpace
+      .create[
+      Task,
+      Par,
+      BindPattern,
+      ListParWithRandom,
+      ListParWithRandom,
+      TaggedContinuation
+      ](dbDir, 1024L * 1024L * 1024L, Branch("test")))
+      .unsafeRunSync
+    implicit val errLog = errorLog
+    val reducer         = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
+    reducer.setPhlo(Cost.UNSAFE_MAX).runSyncUnsafe(1.second)
+    try {
+      f(TestFixture(space, reducer))
+    } finally {
+      space.close()
+      dbDir.recursivelyDelete()
+    }
+  }
+
+  def fixture[R](f: (RhoISpace[Task], ChargingReducer[Task]) => Task[R])(
+    implicit errorLog: ErrorLog[Task]
+  ): R = {
+    implicit val logF: Log[Task]           = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+    implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
+    mkRhoISpace[Task]("rholang-interpreter-test-")
+      .use { rspace =>
+        for {
+          cost <- CostAccounting.emptyCost[Task]
+          reducer = {
+            implicit val c = cost
+            RholangOnlyDispatcher.create[Task, Task.Par](rspace)._2
+          }
+          _   <- reducer.setPhlo(Cost.UNSAFE_MAX)
+          res <- f(rspace, reducer)
+        } yield res
+      }
+      .runSyncUnsafe(3.seconds)
+  }
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -23,16 +23,17 @@ import coop.rchain.rspace._
 import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.{AppendedClues, Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 import scala.collection.mutable.HashMap
-import scala.collection.{SortedSet, mutable}
+import scala.collection.{mutable, SortedSet}
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.prop.TableDrivenPropertyChecks._
 
 
-class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
+class ReduceSpec extends FlatSpec with Matchers with AppendedClues with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
 
   private[this] def mapData(elements: Map[Par, (Seq[Par], Blake2b512Random)]): Iterable[
@@ -533,7 +534,12 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val splitRand1 = rand.splitByte(1)
     val mergeRand  = Blake2b512Random.merge(Seq(splitRand1, splitRand0))
     val send =
-      Send(EPlus(GInt(7L), GInt(8L)), List(GInt(7L), GInt(8L), GInt(9L)), persistent = false, BitSet())
+      Send(
+        EPlus(GInt(7L), GInt(8L)),
+        List(GInt(7L), GInt(8L), GInt(9L)),
+        persistent = false,
+        BitSet()
+      )
     val receive = Receive(
       Seq(
         ReceiveBind(
@@ -672,10 +678,16 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val splitRand = rand.splitByte(0)
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
-        val pattern = Send(EVar(FreeVar(0)), List(GInt(7L), EVar(FreeVar(1))), persistent = false, BitSet())
-          .withConnectiveUsed(true)
+        val pattern =
+          Send(EVar(FreeVar(0)), List(GInt(7L), EVar(FreeVar(1))), persistent = false, BitSet())
+            .withConnectiveUsed(true)
         val sendTarget =
-          Send(EVar(BoundVar(1)), List(GInt(7L), EVar(BoundVar(0))), persistent = false, BitSet(0, 1))
+          Send(
+            EVar(BoundVar(1)),
+            List(GInt(7L), EVar(BoundVar(0))),
+            persistent = false,
+            BitSet(0, 1)
+          )
         val matchTerm = Match(
           sendTarget,
           List(
@@ -1045,8 +1057,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     )
     val serializedProcess =
       com.google.protobuf.ByteString.copyFrom(Serialize[Par].encode(proc).toArray)
-    val toByteArrayCall           = EMethod("toByteArray", proc, List[Par]())
-    def wrapWithSend(p: Par): Par = Send(GString("result"), List[Par](p), persistent = false, BitSet())
+    val toByteArrayCall = EMethod("toByteArray", proc, List[Par]())
+    def wrapWithSend(p: Par): Par =
+      Send(GString("result"), List[Par](p), persistent = false, BitSet())
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         val env         = Env[Par]()
@@ -1101,7 +1114,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toByteArrayWithArgumentsCall: EMethod =
       EMethod(
         "toByteArray",
-        Par(sends = Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))),
+        Par(
+          sends =
+            Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))
+        ),
         List[Par](GInt(1L))
       )
 
@@ -1121,12 +1137,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   "eval of hexToBytes" should "transform encoded string to byte array (not the rholang term)" in {
     implicit val errorLog = new ErrorLog[Task]()
 
-    val splitRand                 = rand.splitByte(0)
-    val testString                = "testing testing"
-    val base16Repr                = Base16.encode(testString.getBytes)
-    val proc: Par                 = GString(base16Repr)
-    val toByteArrayCall           = EMethod("hexToBytes", proc, List[Par]())
-    def wrapWithSend(p: Par): Par = Send(GString("result"), List[Par](p), persistent = false, BitSet())
+    val splitRand       = rand.splitByte(0)
+    val testString      = "testing testing"
+    val base16Repr      = Base16.encode(testString.getBytes)
+    val proc: Par       = GString(base16Repr)
+    val toByteArrayCall = EMethod("hexToBytes", proc, List[Par]())
+    def wrapWithSend(p: Par): Par =
+      Send(GString("result"), List[Par](p), persistent = false, BitSet())
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         val env         = Env[Par]()
@@ -1146,12 +1163,13 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   }
 
   "eval of `toUtf8Bytes`" should "transform string to UTF-8 byte array (not the rholang term)" in {
-    implicit val errorLog         = new ErrorLog[Task]()
-    val splitRand                 = rand.splitByte(0)
-    val testString                = "testing testing"
-    val proc: Par                 = GString(testString)
-    val toUtf8BytesCall           = EMethod("toUtf8Bytes", proc, List[Par]())
-    def wrapWithSend(p: Par): Par = Send(GString("result"), List[Par](p), persistent = false, BitSet())
+    implicit val errorLog = new ErrorLog[Task]()
+    val splitRand         = rand.splitByte(0)
+    val testString        = "testing testing"
+    val proc: Par         = GString(testString)
+    val toUtf8BytesCall   = EMethod("toUtf8Bytes", proc, List[Par]())
+    def wrapWithSend(p: Par): Par =
+      Send(GString("result"), List[Par](p), persistent = false, BitSet())
     val result = withTestSpace(errorLog) {
       case TestFixture(space, reducer) =>
         val env         = Env[Par]()
@@ -1175,7 +1193,10 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     val toUtfBytesWithArgumentsCall: EMethod =
       EMethod(
         "toUtf8Bytes",
-        Par(sends = Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))),
+        Par(
+          sends =
+            Seq(Send(GString("result"), List(GString("Success")), persistent = false, BitSet()))
+        ),
         List[Par](GInt(1L))
       )
 
@@ -2161,10 +2182,11 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
     result.exprs should be(Seq(Expr(resultList)))
     errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
   }
-  "toSet" should "transform [1, 2, 3] into Set(1, 2, 3)" in {
 
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
+  val successfulExamples = Table(
+    ("clue", "input", "output"),
+    (
+      "[1, 2, 3].toSet() => Set(1, 2, 3)",
       EMethod(
         "toSet",
         EListBody(
@@ -2177,15 +2199,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List[Par]()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toSetTask             = reducer.evalExpr(toSetCall)
-        Await.result(toSetTask.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       ESetBody(
         ParSet(
           List(
@@ -2195,15 +2209,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-
-  "toSet" should "transform [1, 1] into Set(1)" in {
-
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
+    ),
+    (
+      "[1, 1].toSet() => Set(1)",
       EMethod(
         "toSet",
         EListBody(
@@ -2215,15 +2223,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List[Par]()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toSetTask             = reducer.evalExpr(toSetCall)
-        Await.result(toSetTask.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       ESetBody(
         ParSet(
           List(
@@ -2231,44 +2231,28 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-  it should "transform [] into Set()" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
+    ),
+    (
+      "[].toSet() => Set()",
       EMethod(
         "toSet",
         EListBody(
           EList(
             List[Par](
-            )
+              )
           )
         ),
         List()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toSetTask             = reducer.evalExpr(toSetCall)
-        Await.result(toSetTask.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       ESetBody(
         ParSet(
           List(
-          )
+            )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-  it should "keep Set(1, 2, 3) unchanged" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
+    ),
+    (
+      "Set(1, 2, 3).toSet() => Set(1, 2, 3)",
       EMethod(
         "toSet",
         ESetBody(
@@ -2281,15 +2265,7 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toSetTask             = reducer.evalExpr(toSetCall)
-        Await.result(toSetTask.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       ESetBody(
         ParSet(
           List(
@@ -2299,66 +2275,9 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-
-  it should "return an error when `toSet` is called with arguments" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
-      EMethod(
-        "toSet",
-        ESetBody(
-          ParSet(
-            List(
-              GInt(1L),
-              GInt(2L),
-              GInt(3L)
-            )
-          )
-        ),
-        List(GInt(1))
-      )
-
-    val result = withTestSpace(errorLog) {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTask  = reducer.eval(toSetCall) >> space.toMap
-        Await.result(inspectTask.runToFuture, 3.seconds)
-    }
-    result should be(mutable.HashMap.empty)
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(
-      Vector(MethodArgumentNumberMismatch("toSet", 0, 1))
-    )
-  }
-
-  it should "return an error when `toSet` is called on GInt" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
-      EMethod(
-        "toSet",
-        GInt(1L),
-        List()
-      )
-
-    val result = withTestSpace(errorLog) {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTask  = reducer.eval(toSetCall) >> space.toMap
-        Await.result(inspectTask.runToFuture, 3.seconds)
-    }
-    result should be(mutable.HashMap.empty)
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(
-      Vector(MethodNotDefined("toSet", "Int"))
-    )
-  }
-
-
-  "toMap" should """transform [("a",1), ("b",2), ("c",3)] into {"a":1, "b":2, "c":3)""" in {
-
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toMapCall: EMethod =
+    ),
+    (
+      """[("a",1), ("b",2), ("c",3)].toMap() => {"a":1, "b":2, "c":3)""",
       EMethod(
         "toMap",
         EListBody(
@@ -2371,32 +2290,19 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List[Par]()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val task             = reducer.evalExpr(toMapCall)
-        Await.result(task.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       EMapBody(
         ParMap(
-          List[(Par,Par)](
+          List[(Par, Par)](
             (GString("a"), GInt(1L)),
             (GString("b"), GInt(2L)),
             (GString("c"), GInt(3L))
           )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-  "toMap" should """transform [("a",1), ("a",2)] into {"a":2)""" in {
-
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toSetCall: EMethod =
+    ),
+    (
+      """[("a",1), ("a",2)].toMap() => {"a":2)""",
       EMethod(
         "toMap",
         EListBody(
@@ -2408,30 +2314,57 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List[Par]()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val toSetTask             = reducer.evalExpr(toSetCall)
-        Await.result(toSetTask.runToFuture, 3.seconds)
-    }
-    val resultList =
+      ),
       EMapBody(
         ParMap(
-          List[(Par,Par)](
+          List[(Par, Par)](
             (GString("a"), GInt(2L))
           )
         )
       )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
+    ),
+    (
+      """[].toMap() => {}""",
+      EMethod(
+        "toMap",
+        EListBody(
+          EList(
+            List[Par](
+              )
+          )
+        ),
+        List()
+      ),
+      EMapBody(
+        ParMap(
+          List(
+            )
+        )
+      )
+    )
+  )
+
+  "Reducer" should "work correctly in succesful cases" in {
+    forAll(successfulExamples) { (clue, input, output) =>
+      implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
+
+      val result: Par = withTestSpace(errorLog) {
+        case TestFixture(_, reducer) =>
+          implicit val env: Env[Par] = Env[Par]()
+          val toSetTask              = reducer.evalExpr(input)
+          Await.result(toSetTask.runToFuture, 3.seconds)
+      }
+
+      result.exprs should be(Seq(Expr(output))) withClue (clue)
+      errorLog
+        .readAndClearErrorVector()
+        .unsafeRunSync should be(Vector.empty[InterpreterError]) withClue ("no errors are expected")
+    }
   }
 
-  "toMap" should """return an error when applied to ["a", ("b",2)]""" in {
-
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toMapCall: EMethod =
+  val errorExamples = Table(
+    ("clue", "input", "output"),
+    ( """["a", ("b",2)].toMap() => MethodNotDefined""",
       EMethod(
         "toMap",
         EListBody(
@@ -2443,98 +2376,68 @@ class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
           )
         ),
         List[Par]()
-      )
-
-    val result = withTestSpace(errorLog) {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTask  = reducer.eval(toMapCall) >> space.toMap
-        Await.result(inspectTask.runToFuture, 3.seconds)
-    }
-
-    result should be(mutable.HashMap.empty)
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(
-      Vector(MethodNotDefined("toMap", "types except List[(K,V)]"))
-    )
-  }
-
-
-  it should "transform [] into {}" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toMapCall: EMethod =
+      ),
+      MethodNotDefined("toMap", "types except List[(K,V)]")
+    ),
+    ("""[("a", 1)].toMap(1) => MethodArgumentNumberMismatch""",
       EMethod(
         "toMap",
         EListBody(
           EList(
             List[Par](
-            )
-          )
-        ),
-        List()
-      )
-
-    val result: Par = withTestSpace(errorLog) {
-      case TestFixture(_, reducer) =>
-        implicit val env: Env[Par] = Env[Par]()
-        val task = reducer.evalExpr(toMapCall)
-        Await.result(task.runToFuture, 3.seconds)
-    }
-    val resultList =
-      EMapBody(
-        ParMap(
-          List(
-          )
-        )
-      )
-    result.exprs should be(Seq(Expr(resultList)))
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector.empty[InterpreterError])
-  }
-
-  it should "return an error when `toMap` is called with arguments" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toMapCall: EMethod =
-      EMethod(
-        "toMap",
-        EMapBody(
-          ParMap(
-            List[(Par,Par)](
-              (GString("a"), GInt(1L))
+              ETupleBody(ETuple(Seq(GString("a"), GInt(1L))))
             )
           )
         ),
         List(GInt(1))
-      )
-
-    val result = withTestSpace(errorLog) {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTask  = reducer.eval(toMapCall) >> space.toMap
-        Await.result(inspectTask.runToFuture, 3.seconds)
-    }
-    result should be(mutable.HashMap.empty)
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(
-      Vector(MethodArgumentNumberMismatch("toMap", 0, 1))
-    )
-  }
-
-  it should "return an error when `toMap` is called on GInt" in {
-    implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
-    val toMapCall: EMethod =
+      ),
+      MethodArgumentNumberMismatch("toMap", 0, 1)
+    )  ,
+    ("1.toMap() => MethodNotDefined",
       EMethod(
         "toMap",
         GInt(1L),
         List()
-      )
-
-    val result = withTestSpace(errorLog) {
-      case TestFixture(space, reducer) =>
-        implicit val env = Env[Par]()
-        val inspectTask  = reducer.eval(toMapCall) >> space.toMap
-        Await.result(inspectTask.runToFuture, 3.seconds)
-    }
-    result should be(mutable.HashMap.empty)
-    errorLog.readAndClearErrorVector().unsafeRunSync should be(
-      Vector(MethodNotDefined("toMap", "Int"))
+      ),
+      MethodNotDefined("toMap", "Int")
+    ),
+    ("[].toSet(1) => MethodArgumentNumberMismatch",
+      EMethod(
+        "toSet",
+        ESetBody(
+          ParSet(
+            List(
+            )
+          )
+        ),
+        List(GInt(1))
+      ),
+      MethodArgumentNumberMismatch("toSet", 0, 1)
+    ),
+    ("1.toSet() => MethodNotDefined",
+      EMethod(
+        "toSet",
+        GInt(1L),
+        List()
+      ),
+      MethodNotDefined("toSet", "Int")
     )
+  )
+
+  "Reducer" should """return report errors in failure cases""" in {
+
+    forAll(errorExamples) { (clue, input, error) =>
+      implicit val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
+
+      val result = withTestSpace(errorLog) {
+        case TestFixture(space, reducer) =>
+          implicit val env = Env[Par]()
+          val inspectTask  = reducer.eval(input) >> space.toMap
+          Await.result(inspectTask.runToFuture, 3.seconds)
+      }
+
+      result should be(mutable.HashMap.empty)
+      errorLog.readAndClearErrorVector().unsafeRunSync should be(Vector(error))
+    }
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2301,6 +2301,31 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       )
     ),
     (
+      """{"a":1, "b":2, "c":3}.toSet() => Set(("a",1), ("b",2), ("c",3))""",
+      EMethod(
+        "toSet",
+        EMapBody(
+          ParMap(
+            List[(Par, Par)](
+              (GString("a"), GInt(1L)),
+              (GString("b"), GInt(2L)),
+              (GString("c"), GInt(3L))
+            )
+          )
+        ),
+        List[Par]()
+      ),
+      ESetBody(
+        ParSet(
+          List[Par](
+            ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
+            ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
+            ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
+          )
+        )
+      )
+    ),
+    (
       """[("a",1), ("a",2)].toMap() => {"a":2)""",
       EMethod(
         "toMap",

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -15,14 +15,11 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.implicits._
-import coop.rchain.rholang.Resources._
-import coop.rchain.rspace._
-import coop.rchain.rspace.{RSpace, ReplayRSpace}
-import coop.rchain.rspace.history.Branch
 import coop.rchain.rspace._
 import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
+import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{AppendedClues, Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
@@ -30,7 +27,6 @@ import scala.collection.mutable.HashMap
 import scala.collection.{mutable, SortedSet}
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import org.scalatest.prop.TableDrivenPropertyChecks._
 
 class ReduceSpec extends FlatSpec with Matchers with AppendedClues with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2364,7 +2364,8 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
 
   val errorExamples = Table(
     ("clue", "input", "output"),
-    ( """["a", ("b",2)].toMap() => MethodNotDefined""",
+    (
+      """["a", ("b",2)].toMap() => MethodNotDefined""",
       EMethod(
         "toMap",
         EListBody(
@@ -2379,7 +2380,8 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       ),
       MethodNotDefined("toMap", "types except List[(K,V)]")
     ),
-    ("""[("a", 1)].toMap(1) => MethodArgumentNumberMismatch""",
+    (
+      """[("a", 1)].toMap(1) => MethodArgumentNumberMismatch""",
       EMethod(
         "toMap",
         EListBody(
@@ -2392,8 +2394,9 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
         List(GInt(1))
       ),
       MethodArgumentNumberMismatch("toMap", 0, 1)
-    )  ,
-    ("1.toMap() => MethodNotDefined",
+    ),
+    (
+      "1.toMap() => MethodNotDefined",
       EMethod(
         "toMap",
         GInt(1L),
@@ -2401,20 +2404,22 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       ),
       MethodNotDefined("toMap", "Int")
     ),
-    ("[].toSet(1) => MethodArgumentNumberMismatch",
+    (
+      "[].toSet(1) => MethodArgumentNumberMismatch",
       EMethod(
         "toSet",
         ESetBody(
           ParSet(
             List(
-            )
+              )
           )
         ),
         List(GInt(1))
       ),
       MethodArgumentNumberMismatch("toSet", 0, 1)
     ),
-    ("1.toSet() => MethodNotDefined",
+    (
+      "1.toSet() => MethodNotDefined",
       EMethod(
         "toSet",
         GInt(1L),

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -32,7 +32,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
-
 class ReduceSpec extends FlatSpec with Matchers with AppendedClues with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
 
@@ -550,7 +549,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       ),
       Send(GString("result"), List(GString("Success")), persistent = false, BitSet()),
       persistent = false,
-      peek=false,
+      peek = false,
       3,
       BitSet()
     )
@@ -600,7 +599,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       Seq(ReceiveBind(Seq(GInt(2L)), GInt(2L))),
       Par(),
       persistent = false,
-      peek=false,
+      peek = false,
       0,
       BitSet()
     )
@@ -610,7 +609,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GInt(1L), freeCount = 1)),
       EVar(BoundVar(0)),
       persistent = false,
-      peek=false,
+      peek = false,
       1,
       BitSet()
     )
@@ -1051,7 +1050,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       Seq(ReceiveBind(Seq(EVar(FreeVar(0))), GString("channel"))),
       Par(),
       persistent = false,
-      peek=false,
+      peek = false,
       1,
       BitSet()
     )
@@ -2354,7 +2353,8 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
 
   val idempotenceExamples = Table(
     ("method", "input"),
-    ("toSet",
+    (
+      "toSet",
       ESetBody(
         ParSet(
           List(
@@ -2365,7 +2365,8 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
         )
       )
     ),
-    ( "toMap",
+    (
+      "toMap",
       EMapBody(
         ParMap(
           List[(Par, Par)](
@@ -2374,7 +2375,8 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
             (GString("c"), GInt(3L))
           )
         )
-      ))
+      )
+    )
   )
   "Idempotent methods" should "return the input" in {
     forAll(idempotenceExamples) { (method, input) =>
@@ -2466,7 +2468,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
 
   type RSpaceMap = Map[Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]]
 
-  def runReducer(input : Par, timeout : Duration = 3.seconds) : Either[Throwable, Par] = {
+  def runReducer(input: Par, timeout: Duration = 3.seconds): Either[Throwable, Par] = {
     val errorLog: ErrorLog[Task] = new ErrorLog[Task]()
 
     val task =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -1,21 +1,17 @@
 package coop.rchain.rholang.interpreter
 
-import java.nio.file.Files
-
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.metrics
-import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.metrics.NoopSpan
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
-import coop.rchain.rholang.interpreter.Runtime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.implicits._
@@ -23,75 +19,18 @@ import coop.rchain.rholang.Resources._
 import coop.rchain.rspace._
 import coop.rchain.rspace.{RSpace, ReplayRSpace}
 import coop.rchain.rspace.history.Branch
+import coop.rchain.rspace._
 import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
-import coop.rchain.shared.Log
-import coop.rchain.shared.PathOps._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
-import scala.collection.{SortedSet, mutable}
 import scala.collection.mutable.HashMap
+import scala.collection.{SortedSet, mutable}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-final case class TestFixture(space: RhoISpace[Task], reducer: ChargingReducer[Task])
-
-trait PersistentStoreTester {
-
-  def withTestSpace[R](
-      errorLog: ErrorLog[Task]
-  )(f: TestFixture => R): R = {
-    val dbDir                              = Files.createTempDirectory("rholang-interpreter-test-")
-    implicit val logF: Log[Task]           = new Log.NOPLog[Task]
-    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
-    implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
-
-    implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
-
-    val space = (RSpace
-      .create[
-        Task,
-        Par,
-        BindPattern,
-        ListParWithRandom,
-        ListParWithRandom,
-        TaggedContinuation
-      ](dbDir, 1024L * 1024L * 1024L, Branch("test")))
-      .unsafeRunSync
-    implicit val errLog = errorLog
-    val reducer         = RholangOnlyDispatcher.create[Task, Task.Par](space)._2
-    reducer.setPhlo(Cost.UNSAFE_MAX).runSyncUnsafe(1.second)
-    try {
-      f(TestFixture(space, reducer))
-    } finally {
-      space.close()
-      dbDir.recursivelyDelete()
-    }
-  }
-
-  def fixture[R](f: (RhoISpace[Task], ChargingReducer[Task]) => Task[R])(
-      implicit errorLog: ErrorLog[Task]
-  ): R = {
-    implicit val logF: Log[Task]           = new Log.NOPLog[Task]
-    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
-    implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
-    mkRhoISpace[Task]("rholang-interpreter-test-")
-      .use { rspace =>
-        for {
-          cost <- CostAccounting.emptyCost[Task]
-          reducer = {
-            implicit val c = cost
-            RholangOnlyDispatcher.create[Task, Task.Par](rspace)._2
-          }
-          _   <- reducer.setPhlo(Cost.UNSAFE_MAX)
-          res <- f(rspace, reducer)
-        } yield res
-      }
-      .runSyncUnsafe(3.seconds)
-  }
-}
 
 class ReduceSpec extends FlatSpec with Matchers with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2458,7 +2458,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
     )
   )
 
-  "Reducer" should """return report errors in failure cases""" in {
+  "Reducer" should "return report errors in failure cases" in {
     forAll(errorExamples) { (clue, input, error) =>
       runReducer(input) should be(Left(error)) withClue (clue)
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2252,11 +2252,36 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
       )
     ),
     (
-      """[("a",1), ("b",2), ("c",3)].toMap() => {"a":1, "b":2, "c":3)""",
+      """[("a",1), ("b",2), ("c",3)].toMap() => {"a":1, "b":2, "c":3}""",
       EMethod(
         "toMap",
         EListBody(
           EList(
+            List[Par](
+              ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
+              ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),
+              ETupleBody(ETuple(Seq(GString("c"), GInt(3L))))
+            )
+          )
+        ),
+        List[Par]()
+      ),
+      EMapBody(
+        ParMap(
+          List[(Par, Par)](
+            (GString("a"), GInt(1L)),
+            (GString("b"), GInt(2L)),
+            (GString("c"), GInt(3L))
+          )
+        )
+      )
+    ),
+    (
+      """Set(("a",1), ("b",2), ("c",3)).toMap() => {"a":1, "b":2, "c":3}""",
+      EMethod(
+        "toMap",
+        ESetBody(
+          ParSet(
             List[Par](
               ETupleBody(ETuple(Seq(GString("a"), GInt(1L)))),
               ETupleBody(ETuple(Seq(GString("b"), GInt(2L)))),


### PR DESCRIPTION
## Overview
Implement toSet and toMap used for converting lists.

This is needed in PoS implementation of withdraw, where we currently implemented these conversions in Rholang

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3465
https://rchain.atlassian.net/browse/RCHAIN-3466

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
