### PR TITLE
Enable gRPC server reflection and CORS on HTTP service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -258,6 +258,7 @@ lazy val node = (project in file("node"))
       apiServerDependencies ++ commonDependencies ++ kamonDependencies ++ protobufDependencies ++ Seq(
         catsCore,
         grpcNetty,
+        grpcServices,
         jline,
         scallop,
         scalaUri,

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -185,3 +185,17 @@ message WaitingContinuationInfo {
   repeated BindPattern postBlockPatterns = 1;
   Par postBlockContinuation = 2;
 }
+
+// This type holds return types for success values inside Either for deploy service methods
+message DeployEitherMeta {
+  DeployServiceResponse DoDeploy = 1;
+  BlockQueryResponse getBlock = 2;
+  VisualizeBlocksResponse visualizeDag = 3;
+  LightBlockInfo showMainChain = 4;
+  LightBlockInfo getBlocks = 5;
+  ListeningNameDataResponse listenForDataAtName = 6;
+  ListeningNameContinuationResponse listenForContinuationAtName = 7;
+  LightBlockQueryResponse findDeploy = 8;
+  PrivateNamePreviewResponse previewPrivateNames = 9;
+  BlockQueryResponse lastFinalizedBlock = 10;
+}

--- a/models/src/main/protobuf/DeployService.proto
+++ b/models/src/main/protobuf/DeployService.proto
@@ -23,7 +23,7 @@ option (scalapb.options) = {
 };
 
 // Use `DoDeploy` to queue deployments of Rholang code and then
-// `createBlock` to make a new block with the results of running them
+// `ProposeService.propose` to make a new block with the results of running them
 // all.
 //
 // To get results back, use `listenForDataAtName`.
@@ -186,8 +186,8 @@ message WaitingContinuationInfo {
   Par postBlockContinuation = 2;
 }
 
-// This type holds return types for success values inside Either for deploy service methods
-message DeployEitherMeta {
+// This type holds response types inside Either for DeployService methods
+message DeployServiceResponseMeta {
   DeployServiceResponse DoDeploy = 1;
   BlockQueryResponse getBlock = 2;
   VisualizeBlocksResponse visualizeDag = 3;

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -42,6 +42,7 @@ import monix.eval.{Task, TaskLocal}
 import monix.execution.Scheduler
 import org.http4s.implicits._
 import org.http4s.server.blaze._
+import org.http4s.server.middleware._
 import org.http4s.server.Router
 
 import scala.concurrent.duration._
@@ -141,9 +142,9 @@ class NodeRuntime private[node] (
                           .bindHttp(conf.server.httpPort, "0.0.0.0")
                           .withHttpApp(
                             Router(
-                              "/metrics" -> prometheusService,
-                              "/version" -> VersionInfo.service[Task],
-                              "/status"  -> StatusInfo.service[Task]
+                              "/metrics" -> CORS(prometheusService),
+                              "/version" -> CORS(VersionInfo.service[Task]),
+                              "/status"  -> CORS(StatusInfo.service[Task])
                             ).orNotFound
                           )
                           .resource

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -49,6 +49,7 @@ package object api {
           ProposeServiceGrpcMonix
             .bindService(ProposeGrpcService.instance(blockApiLock, tracing), grpcExecutor)
         )
+        .addService(ProtoReflectionService.newInstance())
         .build
     )
 

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -13,6 +13,7 @@ import coop.rchain.node.model.repl._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared._
 import io.grpc.netty.NettyServerBuilder
+import io.grpc.protobuf.services.ProtoReflectionService
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -70,6 +71,7 @@ package object api {
           ProposeServiceGrpcMonix
             .bindService(ProposeGrpcService.instance(blockApiLock, tracing), grpcExecutor)
         )
+        .addService(ProtoReflectionService.newInstance())
         .build
     )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,6 +60,7 @@ object Dependencies {
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntimegGrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
   val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
+  val grpcServices        = "io.grpc"                     % "grpc-services"             % scalapb.compiler.Version.grpcJavaVersion
   val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.8.Final"
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.8.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.8.Final" classifier "linux-x86_64"


### PR DESCRIPTION
## Overview
This PR has three parts:
1. adds gRPC reflection for client to inspects API
2. adds additional proto type to describe response types
3. enables CORS on HTTP endpoints.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3804

### Notes
## gRPC service reflection

Setup of reflection is based on _grpc-java_ documentation [gRPC Server Reflection Tutorial](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md)

With reflection service enabled client libraries with gRPC bindings can inspect Casper API without the need for source protobuf files. We can also use generic tools like [grpcui](https://github.com/fullstorydev/grpcui), [grpc-ui](https://github.com/lazada/grpc-ui), [grpcox](https://github.com/gusaul/grpcox) or [grpcurl](https://github.com/fullstorydev/grpcurl) to inspect schema and execute requests.

## Static types for service responses inside Either

With reflection enabled it's still a problem to get information about type which Either holds for success value. Dynamically `type-url` resolves the type but in proto files this info is only in comments so to provide TypeScript definitions I have to parse proto files directly [rnode-grpc-js](https://github.com/tgrospic/rnode-grpc-js/blob/6b148cf9d011974ae0ce7953f2aeea59dba88953/src/cli/typings.js#L43).
For reflection there is no workaround so I've added a new type `DeployEitherMeta` wich just holds dynamic value for each deploy method. The requirement is of course that names of the fields correspond exactly to name of the service methods. Unit responses are skipped like in comments.

## CORS enabled on HTTP endpoints

Currently it's not possible to make HTTP requests to RNode from the browser e.g. `fetch('http://node0.testnet.rchain-dev.tk:40403/status')`. RNode does not specify headers to allow browsers to accept responses from different domain than self. With CORS enabled RNode can be called from page on any domain.

_Examples_

```sh
# Example of curl-like inspect request (reflection API)
$ grpcurl -plaintext localhost:40401 describe coop.rchain.casper.protocol.DeployService
coop.rchain.casper.protocol.DeployService is a service:
service DeployService {
  rpc DoDeploy ( .coop.rchain.casper.protocol.DeployData ) returns ( .Either );
  rpc findDeploy ( .coop.rchain.casper.protocol.FindDeployQuery ) returns ( .Either );
  ...
}

# Example of Casper API request
$ grpcurl -plaintext localhost:40401 coop.rchain.casper.protocol.DeployService/lastFinalizedBlock
{
  "success": {
    "response": {
      "typeUrl": "type.rchain.coop/coop.rchain.casper.protocol.LastFinalizedBlockResponse",
      "value": "CkBlN...TJkNWZhYjIE2MjhiMTZlYTE4NTEzMTBmODZmOWRmZTAp0KCn0="
    }
  }
}

# Exaample of request to meta object with response types
$ grpcurl -plaintext localhost:40401 describe coop.rchain.casper.protocol.DeployEitherMeta
coop.rchain.casper.protocol.DeployEitherMeta is a message:
message DeployEitherMeta {
  .coop.rchain.casper.protocol.DeployServiceResponse DoDeploy = 1;
  .coop.rchain.casper.protocol.BlockQueryResponse getBlock = 2;
  .coop.rchain.casper.protocol.VisualizeBlocksResponse visualizeDag = 3;
  .coop.rchain.casper.protocol.LightBlockInfo showMainChain = 4;
  .coop.rchain.casper.protocol.LightBlockInfo getBlocks = 5;
  .coop.rchain.casper.protocol.ListeningNameDataResponse listenForDataAtName = 6;
  .coop.rchain.casper.protocol.ListeningNameContinuationResponse listenForContinuationAtName = 7;
  .coop.rchain.casper.protocol.LightBlockQueryResponse findDeploy = 8;
  .coop.rchain.casper.protocol.PrivateNamePreviewResponse previewPrivateNames = 9;
  .coop.rchain.casper.protocol.BlockQueryResponse lastFinalizedBlock = 10;
}
```
UI example with gRPCox.
![grpc-reflection-ui](https://user-images.githubusercontent.com/5306205/63968913-fb3a7080-caa0-11e9-929b-4aba6a2b562d.png)

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [ ] includes tests for all added features,
- [ ] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
