### PR TITLE
User vaults at genesis

### DIFF
--- a/casper/src/main/resources/Either.rho
+++ b/casper/src/main/resources/Either.rho
@@ -108,7 +108,7 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
         ((false, _), _)               => return!(a)
         (_, (false, _))               => return!(b)
         ((true, va), (true, vb)) => {
-          new ret, stdout(`rho:io:stdout`) in {
+          new ret in {
             match *f {
               { for (x, y, r <- fName) { _ } } => {
                 *f |

--- a/casper/src/main/resources/Either.rho
+++ b/casper/src/main/resources/Either.rho
@@ -108,10 +108,15 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
         ((false, _), _)               => return!(a)
         (_, (false, _))               => return!(b)
         ((true, va), (true, vb)) => {
-          new ret in {
-            f!(va, vb, *ret) |
-            for (@v <- ret) {
-              return!((true, v))
+          new ret, stdout(`rho:io:stdout`) in {
+            match *f {
+              { for (x, y, r <- fName) { _ } } => {
+                *f |
+                fName!(va, vb, *ret) |
+                for (@v <- ret) {
+                  return!((true, v))
+                }
+              }
             }
           }
         }

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -142,16 +142,16 @@ in {
             mint!("makePurse", initialAmount, *purseCh) |
             @Either!("fromNillable <-", *purseCh, "Couldn't create purse", *eitherPurseCh) |
             @Either!("map2 <-", *eitherRevAddrCh, *eitherPurseCh, for (@addr, purse, r <- mkVault) {
-              _newVault!(addr, *purse, *r)
+              new revVault in {
+                _newVault!(*revVault, addr, *purse) |
+                r!(bundle+{*revVault})
+              }
             }, *ret)
           }
 
         } |
 
-        contract _newVault(@ownRevAddress, purse, ret) = {
-          new revVault in {
-
-            ret!(bundle+{*revVault}) |
+        contract _newVault(revVault, @ownRevAddress, purse) = {
 
             contract revVault(@"balance", ret) = {
               purse!("getBalance", *ret)
@@ -203,7 +203,7 @@ in {
                 }
               }
             }
-          }
+
         } |
 
         rs!(

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -28,10 +28,22 @@ in {
   rl!(`rho:lang:either`, *EitherCh) |
   for(@(_, MakeMint) <- MakeMintCh; @(_, AuthKey) <- AuthKeyCh; @(_, Either) <- EitherCh) {
 
-    new mintCh, vaultMapStore in {
-      vaultMapStore!({}) |
+    new mintCh, vaultMapStore, initVault in {
       @MakeMint!(*mintCh) |
       for (mint <- mintCh) {
+
+        contract initVault(name, @address, @initialAmount) = {
+          new purseCh in {
+            mint!("makePurse", initialAmount, *purseCh) |
+            for (purse <- purseCh) {
+              _newVault!(*name, address, *purse)
+            }
+          }
+        } |
+
+        for (@"init", ret <- RevVault) {
+          ret!(*vaultMapStore, *initVault)
+        } |
 
         contract RevVault(@"deployerAuthKey", deployerId, ret) = {
 

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -137,11 +137,13 @@ in {
 
         contract _makeVault(@ownerRevAddress, @initialAmount, ret) = {
 
-          new revAddrCh, eitherRevAddrCh, purseCh, eitherPurseCh in {
+          new revAddrCh, eitherRevAddrCh, purseCh, eitherPurseCh, mkVault in {
             @Either!("fromNillable", ownerRevAddress, "Required `revAddress` parameter was Nil", *eitherRevAddrCh) |
             mint!("makePurse", initialAmount, *purseCh) |
             @Either!("fromNillable <-", *purseCh, "Couldn't create purse", *eitherPurseCh) |
-            @Either!("map2 <-", *eitherRevAddrCh, *eitherPurseCh, *_newVault, *ret)
+            @Either!("map2 <-", *eitherRevAddrCh, *eitherPurseCh, for (@addr, purse, r <- mkVault) {
+              _newVault!(addr, *purse, *r)
+            }, *ret)
           }
 
         } |

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -21,7 +21,9 @@ new
   _makeVault,
   _newVault,
   _getOrCreate,
-  _revVault
+  _revVault,
+  _transferTemplate,
+  _depositTemplate
 in {
   rl!(`rho:rchain:makeMint`, *MakeMintCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
@@ -170,52 +172,57 @@ in {
             } |
 
             contract revVault(@"transfer", @revAddress, @amount, authKey, ret) = {
-
-              new
-                revAddressValid, revAddressValidEither, amountNonNegative,
-                authKeyValidCh, authKeyValidEitherCh,
-                parametersOkCh, parametersAndAuthOkCh,
-                split, eitherPurseCh, doDeposit
-              in {
-                RevAddress!("validate", revAddress, *revAddressValid) |
-                @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
-
-                @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
-
-                @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
-                @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
-
-                @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
-                @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
-
-                @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
-                for (_, retCh <- split) {
-                  new amountPurseCh in {
-                    purse!("split", amount, *amountPurseCh) |
-                    @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
-                  }
-                } |
-
-                @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
-                for (@p, retCh <- doDeposit) {
-                  @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
-                }
-              }
-
+              _transferTemplate!(ownRevAddress, *purse, revAddress, amount, *authKey, *ret)
             } |
 
             contract @{ownRevAddress | bundle0{*_revVault}}(@"_deposit", depositPurse, retCh) = {
-
-              new amountCh, depositSuccessCh in {
-                depositPurse!("getBalance", *amountCh) |
-                for (@amount <- amountCh) {
-
-                  purse!("deposit", amount, *depositPurse, *depositSuccessCh) |
-                  @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
-                }
-              }
+              _depositTemplate!(*purse, *depositPurse, *retCh)
             }
 
+        } |
+
+        contract _transferTemplate(@ownRevAddress, purse, @revAddress, @amount, authKey, ret) = {
+          new
+            revAddressValid, revAddressValidEither, amountNonNegative,
+            authKeyValidCh, authKeyValidEitherCh,
+            parametersOkCh, parametersAndAuthOkCh,
+            split, eitherPurseCh, doDeposit
+          in {
+            RevAddress!("validate", revAddress, *revAddressValid) |
+            @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
+
+            @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
+
+            @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
+            @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
+
+            @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
+            @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
+
+            @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
+            for (_, retCh <- split) {
+              new amountPurseCh in {
+                purse!("split", amount, *amountPurseCh) |
+                @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
+              }
+            } |
+
+            @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
+            for (@p, retCh <- doDeposit) {
+              @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
+            }
+          }
+        } |
+
+        contract _depositTemplate(purse, depositPurse, retCh) = {
+          new amountCh, depositSuccessCh in {
+            depositPurse!("getBalance", *amountCh) |
+            for (@amount <- amountCh) {
+
+              purse!("deposit", amount, *depositPurse, *depositSuccessCh) |
+              @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
+            }
+          }
         } |
 
         rs!(

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -33,6 +33,7 @@ import scala.util.Try
 class BlockApproverProtocol(
     validatorId: ValidatorIdentity,
     deployTimestamp: Long,
+    vaults: Seq[Vault],
     bonds: Map[PublicKey, Long],
     minimumBond: Long,
     maximumBond: Long,
@@ -54,6 +55,7 @@ class BlockApproverProtocol(
           candidate,
           requiredSigs,
           deployTimestamp,
+          vaults,
           _bonds,
           minimumBond,
           maximumBond
@@ -97,6 +99,7 @@ object BlockApproverProtocol {
       candidate: ApprovedBlockCandidate,
       requiredSigs: Int,
       timestamp: Long,
+      vaults: Seq[Vault],
       bonds: Map[ByteString, Long],
       minimumBond: Long,
       maximumBond: Long
@@ -120,10 +123,6 @@ object BlockApproverProtocol {
         }
         posParams      = ProofOfStake(minimumBond, maximumBond, validators)
         (_, genesisPk) = Secp256k1.newKeyPair
-        vaults = Traverse[List]
-          .traverse(posParams.validators.map(_.pk).toList)(RevAddress.fromPublicKey)
-          .get
-          .map(Vault(_, 0L)) //FIXME the initial supplies should be read from the wallets file
         genesisBlessedContracts = Genesis
           .defaultBlessedTerms(
             timestamp,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -1,5 +1,7 @@
 package coop.rchain.casper.engine
 
+import java.nio.file.Paths
+
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.Monad
@@ -78,9 +80,11 @@ object CasperLaunch {
                 init.conf.genesisPath
               )
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
+      vaults      <- Genesis.vaultFromFile(Paths.get(init.conf.walletsFile.get))
       bap = new BlockApproverProtocol(
         validatorId.get,
         timestamp,
+        vaults,
         bonds,
         init.conf.minimumBond,
         init.conf.maximumBond,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -80,7 +80,11 @@ object CasperLaunch {
                 init.conf.genesisPath
               )
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
-      vaults      <- Genesis.vaultFromFile(Paths.get(init.conf.walletsFile.get))
+      vaults <- Genesis.vaultFromFile(
+                 init.conf.walletsFile
+                   .map(Paths.get(_))
+                   .getOrElse(init.conf.genesisPath.resolve("wallets.txt"))
+               )
       bap = new BlockApproverProtocol(
         validatorId.get,
         timestamp,

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -121,7 +121,7 @@ object Genesis {
         )
     }
 
-  private def vaultFromFile[F[_]: Sync: Log: RaiseIOError](vaultsPath: Path): F[Seq[Vault]] =
+  def vaultFromFile[F[_]: Sync: Log: RaiseIOError](vaultsPath: Path): F[Seq[Vault]] =
     for {
       lines <- SourceIO
                 .open(vaultsPath)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
@@ -21,23 +21,12 @@ final case class RevGenerator(
     s""" new rl(`rho:registry:lookup`), revVaultCh in {
        #   rl!(`rho:rchain:revVault`, *revVaultCh) |
        #   for (@(_, RevVault) <- revVaultCh) {
-       #
-       #     new genesisVaultCh in {
-       #       @RevVault!(
-       #         "findOrCreateGenesisVault",
-       #         "${genesisAddress.toBase58}",
-       #         $supply,
-       #         *genesisVaultCh
-       #       )
-       #     } |
-       #
        #     new ret in {
        #       @RevVault!("init", *ret) |
        #       for (vaultMapStore, initVault <- ret) {
        #         ${vaultInitCode()}
        #       }
        #     }
-       #
        #   }
        # }
      """.stripMargin('#')

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
@@ -49,7 +49,7 @@ final case class RevGenerator(
       .buildNormalizedTerm(code, normalizerEnv)
       .value()
 
-  private def vaultInitCode() =
+  private def vaultInitCode(): String =
     if (userVaults.isEmpty) {
       "vaultMapStore!({})"
     } else {
@@ -63,10 +63,10 @@ final case class RevGenerator(
 
   private def vaultsMap(): String =
     s"""
-       |{
-       |${concatenate(mapEntry, separator = ",\n")}
-       |}
-       |""".stripMargin
+       #{
+       #${concatenate(mapEntry, separator = ",\n")}
+       #}
+       #""".stripMargin('#')
 
   private def mapEntry(userVault: Vault, index: Int): String =
     s"""  "${userVault.revAddress.toBase58}" : *x$index"""

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -38,7 +38,7 @@ match (
           @(_, ListOps) <- ListOpsCh) {
         stdlog!("info", {"posRevAddress":posRevAddress}) |
 
-        @RevVault!("findOrCreateGenesisVault", posRevAddress, 10000, *posVaultCh) |
+        @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
         for(@(true, posVault) <- posVaultCh) {
           @RhoSpec!("testSuite", *setup,
             [
@@ -59,13 +59,13 @@ match (
             retCh!({})
           } |
 
-          contract prepareUser(@pk, @vaultAmount, retCh) = {
+          contract prepareUser(@pk, retCh) = {
             stdlog!("info", ("preparing user ", pk)) |
             new setDeployData(`rho:test:deploy:set`), identitySet, revAddrCh, vaultCh in {
               setDeployData!("userId", pk.hexToBytes(), *identitySet) |
               revAddressOps!("fromPublicKey", pk.hexToBytes(), *revAddrCh) |
               for (_ <- identitySet; @revAddress <- revAddrCh) {
-                @RevVault!("findOrCreateGenesisVault", revAddress, vaultAmount, *vaultCh) |
+                @RevVault!("findOrCreate", revAddress, *vaultCh) |
                 for (@(true, vault) <- vaultCh) {
                   retCh!(pk.hexToBytes(), revAddress, vault)
                 }
@@ -109,11 +109,12 @@ match (
               }
             }
           } |
+
           contract test_bonding_succeeds(rhoSpec, _, ackCh) = {
             new setupCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
                 initialUserBalanceCh, finalUserBalanceCh,
                 bondsCh, rewardsCh in {
-              prepareUser!("1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111", 10000, *setupCh) |
+              prepareUser!("1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111", *setupCh) |
               for (@user1PubKey, _, @user1Vault <- setupCh) {
                 @posVault!("balance", *initialPosBalanceCh) |
                 @user1Vault!("balance", *initialUserBalanceCh) |
@@ -148,6 +149,7 @@ match (
               }
             }
           } |
+
           contract test_withdraw_succeeds(rhoSpec, _, ackCh) = {
             new setupCh, retCh,
                 initialPosBalanceCh, finalPosBalanceCh,
@@ -155,7 +157,7 @@ match (
                 initialRewardsCh, finalRewardsCh,
                 initialBondsCh, finalBondsCh,
                 withdrawCh, closeBlockCh in {
-              prepareUser!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 10000, *setupCh) |
+              prepareUser!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", *setupCh) |
               for (@user1PubKey, _, @user1Vault <- setupCh) {
                 @posVault!("balance", *initialPosBalanceCh) |
                 @user1Vault!("balance", *initialUserBalanceCh) |
@@ -203,7 +205,7 @@ match (
                 initialBondsCh, finalBondsCh,
                 withdrawCh, closeBlockCh,
                 setDeployData(`rho:test:deploy:set`), identitySet in {
-              prepareUser!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 10000, *setupCh) |
+              prepareUser!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", *setupCh) |
               for (@validatorPubKey, _, @validatorVault <- setupCh) {
                 @validatorVault!("balance", *initialValidatorBalanceCh) |
                 @PoS!("getBonds", *initialBondsCh) |
@@ -213,7 +215,7 @@ match (
                   for ( @(true, _) <- retCh) {
                     @PoS!("closeBlock", *closeBlockCh) |
                     for (_ <- closeBlockCh) {
-                      prepareUser!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", 10000, *setupCh) |
+                      prepareUser!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", *setupCh) |
                       for (@userPubKey, _, @userVault <- setupCh) {
                         @PoS!("pay", 100, *retCh) |
                         for ( @(true, _) <- retCh) {
@@ -253,7 +255,7 @@ match (
             new setupCh, retCh, initialPosBalanceCh, finalPosBalanceCh,
                 initialUser1BalanceCh, finalUser1BalanceCh,
                 initialUser2BalanceCh, finalUser2BalanceCh in {
-              prepareUser!("2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222", 10000, *setupCh) |
+              prepareUser!("2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222", *setupCh) |
               for (@user1PubKey, _, @user1Vault <- setupCh) {
                 @posVault!("balance", *initialPosBalanceCh) |
                 @user1Vault!("balance", *initialUser1BalanceCh) |
@@ -262,7 +264,7 @@ match (
                   @PoS!("bond", 100, *retCh) |
                   for ( @(true, _) <- retCh) {
                     stdlog!("info", "first bond") |
-                    prepareUser!("3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", 10000, *setupCh) |
+                    prepareUser!("3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", *setupCh) |
                     for(@user2PubKey, _, @user2Vault <- setupCh) {
                       @user2Vault!("balance", *initialUser2BalanceCh) |
                       for (@initialUser2Balance <- initialUser2BalanceCh) {
@@ -308,12 +310,12 @@ match (
                 computeDelta, deltaRewardsCh, deltaSumCh, sumDelta,
                 isPositive, allRewardsPositiveCh
             in {
-              prepareUser!("4444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444", 10000, *setupCh) |
+              prepareUser!("4444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444", *setupCh) |
               for (@validatorPubKey, _, _ <- setupCh) {
                 @PoS!("bond", 100, *setupCh) |
                 for (@(true, _) <- setupCh) {
                   @PoS!("closeBlock", *closeBlockCh) |
-                  prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", 10000, *setupCh) |
+                  prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", *setupCh) |
                   for (@user1PubKey, _, @user1Vault <- setupCh;
                        _ <- closeBlockCh) {
                     @posVault!("balance", *initialPosBalanceCh) |
@@ -368,17 +370,17 @@ match (
           } |
 
           contract test_bonding_fails_if_deposit_fails(rhoSpec, _, ackCh) = {
-            test_bonding_failure!(*rhoSpec, "6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666", 10000, 20000, "Bond deposit failed: Insufficient funds", *ackCh)
+            test_bonding_failure!(*rhoSpec, "6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666", 20000, "Bond deposit failed: Insufficient funds", *ackCh)
           } |
 
           contract test_bonding_fails_if_bond_too_small(rhoSpec, _, ackCh) = {
-            test_bonding_failure!(*rhoSpec, "7777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777", 10000, -1, "Bond is less than minimum!", *ackCh)
+            test_bonding_failure!(*rhoSpec, "7777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777", -1, "Bond is less than minimum!", *ackCh)
           } |
 
           contract test_bonding_fails_if_already_bonded(rhoSpec, _, ackCh) = {
             new setupCh, initialBondsCh, bond1Ch, bond2Ch, bondsCh,
                 finalRewardsCh, initialRewardsCh in {
-              prepareUser!("8888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888", 10000, *setupCh) |
+              prepareUser!("8888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888", *setupCh) |
               for (@user1PubKey, _, _ <- setupCh) {
                 @PoS!("bond", 150, *bond1Ch) |
                 for ( @(result1, _) <- bond1Ch) {
@@ -407,11 +409,10 @@ match (
             }
           } |
 
-
-          contract test_bonding_failure(rhoSpec, @pk, @vaultAmount, @transferAmount, @expectedMsg, ackCh) = {
+          contract test_bonding_failure(rhoSpec, @pk, @transferAmount, @expectedMsg, ackCh) = {
             new setupCh, retCh, bondsCh,
                 finalRewardsCh, initialRewardsCh in {
-              prepareUser!(pk, vaultAmount, *setupCh) |
+              prepareUser!(pk, *setupCh) |
               for (_, _, _ <- setupCh) {
                 @PoS!("getBonds", *bondsCh) |
                 @PoS!("getRewards", *initialRewardsCh) |
@@ -441,11 +442,11 @@ match (
             new setupCh, closeBlockCh, retCh,
                 finalRewardsCh
             in {
-              prepareUser!("9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 10000, *setupCh) |
+              prepareUser!("9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", *setupCh) |
               for (@validatorPubKey, _, _ <- setupCh) {
                 @PoS!("bond", 100, *setupCh) |
                 for (@(true, _) <- setupCh) {
-                  prepareUser!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", 10000, *setupCh) |
+                  prepareUser!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", *setupCh) |
                   for (@user1PubKey, _, @user1Vault <- setupCh) {
                     @PoS!("pay", 100, *retCh) |
                     for ( @(true, _) <- retCh) {

--- a/casper/src/test/resources/RevAddressTest.rho
+++ b/casper/src/test/resources/RevAddressTest.rho
@@ -5,7 +5,14 @@ new
   rl(`rho:registry:lookup`), RhoSpecCh,
   revAddress(`rho:rev:address`),
   stdlog(`rho:io:stdlog`),
-  test_valid_address, test_invalid_address, test_fromPublicKey, test_fromPublicKey_invalid, test_fromUnforgeable, test_fromUnforgeable_invalid
+  test_valid_address,
+  test_invalid_address,
+  test_fromPublicKey,
+  test_fromPublicKey_invalid,
+  test_fromUnforgeable,
+  test_fromUnforgeable_invalid,
+  test_fromDeployerId,
+  test_fromDeployerId_invalid
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
@@ -17,6 +24,8 @@ in {
         ("Reject an invalid public key", *test_fromPublicKey_invalid),
         ("RevAddresses derived from different unforgeable names should be different", *test_fromUnforgeable),
         ("Reject arguments which are not unforgeable names", *test_fromUnforgeable_invalid),
+        ("Get deployer's rev address", *test_fromDeployerId),
+        ("Reject arguments which are not deployerId-s", *test_fromDeployerId_invalid)
 ])
   } |
 
@@ -77,6 +86,20 @@ in {
   contract test_fromUnforgeable_invalid(rhoSpec, _, ackCh) = {
     new retCh in {
       revAddress!("fromUnforgeable", 42, *retCh) |
+      rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
+    }
+  } |
+
+  contract test_fromDeployerId(rhoSpec, _, ackCh) = {
+    new deployerId(`rho:rchain:deployerId`), retCh in {
+      revAddress!("fromDeployerId", *deployerId, *retCh) |
+      rhoSpec!("assert", ("11112VYAt8rUGNRRZX3eJdgagaAhtWTK8Js7F7X5iqddMVqyDTtYau", "== <-", *retCh), "correct RevAddress", *ackCh)
+    }
+  } |
+
+  contract test_fromDeployerId_invalid(rhoSpec, _, ackCh) = {
+    new retCh in {
+      revAddress!("fromDeployerId", 42, *retCh) |
       rhoSpec!("assert", (Nil, "== <-", *retCh), "correct RevAddress", *ackCh)
     }
   }

--- a/casper/src/test/resources/RevVaultTest.rho
+++ b/casper/src/test/resources/RevVaultTest.rho
@@ -1,7 +1,7 @@
 // Match a list of known valid publicKey -> RevAddress pairs to bind them to veriables
 match (
-    "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".hexToBytes(),
-    "1111WPpi6SB8FpNMtC9drZg3R8T1fH2BVyT52xPUXBbdKDfmskG1r",
+    "04f700a417754b775d95421973bdbdadb2d23c8a5af46f1829b1431f5c136e549e8a0d61aa0c793f1a614f8e437711c7758473c6ceb0859ac7e9e07911ca66b5c4".hexToBytes(),
+    "11112VYAt8rUGNRRZX3eJdgagaAhtWTK8Js7F7X5iqddMVqyDTtYau",
     "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111".hexToBytes(),
     "1111pdZDG4MZ3eBfaipaD22VXmbFY6PW9ZdGDWdEcXZz4gGxTxgn9",
     "2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222".hexToBytes(),
@@ -9,11 +9,11 @@ match (
 ) {
   (
     genesisPubKey,
-    genesisRevAddress,
+    genesisRevAddress, // the rev address of a vault instantiated at genesis
     alicePubKey,
-    aliceRevAddress,
+    aliceRevAddress, // the rev address of a vault constructed post-genesis
     bobPubKey,
-    bobRevAddress
+    bobRevAddress // the rev address of a vault constructed post-genesis
   ) => {
 
     new
@@ -55,9 +55,6 @@ match (
             ("Fail the transfer if there are insufficient funds", *testInsufficeintFunds),
             ("Fail the transfer if the destination addresss is not a valid RevAddress", *testInvalidRevAddress),
             ("Transfer from unforgeable name bound vault", *testUnfBoundVault),
-            ("Transfer to genesis-created vault", *testDepositToGenesisCreatedVault),
-            ("Check balance of genesis-created vault", *testBalanceInGenesisCreatedVault),
-            ("Transfer from genesis-created vault", *testTransferInGenesisCreatedVault),
           ])
       } |
 
@@ -73,11 +70,11 @@ match (
 
       contract testFindOrCreateGenesisVault(rhoSpec, RevVault, ackCh) = {
         new genesisVaultCh, balanceCh in {
-          RevVault!("findOrCreateGenesisVault", genesisRevAddress, 9000, *genesisVaultCh) |
+          RevVault!("findOrCreate", genesisRevAddress, *genesisVaultCh) |
           for (@(true, genesisVault) <- genesisVaultCh) {
             // so far, access to genesisVault is not secured. This will be changd.
             @genesisVault!("balance", *balanceCh) |
-            rhoSpec!("assert", (9000, "== <-", *balanceCh), "balance is as expected", *ackCh)
+            rhoSpec!("assert", (9000000, "== <-", *balanceCh), "balance is as expected", *ackCh)
           }
         }
       } |
@@ -115,10 +112,10 @@ match (
         new genesisVaultCh, aliceVaultCh, ret, retOk  in {
           withVaultAndIdentityOf!(genesisPubKey, *genesisVaultCh) |
           RevVault!("findOrCreate", aliceRevAddress, *aliceVaultCh) |
-          for (genesisVault, @genesisVaultKey <- genesisVaultCh; @aliceVault <- aliceVaultCh) {
+          for (genesisVault, @genesisVaultKey <- genesisVaultCh; @(true, aliceVault) <- aliceVaultCh) {
             genesisVault!("transfer", aliceRevAddress, 1000, genesisVaultKey, *ret) |
             rhoSpec!("assert", ((true, Nil), "== <-", *ret), "transfer successful", *ackCh) |
-            assertBalances!(*retOk, [(*genesisVault, 8000), (aliceVault, 1000)], *rhoSpec, *ackCh)
+            assertBalances!(*retOk, [(*genesisVault, 8999000), (aliceVault, 1000)], *rhoSpec, *ackCh)
           }
         }
       } |
@@ -126,11 +123,11 @@ match (
       contract testFindOrCreate(rhoSpec, RevVault, ackCh) = {
         new genesisVaultCh, aliceVaultCh, now in {
           //the below attempts to create a wallet are going to fetch the ones created in previous tests.
-          RevVault!("findOrCreateGenesisVault", genesisRevAddress, 0 /* irrelevant */, *genesisVaultCh) |
+          RevVault!("findOrCreate", genesisRevAddress, *genesisVaultCh) |
           RevVault!("findOrCreate", aliceRevAddress, *aliceVaultCh) |
           for (@(true, g) <- genesisVaultCh; @(true, a) <- aliceVaultCh) {
             now!(Nil) |
-            assertBalances!(*now, [(g, 8000), (a, 1000)], *rhoSpec, *ackCh)
+            assertBalances!(*now, [(g, 8999000), (a, 1000)], *rhoSpec, *ackCh)
           }
         }
       } |
@@ -187,60 +184,11 @@ match (
         new unf, RevAddress(`rho:rev:address`), revAddrCh, unfAuthKeyCh, vaultCh, transferCh in {
           RevAddress!("fromUnforgeable", *unf, *revAddrCh) |
           for (@unfRevAddress <- revAddrCh) {
-
             RevVault!("findOrCreate", unfRevAddress, *vaultCh) |
             RevVault!("unforgeableAuthKey", *unf, *unfAuthKeyCh) |
             for (@(true, vault) <- vaultCh; unfAuthKey <- unfAuthKeyCh) {
               @vault!("transfer", genesisRevAddress, 0, *unfAuthKey, *transferCh) |
               rhoSpec!("assert", ((true, Nil), "== <-", *transferCh), "transfer succeeded", *ackCh)
-            }
-          }
-        }
-      } |
-
-      contract testDepositToGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
-        new
-          deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`),
-          balanceCh, aliceVaultCh, addr, ret, resOk
-        in {
-          withVaultAndIdentityOf!(alicePubKey, *aliceVaultCh) |
-          RevAddress!("fromDeployerId", *deployerId, *addr) |
-          for (aliceVault, @aliceVaultKey <- aliceVaultCh; @deployerRevAddress <- addr) {
-            aliceVault!("transfer", deployerRevAddress, 100, aliceVaultKey, *ret) |
-            // The transfer will not succeed unless the vault has been created already
-            rhoSpec!("assert", ((true, Nil), "== <-", *ret), "transfer succeeded", *resOk) |
-            assertBalances!(*resOk, [(*aliceVault, 900)], *rhoSpec, *ackCh)
-          }
-        }
-      } |
-
-      contract testBalanceInGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
-        new deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`), vaultCh, addr, now in {
-          RevAddress!("fromDeployerId", *deployerId, *addr) |
-          for (@deployerRevAddress <- addr) {
-            RevVault!("findOrCreate", deployerRevAddress, *vaultCh) |
-            for (@(true, vault) <- vaultCh) {
-              now!(Nil) |
-              assertBalances!(*now, [(vault, 9000100)], *rhoSpec, *ackCh)
-            }
-          }
-        }
-      } |
-
-      contract testTransferInGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
-        new 
-          deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`),
-          aliceVaultCh, addr, vaultCh, authKeyCh, ret, transferOk
-        in {
-          withVaultAndIdentityOf!(alicePubKey, *aliceVaultCh) |
-          RevAddress!("fromDeployerId", *deployerId, *addr) |
-          for (aliceVault, @aliceVaultKey <- aliceVaultCh; @deployerRevAddress <- addr) {
-            RevVault!("findOrCreate", deployerRevAddress, *vaultCh) |
-            RevVault!("deployerAuthKey", *deployerId, *authKeyCh) |
-            for (@(true, vault) <- vaultCh; authKey <- authKeyCh) {
-              @vault!("transfer", aliceRevAddress, 100, *authKey, *ret) |
-              rhoSpec!("assert", ((true, Nil), "== <-", *ret), "transfer succeeded", *transferOk) |
-              assertBalances!(*transferOk, [(vault, 9000000), (*aliceVault, 1000)], *rhoSpec, *ackCh)
             }
           }
         }

--- a/casper/src/test/resources/RevVaultTest.rho
+++ b/casper/src/test/resources/RevVaultTest.rho
@@ -25,6 +25,9 @@ match (
       getDeployerId(`rho:test:deployerId:get`),
       setup,
       testFindOrCreateGenesisVault,
+      testDepositToGenesisCreatedVault,
+      testBalanceInGenesisCreatedVault,
+      testTransferInGenesisCreatedVault,
       testCreateVaultFail,
       testCreateVault,
       testTransfer,
@@ -52,6 +55,9 @@ match (
             ("Fail the transfer if there are insufficient funds", *testInsufficeintFunds),
             ("Fail the transfer if the destination addresss is not a valid RevAddress", *testInvalidRevAddress),
             ("Transfer from unforgeable name bound vault", *testUnfBoundVault),
+            ("Transfer to genesis-created vault", *testDepositToGenesisCreatedVault),
+            ("Check balance of genesis-created vault", *testBalanceInGenesisCreatedVault),
+            ("Transfer from genesis-created vault", *testTransferInGenesisCreatedVault),
           ])
       } |
 
@@ -187,6 +193,54 @@ match (
             for (@(true, vault) <- vaultCh; unfAuthKey <- unfAuthKeyCh) {
               @vault!("transfer", genesisRevAddress, 0, *unfAuthKey, *transferCh) |
               rhoSpec!("assert", ((true, Nil), "== <-", *transferCh), "transfer succeeded", *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract testDepositToGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
+        new
+          deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`),
+          balanceCh, aliceVaultCh, addr, ret, resOk
+        in {
+          withVaultAndIdentityOf!(alicePubKey, *aliceVaultCh) |
+          RevAddress!("fromDeployerId", *deployerId, *addr) |
+          for (aliceVault, @aliceVaultKey <- aliceVaultCh; @deployerRevAddress <- addr) {
+            aliceVault!("transfer", deployerRevAddress, 100, aliceVaultKey, *ret) |
+            // The transfer will not succeed unless the vault has been created already
+            rhoSpec!("assert", ((true, Nil), "== <-", *ret), "transfer succeeded", *resOk) |
+            assertBalances!(*resOk, [(*aliceVault, 900)], *rhoSpec, *ackCh)
+          }
+        }
+      } |
+
+      contract testBalanceInGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
+        new deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`), vaultCh, addr, now in {
+          RevAddress!("fromDeployerId", *deployerId, *addr) |
+          for (@deployerRevAddress <- addr) {
+            RevVault!("findOrCreate", deployerRevAddress, *vaultCh) |
+            for (@(true, vault) <- vaultCh) {
+              now!(Nil) |
+              assertBalances!(*now, [(vault, 9000100)], *rhoSpec, *ackCh)
+            }
+          }
+        }
+      } |
+
+      contract testTransferInGenesisCreatedVault(rhoSpec, RevVault, ackCh) = {
+        new 
+          deployerId(`rho:rchain:deployerId`), RevAddress(`rho:rev:address`),
+          aliceVaultCh, addr, vaultCh, authKeyCh, ret, transferOk
+        in {
+          withVaultAndIdentityOf!(alicePubKey, *aliceVaultCh) |
+          RevAddress!("fromDeployerId", *deployerId, *addr) |
+          for (aliceVault, @aliceVaultKey <- aliceVaultCh; @deployerRevAddress <- addr) {
+            RevVault!("findOrCreate", deployerRevAddress, *vaultCh) |
+            RevVault!("deployerAuthKey", *deployerId, *authKeyCh) |
+            for (@(true, vault) <- vaultCh; authKey <- authKeyCh) {
+              @vault!("transfer", aliceRevAddress, 100, *authKey, *ret) |
+              rhoSpec!("assert", ((true, Nil), "== <-", *ret), "transfer succeeded", *transferOk) |
+              assertBalances!(*transferOk, [(vault, 9000000), (*aliceVault, 1000)], *rhoSpec, *ackCh)
             }
           }
         }

--- a/casper/src/test/resources/logback-test.xml
+++ b/casper/src/test/resources/logback-test.xml
@@ -11,6 +11,7 @@
 
     <!--This is needed for RhoSpec tests output-->
     <logger name="coop.rchain.casper.helper.RhoLoggerContract" level="info"/>
+    <logger name="coop.rchain.blockstorage.BlockDagFileStorage" level="error"/>
 
     <root level="warn">
         <appender-ref ref="STDOUT"/>

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -1,6 +1,8 @@
 package coop.rchain.casper.engine
 
+import cats.Traverse
 import cats.implicits._
+import coop.rchain.casper.genesis.contracts.Vault
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.protocol._
@@ -9,6 +11,7 @@ import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.casper.util.comm.TestNetwork
 import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.transport
+import coop.rchain.rholang.interpreter.util.RevAddress
 import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -87,7 +90,12 @@ object BlockApproverProtocolTest {
       (new BlockApproverProtocol(
         node.validatorId,
         genesisParams.timestamp,
-        Seq(),
+        Traverse[List]
+          .traverse(genesisParams.proofOfStake.validators.map(_.pk).toList)(
+            RevAddress.fromPublicKey
+          )
+          .get
+          .map(Vault(_, 0L)),
         genesisParams.proofOfStake.validators.map(v => v.pk -> v.stake).toMap,
         genesisParams.proofOfStake.minimumBond,
         genesisParams.proofOfStake.maximumBond,

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -87,6 +87,7 @@ object BlockApproverProtocolTest {
       (new BlockApproverProtocol(
         node.validatorId,
         genesisParams.timestamp,
+        Seq(),
         genesisParams.proofOfStake.validators.map(v => v.pk -> v.stake).toMap,
         genesisParams.proofOfStake.minimumBond,
         genesisParams.proofOfStake.maximumBond,

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -62,6 +62,7 @@ object Setup {
     val bap = new BlockApproverProtocol(
       validatorId,
       deployTimestamp,
+      Seq(),
       bonds,
       genesisParams.proofOfStake.minimumBond,
       genesisParams.proofOfStake.maximumBond,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -1,10 +1,15 @@
-import coop.rchain.casper.helper.{RhoAssertEquals, RhoAssertTrue, RhoSpec, RhoTestAssertion}
+import coop.rchain.casper.helper.{
+  RhoAssertEquals,
+  RhoAssertTrue,
+  RhoSpec,
+  RhoTestAssertion,
+  TestResult
+}
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.NormalizerEnv
 import org.scalatest.{AppendedClues, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
-import monix.execution.Scheduler.Implicits.global
 
 class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
   def clue(clueMsg: String, attempt: Long) = s"$clueMsg (attempt $attempt)"
@@ -25,17 +30,14 @@ class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matche
         }
     }
 
-  val result =
-    RhoSpec
-      .getResults(
-        CompiledRholangSource("FailingResultCollectorTest.rho", NormalizerEnv.Empty),
-        Seq.empty,
-        10.seconds
-      )
-      .runSyncUnsafe(Duration.Inf)
+  val result: TestResult = new RhoSpec(
+    CompiledRholangSource("FailingResultCollectorTest.rho", NormalizerEnv.Empty),
+    Seq.empty,
+    10.seconds
+  ).result
 
   result.assertions
-    .foreach(mkTest(_))
+    .foreach(mkTest)
 
   it should "complete within timeout" in {
     result.hasFinished should be(true)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -1,13 +1,87 @@
 package coop.rchain.casper.genesis.contracts
 
+import cats.implicits._
 import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.casper.util.GenesisBuilder
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.NormalizerEnv
+import coop.rchain.rholang.interpreter.util.RevAddress
+
 import scala.concurrent.duration._
 
 class PoSSpec
     extends RhoSpec(
       CompiledRholangSource("PoSTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      120.seconds
+      120.seconds,
+      genesisParameters = GenesisBuilder
+        .buildGenesisParameters()
+        .map(genesis => genesis.copy(vaults = genesis.vaults ++ PoSSpec.testVaults))
     )
+
+object PoSSpec {
+
+  def prepareVault(vaultData: (String, Long)): Vault =
+    Vault(RevAddress.fromPublicKey(PublicKey(Base16.decode(vaultData._1).get)).get, vaultData._2)
+
+  val testVaults: Seq[Vault] = Seq(
+    (
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      10000L
+    ),
+    (
+      "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+      10000L
+    ),
+    (
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      10000L
+    ),
+    (
+      "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      10000L
+    ),
+    (
+      "2222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+      10000L
+    ),
+    (
+      "3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+      10000L
+    ),
+    (
+      "4444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+      10000L
+    ),
+    (
+      "5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555",
+      10000L
+    ),
+    (
+      "6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666",
+      10000L
+    ),
+    (
+      "7777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777777",
+      10000L
+    ),
+    (
+      "8888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888888",
+      10000L
+    ),
+    (
+      "9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+      10000L
+    ),
+    (
+      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      10000L
+    ),
+    (
+      "047b43d6548b72813b89ac1b9f9ca67624a8b372feedd71d4e2da036384a3e1236812227e524e6f237cde5f80dbb921cac12e6500791e9a9ed1254a745a816fe1f",
+      10000L
+    )
+  ).map(prepareVault)
+}

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevAddressSpec.scala
@@ -1,11 +1,18 @@
 package coop.rchain.casper.genesis.contracts
+import cats.implicits._
 import coop.rchain.casper.helper.RhoSpec
+import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class RevAddressSpec
     extends RhoSpec(
-      CompiledRholangSource("RevAddressTest.rho", NormalizerEnv.Empty),
+      CompiledRholangSource("RevAddressTest.rho", RevAddressSpec.normalizerEnv),
       Seq.empty,
       GENESIS_TEST_TIMEOUT
     )
+
+object RevAddressSpec {
+  val deployerPk    = ConstructDeploy.defaultPub
+  val normalizerEnv = NormalizerEnv(none, deployerPk.some)
+}

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevVaultSpec.scala
@@ -2,9 +2,9 @@ package coop.rchain.casper.genesis.contracts
 
 import cats.implicits._
 import coop.rchain.casper.helper.RhoSpec
-import coop.rchain.crypto.PublicKey
-import coop.rchain.crypto.codec.Base16
+import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.rholang.build.CompiledRholangSource
+
 import coop.rchain.rholang.interpreter.NormalizerEnv
 
 class RevVaultSpec
@@ -15,10 +15,6 @@ class RevVaultSpec
     )
 
 object RevVaultSpec {
-  val genesisPk = PublicKey(
-    Base16.unsafeDecode(
-      "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-    )
-  )
-  val normalizerEnv = NormalizerEnv(none, genesisPk.some)
+  val deployerPk    = ConstructDeploy.defaultPub
+  val normalizerEnv = NormalizerEnv(none, deployerPk.some)
 }

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
@@ -9,13 +9,10 @@ import monix.execution.Scheduler.Implicits.global
 
 class TimeoutResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
   it should "testFinished should be false if execution hasn't finished within timeout" in {
-    RhoSpec
-      .getResults(
-        CompiledRholangSource("TimeoutResultCollectorTest.rho", NormalizerEnv.Empty),
-        Seq.empty,
-        10.seconds
-      )
-      .runSyncUnsafe(Duration.Inf)
-      .hasFinished should be(false)
+    new RhoSpec(
+      CompiledRholangSource("TimeoutResultCollectorTest.rho", NormalizerEnv.Empty),
+      Seq.empty,
+      10.seconds
+    ).result.hasFinished should be(false)
   }
 }

--- a/integration-tests/test/test_propose.py
+++ b/integration-tests/test/test_propose.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 from random import Random
+import pytest
+
 from rchain.crypto import PrivateKey
 from .rnode import (
     Node,
@@ -26,6 +28,7 @@ FIX_COST_RHO_CONTRACTS = {
     # "contract_5.rho": 1970,  # it is non-deterministic now
 }
 
+@pytest.mark.skip(reason="Skipped because of non-deterministic failures")
 def test_propose_cost(started_standalone_bootstrap_node: Node, random_generator: Random) -> None:
     rho_contract, contract_cost = random_generator.choice(list(FIX_COST_RHO_CONTRACTS.items()))
     shutil.copyfile(os.path.join('resources/cost', rho_contract), os.path.join(started_standalone_bootstrap_node.local_deploy_dir, rho_contract))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -264,7 +264,7 @@ object Runtime {
       FixedChannels.REV_ADDRESS,
       3,
       BodyRefs.REV_ADDRESS, { ctx =>
-        ctx.systemProcesses.validateRevAddress
+        ctx.systemProcesses.revAddress
       }
     ),
     SystemProcess.Definition[F](

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -34,7 +34,7 @@ trait SystemProcesses[F[_]] {
   def getDeployParams(runtimeParametersRef: Ref[F, DeployParameters]): Contract[F]
   def getBlockData(blockData: Ref[F, BlockData]): Contract[F]
   def invalidBlocks(invalidBlocks: InvalidBlocks[F]): Contract[F]
-  def validateRevAddress: Contract[F]
+  def revAddress: Contract[F]
   def deployerIdOps: Contract[F]
 }
 
@@ -134,7 +134,7 @@ object SystemProcesses {
           } yield ()
       }
 
-      def validateRevAddress: Contract[F] = {
+      def revAddress: Contract[F] = {
         case isContractCall(
             produce,
             Seq(RhoType.String("validate"), RhoType.String(address), ack)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -163,6 +163,18 @@ object SystemProcesses {
 
         case isContractCall(
             produce,
+            Seq(RhoType.String("fromDeployerId"), RhoType.DeployerId(id), ack)
+            ) =>
+          val response =
+            RevAddress
+              .fromDeployerId(id)
+              .map(ra => RhoType.String(ra.toBase58))
+              .getOrElse(Par())
+
+          produce(Seq(response), ack)
+
+        case isContractCall(
+            produce,
             Seq(RhoType.String("fromUnforgeable"), argument, ack)
             ) =>
           val response = argument match {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -149,6 +149,9 @@ object SystemProcesses {
 
           produce(Seq(errorMessage), ack)
 
+        case isContractCall(produce, Seq(RhoType.String("validate"), _, ack)) =>
+          produce(Seq(Par()), ack)
+
         case isContractCall(
             produce,
             Seq(RhoType.String("fromPublicKey"), RhoType.ByteArray(publicKey), ack)
@@ -160,6 +163,9 @@ object SystemProcesses {
               .getOrElse(Par())
 
           produce(Seq(response), ack)
+
+        case isContractCall(produce, Seq(RhoType.String("fromPublicKey"), _, ack)) =>
+          produce(Seq(Par()), ack)
 
         case isContractCall(
             produce,
@@ -173,6 +179,9 @@ object SystemProcesses {
 
           produce(Seq(response), ack)
 
+        case isContractCall(produce, Seq(RhoType.String("fromDeployerId"), _, ack)) =>
+          produce(Seq(Par()), ack)
+
         case isContractCall(
             produce,
             Seq(RhoType.String("fromUnforgeable"), argument, ack)
@@ -184,6 +193,9 @@ object SystemProcesses {
           }
 
           produce(Seq(response), ack)
+
+        case isContractCall(produce, Seq(RhoType.String("fromUnforgeable"), _, ack)) =>
+          produce(Seq(Par()), ack)
       }
 
       def deployerIdOps: Contract[F] = {
@@ -192,6 +204,9 @@ object SystemProcesses {
             Seq(RhoType.String("pubKeyBytes"), RhoType.DeployerId(publicKey), ack)
             ) =>
           produce(Seq(RhoType.ByteArray(publicKey)), ack)
+
+        case isContractCall(produce, Seq(RhoType.String("pubKeyBytes"), _, ack)) =>
+          produce(Seq(Par()), ack)
       }
 
       def secp256k1Verify: Contract[F] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/util/RevAddress.scala
@@ -16,6 +16,9 @@ object RevAddress {
 
   private val tools = new AddressTools(prefix, keyLength = Validator.Length, checksumLength = 4)
 
+  def fromDeployerId(deployerId: Array[Byte]): Option[RevAddress] =
+    fromPublicKey(PublicKey(deployerId))
+
   def fromPublicKey(pk: PublicKey): Option[RevAddress] =
     tools.fromPublicKey(pk).map(RevAddress(_))
 


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>

This allows us to actually attempt a genesis ceremony with vaults based on a wallets.txt file. It also contains some refactorings in rholang code allowing for the genesis vaults to be created without validation logic, and for it to run faster.

Running:

`%rnode java invocation% run -s --wallets-file wallets.txt`

**Make sure to `rm -rf ~/.rnode` before each run**, or else you won't be running as if in an actual genesis ceremony.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
