### PR TITLE
Fix leaking implicit class val problem using scalafix

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/byteOps.scala
@@ -10,7 +10,7 @@ import coop.rchain.models.Validator
 import coop.rchain.shared.Language.ignore
 
 object byteOps {
-  implicit class ByteBufferRich(val byteBuffer: ByteBuffer) extends AnyVal {
+  implicit class ByteBufferRich(private val byteBuffer: ByteBuffer) extends AnyVal {
     def getBlockHash(): BlockHash = {
       val blockHashBytes = Array.ofDim[Byte](BlockHash.Length)
       ignore { byteBuffer.get(blockHashBytes) }
@@ -24,7 +24,7 @@ object byteOps {
     }
   }
 
-  implicit class IntRich(val value: Int) extends AnyVal {
+  implicit class IntRich(private val value: Int) extends AnyVal {
     def toByteString: ByteString = {
       val byteBuffer = ByteBuffer.allocate(4)
       ignore { byteBuffer.putInt(value) }
@@ -32,7 +32,7 @@ object byteOps {
     }
   }
 
-  implicit class LongRich(val value: Long) extends AnyVal {
+  implicit class LongRich(private val value: Long) extends AnyVal {
     def toByteString: ByteString = {
       val byteBuffer = ByteBuffer.allocate(8)
       ignore { byteBuffer.putLong(value) }
@@ -40,7 +40,8 @@ object byteOps {
     }
   }
 
-  implicit class EquivocationRecordRich(val equivocationRecord: EquivocationRecord) extends AnyVal {
+  implicit class EquivocationRecordRich(private val equivocationRecord: EquivocationRecord)
+      extends AnyVal {
     def toByteString: ByteString = {
       val blockHashes =
         equivocationRecord.equivocationDetectedBlockHashes.fold(ByteString.EMPTY)(_.concat(_))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -21,7 +21,7 @@ object PrettyPrinter {
   def apply(freeShift: Int, boundShift: Int): PrettyPrinter =
     PrettyPrinter(freeShift, boundShift, Vector.empty[Int], "free", "a", 23, 128)
 
-  implicit class CappedOps(val str: String) extends AnyVal {
+  implicit class CappedOps(private val str: String) extends AnyVal {
     def cap() = Printer.OUTPUT_CAPPED.map(n => s"${str.take(n)}...").getOrElse(str)
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
@@ -41,7 +41,7 @@ object Serialize {
       case Right(value) => value.pure[F]
     }
 
-  implicit class RichSerialize[A](val instance: Serialize[A]) extends AnyVal {
+  implicit class RichSerialize[A](private val instance: Serialize[A]) extends AnyVal {
 
     def toCodec: Codec[A] = new Codec[A] {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -122,7 +122,8 @@ object internal {
     def empty[K, V]: MultisetMultiMap[K, V] = new TrieMap[K, Multiset[V]]()
   }
 
-  implicit class RichMultisetMultiMap[K, V](val value: MultisetMultiMap[K, V]) extends AnyVal {
+  implicit class RichMultisetMultiMap[K, V](private val value: MultisetMultiMap[K, V])
+      extends AnyVal {
 
     def addBinding(k: K, v: V): MultisetMultiMap[K, V] =
       value.get(k) match {


### PR DESCRIPTION
See https://scalacenter.github.io/scalafix/docs/rules/LeakingImplicitClassVal.html

The scalafix setup was done locally (as a global plugin)and was as easy
as described in the docs.

Hint: use `scalafixEnable` in an sbt session to enable support for
semantic rules without mucking around with sbt configs.

## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3694



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
