### PR TITLE
Implement deploy indexing

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagFileStorage.scala
@@ -8,10 +8,10 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Concurrent, Resource, Sync}
 import cats.implicits._
 import cats.mtl.MonadState
-
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockDagFileStorage.{Checkpoint, CheckpointedDagInfo}
-import coop.rchain.blockstorage.util.BlockMessageUtil.{blockNumber, bonds, parentHashes}
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.util.BlockMessageUtil._
 import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io.{IOError, _}
@@ -24,14 +24,13 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
 import coop.rchain.shared.ByteStringOps._
 import coop.rchain.shared.Language.ignore
-import coop.rchain.shared.{AtomicMonadState, Log, LogSource}
-
+import coop.rchain.shared.{AtomicMonadState, Log, LogSource, StreamT}
 import monix.execution.atomic.AtomicAny
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.{Env, EnvFlags}
+
 import scala.ref.WeakReference
 import scala.util.matching.Regex
-
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.metrics.Metrics.Source
 
@@ -40,6 +39,7 @@ private final case class BlockDagFileStorageState[F[_]: Sync](
     childMap: Map[BlockHash, Set[BlockHash]],
     dataLookup: Map[BlockHash, BlockMetadata],
     topoSort: Vector[Vector[BlockHash]],
+    blockHashesByDeploy: Map[DeployId, BlockHash],
     equivocationsTracker: Set[EquivocationRecord],
     invalidBlocks: Set[BlockMetadata],
     sortOffset: Long,
@@ -49,6 +49,8 @@ private final case class BlockDagFileStorageState[F[_]: Sync](
     latestMessagesCrc: Crc32[F],
     blockMetadataLogOutputStream: FileOutputStreamIO[F],
     blockMetadataCrc: Crc32[F],
+    blockHashesByDeployLogOutputStream: FileOutputStreamIO[F],
+    blockHashesByDeployCrc: Crc32[F],
     equivocationsTrackerLogOutputStream: FileOutputStreamIO[F],
     equivocationsTrackerCrc: Crc32[F],
     invalidBlocksLogOutputStream: FileOutputStreamIO[F],
@@ -67,6 +69,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     equivocationTrackerCrcPath: Path,
     invalidBlocksLogPath: Path,
     invalidBlocksCrcPath: Path,
+    blockHashesByDeployLogPath: Path,
+    blockHashesByDeployCrcPath: Path,
     state: MonadState[F, BlockDagFileStorageState[F]]
 ) extends BlockDagStorage[F] {
   implicit private val logSource: LogSource = LogSource(BlockDagFileStorage.getClass)
@@ -79,6 +83,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.get.map(_.dataLookup)
   private[this] def getTopoSort: F[Vector[Vector[BlockHash]]] =
     state.get.map(_.topoSort)
+  private[this] def getBlockHashesByDeploy: F[Map[DeployId, BlockHash]] =
+    state.get.map(_.blockHashesByDeploy)
   private[this] def getSortOffset: F[Long] =
     state.get.map(_.sortOffset)
   private[this] def getEquviocationsTracker: F[Set[EquivocationRecord]] =
@@ -97,6 +103,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     state.get.map(_.blockMetadataLogOutputStream)
   private[this] def getBlockMetadataCrc: F[Crc32[F]] =
     state.get.map(_.blockMetadataCrc)
+  private[this] def getBlockHashesByDeployLogOutputStream: F[FileOutputStreamIO[F]] =
+    state.get.map(_.blockHashesByDeployLogOutputStream)
+  private[this] def getBlockHashesByDeployCrc: F[Crc32[F]] =
+    state.get.map(_.blockHashesByDeployCrc)
   private[this] def getEquivocationsTrackerLogOutputStream: F[FileOutputStreamIO[F]] =
     state.get.map(_.equivocationsTrackerLogOutputStream)
   private[this] def getEquivocationsTrackerCrc: F[Crc32[F]] =
@@ -145,6 +155,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       f: Vector[Vector[BlockHash]] => Vector[Vector[BlockHash]]
   ): F[Unit] =
     state.modify(s => s.copy(topoSort = f(s.topoSort)))
+  private[this] def modifyBlockHashesByDeploy(
+      f: Map[DeployId, BlockHash] => Map[DeployId, BlockHash]
+  ): F[Unit] =
+    state.modify(s => s.copy(blockHashesByDeploy = f(s.blockHashesByDeploy)))
   private[this] def modifyEquivocationsTracker(
       f: Set[EquivocationRecord] => Set[EquivocationRecord]
   ): F[Unit] =
@@ -174,6 +188,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       childMap: Map[BlockHash, Set[BlockHash]],
       dataLookup: Map[BlockHash, BlockMetadata],
       topoSortVector: Vector[Vector[BlockHash]],
+      blockHashesByDeploy: Map[DeployId, BlockHash],
       invalidBlocksSet: Set[BlockMetadata],
       sortOffset: Long
   ) extends BlockDagRepresentation[F] {
@@ -222,6 +237,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       } else {
         false.pure[F]
       }
+    def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
+      blockHashesByDeploy.get(deployId).pure[F]
     def topoSort(startBlockNumber: Long): F[Vector[Vector[BlockHash]]] =
       if (startBlockNumber >= sortOffset) {
         val offset = startBlockNumber - sortOffset
@@ -420,6 +437,26 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       _                      <- updateCrcFile(dataLookupCrc, blockMetadataCrcPath)
     } yield ()
 
+  private def updateBlockHashByDeployFile(
+      newDeployIds: List[DeployId],
+      blockHash: BlockHash
+  ): F[Unit] =
+    for {
+      blockHashesByDeployCrc             <- getBlockHashesByDeployCrc
+      blockHashesByDeployLogOutputStream <- getBlockHashesByDeployLogOutputStream
+      _ <- newDeployIds.traverse_ { deployId =>
+            // Deploy signatures have variable length (70-71 usually) hence we need to know its size
+            val toAppend = deployId.size.toByteString.concat(deployId).concat(blockHash).toByteArray
+            for {
+              _ <- blockHashesByDeployLogOutputStream.write(toAppend)
+              _ <- blockHashesByDeployLogOutputStream.flush
+              _ <- blockHashesByDeployCrc.update(toAppend).flatMap { _ =>
+                    updateCrcFile(blockHashesByDeployCrc, blockHashesByDeployCrcPath)
+                  }
+            } yield ()
+          }
+    } yield ()
+
   private def updateEquivocationsTrackerFile(equivocationRecord: EquivocationRecord): F[Unit] =
     for {
       equivocationsTrackerCrc             <- getEquivocationsTrackerCrc
@@ -447,17 +484,19 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
 
   private def representation: F[BlockDagRepresentation[F]] =
     for {
-      latestMessages <- getLatestMessages
-      childMap       <- getChildMap
-      dataLookup     <- getDataLookup
-      topoSort       <- getTopoSort
-      invalidBlocks  <- getInvalidBlocks
-      sortOffset     <- getSortOffset
+      latestMessages      <- getLatestMessages
+      childMap            <- getChildMap
+      dataLookup          <- getDataLookup
+      topoSort            <- getTopoSort
+      blockHashesByDeploy <- getBlockHashesByDeploy
+      invalidBlocks       <- getInvalidBlocks
+      sortOffset          <- getSortOffset
     } yield FileDagRepresentation(
       latestMessages,
       childMap,
       dataLookup,
       topoSort,
+      blockHashesByDeploy,
       invalidBlocks,
       sortOffset
     )
@@ -520,6 +559,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
                                                             BlockSenderIsMalformed(block)
                                                           )
                                                         }
+                deployHashes = deployData(block).map(_.sig).toList
                 _ <- modifyLatestMessages { latestMessages =>
                       newValidatorsWithSenderLatestMessages.foldLeft(latestMessages) {
                         //Update new validators with block in which
@@ -528,9 +568,11 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
                       }
                     }
                 _ <- putBlockNumber(block.blockHash, blockNumber(block))
+                _ <- modifyBlockHashesByDeploy(_ ++ deployHashes.map(_ -> block.blockHash).toMap)
                 _ <- updateLatestMessagesFile(newValidatorsWithSenderLatestMessages.toList)
                 _ <- updateDataLookupFile(blockMetadata)
                 _ <- updateInvalidBlocksFile(blockMetadata)
+                _ <- updateBlockHashByDeployFile(deployHashes, block.blockHash)
               } yield ()
             }
         dag <- representation
@@ -589,6 +631,8 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
         _                                   <- blockMetadataLogOutputStream.close
         equivocationsTrackerLogOutputStream <- getEquivocationsTrackerLogOutputStream
         _                                   <- equivocationsTrackerLogOutputStream.close
+        blockHashesByDeployLogOutputStream  <- getBlockHashesByDeployLogOutputStream
+        _                                   <- blockHashesByDeployLogOutputStream.close
         _                                   <- blockNumberIndex.close
       } yield ()
     )
@@ -611,6 +655,8 @@ object BlockDagFileStorage {
       equivocationsTrackerCrcPath: Path,
       invalidBlocksLogPath: Path,
       invalidBlocksCrcPath: Path,
+      blockHashesByDeployLogPath: Path,
+      blockHashesByDeployCrcPath: Path,
       checkpointsDirPath: Path,
       blockNumberIndexPath: Path,
       mapSize: Long,
@@ -1040,6 +1086,100 @@ object BlockDagFileStorage {
             }
     } yield LMDBStore[F](env, dbi)
 
+  private def readBlockHashesByDeploy[F[_]: Sync](
+      randomAccessIO: RandomAccessIO[F]
+  ): F[List[(DeployId, BlockHash)]] = {
+    def readDeployBytes(deployIdSize: Int): F[(DeployId, BlockHash)] =
+      for {
+        deployIdResult       <- randomAccessIO.readByteString(deployIdSize)
+        blockHashBytesResult <- randomAccessIO.readByteString(BlockHash.Length)
+        readResult           = deployIdResult.product(blockHashBytesResult)
+        result               <- readResult.liftTo[F](BlockHashesByDeployLogIsCorrupted)
+      } yield result
+
+    StreamT
+      .continually(randomAccessIO.readInt)
+      .takeWhile(_.isDefined)
+      .mapF {
+        case Some(deployIdSize) => readDeployBytes(deployIdSize)
+        case None               => Sync[F].raiseError[(DeployId, BlockHash)](new IllegalStateException())
+      }
+      .toList
+  }
+
+  def calculateBlockHashesByDeployCrc[F[_]: Monad](
+      blockHashesByDeploy: List[(DeployId, BlockHash)]
+  ): F[Crc32[F]] = {
+    val crc = Crc32.empty[F]()
+    blockHashesByDeploy.traverse_[F, Unit] {
+      case (deployId, blockHash) =>
+        crc.update(deployId.size.toByteString.concat(deployId).concat(blockHash).toByteArray)
+    } >> crc.pure[F]
+  }
+
+  private def truncateBlockHashesByDeployLog[F[_]: Sync](
+      randomAccessIO: RandomAccessIO[F],
+      blockHashesByDeploy: List[(DeployId, BlockHash)]
+  ): F[Unit] = {
+    val lastRecordSize: Long = BlockHash.Length.toLong + BlockHash.Length.toLong
+    for {
+      length <- randomAccessIO.length
+      _      <- randomAccessIO.setLength(length - lastRecordSize)
+    } yield ()
+  }
+
+  private def validateBlockHashesByDeploy[F[_]: Sync](
+      randomAccessIO: RandomAccessIO[F],
+      readBlockHashesByDeployCrc: Long,
+      blockHashesByDeploy: List[(DeployId, BlockHash)]
+  ): F[(List[(DeployId, BlockHash)], Crc32[F])] =
+    for {
+      fullCalculatedCrc <- calculateBlockHashesByDeployCrc[F](blockHashesByDeploy)
+      result <- Monad[F].ifM(fullCalculatedCrc.value.map(_ == readBlockHashesByDeployCrc))(
+                 (blockHashesByDeploy, fullCalculatedCrc).pure[F],
+                 if (blockHashesByDeploy.isEmpty) {
+                   Sync[F].raiseError[(List[(DeployId, BlockHash)], Crc32[F])](
+                     BlockHashesByDeployLogIsCorrupted
+                   )
+                 } else {
+                   // Trying to delete the last log entry
+                   val blockHashesWithoutLast = blockHashesByDeploy.init
+                   calculateBlockHashesByDeployCrc[F](blockHashesWithoutLast).flatMap {
+                     withoutLastCrc =>
+                       Monad[F].ifM(withoutLastCrc.value.map(_ == readBlockHashesByDeployCrc))(
+                         for {
+                           _ <- truncateBlockHashesByDeployLog(randomAccessIO, blockHashesByDeploy)
+                         } yield (blockHashesWithoutLast, withoutLastCrc),
+                         Sync[F].raiseError[(List[(DeployId, BlockHash)], Crc32[F])](
+                           BlockHashesByDeployLogIsCorrupted
+                         )
+                       )
+                   }
+                 }
+               )
+    } yield result
+
+  private def loadBlockHashesByDeploy[F[_]: Sync: Log: RaiseIOError](
+      blockHashesByDeployLogPath: Path,
+      blockHashesByDeployCrcPath: Path
+  ): F[(Map[DeployId, BlockHash], Crc32[F])] =
+    Resource
+      .make(
+        RandomAccessIO.open[F](blockHashesByDeployLogPath, RandomAccessIO.ReadWrite)
+      )(_.close)
+      .use { blockHashesByDeployLogFile =>
+        for {
+          blockHashesByDeploy <- readBlockHashesByDeploy(blockHashesByDeployLogFile)
+          readCrc             <- readCrc[F](blockHashesByDeployCrcPath)
+          result <- validateBlockHashesByDeploy[F](
+                     blockHashesByDeployLogFile,
+                     readCrc,
+                     blockHashesByDeploy
+                   )
+          (blockHashesByDeployList, blockHashesCrc) = result
+        } yield (blockHashesByDeployList.toMap, blockHashesCrc)
+      }
+
   def create[F[_]: Concurrent: Sync: Log: Metrics](
       config: Config
   ): F[BlockDagFileStorage[F]] = {
@@ -1122,7 +1262,12 @@ object BlockDagFileStorage {
                               } yield result
                             }
       (invalidBlocksList, calculatedInvalidBlocksCrc) = invalidBlocksResult
-      sortedCheckpoints                               <- loadCheckpoints(config.checkpointsDirPath)
+      blockHashesByDeployResult <- loadBlockHashesByDeploy(
+                                    config.blockHashesByDeployLogPath,
+                                    config.blockHashesByDeployCrcPath
+                                  )
+      (blockHashesByDeploy, blockHashesByDeployCrc) = blockHashesByDeployResult
+      sortedCheckpoints                             <- loadCheckpoints(config.checkpointsDirPath)
       latestMessagesLogOutputStream <- FileOutputStreamIO.open[F](
                                         config.latestMessagesLogPath,
                                         true
@@ -1139,6 +1284,10 @@ object BlockDagFileStorage {
                                        config.invalidBlocksLogPath,
                                        true
                                      )
+      blockHashesByDeployLogOutputStream <- FileOutputStreamIO.open[F](
+                                             config.blockHashesByDeployLogPath,
+                                             true
+                                           )
       state = BlockDagFileStorageState(
         latestMessages = latestMessagesMap,
         childMap = childMap,
@@ -1156,7 +1305,10 @@ object BlockDagFileStorage {
         equivocationsTrackerLogOutputStream = equivocationsTrackerLogOutputStream,
         equivocationsTrackerCrc = calculatedEquivocationsTrackerCrc,
         invalidBlocksLogOutputStream = invalidBlocksLogOutputStream,
-        invalidBlocksCrc = calculatedInvalidBlocksCrc
+        invalidBlocksCrc = calculatedInvalidBlocksCrc,
+        blockHashesByDeploy = blockHashesByDeploy,
+        blockHashesByDeployLogOutputStream = blockHashesByDeployLogOutputStream,
+        blockHashesByDeployCrc = blockHashesByDeployCrc
       )
     } yield new BlockDagFileStorage[F](
       lock,
@@ -1170,6 +1322,8 @@ object BlockDagFileStorage {
       config.equivocationsTrackerCrcPath,
       config.invalidBlocksLogPath,
       config.invalidBlocksCrcPath,
+      config.blockHashesByDeployLogPath,
+      config.blockHashesByDeployCrcPath,
       new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
     )
   }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -1,5 +1,7 @@
 package coop.rchain.blockstorage
 
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
@@ -19,6 +21,8 @@ trait BlockDagStorage[F[_]] {
 }
 
 object BlockDagStorage {
+  type DeployId = ByteString
+
   def apply[F[_]](implicit B: BlockDagStorage[F]): BlockDagStorage[F] = B
 }
 
@@ -26,6 +30,7 @@ trait BlockDagRepresentation[F[_]] {
   def children(blockHash: BlockHash): F[Option[Set[BlockHash]]]
   def lookup(blockHash: BlockHash): F[Option[BlockMetadata]]
   def contains(blockHash: BlockHash): F[Boolean]
+  def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]]
   def topoSort(startBlockNumber: Long): F[Vector[Vector[BlockHash]]]
   def topoSortTail(tailLength: Int): F[Vector[Vector[BlockHash]]]
   def deriveOrdering(startBlockNumber: Long): F[Ordering[BlockMetadata]]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -18,6 +18,7 @@ final case object EquivocationsTrackerLogIsMalformed                          ex
 final case object LatestMessagesLogIsCorrupted                                extends StorageError
 final case object DataLookupIsCorrupted                                       extends StorageError
 final case object InvalidBlocksIsCorrupted                                    extends StorageError
+final case object BlockHashesByDeployLogIsCorrupted                           extends StorageError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
@@ -45,6 +46,8 @@ object StorageError {
         "Data lookup log is corrupted"
       case InvalidBlocksIsCorrupted =>
         "Invalid blocks log is corrupted"
+      case BlockHashesByDeployLogIsCorrupted =>
+        "Block hashes by deploy log is corrupted"
     }
 
   implicit class StorageErrorToMessage(storageError: StorageError) {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/BlockMessageUtil.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/BlockMessageUtil.scala
@@ -1,7 +1,7 @@
 package coop.rchain.blockstorage.util
 
 import com.google.protobuf.ByteString
-import coop.rchain.casper.protocol.{BlockMessage, Bond}
+import coop.rchain.casper.protocol.{BlockMessage, Bond, DeployData}
 
 object BlockMessageUtil {
   // TODO: Remove once optional fields are removed
@@ -16,6 +16,11 @@ object BlockMessageUtil {
       bd <- b.body
       ps <- bd.state
     } yield ps.bonds).getOrElse(List.empty[Bond])
+
+  def deployData(b: BlockMessage): Seq[DeployData] =
+    (for {
+      bs <- b.body
+    } yield bs.deploys.flatMap(_.deploy)).getOrElse(List.empty)
 
   def parentHashes(b: BlockMessage): Seq[ByteString] =
     b.header.fold(Seq.empty[ByteString])(_.parentsHashList)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 
 import cats.effect.Sync
 import cats.implicits._
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 
 import scala.language.higherKinds
@@ -32,6 +33,11 @@ final case class RandomAccessIO[F[_]: Sync: RaiseIOError] private (
       case _: EOFException => none[Unit].pure[F]
       case e               => RaiseIOError[F].raise[Option[Unit]](ByteArrayReadFailed(e))
     })
+
+  def readByteString(len: Int): F[Option[ByteString]] = {
+    val bytes = Array.ofDim[Byte](len)
+    readFully(bytes).map(_.map(_ => ByteString.copyFrom(bytes)))
+  }
 
   def length: F[Long] =
     handleIo(file.length(), UnexpectedIOError.apply)

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -142,6 +142,12 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
   private def defaultInvalidBlocksCrc(dagDataDir: Path): Path =
     dagDataDir.resolve("invalid-blocks-checksum")
 
+  private def defaultBlockHasesByDeploy(dagDataDir: Path): Path =
+    dagDataDir.resolve("block-hashes-by-deploy")
+
+  private def defaultBlockHasesByDeployCrc(dagDataDir: Path): Path =
+    dagDataDir.resolve("block-hashes-by-deploy-checksum")
+
   private def defaultCheckpointsDir(dagDataDir: Path): Path =
     dagDataDir.resolve("checkpoints")
 
@@ -164,6 +170,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         defaultEquivocationsTrackerCrc(dagDataDir),
         defaultInvalidBlocksLog(dagDataDir),
         defaultInvalidBlocksCrc(dagDataDir),
+        defaultBlockHasesByDeploy(dagDataDir),
+        defaultBlockHasesByDeployCrc(dagDataDir),
         defaultCheckpointsDir(dagDataDir),
         defaultBlockNumberIndex(dagDataDir),
         100L * 1024L * 1024L * 4096L,

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -491,6 +491,25 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     }
   }
 
+  it should "be able to restore deploy index on startup" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      withDagStorageLocation { dagDataDir =>
+        for {
+          firstStorage  <- createAtDefaultLocation(dagDataDir)
+          _             <- blockElements.traverse_(firstStorage.insert(_, genesis, true))
+          _             <- firstStorage.close()
+          secondStorage <- createAtDefaultLocation(dagDataDir)
+          dag           <- secondStorage.getRepresentation
+          (deploys, blockHashes) = blockElements
+            .flatMap(b => b.body.get.deploys.map(_ -> b.blockHash))
+            .unzip
+          deployLookups <- deploys.traverse(d => dag.lookupByDeployId(d.deploy.get.sig))
+          _             <- secondStorage.close()
+        } yield deployLookups shouldBe blockHashes.map(_.some)
+      }
+    }
+  }
+
   it should "be able to load checkpoints" in {
     forAll(blockElementsWithParentsGen, minSize(1), sizeRange(2)) { blockElements =>
       withDagStorageLocation { dagDataDir =>

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -15,6 +15,7 @@ import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.shared._
 import cats.effect.concurrent.Semaphore
 
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -5,6 +5,7 @@ import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.DeployError._
@@ -215,7 +216,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: ConnectionsCell: TransportLa
             s.copy(deployHistory = s.deployHistory + deploy)
           }
       _ <- Log[F].info(s"Received ${PrettyPrinter.buildString(deploy)}")
-    } yield (deploy.sig.toByteArray)
+    } yield deploy.sig
 
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     Estimator.tips[F](dag, genesis)

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -5,7 +5,6 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 
 package object casper {
-  type DeployId = Array[Byte]
   type TopoSort = Vector[Vector[BlockHash]]
 
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")

--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper
 import cats.data.EitherT
 import cats.effect.{Resource, Sync}
 import cats.implicits._
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts._

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
@@ -27,7 +27,7 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
         deploy   <- ConstructDeploy.basicDeployData[Effect](0)
         res      <- MultiParentCasper[Effect].deploy(deploy)
         deployId = res.right.get
-        _        = deployId shouldBe ConstructDeploy.sign(deploy).sig.toByteArray
+        _        = deployId shouldBe ConstructDeploy.sign(deploy).sig
         _        = logEff.infos.size should be(1)
         result   = logEff.infos.head.contains("Received Deploy") should be(true)
       } yield result

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -159,7 +159,6 @@ class BlockQueryResponseAPITest
         deployId = SignDeployment
           .sign(PrivateKey(sk.bytes), randomDeploys.head.deploy.get)
           .sig
-          .toByteArray
         blockQueryResponse <- BlockAPI.findDeploy[Task](deployId)(
                                Sync[Task],
                                casperRef,
@@ -187,7 +186,7 @@ class BlockQueryResponseAPITest
       for {
         effects                                 <- emptyEffects(blockStore, blockDagStorage)
         (logEff, casperRef, cliqueOracleEffect) = effects
-        deployId                                = "asdfQwertyUiopxyzcbv".getBytes
+        deployId                                = ByteString.copyFromUtf8("asdfQwertyUiopxyzcbv")
         blockQueryResponse <- BlockAPI.findDeploy[Task](deployId)(
                                Sync[Task],
                                casperRef,

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import coop.rchain.blockstorage.BlockDagRepresentation
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.casper._
 import coop.rchain.casper.api.BlockAPI.ApiErr
 import coop.rchain.casper.helper.HashSetCasperTestNode

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -131,6 +131,8 @@ object BlockDagStorageTestFixture {
         blockDagStorageDir.resolve("equivocations-tracker-crc"),
         blockDagStorageDir.resolve("invalid-blocks-data"),
         blockDagStorageDir.resolve("invalid-blocks-crc"),
+        blockDagStorageDir.resolve("block-hashes-by-deploy-data"),
+        blockDagStorageDir.resolve("block-hashes-by-deploy-crc"),
         blockDagStorageDir.resolve("checkpoints"),
         blockDagStorageDir.resolve("block-number-index"),
         mapSize

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -301,6 +301,8 @@ object HashSetCasperTestNode {
       blockDagDir.resolve("equivocations-tracker-crc"),
       blockDagDir.resolve("invalid-blocks-data"),
       blockDagDir.resolve("invalid-blocks-crc"),
+      blockDagDir.resolve("block-hashes-by-deploy-data"),
+      blockDagDir.resolve("block-hashes-by-deploy-crc"),
       blockDagDir.resolve("checkpoints"),
       blockDagDir.resolve("block-number-index"),
       mapSize

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -4,6 +4,7 @@ import cats.effect.{Resource, Sync}
 import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import coop.rchain.casper._
 import coop.rchain.casper.DeployError
@@ -35,7 +36,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
     } yield BlockStatus.valid
   def contains(blockHash: BlockHash): F[Boolean] = false.pure[F]
   def deploy(r: DeployData): F[Either[DeployError, DeployId]] =
-    Applicative[F].pure(Right(Array[Byte]()))
+    Applicative[F].pure(Right(ByteString.EMPTY))
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -49,9 +49,6 @@ service DeployService {
   // Find processes receiving on a name.
   // Returns on success ListeningNameContinuationResponse
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (Either) {}
-  // Find block from a deploy.
-  // Returns on success BlockQueryResponse
-  rpc findBlockWithDeploy(FindDeployInBlockQuery) returns (Either) {}
   // Find block containing a deploy.
   // Returns on success LightBlockQueryResponse
   rpc findDeploy(FindDeployQuery) returns (Either) {}
@@ -65,11 +62,6 @@ service DeployService {
 
 message FindDeployQuery {
   bytes deployId = 1;
-}
-
-message FindDeployInBlockQuery {
-  bytes user = 1;
-  int64 timestamp = 2;
 }
 
 message BlockQuery {

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -112,7 +112,6 @@ object EqualM extends EqualMDerivation {
   implicit val BodyHash                   = gen[Body]
   implicit val BondHash                   = gen[Bond]
   implicit val DeployDataHash             = gen[DeployData]
-  implicit val FindDeployInBlockQueryHash = gen[FindDeployInBlockQuery]
   implicit val HeaderHash                 = gen[Header]
   implicit val ProcessedDeployHash        = gen[ProcessedDeploy]
   implicit val RChainStateHash            = gen[RChainState]

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -141,7 +141,6 @@ object HashM extends HashMDerivation {
   implicit val BodyHash                   = gen[Body]
   implicit val BondHash                   = gen[Bond]
   implicit val DeployDataHash             = gen[DeployData]
-  implicit val FindDeployInBlockQueryHash = gen[FindDeployInBlockQuery]
   implicit val HeaderHash                 = gen[Header]
   implicit val ProcessedDeployHash        = gen[ProcessedDeploy]
   implicit val RChainStateHash            = gen[RChainState]

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -443,6 +443,8 @@ class NodeRuntime private[node] (
       equivocationsTrackerCrcPath = dagStoragePath.resolve("equivocationsTrackerCrcPath"),
       invalidBlocksLogPath = dagStoragePath.resolve("invalidBlocksLogPath"),
       invalidBlocksCrcPath = dagStoragePath.resolve("invalidBlocksCrcPath"),
+      blockHashesByDeployLogPath = dagStoragePath.resolve("blockHashesByDeployLogPath"),
+      blockHashesByDeployCrcPath = dagStoragePath.resolve("blockHashesByDeployCrcPath"),
       checkpointsDirPath = dagStoragePath.resolve("checkpointsDirPath"),
       blockNumberIndexPath = dagStoragePath.resolve("blockNumberIndexPath"),
       mapSize = 8L * 1024L * 1024L * 1024L,

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -111,7 +111,7 @@ private[api] object DeployGrpcService {
           .flatMap(Observable.fromIterable)
 
       override def findDeploy(request: FindDeployQuery): Task[GrpcEither] =
-        defer(BlockAPI.findDeploy[F](request.deployId.toByteArray))
+        defer(BlockAPI.findDeploy[F](request.deployId))
 
       override def previewPrivateNames(
           request: PrivateNamePreviewQuery

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -110,9 +110,6 @@ private[api] object DeployGrpcService {
           .fromTask(deferList(BlockAPI.showMainChain[F](request.depth)))
           .flatMap(Observable.fromIterable)
 
-      override def findBlockWithDeploy(request: FindDeployInBlockQuery): Task[GrpcEither] =
-        defer(BlockAPI.findBlockWithDeploy[F](request.user, request.timestamp))
-
       override def findDeploy(request: FindDeployQuery): Task[GrpcEither] =
         defer(BlockAPI.findDeploy[F](request.deployId.toByteArray))
 

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -137,6 +137,8 @@ object Configuration {
       dataDir.resolve("casper-block-dag-file-storage-equivocation-tracker-crc"),
       dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-log"),
       dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-crc"),
+      dataDir.resolve("casper-block-dag-file-storage-block-hashes-by-deploy-data"),
+      dataDir.resolve("casper-block-dag-file-storage-block-hashes-by-deploy-crc"),
       dataDir.resolve("casper-block-dag-file-storage-checkpoints"),
       dataDir.resolve("casper-block-dag-file-storage-block-number-index"),
       server.dagStorageSize


### PR DESCRIPTION
## Overview
- Adds DAG storage index for deploys by their signatures to support efficient lookup
- Removes obsolete API for looking up blocks by their deploy creator and timestamp
- Adapts BlockAPI to use the new DAG storage index to lookup blocks by deploy signature


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3526


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
