### PR TITLE
Rchain 3467: add PoS methods commitRandomImage and commitRandom

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -65,6 +65,8 @@ new  PoS,
               "committedRewards":{},
               "activeValidators":initialActive,
               "withdrawers":{},
+              "randomImages":{},
+              "randomNumbers":{},
               "allBonds":$$initialBonds$$
             }) |
 
@@ -257,7 +259,9 @@ new  PoS,
                             "committedRewards":newRewards,
                             "activeValidators":newValidators,
                             "withdrawers":newWithdrawers,
-                            "allBonds":newBonds
+                            "allBonds":newBonds,
+                            "randomImages":{},
+                            "randomNumbers":{},
                           },
                           Nil)
                       }
@@ -340,6 +344,54 @@ new  PoS,
                   }
                 }
               }
+            } |
+
+            contract PoS(@"commitRandomImage", @hash, ackCh) = {
+              new userCh, mvarCh in {
+                getUser!(*userCh) |
+
+                runMVar!(*stateCh, *mvarCh, *ackCh) |
+                for (@validator <- userCh;
+                     @state, resultCh <- mvarCh) {
+                  if (state.get("randomImages").contains(validator)) {
+                    resultCh!(state, (false, "Image already committed"))
+                  }
+                  else {
+                    resultCh!(
+                      state.set("randomImages",
+                               state.get("randomImages").set(validator, hash)),
+                      true)
+                  }
+               }
+             }
+            } |
+
+            contract PoS(@"revealRandom", @random, ackCh) = {
+              new userCh, mvarCh, computeHash(`rho:crypto:keccak256Hash`), hashCh in {
+                getUser!(*userCh) |
+
+                runMVar!(*stateCh, *mvarCh, *ackCh) |
+                computeHash!(random, *hashCh) |
+                for (@validator <- userCh;
+                     @state, resultCh <- mvarCh;
+                     @hash <- hashCh) {
+                  if (state.get("randomImages").contains(validator)) {
+                    if (hash == state.get("randomImages").get(validator))
+                    {
+                      resultCh!(
+                        state.set("randomNumbers",
+                          state.get("randomNumbers").set(validator, random)),
+                        true)
+                    } else
+                    {
+                      resultCh!(state, (false, "Previously committed image doesn't match the random number"))
+                    }
+                  }
+                  else {
+                      resultCh! (state, (false, "Previously committed random image not found"))
+                  }
+               }
+             }
             }
           }
         } |

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -23,6 +23,7 @@ match (
       test_bonding_fails_if_already_bonded,
       test_bonding_fails_if_bond_too_small,
       test_pay_succeeds,
+      test_commit_random,
       test_dont_pay_inactive_validators,
       test_bonding_failure
     in {
@@ -52,7 +53,8 @@ match (
               ("payment works", *test_pay_succeeds),
               ("bonding fails if already bonded", *test_bonding_fails_if_already_bonded),
               ("bonding fails is bond is too small", *test_bonding_fails_if_bond_too_small),
-              ("payment is not distributed to inactive validators", *test_dont_pay_inactive_validators)
+              ("payment is not distributed to inactive validators", *test_dont_pay_inactive_validators),
+              ("commited random matches its image", *test_commit_random)
             ]) |
 
           contract setup(_, retCh) = {
@@ -457,6 +459,47 @@ match (
                           rhoSpec!("assertMany",
                             [
                               ((Nil, "==", finalRewards.get(validatorPubKey)), "the new validator should have no reward")
+                            ],
+                            *ackCh
+                          )
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          } |
+
+          contract test_commit_random(rhoSpec, _, ackCh) = {
+            new setupCh, closeBlockCh, retCh,
+                finalRewardsCh, computeHash(`rho:crypto:keccak256Hash`), hash00Ch, hashFFCh
+            in {
+              prepareUser!("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", *setupCh) |
+              for (@validatorPubKey, _, _ <- setupCh) {
+                @PoS!("revealRandom", "FF".hexToBytes(), *retCh) |
+
+                computeHash!("00".hexToBytes(), *hash00Ch) |
+                computeHash!("FF".hexToBytes(), *hashFFCh) |
+
+                for (@result0 <- retCh;
+                     @hash00 <- hash00Ch;
+                     @hashFF <- hashFFCh) {
+                  @PoS!("commitRandomImage", hash00, *retCh) |
+                  for (@result1 <- retCh) {
+                    @PoS!("commitRandomImage", hashFF, *retCh) |
+                    for (@result2 <- retCh) {
+                      @PoS!("revealRandom", "FF".hexToBytes(), *retCh) |
+                      for (@result3 <- retCh) {
+                        @PoS!("revealRandom", "00".hexToBytes(), *retCh) |
+                        for (@result4 <- retCh) {
+                          rhoSpec!("assertMany",
+                            [
+                              (((false, "Previously committed random image not found"), "==", result0), "commitRandom before commitRandomImage fails"),
+                              ((true, "==", result1), "the first commitRandomImage is successful"),
+                              (((false, "Image already committed"), "==", result2), "the second commitRandomImage for the same validator fails"),
+                              (((false, "Previously committed image doesn't match the random number"), "==", result3), "the random value doesn't match the commited image stored by the first commitRandomImage"),
+                              ((true, "==", result4), "the random value matches the commited image")
                             ],
                             *ackCh
                           )

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/PoSSpec.scala
@@ -15,7 +15,7 @@ class PoSSpec
     extends RhoSpec(
       CompiledRholangSource("PoSTest.rho", NormalizerEnv.Empty),
       Seq.empty,
-      120.seconds,
+      180.seconds,
       genesisParameters = GenesisBuilder
         .buildGenesisParameters()
         .map(genesis => genesis.copy(vaults = genesis.vaults ++ PoSSpec.testVaults))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -333,6 +333,7 @@ object Runtime {
     val urnMap: Map[String, Par] = Map[String, Par](
       "rho:crypto:secp256k1Verify"   -> Bundle(FixedChannels.SECP256K1_VERIFY, writeFlag = true),
       "rho:crypto:blake2b256Hash"    -> Bundle(FixedChannels.BLAKE2B256_HASH, writeFlag = true),
+      "rho:crypto:keccak256Hash"     -> Bundle(FixedChannels.KECCAK256_HASH, writeFlag = true),
       "rho:registry:lookup"          -> Bundle(FixedChannels.REG_LOOKUP, writeFlag = true),
       "rho:registry:insertArbitrary" -> Bundle(FixedChannels.REG_INSERT_RANDOM, writeFlag = true),
       "rho:registry:insertSigned:secp256k1" -> Bundle(


### PR DESCRIPTION
## Overview
The two added methods will be needed further on to produce a random number

Details of the protocol can be found here: https://rchain.atlassian.net/wiki/spaces/CORE/pages/750288944/Proof+of+Stake+contract+specification

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3467



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
