### PR TITLE
Revert accidental changes to RegistrySigGen

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RegistrySigGen.scala
@@ -158,25 +158,7 @@ object RegistrySigGen {
     */
   def main(argv: Array[String]) = {
     // these could be command-line args...
-    //val info = RegistrySigGen.deriveFrom(Args.parse(argv))
-    val (key, pub) = (
-      PrivateKey(
-        Base16.unsafeDecode("84e1aa32db02b53a4024d8a3fb460f37d30996bfa566f1df953c1c14b694b618")
-      ),
-      PublicKey(
-        Base16.unsafeDecode(
-          "049d575d3b375ea985dfa087a3e7511c0e3903ce6042407cd83cfc22a8b8b32b78b3070169f20a1d050c78ec13d9ea7653e78119bb3963d470fa989d19ebfdf8bf"
-        )
-      )
-    )
-    val toSign: Par = ETuple(Seq(GInt(790), GString("entryReplace")))
-    val hash        = Blake2b256.hash(toSign.toByteArray)
-    println(Base16.encode(key.bytes))
-    println(Base16.encode(pub.bytes))
-    println(hash)
-    println(hash.length)
-    val sig  = Secp256k1.sign(hash, key.bytes)
-    val info = Base16.encode(sig)
+    val info = RegistrySigGen.deriveFrom(Args.parse(argv))
     System.out.println(info)
   }
 


### PR DESCRIPTION
I accidentally committed the debug scripts I was playing
around with when migrating over to secp256k1 (from https://github.com/rchain/rchain/pull/2470)

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
