### PR TITLE
Use traverse_ instead of parTraverse_ in Reduce

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -168,7 +168,7 @@ class DebruijnInterpreter[M[_], F[_]](
             env: Env[Par],
             sequenceNumber: Int
         ): M[Unit] =
-          input.zipWithIndex.toList.parTraverse_ {
+          input.zipWithIndex.toList.traverse_ {
             case (term, idx) =>
               handler(term)(env, mkRand(idx), sequenceNumber)
           }
@@ -257,7 +257,7 @@ class DebruijnInterpreter[M[_], F[_]](
 
     val starts = jobs.map(_.size).scanLeft(0)(_ + _).toVector
 
-    jobs.zipWithIndex.parTraverse_ {
+    jobs.zipWithIndex.traverse_ {
       case (job, jobIdx) => {
         def mkRand(termIdx: Int): Blake2b512Random =
           split(starts.last, starts(jobIdx), rand)(termIdx)


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This is simply to test traverse_ in a production environment

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
