### PR TITLE
Extract static 'template' methods for RevVault's instance methods

### DIFF
--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -21,7 +21,9 @@ new
   _makeVault,
   _newVault,
   _getOrCreate,
-  _revVault
+  _revVault,
+  _transferTemplate,
+  _depositTemplate
 in {
   rl!(`rho:rchain:makeMint`, *MakeMintCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
@@ -156,50 +158,55 @@ in {
             } |
 
             contract revVault(@"transfer", @revAddress, @amount, authKey, ret) = {
-
-              new
-                revAddressValid, revAddressValidEither, amountNonNegative,
-                authKeyValidCh, authKeyValidEitherCh,
-                parametersOkCh, parametersAndAuthOkCh,
-                split, eitherPurseCh, doDeposit
-              in {
-                RevAddress!("validate", revAddress, *revAddressValid) |
-                @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
-
-                @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
-
-                @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
-                @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
-
-                @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
-                @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
-
-                @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
-                for (_, retCh <- split) {
-                  new amountPurseCh in {
-                    purse!("split", amount, *amountPurseCh) |
-                    @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
-                  }
-                } |
-
-                @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
-                for (@p, retCh <- doDeposit) {
-                  @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
-                }
-              }
-
+              _transferTemplate!(ownRevAddress, *purse, revAddress, amount, *authKey, *ret)
             } |
 
             contract @{ownRevAddress | bundle0{*_revVault}}(@"_deposit", depositPurse, retCh) = {
+              _depositTemplate!(*purse, *depositPurse, *retCh)
+            }
+          }
+        } |
 
-              new amountCh, depositSuccessCh in {
-                depositPurse!("getBalance", *amountCh) |
-                for (@amount <- amountCh) {
+        contract _transferTemplate(@ownRevAddress, purse, @revAddress, @amount, authKey, ret) = {
+          new
+            revAddressValid, revAddressValidEither, amountNonNegative,
+            authKeyValidCh, authKeyValidEitherCh,
+            parametersOkCh, parametersAndAuthOkCh,
+            split, eitherPurseCh, doDeposit
+          in {
+            RevAddress!("validate", revAddress, *revAddressValid) |
+            @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
 
-                  purse!("deposit", amount, *depositPurse, *depositSuccessCh) |
-                  @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
-                }
+            @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
+
+            @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
+            @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
+
+            @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
+            @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
+
+            @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
+            for (_, retCh <- split) {
+              new amountPurseCh in {
+                purse!("split", amount, *amountPurseCh) |
+                @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
               }
+            } |
+
+            @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
+            for (@p, retCh <- doDeposit) {
+              @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
+            }
+          }
+        } |
+
+        contract _depositTemplate(purse, depositPurse, retCh) = {
+          new amountCh, depositSuccessCh in {
+            depositPurse!("getBalance", *amountCh) |
+            for (@amount <- amountCh) {
+
+              purse!("deposit", amount, *depositPurse, *depositSuccessCh) |
+              @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
             }
           }
         } |


### PR DESCRIPTION
As discussed during the ongoing standup call:

This should reduce the collective size of persistent contracts we store
in the tuplespace per a RevVault instance.

## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
