### PR TITLE
Replace TaskLocal Span with ReaderT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val shared = (project in file("shared"))
       catsEffect,
       catsMtl,
       catsPar,
+      catsTagless,
       lz4,
       monix,
       scodecCore,
@@ -189,6 +190,7 @@ lazy val comm = (project in file("comm"))
       hasher,
       catsCore,
       catsMtl,
+      catsTagless,
       monix,
       guava
     ),
@@ -257,6 +259,7 @@ lazy val node = (project in file("node"))
     libraryDependencies ++=
       apiServerDependencies ++ commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
         catsCore,
+        catsTagless,
         grpcNetty,
         jline,
         scallop,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -116,7 +116,7 @@ object CasperLaunch {
                 init.conf.approveGenesisDuration,
                 init.conf.approveGenesisInterval
               )
-      // TODO OMG Fix, use Concurrent+!11
+      // TODO track fiber
       _ <- Concurrent[F].start(
             GenesisCeremonyMaster
               .approveBlockInterval[F](

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -14,7 +14,6 @@ import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.metrics.{Metrics, Span}
@@ -25,7 +24,7 @@ object CasperLaunch {
   class CasperInit[F[_]](
       val conf: CasperConf
   )
-  def apply[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Sync: Concurrent: Time: Log: EventLog: BlockDagStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks](
+  def apply[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Sync: Concurrent: Time: Log: EventLog: BlockDagStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks](
       init: CasperInit[F]
   ): F[Unit] =
     BlockStore[F].getApprovedBlock map {
@@ -50,7 +49,7 @@ object CasperLaunch {
       case (msg, action) => Log[F].info(msg) >> action
     }
 
-  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: ConnectionsCell: NodeDiscovery: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: EngineCell: EnvVars: RuntimeManager: Running.RequestedBlocks](
+  def connectToExistingNetwork[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: EngineCell: EnvVars: RuntimeManager: Running.RequestedBlocks](
       approvedBlock: ApprovedBlock,
       init: CasperInit[F]
   ): F[Unit] =

--- a/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/NodeDiscovery.scala
@@ -1,8 +1,12 @@
 package coop.rchain.comm.discovery
 
+import cats.tagless._
 import cats.Monad
 import coop.rchain.comm.{NodeIdentifier, PeerNode}
 
+@autoFunctorK
+@autoSemigroupalK
+@autoProductNK
 trait NodeDiscovery[F[_]] {
   def discover: F[Unit]
   def peers: F[Seq[PeerNode]]

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -34,8 +34,7 @@ class GrpcTransportServer(
     maxMessageSize: Int,
     maxStreamMessageSize: Long,
     tempFolder: Path,
-    parallelism: Int,
-    tracing: Boolean
+    parallelism: Int
 )(
     implicit scheduler: Scheduler,
     rPConfAsk: RPConfAsk[Task],
@@ -79,10 +78,7 @@ class GrpcTransportServer(
   ): Task[Cancelable] = {
 
     val dispatchSend: Send => Task[Unit] =
-      s =>
-        dispatch(s.msg)
-          .executeWithOptions(TaskContrib.enableTracing(tracing))
-          .attemptAndLog >> metrics.incrementCounter("dispatched.messages")
+      s => dispatch(s.msg).attemptAndLog >> metrics.incrementCounter("dispatched.messages")
 
     val dispatchBlob: StreamMessage => Task[Unit] =
       msg =>
@@ -90,7 +86,7 @@ class GrpcTransportServer(
           case Left(ex) =>
             Log[Task].error("Could not restore data from file while handling stream", ex)
           case Right(blob) =>
-            handleStreamed(blob).executeWithOptions(TaskContrib.enableTracing(tracing))
+            handleStreamed(blob)
         }) >> metrics.incrementCounter("dispatched.packets")
 
     for {
@@ -128,8 +124,7 @@ object GrpcTransportServer {
       maxMessageSize: Int,
       maxStreamMessageSize: Long,
       folder: Path,
-      parallelism: Int,
-      tracing: Boolean
+      parallelism: Int
   )(
       implicit scheduler: Scheduler,
       rPConfAsk: RPConfAsk[Task],
@@ -147,8 +142,7 @@ object GrpcTransportServer {
         maxMessageSize,
         maxStreamMessageSize,
         folder,
-        parallelism,
-        tracing
+        parallelism
       )
     )
   }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayer.scala
@@ -1,11 +1,15 @@
 package coop.rchain.comm.transport
 
+import cats.tagless._
 import coop.rchain.comm.CommError.CommErr
 import coop.rchain.comm.protocol.routing._
 import coop.rchain.comm.{CommError, PeerNode}
 
 final case class Blob(sender: PeerNode, packet: Packet)
 
+@autoFunctorK
+@autoSemigroupalK
+@autoProductNK
 trait TransportLayer[F[_]] {
   def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]]
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]]

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -79,8 +79,7 @@ class TcpTransportLayerSpec
         maxMessageSize,
         maxStreamMessageSize,
         tempFolder,
-        4,
-        false
+        4
       )
     }
 }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -49,7 +49,7 @@ object Main {
 
     Task
       .defer(logUnknownConfigurationKeys(configuration) >> mainProgram(configuration))
-      .unsafeRunSyncTracing(configuration.kamon.zipkin)
+      .unsafeRunSync
   }
 
   private def logUnknownConfigurationKeys(conf: Configuration): Task[Unit] =
@@ -141,7 +141,7 @@ object Main {
         proposeService.close()
         replService.close()
         deployService.close()
-        console.close.unsafeRunSyncTracing(conf.kamon.zipkin)(scheduler)
+        console.close.unsafeRunSync(scheduler)
       }
     ) >> program
   }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -195,7 +195,7 @@ object Main {
       _             <- log.info(VersionInfo.get)
       _             <- logConfiguration(confWithPorts)
       runtime       <- NodeRuntime(confWithPorts)
-      _             <- runtime.main.run(Trace.next)
+      _             <- runtime.main.run(NodeCallCtx.init)
     } yield ()
   }
 

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -12,6 +12,7 @@ import coop.rchain.crypto.util.KeyUtil
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 import coop.rchain.node.configuration._
+import coop.rchain.node.diagnostics.Trace
 import coop.rchain.node.effects._
 import coop.rchain.shared.StringOps._
 import coop.rchain.shared._
@@ -194,7 +195,7 @@ object Main {
       _             <- log.info(VersionInfo.get)
       _             <- logConfiguration(confWithPorts)
       runtime       <- NodeRuntime(confWithPorts)
-      _             <- runtime.main
+      _             <- runtime.main.run(Trace.next)
     } yield ()
   }
 

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -483,7 +483,7 @@ class NodeRuntime private[node] (
     raiseIOError    = IOError.raiseIOErrorThroughSync[Task]
     requestedBlocks <- Cell.mvarCell[Task, Map[BlockHash, Running.Requested]](Map.empty)
     casperInit      = new CasperInit[Task](conf.casper)
-    _ <- CasperLaunch[Task](casperInit, identity)(
+    _ <- CasperLaunch[Task](casperInit)(
           lab,
           metrics,
           span,
@@ -504,8 +504,7 @@ class NodeRuntime private[node] (
           envVars,
           raiseIOError,
           runtimeManager,
-          requestedBlocks,
-          scheduler
+          requestedBlocks
         )
     packetHandler = {
       implicit val ev: EngineCell[Task] = engineCell

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -388,7 +388,7 @@ class NodeRuntime private[node] (
 
     // 3. create instances of typeclasses
     metrics       = diagnostics.effects.metrics[Task]
-    time          = effects.time
+    time          = effects.time[Task]
     commTmpFolder = conf.server.dataDir.resolve("tmp").resolve("comm")
     _ <- commTmpFolder.toFile
           .exists()

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -2,18 +2,15 @@ package coop.rchain.node
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
-import java.util.UUID
 
 import cats._
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
-import cats.mtl.{ApplicativeLocal, DefaultApplicativeLocal, MonadState}
+import cats.mtl.MonadState
 import cats.temp.par.Par
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.util.io.IOError
-import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
-import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.casper.engine.CasperLaunch.CasperInit
 import coop.rchain.casper.engine.EngineCell._
@@ -33,10 +30,9 @@ import coop.rchain.comm.transport._
 import coop.rchain.grpc.Server
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.node.NodeRuntime.Cleanup
+import coop.rchain.node.NodeRuntime.{APIServers, Cleanup, RuntimeConf}
 import coop.rchain.node.api.{DeployGrpcService, ProposeGrpcService, ReplGrpcService}
 import coop.rchain.node.configuration.Configuration
-import coop.rchain.node.diagnostics.Trace.TraceId
 import coop.rchain.node.diagnostics._
 import coop.rchain.node.model.repl.ReplGrpcMonix
 import coop.rchain.p2p.effects._
@@ -47,7 +43,7 @@ import coop.rchain.shared._
 import kamon._
 import kamon.system.SystemMetrics
 import kamon.zipkin.ZipkinReporter
-import monix.eval.{Task, TaskLocal}
+import monix.eval.Task
 import monix.execution.Scheduler
 import org.http4s.implicits._
 import org.http4s.server.blaze._
@@ -70,8 +66,7 @@ class NodeRuntime private[node] (
     Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionLogger)
   private[this] val grpcScheduler =
     Scheduler.cached("grpc-io", 4, 64, reporter = UncaughtExceptionLogger)
-  private[this] val rspaceScheduler = RChainScheduler.interpreterScheduler
-
+  private[this] val rspaceScheduler         = RChainScheduler.interpreterScheduler
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
   /** Configuration */
@@ -82,155 +77,161 @@ class NodeRuntime private[node] (
   private val storageSize       = conf.server.mapSize
   private val defaultTimeout    = conf.server.defaultTimeout // TODO remove
 
-  case class Servers(
-      kademliaRPCServer: Server[Task],
-      transportServer: TransportServer,
-      externalApiServer: Server[Task],
-      internalApiServer: Server[Task],
-      httpServer: Fiber[Task, Unit]
-  )
+  /**
+    * Main node entry. It will:
+    * 1. set up configurations
+    * 2. create instances of typeclasses
+    * 3. run the node program.
+    */
+  // TODO: Resolve scheduler chaos in Runtime, RuntimeManager and CasperPacketHandler
+  val main: Task[Unit] = for {
+    // 1. fetch local peer node
+    local <- WhoAmI
+              .fetchLocalPeerNode[Task](
+                conf.server.host,
+                conf.server.port,
+                conf.server.kademliaPort,
+                conf.server.noUpnp,
+                id
+              )
 
-  case class APIServers(
-      repl: ReplGrpcMonix.Repl,
-      propose: ProposeServiceGrpcMonix.ProposeService,
-      deploy: DeployServiceGrpcMonix.DeployService
-  )
+    // 3. create instances of typeclasses
+    metrics       = diagnostics.effects.metrics[Task]
+    time          = effects.time[Task]
+    commTmpFolder = conf.server.dataDir.resolve("tmp").resolve("comm")
+    _ <- commTmpFolder.toFile
+          .exists()
+          .fold(
+            commTmpFolder.deleteDirectory[Task](),
+            Task.unit
+          )
+    transport <- effects
+                  .transportClient(
+                    conf.server.networkId,
+                    conf.tls.certificate,
+                    conf.tls.key,
+                    conf.server.maxMessageSize,
+                    conf.server.packetChunkSize,
+                    commTmpFolder
+                  )(grpcScheduler, log, metrics)
 
-  def acquireAPIServers[F[_]](runtime: Runtime[F], blockApiLock: Semaphore[F])(
-      implicit
-      blockStore: BlockStore[F],
-      oracle: SafetyOracle[F],
-      concurrent: Concurrent[F],
-      span: Span[F],
-      engineCell: EngineCell[F],
-      logF: Log[F],
-      taskable: Taskable[F]
-  ): APIServers = {
-    implicit val s: Scheduler = scheduler
-    val repl                  = ReplGrpcService.instance(runtime, s)
-    val deploy                = DeployGrpcService.instance(blockApiLock)
-    val propose               = ProposeGrpcService.instance(blockApiLock)
-    APIServers(repl, propose, deploy)
-  }
-
-  def acquireServers(apiServers: APIServers)(
-      implicit
-      kademliaStore: KademliaStore[Task],
-      nodeDiscovery: NodeDiscovery[Task],
-      connectionsCell: ConnectionsCell[Task],
-      concurrent: Concurrent[Task],
-      metrics: Metrics[Task],
-      rPConfAsk: RPConfAsk[Task]
-  ): Task[Servers] = {
-    implicit val s: Scheduler = scheduler
-    for {
-      kademliaRPCServer <- discovery
-                            .acquireKademliaRPCServer(
-                              conf.server.networkId,
-                              conf.server.kademliaPort,
-                              KademliaHandleRPC.handlePing[Task],
-                              KademliaHandleRPC.handleLookup[Task]
-                            )(grpcScheduler)
-
-      transportServer <- Task
-                          .delay(
-                            GrpcTransportServer.acquireServer(
-                              conf.server.networkId,
-                              conf.server.port,
-                              conf.tls.certificate,
-                              conf.tls.key,
-                              conf.server.maxMessageSize,
-                              conf.server.maxStreamMessageSize,
-                              conf.server.dataDir.resolve("tmp").resolve("comm"),
-                              conf.server.messageConsumers
-                            )(grpcScheduler, rPConfAsk, log, metrics)
-                          )
-
-      externalApiServer <- api
-                            .acquireExternalServer[Task](
-                              conf.grpcServer.portExternal,
-                              grpcScheduler,
-                              apiServers.deploy,
-                              apiServers.propose
-                            )
-      internalApiServer <- api
-                            .acquireInternalServer(
-                              conf.grpcServer.portInternal,
-                              grpcScheduler,
-                              apiServers.repl,
-                              apiServers.propose
-                            )
-
-      prometheusReporter = new NewPrometheusReporter()
-      prometheusService  = NewPrometheusReporter.service[Task](prometheusReporter)
-
-      httpServerFiber <- BlazeServerBuilder[Task]
-                          .bindHttp(conf.server.httpPort, "0.0.0.0")
-                          .withHttpApp(
-                            Router(
-                              "/metrics" -> prometheusService,
-                              "/version" -> VersionInfo.service[Task],
-                              "/status"  -> StatusInfo.service[Task]
-                            ).orNotFound
-                          )
-                          .resource
-                          .use(_ => Task.never[Unit])
-                          .start
-
-      _ <- Task.delay {
-            Kamon.reconfigure(conf.underlying.withFallback(Kamon.config()))
-            if (conf.kamon.influxDb) Kamon.addReporter(new BatchInfluxDBReporter())
-            if (conf.kamon.influxDbUdp) Kamon.addReporter(new UdpInfluxDBReporter())
-            if (conf.kamon.prometheus) Kamon.addReporter(prometheusReporter)
-            if (conf.kamon.zipkin) Kamon.addReporter(new ZipkinReporter())
-            if (conf.kamon.sigar) SystemMetrics.startCollecting()
-          }
-    } yield Servers(
-      kademliaRPCServer,
-      transportServer,
-      externalApiServer,
-      internalApiServer,
-      httpServerFiber
+    initPeer       = if (conf.server.standalone) None else Some(conf.server.bootstrap)
+    peerNode       = rpConf(local, initPeer)
+    rpConfState    = effects.rpConfState[Task](peerNode)
+    peerNodeAsk    = effects.peerNodeAsk[Task](Monad[Task], Sync[Task], rpConfState)
+    defaultTimeout = conf.server.defaultTimeout
+    kademliaRPC = effects.kademliaRPC(
+      conf.server.networkId,
+      defaultTimeout,
+      conf.server.allowPrivateAddresses
+    )(
+      grpcScheduler,
+      peerNodeAsk,
+      metrics
     )
-  }
+    kademliaStore = effects.kademliaStore(id)(kademliaRPC, metrics)
+    _             <- initPeer.fold(Task.unit)(p => kademliaStore.updateLastSeen(p))
+    nodeDiscovery = effects.nodeDiscovery(id)(Monad[Task], kademliaStore, kademliaRPC)
 
-  def clearResources(
-      servers: Servers,
-      runtimeCleanup: Cleanup[Task]
-  )(
-      implicit
-      blockStore: BlockStore[Task],
-      blockDagStorage: BlockDagStorage[Task]
-  ): Unit =
-    (for {
-      _ <- log.info("Shutting down API servers...")
-      _ <- servers.externalApiServer.stop
-      _ <- servers.internalApiServer.stop
-      _ <- log.info("Shutting down Kademlia RPC server...")
-      _ <- servers.kademliaRPCServer.stop
-      _ <- log.info("Shutting down transport layer...")
-      _ <- servers.transportServer.stop()
-      _ <- log.info("Shutting down HTTP server....")
-      _ <- Task.delay(Kamon.stopAllReporters())
-      _ <- servers.httpServer.cancel.attempt
-      _ <- runtimeCleanup.close()
-      _ <- log.info("Bringing DagStorage down ...")
-      _ <- blockDagStorage.close()
-      _ <- log.info("Bringing BlockStore down ...")
-      _ <- blockStore.close()
-      _ <- log.info("Goodbye.")
-    } yield ()).unsafeRunSync(scheduler)
+    /**
+      * We need to come up with a consistent way with folder creation. Some layers create folder on their own (if not available),
+      * others (like blockstore) relay on the structure being created for them (and will fail if it does not exist). For now
+      * this small fix should suffice, but we should unify this.
+      */
+    _             <- mkDirs(conf.server.dataDir)
+    _             <- mkDirs(blockstorePath)
+    _             <- mkDirs(dagStoragePath)
+    blockstoreEnv = Context.env(blockstorePath, 8L * 1024L * 1024L * 1024L)
+    dagConfig = BlockDagFileStorage.Config(
+      latestMessagesLogPath = dagStoragePath.resolve("latestMessagesLogPath"),
+      latestMessagesCrcPath = dagStoragePath.resolve("latestMessagesCrcPath"),
+      blockMetadataLogPath = dagStoragePath.resolve("blockMetadataLogPath"),
+      blockMetadataCrcPath = dagStoragePath.resolve("blockMetadataCrcPath"),
+      equivocationsTrackerLogPath = dagStoragePath.resolve("equivocationsTrackerLogPath"),
+      equivocationsTrackerCrcPath = dagStoragePath.resolve("equivocationsTrackerCrcPath"),
+      invalidBlocksLogPath = dagStoragePath.resolve("invalidBlocksLogPath"),
+      invalidBlocksCrcPath = dagStoragePath.resolve("invalidBlocksCrcPath"),
+      blockHashesByDeployLogPath = dagStoragePath.resolve("blockHashesByDeployLogPath"),
+      blockHashesByDeployCrcPath = dagStoragePath.resolve("blockHashesByDeployCrcPath"),
+      checkpointsDirPath = dagStoragePath.resolve("checkpointsDirPath"),
+      blockNumberIndexPath = dagStoragePath.resolve("blockNumberIndexPath"),
+      mapSize = 8L * 1024L * 1024L * 1024L,
+      latestMessagesLogMaxSizeFactor = 10
+    )
+    casperConfig = RuntimeConf(casperStoragePath, storageSize)
+    cliConfig    = RuntimeConf(storagePath, 800L * 1024L * 1024L) // 800MB for cli
 
-  def addShutdownHook(
-      servers: Servers,
-      runtimeCleanup: Cleanup[Task]
-  )(
-      implicit blockStore: BlockStore[Task],
-      blockDagStorage: BlockDagStorage[Task]
-  ): Task[Unit] =
-    Task.delay(sys.addShutdownHook(clearResources(servers, runtimeCleanup)))
+    result <- NodeRuntime.setupNodeProgramF[Task](
+               rpConfState,
+               conf,
+               dagConfig,
+               blockstoreEnv,
+               casperConfig,
+               cliConfig,
+               blockstorePath,
+               rspaceScheduler,
+               scheduler
+             )(
+               metrics,
+               transport,
+               Sync[Task],
+               Concurrent[Task],
+               time,
+               log,
+               eventLog,
+               ContextShift[Task],
+               Par[Task],
+               Taskable[Task]
+             )
+    (
+      rpConnections,
+      rpConfAsk,
+      blockStore,
+      blockDagStorage,
+      engineCell,
+      requestedBlocks,
+      runtimeCleanup,
+      packetHandler,
+      apiServers
+    ) = result
 
-  private def exit0: Task[Unit] = Task.delay(System.exit(0))
+    // 4. run the node program.
+    program = nodeProgram(apiServers, runtimeCleanup)(
+      time,
+      rpConfState,
+      rpConfAsk,
+      peerNodeAsk,
+      metrics,
+      transport,
+      kademliaStore,
+      nodeDiscovery,
+      rpConnections,
+      blockDagStorage,
+      blockStore,
+      packetHandler,
+      engineCell,
+      requestedBlocks
+    )
+    _ <- handleUnrecoverableErrors(program)
+  } yield ()
+
+  private val rpClearConnConf = ClearConnectionsConf(
+    numOfConnectionsPinged = 10
+  ) // TODO read from conf
+
+  private def rpConf(local: PeerNode, bootstrapNode: Option[PeerNode]) =
+    RPConf(
+      local,
+      conf.server.networkId,
+      bootstrapNode,
+      defaultTimeout,
+      conf.server.maxNumOfConnections,
+      rpClearConnConf
+    )
+
+  // TODO this should use existing algebra
+  private def mkDirs(path: Path): Task[Unit] =
+    Sync[Task].delay(Files.createDirectories(path))
 
   private def nodeProgram(
       apiServers: APIServers,
@@ -338,6 +339,44 @@ class NodeRuntime private[node] (
     } yield ()
   }
 
+  def addShutdownHook(
+      servers: Servers,
+      runtimeCleanup: Cleanup[Task]
+  )(
+      implicit blockStore: BlockStore[Task],
+      blockDagStorage: BlockDagStorage[Task]
+  ): Task[Unit] =
+    Task.delay(sys.addShutdownHook(clearResources(servers, runtimeCleanup)))
+
+  def clearResources(
+      servers: Servers,
+      runtimeCleanup: Cleanup[Task]
+  )(
+      implicit
+      blockStore: BlockStore[Task],
+      blockDagStorage: BlockDagStorage[Task]
+  ): Unit =
+    (for {
+      _ <- log.info("Shutting down API servers...")
+      _ <- servers.externalApiServer.stop
+      _ <- servers.internalApiServer.stop
+      _ <- log.info("Shutting down Kademlia RPC server...")
+      _ <- servers.kademliaRPCServer.stop
+      _ <- log.info("Shutting down transport layer...")
+      _ <- servers.transportServer.stop()
+      _ <- log.info("Shutting down HTTP server....")
+      _ <- Task.delay(Kamon.stopAllReporters())
+      _ <- servers.httpServer.cancel.attempt
+      _ <- runtimeCleanup.close()
+      _ <- log.info("Bringing DagStorage down ...")
+      _ <- blockDagStorage.close()
+      _ <- log.info("Bringing BlockStore down ...")
+      _ <- blockStore.close()
+      _ <- log.info("Goodbye.")
+    } yield ()).unsafeRunSync(scheduler)
+
+  private def exit0: Task[Unit] = Task.delay(System.exit(0))
+
   /**
     * Handles unrecoverable errors in program. Those are errors that should not happen in properly
     * configured enviornment and they mean immediate termination of the program
@@ -350,154 +389,136 @@ class NodeRuntime private[node] (
         }
       } >> exit0.as(Right(()))
 
-  private val rpClearConnConf = ClearConnectionsConf(
-    numOfConnectionsPinged = 10
-  ) // TODO read from conf
+  case class Servers(
+      kademliaRPCServer: Server[Task],
+      transportServer: TransportServer,
+      externalApiServer: Server[Task],
+      internalApiServer: Server[Task],
+      httpServer: Fiber[Task, Unit]
+  )
 
-  private def rpConf(local: PeerNode, bootstrapNode: Option[PeerNode]) =
-    RPConf(
-      local,
-      conf.server.networkId,
-      bootstrapNode,
-      defaultTimeout,
-      conf.server.maxNumOfConnections,
-      rpClearConnConf
+  def acquireServers(apiServers: APIServers)(
+      implicit
+      kademliaStore: KademliaStore[Task],
+      nodeDiscovery: NodeDiscovery[Task],
+      connectionsCell: ConnectionsCell[Task],
+      concurrent: Concurrent[Task],
+      metrics: Metrics[Task],
+      rPConfAsk: RPConfAsk[Task]
+  ): Task[Servers] = {
+    implicit val s: Scheduler = scheduler
+    for {
+      kademliaRPCServer <- discovery
+                            .acquireKademliaRPCServer(
+                              conf.server.networkId,
+                              conf.server.kademliaPort,
+                              KademliaHandleRPC.handlePing[Task],
+                              KademliaHandleRPC.handleLookup[Task]
+                            )(grpcScheduler)
+
+      transportServer <- Task
+                          .delay(
+                            GrpcTransportServer.acquireServer(
+                              conf.server.networkId,
+                              conf.server.port,
+                              conf.tls.certificate,
+                              conf.tls.key,
+                              conf.server.maxMessageSize,
+                              conf.server.maxStreamMessageSize,
+                              conf.server.dataDir.resolve("tmp").resolve("comm"),
+                              conf.server.messageConsumers
+                            )(grpcScheduler, rPConfAsk, log, metrics)
+                          )
+
+      externalApiServer <- api
+                            .acquireExternalServer[Task](
+                              conf.grpcServer.portExternal,
+                              grpcScheduler,
+                              apiServers.deploy,
+                              apiServers.propose
+                            )
+      internalApiServer <- api
+                            .acquireInternalServer(
+                              conf.grpcServer.portInternal,
+                              grpcScheduler,
+                              apiServers.repl,
+                              apiServers.propose
+                            )
+
+      prometheusReporter = new NewPrometheusReporter()
+      prometheusService  = NewPrometheusReporter.service[Task](prometheusReporter)
+
+      httpServerFiber <- BlazeServerBuilder[Task]
+                          .bindHttp(conf.server.httpPort, "0.0.0.0")
+                          .withHttpApp(
+                            Router(
+                              "/metrics" -> prometheusService,
+                              "/version" -> VersionInfo.service[Task],
+                              "/status"  -> StatusInfo.service[Task]
+                            ).orNotFound
+                          )
+                          .resource
+                          .use(_ => Task.never[Unit])
+                          .start
+
+      _ <- Task.delay {
+            Kamon.reconfigure(conf.underlying.withFallback(Kamon.config()))
+            if (conf.kamon.influxDb) Kamon.addReporter(new BatchInfluxDBReporter())
+            if (conf.kamon.influxDbUdp) Kamon.addReporter(new UdpInfluxDBReporter())
+            if (conf.kamon.prometheus) Kamon.addReporter(prometheusReporter)
+            if (conf.kamon.zipkin) Kamon.addReporter(new ZipkinReporter())
+            if (conf.kamon.sigar) SystemMetrics.startCollecting()
+          }
+    } yield Servers(
+      kademliaRPCServer,
+      transportServer,
+      externalApiServer,
+      internalApiServer,
+      httpServerFiber
     )
+  }
 
-  // TODO this should use existing algebra
-  private def mkDirs(path: Path): Task[Unit] =
-    Sync[Task].delay(Files.createDirectories(path))
+}
 
-  /**
-    * Main node entry. It will:
-    * 1. set up configurations
-    * 2. create instances of typeclasses
-    * 3. run the node program.
-    */
-  // TODO: Resolve scheduler chaos in Runtime, RuntimeManager and CasperPacketHandler
-  val main: Task[Unit] = for {
-    // 1. fetch local peer node
-    local <- WhoAmI
-              .fetchLocalPeerNode[Task](
-                conf.server.host,
-                conf.server.port,
-                conf.server.kademliaPort,
-                conf.server.noUpnp,
-                id
-              )
+object NodeRuntime {
+  def apply(
+      conf: Configuration
+  )(implicit scheduler: Scheduler, log: Log[Task], eventLog: EventLog[Task]): Task[NodeRuntime] =
+    for {
+      id      <- NodeEnvironment.create(conf)
+      runtime <- Task.delay(new NodeRuntime(conf, id, scheduler))
+    } yield runtime
 
-    // 3. create instances of typeclasses
-    metrics       = diagnostics.effects.metrics[Task]
-    time          = effects.time[Task]
-    commTmpFolder = conf.server.dataDir.resolve("tmp").resolve("comm")
-    _ <- commTmpFolder.toFile
-          .exists()
-          .fold(
-            commTmpFolder.deleteDirectory[Task](),
-            Task.unit
-          )
-    transport <- effects
-                  .transportClient(
-                    conf.server.networkId,
-                    conf.tls.certificate,
-                    conf.tls.key,
-                    conf.server.maxMessageSize,
-                    conf.server.packetChunkSize,
-                    commTmpFolder
-                  )(grpcScheduler, log, metrics)
+  trait Cleanup[F[_]] {
+    def close(): F[Unit]
+  }
 
-    initPeer       = if (conf.server.standalone) None else Some(conf.server.bootstrap)
-    peerNode       = rpConf(local, initPeer)
-    rpConfState    = effects.rpConfState[Task](peerNode)
-    peerNodeAsk    = effects.peerNodeAsk[Task](Monad[Task], Sync[Task], rpConfState)
-    defaultTimeout = conf.server.defaultTimeout
-    kademliaRPC = effects.kademliaRPC(
-      conf.server.networkId,
-      defaultTimeout,
-      conf.server.allowPrivateAddresses
-    )(
-      grpcScheduler,
-      peerNodeAsk,
-      metrics
-    )
-    kademliaStore = effects.kademliaStore(id)(kademliaRPC, metrics)
-    _             <- initPeer.fold(Task.unit)(p => kademliaStore.updateLastSeen(p))
-    nodeDiscovery = effects.nodeDiscovery(id)(Monad[Task], kademliaStore, kademliaRPC)
+  def cleanup[F[_]: Sync: Log](runtime: Runtime[F], casperRuntime: Runtime[F]): Cleanup[F] =
+    new Cleanup[F] {
+      override def close(): F[Unit] =
+        for {
+          _ <- Log[F].info("Shutting down interpreter runtime ...")
+          _ <- runtime.close()
+          _ <- Log[F].info("Shutting down Casper runtime ...")
+          _ <- casperRuntime.close()
+        } yield ()
+    }
 
-    /**
-      * We need to come up with a consistent way with folder creation. Some layers create folder on their own (if not available),
-      * others (like blockstore) relay on the structure being created for them (and will fail if it does not exist). For now
-      * this small fix should suffice, but we should unify this.
-      */
-    _             <- mkDirs(conf.server.dataDir)
-    _             <- mkDirs(blockstorePath)
-    _             <- mkDirs(dagStoragePath)
-    blockstoreEnv = Context.env(blockstorePath, 8L * 1024L * 1024L * 1024L)
-    dagConfig = BlockDagFileStorage.Config(
-      latestMessagesLogPath = dagStoragePath.resolve("latestMessagesLogPath"),
-      latestMessagesCrcPath = dagStoragePath.resolve("latestMessagesCrcPath"),
-      blockMetadataLogPath = dagStoragePath.resolve("blockMetadataLogPath"),
-      blockMetadataCrcPath = dagStoragePath.resolve("blockMetadataCrcPath"),
-      equivocationsTrackerLogPath = dagStoragePath.resolve("equivocationsTrackerLogPath"),
-      equivocationsTrackerCrcPath = dagStoragePath.resolve("equivocationsTrackerCrcPath"),
-      invalidBlocksLogPath = dagStoragePath.resolve("invalidBlocksLogPath"),
-      invalidBlocksCrcPath = dagStoragePath.resolve("invalidBlocksCrcPath"),
-      blockHashesByDeployLogPath = dagStoragePath.resolve("blockHashesByDeployLogPath"),
-      blockHashesByDeployCrcPath = dagStoragePath.resolve("blockHashesByDeployCrcPath"),
-      checkpointsDirPath = dagStoragePath.resolve("checkpointsDirPath"),
-      blockNumberIndexPath = dagStoragePath.resolve("blockNumberIndexPath"),
-      mapSize = 8L * 1024L * 1024L * 1024L,
-      latestMessagesLogMaxSizeFactor = 10
-    )
-    result <- setupNodeProgramF[Task](rpConfState, conf, dagConfig, blockstoreEnv)(
-               metrics,
-               transport,
-               Sync[Task],
-               Concurrent[Task],
-               time,
-               log,
-               eventLog,
-               ContextShift[Task],
-               Par[Task],
-               Taskable[Task]
-             )
-    (
-      rpConnections,
-      rpConfAsk,
-      blockStore,
-      blockDagStorage,
-      engineCell,
-      requestedBlocks,
-      runtimeCleanup,
-      packetHandler,
-      apiServers
-    ) = result
-
-    // 4. run the node program.
-    program = nodeProgram(apiServers, runtimeCleanup)(
-      time,
-      rpConfState,
-      rpConfAsk,
-      peerNodeAsk,
-      metrics,
-      transport,
-      kademliaStore,
-      nodeDiscovery,
-      rpConnections,
-      blockDagStorage,
-      blockStore,
-      packetHandler,
-      engineCell,
-      requestedBlocks
-    )
-    _ <- handleUnrecoverableErrors(program)
-  } yield ()
+  final case class RuntimeConf(
+      storage: Path,
+      size: Long
+  )
 
   def setupNodeProgramF[F[_]: Metrics: TransportLayer: Sync: Concurrent: Time: Log: EventLog: ContextShift: Par: Taskable](
       rpConfState: MonadState[F, RPConf],
       conf: Configuration,
       dagConfig: BlockDagFileStorage.Config,
-      blockstoreEnv: Env[ByteBuffer]
+      blockstoreEnv: Env[ByteBuffer],
+      casperConf: RuntimeConf,
+      cliConf: RuntimeConf,
+      blockstorePath: Path,
+      rspaceScheduler: Scheduler,
+      scheduler: Scheduler
   ) =
     for {
       rpConnections <- effects.rpConnections
@@ -531,7 +552,7 @@ class NodeRuntime private[node] (
         implicit val s  = rspaceScheduler
         implicit val sp = span
         Runtime
-          .createWithEmptyCost[F](storagePath, storageSize, Seq.empty)
+          .createWithEmptyCost[F](cliConf.storage, cliConf.size, Seq.empty)
       }
       _ <- Runtime.bootstrapRegistry[F](runtime)
       casperRuntime <- {
@@ -539,8 +560,8 @@ class NodeRuntime private[node] (
         implicit val sp = span
         Runtime
           .createWithEmptyCost[F](
-            casperStoragePath,
-            storageSize,
+            casperConf.storage,
+            casperConf.size,
             Seq.empty
           )
       }
@@ -574,7 +595,7 @@ class NodeRuntime private[node] (
         CasperPacketHandler[F]
       }
       blockApiLock <- Semaphore[F](1)
-      apiServers = acquireAPIServers(runtime, blockApiLock)(
+      apiServers = NodeRuntime.acquireAPIServers[F](runtime, blockApiLock, scheduler)(
         blockStore,
         oracle,
         Concurrent[F],
@@ -595,29 +616,31 @@ class NodeRuntime private[node] (
       packetHandler,
       apiServers
     )
-}
 
-object NodeRuntime {
-  def apply(
-      conf: Configuration
-  )(implicit scheduler: Scheduler, log: Log[Task], eventLog: EventLog[Task]): Task[NodeRuntime] =
-    for {
-      id      <- NodeEnvironment.create(conf)
-      runtime <- Task.delay(new NodeRuntime(conf, id, scheduler))
-    } yield runtime
+  final case class APIServers(
+      repl: ReplGrpcMonix.Repl,
+      propose: ProposeServiceGrpcMonix.ProposeService,
+      deploy: DeployServiceGrpcMonix.DeployService
+  )
 
-  trait Cleanup[F[_]] {
-    def close(): F[Unit]
+  def acquireAPIServers[F[_]](
+      runtime: Runtime[F],
+      blockApiLock: Semaphore[F],
+      scheduler: Scheduler
+  )(
+      implicit
+      blockStore: BlockStore[F],
+      oracle: SafetyOracle[F],
+      concurrent: Concurrent[F],
+      span: Span[F],
+      engineCell: EngineCell[F],
+      logF: Log[F],
+      taskable: Taskable[F]
+  ): APIServers = {
+    implicit val s: Scheduler = scheduler
+    val repl                  = ReplGrpcService.instance(runtime, s)
+    val deploy                = DeployGrpcService.instance(blockApiLock)
+    val propose               = ProposeGrpcService.instance(blockApiLock)
+    APIServers(repl, propose, deploy)
   }
-
-  def cleanup[F[_]: Sync: Log](runtime: Runtime[F], casperRuntime: Runtime[F]): Cleanup[F] =
-    new Cleanup[F] {
-      override def close(): F[Unit] =
-        for {
-          _ <- Log[F].info("Shutting down interpreter runtime ...")
-          _ <- runtime.close()
-          _ <- Log[F].info("Shutting down Casper runtime ...")
-          _ <- casperRuntime.close()
-        } yield ()
-    }
 }

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -26,8 +26,7 @@ import monix.reactive.Observable
 
 private[api] object DeployGrpcService {
   def instance[F[_]: Concurrent: Log: SafetyOracle: BlockStore: Taskable: Span: EngineCell](
-      blockApiLock: Semaphore[F],
-      tracing: Boolean
+      blockApiLock: Semaphore[F]
   )(
       implicit worker: Scheduler
   ): DeployServiceGrpcMonix.DeployService =
@@ -39,7 +38,6 @@ private[api] object DeployGrpcService {
         Task
           .defer(task.toTask)
           .executeOn(worker)
-          .executeWithOptions(TaskContrib.enableTracing(tracing))
           .attemptAndLog
           .attempt
           .map(_.fold(_.asLeft[A].toGrpcEither, _.toGrpcEither))
@@ -48,7 +46,6 @@ private[api] object DeployGrpcService {
         Task
           .defer(task.toTask)
           .executeOn(worker)
-          .executeWithOptions(TaskContrib.enableTracing(tracing))
           .attemptAndLog
           .attempt
           .map(_.fold(t => List(t.asLeft[A].toGrpcEither), _.map(_.asRight[String].toGrpcEither)))

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcService.scala
@@ -24,7 +24,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
-private[api] object DeployGrpcService {
+object DeployGrpcService {
   def instance[F[_]: Concurrent: Log: SafetyOracle: BlockStore: Taskable: Span: EngineCell](
       blockApiLock: Semaphore[F]
   )(

--- a/node/src/main/scala/coop/rchain/node/api/ProposeGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ProposeGrpcService.scala
@@ -21,8 +21,7 @@ import monix.execution.Scheduler
 
 private[api] object ProposeGrpcService {
   def instance[F[_]: Concurrent: Log: SafetyOracle: BlockStore: Taskable: Span: EngineCell](
-      blockApiLock: Semaphore[F],
-      tracing: Boolean
+      blockApiLock: Semaphore[F]
   )(
       implicit worker: Scheduler
   ): ProposeServiceGrpcMonix.ProposeService =
@@ -34,7 +33,6 @@ private[api] object ProposeGrpcService {
         Task
           .defer(task.toTask)
           .executeOn(worker)
-          .executeWithOptions(TaskContrib.enableTracing(tracing))
           .attemptAndLog
           .attempt
           .map(_.fold(_.asLeft[A].toGrpcEither, _.toGrpcEither))

--- a/node/src/main/scala/coop/rchain/node/api/ProposeGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ProposeGrpcService.scala
@@ -19,7 +19,7 @@ import coop.rchain.metrics.Span
 import monix.eval.Task
 import monix.execution.Scheduler
 
-private[api] object ProposeGrpcService {
+object ProposeGrpcService {
   def instance[F[_]: Concurrent: Log: SafetyOracle: BlockStore: Taskable: Span: EngineCell](
       blockApiLock: Semaphore[F]
   )(

--- a/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
@@ -37,8 +37,7 @@ import coop.rchain.rholang.interpreter._
 import Interpreter._
 import storage.StoragePrinter
 
-private[api] class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler)
-    extends ReplGrpcMonix.Repl {
+class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler) extends ReplGrpcMonix.Repl {
 
   def exec(source: String, printUnmatchedSendsOnly: Boolean = false): Task[ReplResponse] =
     ParBuilder[Task]

--- a/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/ReplGrpcService.scala
@@ -35,56 +35,61 @@ import coop.rchain.shared._
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter._
 import Interpreter._
+import cats.effect.Sync
 import storage.StoragePrinter
 
-class ReplGrpcService(runtime: Runtime[Task], worker: Scheduler) extends ReplGrpcMonix.Repl {
+object ReplGrpcService {
+  def instance[F[_]: Sync: Taskable](runtime: Runtime[F], worker: Scheduler): ReplGrpcMonix.Repl =
+    new ReplGrpcMonix.Repl {
+      def exec(source: String, printUnmatchedSendsOnly: Boolean = false): F[ReplResponse] =
+        Sync[F]
+          .attempt(
+            ParBuilder[F]
+              .buildNormalizedTerm(source, NormalizerEnv.Empty)
+          )
+          .flatMap {
+            case Left(er) =>
+              er match {
+                case _: InterpreterError => Sync[F].delay(s"Error: ${er.toString}")
+                case th: Throwable       => Sync[F].delay(s"Error: $th")
+              }
+            case Right(term) =>
+              for {
+                _ <- Sync[F].delay(printNormalizedTerm(term))
+                res <- {
+                  implicit val c = runtime.cost
+                  Interpreter[F].evaluate(runtime, source, NormalizerEnv.Empty)
+                }
+                prettyStorage <- if (printUnmatchedSendsOnly)
+                                  StoragePrinter.prettyPrintUnmatchedSends(runtime.space)
+                                else StoragePrinter.prettyPrint(runtime.space)
+                EvaluateResult(cost, errors) = res
+              } yield {
+                val errorStr =
+                  if (errors.isEmpty)
+                    ""
+                  else
+                    errors
+                      .map(_.toString())
+                      .mkString("Errors received during evaluation:\n", "\n", "\n")
+                s"Deployment cost: $cost\n" +
+                  s"${errorStr}Storage Contents:\n$prettyStorage"
+              }
+          }
+          .map(ReplResponse(_))
 
-  def exec(source: String, printUnmatchedSendsOnly: Boolean = false): Task[ReplResponse] =
-    ParBuilder[Task]
-      .buildNormalizedTerm(source, NormalizerEnv.Empty)
-      .attempt
-      .flatMap {
-        case Left(er) =>
-          er match {
-            case _: InterpreterError => Task.now(s"Error: ${er.toString}")
-            case th: Throwable       => Task.now(s"Error: $th")
-          }
-        case Right(term) =>
-          for {
-            _ <- Task.now(printNormalizedTerm(term))
-            res <- {
-              implicit val c = runtime.cost
-              Interpreter[Task].evaluate(runtime, source, NormalizerEnv.Empty)
-            }
-            prettyStorage <- if (printUnmatchedSendsOnly)
-                              StoragePrinter.prettyPrintUnmatchedSends(runtime.space)
-                            else StoragePrinter.prettyPrint(runtime.space)
-            EvaluateResult(cost, errors) = res
-          } yield {
-            val errorStr =
-              if (errors.isEmpty)
-                ""
-              else
-                errors
-                  .map(_.toString())
-                  .mkString("Errors received during evaluation:\n", "\n", "\n")
-            s"Deployment cost: $cost\n" +
-              s"${errorStr}Storage Contents:\n$prettyStorage"
-          }
+      private def defer[A](task: F[A]): Task[A] =
+        Task.defer(task.toTask).executeOn(worker)
+
+      def run(request: CmdRequest): Task[ReplResponse] =
+        defer(exec(request.line))
+
+      def eval(request: EvalRequest): Task[ReplResponse] =
+        defer(exec(request.program, request.printUnmatchedSendsOnly))
+
+      private def printNormalizedTerm(normalizedTerm: Par): Unit = {
+        Console.println("\nEvaluating:")
+        Console.println(PrettyPrinter().buildString(normalizedTerm))
       }
-      .map(ReplResponse(_))
-
-  private def defer[A](task: Task[A]): Task[A] =
-    Task.defer(task).executeOn(worker)
-
-  def run(request: CmdRequest): Task[ReplResponse] =
-    defer(exec(request.line))
-
-  def eval(request: EvalRequest): Task[ReplResponse] =
-    defer(exec(request.program, request.printUnmatchedSendsOnly))
-
-  private def printNormalizedTerm(normalizedTerm: Par): Unit = {
-    Console.println("\nEvaluating:")
-    Console.println(PrettyPrinter().buildString(normalizedTerm))
-  }
+    }
 }

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -26,8 +26,7 @@ package object api {
       port: Int,
       runtime: Runtime[Task],
       grpcExecutor: Scheduler,
-      blockApiLock: Semaphore[Task],
-      tracing: Boolean
+      blockApiLock: Semaphore[Task]
   )(
       implicit worker: Scheduler,
       safetyOracle: SafetyOracle[Task],
@@ -46,7 +45,7 @@ package object api {
         )
         .addService(
           ProposeServiceGrpcMonix
-            .bindService(ProposeGrpcService.instance(blockApiLock, tracing), grpcExecutor)
+            .bindService(ProposeGrpcService.instance(blockApiLock), grpcExecutor)
         )
         .build
     )
@@ -54,8 +53,7 @@ package object api {
   def acquireExternalServer[F[_]: Concurrent: Log: SafetyOracle: BlockStore: Taskable: Span](
       port: Int,
       grpcExecutor: Scheduler,
-      blockApiLock: Semaphore[F],
-      tracing: Boolean
+      blockApiLock: Semaphore[F]
   )(implicit worker: Scheduler, engineCell: EngineCell[F]): F[Server[F]] =
     GrpcServer[F](
       NettyServerBuilder
@@ -64,11 +62,11 @@ package object api {
         .maxMessageSize(maxMessageSize)
         .addService(
           DeployServiceGrpcMonix
-            .bindService(DeployGrpcService.instance(blockApiLock, tracing), grpcExecutor)
+            .bindService(DeployGrpcService.instance(blockApiLock), grpcExecutor)
         )
         .addService(
           ProposeServiceGrpcMonix
-            .bindService(ProposeGrpcService.instance(blockApiLock, tracing), grpcExecutor)
+            .bindService(ProposeGrpcService.instance(blockApiLock), grpcExecutor)
         )
         .build
     )

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -23,9 +23,8 @@ package object api {
 
   def acquireInternalServer(
       port: Int,
-      runtime: Runtime[Task],
       grpcExecutor: Scheduler,
-      replGrpcService: ReplGrpcService,
+      replGrpcService: ReplGrpcMonix.Repl,
       proposeGrpcService: ProposeServiceGrpcMonix.ProposeService
   ): Task[Server[Task]] =
     GrpcServer[Task](

--- a/node/src/main/scala/coop/rchain/node/diagnostics/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/diagnostics/effects/package.scala
@@ -93,7 +93,7 @@ package object effects {
                   .putIfAbsent(environment.trace, SourceTrace(source, networkId, host, parent))
                   .map(_ => environment)
                   .getOrElse(environment)
-              })(scope(_)(block)) { environment =>
+              })(scope(_)(withMarks("trace")(block))) { environment =>
                 Sync[F]
                   .delay(spans.remove(environment.trace))
                   .flatMap(_.map(_.end()).getOrElse(Sync[F].unit))

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -5,11 +5,9 @@ import java.nio.file.Path
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.tools.jline.console._
-
-import cats.effect.Timer
+import cats.effect.{Concurrent, Timer}
 import cats.mtl._
 import cats.Applicative
-
 import coop.rchain.comm._
 import coop.rchain.comm.discovery._
 import coop.rchain.comm.rp._
@@ -17,7 +15,6 @@ import coop.rchain.comm.rp.Connect._
 import coop.rchain.comm.transport._
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared._
-
 import monix.eval._
 import monix.execution._
 import monix.execution.atomic.AtomicAny
@@ -72,8 +69,8 @@ package object effects {
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)
 
-  def rpConnections: Task[ConnectionsCell[Task]] =
-    Cell.mvarCell[Task, Connections](Connections.empty)
+  def rpConnections[F[_]: Concurrent]: F[ConnectionsCell[F]] =
+    Cell.mvarCell[F, Connections](Connections.empty)
 
   def rpConfState(conf: RPConf): MonadState[Task, RPConf] =
     new AtomicMonadState[Task, RPConf](AtomicAny(conf))

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -36,11 +36,11 @@ package object effects {
       kademliaRPC: KademliaRPC[F]
   ): NodeDiscovery[F] = NodeDiscovery.kademlia(id)
 
-  def time(implicit timer: Timer[Task]): Time[Task] =
-    new Time[Task] {
-      def currentMillis: Task[Long]                   = timer.clock.realTime(MILLISECONDS)
-      def nanoTime: Task[Long]                        = timer.clock.monotonic(NANOSECONDS)
-      def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
+  def time[F[_]](implicit timer: Timer[F]): Time[F] =
+    new Time[F] {
+      def currentMillis: F[Long]                   = timer.clock.realTime(MILLISECONDS)
+      def nanoTime: F[Long]                        = timer.clock.monotonic(NANOSECONDS)
+      def sleep(duration: FiniteDuration): F[Unit] = timer.sleep(duration)
     }
 
   def kademliaRPC(networkId: String, timeout: FiniteDuration, allowPrivateAddresses: Boolean)(

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -10,8 +10,7 @@ import scala.tools.jline.console._
 import cats.effect.{Concurrent, Sync, Timer}
 import cats.mtl._
 import cats.implicits._
-import cats.tagless.FunctorK
-import cats.{~>, Applicative, Monad}
+import cats.{Applicative, Monad}
 import coop.rchain.comm._
 import coop.rchain.comm.discovery._
 import coop.rchain.comm.rp._
@@ -95,15 +94,15 @@ package object effects {
       def ask: F[PeerNode]            = state.get.map(_.local)
     }
 
-  def readerTApplicativeAsk[F[_]: Monad: Sync, E](
-      askF: ApplicativeAsk[F, E]
-  ): ApplicativeAsk[ReaderT[F, E, ?], E] =
-    new ApplicativeAsk[ReaderT[F, E, ?], E] {
+  def readerTApplicativeAsk[F[_]: Monad: Sync, E, B](
+      askF: ApplicativeAsk[F, B]
+  ): ApplicativeAsk[ReaderT[F, E, ?], B] =
+    new ApplicativeAsk[ReaderT[F, E, ?], B] {
       override val applicative: Applicative[ReaderT[F, E, ?]] = Applicative[ReaderT[F, E, ?]]
 
-      override def ask: ReaderT[F, E, E] = ReaderT.liftF(askF.ask)
+      override def ask: ReaderT[F, E, B] = ReaderT.liftF(askF.ask)
 
-      override def reader[A](f: E => A): ReaderT[F, E, A] = ReaderT.liftF(askF.reader(f))
+      override def reader[A](f: B => A): ReaderT[F, E, A] = ReaderT.liftF(askF.reader(f))
     }
 
   def readerTMonadState[F[_]: Monad: Sync, E, S](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
   val catsPar             = "io.chrisdavenport"          %% "cats-par"                  % "0.3.0-M1"
+  val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.9"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
@@ -100,6 +101,9 @@ object Dependencies {
 
   private val kindProjector = compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
 
+  private val macroParadise = compilerPlugin(
+    "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+
   private val testing = Seq(scalactic, scalatest, scalacheck)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
@@ -123,5 +127,5 @@ object Dependencies {
     http4sDependencies ++ circeDependencies
 
   val commonDependencies: Seq[ModuleID] =
-    logging ++ testing :+ kindProjector
+    logging ++ testing :+ kindProjector :+ macroParadise
 }

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -8,19 +8,11 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 object TaskContrib {
-  def enableTracing(tracing: Boolean): Task.Options => Task.Options =
-    opts => if (tracing) opts.enableLocalContextPropagation else opts
 
   implicit class TaskOps[A](task: Task[A]) {
     def unsafeRunSync(implicit scheduler: Scheduler): A =
       Await.result(
         task.runToFuture,
-        Duration.Inf
-      )
-
-    def unsafeRunSyncTracing(tracing: Boolean)(implicit scheduler: Scheduler): A =
-      Await.result(
-        task.executeWithOptions(enableTracing(tracing)).runToFuture,
         Duration.Inf
       )
 

--- a/shared/src/main/scala/coop/rchain/shared/EventLog.scala
+++ b/shared/src/main/scala/coop/rchain/shared/EventLog.scala
@@ -1,5 +1,7 @@
 package coop.rchain.shared
 
+import cats.tagless._
+
 sealed trait Event
 object Event {
   final case class NodeStarted(address: String)                             extends Event
@@ -10,6 +12,9 @@ object Event {
   final case class SentApprovedBlock(blockHash: String)                     extends Event
 }
 
+@autoFunctorK
+@autoSemigroupalK
+@autoProductNK
 trait EventLog[F[_]] {
   def publish(event: Event): F[Unit]
 }

--- a/shared/src/main/scala/coop/rchain/shared/Log.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Log.scala
@@ -3,6 +3,7 @@ package coop.rchain.shared
 import cats._
 import cats.effect.Sync
 import cats.implicits._
+import cats.tagless._
 import coop.rchain.catscontrib.effect.implicits._
 
 import scala.language.experimental.macros
@@ -34,6 +35,9 @@ class LogSourceMacros(val c: blackbox.Context) {
   }
 }
 
+@autoFunctorK
+@autoSemigroupalK
+@autoProductNK
 trait Log[F[_]] {
   def isTraceEnabled(implicit ev: LogSource): F[Boolean]
   def trace(msg: => String)(implicit ev: LogSource): F[Unit]

--- a/shared/src/main/scala/coop/rchain/shared/Time.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Time.scala
@@ -1,10 +1,14 @@
 package coop.rchain.shared
 
 import cats._, cats.data._, cats.implicits._
+import cats.tagless._
 import coop.rchain.catscontrib._, Catscontrib._
 
 import scala.concurrent.duration.FiniteDuration
 
+@autoFunctorK
+@autoSemigroupalK
+@autoProductNK
 trait Time[F[_]] {
   def currentMillis: F[Long]
   def nanoTime: F[Long]


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
Using monix TaskLocal proved to be unreliable.
This change first aligns as much of NodeRuntime with an abstract F as possible, delivers implementations of ReaderT[Task, Env, A] for the other cases and rewires spans to rely upon an ApplicativeLocal implemented via ReaderT.

The observed impact between noop (spans disabled) and ReaderT is ~4%.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/projects/RCHAIN/issues/RCHAIN-3703
https://rchain.atlassian.net/browse/RCHAIN-3771


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
