### PR TITLE
Rchain 3755: Fix genesis block approval protocol

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -117,10 +117,23 @@ object ApproveBlockProtocol {
                            (newSigs, (sigs, newSigs))
                          })
           (before, after) = modifyResult
+
           _ <- if (after > before)
-                Metrics[F].incrementCounter("genesis")
-              else ().pure[F]
+                Log[F].info("APPROVAL: New signature received") >>
+                  Metrics[F].incrementCounter("genesis")
+              else
+                Log[F].info("APPROVAL: No new sigs received")
+
           _ <- Log[F].info(s"APPROVAL: received block approval from $sender")
+
+          _ <- Log[F].info(
+                s"APPROVAL: ${after.size} approvals received: ${after
+                  .map(s => PrettyPrinter.buildString(s.publicKey))
+                  .mkString(", ")}"
+              )
+          _ <- Log[F].info(
+                s"APPROVAL: Remaining approvals needed: ${requiredSigs - after.size + 1}"
+              )
           _ <- EventLog[F].publish(
                 shared.Event.BlockApprovalReceived(
                   a.candidate

--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -112,9 +112,11 @@ object ApproveBlockProtocol {
 
       FlatMap[F].ifM(isValid)(
         for {
-          before <- sigsF.get
-          _      <- sigsF.update(_ + validSig.get)
-          after  <- sigsF.get
+          modifyResult <- sigsF.modify(sigs => {
+                           val newSigs = sigs + validSig.get
+                           (newSigs, (sigs, newSigs))
+                         })
+          (before, after) = modifyResult
           _ <- if (after > before)
                 Metrics[F].incrementCounter("genesis")
               else ().pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -142,12 +142,10 @@ object CasperLaunch {
       init: CasperInit[F]
   ): F[Unit] =
     for {
-      validators  <- CasperConf.parseValidatorsFile[F](init.conf.knownValidatorsFile)
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
       _ <- Engine.transitionToInitializing(
             init.conf.shardId,
             validatorId,
-            validators,
             CommUtil.requestApprovedBlock[F]
           )
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -144,7 +144,7 @@ object CasperLaunch {
     for {
       validators  <- CasperConf.parseValidatorsFile[F](init.conf.knownValidatorsFile)
       validatorId <- ValidatorIdentity.fromConfig[F](init.conf)
-      _ <- Engine.tranistionToInitializing(
+      _ <- Engine.transitionToInitializing(
             init.conf.shardId,
             validatorId,
             validators,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -95,8 +95,7 @@ object Engine {
   def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: RuntimeManager: Running.RequestedBlocks](
       shardId: String,
       validatorId: Option[ValidatorIdentity],
-      validators: Set[ByteString],
       init: F[Unit]
-  ): F[Unit] = EngineCell[F].set(new Initializing(shardId, validatorId, validators, init))
+  ): F[Unit] = EngineCell[F].set(new Initializing(shardId, validatorId, init))
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -92,7 +92,7 @@ object Engine {
 
     } yield ()
 
-  def tranistionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: RuntimeManager: Running.RequestedBlocks](
+  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: RuntimeManager: Running.RequestedBlocks](
       shardId: String,
       validatorId: Option[ValidatorIdentity],
       validators: Set[ByteString],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -32,7 +32,7 @@ class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: ConnectionsCell: T
     case ub: UnapprovedBlock =>
       blockApprover.unapprovedBlockPacketHandler(peer, ub) >> {
         val validators = Set(ByteString.copyFrom(validatorId.publicKey.bytes))
-        Engine.tranistionToInitializing(shardId, Some(validatorId), validators, init = noop)
+        Engine.transitionToInitializing(shardId, Some(validatorId), validators, init = noop)
       }
     case na: NoApprovedBlockAvailable => logNoApprovedBlockAvailable[F](na.nodeIdentifer)
     case _                            => noop

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -31,8 +31,7 @@ class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: ConnectionsCell: T
     case br: ApprovedBlockRequest => sendNoApprovedBlockAvailable(peer, br.identifier)
     case ub: UnapprovedBlock =>
       blockApprover.unapprovedBlockPacketHandler(peer, ub) >> {
-        val validators = Set(ByteString.copyFrom(validatorId.publicKey.bytes))
-        Engine.transitionToInitializing(shardId, Some(validatorId), validators, init = noop)
+        Engine.transitionToInitializing(shardId, Some(validatorId), init = noop)
       }
     case na: NoApprovedBlockAvailable => logNoApprovedBlockAvailable[F](na.nodeIdentifer)
     case _                            => noop

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -21,8 +21,6 @@ class InitializingSpec extends WordSpec {
       val fixture = Setup()
       import fixture._
 
-      val validators = Set(ByteString.copyFrom(validatorPk.bytes))
-
       val theInit = Task.unit
 
       implicit val engineCell = Cell.unsafe[Task, Engine[Task]](Engine.noop)
@@ -32,7 +30,6 @@ class InitializingSpec extends WordSpec {
         new Initializing[Task](
           shardId,
           Some(validatorId),
-          validators,
           theInit
         )
 


### PR DESCRIPTION
## Overview
The bootstrap node waits for a minimum block-approval-duration and a minimum number of signatures before it sends the ApprovedBlock to the validators. 

On the validator side each validator verifies that ApprovedBlock has the required number of signatures AND that his own signature is present in the ApprovedBlock. 

If some validator cannot validate the genesis block and send his block approval in time before the block-approval-duration expires then his signature won’t appear in the block signatures and he will consider the block to be invalid.

The fix that I discussed with @woky is to remove from the validator condition for valid block the part that he requires his own signature to be present because this condition contradicts the idea that we have a valid genesis block with just the minimum required number of valid signatures.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3755



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
