### PR TITLE
Improve Casper code with EitherT

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -1,81 +1,33 @@
 package coop.rchain.casper
 
 sealed trait BlockStatus
-
-sealed trait BlockError extends BlockStatus
-
-sealed trait InvalidBlock extends BlockError
-
-sealed trait Slashable
-
-sealed trait ValidBlock extends BlockStatus
-
-case object Valid extends ValidBlock
-
-case object Processing extends BlockStatus
-
-final case class BlockException(ex: Throwable) extends BlockError
-
-// AdmissibleEquivocation are blocks that would create an equivocation but are
-// pulled in through a justification of another block
-case object AdmissibleEquivocation extends InvalidBlock with Slashable
-// TODO: Make IgnorableEquivocation slashable again and remember to add an entry to the equivocation record.
-// For now we won't eagerly slash equivocations that we can just ignore,
-// as we aren't forced to add it to our view as a dependency.
-// TODO: The above will become a DOS vector if we don't fix.
-case object IgnorableEquivocation extends InvalidBlock
-case object MissingBlocks         extends InvalidBlock
-
-sealed trait InvalidUnslashableBlock extends InvalidBlock
-case object InvalidFormat            extends InvalidUnslashableBlock
-case object InvalidSignature         extends InvalidUnslashableBlock
-case object InvalidSender            extends InvalidUnslashableBlock
-case object InvalidVersion           extends InvalidUnslashableBlock
-case object InvalidTimestamp         extends InvalidUnslashableBlock
-
-case object InvalidBlockNumber      extends InvalidBlock with Slashable
-case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
-case object InvalidParents          extends InvalidBlock with Slashable
-case object InvalidFollows          extends InvalidBlock with Slashable
-case object InvalidSequenceNumber   extends InvalidBlock with Slashable
-case object InvalidShardId          extends InvalidBlock with Slashable
-case object JustificationRegression extends InvalidBlock with Slashable
-case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
-case object NeglectedEquivocation   extends InvalidBlock with Slashable
-case object InvalidTransaction      extends InvalidBlock with Slashable
-case object InvalidBondsCache       extends InvalidBlock with Slashable
-case object InvalidBlockHash        extends InvalidBlock with Slashable
-case object InvalidDeployCount      extends InvalidBlock with Slashable
-case object ContainsExpiredDeploy   extends InvalidBlock with Slashable
-case object ContainsFutureDeploy    extends InvalidBlock with Slashable
-
 object BlockStatus {
-  def valid: ValidBlock                    = Valid
-  def processing: BlockStatus              = Processing
-  def exception(ex: Throwable): BlockError = BlockException(ex)
-  def admissibleEquivocation: BlockError   = AdmissibleEquivocation
-  def ignorableEquivocation: BlockError    = IgnorableEquivocation
-  def missingBlocks: BlockError            = MissingBlocks
-  def invalidFormat: BlockError            = InvalidFormat
-  def invalidSignature: BlockError         = InvalidSignature
-  def invalidSender: BlockError            = InvalidSender
-  def invalidVersion: BlockError           = InvalidVersion
-  def invalidTimestamp: BlockError         = InvalidTimestamp
-  def invalidBlockNumber: BlockError       = InvalidBlockNumber
-  def invalidRepeatDeploy: BlockError      = InvalidRepeatDeploy
-  def invalidParents: BlockError           = InvalidParents
-  def invalidFollows: BlockError           = InvalidFollows
-  def invalidSequenceNumber: BlockError    = InvalidSequenceNumber
-  def invalidShardId: BlockError           = InvalidShardId
-  def justificationRegression: BlockError  = JustificationRegression
-  def neglectedInvalidBlock: BlockError    = NeglectedInvalidBlock
-  def neglectedEquivocation: BlockError    = NeglectedEquivocation
-  def invalidTransaction: BlockError       = InvalidTransaction
-  def invalidBondsCache: BlockError        = InvalidBondsCache
-  def invalidBlockHash: BlockError         = InvalidBlockHash
-  def invalidDeployCount: BlockError       = InvalidDeployCount
-  def containsExpiredDeploy: BlockError    = ContainsExpiredDeploy
-  def containsFutureDeploy: BlockError     = ContainsFutureDeploy
+  def valid: ValidBlock                    = ValidBlock.Valid
+  def processing: BlockError               = BlockError.Processing
+  def exception(ex: Throwable): BlockError = BlockError.BlockException(ex)
+  def admissibleEquivocation: BlockError   = InvalidBlock.AdmissibleEquivocation
+  def ignorableEquivocation: BlockError    = InvalidBlock.IgnorableEquivocation
+  def missingBlocks: BlockError            = InvalidBlock.MissingBlocks
+  def invalidFormat: BlockError            = InvalidBlock.InvalidFormat
+  def invalidSignature: BlockError         = InvalidBlock.InvalidSignature
+  def invalidSender: BlockError            = InvalidBlock.InvalidSender
+  def invalidVersion: BlockError           = InvalidBlock.InvalidVersion
+  def invalidTimestamp: BlockError         = InvalidBlock.InvalidTimestamp
+  def invalidBlockNumber: BlockError       = InvalidBlock.InvalidBlockNumber
+  def invalidRepeatDeploy: BlockError      = InvalidBlock.InvalidRepeatDeploy
+  def invalidParents: BlockError           = InvalidBlock.InvalidParents
+  def invalidFollows: BlockError           = InvalidBlock.InvalidFollows
+  def invalidSequenceNumber: BlockError    = InvalidBlock.InvalidSequenceNumber
+  def invalidShardId: BlockError           = InvalidBlock.InvalidShardId
+  def justificationRegression: BlockError  = InvalidBlock.JustificationRegression
+  def neglectedInvalidBlock: BlockError    = InvalidBlock.NeglectedInvalidBlock
+  def neglectedEquivocation: BlockError    = InvalidBlock.NeglectedEquivocation
+  def invalidTransaction: BlockError       = InvalidBlock.InvalidTransaction
+  def invalidBondsCache: BlockError        = InvalidBlock.InvalidBondsCache
+  def invalidBlockHash: BlockError         = InvalidBlock.InvalidBlockHash
+  def invalidDeployCount: BlockError       = InvalidBlock.InvalidDeployCount
+  def containsExpiredDeploy: BlockError    = InvalidBlock.ContainsExpiredDeploy
+  def containsFutureDeploy: BlockError     = InvalidBlock.ContainsFutureDeploy
 
   def isInDag(blockStatus: BlockStatus): Boolean =
     blockStatus match {
@@ -83,4 +35,73 @@ object BlockStatus {
       case _: InvalidBlock => true
       case _               => false
     }
+}
+
+sealed trait ValidBlock extends BlockStatus
+object ValidBlock {
+  case object Valid extends ValidBlock
+}
+
+sealed trait BlockError extends BlockStatus
+object BlockError {
+  case object Processing                         extends BlockError
+  final case class BlockException(ex: Throwable) extends BlockError
+}
+
+sealed trait InvalidBlock extends BlockError
+object InvalidBlock {
+  // AdmissibleEquivocation are blocks that would create an equivocation but are
+  // pulled in through a justification of another block
+  case object AdmissibleEquivocation extends InvalidBlock
+  // TODO: Make IgnorableEquivocation slashable again and remember to add an entry to the equivocation record.
+  // For now we won't eagerly slash equivocations that we can just ignore,
+  // as we aren't forced to add it to our view as a dependency.
+  // TODO: The above will become a DOS vector if we don't fix.
+  case object IgnorableEquivocation extends InvalidBlock
+  case object MissingBlocks         extends InvalidBlock
+
+  case object InvalidFormat    extends InvalidBlock
+  case object InvalidSignature extends InvalidBlock
+  case object InvalidSender    extends InvalidBlock
+  case object InvalidVersion   extends InvalidBlock
+  case object InvalidTimestamp extends InvalidBlock
+
+  case object InvalidBlockNumber      extends InvalidBlock
+  case object InvalidRepeatDeploy     extends InvalidBlock
+  case object InvalidParents          extends InvalidBlock
+  case object InvalidFollows          extends InvalidBlock
+  case object InvalidSequenceNumber   extends InvalidBlock
+  case object InvalidShardId          extends InvalidBlock
+  case object JustificationRegression extends InvalidBlock
+  case object NeglectedInvalidBlock   extends InvalidBlock
+  case object NeglectedEquivocation   extends InvalidBlock
+  case object InvalidTransaction      extends InvalidBlock
+  case object InvalidBondsCache       extends InvalidBlock
+  case object InvalidBlockHash        extends InvalidBlock
+  case object InvalidDeployCount      extends InvalidBlock
+  case object ContainsExpiredDeploy   extends InvalidBlock
+  case object ContainsFutureDeploy    extends InvalidBlock
+
+  val slashableOffenses: Set[InvalidBlock] =
+    Set(
+      AdmissibleEquivocation,
+      InvalidBlockNumber,
+      InvalidRepeatDeploy,
+      InvalidParents,
+      InvalidFollows,
+      InvalidSequenceNumber,
+      InvalidShardId,
+      JustificationRegression,
+      NeglectedInvalidBlock,
+      NeglectedEquivocation,
+      InvalidTransaction,
+      InvalidBondsCache,
+      InvalidBlockHash,
+      InvalidDeployCount,
+      ContainsExpiredDeploy,
+      ContainsFutureDeploy
+    )
+
+  def isSlashable(invalidBlock: InvalidBlock): Boolean =
+    slashableOffenses.contains(invalidBlock)
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -4,58 +4,86 @@ sealed trait BlockStatus {
   val inDag: Boolean
 }
 
-final case object Processing extends BlockStatus {
-  override val inDag: Boolean = false
+sealed trait BlockError extends BlockStatus
+
+sealed trait InvalidBlock extends BlockError {
+  override val inDag: Boolean = true
 }
-final case class BlockException(ex: Throwable) extends BlockStatus {
-  override val inDag: Boolean = false
-}
+
+sealed trait Slashable
 
 sealed trait ValidBlock extends BlockStatus {
   override val inDag: Boolean = true
 }
-sealed trait InvalidBlock extends BlockStatus {
-  override val inDag: Boolean = true
-}
-sealed trait Slashable
 
-final case object Valid extends ValidBlock
+case object Valid extends ValidBlock
+
+case object Processing extends BlockStatus {
+  override val inDag: Boolean = false
+}
+
+final case class BlockException(ex: Throwable) extends BlockError {
+  override val inDag: Boolean = false
+}
 
 // AdmissibleEquivocation are blocks that would create an equivocation but are
 // pulled in through a justification of another block
-final case object AdmissibleEquivocation extends InvalidBlock with Slashable
+case object AdmissibleEquivocation extends InvalidBlock with Slashable
 // TODO: Make IgnorableEquivocation slashable again and remember to add an entry to the equivocation record.
 // For now we won't eagerly slash equivocations that we can just ignore,
 // as we aren't forced to add it to our view as a dependency.
 // TODO: The above will become a DOS vector if we don't fix.
-final case object IgnorableEquivocation extends InvalidBlock
-final case object MissingBlocks         extends InvalidBlock
+case object IgnorableEquivocation extends InvalidBlock
+case object MissingBlocks         extends InvalidBlock
 
 sealed trait InvalidUnslashableBlock extends InvalidBlock
-final case object InvalidFormat      extends InvalidUnslashableBlock
-final case object InvalidSignature   extends InvalidUnslashableBlock
-final case object InvalidSender      extends InvalidUnslashableBlock
-final case object InvalidVersion     extends InvalidUnslashableBlock
-final case object InvalidTimestamp   extends InvalidUnslashableBlock
+case object InvalidFormat            extends InvalidUnslashableBlock
+case object InvalidSignature         extends InvalidUnslashableBlock
+case object InvalidSender            extends InvalidUnslashableBlock
+case object InvalidVersion           extends InvalidUnslashableBlock
+case object InvalidTimestamp         extends InvalidUnslashableBlock
 
-final case object InvalidBlockNumber      extends InvalidBlock with Slashable
-final case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
-final case object InvalidParents          extends InvalidBlock with Slashable
-final case object InvalidFollows          extends InvalidBlock with Slashable
-final case object InvalidSequenceNumber   extends InvalidBlock with Slashable
-final case object InvalidShardId          extends InvalidBlock with Slashable
-final case object JustificationRegression extends InvalidBlock with Slashable
-final case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
-final case object NeglectedEquivocation   extends InvalidBlock with Slashable
-final case object InvalidTransaction      extends InvalidBlock with Slashable
-final case object InvalidBondsCache       extends InvalidBlock with Slashable
-final case object InvalidBlockHash        extends InvalidBlock with Slashable
-final case object InvalidDeployCount      extends InvalidBlock with Slashable
-final case object ContainsExpiredDeploy   extends InvalidBlock with Slashable
-final case object ContainsFutureDeploy    extends InvalidBlock with Slashable
+case object InvalidBlockNumber      extends InvalidBlock with Slashable
+case object InvalidRepeatDeploy     extends InvalidBlock with Slashable
+case object InvalidParents          extends InvalidBlock with Slashable
+case object InvalidFollows          extends InvalidBlock with Slashable
+case object InvalidSequenceNumber   extends InvalidBlock with Slashable
+case object InvalidShardId          extends InvalidBlock with Slashable
+case object JustificationRegression extends InvalidBlock with Slashable
+case object NeglectedInvalidBlock   extends InvalidBlock with Slashable
+case object NeglectedEquivocation   extends InvalidBlock with Slashable
+case object InvalidTransaction      extends InvalidBlock with Slashable
+case object InvalidBondsCache       extends InvalidBlock with Slashable
+case object InvalidBlockHash        extends InvalidBlock with Slashable
+case object InvalidDeployCount      extends InvalidBlock with Slashable
+case object ContainsExpiredDeploy   extends InvalidBlock with Slashable
+case object ContainsFutureDeploy    extends InvalidBlock with Slashable
 
 object BlockStatus {
-  def valid: BlockStatus                    = Valid
-  def processing: BlockStatus               = Processing
-  def exception(ex: Throwable): BlockStatus = BlockException(ex)
+  def valid: ValidBlock                    = Valid
+  def processing: BlockStatus              = Processing
+  def exception(ex: Throwable): BlockError = BlockException(ex)
+  def admissibleEquivocation: BlockError   = AdmissibleEquivocation
+  def ignorableEquivocation: BlockError    = IgnorableEquivocation
+  def missingBlocks: BlockError            = MissingBlocks
+  def invalidFormat: BlockError            = InvalidFormat
+  def invalidSignature: BlockError         = InvalidSignature
+  def invalidSender: BlockError            = InvalidSender
+  def invalidVersion: BlockError           = InvalidVersion
+  def invalidTimestamp: BlockError         = InvalidTimestamp
+  def invalidBlockNumber: BlockError       = InvalidBlockNumber
+  def invalidRepeatDeploy: BlockError      = InvalidRepeatDeploy
+  def invalidParents: BlockError           = InvalidParents
+  def invalidFollows: BlockError           = InvalidFollows
+  def invalidSequenceNumber: BlockError    = InvalidSequenceNumber
+  def invalidShardId: BlockError           = InvalidShardId
+  def justificationRegression: BlockError  = JustificationRegression
+  def neglectedInvalidBlock: BlockError    = NeglectedInvalidBlock
+  def neglectedEquivocation: BlockError    = NeglectedEquivocation
+  def invalidTransaction: BlockError       = InvalidTransaction
+  def invalidBondsCache: BlockError        = InvalidBondsCache
+  def invalidBlockHash: BlockError         = InvalidBlockHash
+  def invalidDeployCount: BlockError       = InvalidDeployCount
+  def containsExpiredDeploy: BlockError    = ContainsExpiredDeploy
+  def containsFutureDeploy: BlockError     = ContainsFutureDeploy
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -1,30 +1,20 @@
 package coop.rchain.casper
 
-sealed trait BlockStatus {
-  val inDag: Boolean
-}
+sealed trait BlockStatus
 
 sealed trait BlockError extends BlockStatus
 
-sealed trait InvalidBlock extends BlockError {
-  override val inDag: Boolean = true
-}
+sealed trait InvalidBlock extends BlockError
 
 sealed trait Slashable
 
-sealed trait ValidBlock extends BlockStatus {
-  override val inDag: Boolean = true
-}
+sealed trait ValidBlock extends BlockStatus
 
 case object Valid extends ValidBlock
 
-case object Processing extends BlockStatus {
-  override val inDag: Boolean = false
-}
+case object Processing extends BlockStatus
 
-final case class BlockException(ex: Throwable) extends BlockError {
-  override val inDag: Boolean = false
-}
+final case class BlockException(ex: Throwable) extends BlockError
 
 // AdmissibleEquivocation are blocks that would create an equivocation but are
 // pulled in through a justification of another block
@@ -86,4 +76,11 @@ object BlockStatus {
   def invalidDeployCount: BlockError       = InvalidDeployCount
   def containsExpiredDeploy: BlockError    = ContainsExpiredDeploy
   def containsFutureDeploy: BlockError     = ContainsFutureDeploy
+
+  def isInDag(blockStatus: BlockStatus): Boolean =
+    blockStatus match {
+      case _: ValidBlock   => true
+      case _: InvalidBlock => true
+      case _               => false
+    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -56,7 +56,7 @@ trait Casper[F[_], A] {
   def addBlock(
       b: BlockMessage,
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus]
+  ): F[ValidBlockProcessing]
   def contains(hash: BlockHash): F[Boolean]
   def deploy(d: DeployData): F[Either[DeployError, DeployId]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -108,7 +108,8 @@ sealed abstract class MultiParentCasperInstances {
                                         runtimeManager
                                       )
         postGenesisStateHash <- maybePostGenesisStateHash match {
-                                 case Left(BlockException(ex)) => Sync[F].raiseError[StateHash](ex)
+                                 case Left(BlockError.BlockException(ex)) =>
+                                   Sync[F].raiseError[StateHash](ex)
                                  case Left(error) =>
                                    Sync[F].raiseError[StateHash](
                                      new Exception(s"Block error: $error")

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -109,6 +109,10 @@ sealed abstract class MultiParentCasperInstances {
                                       )
         postGenesisStateHash <- maybePostGenesisStateHash match {
                                  case Left(BlockException(ex)) => Sync[F].raiseError[StateHash](ex)
+                                 case Left(error) =>
+                                   Sync[F].raiseError[StateHash](
+                                     new Exception(s"Block error: $error")
+                                   )
                                  case Right(None) =>
                                    Sync[F].raiseError[StateHash](
                                      new Exception("Genesis tuplespace validation failed!")

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -23,7 +23,7 @@ object EquivocationDetector {
       blockBufferDependencyDag: DoublyLinkedDag[BlockHash],
       block: BlockMessage,
       dag: BlockDagRepresentation[F]
-  ): F[Either[BlockError, ValidBlock]] =
+  ): F[ValidBlockProcessing] =
     for {
       maybeLatestMessageOfCreatorHash <- dag.latestMessageHash(block.sender)
       maybeCreatorJustification       = creatorJustificationHash(block)
@@ -64,7 +64,7 @@ object EquivocationDetector {
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage
-  ): F[Either[BlockError, ValidBlock]] =
+  ): F[ValidBlockProcessing] =
     for {
       neglectedEquivocationDetected <- isNeglectedEquivocationDetectedWithUpdate[F](
                                         block,

--- a/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EstimatorHelper.scala
@@ -32,10 +32,12 @@ object EstimatorHelper {
       result <- blocks
                  .foldM(List.empty[BlockMetadata]) {
                    case (acc, b) =>
-                     Monad[F].ifM(acc.forallM(nonConflicting(b)))(
-                       (b :: acc).pure[F],
-                       acc.pure[F]
-                     )
+                     acc
+                       .forallM(nonConflicting(b))
+                       .ifM(
+                         (b :: acc).pure[F],
+                         acc.pure[F]
+                       )
                  }
                  .map(_.reverse)
     } yield result

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -502,7 +502,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: ConnectionsCell: TransportLa
     for {
       successfulAdds <- attempts
                          .filter {
-                           case (_, (status, _)) => status.inDag
+                           case (_, (status, _)) => BlockStatus.isInDag(status)
                          }
                          .pure[F]
       _ <- unsafeRemoveFromBlockBuffer(successfulAdds)

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -637,13 +637,11 @@ object Validate {
               validator,
               genesis.blockHash
             )
-          Monad[F].ifM(
-            isJustificationRegression[F](
-              dag,
-              currentBlockJustificationHash,
-              previousBlockJustificationHash
-            )
-          )(
+          isJustificationRegression[F](
+            dag,
+            currentBlockJustificationHash,
+            previousBlockJustificationHash
+          ).ifM(
             {
               val message =
                 s"block ${PrettyPrinter.buildString(currentBlockJustificationHash)} by ${PrettyPrinter

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -6,10 +6,10 @@ import cats.{Applicative, Monad}
 import cats.data.EitherT
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{Applicative, Monad}
-import com.google.protobuf.ByteString
+
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.casper.protocol._
 import coop.rchain.casper.protocol.Event.EventInstance
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.bonds

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -548,15 +548,13 @@ object BlockAPI {
     }
 
   private def addResponse[F[_]: Concurrent](
-      status: BlockStatus,
+      status: ValidBlockProcessing,
       block: BlockMessage,
       casper: MultiParentCasper[F],
       printUnmatchedSends: Boolean
   ): Effect[F, DeployServiceResponse] =
-    status match {
-      case _: InvalidBlock =>
-        s"Failure! Invalid block: $status".asLeft[DeployServiceResponse].pure[F]
-      case _: ValidBlock =>
+    status
+      .map { _ =>
         val hash    = PrettyPrinter.buildString(block.blockHash)
         val deploys = block.body.get.deploys.map(_.deploy.get)
         val maybeUnmatchedSendsOutputF =
@@ -568,13 +566,18 @@ object BlockAPI {
                 s"Success! Block $hash created and added.${maybeOutput.map("\n" + _).getOrElse("")}"
               ).asRight[Error].pure[F]
           )
-      case BlockError.BlockException(ex) =>
-        s"Error during block processing: $ex".asLeft[DeployServiceResponse].pure[F]
-      case BlockError.Processing =>
-        "No action taken since other thread is already processing the block."
-          .asLeft[DeployServiceResponse]
-          .pure[F]
-    }
+      }
+      .leftMap {
+        case _: InvalidBlock =>
+          s"Failure! Invalid block: $status".asLeft[DeployServiceResponse].pure[F]
+        case BlockError.BlockException(ex) =>
+          s"Error during block processing: $ex".asLeft[DeployServiceResponse].pure[F]
+        case BlockError.Processing =>
+          "No action taken since other thread is already processing the block."
+            .asLeft[DeployServiceResponse]
+            .pure[F]
+      }
+      .merge
 
   private def prettyPrintUnmatchedSends[F[_]: Concurrent](
       casper: MultiParentCasper[F],

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -407,9 +407,12 @@ object BlockAPI {
                                case Some(block) =>
                                  for {
                                    blockInfo <- getFullBlockInfo[F](block)
-                                 } yield BlockQueryResponse(blockInfo = Some(blockInfo)).asRight
+                                 } yield BlockQueryResponse(blockInfo = Some(blockInfo))
+                                   .asRight[Error]
                                case None =>
-                                 s"Error: Failure to find block with hash ${q.hash}".asLeft.pure[F]
+                                 s"Error: Failure to find block with hash ${q.hash}"
+                                   .asLeft[BlockQueryResponse]
+                                   .pure[F]
                              }
       } yield blockQueryResponse
 
@@ -565,9 +568,9 @@ object BlockAPI {
                 s"Success! Block $hash created and added.${maybeOutput.map("\n" + _).getOrElse("")}"
               ).asRight[Error].pure[F]
           )
-      case BlockException(ex) =>
+      case BlockError.BlockException(ex) =>
         s"Error during block processing: $ex".asLeft[DeployServiceResponse].pure[F]
-      case Processing =>
+      case BlockError.Processing =>
         "No action taken since other thread is already processing the block."
           .asLeft[DeployServiceResponse]
           .pure[F]

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -173,7 +173,7 @@ object Running {
 
   def handleBlockMessage[F[_]: Monad: Log: RequestedBlocks](peer: PeerNode, b: BlockMessage)(
       casperContains: BlockHash => F[Boolean],
-      casperAdd: BlockMessage => F[BlockStatus]
+      casperAdd: BlockMessage => F[ValidBlockProcessing]
   ): F[Unit] =
     casperContains(b.blockHash)
       .ifM(
@@ -181,7 +181,7 @@ object Running {
         for {
           _      <- Log[F].info(s"Received ${PrettyPrinter.buildString(b)}.")
           status <- casperAdd(b)
-          _ <- if (BlockStatus.isInDag(status)) RequestedBlocks[F].modify(_ - b.blockHash)
+          _ <- if (BlockStatus.isInDag(status.merge)) RequestedBlocks[F].modify(_ - b.blockHash)
               else noop[F]
         } yield ()
       )
@@ -242,7 +242,7 @@ class Running[F[_]: Sync: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer
   import Engine._
   import Running._
 
-  private def casperAdd(peer: PeerNode): BlockMessage => F[BlockStatus] = {
+  private def casperAdd(peer: PeerNode): BlockMessage => F[ValidBlockProcessing] = {
     def handleDoppelganger: (BlockMessage, Validator) => F[Unit] =
       (bm: BlockMessage, self: Validator) =>
         if (bm.sender == self) {
@@ -251,7 +251,7 @@ class Running[F[_]: Sync: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer
           Log[F].warn(warnMessage)
         } else ().pure[F]
 
-    (b: BlockMessage) => casper.addBlock(b, handleDoppelganger)
+    b: BlockMessage => casper.addBlock(b, handleDoppelganger)
   }
 
   def applicative: Applicative[F] = Applicative[F]

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -181,7 +181,8 @@ object Running {
         for {
           _      <- Log[F].info(s"Received ${PrettyPrinter.buildString(b)}.")
           status <- casperAdd(b)
-          _      <- if (status.inDag) RequestedBlocks[F].modify(_ - b.blockHash) else noop[F]
+          _ <- if (BlockStatus.isInDag(status)) RequestedBlocks[F].modify(_ - b.blockHash)
+              else noop[F]
         } yield ()
       )
 

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -5,7 +5,9 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 
 package object casper {
-  type TopoSort = Vector[Vector[BlockHash]]
+  type TopoSort             = Vector[Vector[BlockHash]]
+  type BlockProcessing[A]   = Either[BlockError, A]
+  type ValidBlockProcessing = BlockProcessing[ValidBlock]
 
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -44,14 +44,18 @@ object CommUtil {
   def sendBlockRequest[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk: Running.RequestedBlocks](
       hash: BlockHash
   ): F[Unit] =
-    (Running.RequestedBlocks[F].read map (_.contains(hash))).ifM(
-      ().pure[F],
-      for {
-        _ <- Running.addNewEntry[F](hash)
-        _ <- sendToPeers[F](transport.HasBlockRequest, HasBlockRequest(hash).toByteString)
-        _ <- Log[F].info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
-      } yield ()
-    )
+    Running
+      .RequestedBlocks[F]
+      .read
+      .map(_.contains(hash))
+      .ifM(
+        ().pure[F],
+        for {
+          _ <- Running.addNewEntry[F](hash)
+          _ <- sendToPeers[F](transport.HasBlockRequest, HasBlockRequest(hash).toByteString)
+          _ <- Log[F].info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
+        } yield ()
+      )
 
   def sendForkChoiceTipRequest[F[_]: Monad: ConnectionsCell: TransportLayer: Log: Time: RPConfAsk]
       : F[Unit] = {

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -35,7 +35,7 @@ object InterpreterUtil {
       b: BlockMessage,
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager[F]
-  ): F[Either[BlockError, Option[StateHash]]] = {
+  ): F[BlockProcessing[Option[StateHash]]] = {
     val preStateHash    = ProtoUtil.preStateHash(b)
     val tsHash          = ProtoUtil.tuplespace(b)
     val deploys         = ProtoUtil.deploys(b)
@@ -77,7 +77,7 @@ object InterpreterUtil {
       blockData: BlockData,
       invalidBlocks: Map[BlockHash, Validator],
       isGenesis: Boolean
-  ): F[Either[BlockError, Option[StateHash]]] =
+  ): F[BlockProcessing[Option[StateHash]]] =
     possiblePreStateHash match {
       case Left(ex) =>
         BlockStatus.exception(ex).asLeft[Option[StateHash]].pure[F]
@@ -109,7 +109,7 @@ object InterpreterUtil {
       blockData: BlockData,
       invalidBlocks: Map[BlockHash, Validator],
       isGenesis: Boolean
-  ): F[Either[BlockError, Option[StateHash]]] =
+  ): F[BlockProcessing[Option[StateHash]]] =
     runtimeManager
       .replayComputeState(preStateHash)(internalDeploys, blockData, invalidBlocks, isGenesis)
       .flatMap {

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -3,12 +3,13 @@ package coop.rchain.casper.util.rholang
 import cats.Monad
 import cats.effect._
 import cats.implicits._
-import com.google.protobuf.ByteString
+
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
-import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
+import coop.rchain.casper.util.rholang.RuntimeManager._
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.Span
 import coop.rchain.models.{BlockMetadata, Par}
@@ -207,6 +208,7 @@ object InterpreterUtil {
         computeMultiParentsPostState[F](parents, dag, runtimeManager, initStateHash)
     }
   }
+
   // In the case of multiple parents we need to apply all of the deploys that have been
   // made in all of the branches of the DAG being merged. This is done by computing uncommon ancestors
   // and applying the deploys in those blocks on top of the initial parent.
@@ -225,49 +227,53 @@ object InterpreterUtil {
       _             <- Span[F].mark("before-compute-parents-post-state-get-blocks")
       blocksToApply <- blockHashesToApply.traverse(b => ProtoUtil.getBlock[F](b.blockHash))
       _             <- Span[F].mark("before-compute-parents-post-state-replay")
-      replayResult <- blocksToApply.toList.foldM(Right(initStateHash).leftCast[Throwable]) {
-                       (acc, block) =>
-                         acc match {
-                           case Right(stateHash) =>
-                             val deploys =
-                               block.getBody.deploys
-                                 .flatMap(InternalProcessedDeploy.fromProcessedDeploy)
+      replayResult <- (initStateHash, blocksToApply).tailRecM {
+                       case (hash, blocks) if blocks.isEmpty =>
+                         hash.asRight[Throwable].asRight[(StateHash, Vector[BlockMessage])].pure[F]
 
-                             val timestamp   = block.header.get.timestamp // TODO: Ensure header exists through type
-                             val blockNumber = block.body.get.state.get.blockNumber
-
-                             for {
-                               invalidBlocksSet <- dag.invalidBlocks
-                               unseenBlocksSet  <- ProtoUtil.unseenBlockHashes(dag, block)
-                               seenInvalidBlocksSet = invalidBlocksSet.filterNot(
-                                 block => unseenBlocksSet.contains(block.blockHash)
-                               )
-                               invalidBlocks = seenInvalidBlocksSet
-                                 .map(block => (block.blockHash, block.sender))
-                                 .toMap
-                               replayResult <- runtimeManager.replayComputeState(stateHash)(
-                                                deploys,
-                                                BlockData(timestamp, blockNumber),
-                                                invalidBlocks,
-                                                isGenesis = parents.isEmpty //should always be false
-                                              )
-                             } yield replayResult match {
-                               case result @ Right(_) => result.leftCast[Throwable]
-                               case Left((_, status)) =>
-                                 val parentHashes =
-                                   parents.map(
-                                     p => Base16.encode(p.blockHash.toByteArray).take(8)
-                                   )
-                                 Left(
-                                   new Exception(
-                                     s"Failed status while computing post state of $parentHashes: $status"
-                                   )
-                                 )
-                             }
-                           case Left(_) => acc.pure[F]
+                       case (hash, blocks) =>
+                         replayBlock(hash, blocks.head, parents.isEmpty, dag, runtimeManager).map {
+                           case Right(h) => (h, blocks.tail).asLeft
+                           case Left((_, status)) =>
+                             val parentHashes =
+                               parents.map(p => Base16.encode(p.blockHash.toByteArray).take(8))
+                             new Exception(
+                               s"Failed status while computing post state of $parentHashes: $status"
+                             ).asInstanceOf[Throwable]
+                               .asLeft[StateHash]
+                               .asRight
                          }
                      }
     } yield replayResult
+
+  private[rholang] def replayBlock[F[_]: Sync: BlockStore](
+      hash: StateHash,
+      block: BlockMessage,
+      isGenesis: Boolean,
+      dag: BlockDagRepresentation[F],
+      runtimeManager: RuntimeManager[F]
+  ): F[Either[ReplayFailure, StateHash]] = {
+    val deploys     = block.getBody.deploys.flatMap(InternalProcessedDeploy.fromProcessedDeploy)
+    val timestamp   = block.header.get.timestamp // TODO: Ensure header exists through type
+    val blockNumber = block.body.get.state.get.blockNumber
+
+    for {
+      invalidBlocksSet <- dag.invalidBlocks
+      unseenBlocksSet  <- ProtoUtil.unseenBlockHashes(dag, block)
+      seenInvalidBlocksSet = invalidBlocksSet.filterNot(
+        block => unseenBlocksSet.contains(block.blockHash)
+      )
+      invalidBlocks = seenInvalidBlocksSet
+        .map(block => (block.blockHash, block.sender))
+        .toMap
+      replayResult <- runtimeManager.replayComputeState(hash)(
+                       deploys,
+                       BlockData(timestamp, blockNumber),
+                       invalidBlocks,
+                       isGenesis //should always be false
+                     )
+    } yield replayResult
+  }
 
   private[rholang] def findMultiParentsBlockHashesForReplay[F[_]: Monad](
       parents: Seq[BlockMessage],

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperAddBlockSpec.scala
@@ -29,6 +29,9 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
 
   import RSpaceUtil._
   import coop.rchain.casper.util.GenesisBuilder._
+  import ValidBlock._
+  import BlockError._
+  import InvalidBlock._
 
   implicit val timeEff = new LogicalTime[Effect]
 

--- a/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/ValidateTest.scala
@@ -37,6 +37,10 @@ class ValidateTest
     with BeforeAndAfterEach
     with BlockGenerator
     with BlockDagStorageFixture {
+  import ValidBlock._
+  import BlockError._
+  import InvalidBlock._
+
   implicit val log                        = new LogStub[Task]
   implicit val noopMetrics: Metrics[Task] = new Metrics.MetricsNOP[Task]
   implicit val span: Span[Task]           = new NoopSpan[Task]

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -106,7 +106,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def addBlock(
       b: BlockMessage,
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus]                                           = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
+  ): F[ValidBlockProcessing]                                  = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
   def contains(blockHash: BlockHash): F[Boolean]              = underlying.contains(blockHash)
   def deploy(d: DeployData): F[Either[DeployError, DeployId]] = underlying.deploy(d)
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
@@ -1,22 +1,22 @@
 package coop.rchain.casper.engine
 
+import cats.implicits._
+
 import Running.{Requested, RequestedBlocks}
-import coop.rchain.catscontrib.ski._
-import coop.rchain.casper.{BlockError, BlockStatus, ValidBlock}
 import coop.rchain.casper.protocol._
-import coop.rchain.comm.{CommError, Endpoint, NodeIdentifier, PeerNode}, CommError._
+import coop.rchain.catscontrib.ski._
+import coop.rchain.comm._
+import CommError._
+import coop.rchain.casper.{BlockError, ValidBlock, _}
 import coop.rchain.comm.protocol.routing.Protocol
-import coop.rchain.comm.transport.TransportLayer
-import coop.rchain.comm.rp.{ProtocolHelper, RPConf}, ProtocolHelper.toPacket
-import coop.rchain.shared._
-import coop.rchain.p2p.EffectsTestInstances.{LogStub, TransportLayerStub}
+import coop.rchain.comm.rp.RPConf
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.p2p.EffectsTestInstances.{LogStub, TransportLayerStub}
+import coop.rchain.shared._
+
 import com.google.protobuf.ByteString
 import monix.eval.Coeval
 import org.scalatest._
-import cats._, cats.data._, cats.implicits._
-
-import scala.collection.mutable.{Map => MutableMap}
 
 class RunningHandleBlockMessageSpec extends FunSpec with BeforeAndAfterEach with Matchers {
 
@@ -73,7 +73,8 @@ class RunningHandleBlockMessageSpec extends FunSpec with BeforeAndAfterEach with
 
   private def alwaysSuccess: PeerNode => Protocol => CommErr[Unit] = kp(kp(Right(())))
   private def alwaysDoesntContain: BlockHash => Coeval[Boolean]    = kp(false.pure[Coeval])
-  private def blockInDag: BlockMessage => Coeval[BlockStatus]      = kp(ValidBlock.Valid.pure[Coeval])
-  private def blockNotInDag: BlockMessage => Coeval[BlockStatus] =
-    kp(BlockError.Processing.pure[Coeval])
+  private def blockInDag: BlockMessage => Coeval[ValidBlockProcessing] =
+    kp(ValidBlock.Valid.asRight.pure[Coeval])
+  private def blockNotInDag: BlockMessage => Coeval[ValidBlockProcessing] =
+    kp(BlockError.Processing.asLeft.pure[Coeval])
 }

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.engine
 
 import Running.{Requested, RequestedBlocks}
 import coop.rchain.catscontrib.ski._
-import coop.rchain.casper.{BlockStatus, Processing, Valid}
+import coop.rchain.casper.{BlockError, BlockStatus, ValidBlock}
 import coop.rchain.casper.protocol._
 import coop.rchain.comm.{CommError, Endpoint, NodeIdentifier, PeerNode}, CommError._
 import coop.rchain.comm.protocol.routing.Protocol
@@ -73,6 +73,7 @@ class RunningHandleBlockMessageSpec extends FunSpec with BeforeAndAfterEach with
 
   private def alwaysSuccess: PeerNode => Protocol => CommErr[Unit] = kp(kp(Right(())))
   private def alwaysDoesntContain: BlockHash => Coeval[Boolean]    = kp(false.pure[Coeval])
-  private def blockInDag: BlockMessage => Coeval[BlockStatus]      = kp(Valid.pure[Coeval])
-  private def blockNotInDag: BlockMessage => Coeval[BlockStatus]   = kp(Processing.pure[Coeval])
+  private def blockInDag: BlockMessage => Coeval[BlockStatus]      = kp(ValidBlock.Valid.pure[Coeval])
+  private def blockNotInDag: BlockMessage => Coeval[BlockStatus] =
+    kp(BlockError.Processing.pure[Coeval])
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -101,9 +101,11 @@ class HashSetCasperTestNode[F[_]](
   implicit val packetHandlerEff          = CasperPacketHandler[F]
 
   def addBlock(deployDatums: DeployData*): F[BlockMessage] =
-    addBlockStatus(ValidBlock.Valid)(deployDatums: _*)
+    addBlockStatus(ValidBlock.Valid.asRight)(deployDatums: _*)
 
-  def addBlockStatus(expectedStatus: BlockStatus)(deployDatums: DeployData*): F[BlockMessage] =
+  def addBlockStatus(
+      expectedStatus: ValidBlockProcessing
+  )(deployDatums: DeployData*): F[BlockMessage] =
     for {
       block  <- createBlock(deployDatums: _*)
       status <- casperEff.addBlock(block, ignoreDoppelgangerCheck[F])

--- a/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/HashSetCasperTestNode.scala
@@ -101,7 +101,7 @@ class HashSetCasperTestNode[F[_]](
   implicit val packetHandlerEff          = CasperPacketHandler[F]
 
   def addBlock(deployDatums: DeployData*): F[BlockMessage] =
-    addBlockStatus(Valid)(deployDatums: _*)
+    addBlockStatus(ValidBlock.Valid)(deployDatums: _*)
 
   def addBlockStatus(expectedStatus: BlockStatus)(deployDatums: DeployData*): F[BlockMessage] =
     for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -30,11 +30,11 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def addBlock(
       b: BlockMessage,
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus] =
+  ): F[ValidBlockProcessing] =
     for {
       _ <- Sync[F].delay(blockStore.update(b.blockHash, b))
       _ <- BlockStore[F].put(b.blockHash, b)
-    } yield BlockStatus.valid
+    } yield BlockStatus.valid.asRight
   def contains(blockHash: BlockHash): F[Boolean] = false.pure[F]
   def deploy(r: DeployData): F[Either[DeployError, DeployId]] =
     Applicative[F].pure(Right(ByteString.EMPTY))


### PR DESCRIPTION
## Overview
Improvements:
- Use of `EitherT` instead of `joinRight.traverse`
- Make the `BlockStatus` _is in dag_ logic explicit instead of using inheritance
- Make the `BlockStatus` _Slashable_ logic explicit instead of using inheritance
- Unify Casper functions return types to `ValidBlockProcessing`
- Improve code readability in Casper
- Change Casper `foldM` to `tailRecM` in `InterpreterUtil` and `RuntimeManager`

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3616
