### PR TITLE
Introduce more specific InvalidUnslashableBlock errors

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -28,9 +28,15 @@ final case object AdmissibleEquivocation extends InvalidBlock with Slashable
 // For now we won't eagerly slash equivocations that we can just ignore,
 // as we aren't forced to add it to our view as a dependency.
 // TODO: The above will become a DOS vector if we don't fix.
-final case object IgnorableEquivocation   extends InvalidBlock
-final case object InvalidUnslashableBlock extends InvalidBlock
-final case object MissingBlocks           extends InvalidBlock
+final case object IgnorableEquivocation extends InvalidBlock
+final case object MissingBlocks         extends InvalidBlock
+
+sealed trait InvalidUnslashableBlock extends InvalidBlock
+final case object InvalidFormat      extends InvalidUnslashableBlock
+final case object InvalidSignature   extends InvalidUnslashableBlock
+final case object InvalidSender      extends InvalidUnslashableBlock
+final case object InvalidVersion     extends InvalidUnslashableBlock
+final case object InvalidTimestamp   extends InvalidUnslashableBlock
 
 final case object InvalidBlockNumber      extends InvalidBlock with Slashable
 final case object InvalidRepeatDeploy     extends InvalidBlock with Slashable

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -374,7 +374,7 @@ object Validate {
                            s"block timestamp $timestamp is not between latest parent block time and current time."
                          )
                        )
-                 } yield Left(InvalidUnslashableBlock)
+                 } yield Left(InvalidTimestamp)
                }
     } yield result
 

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -162,7 +162,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
         block           <- node.createBlock(basicDeployData)
         invalidBlock    = block.withSig(ByteString.EMPTY)
         status          <- node.casperEff.addBlock(invalidBlock, ignoreDoppelgangerCheck[Effect])
-        _               = status shouldBe InvalidUnslashableBlock
+        _               = status shouldBe InvalidFormat
         _               <- node.casperEff.contains(invalidBlock.blockHash) shouldBeF false
         _               = node.logEff.warns.head.contains("Ignoring block") should be(true)
       } yield ()
@@ -196,14 +196,14 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
       implicit val timeEff = new LogicalTime[Effect]
 
       for {
-        basicDeployData         <- ConstructDeploy.basicDeployData[Effect](0)
-        block                   <- node.createBlock(basicDeployData)
-        dag                     <- node.blockDagStorage.getRepresentation
-        (sk, pk)                = Secp256k1.newKeyPair
-        illSignedBlock          <- ProtoUtil.signBlock(block, dag, pk, sk, Secp256k1.name, block.shardId)
-        status                  <- node.casperEff.addBlock(illSignedBlock, ignoreDoppelgangerCheck[Effect])
-        InvalidUnslashableBlock = status
-        _                       = node.logEff.warns.head.contains("Ignoring block") should be(true)
+        basicDeployData <- ConstructDeploy.basicDeployData[Effect](0)
+        block           <- node.createBlock(basicDeployData)
+        dag             <- node.blockDagStorage.getRepresentation
+        (sk, pk)        = Secp256k1.newKeyPair
+        illSignedBlock  <- ProtoUtil.signBlock(block, dag, pk, sk, Secp256k1.name, block.shardId)
+        status          <- node.casperEff.addBlock(illSignedBlock, ignoreDoppelgangerCheck[Effect])
+        InvalidSender   = status
+        _               = node.logEff.warns.head.contains("Ignoring block") should be(true)
       } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -176,7 +176,7 @@ class ValidateTest
         _ <- Validate.timestamp[Task](
               block.withHeader(modifiedTimestampHeader),
               dag
-            ) shouldBeF InvalidUnslashableBlock.asLeft[ValidBlock]
+            ) shouldBeF InvalidTimestamp.asLeft[ValidBlock]
         _      <- Validate.timestamp[Task](block, dag) shouldBeF Valid.asRight[InvalidBlock]
         _      = log.warns.size should be(1)
         result = log.warns.head.contains("block timestamp") should be(true)
@@ -193,7 +193,7 @@ class ValidateTest
         _ <- Validate.timestamp[Task](
               block.withHeader(modifiedTimestampHeader),
               dag
-            ) shouldBeF Left(InvalidUnslashableBlock)
+            ) shouldBeF Left(InvalidTimestamp)
         _      <- Validate.timestamp[Task](block, dag) shouldBeF Right(Valid)
         _      = log.warns.size should be(1)
         result = log.warns.head.contains("block timestamp") should be(true)


### PR DESCRIPTION
## Overview
Makes it easier to debug as to which of the conditions failed from only client side messages (i.e. specific "Failure! Invalid block: InvalidSignature" instead of generic "Failure! Invalid block: InvalidUnslashableBlock").


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3802


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
