### PR TITLE
Update Par evaluation to reduce extraneous thread creation

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -149,17 +149,17 @@ class DebruijnInterpreter[M[_], F[_]](
     ) >>= (go(_))
   }
 
-  private def reportErrors(process: M[Unit]): M[Unit] =
-    process.handleErrorWith {
-      case e @ OutOfPhlogistonsError => e.raiseError[M, Unit]
-      case e                         => fTell.tell(e)
-    }
-
   override def eval(par: Par)(
       implicit env: Env[Par],
       rand: Blake2b512Random,
       sequenceNumber: Int
   ): M[Unit] = spanM.trace(parSpanLabel) {
+
+    def reportErrors(process: M[Unit]): M[Unit] =
+      process.handleErrorWith {
+        case e @ OutOfPhlogistonsError => e.raiseError[M, Unit]
+        case e                         => fTell.tell(e)
+      }
 
     val terms = Seq(
       par.sends,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -161,21 +161,19 @@ class DebruijnInterpreter[M[_], F[_]](
       sequenceNumber: Int
   ): M[Unit] = spanM.trace(parSpanLabel) {
 
-    val filteredExprs = par.exprs.filter { expr =>
-      expr.exprInstance match {
-        case _: EVarBody    => true
-        case _: EMethodBody => true
-        case _              => false
-      }
-    }
-
     val terms = Seq(
       par.sends,
       par.receives,
       par.news,
       par.matches,
       par.bundles,
-      filteredExprs
+      par.exprs.filter { expr =>
+        expr.exprInstance match {
+          case _: EVarBody    => true
+          case _: EMethodBody => true
+          case _              => false
+        }
+      }
     ).filter(_.nonEmpty).flatten
 
     def split(id: Int): Blake2b512Random =


### PR DESCRIPTION
### Summary:
Previous to this PR, the Reducer would create a list of six EvalJobs, each of which would represent a sequence of processes to run in parallel. There were six because there are six different kinds of top-level processes. Then, it would spawn a thread for each EvalJob, so six threads. Then, each EvalJob would process its sequence of processes in parallel, spawning a thread for each process. These threads represent the execution of the actual processes. That means, in the worst case where you have a program with where all Pars use all six different kinds of top-level processes, six threads were needlessly introduced (one for each EvalJob) per Par. With these changes, the spawned threads map 1-to-1 to the top-level processes in the Par. Plus, we can get rid of the EvalJob craziness.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3699