### PR TITLE
Unused COMM events logging

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -134,9 +134,8 @@ object InterpreterUtil {
           }
         case Left((None, status)) =>
           status match {
-            case UnusedCommEvent(ex: ReplayException) =>
-              Log[F].warn(s"Found unused comm event ${ex.getMessage}") >>
-                none[StateHash].asRight[BlockException].pure[F]
+            case UnusedCommEvent(_: ReplayException) =>
+              none[StateHash].asRight[BlockException].pure[F]
             case InternalErrors(_) => throw new RuntimeException("found InternalErrors")
             case ReplayStatusMismatch(_, _) =>
               throw new RuntimeException("found ReplayStatusMismatch")

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -31,6 +31,7 @@ import coop.rchain.rholang.interpreter.{
   Runtime
 }
 import coop.rchain.rspace.{trace, Blake2b256Hash, ReplayException}
+import coop.rchain.shared.Log
 
 trait RuntimeManager[F[_]] {
 
@@ -65,7 +66,7 @@ trait RuntimeManager[F[_]] {
   def withRuntimeLock[A](f: Runtime[F] => F[A]): F[A]
 }
 
-class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span] private[rholang] (
+class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log] private[rholang] (
     val emptyStateHash: StateHash,
     runtimeContainer: MVar[F, Runtime[F]]
 ) extends RuntimeManager[F] {
@@ -367,7 +368,7 @@ object RuntimeManager {
 
   type StateHash = ByteString
 
-  def fromRuntime[F[_]: Concurrent: Sync: Metrics: Span](
+  def fromRuntime[F[_]: Concurrent: Sync: Metrics: Span: Log](
       runtime: Runtime[F]
   ): F[RuntimeManager[F]] =
     for {

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -334,9 +334,11 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log] private[rholang] 
                      .attempt
                      .flatMap {
                        case Right(_) => none[ReplayFailure].pure[F]
-                       case Left(ex: ReplayException) =>
-                         (none[DeployData], UnusedCommEvent(ex): Failed).some
-                           .pure[F]
+                       case Left(ex: ReplayException) => {
+                         Log[F].error(s"Failed during processing of deploy: ${processedDeploy}") >>
+                           (none[DeployData], UnusedCommEvent(ex): Failed).some
+                             .pure[F]
+                       }
                        case Left(ex) =>
                          (none[DeployData], UserErrors(Vector(ex)): Failed).some
                            .pure[F]

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -269,7 +269,10 @@ object GenesisTest {
   )(implicit metrics: Metrics[Task], span: Span[Task]): Task[Unit] =
     withRawGenResources {
       (runtime: Runtime[Task], genesisPath: Path, log: LogStub[Task], time: LogicalTime[Task]) =>
-        RuntimeManager.fromRuntime(runtime).flatMap(body(_, genesisPath, log, time))
+        {
+          implicit val _log = log
+          RuntimeManager.fromRuntime(runtime).flatMap(body(_, genesisPath, log, time))
+        }
     }
 
   def taskTest[R](f: Task[R]): R =

--- a/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
@@ -56,7 +56,7 @@ trait IReplaySpace[F[_], C, P, A, K] extends ISpace[F, C, P, A, K] {
         ifTrue = syncF.unit,
         ifFalse = {
           val msg =
-            s"unused comm event: replayData multimap has ${replayData.size}"
+            s"Unused COMM event: replayData multimap has ${replayData.size} elements left"
           logF.error(msg) >> logF.error(replayData.toString) >> syncF.raiseError[Unit](
             new ReplayException(msg)
           )

--- a/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/IReplaySpace.scala
@@ -55,8 +55,9 @@ trait IReplaySpace[F[_], C, P, A, K] extends ISpace[F, C, P, A, K] {
       .ifM(
         ifTrue = syncF.unit,
         ifFalse = {
-          val msg = s"unused comm event: replayData multimap has ${replayData.size} elements left"
-          logF.error(msg) >> syncF.raiseError[Unit](
+          val msg =
+            s"unused comm event: replayData multimap has ${replayData.size}"
+          logF.error(msg) >> logF.error(replayData.toString) >> syncF.raiseError[Unit](
             new ReplayException(msg)
           )
         }


### PR DESCRIPTION
## Overview
Improves logging of unused COMM event errors occurring during replay


### JIRA ticket:
Prerequisite for: https://rchain.atlassian.net/browse/RCHAIN-3757


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
