### PR TITLE
Fix LCA algorithm bug

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -72,9 +72,10 @@ class DagOperationsTest
         dag <- blockDagStorage.getRepresentation
 
         _      <- DagOperations.lowestCommonAncestorF[Task](b1, b5, dag) shouldBeF b1
+        _      <- DagOperations.lowestCommonAncestorF[Task](b2, b8, dag) shouldBeF b2
         _      <- DagOperations.lowestCommonAncestorF[Task](b2, b3, dag) shouldBeF b1
         _      <- DagOperations.lowestCommonAncestorF[Task](b3, b2, dag) shouldBeF b1
-        _      <- DagOperations.lowestCommonAncestorF[Task](b6, b7, dag) shouldBeF b1
+        _      <- DagOperations.lowestCommonAncestorF[Task](b6, b7, dag) shouldBeF b4
         _      <- DagOperations.lowestCommonAncestorF[Task](b2, b2, dag) shouldBeF b2
         _      <- DagOperations.lowestCommonAncestorF[Task](b10, b9, dag) shouldBeF b8
         result <- DagOperations.lowestCommonAncestorF[Task](b3, b7, dag) shouldBeF b3


### PR DESCRIPTION
## Overview
Fixes how LCA algorithm handles cases where there are multiple blocks with the same block number. More information in the ticket.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3828


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
