### PR TITLE
In-memory block store cache

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/CachingBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/CachingBlockStore.scala
@@ -1,0 +1,66 @@
+package coop.rchain.blockstorage
+
+import cats.effect.Sync
+import cats.implicits._
+import com.google.common.cache.{Cache, CacheBuilder}
+import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+
+class CachingBlockStore[F[_]: Sync: Metrics] private (
+    underlying: BlockStore[F],
+    cache: Cache[BlockHash, BlockMessage]
+) extends BlockStore[F] {
+  implicit private val ms = Metrics.Source(BlockStorageMetricsSource, "caching-block-storage")
+
+  override def get(blockHash: BlockHash): F[Option[BlockMessage]] =
+    Sync[F].delay(Option(cache.getIfPresent(blockHash))) >>= {
+      case Some(blockMessage) =>
+        Metrics[F].incrementCounter("get-hit") >> blockMessage.some.pure[F]
+      case None =>
+        for {
+          _               <- Metrics[F].incrementCounter("get-miss")
+          blockMessageOpt <- underlying.get(blockHash)
+          _               <- blockMessageOpt.traverse_(b => Sync[F].delay(cache.put(blockHash, b)))
+        } yield blockMessageOpt
+    }
+
+  override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]] =
+    underlying.find(p)
+
+  override def put(f: => (BlockHash, BlockMessage)): F[Unit] = {
+    val (blockHash, blockMessage) = f
+    Sync[F].delay(cache.put(blockHash, blockMessage)) >> underlying.put(f)
+  }
+
+  override def getApprovedBlock: F[Option[ApprovedBlock]] =
+    underlying.getApprovedBlock
+
+  override def putApprovedBlock(block: ApprovedBlock): F[Unit] =
+    underlying.putApprovedBlock(block)
+
+  override def checkpoint(): F[Unit] =
+    underlying.checkpoint()
+
+  override def clear(): F[Unit] =
+    Sync[F].delay(cache.invalidateAll()) >> underlying.clear()
+
+  override def close(): F[Unit] =
+    underlying.close()
+}
+
+object CachingBlockStore {
+  def apply[F[_]: Sync: Metrics](
+      underlying: BlockStore[F],
+      maxSize: Long
+  ): F[BlockStore[F]] =
+    for {
+      cache <- Sync[F].delay {
+                CacheBuilder
+                  .newBuilder()
+                  .maximumWeight(maxSize)
+                  .weigher[BlockHash, BlockMessage]((_, value) => value.serializedSize)
+                  .build[BlockHash, BlockMessage]()
+              }
+    } yield new CachingBlockStore(underlying, cache)
+}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockStoreTest.scala
@@ -110,7 +110,7 @@ trait BlockStoreTest
   }
 }
 
-class InMemBlockStoreTest extends BlockStoreTest {
+object InMemBlockStoreTest extends BlockStoreTest {
   override def withStore[R](f: BlockStore[Task] => Task[R]): R = {
     val test = for {
       refTask          <- emptyMapRef[Task]
@@ -124,7 +124,7 @@ class InMemBlockStoreTest extends BlockStoreTest {
   }
 }
 
-class FileLMDBIndexBlockStoreTest extends BlockStoreTest {
+object FileLMDBIndexBlockStoreTest extends BlockStoreTest {
   val scheduler = Scheduler.fixedPool("block-storage-test-scheduler", 4)
 
   import java.nio.file.{Files, Path}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/CachingBlockStoreTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/CachingBlockStoreTest.scala
@@ -1,0 +1,105 @@
+package coop.rchain.blockstorage
+
+import cats.effect.concurrent.Ref
+import cats.implicits._
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.blockImplicits._
+import monix.eval.Task
+import org.scalacheck.Gen
+import org.scalatest._
+import org.scalatest.Matchers
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class CachingBlockStoreTest
+    extends WordSpecLike
+    with Matchers
+    with OptionValues
+    with GeneratorDrivenPropertyChecks {
+
+  class CountingMetrics extends Metrics.MetricsNOP[Task] {
+    val counterRef = Ref.unsafe[Task, Map[String, Long]](Map.empty)
+
+    override def incrementCounter(name: String, delta: Long = 1)(
+        implicit ev: Metrics.Source
+    ): Task[Unit] =
+      counterRef.update {
+        _ |+| Map(name -> delta)
+      }
+  }
+
+  case class TestEnvironment(
+      blockStore: BlockStore[Task],
+      cache: BlockStore[Task],
+      metrics: CountingMetrics
+  )
+
+  def withCache(maxSize: Long = 256L * 1024L * 1024L)(f: TestEnvironment => Task[Unit]): Unit = {
+    implicit val metrics = new CountingMetrics()
+
+    FileLMDBIndexBlockStoreTest.withStore { blockStore =>
+      for {
+        cache <- CachingBlockStore(blockStore, maxSize)
+        _     <- f(TestEnvironment(blockStore, cache, metrics))
+      } yield ()
+    }
+  }
+
+  "CachingBlockStore" when {
+    "block is not cached" should {
+      "get it from the underlying storage and cache it" in {
+        forAll(blockElementGen) { block =>
+          withCache() { e =>
+            for {
+              _              <- e.blockStore.put(block)
+              b1             <- e.cache.get(block.blockHash)
+              _              = b1.value shouldBe block
+              b2             <- e.cache.get(block.blockHash)
+              _              = b2.value shouldBe block
+              metricsCounter <- e.metrics.counterRef.get
+              _              = metricsCounter.getOrElse("get-miss", 0) shouldBe 1
+              _              = metricsCounter.getOrElse("get-hit", 0) shouldBe 1
+            } yield ()
+          }
+        }
+      }
+    }
+
+    "block is being added" should {
+      "cache it" in {
+        forAll(blockElementGen) { block =>
+          withCache() { e =>
+            for {
+              _              <- e.cache.put(block)
+              b              <- e.cache.get(block.blockHash)
+              _              = b.value shouldBe block
+              metricsCounter <- e.metrics.counterRef.get
+              _              = metricsCounter.getOrElse("get-miss", 0) shouldBe 0
+              _              = metricsCounter.getOrElse("get-hit", 0) shouldBe 1
+            } yield ()
+          }
+        }
+      }
+
+      "evict least recent used blocks" in {
+        forAll(blockElementsGen, minSize(20), sizeRange(80)) { blocks =>
+          whenever(blocks.size >= 20) {
+            withCache(blocks.take(10).map(_.serializedSize).sum.toLong) { e =>
+              val first :: others = blocks
+              for {
+                _              <- e.cache.put(first)
+                b1             <- e.cache.get(first.blockHash) // Hit
+                _              <- others.traverse_(e.cache.put)
+                _              <- e.cache.get(others.last.blockHash) // Hit
+                b2             <- e.cache.get(first.blockHash) // Miss
+                _              = b1 shouldBe b2
+                metricsCounter <- e.metrics.counterRef.get
+                _              = metricsCounter.getOrElse("get-miss", 0) shouldBe 1
+                _              = metricsCounter.getOrElse("get-hit", 0) shouldBe (1 + 1)
+              } yield ()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -162,6 +162,9 @@ rnode {
 
     # Casper block DAG storage map size (in bytes)
     dag-storage-size = 1G
+
+    # Maximum size of in-memory cache for block store in bytes.
+    block-store-cache-max-size = 512M
   }
 
   influxdb {

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -39,12 +39,6 @@ rnode {
     # Path to data directory
     # data-dir = ${user.home}/.rnode
 
-    # Casper block store map size (in bytes)
-    store-size = 1G
-
-    # Casper block DAG storage map size (in bytes)
-    dag-storage-size = 1G
-
     # Map size (in bytes)
     map-size = 1G
 
@@ -160,6 +154,14 @@ rnode {
 
     # Timestamp for the deploys
     # deploy-timestamp = 0
+  }
+  
+  blockstorage {
+    # Casper block store map size (in bytes)
+    block-store-size = 1G
+
+    # Casper block DAG storage map size (in bytes)
+    dag-storage-size = 1G
   }
 
   influxdb {

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -433,7 +433,7 @@ class NodeRuntime private[node] (
     _             <- mkDirs(conf.server.dataDir)
     _             <- mkDirs(blockstorePath)
     _             <- mkDirs(dagStoragePath)
-    blockstoreEnv = Context.env(blockstorePath, 8L * 1024L * 1024L * 1024L)
+    blockstoreEnv = Context.env(blockstorePath, conf.blockstorage.blockStoreSize)
     blockStore <- FileLMDBIndexBlockStore
                    .create[Task](blockstoreEnv, blockstorePath)(
                      Concurrent[Task],
@@ -452,7 +452,7 @@ class NodeRuntime private[node] (
       invalidBlocksCrcPath = dagStoragePath.resolve("invalidBlocksCrcPath"),
       checkpointsDirPath = dagStoragePath.resolve("checkpointsDirPath"),
       blockNumberIndexPath = dagStoragePath.resolve("blockNumberIndexPath"),
-      mapSize = 8L * 1024L * 1024L * 1024L,
+      mapSize = conf.blockstorage.dagStorageSize,
       latestMessagesLogMaxSizeFactor = 10
     )
     blockDagStorage <- BlockDagFileStorage.create[Task](dagConfig)(

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -441,6 +441,12 @@ class NodeRuntime private[node] (
                      log
                    )
                    .map(_.right.get) // TODO handle errors
+                   .flatMap { underlying =>
+                     CachingBlockStore(underlying, conf.blockstorage.blockStoreCacheMaxSize)(
+                       Sync[Task],
+                       metrics
+                     )
+                   }
     dagConfig = BlockDagFileStorage.Config(
       latestMessagesLogPath = dagStoragePath.resolve("latestMessagesLogPath"),
       latestMessagesCrcPath = dagStoragePath.resolve("latestMessagesCrcPath"),

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -125,30 +125,9 @@ object Configuration {
         customCertificateLocation = customCertificateLocation,
         customKeyLocation = customKeyLocation
       )
-    val kamon   = hocon.Kamon.fromConfig(config)
-    val casper  = hocon.Casper.fromConfig(config)
-    val dataDir = server.dataDir
-    val blockDagStorage = BlockDagFileStorage.Config(
-      dataDir.resolve("casper-block-dag-file-storage-latest-messages-log"),
-      dataDir.resolve("casper-block-dag-file-storage-latest-messages-crc"),
-      dataDir.resolve("casper-block-dag-file-storage-block-metadata-log"),
-      dataDir.resolve("casper-block-dag-file-storage-block-metadata-crc"),
-      dataDir.resolve("casper-block-dag-file-storage-equivocation-tracker-log"),
-      dataDir.resolve("casper-block-dag-file-storage-equivocation-tracker-crc"),
-      dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-log"),
-      dataDir.resolve("casper-block-dag-file-storage-invalid-blocks-crc"),
-      dataDir.resolve("casper-block-dag-file-storage-checkpoints"),
-      dataDir.resolve("casper-block-dag-file-storage-block-number-index"),
-      server.dagStorageSize
-    )
-    val blockStorage =
-      FileLMDBIndexBlockStore.Config(
-        dataDir.resolve("casper-block-store").resolve("storage"),
-        dataDir.resolve("casper-block-store").resolve("index"),
-        dataDir.resolve("casper-block-store").resolve("approved-block"),
-        dataDir.resolve("casper-block-store").resolve("checkpoints"),
-        server.storeSize
-      )
+    val kamon        = hocon.Kamon.fromConfig(config)
+    val casper       = hocon.Casper.fromConfig(config)
+    val blockstorage = hocon.BlockStorage.fromConfig(config)
     val maxMessageSize: Int =
       Math.max(
         MaxMessageSizeMinimumValue,
@@ -191,8 +170,7 @@ object Configuration {
       grpcServer.copy(maxMessageSize = grpcMaxMessageSize),
       tls,
       casper.copy(createGenesis = server.standalone),
-      blockStorage,
-      blockDagStorage,
+      blockstorage,
       kamon
     )
   }
@@ -243,8 +221,7 @@ final case class Configuration(
     grpcServer: GrpcServer,
     tls: Tls,
     casper: CasperConf,
-    blockstorage: FileLMDBIndexBlockStore.Config,
-    blockDagStorage: BlockDagFileStorage.Config,
+    blockstorage: BlockStorage,
     kamon: Kamon,
     printHelpToConsole: () => Unit = () => ()
 ) {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -46,8 +46,6 @@ object ConfigMapper {
         add(keys.Standalone, run.standalone)
         add(keys.Bootstrap, run.bootstrap)
         add(keys.DataDir, run.dataDir)
-        add(keys.StoreSize, run.casperBlockStoreSize)
-        add(keys.DagStorageSize, run.casperBlockDagStorageSize)
         add(keys.MapSize, run.mapSize)
         add(keys.MaxConnections, run.maxNumOfConnections)
         add(keys.AllowPrivateAddresses, run.allowPrivateAddresses)
@@ -74,6 +72,14 @@ object ConfigMapper {
         add(keys.InfluxdbUdp, run.influxdbUdp)
         add(keys.Zipkin, run.zipkin)
         add(keys.Sigar, run.sigar)
+      }
+
+      {
+        import BlockStorage._
+        val add = addToMap(Key)
+
+        add(keys.BlockStoreSize, run.blockstorageBlockStoreSize)
+        add(keys.DagStorageSize, run.blockstorageDagStorageSize)
       }
 
       {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -80,6 +80,7 @@ object ConfigMapper {
 
         add(keys.BlockStoreSize, run.blockstorageBlockStoreSize)
         add(keys.DagStorageSize, run.blockstorageDagStorageSize)
+        add(keys.BlockStoreCacheMaxSize, run.blockstorageBlockStoreCacheMaxSize)
       }
 
       {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -281,17 +281,11 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val threadPoolSize =
       opt[Int](descr = "Maximum number of threads used by rnode", hidden = true)
 
-    val casperBlockStoreSize =
+    val blockstorageBlockStoreSize =
       opt[Long](required = false, descr = "Casper BlockStore map size (in bytes)")
 
-    val casperBlockDagStorageSize =
+    val blockstorageDagStorageSize =
       opt[Long](required = false, descr = "Casper BlockDagStorage map size (in bytes)")
-
-    val casperLatestMessagesDataPath =
-      opt[Path](required = false, descr = "Path to latest messages data file")
-
-    val casperLatestMessagesCrcPath =
-      opt[Path](required = false, descr = "Path to latest messages crc file")
 
     val validatorPublicKey = opt[String](
       descr = "Base16 encoding of the public key to use for signing a proposed blocks. " +

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -287,6 +287,12 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val blockstorageDagStorageSize =
       opt[Long](required = false, descr = "Casper BlockDagStorage map size (in bytes)")
 
+    val blockstorageBlockStoreCacheMaxSize =
+      opt[Long](
+        required = false,
+        descr = "Maximum size of in-memory cache for block store in bytes."
+      )
+
     val validatorPublicKey = opt[String](
       descr = "Base16 encoding of the public key to use for signing a proposed blocks. " +
         "Can be inferred from the private key for some signature algorithms."

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -221,8 +221,9 @@ object BlockStorage {
   val Keys: List[String] = keys.all.map(k => s"$Key.$k")
 
   object keys {
-    val BlockStoreSize = "block-store-size"
-    val DagStorageSize = "dag-storage-size"
+    val BlockStoreSize         = "block-store-size"
+    val DagStorageSize         = "dag-storage-size"
+    val BlockStoreCacheMaxSize = "block-store-cache-max-size"
 
     val all =
       List(
@@ -236,7 +237,8 @@ object BlockStorage {
 
     configuration.BlockStorage(
       blockStoreSize = blockStorage.getBytes(keys.BlockStoreSize),
-      dagStorageSize = blockStorage.getBytes(keys.DagStorageSize)
+      dagStorageSize = blockStorage.getBytes(keys.DagStorageSize),
+      blockStoreCacheMaxSize = blockStorage.getBytes(keys.BlockStoreCacheMaxSize)
     )
   }
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -47,8 +47,6 @@ object Server {
     val SendTimeout             = "send-timeout"
     val Standalone              = "standalone"
     val DataDir                 = "data-dir"
-    val StoreSize               = "store-size"
-    val DagStorageSize          = "dag-storage-size"
     val MapSize                 = "map-size"
     val MaxConnections          = "max-connections"
     val AllowPrivateAddresses   = "allow-private-addresses"
@@ -72,8 +70,6 @@ object Server {
         SendTimeout,
         Standalone,
         DataDir,
-        StoreSize,
-        DagStorageSize,
         MapSize,
         MaxConnections,
         AllowPrivateAddresses,
@@ -111,8 +107,6 @@ object Server {
       standalone = server.getBoolean(keys.Standalone),
       bootstrap = bootstrap,
       dataDir = server.getPath(keys.DataDir),
-      storeSize = server.getBytes(keys.StoreSize),
-      dagStorageSize = server.getBytes(keys.DagStorageSize),
       mapSize = server.getBytes(keys.MapSize),
       maxNumOfConnections = server.getInt(keys.MaxConnections),
       allowPrivateAddresses = server.getBoolean(keys.AllowPrivateAddresses),
@@ -218,6 +212,31 @@ object GrpcServer {
       portExternal = grpc.getInt(keys.PortExternal),
       portInternal = grpc.getInt(keys.PortInternal),
       maxMessageSize = grpc.getBytes(keys.MaxMessageSize).toInt
+    )
+  }
+}
+
+object BlockStorage {
+  val Key                = s"${Configuration.Key}.blockstorage"
+  val Keys: List[String] = keys.all.map(k => s"$Key.$k")
+
+  object keys {
+    val BlockStoreSize = "block-store-size"
+    val DagStorageSize = "dag-storage-size"
+
+    val all =
+      List(
+        BlockStoreSize,
+        DagStorageSize
+      )
+  }
+
+  def fromConfig(config: Config): configuration.BlockStorage = {
+    val blockStorage = config.getConfig(Key)
+
+    configuration.BlockStorage(
+      blockStoreSize = blockStorage.getBytes(keys.BlockStoreSize),
+      dagStorageSize = blockStorage.getBytes(keys.DagStorageSize)
     )
   }
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -56,7 +56,8 @@ final case class Kamon(
 
 final case class BlockStorage(
     blockStoreSize: Long,
-    dagStorageSize: Long
+    dagStorageSize: Long,
+    blockStoreCacheMaxSize: Long
 )
 
 sealed trait Command

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -22,8 +22,6 @@ final case class Server(
     standalone: Boolean,
     dataDir: Path,
     mapSize: Long,
-    storeSize: Long,
-    dagStorageSize: Long,
     maxNumOfConnections: Int,
     allowPrivateAddresses: Boolean,
     maxMessageSize: Int,
@@ -54,6 +52,11 @@ final case class Kamon(
     influxDbUdp: Boolean,
     zipkin: Boolean,
     sigar: Boolean
+)
+
+final case class BlockStorage(
+    blockStoreSize: Long,
+    dagStorageSize: Long
 )
 
 sealed trait Command

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -157,7 +157,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
       Seq(
         "run",
         "--blockstorage-block-store-size 2000",
-        "--blockstorage-dag-storage-size 3000"
+        "--blockstorage-dag-storage-size 3000",
+        "--blockstorage-block-store-cache-max-size 4000"
       ).mkString(" ")
 
     val options = Options(args.split(' '))
@@ -166,7 +167,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
     val expectedBlockstorage =
       configuration.BlockStorage(
         blockStoreSize = 2000,
-        dagStorageSize = 3000
+        dagStorageSize = 3000,
+        blockStoreCacheMaxSize = 4000
       )
 
     val blockstorage = hocon.BlockStorage.fromConfig(config)

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -30,8 +30,6 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--standalone",
         "--bootstrap rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404",
         "--data-dir /root/.rnode",
-        "--casper-block-store-size 2000",
-        "--casper-block-dag-storage-size 3000",
         "--map-size 1000",
         "--max-num-of-connections 500",
         "--allow-private-addresses",
@@ -65,8 +63,6 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         standalone = true,
         dataDir = Paths.get("/root/.rnode"),
         mapSize = 1000,
-        storeSize = 2000,
-        dagStorageSize = 3000,
         maxNumOfConnections = 500,
         allowPrivateAddresses = true,
         maxMessageSize = 256,
@@ -154,6 +150,27 @@ class ConfigMapperSpec extends FunSuite with Matchers {
 
     val grpc = hocon.GrpcServer.fromConfig(config)
     grpc shouldEqual expectedGrpc
+  }
+
+  test("Map blockstorage command line arguments to Lightbend config") {
+    val args =
+      Seq(
+        "run",
+        "--blockstorage-block-store-size 2000",
+        "--blockstorage-dag-storage-size 3000"
+      ).mkString(" ")
+
+    val options = Options(args.split(' '))
+    val config  = ConfigMapper.fromOptions(options)
+
+    val expectedBlockstorage =
+      configuration.BlockStorage(
+        blockStoreSize = 2000,
+        dagStorageSize = 3000
+      )
+
+    val blockstorage = hocon.BlockStorage.fromConfig(config)
+    blockstorage shouldEqual expectedBlockstorage
   }
 
   test("Map Casper command line arguments to Lightbend config") {

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -30,8 +30,6 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
       |    standalone = true
       |    bootstrap = "rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404"
       |    data-dir = /root/.rnode
-      |    store-size = 1G
-      |    dag-storage-size = 512M
       |    map-size = 1G
       |    max-connections = 500
       |    allow-private-addresses = true
@@ -64,8 +62,6 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         standalone = true,
         dataDir = Paths.get("/root/.rnode"),
         mapSize = 1024 * 1024 * 1024,
-        storeSize = 1024 * 1024 * 1024,
-        dagStorageSize = 512 * 1024 * 1024,
         maxNumOfConnections = 500,
         allowPrivateAddresses = true,
         maxMessageSize = 256 * 1024,
@@ -158,6 +154,27 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
 
     val grpc = GrpcServer.fromConfig(ConfigFactory.parseString(conf))
     grpc shouldEqual expectedGrpc
+  }
+
+  test("Parse blockstorage section") {
+    val conf =
+      """
+        |rnode {
+        |  blockstorage {
+        |    block-store-size = 1G
+        |    dag-storage-size = 512M
+        |  }
+        |}
+      """.stripMargin
+
+    val expectedBlockstorage =
+      configuration.BlockStorage(
+        blockStoreSize = 1024 * 1024 * 1024,
+        dagStorageSize = 512 * 1024 * 1024
+      )
+
+    val blockstorage = BlockStorage.fromConfig(ConfigFactory.parseString(conf))
+    blockstorage shouldEqual expectedBlockstorage
   }
 
   test("Parse casper section") {

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -163,6 +163,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         |  blockstorage {
         |    block-store-size = 1G
         |    dag-storage-size = 512M
+        |    block-store-cache-max-size = 256M
         |  }
         |}
       """.stripMargin
@@ -170,7 +171,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
     val expectedBlockstorage =
       configuration.BlockStorage(
         blockStoreSize = 1024 * 1024 * 1024,
-        dagStorageSize = 512 * 1024 * 1024
+        dagStorageSize = 512 * 1024 * 1024,
+        blockStoreCacheMaxSize = 256 * 1024 * 1024
       )
 
     val blockstorage = BlockStorage.fromConfig(ConfigFactory.parseString(conf))


### PR DESCRIPTION
## Overview
Adds a fixed-size (512M by default) in-memory cache for block storage for more efficient lookup of recently read blocks. I decided to use Guava's concurrent LRU cache implementation since it was already in our dependencies.

Also refactors how blockstorage configuration options are handled.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3737


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
