### PR TITLE
Bump rnode version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,7 +242,7 @@ lazy val node = (project in file("node"))
   .settings(commonSettings: _*)
   .enablePlugins(RpmPlugin, DebianPlugin, JavaAppPackaging, BuildInfoPlugin)
   .settings(
-    version := "0.9.10" + git.gitHeadCommit.value.map(".git" + _.take(8)).getOrElse(""),
+    version := "0.9.11" + git.gitHeadCommit.value.map(".git" + _.take(8)).getOrElse(""),
     name := "rnode",
     maintainer := "RChain Cooperative https://www.rchain.coop/",
     packageSummary := "RChain Node",


### PR DESCRIPTION
Bump rnode version from 0.9.10 to 0.9.11 to match the release docs.

## Overview
<sup>Increase version to 0.9.11 per release notes.</sup>



### JIRA ticket:
<sup>https://rchain.atlassian.net/browse/RCHAIN-3716</sup>



### Notes
<sup>Bump rnode version from 0.9.10 to 0.9.11 to match the release docs</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
