### PR TITLE
Store peeked channels' indexes in casper events proto

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -124,6 +124,17 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
     }
   }
 
+  it should "create valid blocks when peek syntax is present in a deploy" in effectTest {
+    HashSetCasperTestNode.standaloneEff(genesis).use { node =>
+      val source = " for(@x <<- @0){ Nil } | @0!(0) "
+      for {
+        deploy <- ConstructDeploy.sourceDeployNowF[Effect](source)
+        block  <- node.addBlock(deploy)
+        result <- node.casperEff.contains(block.blockHash) shouldBeF true
+      } yield result
+    }
+  }
+
   it should "reject unsigned blocks" in effectTest {
     HashSetCasperTestNode.standaloneEff(genesis).use { node =>
       implicit val timeEff = new LogicalTime[Effect]

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -195,6 +195,11 @@ message ConsumeEvent {
 message CommEvent {
   ConsumeEvent consume = 1;
   repeated ProduceEvent produces = 2;
+  repeated Peek peeks = 3;
+}
+
+message Peek {
+  int32 channelIndex = 1;
 }
 
 message Bond {

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -40,7 +40,7 @@ object Event {
 final case class COMM(
     consume: Consume,
     produces: Seq[Produce],
-    peeks: SortedSet[Int] = SortedSet.empty
+    peeks: SortedSet[Int]
 ) extends Event {
   def nextSequenceNumber: Int =
     Math.max(


### PR DESCRIPTION
## Overview
Fixes a bug with COMM events with peek being not replayable


### JIRA ticket:
Related to: https://rchain.atlassian.net/browse/RCHAIN-3639


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
