### PR TITLE
Refactor ProtoUtil.unsafeGetBlock

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -79,7 +79,7 @@ object BlockCreator {
             }
         _                <- updateDeployHistory[F](state, maxBlockNumber)
         deploys          <- extractDeploys[F](dag, parentMetadatas, maxBlockNumber, expirationThreshold)
-        parents          <- parentMetadatas.toList.traverse(p => ProtoUtil.unsafeGetBlock[F](p.blockHash))
+        parents          <- parentMetadatas.toList.traverse(p => ProtoUtil.getBlock[F](p.blockHash))
         justifications   <- computeJustifications[F](dag, parents)
         now              <- Time[F].currentMillis
         invalidBlocksSet <- dag.invalidBlocks
@@ -156,7 +156,7 @@ object BlockCreator {
                  )
                  .foldLeftF(validDeploys) { (deploys, blockMetadata) =>
                    for {
-                     block        <- ProtoUtil.unsafeGetBlock[F](blockMetadata.blockHash)
+                     block        <- ProtoUtil.getBlock[F](blockMetadata.blockHash)
                      blockDeploys = ProtoUtil.deploys(block).flatMap(_.deploy)
                    } yield deploys -- blockDeploys
                  }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -78,7 +78,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
   def ignoreDoppelgangerCheck[F[_]: Applicative]: (BlockMessage, Validator) => F[Unit] =
     kp2(().pure[F])
 
-  def forkChoiceTip[F[_]: Monad: BlockStore](casper: MultiParentCasper[F]): F[BlockMessage] =
+  def forkChoiceTip[F[_]: Sync: BlockStore](casper: MultiParentCasper[F]): F[BlockMessage] =
     for {
       dag       <- casper.blockDag
       tipHashes <- casper.estimator(dag)

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -83,7 +83,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
       dag       <- casper.blockDag
       tipHashes <- casper.estimator(dag)
       tipHash   = tipHashes.head
-      tip       <- ProtoUtil.unsafeGetBlock[F](tipHash)
+      tip       <- ProtoUtil.getBlock[F](tipHash)
     } yield tip
 }
 

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper
 
+import cats.effect.Sync
 import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
@@ -67,7 +68,7 @@ object EquivocationDetector {
     } yield maybeCreatorJustification.latestBlockHash
 
   // See summary of algorithm above
-  def checkNeglectedEquivocationsWithUpdate[F[_]: Monad: BlockStore: BlockDagStorage](
+  def checkNeglectedEquivocationsWithUpdate[F[_]: Sync: BlockStore: BlockDagStorage](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage
@@ -85,7 +86,7 @@ object EquivocationDetector {
       }
     } yield status
 
-  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: Monad: BlockStore: BlockDagStorage](
+  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: Sync: BlockStore: BlockDagStorage](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage
@@ -111,7 +112,7 @@ object EquivocationDetector {
     *
     * @return Whether a neglected equivocation was discovered.
     */
-  private def updateEquivocationsTracker[F[_]: Monad: BlockStore](
+  private def updateEquivocationsTracker[F[_]: Sync: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -141,7 +142,7 @@ object EquivocationDetector {
           } else ().pure[F]
     } yield neglectedEquivocationDetected
 
-  private def getEquivocationDiscoveryStatus[F[_]: Monad: BlockStore](
+  private def getEquivocationDiscoveryStatus[F[_]: Sync: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -170,7 +171,7 @@ object EquivocationDetector {
     }
   }
 
-  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: Monad: BlockStore](
+  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
       latestMessages: Map[Validator, BlockHash],
@@ -197,7 +198,7 @@ object EquivocationDetector {
       Applicative[F].pure(EquivocationDetected)
     }
 
-  private def isEquivocationDetectable[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectable[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       latestMessages: Seq[(Validator, BlockHash)],
       equivocationRecord: EquivocationRecord,
@@ -217,7 +218,7 @@ object EquivocationDetector {
         )
     }
 
-  private def isEquivocationDetectableAfterViewingBlock[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectableAfterViewingBlock[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       justificationBlockHash: BlockHash,
       equivocationRecord: EquivocationRecord,
@@ -241,7 +242,7 @@ object EquivocationDetector {
       } yield equivocationDetected
     }
 
-  private def isEquivocationDetectableThroughChildren[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectableThroughChildren[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
@@ -276,7 +277,7 @@ object EquivocationDetector {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
-  private def maybeAddEquivocationChild[F[_]: Monad: BlockStore](
+  private def maybeAddEquivocationChild[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       justificationBlock: BlockMessage,
       equivocatingValidator: Validator,
@@ -326,7 +327,7 @@ object EquivocationDetector {
     }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
-  private def addEquivocationChild[F[_]: Monad: BlockStore](
+  private def addEquivocationChild[F[_]: Sync: BlockStore](
       blockDag: BlockDagRepresentation[F],
       justificationBlock: BlockMessage,
       equivocationBaseBlockSeqNum: SequenceNumber,

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -230,7 +230,7 @@ object EquivocationDetector {
       true.pure[F]
     } else {
       for {
-        justificationBlock <- ProtoUtil.unsafeGetBlock[F](justificationBlockHash)
+        justificationBlock <- ProtoUtil.getBlock[F](justificationBlockHash)
         equivocationDetected <- isEquivocationDetectableThroughChildren[F](
                                  blockDag,
                                  equivocationRecord,
@@ -307,7 +307,7 @@ object EquivocationDetector {
       maybeLatestEquivocatingValidatorBlockHash match {
         case Some(blockHash) =>
           for {
-            latestEquivocatingValidatorBlock <- ProtoUtil.unsafeGetBlock[F](blockHash)
+            latestEquivocatingValidatorBlock <- ProtoUtil.getBlock[F](blockHash)
             updatedEquivocationChildren <- if (latestEquivocatingValidatorBlock.seqNum > equivocationBaseBlockSeqNum) {
                                             addEquivocationChild[F](
                                               blockDag,
@@ -340,7 +340,7 @@ object EquivocationDetector {
     ).flatMap {
       case Some(equivocationChildHash) =>
         for {
-          equivocationChild <- ProtoUtil.unsafeGetBlock[F](equivocationChildHash)
+          equivocationChild <- ProtoUtil.getBlock[F](equivocationChildHash)
         } yield equivocationChildren + equivocationChild
       case None =>
         throw new Exception(

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -37,7 +37,7 @@ final class LastFinalizedBlockCalculator[F[_]: Sync: Log: Concurrent: BlockStore
       finalizedChildHash: BlockHash
   )(implicit state: CasperStateCell[F]): F[Unit] =
     for {
-      block              <- ProtoUtil.unsafeGetBlock[F](finalizedChildHash)
+      block              <- ProtoUtil.getBlock[F](finalizedChildHash)
       deploys            = block.body.get.deploys.map(_.deploy.get).toList
       stateBefore        <- state.read
       initialHistorySize = stateBefore.deployHistory.size

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -245,7 +245,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: ConnectionsCell: TransportLa
       updatedLastFinalizedBlockHash <- LastFinalizedBlockCalculator[F]
                                         .run(dag, lastFinalizedBlockHash)
       _            <- lastFinalizedBlockHashContainer.set(updatedLastFinalizedBlockHash)
-      blockMessage <- ProtoUtil.unsafeGetBlock[F](updatedLastFinalizedBlockHash)
+      blockMessage <- ProtoUtil.getBlock[F](updatedLastFinalizedBlockHash)
     } yield blockMessage
 
   def blockDag: F[BlockDagRepresentation[F]] =

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -334,7 +334,7 @@ object Validate {
   }
 
   // This is not a slashable offence
-  def timestamp[F[_]: Monad: Log: Time: BlockStore](
+  def timestamp[F[_]: Sync: Log: Time: BlockStore](
       b: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Either[InvalidBlock, ValidBlock]] =
@@ -575,7 +575,7 @@ object Validate {
   /*
    * This check must come before Validate.parents
    */
-  def justificationFollows[F[_]: Monad: Log: BlockStore](
+  def justificationFollows[F[_]: Sync: Log: BlockStore](
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F]

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -299,7 +299,7 @@ object Validate {
                                        )
                                        .findF { blockMetadata =>
                                          for {
-                                           block <- ProtoUtil.unsafeGetBlock[F](
+                                           block <- ProtoUtil.getBlock[F](
                                                      blockMetadata.blockHash
                                                    )
                                            blockDeploys = ProtoUtil.deploys(block).flatMap(_.deploy)
@@ -312,7 +312,7 @@ object Validate {
                      .traverse(
                        duplicatedBlockMetadata => {
                          for {
-                           duplicatedBlock <- ProtoUtil.unsafeGetBlock[F](
+                           duplicatedBlock <- ProtoUtil.getBlock[F](
                                                duplicatedBlockMetadata.blockHash
                                              )
                            currentBlockHashString = PrettyPrinter.buildString(block.blockHash)
@@ -345,7 +345,7 @@ object Validate {
       latestParentTimestamp <- ProtoUtil.parentHashes(b).toList.foldM(0L) {
                                 case (latestTimestamp, parentHash) =>
                                   ProtoUtil
-                                    .unsafeGetBlock[F](parentHash)
+                                    .getBlock[F](parentHash)
                                     .map(parent => {
                                       val timestamp =
                                         parent.header.fold(latestTimestamp)(_.timestamp)
@@ -583,7 +583,7 @@ object Validate {
     val justifiedValidators = b.justifications.map(_.validator).toSet
     val mainParentHash      = ProtoUtil.parentHashes(b).head
     for {
-      mainParent       <- ProtoUtil.unsafeGetBlock[F](mainParentHash)
+      mainParent       <- ProtoUtil.getBlock[F](mainParentHash)
       bondedValidators = ProtoUtil.bonds(mainParent).map(_.validator).toSet
       status <- if (bondedValidators == justifiedValidators) {
                  Applicative[F].pure(Right(Valid))

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -177,7 +177,7 @@ object BlockAPI {
     ))
   }
 
-  private def getMainChainFromTip[F[_]: Monad: Log: SafetyOracle: BlockStore](depth: Int)(
+  private def getMainChainFromTip[F[_]: Sync: Log: SafetyOracle: BlockStore](depth: Int)(
       implicit casper: MultiParentCasper[F]
   ): F[IndexedSeq[BlockMessage]] =
     for {
@@ -308,7 +308,7 @@ object BlockAPI {
           .map(MachineVerifyResponse(_).asRight[Error])
     }
 
-  def getBlocks[F[_]: Monad: EngineCell: Log: SafetyOracle: BlockStore](
+  def getBlocks[F[_]: Sync: EngineCell: Log: SafetyOracle: BlockStore](
       depth: Option[Int]
   ): Effect[F, List[LightBlockInfo]] =
     toposortDag[F, List[LightBlockInfo]](depth) {
@@ -327,7 +327,7 @@ object BlockAPI {
           .map(_.reverse.asRight[Error])
     }
 
-  def showMainChain[F[_]: Monad: EngineCell: Log: SafetyOracle: BlockStore](
+  def showMainChain[F[_]: Sync: EngineCell: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[LightBlockInfo]] = {
 
@@ -350,7 +350,7 @@ object BlockAPI {
     ))
   }
 
-  def findDeploy[F[_]: Monad: EngineCell: Log: SafetyOracle: BlockStore](
+  def findDeploy[F[_]: Sync: EngineCell: Log: SafetyOracle: BlockStore](
       id: DeployId
   ): Effect[F, LightBlockQueryResponse] =
     EngineCell[F].read >>= (
@@ -379,7 +379,7 @@ object BlockAPI {
     )
 
   // TODO: Replace with call to BlockStore
-  def findBlockWithDeploy[F[_]: Monad: EngineCell: Log: SafetyOracle: BlockStore](
+  def findBlockWithDeploy[F[_]: Sync: EngineCell: Log: SafetyOracle: BlockStore](
       user: ByteString,
       timestamp: Long
   ): Effect[F, BlockQueryResponse] = {
@@ -413,7 +413,7 @@ object BlockAPI {
     ))
   }
 
-  private def findBlockWithDeploy[F[_]: Monad: Log: BlockStore](
+  private def findBlockWithDeploy[F[_]: Sync: Log: BlockStore](
       blockHashes: Vector[BlockHash],
       user: ByteString,
       timestamp: Long

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -106,7 +106,7 @@ object GraphzGenerator {
       blockHashes: Vector[BlockHash]
   ): F[DagInfo[G]] =
     for {
-      blocks    <- blockHashes.traverse(ProtoUtil.unsafeGetBlock[F])
+      blocks    <- blockHashes.traverse(ProtoUtil.getBlock[F])
       timeEntry = blocks.head.getBody.getState.blockNumber
       validators = blocks.toList.map {
         case b =>

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -73,7 +73,7 @@ object Engine {
       _   <- TransportLayer[F].stream(peer, msg)
     } yield ()
 
-  def transitionToRunning[F[_]: Monad: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: Running.RequestedBlocks](
+  def transitionToRunning[F[_]: Sync: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: Running.RequestedBlocks](
       casper: MultiParentCasper[F],
       approvedBlock: ApprovedBlock,
       init: F[Unit]

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -205,7 +205,7 @@ object Running {
           }
     } yield ()
 
-  def handleForkChoiceTipRequest[F[_]: Monad: RPConfAsk: Log: TransportLayer: BlockStore](
+  def handleForkChoiceTipRequest[F[_]: Sync: RPConfAsk: Log: TransportLayer: BlockStore](
       peer: PeerNode,
       fctr: ForkChoiceTipRequest
   )(casper: MultiParentCasper[F]): F[Unit] =
@@ -233,7 +233,7 @@ object Running {
 
 }
 
-class Running[F[_]: RPConfAsk: BlockStore: Monad: ConnectionsCell: TransportLayer: Log: Time: Running.RequestedBlocks](
+class Running[F[_]: Sync: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Log: Time: Running.RequestedBlocks](
     casper: MultiParentCasper[F],
     approvedBlock: ApprovedBlock,
     theInit: F[Unit]

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -62,7 +62,7 @@ object ProtoUtil {
       mainChain <- maybeMainParentHash match {
                     case Some(mainParentHash) =>
                       for {
-                        updatedEstimate <- unsafeGetBlock[F](mainParentHash)
+                        updatedEstimate <- getBlock[F](mainParentHash)
                         depthDelta      = blockNumber(updatedEstimate) - blockNumber(estimate)
                         newDepth        = depth + depthDelta.toInt
                         mainChain <- if (newDepth <= 0) {
@@ -80,7 +80,7 @@ object ProtoUtil {
     } yield mainChain
   }
 
-  def unsafeGetBlock[F[_]: Sync: BlockStore](hash: BlockHash): F[BlockMessage] =
+  def getBlock[F[_]: Sync: BlockStore](hash: BlockHash): F[BlockMessage] =
     for {
       maybeBlock <- BlockStore[F].get(hash)
       block <- maybeBlock match {
@@ -220,7 +220,7 @@ object ProtoUtil {
 
   def unsafeGetParents[F[_]: Sync: BlockStore](b: BlockMessage): F[List[BlockMessage]] =
     ProtoUtil.parentHashes(b).toList.traverse { parentHash =>
-      ProtoUtil.unsafeGetBlock[F](parentHash)
+      ProtoUtil.getBlock[F](parentHash)
     }
 
   def getParentsMetadata[F[_]: Sync](

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -51,7 +51,7 @@ object ProtoUtil {
       } yield result
     }
 
-  def getMainChainUntilDepth[F[_]: Monad: BlockStore](
+  def getMainChainUntilDepth[F[_]: Sync: BlockStore](
       estimate: BlockMessage,
       acc: IndexedSeq[BlockMessage],
       depth: Int
@@ -80,15 +80,16 @@ object ProtoUtil {
     } yield mainChain
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Throw")) // TODO remove throw
-  def unsafeGetBlock[F[_]: Monad: BlockStore](hash: BlockHash): F[BlockMessage] =
+  def unsafeGetBlock[F[_]: Sync: BlockStore](hash: BlockHash): F[BlockMessage] =
     for {
       maybeBlock <- BlockStore[F].get(hash)
-      block = maybeBlock match {
-        case Some(b) => b
-        case None =>
-          throw new Exception(s"BlockStore is missing hash ${PrettyPrinter.buildString(hash)}")
-      }
+      block <- maybeBlock match {
+                case Some(b) => b.pure[F]
+                case None =>
+                  Sync[F].raiseError[BlockMessage](
+                    new Exception(s"BlockStore is missing hash ${PrettyPrinter.buildString(hash)}")
+                  )
+              }
     } yield block
 
   def getBlockMetadata[F[_]: Sync](
@@ -217,7 +218,7 @@ object ProtoUtil {
   def parentHashes(b: BlockMessage): Seq[ByteString] =
     b.header.fold(Seq.empty[ByteString])(_.parentsHashList)
 
-  def unsafeGetParents[F[_]: Monad: BlockStore](b: BlockMessage): F[List[BlockMessage]] =
+  def unsafeGetParents[F[_]: Sync: BlockStore](b: BlockMessage): F[List[BlockMessage]] =
     ProtoUtil.parentHashes(b).toList.traverse { parentHash =>
       ProtoUtil.unsafeGetBlock[F](parentHash)
     }

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -218,7 +218,7 @@ object ProtoUtil {
   def parentHashes(b: BlockMessage): Seq[ByteString] =
     b.header.fold(Seq.empty[ByteString])(_.parentsHashList)
 
-  def unsafeGetParents[F[_]: Sync: BlockStore](b: BlockMessage): F[List[BlockMessage]] =
+  def getParents[F[_]: Sync: BlockStore](b: BlockMessage): F[List[BlockMessage]] =
     ProtoUtil.parentHashes(b).toList.traverse { parentHash =>
       ProtoUtil.getBlock[F](parentHash)
     }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -216,7 +216,7 @@ object InterpreterUtil {
       _                  <- Span[F].mark("before-compute-parents-post-state-find-multi-parents")
       blockHashesToApply <- findMultiParentsBlockHashesForReplay(parents, dag)
       _                  <- Span[F].mark("before-compute-parents-post-state-get-blocks")
-      blocksToApply      <- blockHashesToApply.traverse(b => ProtoUtil.unsafeGetBlock[F](b.blockHash))
+      blocksToApply      <- blockHashesToApply.traverse(b => ProtoUtil.getBlock[F](b.blockHash))
       _                  <- Span[F].mark("before-compute-parents-post-state-replay")
       replayResult <- blocksToApply.toList.foldM(Right(initStateHash).leftCast[Throwable]) {
                        (acc, block) =>

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -42,7 +42,7 @@ object InterpreterUtil {
     val blockNumber     = b.body.get.state.get.blockNumber
     for {
       _                    <- Span[F].mark("before-unsafe-get-parents")
-      parents              <- ProtoUtil.unsafeGetParents[F](b)
+      parents              <- ProtoUtil.getParents[F](b)
       _                    <- Span[F].mark("before-compute-parents-post-state")
       possiblePreStateHash <- computeParentsPostState[F](parents, dag, runtimeManager)
       _                    <- Log[F].info(s"Computed parents post state for ${PrettyPrinter.buildString(b)}.")

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -84,7 +84,7 @@ class ManyValidatorsTest
         engineCell         <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
         result <- BlockAPI.getBlocks[Task](Some(Int.MaxValue))(
-                   Monad[Task],
+                   Sync[Task],
                    engineCell,
                    logEff,
                    cliqueOracleEffect,

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -51,7 +51,7 @@ object BlockGenerator {
       runtimeManager: RuntimeManager[F]
   ): F[(StateHash, Seq[ProcessedDeploy])] = Span[F].trace(GenerateBlockMetricsSource) {
     for {
-      parents <- ProtoUtil.unsafeGetParents[F](b)
+      parents <- ProtoUtil.getParents[F](b)
       deploys = ProtoUtil.deploys(b).flatMap(_.deploy)
       now     <- Time[F].currentMillis
       result <- computeDeploysCheckpoint[F](


### PR DESCRIPTION
## Overview
Removes `throw` from `ProtoUtil.unsafeGetBlock` and renames it to `ProtoUtil.getBlock`. Discussed with @ArturGajowy in https://github.com/rchain/rchain/pull/2660#discussion_r312805012


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3777


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
