### PR TITLE
Convert serializedSize calls to constants

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Chargeable.scala
@@ -14,6 +14,6 @@ object Chargeable {
 
   implicit def fromProtobuf[T <: StacksafeMessage[_]] =
     new Chargeable[T] {
-      override def cost(a: T): Long = ProtoM.serializedSize(a).value.toLong
+      override def cost(a: T): Long = 100L // TODO: Potentially make more accurate by looking at serializedSize
     }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -34,7 +34,7 @@ trait Costs {
 
   def equalityCheckCost[T <: StacksafeMessage[_], P <: StacksafeMessage[_]](x: T, y: P): Cost =
     Cost(
-      scala.math.min(ProtoM.serializedSize(x).value, ProtoM.serializedSize(y).value),
+      100, // TODO: Potentially make more accurate by looking at serializedSize
       "equality check"
     )
 
@@ -79,7 +79,7 @@ trait Costs {
   // + allocates byte array of the same size as `serializedSize`
   // + then it copies all elements of the Par
   def toByteArrayCost[T <: StacksafeMessage[_]](a: T): Cost =
-    Cost(ProtoM.serializedSize(a).value, "to byte array")
+    Cost(100, "to byte array") // TODO: Potentially make more accurate by looking at serializedSize
   //TODO: adjust the cost of size method
   def sizeMethodCost(size: Int): Cost = Cost(size, "size")
   // slice(from, to) needs to drop `from` elements and then append `to - from` elements
@@ -116,7 +116,8 @@ trait Costs {
   implicit def toStorageCostOps[A <: StacksafeMessage[_]](a: A) = new StorageCostOps(a)
 
   class StorageCostOps[A <: StacksafeMessage[_]](a: A*) {
-    def storageCost: Cost = Cost(a.map(a => ProtoM.serializedSize(a).value).sum, "storage cost")
+    def storageCost: Cost =
+      Cost(a.map(_ => 100L).sum, "storage cost") // TODO: Potentially make more accurate by looking at serializedSize
   }
 
   // Even though we use Long for phlo limit we can't use Long.MaxValue here.


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Before on test against 300 vaults: 2m1s, 1m57s, and 1m59s
After on test against 300 vaults: 1m50s, 1m52s, and 1m50s

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
