### PR TITLE
Update RholangBuildTest to have same scheduler as prod

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -23,7 +23,7 @@ import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Log, UncaughtExceptionLogger}
+import coop.rchain.shared.{Log, RchainScheduler, UncaughtExceptionLogger}
 import monix.execution.ExecutionModel.BatchedExecution
 import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
@@ -33,15 +33,8 @@ import scala.util.{Failure, Success, Try}
 
 class RholangBuildTest extends FlatSpec with Matchers {
 
-  val availableProcessors = java.lang.Runtime.getRuntime.availableProcessors()
-  implicit val scheduler = Scheduler.forkJoin(
-    name = "rspace",
-    parallelism = availableProcessors * 2,
-    maxThreads = availableProcessors * 2,
-    reporter = UncaughtExceptionLogger,
-    executionModel = BatchedExecution(1024)
-  )
-  val genesis = buildGenesis()
+  implicit val scheduler = RchainScheduler.interpreterScheduler
+  val genesis            = buildGenesis()
 
   "Our build system" should "allow import of rholang sources into scala code" in effectTest {
     HashSetCasperTestNode

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -39,7 +39,7 @@ class RholangBuildTest extends FlatSpec with Matchers {
     parallelism = availableProcessors * 2,
     maxThreads = availableProcessors * 2,
     reporter = UncaughtExceptionLogger,
-    executionModel = BatchedExecution(888888881)
+    executionModel = BatchedExecution(1024)
   )
   val genesis = buildGenesis()
 

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -23,8 +23,9 @@ import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.Log
-import monix.execution.Scheduler.Implicits.global
+import coop.rchain.shared.{Log, UncaughtExceptionLogger}
+import monix.execution.ExecutionModel.BatchedExecution
+import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.io.Source
@@ -32,6 +33,14 @@ import scala.util.{Failure, Success, Try}
 
 class RholangBuildTest extends FlatSpec with Matchers {
 
+  val availableProcessors = java.lang.Runtime.getRuntime.availableProcessors()
+  implicit val scheduler = Scheduler.forkJoin(
+    name = "rspace",
+    parallelism = availableProcessors * 2,
+    maxThreads = availableProcessors * 2,
+    reporter = UncaughtExceptionLogger,
+    executionModel = BatchedExecution(888888881)
+  )
   val genesis = buildGenesis()
 
   "Our build system" should "allow import of rholang sources into scala code" in effectTest {

--- a/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/RholangBuildTest.scala
@@ -1,39 +1,25 @@
 package coop.rchain.casper
 
-import java.nio.file.{Path, Paths}
-
-import cats.effect.Sync
 import cats.implicits._
-import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
-import coop.rchain.blockstorage.util.io.SourceIO
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.Genesis.{fromLine, getVaults}
-import coop.rchain.casper.genesis.contracts.{ProofOfStake, RevGenerator, Validator, Vault}
-import coop.rchain.casper.genesis.contracts.StandardDeploys.toDeploy
+import coop.rchain.casper.genesis.contracts.Vault
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
-import coop.rchain.casper.util.ConstructDeploy.{defaultPub, defaultPub2}
 import coop.rchain.casper.util.GenesisBuilder._
 import coop.rchain.casper.util.RSpaceUtil._
 import coop.rchain.casper.util.rholang.RegistrySigGen
-import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.interpreter.util.RevAddress
-import coop.rchain.shared.{Log, RchainScheduler, UncaughtExceptionLogger}
-import monix.execution.ExecutionModel.BatchedExecution
-import monix.execution.Scheduler
+import coop.rchain.shared.RChainScheduler
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.io.Source
-import scala.util.{Failure, Success, Try}
 
 class RholangBuildTest extends FlatSpec with Matchers {
 
-  implicit val scheduler = RchainScheduler.interpreterScheduler
+  implicit val scheduler = RChainScheduler.interpreterScheduler
   val genesis            = buildGenesis()
 
   "Our build system" should "allow import of rholang sources into scala code" in effectTest {

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -60,15 +60,7 @@ class NodeRuntime private[node] (
     Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionLogger)
   private[this] val grpcScheduler =
     Scheduler.cached("grpc-io", 4, 64, reporter = UncaughtExceptionLogger)
-  private[this] val availableProcessors = java.lang.Runtime.getRuntime.availableProcessors()
-  // TODO: make it configurable
-  // TODO: fine tune this
-  private[this] val rspaceScheduler = Scheduler.forkJoin(
-    name = "rspace",
-    parallelism = availableProcessors * 2,
-    maxThreads = availableProcessors * 2,
-    reporter = UncaughtExceptionLogger
-  )
+  private[this] val rspaceScheduler = RchainScheduler.interpreterScheduler
 
   implicit private val logSource: LogSource = LogSource(this.getClass)
 

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -60,7 +60,7 @@ class NodeRuntime private[node] (
     Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionLogger)
   private[this] val grpcScheduler =
     Scheduler.cached("grpc-io", 4, 64, reporter = UncaughtExceptionLogger)
-  private[this] val rspaceScheduler = RchainScheduler.interpreterScheduler
+  private[this] val rspaceScheduler = RChainScheduler.interpreterScheduler
 
   implicit private val logSource: LogSource = LogSource(this.getClass)
 

--- a/shared/src/main/scala/coop/rchain/shared/RChainScheduler.scala
+++ b/shared/src/main/scala/coop/rchain/shared/RChainScheduler.scala
@@ -3,7 +3,7 @@ package coop.rchain.shared
 import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 
-object RchainScheduler {
+object RChainScheduler {
   val availableProcessors: Int = java.lang.Runtime.getRuntime.availableProcessors()
   // TODO: make it configurable
   // TODO: fine tune this

--- a/shared/src/main/scala/coop/rchain/shared/RchainScheduler.scala
+++ b/shared/src/main/scala/coop/rchain/shared/RchainScheduler.scala
@@ -1,0 +1,16 @@
+package coop.rchain.shared
+
+import monix.execution.Scheduler
+import monix.execution.schedulers.SchedulerService
+
+object RchainScheduler {
+  val availableProcessors: Int = java.lang.Runtime.getRuntime.availableProcessors()
+  // TODO: make it configurable
+  // TODO: fine tune this
+  val interpreterScheduler: SchedulerService = Scheduler.forkJoin(
+    name = "interpreter-rspace",
+    parallelism = availableProcessors * 2,
+    maxThreads = availableProcessors * 2,
+    reporter = UncaughtExceptionLogger
+  )
+}


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

Just in case the scheduler makes a difference. This is part of the genesis ceremony optimization.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
