### PR TITLE
Make history trie creation invalidate cache more aggresively (#RCHAIN…

### DIFF
--- a/rspace/src/test/scala/coop/rchain/rspace/history/CachingHistorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/CachingHistorySpec.scala
@@ -1,0 +1,60 @@
+package coop.rchain.rspace.history
+
+import coop.rchain.rspace.history.HistoryInstances.{CachingHistoryStore, MergingHistory}
+import coop.rchain.rspace.history.TestData._
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+import scala.concurrent.duration._
+
+class CachingHistorySpec
+    extends FlatSpec
+    with Matchers
+    with OptionValues
+    with InMemoryHistoryTestBase {
+
+  def create: (MergingHistory[Task], CachingHistoryStore[Task]) = {
+    val historyStore = inMemHistoryStore
+    val caching      = CachingHistoryStore(historyStore)
+    val history      = new MergingHistory[Task](History.emptyRootHash, caching)
+    (history, caching)
+  }
+
+  protected def withEmptyTrie(
+      f: (MergingHistory[Task], CachingHistoryStore[Task]) => Task[Unit]
+  ): Unit = {
+    val (history, caching) = create
+    runEffect(f(history, caching).flatMap(_ => history.close()))
+  }
+
+  /**
+    * the expected shape of the in-mem history trie is:
+    *
+    * PB(0)
+    *  |
+    * S(28x0)
+    *  |
+    * PB(0, 1, 2)
+    *  | (2)
+    * S(000)
+    *  |
+    * Leaf (leafs aren't cached)
+  **/
+  "processing of multiple mixed actions" should "remove data from cache" in withEmptyTrie {
+    (history, cache) =>
+      def setupActions() =
+        insert(prefixWithZeros("0001")) ::
+          insert(prefixWithZeros("0010")) ::
+          delete(prefixWithZeros("0011")) ::
+          insert(prefixWithZeros("1000")) ::
+          delete(prefixWithZeros("1001")) ::
+          insert(prefixWithZeros("2000")) ::
+          Nil
+      val zero = setupActions()
+      for {
+        _ <- history.processSubtree(History.emptyRootHash)(0.toByte, zero)
+        _ = cache.cache.size shouldBe 4
+      } yield ()
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
@@ -110,6 +110,11 @@ object TestData {
   val _zerosOnes: KeyPath       = (List.fill(16)(0) ++ List.fill(16)(1)).map(_.toByte)
   val _31zeros: KeyPath         = List.fill(31)(0).map(_.toByte)
   def zerosAnd(i: Int): KeyPath = _31zeros :+ i.toByte
+  def prefixWithZeros(s: String): KeyPath = {
+    val a = List.fill(32 - (s.length))(0).map(_.toByte)
+    val b = s.toCharArray.toList.map(_.asDigit).map(_.toByte)
+    a ++ b
+  }
 
   def randomBlake: Blake2b256Hash =
     Blake2b256Hash.create(Random.alphanumeric.take(32).map(_.toByte).toArray)


### PR DESCRIPTION
…-3735)

## Overview
<sup>_What this PR does, and why it's needed_</sup>



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RCHAIN-3735


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
