### PR TITLE
Remove roundTrip from getContinuations

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -10,10 +10,8 @@ import coop.rchain.shared.Cell
 import coop.rchain.shared.MapOps._
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.Serialize._
-import coop.rchain.rspace.trace.Consume
 import scodec.Codec
 
-import scala.collection.SortedSet
 import scala.collection.concurrent.TrieMap
 
 final case class Snapshot[C, P, A, K](private[rspace] val cache: Cache[C, P, A, K])

--- a/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Serialize.scala
@@ -33,14 +33,6 @@ object Serialize {
         .fold(err => Left(new Exception(err.message)), v => Right(v.value))
   }
 
-  def roundTrip[F[_]: Applicative, E: Serialize](
-      k: E
-  )(implicit FR: FunctorRaise[F, Throwable]): F[E] =
-    Serialize[E].decode(Serialize[E].encode(k)) match {
-      case Left(ex)     => FR.raise(ex)
-      case Right(value) => value.pure[F]
-    }
-
   implicit class RichSerialize[A](private val instance: Serialize[A]) extends AnyVal {
 
     def toCodec: Codec[A] = new Codec[A] {

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -706,7 +706,10 @@ trait StorageActionsTests[F[_]]
 
         _ = r3 shouldBe defined
         _ = runK(r3)
-      } yield (getK(r3).results should contain theSameElementsAs List(List("datum2")))
+      } yield (getK(r3).results should contain theSameElementsAs List(
+        List("datum1"),
+        List("datum2")
+      ))
   }
 
   "consuming and doing a persistient produce" should "work" in fixture { (store, _, space) =>


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This is a pretty large performance optimization for processing the genesis block. Please see https://github.com/rchain/rchain/pull/2617 for flamegraphs.

This is safe because we do not modify the continuations
that are returned from getContinuations in the interpreter.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

See https://rchain.atlassian.net/browse/RCHAIN-3257

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
