### PR TITLE
Rchain 3509 remove source

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -119,7 +119,7 @@ object StoragePrinter {
 
   private[this] def toSends(data: Seq[Datum[ListParWithRandom]])(channels: Seq[Par]): Par = {
     val sends: Seq[Send] = data.flatMap {
-      case Datum(as: ListParWithRandom, persist: Boolean, _: Produce, _) =>
+      case Datum(as: ListParWithRandom, persist: Boolean, _) =>
         channels.map { channel =>
           Send(channel, as.pars, persist)
         }
@@ -138,7 +138,7 @@ object StoragePrinter {
           continuation: TaggedContinuation,
           persist: Boolean,
           peeks: SortedSet[Int],
-          _: Consume
+          _: Int
           ) =>
         val receiveBinds: Seq[ReceiveBind] = (channels zip patterns).map {
           case (channel, pattern) =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -119,7 +119,7 @@ object StoragePrinter {
 
   private[this] def toSends(data: Seq[Datum[ListParWithRandom]])(channels: Seq[Par]): Par = {
     val sends: Seq[Send] = data.flatMap {
-      case Datum(as: ListParWithRandom, persist: Boolean, _: Produce) =>
+      case Datum(as: ListParWithRandom, persist: Boolean, _: Produce, _) =>
         channels.map { channel =>
           Send(channel, as.pars, persist)
         }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -160,7 +160,6 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
     def data(p: Par, rand: Blake2b512Random) = Row(
       List(
         Datum.create(
-          channel,
           ListParWithRandom(Seq(p), rand),
           false
         )

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -43,7 +43,6 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
           Row[BindPattern, ListParWithRandom, TaggedContinuation](
             List(
               Datum.create(
-                channel,
                 ListParWithRandom(
                   data,
                   rand
@@ -960,7 +959,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
           Row(
             List(
               Datum.create(
-                channel0,
+                
                 ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(Array[Byte](42)))), result0Rand),
                 persist = false)),
             List()),
@@ -968,7 +967,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
           Row(
             List(
               Datum.create(
-                channel1,
+               
                 ListParWithRandom(Seq(GPrivate(ByteString.copyFrom(chosenName))), result1Rand),
                 persist = false)),
             List())

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RegistrySpec.scala
@@ -317,7 +317,6 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         Row(
           List(
             Datum.create[Par, ListParWithRandom](
-              GString(s),
               ListParWithRandom(Seq(expected), rand),
               false,
               sequenceNumber
@@ -335,7 +334,7 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
   private def resultSequenceNumber(
       resultRow: Option[Row[BindPattern, ListParWithRandom, TaggedContinuation]]
   ) =
-    resultRow.fold(0)(_.data.head.source.sequenceNumber)
+    resultRow.fold(0)(_.data.head.sequenceNumber)
 
   "lookup" should "recurse" in {
     val lookupString: String =
@@ -592,7 +591,6 @@ class RegistrySpec extends FlatSpec with Matchers with RegistryTester {
         Row(
           List(
             Datum.create[Par, ListParWithRandom](
-              Registry.registryRoot,
               ListParWithRandom(Seq(EMapBody(ParMap(SortedParMap.empty))), rootRand),
               false,
               sequenceNumber

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ExamplesSerializerBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ExamplesSerializerBench.scala
@@ -85,7 +85,7 @@ abstract class ExamplesSerializerBenchState {
 
   val channel  = Channel("colleagues")
   val channels = List(channel, Channel("friends"))
-  val datum    = Datum.create(channel, data, false)
+  val datum    = Datum.create(data, false)
   val patterns = Seq[Pattern](CityMatch(city = "Crystal Lake"))
   val continuation =
     WaitingContinuation.create(channels, patterns, new EntriesCaptor(), false, SortedSet.empty)
@@ -103,7 +103,7 @@ abstract class ExamplesSerializerBenchState {
 
     GNAT[Channel, Pattern, Entry, EntriesCaptor](
       channels,
-      range.map(i => Datum.create(channels(i - 1), data, false)),
+      range.map(i => Datum.create(data, false)),
       range.map(
         i =>
           WaitingContinuation

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ModelSerializerBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/serialization/ModelSerializerBench.scala
@@ -142,22 +142,17 @@ abstract class ModelSerializerBenchState {
 
   implicit def arbitraryDatum[C, T](chan: C)(
       implicit
-      arbT: Arbitrary[T],
-      serializeC: Serialize[C],
-      serializeT: Serialize[T]
+      arbT: Arbitrary[T]
   ): Arbitrary[Datum[T]] =
     Arbitrary(for {
       t <- arbT.arbitrary
       b <- Arbitrary.arbitrary[Boolean]
-    } yield Datum.create(chan, t, b))
+    } yield Datum.create(t, b))
 
   def arbitraryWaitingContinuation[C, P, K](chans: List[C])(
       implicit
       arbP: Arbitrary[P],
-      arbK: Arbitrary[K],
-      serializeC: Serialize[C],
-      serializeP: Serialize[P],
-      serializeK: Serialize[K]
+      arbK: Arbitrary[K]
   ): Arbitrary[WaitingContinuation[P, K]] =
     Arbitrary(
       for {
@@ -167,13 +162,7 @@ abstract class ModelSerializerBenchState {
       } yield WaitingContinuation.create(chans, pats, continuation, boolean, SortedSet.empty)
     )
 
-  implicit def arbitraryGnat()(
-      implicit
-      serializeC: Serialize[Par],
-      serializeP: Serialize[BindPattern],
-      serializeA: Serialize[ListParWithRandom],
-      serializeK: Serialize[TaggedContinuation]
-  ): Arbitrary[TestGNAT] =
+  implicit def arbitraryGnat(): Arbitrary[TestGNAT] =
     Arbitrary(Gen.sized { size =>
       val constrainedSize = Math.max(1, size)
       for {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -173,7 +173,7 @@ abstract class RSpaceOps[F[_]: Concurrent, C, P, A, K](
                                continuation,
                                persist = true,
                                SortedSet.empty,
-                               consumeRef
+                               consumeRef.sequenceNumber
                              )
                            )
                        _ <- channels.traverse { channel =>

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -99,8 +99,10 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
                                      store
                                        .getData(c)
                                        .map(_.zipWithIndex.filter {
-                                         case (Datum(_, _, source), _) =>
-                                           comm.produces.contains(source)
+                                         case (Datum(_data, _persist, _, _), _) =>
+                                           comm.produces.contains(
+                                             Produce.create(c, _data, _persist, sequenceNumber)
+                                           )
                                        })
                                        .map(v => c -> v)
                                    }
@@ -124,7 +126,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
         r <- mats.toList
               .sortBy(_.datumIndex)(Ordering[Int].reverse)
               .traverse {
-                case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                case DataCandidate(candidateChannel, Datum(_, persistData, _, _), dataIndex) =>
                   if (shouldRemove(persistData, candidateChannel)) {
                     store.removeDatum(candidateChannel, dataIndex)
                   } else ().pure[F]
@@ -261,8 +263,10 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
                                            (for {
                                              data <- store.getData(c)
                                            } yield (data.zipWithIndex.filter {
-                                             case (Datum(_, _, source), _) =>
-                                               comm.produces.contains(source)
+                                             case (Datum(_data, _persist, _, seqNum), _) =>
+                                               comm.produces.contains(
+                                                 Produce.create(c, _data, _persist, seqNum)
+                                               )
                                            })).map(
                                              as =>
                                                c -> {
@@ -348,7 +352,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
             _ <- dataCandidates.toList
                   .sortBy(_.datumIndex)(Ordering[Int].reverse)
                   .traverse {
-                    case DataCandidate(candidateChannel, Datum(_, persistData, _), dataIndex) =>
+                    case DataCandidate(candidateChannel, Datum(_, persistData, _, _), dataIndex) =>
                       def shouldRemove: Boolean = {
                         val idx = channelsToIndex(candidateChannel)
                         dataIndex >= 0 && (!persistData && !peeks.contains(idx))

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -12,17 +12,15 @@ import coop.rchain.rspace.internal._
   * @tparam C a type representing a channel
   * @tparam P a type representing a pattern
   * @tparam A a type representing an arbitrary piece of data and match result
-  * @tparam R a type representing a
   * @tparam K a type representing a continuation
   */
 private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, K] {
 
   protected[this] def MetricsSource: Source
 
-  private[this] val findSpanLabel    = Metrics.Source(MetricsSource, "find-matching-data")
-  private[this] val extractSpanLabel = Metrics.Source(MetricsSource, "extract-matching-data")
-  private[this] val extractFirstSpanLabel =
-    Metrics.Source(MetricsSource, "extract-first-matching-data")
+  private[this] val findSpanLabel         = "find-matching-data"
+  private[this] val extractSpanLabel      = "extract-matching-data"
+  private[this] val extractFirstSpanLabel = "extract-first-matching-data"
 
   implicit val syncF: Sync[F]
   implicit val spanF: Span[F]
@@ -44,11 +42,12 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
       prefix: Seq[(Datum[A], Int)]
   )(
       implicit m: Match[F, P, A]
-  ): F[Option[MatchingDataCandidate]] = spanF.trace(findSpanLabel) {
+  ): F[Option[MatchingDataCandidate]] =
     for {
+      _ <- spanF.mark(findSpanLabel)
       res <- data match {
               case (indexedDatum @ (
-                    Datum(matchCandidate, persist, produceRef, sequenceNumber),
+                    Datum(matchCandidate, persist, sequenceNumber),
                     dataIndex
                   )) +: remaining =>
                 m.get(pattern, matchCandidate).flatMap {
@@ -58,7 +57,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
                     (
                       DataCandidate(
                         channel,
-                        Datum(mat, persist, produceRef, sequenceNumber),
+                        Datum(mat, persist, sequenceNumber),
                         dataIndex
                       ),
                       data
@@ -68,7 +67,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
                     (
                       DataCandidate(
                         channel,
-                        Datum(mat, persist, produceRef, sequenceNumber),
+                        Datum(mat, persist, sequenceNumber),
                         dataIndex
                       ),
                       prefix ++ remaining
@@ -77,7 +76,6 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
               case _ => none[MatchingDataCandidate].pure[F]
             }
     } yield res
-  }
 
   /** Iterates through (channel, pattern) pairs looking for matching data.
     *
@@ -92,36 +90,35 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
       acc: Seq[Option[DataCandidate[C, A]]]
   )(implicit m: Match[F, P, A]): F[Seq[Option[DataCandidate[C, A]]]] =
-    spanF.trace(extractSpanLabel) {
-      for {
-        res <- channelPatternPairs match {
-                case (channel, pattern) +: tail =>
-                  for {
-                    maybeTuple <- channelToIndexedData.get(channel) match {
-                                   case Some(indexedData) =>
-                                     findMatchingDataCandidate(channel, indexedData, pattern, Nil)
-                                   case None =>
-                                     none[(DataCandidate[C, A], Seq[(Datum[A], Int)])].pure[F]
-                                 }
-                    dataCandidates <- maybeTuple match {
-                                       case Some((cand, rem)) =>
-                                         extractDataCandidates(
-                                           tail,
-                                           channelToIndexedData.updated(channel, rem),
-                                           Some(cand) +: acc
-                                         )
-                                       case None =>
-                                         extractDataCandidates(
-                                           tail,
-                                           channelToIndexedData,
-                                           None +: acc
-                                         )
-                                     }
-                  } yield dataCandidates
-                case _ => acc.reverse.pure[F]
-              }
-      } yield res
-    }
+    for {
+      _ <- spanF.mark(extractSpanLabel)
+      res <- channelPatternPairs match {
+              case (channel, pattern) +: tail =>
+                for {
+                  maybeTuple <- channelToIndexedData.get(channel) match {
+                                 case Some(indexedData) =>
+                                   findMatchingDataCandidate(channel, indexedData, pattern, Nil)
+                                 case None =>
+                                   none[(DataCandidate[C, A], Seq[(Datum[A], Int)])].pure[F]
+                               }
+                  dataCandidates <- maybeTuple match {
+                                     case Some((cand, rem)) =>
+                                       extractDataCandidates(
+                                         tail,
+                                         channelToIndexedData.updated(channel, rem),
+                                         Some(cand) +: acc
+                                       )
+                                     case None =>
+                                       extractDataCandidates(
+                                         tail,
+                                         channelToIndexedData,
+                                         None +: acc
+                                       )
+                                   }
+                } yield dataCandidates
+              case _ => acc.reverse.pure[F]
+            }
+    } yield res
 
   /* Produce */
 
@@ -130,30 +127,29 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
       matchCandidates: Seq[(WaitingContinuation[P, K], Int)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]]
   )(implicit m: Match[F, P, A]): F[Option[ProduceCandidate[C, P, A, K]]] =
-    spanF.trace(extractFirstSpanLabel) {
-      for {
-        res <- matchCandidates match {
-                case (p @ WaitingContinuation(patterns, _, _, _, _), index) +: remaining =>
-                  for {
-                    maybeDataCandidates <- extractDataCandidates(
-                                            channels.zip(patterns),
-                                            channelToIndexedData,
-                                            Nil
-                                          ).map(_.sequence)
-                    produceCandidates <- maybeDataCandidates match {
-                                          case None =>
-                                            extractFirstMatch(
-                                              channels,
-                                              remaining,
-                                              channelToIndexedData
-                                            )
-                                          case Some(dataCandidates) =>
-                                            ProduceCandidate(channels, p, index, dataCandidates).some
-                                              .pure[F]
-                                        }
-                  } yield produceCandidates
-                case _ => none[ProduceCandidate[C, P, A, K]].pure[F]
-              }
-      } yield res
-    }
+    for {
+      _ <- spanF.mark(extractFirstSpanLabel)
+      res <- matchCandidates match {
+              case (p @ WaitingContinuation(patterns, _, _, _, _), index) +: remaining =>
+                for {
+                  maybeDataCandidates <- extractDataCandidates(
+                                          channels.zip(patterns),
+                                          channelToIndexedData,
+                                          Nil
+                                        ).map(_.sequence)
+                  produceCandidates <- maybeDataCandidates match {
+                                        case None =>
+                                          extractFirstMatch(
+                                            channels,
+                                            remaining,
+                                            channelToIndexedData
+                                          )
+                                        case Some(dataCandidates) =>
+                                          ProduceCandidate(channels, p, index, dataCandidates).some
+                                            .pure[F]
+                                      }
+                } yield produceCandidates
+              case _ => none[ProduceCandidate[C, P, A, K]].pure[F]
+            }
+    } yield res
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -47,16 +47,30 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
   ): F[Option[MatchingDataCandidate]] = spanF.trace(findSpanLabel) {
     for {
       res <- data match {
-              case (indexedDatum @ (Datum(matchCandidate, persist, produceRef), dataIndex)) +: remaining =>
+              case (indexedDatum @ (
+                    Datum(matchCandidate, persist, produceRef, sequenceNumber),
+                    dataIndex
+                  )) +: remaining =>
                 m.get(pattern, matchCandidate).flatMap {
                   case None =>
                     findMatchingDataCandidate(channel, remaining, pattern, indexedDatum +: prefix)
                   case Some(mat) if persist =>
-                    (DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex), data).some
+                    (
+                      DataCandidate(
+                        channel,
+                        Datum(mat, persist, produceRef, sequenceNumber),
+                        dataIndex
+                      ),
+                      data
+                    ).some
                       .pure[F]
                   case Some(mat) =>
                     (
-                      DataCandidate(channel, Datum(mat, persist, produceRef), dataIndex),
+                      DataCandidate(
+                        channel,
+                        Datum(mat, persist, produceRef, sequenceNumber),
+                        dataIndex
+                      ),
                       prefix ++ remaining
                     ).some.pure[F]
                 }

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -158,4 +158,6 @@ object Consume {
 
   implicit val codecConsume: Codec[Consume] =
     (Codec[Seq[Blake2b256Hash]] :: Codec[Blake2b256Hash] :: bool :: int32).as[Consume]
+
+  def hasJoins(consume: Consume): Boolean = consume.channelsHashes.size > 1
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -77,12 +77,6 @@ package object util {
   def runKs[T](t: Seq[Option[((T) => Unit, T, Int)]]): Unit =
     t.foreach { case Some((k, data, _)) => k(data); case None => () }
 
-  def canonicalize[C, P, A, K](gnat: GNAT[C, P, A, K]): GNAT[C, P, A, K] =
-    gnat.copy(
-      wks = gnat.wks.sortBy(_.source.hash.bytes)(ordByteVector),
-      data = gnat.data.sortBy(_.source.hash.bytes)(ordByteVector)
-    )
-
   @SuppressWarnings(Array("org.wartremover.warts.Return"))
   def veccmp(a: ByteVector, b: ByteVector): Int = {
     val c = a.length - b.length

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -50,7 +50,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       installedContinuations <- Arbitrary.arbitrary[
                                  TrieMap[Seq[String], WaitingContinuation[Pattern, StringsCaptor]]
                                ]
-      data           <- Arbitrary.arbitrary[TrieMap[String, Seq[Datum[String]]]]
+      data           <- Arbitrary.arbitrary[TrieMap[String, Seq[Data]]]
       joins          <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]]
       installedJoins <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]]
     } yield Cache(
@@ -940,7 +940,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
     (channel: String, datumValue: String) =>
       fixture { (_, _, hotStore) =>
         val key   = channel
-        val datum = Datum.create(channel, datumValue, false)
+        val datum = Datum.create(datumValue, false)
 
         for {
           _   <- hotStore.putDatum(key, datum)
@@ -954,8 +954,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
     (channel: String, datumValue: String) =>
       fixture { (_, _, store) =>
         val key    = channel
-        val datum1 = Datum.create(channel, datumValue, false)
-        val datum2 = Datum.create(channel, datumValue + "2", false)
+        val datum1 = Datum.create(datumValue, false)
+        val datum2 = Datum.create(datumValue + "2", false)
 
         for {
           _   <- store.putDatum(key, datum1)
@@ -976,7 +976,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         fixture { (_, _, store) =>
           val key = channel
           val data = List.tabulate(size) { i =>
-            Datum.create(channel, datumValue + i, false)
+            Datum.create(datumValue + i, false)
           }
 
           for {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -133,7 +133,12 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 
         _ <- replaySpace.rigAndReset(emptyPoint.root, rigPoint.log)
 
-        replayResultConsume <- replaySpace.consume(channels, patterns, continuation, false)
+        replayResultConsume <- replaySpace.consume(
+                                channels,
+                                patterns,
+                                continuation,
+                                false
+                              )
         replayResultProduce <- replaySpace.produce(channels(0), datum, false)
         finalPoint          <- replaySpace.createCheckpoint()
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace
 
 import cats.effect._
 import cats.implicits._
-import coop.rchain.rspace._
 import coop.rchain.rspace.examples.StringExamples._
 import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.test._
@@ -38,7 +37,7 @@ trait StorageActionsTests[F[_]]
     for {
       r          <- space.produce(key.head, "datum", persist = false)
       data       <- store.getData(channel)
-      _          = data shouldBe List(Datum.create(channel, "datum", persist = false))
+      _          = data shouldBe List(Datum.create("datum", persist = false))
       cont       <- store.getContinuations(key)
       _          = cont shouldBe Nil
       _          = r shouldBe None
@@ -57,15 +56,15 @@ trait StorageActionsTests[F[_]]
     for {
       r1  <- space.produce(channel, "datum1", persist = false)
       d1  <- store.getData(channel)
-      _   = d1 shouldBe List(Datum.create(channel, "datum1", false))
+      _   = d1 shouldBe List(Datum.create("datum1", false))
       wc1 <- store.getContinuations(key)
       _   = wc1 shouldBe Nil
       _   = r1 shouldBe None
       r2  <- space.produce(key.head, "datum2", persist = false)
       d2  <- store.getData(channel)
       _ = d2 should contain theSameElementsAs List(
-        Datum.create(key.head, "datum1", false),
-        Datum.create(key.head, "datum2", false)
+        Datum.create("datum1", false),
+        Datum.create("datum2", false)
       )
       wc2        <- store.getContinuations(key)
       _          = wc2 shouldBe Nil
@@ -133,7 +132,7 @@ trait StorageActionsTests[F[_]]
     for {
       r1 <- space.produce(channel, "datum", persist = false)
       d1 <- store.getData(channel)
-      _  = d1 shouldBe List(Datum.create(channel, "datum", false))
+      _  = d1 shouldBe List(Datum.create("datum", false))
       c1 <- store.getContinuations(key)
       _  = c1 shouldBe Nil
       _  = r1 shouldBe None
@@ -158,9 +157,9 @@ trait StorageActionsTests[F[_]]
       val key     = List(channel)
 
       for {
-        r1 <- space.produce(channel, "datum", persist = false)
+        r1 <- space.produce(key.head, "datum", false)
         d1 <- store.getData(channel)
-        _  = d1 shouldBe List(Datum.create(channel, "datum", false))
+        _  = d1 shouldBe List(Datum.create("datum", false))
         c1 <- store.getContinuations(key)
         _  = c1 shouldBe Nil
         _  = r1 shouldBe None
@@ -173,7 +172,7 @@ trait StorageActionsTests[F[_]]
                peeks = SortedSet(0)
              )
         d2            <- store.getData(channel)
-        _             = d2 shouldBe List(Datum.create(channel, "datum", false))
+        _             = d2 shouldBe List(Datum.create("datum", false))
         c2            <- store.getContinuations(key)
         _             = c2 shouldBe Nil
         _             = r2 shouldBe defined
@@ -204,7 +203,7 @@ trait StorageActionsTests[F[_]]
 
         r2            <- space.produce(channel, "datum", persist = false)
         d1            <- store.getData(channel)
-        _             = d1 shouldBe List(Datum.create(channel, "datum", false))
+        _             = d1 shouldBe List(Datum.create("datum", false))
         c2            <- store.getContinuations(key)
         _             = c2 shouldBe Nil
         _             = r2 shouldBe defined
@@ -250,7 +249,7 @@ trait StorageActionsTests[F[_]]
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
       d1 <- store.getData(produceKey1.head)
       _ = d1 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false)
+        Datum.create("datum1", persist = false)
       )
       c1 <- store.getContinuations(produceKey1)
       _  = c1 shouldBe Nil
@@ -259,7 +258,7 @@ trait StorageActionsTests[F[_]]
       r2 <- space.consume(consumeKey, consumePattern, new StringsCaptor, persist = false)
       d2 <- store.getData(produceKey1.head)
       _ = d2 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", persist = false)
+        Datum.create("datum1", persist = false)
       )
       _ <- store.getContinuations(produceKey1).map(_ shouldBe Nil)
       _ <- store.getData(produceKey2.head).map(_ shouldBe Nil)
@@ -291,7 +290,7 @@ trait StorageActionsTests[F[_]]
       r1 <- space.produce(produceKey1.head, "datum1", persist = false)
       d1 <- store.getData(produceKey1.head)
       _ = d1 shouldBe List(
-        Datum.create(produceKey1.head, "datum1", false)
+        Datum.create("datum1", false)
       )
       c1 <- store.getContinuations(produceKey1)
       _  = c1 shouldBe Nil
@@ -300,7 +299,7 @@ trait StorageActionsTests[F[_]]
       r2 <- space.produce(produceKey2.head, "datum2", persist = false)
       d2 <- store.getData(produceKey2.head)
       _ = d2 shouldBe List(
-        Datum.create(produceKey2.head, "datum2", false)
+        Datum.create("datum2", false)
       )
       c2 <- store.getContinuations(produceKey2)
       _  = c2 shouldBe Nil
@@ -309,7 +308,7 @@ trait StorageActionsTests[F[_]]
       r3 <- space.produce(produceKey3.head, "datum3", persist = false)
       d3 <- store.getData(produceKey3.head)
       _ = d3 shouldBe List(
-        Datum.create(produceKey3.head, "datum3", false)
+        Datum.create("datum3", false)
       )
       c3 <- store.getContinuations(produceKey3)
       _  = c3 shouldBe Nil
@@ -538,7 +537,7 @@ trait StorageActionsTests[F[_]]
       d1 <- store.getData("ch2")
       _  = d1 shouldBe Nil
       d2 <- store.getData("ch1")
-      _  = d2 shouldBe List(Datum.create("ch1", "datum1", false))
+      _  = d2 shouldBe List(Datum.create("datum1", false))
 
       c1 <- store.getContinuations(List("ch1", "ch2"))
       _  = c1 should not be empty
@@ -604,7 +603,7 @@ trait StorageActionsTests[F[_]]
         _ <- store.getContinuations(List("ch1")).map(_ shouldBe Nil)
         _ <- store.getContinuations(List("ch2")).map(_ shouldBe Nil)
         _ <- store.getData("ch1").map(_ shouldBe Nil)
-        _ <- store.getData("ch2").map(_ shouldBe List(Datum.create("ch2", "datum2", false)))
+        _ <- store.getData("ch2").map(_ shouldBe List(Datum.create("datum2", false)))
 
         _ = r3 shouldBe defined
         _ = r4 shouldBe None
@@ -627,7 +626,7 @@ trait StorageActionsTests[F[_]]
 
     for {
       r1 <- space.produce(key.head, "datum", persist = false)
-      _  <- store.getData(key.head).map(_ shouldBe List(Datum.create(key.head, "datum", false)))
+      _  <- store.getData(key.head).map(_ shouldBe List(Datum.create("datum", false)))
       _  <- store.getContinuations(key).map(_ shouldBe Nil)
       _  = r1 shouldBe None
 
@@ -655,7 +654,7 @@ trait StorageActionsTests[F[_]]
 
       for {
         r1 <- space.produce(key.head, "datum1", persist = false)
-        _  <- store.getData(key.head).map(_ shouldBe List(Datum.create(key.head, "datum1", false)))
+        _  <- store.getData(key.head).map(_ shouldBe List(Datum.create("datum1", false)))
         _  <- store.getContinuations(key).map(_ shouldBe Nil)
         _  = r1 shouldBe None
 
@@ -729,7 +728,7 @@ trait StorageActionsTests[F[_]]
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
       _  = r3 shouldBe None
-      _  <- store.getData("ch1").map(_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getData("ch1").map(_ shouldBe List(Datum.create("datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
     } yield ()
   }
@@ -753,12 +752,12 @@ trait StorageActionsTests[F[_]]
         // All matching continuations have been produced, so the write will "stick"
         r3 <- space.produce("ch1", "datum1", persist = true)
         _  = r3 shouldBe None
-        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("datum1", true)))
         _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
         r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
         _  = r4 shouldBe defined
-        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+        _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("datum1", true)))
         _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
         _ = runK(r4)
@@ -768,12 +767,12 @@ trait StorageActionsTests[F[_]]
   "doing a persistent produce and consuming twice" should "work" in fixture { (store, _, space) =>
     for {
       r1 <- space.produce("ch1", "datum1", persist = true)
-      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
       _  = r1 shouldBe None
 
       r2 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
       _  = r2 shouldBe defined
 
@@ -781,7 +780,7 @@ trait StorageActionsTests[F[_]]
       _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
 
       r3 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
+      _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
       _ = r3 shouldBe defined
@@ -803,9 +802,9 @@ trait StorageActionsTests[F[_]]
         // Matching data exists so the write will not "stick"
         r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
         _ <- store.getData("ch1") map (_ should contain atLeastOneOf (
-              Datum.create("ch1", "datum1", false),
-              Datum.create("ch1", "datum2", false),
-              Datum.create("ch1", "datum3", false)
+              Datum.create("datum1", false),
+              Datum.create("datum2", false),
+              Datum.create("datum3", false)
             ))
         _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
         _ = r4 shouldBe defined
@@ -816,9 +815,9 @@ trait StorageActionsTests[F[_]]
         // Matching data exists so the write will not "stick"
         r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
         _ <- store.getData("ch1") map (_ should contain oneOf (
-              Datum.create("ch1", "datum1", false),
-              Datum.create("ch1", "datum2", false),
-              Datum.create("ch1", "datum3", false)
+              Datum.create("datum1", false),
+              Datum.create("datum2", false),
+              Datum.create("datum3", false)
             ))
         _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
         _ = r5 shouldBe defined

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -151,11 +151,11 @@ class HistoryRepositorySpec
       "cont-" + s,
       true,
       SortedSet.empty,
-      Consume(randomBlake :: Nil, randomBlake, true, 0)
+      0
     )
 
   def datum(s: Any): Datum[String] =
-    Datum[String]("data-" + s, false, Produce(randomBlake, randomBlake, false, 0))
+    Datum[String]("data-" + s, false, 0) //Produce(randomBlake, randomBlake, false, 0))
 
   protected def withEmptyRepository(f: TestHistoryRepository => Task[Unit]): Unit = {
     implicit val codecString: Codec[String] = util.stringCodec


### PR DESCRIPTION
## Overview
<sup>_Remove source of produce/consume from rspace datum & continuation to reduce storage foot-print_</sup>



### JIRA ticket:
<sup>_https://rchain.atlassian.net/browse/RCHAIN-3509_</sup>



### Notes
<sup>_Please check jira ticket for detail analysis of the rspace metrics_</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
