### PR TITLE
Reimplement BlockDagFileStorage by using scodec

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockDagStorage.scala
@@ -16,7 +16,6 @@ trait BlockDagStorage[F[_]] {
   ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
   def checkpoint(): F[Unit]
-  def clear(): F[Unit]
   def close(): F[Unit]
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -167,17 +167,6 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
     )
   override def checkpoint(): F[Unit] = ().pure[F]
 
-  override def clear(): F[Unit] =
-    lock.withPermit(
-      for {
-        _ <- dataLookupRef.set(Map.empty)
-        _ <- childMapRef.set(Map.empty)
-        _ <- topoSortRef.set(Vector.empty)
-        _ <- latestMessagesRef.set(Map.empty)
-        _ <- equivocationsTrackerRef.set(Set.empty)
-      } yield ()
-    )
-
   override def close(): F[Unit] = ().pure[F]
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockDagStorage.scala
@@ -125,7 +125,7 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
                     acc.updated(p, currChildren + block.blockHash)
                 }
             )
-        _ <- topoSortRef.update(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
+        _ <- topoSortRef.update(topoSort => TopologicalSortUtil.update(topoSort, 0L, blockMetadata))
         newValidators = bonds(block)
           .map(_.validator)
           .toSet

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -1,7 +1,7 @@
-package coop.rchain.blockstorage
+package coop.rchain.blockstorage.dag
 
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataPersistentIndex.scala
@@ -1,0 +1,108 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.implicits._
+import cats.Monad
+import cats.effect.Sync
+import cats.mtl.MonadState
+import coop.rchain.blockstorage.DataLookupIsCorrupted
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.TopologicalSortUtil
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
+import coop.rchain.shared.{AtomicMonadState, Log}
+import monix.execution.atomic.AtomicAny
+
+object BlockMetadataPersistentIndex {
+  class PersistentBlockMetadataIndex[F[_]: Monad](
+      private val persistentIndex: PersistentIndex[F, BlockHash, BlockMetadata],
+      private val childMapState: MonadState[F, Map[BlockHash, Set[BlockHash]]],
+      private val topoSortState: MonadState[F, Vector[Vector[BlockHash]]]
+  ) {
+    def add(block: BlockMetadata): F[Unit] =
+      for {
+        _ <- childMapState.modify { childMap =>
+              block.parents
+                .foldLeft(childMap) {
+                  case (acc, p) =>
+                    val currChildren = acc.getOrElse(p, Set.empty[BlockHash])
+                    acc.updated(p, currChildren + block.blockHash)
+                }
+                .updated(block.blockHash, Set.empty[BlockHash])
+            }
+        _ <- topoSortState.modify(topoSort => TopologicalSortUtil.update(topoSort, 0L, block))
+        _ <- persistentIndex.add(block.blockHash, block)
+      } yield ()
+
+    def childMapData: F[Map[BlockHash, Set[BlockHash]]] =
+      childMapState.get
+
+    def topoSortData: F[Vector[Vector[BlockHash]]] =
+      topoSortState.get
+
+    def blockMetadataData: F[Map[BlockHash, BlockMetadata]] =
+      persistentIndex.data
+
+    def close: F[Unit] =
+      persistentIndex.close
+  }
+
+  private def extractChildMap(
+      blockMetadataMap: Map[BlockHash, BlockMetadata]
+  ): Map[BlockHash, Set[BlockHash]] =
+    blockMetadataMap.foldLeft(blockMetadataMap.map(_._1 -> Set.empty[BlockHash])) {
+      case (childMap, (_, blockMetadata)) =>
+        blockMetadata.parents.foldLeft(childMap) {
+          case (acc, p) =>
+            val currentChildren = acc.getOrElse(p, Set.empty[BlockHash])
+            acc.updated(p, currentChildren + blockMetadata.blockHash)
+        }
+    }
+
+  private def extractTopoSort(
+      blockMetadataMap: Map[BlockHash, BlockMetadata]
+  ): Vector[Vector[BlockHash]] = {
+    val blockMetadatas = blockMetadataMap.values.toVector
+    val indexedTopoSort =
+      blockMetadatas.groupBy(_.blockNum).mapValues(_.map(_.blockHash)).toVector.sortBy(_._1)
+    assert(indexedTopoSort.zipWithIndex.forall { case ((readI, _), i) => readI == i })
+    indexedTopoSort.map(_._2)
+  }
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[PersistentBlockMetadataIndex[F]] =
+    for {
+      persistentIndex <- PersistentIndex.load[F, BlockHash, BlockMetadata](
+                          logPath,
+                          crcPath,
+                          DataLookupIsCorrupted
+                        )(Sync[F], Log[F], RaiseIOError[F], codecBlockHash, codecBlockMetadata)
+      blockMetadataMap <- persistentIndex.data
+      childMap         = extractChildMap(blockMetadataMap)
+      topoSort         = extractTopoSort(blockMetadataMap)
+    } yield new PersistentBlockMetadataIndex[F](
+      persistentIndex,
+      new AtomicMonadState(AtomicAny(childMap)),
+      new AtomicMonadState(AtomicAny(topoSort))
+    )
+
+  def read[F[_]: Sync: RaiseIOError](logPath: Path): F[
+    (Map[BlockHash, BlockMetadata], Map[BlockHash, Set[BlockHash]], Vector[Vector[BlockHash]])
+  ] = {
+    val keyValueCodec = codecBlockHash ~ codecBlockMetadata
+    PersistentIndex
+      .readDataList[F, BlockHash, BlockMetadata](
+        logPath,
+        keyValueCodec,
+        DataLookupIsCorrupted
+      )
+      .map { blockMetadataList =>
+        val blockMetadataMap = blockMetadataList.toMap
+        (blockMetadataMap, extractChildMap(blockMetadataMap), extractTopoSort(blockMetadataMap))
+      }
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DeployPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DeployPersistentIndex.scala
@@ -3,7 +3,7 @@ package coop.rchain.blockstorage.dag
 import java.nio.file.Path
 
 import cats.effect.Sync
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.BlockHashesByDeployLogIsCorrupted
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.dag.codecs._

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DeployPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DeployPersistentIndex.scala
@@ -1,0 +1,25 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.BlockHashesByDeployLogIsCorrupted
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.Log
+
+object DeployPersistentIndex {
+  type PersistentDeployIndex[F[_]] = PersistentIndex[F, DeployId, BlockHash]
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[PersistentDeployIndex[F]] =
+    PersistentIndex.load[F, DeployId, BlockHash](
+      logPath,
+      crcPath,
+      BlockHashesByDeployLogIsCorrupted
+    )(Sync[F], Log[F], RaiseIOError[F], codecDeployId, codecBlockHash)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/EquivocationTrackerPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/EquivocationTrackerPersistentIndex.scala
@@ -1,0 +1,57 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.Monad
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.blockstorage.EquivocationsTrackerLogIsMalformed
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.EquivocationRecord
+import coop.rchain.models.EquivocationRecord.SequenceNumber
+import coop.rchain.models.Validator.Validator
+import coop.rchain.shared.Log
+import scodec.codecs._
+
+object EquivocationTrackerPersistentIndex {
+  class PersistentEquivocationTrackerIndex[F[_]: Monad](
+      private val persistentIndex: PersistentIndex[F, (Validator, SequenceNumber), Set[BlockHash]]
+  ) {
+    def add(record: EquivocationRecord): F[Unit] =
+      persistentIndex.add(
+        (record.equivocator, record.equivocationBaseBlockSeqNum),
+        record.equivocationDetectedBlockHashes
+      )
+
+    def addAll(records: List[EquivocationRecord]): F[Unit] =
+      persistentIndex.addAll(
+        records.map {
+          case EquivocationRecord(equivocator, seqNum, blockHashes) =>
+            (equivocator, seqNum) -> blockHashes
+        }
+      )
+
+    def data: F[Set[EquivocationRecord]] =
+      persistentIndex.data.map(_.map {
+        case ((equivocator, seqNum), blockHashes) =>
+          EquivocationRecord(equivocator, seqNum, blockHashes)
+      }.toSet)
+
+    def close: F[Unit] =
+      persistentIndex.close
+  }
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[PersistentEquivocationTrackerIndex[F]] =
+    PersistentIndex
+      .load[F, (Validator, SequenceNumber), Set[BlockHash]](
+        logPath,
+        crcPath,
+        EquivocationsTrackerLogIsMalformed
+      )(Sync[F], Log[F], RaiseIOError[F], codecValidator ~ codecSeqNum, codecBlockHashSet)
+      .map(index => new PersistentEquivocationTrackerIndex(index))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -1,23 +1,24 @@
-package coop.rchain.blockstorage
+package coop.rchain.blockstorage.dag
 
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.util.BlockMessageUtil.{bonds, deployData, parentHashes}
 import coop.rchain.blockstorage.util.TopologicalSortUtil
+import coop.rchain.blockstorage.{BlockSenderIsMalformed, BlockStorageMetricsSource, BlockStore}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord}
 import coop.rchain.shared.Log
-import scala.collection.immutable.HashSet
 
-import coop.rchain.metrics.{Metrics, MetricsSemaphore}
-import coop.rchain.metrics.Metrics.Source
+import scala.collection.immutable.HashSet
 
 final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
     lock: Semaphore[F],

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InvalidBlocksPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InvalidBlocksPersistentIndex.scala
@@ -1,0 +1,25 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import coop.rchain.blockstorage.InvalidBlocksIsCorrupted
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.models.BlockMetadata
+import coop.rchain.shared.Log
+import scodec.codecs._
+
+object InvalidBlocksPersistentIndex {
+  type PersistentInvalidBlocksIndex[F[_]] = PersistentIndex[F, BlockMetadata, Unit]
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[PersistentInvalidBlocksIndex[F]] =
+    PersistentIndex.load[F, BlockMetadata, Unit](
+      logPath,
+      crcPath,
+      InvalidBlocksIsCorrupted
+    )(Sync[F], Log[F], RaiseIOError[F], codecBlockMetadata, ignore(0))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/LatestMessagesPersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/LatestMessagesPersistentIndex.scala
@@ -1,0 +1,25 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import coop.rchain.blockstorage.LatestMessagesLogIsCorrupted
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+import coop.rchain.shared.Log
+
+object LatestMessagesPersistentIndex {
+  type PersistentLatestMessagesIndex[F[_]] = PersistentIndex[F, Validator, BlockHash]
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[PersistentLatestMessagesIndex[F]] =
+    PersistentIndex.load[F, Validator, BlockHash](
+      logPath,
+      crcPath,
+      LatestMessagesLogIsCorrupted
+    )(Sync[F], Log[F], RaiseIOError[F], codecValidator, codecBlockHash)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/PersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/PersistentIndex.scala
@@ -1,0 +1,189 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.{Files, Path, StandardCopyOption, StandardOpenOption}
+import java.nio.{BufferUnderflowException, ByteBuffer}
+
+import cats.Monad
+import cats.effect.Sync
+import cats.implicits._
+import cats.mtl.MonadState
+import coop.rchain.blockstorage.StorageError
+import coop.rchain.blockstorage.dag.PersistentIndex.EncodeError
+import coop.rchain.blockstorage.util.Crc32
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.blockstorage.util.io._
+import coop.rchain.shared.{AtomicMonadState, Log}
+import monix.execution.atomic.AtomicAny
+import scodec.Attempt.{Failure, Successful}
+import scodec._
+import scodec.bits._
+import scodec.codecs._
+
+class PersistentIndex[F[_]: Sync: Log: RaiseIOError, K: Codec, V: Codec](
+    private val logFilePath: Path,
+    private val crcFilePath: Path,
+    private val persistedDataState: MonadState[F, Map[K, V]],
+    private val crc: Crc32[F],
+    private val keyValueCodec: Codec[(K, V)],
+    private val outputStream: FileOutputStreamIO[F]
+) {
+  private def replaceFile(from: Path, to: Path): F[Path] =
+    moveFile[F](from, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+
+  private def updateCrcFile: F[Unit] =
+    for {
+      newCrcBytes <- crc.bytes
+      tmpCrc      <- createSameDirectoryTemporaryFile(crcFilePath)
+      _           <- writeToFile[F](tmpCrc, newCrcBytes)
+      _           <- replaceFile(tmpCrc, crcFilePath)
+    } yield ()
+
+  def add(key: K, value: V): F[Unit] =
+    for {
+      toAppend <- keyValueCodec.encode((key, value)) match {
+                   case Successful(encoded) => Sync[F].delay(encoded.toByteArray)
+                   case Failure(e)          => Sync[F].raiseError[Array[Byte]](EncodeError(e))
+                 }
+      _ <- outputStream.write(toAppend)
+      _ <- outputStream.flush
+      _ <- crc.update(toAppend).flatMap(_ => updateCrcFile)
+      _ <- persistedDataState.modify(_.updated(key, value))
+    } yield ()
+
+  def addAll(newData: List[(K, V)]) =
+    newData.traverse_(add)
+
+  def data: F[Map[K, V]] =
+    persistedDataState.get
+
+  def close: F[Unit] =
+    outputStream.close
+}
+
+object PersistentIndex {
+  private final case class EncodeError(e: Err) extends Exception {
+    override def getMessage: String = s"Could not encode: $e"
+  }
+
+  private final case class DecodeError(e: Err) extends Exception {
+    override def getMessage: String = s"Could not decode: $e"
+  }
+
+  private def truncateDataLog[F[_]: Sync, K, V](
+      randomAccessIO: RandomAccessIO[F],
+      dataCollection: List[(K, V)],
+      keyValueCodec: Codec[(K, V)]
+  ): F[Unit] = {
+    val lastEntry = dataCollection.last
+    for {
+      lastEntrySize <- keyValueCodec.encode(lastEntry) match {
+                        case Successful(encoded) => ((encoded.size + 7) / 8).pure[F]
+                        case Failure(e) =>
+                          Sync[F].raiseError[Long](EncodeError(e))
+                      }
+      length <- randomAccessIO.length
+      _      <- randomAccessIO.setLength(length - lastEntrySize)
+    } yield ()
+  }
+
+  private def readCrc[F[_]: Sync: Log: RaiseIOError](crcPath: Path): F[Long] =
+    for {
+      _          <- createNewFile[F](crcPath)
+      bytes      <- readAllBytesFromFile[F](crcPath)
+      byteBuffer = ByteBuffer.wrap(bytes)
+      result <- Sync[F].delay { byteBuffer.getLong() }.handleErrorWith {
+                 case _: BufferUnderflowException =>
+                   for {
+                     _ <- Log[F].warn(s"CRC file $crcPath did not contain a valid CRC value")
+                   } yield 0
+                 case exception =>
+                   Sync[F].raiseError(exception)
+               }
+    } yield result
+
+  private def calculateCrc[F[_]: Sync, K, V](
+      dataCollection: List[(K, V)],
+      keyValueCodec: Codec[(K, V)]
+  ): F[Crc32[F]] = {
+    val crc = Crc32.empty[F]()
+    dataCollection.traverse_[F, Unit] {
+      case (key, value) =>
+        keyValueCodec.encode((key, value)) match {
+          case Successful(encoded) =>
+            crc.update(encoded.toByteArray)
+          case Failure(e) =>
+            Sync[F].raiseError(EncodeError(e))
+        }
+    } >> crc.pure[F]
+  }
+
+  def readDataList[F[_]: Sync: RaiseIOError, K, V](
+      dataPath: Path,
+      keyValueCodec: Codec[(K, V)],
+      corruptedError: => StorageError
+  ): F[List[(K, V)]] =
+    FileInputStreamIO.open[F](dataPath, StandardOpenOption.READ).use { inputStream =>
+      for {
+        bitVector <- Sync[F].delay { BitVector.fromInputStream(inputStream) }
+        result <- list(keyValueCodec).decode(bitVector) match {
+                   case Successful(DecodeResult(keyValuePairList, BitVector.empty)) =>
+                     keyValuePairList.pure[F]
+                   case _ =>
+                     Sync[F].raiseError[List[(K, V)]](corruptedError)
+                 }
+      } yield result
+    }
+
+  private def validate[F[_]: Sync, K, V](
+      randomAccessIO: RandomAccessIO[F],
+      readCrc: Long,
+      dataList: List[(K, V)],
+      keyValueCodec: Codec[(K, V)],
+      corruptedError: => StorageError
+  ): F[(List[(K, V)], Crc32[F])] =
+    for {
+      fullCalculatedCrc <- calculateCrc(dataList, keyValueCodec)
+      result <- Monad[F].ifM(fullCalculatedCrc.value.map(_ == readCrc))(
+                 (dataList, fullCalculatedCrc).pure[F],
+                 if (dataList.isEmpty) {
+                   Sync[F].raiseError[(List[(K, V)], Crc32[F])](corruptedError)
+                 } else {
+                   // Trying to delete the last log entry which is most likely to be corrupted
+                   val dataWithoutLast = dataList.init
+                   calculateCrc(dataWithoutLast, keyValueCodec).flatMap { withoutLastCrc =>
+                     Monad[F].ifM(withoutLastCrc.value.map(_ == readCrc))(
+                       truncateDataLog(randomAccessIO, dataList, keyValueCodec) >>
+                         (dataWithoutLast, withoutLastCrc).pure[F],
+                       Sync[F].raiseError[(List[(K, V)], Crc32[F])](corruptedError)
+                     )
+                   }
+                 }
+               )
+    } yield result
+
+  def load[F[_]: Sync: Log: RaiseIOError, K: Codec, V: Codec](
+      logPath: Path,
+      crcPath: Path,
+      corruptedError: => StorageError
+  ): F[PersistentIndex[F, K, V]] = {
+    val keyValueCodec = ("key" | Codec[K]) ~ ("value" | Codec[V])
+    for {
+      _        <- createNewFile[F](logPath)
+      dataList <- readDataList(logPath, keyValueCodec, corruptedError)
+      readCrc  <- readCrc(crcPath)
+      result <- RandomAccessIO.openResource(logPath, RandomAccessIO.ReadWrite).use {
+                 randomAccessIO =>
+                   validate(randomAccessIO, readCrc, dataList, keyValueCodec, corruptedError)
+               }
+      (resultList, resultCrc) = result
+      logOutputStream         <- FileOutputStreamIO.open[F](logPath, append = true)
+    } yield new PersistentIndex(
+      logPath,
+      crcPath,
+      new AtomicMonadState[F, Map[K, V]](AtomicAny(resultList.toMap)),
+      resultCrc,
+      keyValueCodec,
+      logOutputStream
+    )
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/codecs.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/codecs.scala
@@ -1,0 +1,31 @@
+package coop.rchain.blockstorage.dag
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.{BlockHash, BlockMetadata, Validator}
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs._
+
+object codecs {
+  private def xmapToByteString(codec: Codec[ByteVector]): Codec[ByteString] =
+    codec.xmap[ByteString](
+      byteVector => ByteString.copyFrom(byteVector.toArray),
+      byteString => ByteVector(byteString.toByteArray)
+    )
+
+  val codecDeployId = xmapToByteString(variableSizeBytes(uint8, bytes))
+
+  val codecBlockHash = xmapToByteString(bytes(BlockHash.Length))
+
+  val codecBlockMetadata = variableSizeBytes(uint16, bytes).xmap[BlockMetadata](
+    byteVector => BlockMetadata.fromBytes(byteVector.toArray),
+    blockMetadata => ByteVector(blockMetadata.toByteString.toByteArray)
+  )
+
+  val codecValidator = xmapToByteString(bytes(Validator.Length))
+
+  val codecSeqNum = int32
+
+  val codecBlockHashSet = listOfN(int32, codecBlockHash).xmap[Set[BlockHash]](_.toSet, _.toList)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/Crc32.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/Crc32.scala
@@ -3,36 +3,33 @@ package coop.rchain.blockstorage.util
 import java.nio.ByteBuffer
 import java.util.zip.CRC32
 
-import cats.Monad
+import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.shared.Language.ignore
 
-final class Crc32[F[_]: Monad](internal: CRC32) {
+final class Crc32[F[_]: Sync] private (internal: CRC32) {
   def update(bytes: Array[Byte]): F[Unit] =
-    internal.update(bytes).pure[F]
+    Sync[F].delay { internal.update(bytes) }
 
   def update(byteBuffer: ByteBuffer): F[Unit] =
-    internal.update(byteBuffer).pure[F]
+    Sync[F].delay { internal.update(byteBuffer) }
 
   def value: F[Long] =
-    internal.getValue.pure[F]
+    Sync[F].delay { internal.getValue }
 
   def bytes: F[Array[Byte]] =
-    value.map { value =>
-      val byteBuffer = ByteBuffer.allocate(8)
-      ignore { byteBuffer.putLong(value) }
-      byteBuffer.array()
+    value >>= { value =>
+      Sync[F].delay {
+        val byteBuffer = ByteBuffer.allocate(8)
+        ignore { byteBuffer.putLong(value) }
+        byteBuffer.array()
+      }
     }
 
   def reset: F[Unit] =
-    internal.reset().pure[F]
+    Sync[F].delay { internal.reset() }
 }
 
 object Crc32 {
-  def apply[F[_]: Monad](initialBytes: Array[Byte]): Crc32[F] = {
-    val crc = new CRC32()
-    crc.update(initialBytes)
-    new Crc32(crc)
-  }
-  def empty[F[_]: Monad](): Crc32[F] = new Crc32(new CRC32())
+  def empty[F[_]: Sync](): Crc32[F] = new Crc32(new CRC32())
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/TopologicalSortUtil.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/TopologicalSortUtil.scala
@@ -1,13 +1,13 @@
 package coop.rchain.blockstorage.util
 
-import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
 
 object TopologicalSortUtil {
   type BlockSort = Vector[Vector[BlockHash]]
-  def update(sort: BlockSort, offset: Long, block: BlockMessage): BlockSort = {
+  def update(sort: BlockSort, offset: Long, block: BlockMetadata): BlockSort = {
     val hash             = block.blockHash
-    val offsetDiff: Long = BlockMessageUtil.blockNumber(block) - offset
+    val offsetDiff: Long = block.blockNum - offset
 
     assert(offsetDiff <= Int.MaxValue)
     val number = offsetDiff.toInt

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileInputStreamIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/FileInputStreamIO.scala
@@ -1,0 +1,17 @@
+package coop.rchain.blockstorage.util.io
+
+import java.io.{FileNotFoundException, InputStream}
+import java.nio.file.{Files, OpenOption, Path}
+
+import cats.effect.{Resource, Sync}
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+
+object FileInputStreamIO {
+  def open[F[_]: Sync: RaiseIOError](path: Path, options: OpenOption*): Resource[F, InputStream] =
+    Resource.make[F, InputStream](
+      handleIo(Files.newInputStream(path, options: _*), {
+        case e: FileNotFoundException => FileNotFound(e)
+        case e                        => UnexpectedIOError(e)
+      })
+    )(stream => handleIo(stream.close(), ClosingFailed.apply))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/RandomAccessIO.scala
@@ -3,7 +3,7 @@ package coop.rchain.blockstorage.util.io
 import java.io.{EOFException, FileNotFoundException, RandomAccessFile}
 import java.nio.file.Path
 
-import cats.effect.Sync
+import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
@@ -60,4 +60,10 @@ object RandomAccessIO {
       case e: FileNotFoundException => FileNotFound(e)
       case e                        => UnexpectedIOError(e)
     }).map(RandomAccessIO.apply[F])
+
+  def openResource[F[_]: Sync: RaiseIOError](
+      path: Path,
+      mode: Mode
+  ): Resource[F, RandomAccessIO[F]] =
+    Resource.make(open(path, mode))(_.close)
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/BlockDagStorageTest.scala
@@ -62,7 +62,6 @@ trait BlockDagStorageTest
                                 }
           latestMessageHashes <- dag.latestMessageHashes
           latestMessages      <- dag.latestMessages
-          _                   <- dagStorage.clear()
           _ = blockElementLookups.zip(blockElements).foreach {
             case ((blockMetadata, latestMessageHash, latestMessage), b) =>
               blockMetadata shouldBe Some(BlockMetadata.fromBlock(b, false))

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/IndexedBlockDagStorage.scala
@@ -62,11 +62,6 @@ final class IndexedBlockDagStorage[F[_]: Monad](
 
   def checkpoint(): F[Unit] = underlying.checkpoint()
 
-  def clear(): F[Unit] =
-    lock.withPermit(
-      underlying.clear() >> idToBlocksRef.set(Map.empty) >> currentIdRef.set(-1)
-    )
-
   def close(): F[Unit] = underlying.close()
 
   def lookupById(id: Int): F[Option[BlockMessage]] =

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -1,40 +1,31 @@
-package coop.rchain.blockstorage
+package coop.rchain.blockstorage.dag
 
 import java.nio.file.StandardOpenOption
 
-import cats.implicits._
-
-import coop.rchain.shared.PathOps._
-import coop.rchain.catscontrib.TaskContrib.TaskOps
 import cats.effect.Sync
-
+import cats.implicits._
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.LatestMessagesLogIsCorrupted
 import coop.rchain.blockstorage.dag.codecs._
-import coop.rchain.blockstorage.util.byteOps._
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.metrics.Metrics.MetricsNOP
+import coop.rchain.catscontrib.TaskContrib.TaskOps
+import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.models.BlockHash
 import coop.rchain.models.Validator.Validator
-import coop.rchain.models.Validator
-import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.models.blockImplicits._
-import coop.rchain.rspace.Context
-import coop.rchain.{metrics, shared}
-import coop.rchain.shared.Log
+import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
+import coop.rchain.shared
 import coop.rchain.shared.AttemptOps._
+import coop.rchain.shared.PathOps._
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import scala.util.Random
 import scodec.codecs._
 
-import coop.rchain.metrics.Metrics
-
-import kamon.metric.Metric
+import scala.util.Random
 
 trait BlockDagStorageTest
     extends FlatSpecLike

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -1,10 +1,11 @@
-package coop.rchain.blockstorage
+package coop.rchain.blockstorage.dag
 
 import cats.Monad
 import cats.effect.Concurrent
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.implicits._
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.BlockStorageMetricsSource
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.metrics.Metrics.Source

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -3,7 +3,8 @@ package coop.rchain.casper
 import cats.Monad
 import cats.effect.Sync
 import cats.implicits._
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil._

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -14,9 +14,9 @@ import coop.rchain.catscontrib._
 import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.shared._
 import cats.effect.concurrent.Semaphore
-
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.catscontrib.ski.kp2

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -4,19 +4,11 @@ import cats.effect.Sync
 import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{
-  BlockDagRepresentation,
-  BlockDagStorage,
-  BlockStore,
-  EquivocationsTracker
-}
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage, EquivocationsTracker}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.casper.util.{DagOperations, DoublyLinkedDag, ProtoUtil}
-import coop.rchain.casper.util.ProtoUtil.{
-  bonds,
-  getCreatorJustificationAsListUntilGoalInMemory,
-  toLatestMessageHashes
-}
+import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.models.Validator.Validator

--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import scala.collection.immutable.{Map, Set}
 import cats.Monad
 import cats.implicits._
-import coop.rchain.blockstorage.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.weightFromValidatorByDag
@@ -13,6 +13,7 @@ import coop.rchain.models.BlockMetadata
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.shared.{Log, LogSource}
 
 object Estimator {

--- a/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
@@ -4,7 +4,8 @@ import cats.Monad
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.{Event => CasperEvent, _}
 import coop.rchain.casper.util.{DagOperations, EventConverter, ProtoUtil}
 import coop.rchain.models.BlockHash.BlockHash

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -2,7 +2,8 @@ package coop.rchain.casper
 
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.catscontrib.ListContrib

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -6,7 +6,8 @@ import cats.effect.concurrent.{Ref, Semaphore}
 import cats.implicits._
 
 import coop.rchain.blockstorage._
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.DeployError._
 import coop.rchain.casper.engine.Running

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -6,8 +6,7 @@ import cats.implicits._
 import coop.rchain.catscontrib._
 import Catscontrib._
 import cats.data.OptionT
-
-import coop.rchain.blockstorage.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.Justification
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, DagOperations, ProtoUtil}

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -4,7 +4,8 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
 import coop.rchain.casper.util.ProtoUtil.bonds

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -7,10 +7,11 @@ import cats.effect.{Concurrent, Sync}
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.engine._
 import EngineCell._
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper._
 import coop.rchain.casper.DeployError._
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.api
 
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.graphz._

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -5,11 +5,12 @@ import java.nio.file.Paths
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.Monad
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.util.comm._
 import EngineCell._
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol._

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -3,12 +3,10 @@ package coop.rchain.casper.engine
 import cats.{Applicative, Monad}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-
 import EngineCell._
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
-
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.comm.{transport, PeerNode}
@@ -18,8 +16,8 @@ import coop.rchain.comm.transport.{Blob, TransportLayer}
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.shared
 import coop.rchain.shared._
-
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.BlockDagStorage
 
 trait Engine[F[_]] {
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -1,16 +1,14 @@
 package coop.rchain.casper.engine
 
 import scala.concurrent.duration.FiniteDuration
-
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.Applicative
-
 import EngineCell._
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
-
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -3,11 +3,9 @@ package coop.rchain.casper.engine
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.Applicative
-
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
-
 import EngineCell._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -16,8 +14,8 @@ import coop.rchain.comm.transport.TransportLayer
 import coop.rchain.comm.PeerNode
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.shared._
-
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.BlockDagStorage
 
 class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: ConnectionsCell: TransportLayer: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: RuntimeManager: Running.RequestedBlocks](
     validatorId: ValidatorIdentity,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -3,7 +3,8 @@ package coop.rchain.casper.engine
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.Applicative
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import EngineCell._

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -6,7 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.casper.util.comm.CommUtil

--- a/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.util
 import cats.{Eval, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.models.BlockMetadata
 import coop.rchain.shared.StreamT
 

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -7,7 +7,8 @@ import cats.effect.Sync
 import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.{DeployData, _}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -4,7 +4,8 @@ import cats.Monad
 import cats.effect._
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}

--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper
 import cats.data.EitherT
 import cats.effect.{Resource, Sync}
 import cats.implicits._
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts._

--- a/casper/src/test/resources/logback-test.xml
+++ b/casper/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 
     <!--This is needed for RhoSpec tests output-->
     <logger name="coop.rchain.casper.helper.RhoLoggerContract" level="info"/>
-    <logger name="coop.rchain.blockstorage.BlockDagFileStorage" level="error"/>
+    <logger name="coop.rchain.blockstorage.dag.BlockDagFileStorage" level="error"/>
 
     <root level="warn">
         <appender-ref ref="STDOUT"/>

--- a/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/CliqueOracleTest.scala
@@ -2,8 +2,7 @@ package coop.rchain.casper
 
 import scala.collection.immutable.HashMap
 import scala.collection.mutable
-
-import coop.rchain.blockstorage.{BlockStore, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
@@ -12,6 +11,7 @@ import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/EstimatorHelperTest.scala
@@ -4,7 +4,8 @@ import cats.Monad
 import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.dag.{BlockDagStorage, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.EstimatorHelper.conflicts
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator, HashSetCasperTestNode}
 import coop.rchain.casper.protocol.Event.EventInstance.{Consume, Produce}

--- a/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ManyValidatorsTest.scala
@@ -3,8 +3,9 @@ package coop.rchain.casper
 import cats.Monad
 import cats.effect.{Resource, Sync}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.IndexedBlockDagStorage
-import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.casper.engine._
+import EngineCell._
+import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
 import coop.rchain.casper.api.BlockAPI
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperMergeSpec.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper
 
 import cats.{Applicative, Functor, Monad}
 import cats.implicits._
-import coop.rchain.blockstorage.{BlockStore, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.helper.HashSetCasperTestNode
 import coop.rchain.casper.helper.HashSetCasperTestNode._
 import coop.rchain.casper.protocol.DeployData

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -5,7 +5,8 @@ import java.nio.file.Files
 import cats.Monad
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockStore, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -4,8 +4,9 @@ import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.engine._, EngineCell._
-import coop.rchain.blockstorage.{BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
 import coop.rchain.casper.protocol._

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -4,11 +4,12 @@ import cats.Monad
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 
-import coop.rchain.blockstorage.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.engine._
 import EngineCell._
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper._
 import coop.rchain.casper.api.BlockAPI.ApiErr
 import coop.rchain.casper.helper.HashSetCasperTestNode

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -6,6 +6,7 @@ import cats.effect.concurrent.Ref
 import cats.effect.{Concurrent, ContextShift}
 import cats.temp.par
 import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, InMemBlockDagStorage}
 import coop.rchain.casper._
 import coop.rchain.casper.genesis.contracts.{Validator, Vault}
 import coop.rchain.casper.helper.BlockDagStorageTestFixture

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -8,6 +8,7 @@ import cats.effect.{Concurrent, Resource, Sync}
 import cats.syntax.functor._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage, IndexedBlockDagStorage}
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.casper.util.rholang.{Resources, RuntimeManager}

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -5,6 +5,7 @@ import cats.effect._
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag._
 import coop.rchain.casper.CasperMetricsSource
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -8,6 +8,7 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Concurrent, Resource, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage}
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper._

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -4,8 +4,9 @@ import cats.effect.{Resource, Sync}
 import cats.implicits._
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.BlockDagStorage.DeployId
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
 import coop.rchain.casper.DeployError
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.util
 import java.nio.file.{Files, Path}
 
 import cats.implicits._
-import coop.rchain.blockstorage.BlockDagFileStorage
+import coop.rchain.blockstorage.dag.BlockDagFileStorage
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts._
 import coop.rchain.casper.helper.BlockDagStorageTestFixture

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -3,7 +3,8 @@ package coop.rchain.casper.util.rholang
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol._

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -6,7 +6,8 @@ import java.nio.file.{Files, Path}
 import cats.effect.{Concurrent, ContextShift, Resource, Sync}
 import cats.implicits._
 import cats.temp.par
-import coop.rchain.blockstorage.{BlockDagFileStorage, BlockDagStorage, BlockStore}
+import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage}
+import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.helper.BlockDagStorageTestFixture
 import coop.rchain.casper.helper.HashSetCasperTestNode.makeBlockDagFileStorageConfig
 import coop.rchain.metrics

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -12,6 +12,7 @@ import cats.tagless.implicits._
 import cats.mtl.{ApplicativeAsk, ApplicativeLocal, MonadState}
 import cats.temp.par.Par
 import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage}
 import coop.rchain.blockstorage.util.io.IOError
 import coop.rchain.casper._
 import coop.rchain.casper.engine.CasperLaunch.CasperInit

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -4,8 +4,8 @@ import java.nio.file.{Path, Paths}
 
 import collection.JavaConverters._
 import scala.util.Try
-
-import coop.rchain.blockstorage.{BlockDagFileStorage, FileLMDBIndexBlockStore}
+import coop.rchain.blockstorage.FileLMDBIndexBlockStore
+import coop.rchain.blockstorage.dag.BlockDagFileStorage
 import coop.rchain.casper.CasperConf
 import coop.rchain.node.configuration.commandline.ConfigMapper
 


### PR DESCRIPTION
## Overview
Heavily simplifies `BlockDagFileStorage` logic by refactoring common persistent index patterns (read crc, read data, validate data againts crc etc) into a separate class `PersistentIndex` which relies on `Codec[(K, V)]` from [scodec](https://github.com/scodec/scodec).

This PR also creates subpackage `dag` for everything related to `BlockDagStorage` as the root package in `blockstorage` is becoming bloated.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3800


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
