### PR TITLE
Fix peek replay

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -153,6 +153,20 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
     }
   }
 
+  it should "propose and replay peek" in effectTest {
+    (1 to 50).toList.map { _ =>
+      HashSetCasperTestNode.networkEff(genesis, networkSize = 1).use { nodes =>
+        for {
+          deploy <- ConstructDeploy.sourceDeployNowF[Effect](
+                     "for(_ <<- @0) { Nil } | @0!(0) | for(_ <- @0) { Nil }"
+                   )
+          block  <- nodes(0).addBlock(deploy)
+          result <- nodes(0).casperEff.contains(block.blockHash) shouldBeF true
+        } yield result
+      }
+    }.parSequence_
+  }
+
   it should "reject unsigned blocks" in effectTest {
     HashSetCasperTestNode.standaloneEff(genesis).use { node =>
       implicit val timeEff = new LogicalTime[Effect]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -51,7 +51,7 @@ object SystemProcesses {
 
       type ContWithMetaData = ContResult[Par, BindPattern, TaggedContinuation]
 
-      type Channels = Seq[Result[ListParWithRandom]]
+      type Channels = Seq[Result[Par, ListParWithRandom]]
 
       private val prettyPrinter = PrettyPrinter()
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -55,7 +55,9 @@ object ChargingRSpace {
           sequenceNumber: Int,
           peeks: SortedSet[Int] = SortedSet.empty[Int]
       ): F[
-        Option[(ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[ListParWithRandom]])]
+        Option[
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
+        ]
       ] =
         for {
           _ <- charge[F](
@@ -88,7 +90,9 @@ object ChargingRSpace {
           persist: Boolean,
           sequenceNumber: Int
       ): F[
-        Option[(ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[ListParWithRandom]])]
+        Option[
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
+        ]
       ] =
         for {
           _       <- charge[F](storageCostProduce(channel, data).copy(operation = "produces storage"))
@@ -98,7 +102,7 @@ object ChargingRSpace {
 
       private def handleResult(
           result: Option[
-            (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[ListParWithRandom]])
+            (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
           ],
           triggeredBy: TriggeredBy
       ): F[Unit] =
@@ -128,7 +132,7 @@ object ChargingRSpace {
         }
 
       private def refundForRemovingProduces(
-          dataList: Seq[Result[ListParWithRandom]],
+          dataList: Seq[Result[Par, ListParWithRandom]],
           cont: ContResult[Par, BindPattern, TaggedContinuation],
           triggeredBy: TriggeredBy
       ): Cost = {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpace.scala
@@ -125,7 +125,7 @@ object ChargingRSpace {
 
               _             <- charge[F](Cost(-refundForConsume.value, "consume storage refund"))
               _             <- charge[F](Cost(-refundForProduces.value, "produces storage refund"))
-              lastIteration = !triggeredBy.persistent && (!cont.peek || consumeId == triggeredBy.id)
+              lastIteration = !triggeredBy.persistent
               _             <- charge[F](eventStorageCost(triggeredBy.channelsCount)).whenA(lastIteration)
               _             <- charge[F](commEventStorageCost(cont.channels.size))
             } yield ()
@@ -143,7 +143,7 @@ object ChargingRSpace {
           // It is going to be 'not removed' and charged for on the last iteration, where it doesn't match anything.
           .filter {
             case (data, _) =>
-              (!cont.peek && !data.persistent) || data.removedDatum.randomState == triggeredBy.id
+              !data.persistent || data.removedDatum.randomState == triggeredBy.id
           }
         removedData
           .map { case (data, channel) => storageCostProduce(channel, data.removedDatum) }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -82,10 +82,12 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
           persist: Boolean,
           sequenceNumber: Int
       ): Task[
-        Option[(ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[ListParWithRandom]])]
+        Option[
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
+        ]
       ] =
         Task.raiseError[Option[
-          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[ListParWithRandom]])
+          (ContResult[Par, BindPattern, TaggedContinuation], Seq[Result[Par, ListParWithRandom]])
         ]](OutOfPhlogistonsError)
     }
     implicit val errorLog    = new ErrorLog[Task]()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -71,7 +71,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
     ("@0!(0) | @0!(0) | for (_ <= @0) { 0 }", 574L),
     ("@0!(0) | for (@0 <- @0) { 0 } | @0!(0) | for (_ <- @0) { 0 }", 663L),
     ("@0!(0) | for (@0 <- @0) { 0 } | @0!(0) | for (@1 <- @0) { 0 }", 551L),
-    ("@0!(0) | for (_ <<- @0) { 0 }", 342L),
+    ("@0!(0) | for (_ <<- @0) { 0 }", 406L),
     ("@0!!(0) | for (_ <<- @0) { 0 }", 343L),
     ("@0!!(0) | @0!!(0) | for (_ <<- @0) { 0 }", 444L),
     ("""new loop in {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
@@ -26,7 +26,7 @@ class ISpaceStub[F[_]: Applicative, C, P, A, K] extends ISpace[F, C, P, A, K] {
       persist: Boolean,
       sequenceNumber: Int,
       peeks: SortedSet[Int]
-  ): F[Option[(ContResult[C, P, K], Seq[Result[A]])]] = ???
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]] = ???
 
   override def install(
       channels: Seq[C],
@@ -39,7 +39,7 @@ class ISpaceStub[F[_]: Applicative, C, P, A, K] extends ISpace[F, C, P, A, K] {
       data: A,
       persist: Boolean,
       sequenceNumber: Int
-  ): F[Option[(ContResult[C, P, K], Seq[Result[A]])]] = ???
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]] = ???
 
   override def createCheckpoint(): F[Checkpoint] = ???
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -3,7 +3,12 @@ package coop.rchain.rspace
 import cats.Id
 import coop.rchain.rspace.internal._
 
-final case class Result[A](matchedDatum: A, removedDatum: A, persistent: Boolean)
+final case class Result[C, A](
+    channel: C,
+    matchedDatum: A,
+    removedDatum: A,
+    persistent: Boolean
+)
 final case class ContResult[C, P, K](
     continuation: K,
     persistent: Boolean,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -120,7 +120,7 @@ class RSpace[F[_], C, P, A, K] private[rspace] (
             peeks.nonEmpty
           ),
           dataCandidates
-            .map(dc => Result(dc.datum.a, dc.removedDatum, dc.datum.persist))
+            .map(dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist))
         )
       )
     }
@@ -332,7 +332,9 @@ class RSpace[F[_], C, P, A, K] private[rspace] (
                 contSequenceNumber,
                 peeks.nonEmpty
               ),
-              dataCandidates.map(dc => Result(dc.datum.a, dc.removedDatum, dc.datum.persist))
+              dataCandidates.map(
+                dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist)
+              )
             )
           )
         }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -63,7 +63,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
 
   private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF(MetricsSource)
 
-  type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[A]])]
+  type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[C, A]])]
 
   protected[this] def consumeLockF(
       channels: Seq[C]

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -146,7 +146,8 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
                       contSequenceNumber,
                       peeks.nonEmpty
                     ),
-                    mats.map(dc => Result(dc.datum.a, dc.removedDatum, dc.datum.persist))
+                    mats
+                      .map(dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist))
                   )
                 )
               }
@@ -361,7 +362,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
                         peeks.nonEmpty
                       ),
                       dataCandidates.map(
-                        dc => Result(dc.datum.a, dc.removedDatum, dc.datum.persist)
+                        dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist)
                       )
                     )
                   )

--- a/rspace/src/main/scala/coop/rchain/rspace/Tuplespace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Tuplespace.scala
@@ -36,7 +36,7 @@ trait Tuplespace[F[_], C, P, A, K] {
       persist: Boolean,
       sequenceNumber: Int = 0,
       peeks: SortedSet[Int] = SortedSet.empty
-  ): F[Option[(ContResult[C, P, K], Seq[Result[A]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]
 
   /** Searches the store for a continuation that has patterns that match the given data at the
     * given channel.
@@ -66,7 +66,7 @@ trait Tuplespace[F[_], C, P, A, K] {
       data: A,
       persist: Boolean,
       sequenceNumber: Int = 0
-  ): F[Option[(ContResult[C, P, K], Seq[Result[A]])]]
+  ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]
 
   def install(channels: Seq[C], patterns: Seq[P], continuation: K): F[Option[(K, Seq[A])]]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -71,7 +71,7 @@ final case class Produce private (
   override def hashCode(): Int = hash.hashCode() * 47 + sequenceNumber.hashCode()
 
   override def toString: String =
-    s"Produce(channels: ${channelsHash.toString}, hash: ${hash.toString})"
+    s"Produce(channels: ${channelsHash.toString}, hash: ${hash.toString}, seqNo: ${sequenceNumber})"
 
 }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -31,15 +31,20 @@ package object util {
 
   implicit def unpackOptionWithPeek[C, P, K, R](
       v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
-  ): Option[(K, Seq[R], Int, Boolean)] =
+  ): Option[(K, Seq[(C, R, R, Boolean)], Int, Boolean)] =
     v.map(unpackTupleWithPeek)
 
   implicit def unpackTupleWithPeek[C, P, K, R](
       v: (ContResult[C, P, K], Seq[Result[C, R]])
-  ): (K, Seq[R], Int, Boolean) =
+  ): (K, Seq[(C, R, R, Boolean)], Int, Boolean) =
     v match {
       case (ContResult(continuation, _, _, _, sequenceNumber, peek), data) =>
-        (continuation, data.map(_.matchedDatum), sequenceNumber, peek)
+        (
+          continuation,
+          data.map(d => (d.channel, d.matchedDatum, d.removedDatum, d.persistent)),
+          sequenceNumber,
+          peek
+        )
     }
 
   implicit def unpackCont[C, P, T](v: ContResult[C, P, T]): T = v.continuation

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -12,50 +12,52 @@ import scala.util.Try
 package object util {
 
   implicit def unpackSeq[C, P, K, R](
-      v: Seq[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+      v: Seq[Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
   ): Seq[Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
   implicit def unpackEither[C, P, E, K, R](
-      v: Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]
+      v: Either[E, Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
   ): Either[E, Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
   implicit def unpackEitherF[F[_], C, P, E, K, R](
-      v: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[R]])]]]
+      v: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[C, R]])]]]
   )(implicit ev: Functor[F]): F[Either[E, Option[(K, Seq[R], Int)]]] =
     ev.map(v)(_.map(unpackOption))
 
   implicit def unpackOption[C, P, K, R](
-      v: Option[(ContResult[C, P, K], Seq[Result[R]])]
+      v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
   ): Option[(K, Seq[R], Int)] =
     v.map(unpackTuple)
 
   implicit def unpackOptionF[F[_], C, P, K, R](
-      v: F[Option[(ContResult[C, P, K], Seq[Result[R]])]]
+      v: F[Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
   )(implicit ev: Functor[F]): F[Option[(K, Seq[R], Int)]] =
     ev.map(v)(unpackOption)
 
-  implicit def unpackTuple[C, P, K, R](v: (ContResult[C, P, K], Seq[Result[R]])): (K, Seq[R], Int) =
+  implicit def unpackTuple[C, P, K, R](
+      v: (ContResult[C, P, K], Seq[Result[C, R]])
+  ): (K, Seq[R], Int) =
     v match {
       case (ContResult(continuation, _, _, _, sequenceNumber, _), data) =>
         (continuation, data.map(_.matchedDatum), sequenceNumber)
     }
 
   implicit def unpackOptionWithPeek[C, P, K, R](
-      v: Option[(ContResult[C, P, K], Seq[Result[R]])]
+      v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
   ): Option[(K, Seq[R], Int, Boolean)] =
     v.map(unpackTupleWithPeek)
 
   implicit def unpackTupleWithPeek[C, P, K, R](
-      v: (ContResult[C, P, K], Seq[Result[R]])
+      v: (ContResult[C, P, K], Seq[Result[C, R]])
   ): (K, Seq[R], Int, Boolean) =
     v match {
       case (ContResult(continuation, _, _, _, sequenceNumber, peek), data) =>
         (continuation, data.map(_.matchedDatum), sequenceNumber, peek)
     }
 
-  implicit def unpack[T](v: Result[T]): T                     = v.matchedDatum
+  implicit def unpack[C, A](v: Result[C, A]): A               = v.matchedDatum
   implicit def unpackCont[C, P, T](v: ContResult[C, P, T]): T = v.continuation
 
   /**

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -16,25 +16,10 @@ package object util {
   ): Seq[Option[(K, Seq[R], Int)]] =
     v.map(unpackOption)
 
-  implicit def unpackEither[C, P, E, K, R](
-      v: Either[E, Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
-  ): Either[E, Option[(K, Seq[R], Int)]] =
-    v.map(unpackOption)
-
-  implicit def unpackEitherF[F[_], C, P, E, K, R](
-      v: F[Either[E, Option[(ContResult[C, P, K], Seq[Result[C, R]])]]]
-  )(implicit ev: Functor[F]): F[Either[E, Option[(K, Seq[R], Int)]]] =
-    ev.map(v)(_.map(unpackOption))
-
   implicit def unpackOption[C, P, K, R](
       v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
   ): Option[(K, Seq[R], Int)] =
     v.map(unpackTuple)
-
-  implicit def unpackOptionF[F[_], C, P, K, R](
-      v: F[Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
-  )(implicit ev: Functor[F]): F[Option[(K, Seq[R], Int)]] =
-    ev.map(v)(unpackOption)
 
   implicit def unpackTuple[C, P, K, R](
       v: (ContResult[C, P, K], Seq[Result[C, R]])
@@ -57,7 +42,6 @@ package object util {
         (continuation, data.map(_.matchedDatum), sequenceNumber, peek)
     }
 
-  implicit def unpack[C, A](v: Result[C, A]): A               = v.matchedDatum
   implicit def unpackCont[C, P, T](v: ContResult[C, P, T]): T = v.continuation
 
   /**
@@ -65,9 +49,6 @@ package object util {
     */
   def getK[A, K](t: Option[(K, A, Int)]): K =
     t.map(_._1).get
-
-  def getK[A, K](e: Either[_, Option[(K, A, Int)]]): K =
-    e.map(_.map(_._1).get).right.get
 
   /** Runs a continuation with the accompanying data
     */

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -65,7 +65,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       continuationCreator: Int => K,
       persist: Boolean,
       peeks: SortedSet[Int] = SortedSet.empty
-  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[A]])]]] =
+  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]] =
     shuffle(range).toList.parTraverse { i: Int =>
       logger.debug("Started consume {}", i)
       space
@@ -82,7 +82,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
       channelCreator: Int => C,
       datumCreator: Int => A,
       persist: Boolean
-  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[A]])]]] =
+  ): Task[List[Option[(ContResult[C, P, K], Seq[Result[C, A]])]]] =
     shuffle(range).toList.parTraverse { i: Int =>
       logger.debug("Started produce {}", i)
       space.produce(channelCreator(i), datumCreator(i), persist).map { r =>
@@ -126,7 +126,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         _ = resultProduce shouldBe Some(
           (
             ContResult(continuation, false, channels, patterns, 1),
-            List(Result(datum, datum, false))
+            List(Result(channels(0), datum, datum, false))
           )
         )
 
@@ -167,7 +167,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         _ = resultProduce shouldBe Some(
           (
             ContResult(continuation, false, channels, patterns, 1, true),
-            List(Result(datum, datum, false))
+            List(Result(channels(0), datum, datum, false))
           )
         )
 
@@ -375,7 +375,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         _ = resultProduce shouldBe Some(
           (
             ContResult(continuation, false, channels, patterns, 1, true),
-            List(Result(datum, datum, false))
+            List(Result(channels(0), datum, datum, false))
           )
         )
         _ <- replaySpace.rigAndReset(emptyPoint.root, rigPoint.log)

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -980,16 +980,6 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
                         )
         finalPoint <- replaySpace.createCheckpoint()
 
-        extractedPlayResults = results.flatten
-        _ = extractedPlayResults.foreach { cr =>
-          cr._1.peek shouldBe true
-        }
-        extractedResults = replayResults.flatten
-        _ = extractedResults.foreach { cr =>
-          cr._1.peek shouldBe true
-        }
-        _ = extractedResults should have size 100
-        _ = extractedResults.map(_._2).flatten.map(_.matchedDatum).toSet should have size 5
         _ = replayResults should contain theSameElementsAs results
         _ = finalPoint.root shouldBe rigPoint.root
         _ = replaySpace.replayData shouldBe empty

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -152,67 +152,65 @@ trait StorageActionsTests[F[_]]
   }
 
   "producing and then consuming on the same channel with peek" should
-    "return the continuation and data and not remove the peeked data" in fixture {
-    (store, _, space) =>
-      val channel = "ch1"
-      val key     = List(channel)
+    "return the continuation and data and remove the peeked data" in fixture { (store, _, space) =>
+    val channel = "ch1"
+    val key     = List(channel)
 
-      for {
-        r1 <- space.produce(channel, "datum", persist = false)
-        d1 <- store.getData(channel)
-        _  = d1 shouldBe List(Datum.create(channel, "datum", false))
-        c1 <- store.getContinuations(key)
-        _  = c1 shouldBe Nil
-        _  = r1 shouldBe None
+    for {
+      r1 <- space.produce(channel, "datum", persist = false)
+      d1 <- store.getData(channel)
+      _  = d1 shouldBe List(Datum.create(channel, "datum", false))
+      c1 <- store.getContinuations(key)
+      _  = c1 shouldBe Nil
+      _  = r1 shouldBe None
 
-        r2 <- space.consume(
-               key,
-               List(Wildcard),
-               new StringsCaptor,
-               persist = false,
-               peeks = SortedSet(0)
-             )
-        d2            <- store.getData(channel)
-        _             = d2 shouldBe List(Datum.create(channel, "datum", false))
-        c2            <- store.getContinuations(key)
-        _             = c2 shouldBe Nil
-        _             = r2 shouldBe defined
-        _             = runK(r2)
-        _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
-        insertActions <- store.changes().map(collectActions[InsertAction])
-        _             = insertActions should have size 1
-      } yield ()
+      r2 <- space.consume(
+             key,
+             List(Wildcard),
+             new StringsCaptor,
+             persist = false,
+             peeks = SortedSet(0)
+           )
+      d2            <- store.getData(channel)
+      _             = d2 shouldBe Nil
+      c2            <- store.getContinuations(key)
+      _             = c2 shouldBe Nil
+      _             = r2 shouldBe defined
+      _             = runK(r2)
+      _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      insertActions <- store.changes().map(collectActions[InsertAction])
+      _             = insertActions shouldBe empty
+    } yield ()
   }
 
   "consuming and then producing on the same channel with peek" should
-    "return the continuation and data and not insert the peeked data" in fixture {
-    (store, _, space) =>
-      val channel = "ch1"
-      val key     = List(channel)
+    "return the continuation and data and remove the peeked data" in fixture { (store, _, space) =>
+    val channel = "ch1"
+    val key     = List(channel)
 
-      for {
-        r1 <- space.consume(
-               key,
-               List(Wildcard),
-               new StringsCaptor,
-               persist = false,
-               peeks = SortedSet(0)
-             )
-        _  = r1 shouldBe None
-        c1 <- store.getContinuations(key)
-        _  = c1 should have size 1
+    for {
+      r1 <- space.consume(
+             key,
+             List(Wildcard),
+             new StringsCaptor,
+             persist = false,
+             peeks = SortedSet(0)
+           )
+      _  = r1 shouldBe None
+      c1 <- store.getContinuations(key)
+      _  = c1 should have size 1
 
-        r2            <- space.produce(channel, "datum", persist = false)
-        d1            <- store.getData(channel)
-        _             = d1 shouldBe Nil
-        c2            <- store.getContinuations(key)
-        _             = c2 shouldBe Nil
-        _             = r2 shouldBe defined
-        _             = runK(r2)
-        _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
-        insertActions <- store.changes().map(collectActions[InsertAction])
-        _             = insertActions should have size 0
-      } yield ()
+      r2            <- space.produce(channel, "datum", persist = false)
+      d1            <- store.getData(channel)
+      _             = d1 shouldBe Nil
+      c2            <- store.getContinuations(key)
+      _             = c2 shouldBe Nil
+      _             = r2 shouldBe defined
+      _             = runK(r2)
+      _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      insertActions <- store.changes().map(collectActions[InsertAction])
+      _             = insertActions should have size 0
+    } yield ()
   }
   "consuming and then producing on the same channel with persistent flag" should
     "return the continuation and data and not insert the persistent data" in fixture {


### PR DESCRIPTION
## Overview
Fixes non-determinism in replay when the same channel is peeked and consumed in the same deploy


### JIRA ticket:
Part of: https://rchain.atlassian.net/browse/RCHAIN-3816


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
