### PR TITLE
Add Whiteblock dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -312,7 +312,7 @@ lazy val node = (project in file("node"))
       Seq(
         Cmd("FROM", dockerBaseImage.value),
         ExecCmd("RUN", "apt", "update"),
-        ExecCmd("RUN", "apt", "install", "-yq", "openssl"),
+        ExecCmd("RUN", "apt", "install", "-yq", "openssl", "openssh-server", "procps"),
         Cmd("LABEL", s"""MAINTAINER="${maintainer.value}""""),
         Cmd("WORKDIR", (defaultLinuxInstallLocation in Docker).value),
         Cmd("ADD", s"--chown=$daemon:$daemon opt /opt"),


### PR DESCRIPTION
Testing a particular Docker image in Whiteblock requires patching it
with those apt packages.  Streamline this by adding them to the official
image.  The size cost should be negligible and time savings significant.

https://rchain.atlassian.net/browse/RCHAIN-3668