### PR TITLE
Removes non-determinism from InterpreterUtilTest

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -58,24 +58,25 @@ class InterpreterUtilTest
     )
 
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in effectTest {
+    val time = 0L
     val b0Deploys = Vector(
       "@1!(1)",
       "@2!(2)",
       "for(@a <- @1){ @123!(5 * a) }"
-    ).map(ConstructDeploy.sourceDeployNow)
+    ).map(d => ConstructDeploy.sourceDeploy(d, time + 1))
 
     val b1Deploys = Vector(
       "@1!(1)",
       "for(@a <- @2){ @456!(5 * a) }"
-    ).map(ConstructDeploy.sourceDeployNow)
+    ).map(d => ConstructDeploy.sourceDeploy(d, time + 2))
 
     val b2Deploys = Vector(
       "for(@a <- @123; @b <- @456){ @1!(a + b) }"
-    ).map(ConstructDeploy.sourceDeployNow)
+    ).map(d => ConstructDeploy.sourceDeploy(d, time + 3))
 
     val b3Deploys = Vector(
       "@7!(7)"
-    ).map(ConstructDeploy.sourceDeployNow)
+    ).map(d => ConstructDeploy.sourceDeploy(d, time + 4))
 
     /*
      * DAG Looks like this:


### PR DESCRIPTION
## Overview
See description


### JIRA ticket:
Ad-hoc



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
