### PR TITLE
Develop a way for RNode operators to learn about the bond status of a node

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -22,7 +22,7 @@ import coop.rchain.shared.ByteStringOps._
 import cats.syntax.either._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.SignDeployment
-import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
@@ -116,6 +116,13 @@ object DeployRuntime {
 
   def isFinalized[F[_]: Sync: DeployService](blockHash: String): F[Unit] =
     gracefulExit(DeployService[F].isFinalized(IsFinalizedQuery(hash = blockHash)))
+
+  def bondStatus[F[_]: Sync: DeployService](publicKey: PublicKey): F[Unit] =
+    gracefulExit(
+      DeployService[F].bondStatus(
+        BondStatusQuery(publicKey = ByteString.copyFrom(publicKey.bytes))
+      )
+    )
 
   private def gracefulExit[F[_]: Monad: Sync, A](
       program: F[Either[Seq[String], String]]

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -27,6 +27,7 @@ trait DeployService[F[_]] {
   ): F[Either[Seq[String], Seq[ContinuationsWithBlockInfo]]]
   def lastFinalizedBlock: F[Either[Seq[String], String]]
   def isFinalized(q: IsFinalizedQuery): F[Either[Seq[String], String]]
+  def bondStatus(q: BondStatusQuery): F[Either[Seq[String], String]]
 }
 
 object DeployService {
@@ -149,6 +150,17 @@ class GrpcDeployService(host: String, port: Int, maxMessageSize: Int)
         _.ifM(
           "Block is finalized".asRight,
           Seq("Block is not finalized").asLeft
+        )
+      )
+
+  def bondStatus(request: BondStatusQuery): Task[Either[Seq[String], String]] =
+    stub
+      .bondStatus(request)
+      .toEitherF(_.message.error, _.message.isBonded)
+      .map(
+        _.ifM(
+          "Validator is bonded".asRight,
+          Seq("Validator is not bonded").asLeft
         )
       )
 

--- a/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
@@ -1,0 +1,86 @@
+package coop.rchain.casper.api
+
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
+import cats.instances.list._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.engine.Engine
+import coop.rchain.casper.helper.BlockGenerator._
+import coop.rchain.casper.helper.TestNode.Effect
+import coop.rchain.casper.helper._
+import coop.rchain.casper.util.GenesisBuilder._
+import coop.rchain.casper.EngineWithCasper
+import coop.rchain.casper.util.ConstructDeploy
+import coop.rchain.casper.util.ConstructDeploy.basicDeployData
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.metrics.Metrics
+import coop.rchain.shared.scalatestcontrib._
+import coop.rchain.shared.Cell
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+
+class BondedStatusAPITest
+    extends FlatSpec
+    with Matchers
+    with EitherValues
+    with BlockGenerator
+    with BlockDagStorageFixture {
+  val genesisParameters = buildGenesisParameters(
+    defaultValidatorKeyPairs.take(3) :+ ConstructDeploy.defaultKeyPair,
+    createBonds(defaultValidatorPks.take(3))
+  )
+  val genesisContext = buildGenesis(genesisParameters)
+
+  implicit val metricsEff = new Metrics.MetricsNOP[Task]
+
+  def bondedStatus(publicKey: PublicKey)(node: TestNode[Effect]): Task[Boolean] = {
+    import node.logEff
+    val engine = new EngineWithCasper[Task](node.casperEff)
+    Cell.mvarCell[Task, Engine[Task]](engine).flatMap { implicit engineCell =>
+      BlockAPI
+        .bondStatus[Task](ByteString.copyFrom(publicKey.bytes))
+        .map(_.right.value)
+    }
+  }
+
+  "bondStatus" should "return true for bonded validator" in effectTest {
+    TestNode.networkEff(genesisContext, networkSize = 3).use {
+      case n1 +: n2 +: n3 +: _ =>
+        (bondedStatus(n1.validatorId.publicKey)(n1) shouldBeF true) >>
+          (bondedStatus(n2.validatorId.publicKey)(n1) shouldBeF true) >>
+          (bondedStatus(n3.validatorId.publicKey)(n1) shouldBeF true)
+    }
+  }
+
+  "bondStatus" should "return false for not bonded validators" in effectTest {
+    TestNode.standaloneEff(genesisContext).use { node =>
+      val (_, publicKey) = Secp256k1.newKeyPair
+      bondedStatus(publicKey)(node) shouldBeF false
+    }
+  }
+
+  "bondStatus" should "return true for newly bonded validator" in effectTest {
+    TestNode.networkEff(genesisContext, networkSize = 4).use {
+      case nodes @ n1 +: n2 +: n3 +: n4 +: _ =>
+        for {
+          produceDeploys <- (0 until 3).toList.traverse(i => basicDeployData[Task](i))
+          bondDeploy     <- BondingUtil.bondingDeploy[Task](1000, n4.validatorId.privateKey)
+
+          _  <- bondedStatus(n4.validatorId.publicKey)(n1) shouldBeF false
+          b1 <- n1.propagateBlock(bondDeploy)(nodes: _*)
+          b2 <- n2.propagateBlock(produceDeploys(0))(nodes: _*)
+
+          // n4 is still not bonded since b1 is not finalized yet
+          _ <- bondedStatus(n4.validatorId.publicKey)(n1) shouldBeF false
+
+          b3 <- n3.propagateBlock(produceDeploys(1))(nodes: _*)
+          b4 <- n1.propagateBlock(produceDeploys(2))(nodes: _*)
+
+          // b1 is now finalized, hence n4 is now bonded
+          _ <- bondedStatus(n4.validatorId.publicKey)(n1) shouldBeF true
+        } yield ()
+    }
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/BondingUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BondingUtil.scala
@@ -1,0 +1,25 @@
+package coop.rchain.casper.helper
+
+import cats.Functor
+import cats.syntax.functor._
+import coop.rchain.casper.SignDeployment
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.casper.util.ConstructDeploy
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.shared.Time
+
+object BondingUtil {
+  def bondingDeploy[F[_]: Functor: Time](amount: Long, privateKey: PrivateKey): F[DeployData] =
+    ConstructDeploy
+      .sourceDeployNowF(
+        s"""
+         |new retCh, PoSCh, rl(`rho:registry:lookup`), stdout(`rho:io:stdout`), deployerId(`rho:rchain:deployerId`) in {
+         |  rl!(`rho:rchain:pos`, *PoSCh) |
+         |  for(@(_, PoS) <- PoSCh) {
+         |    @PoS!("bond", *deployerId, 1000, *retCh)
+         |  }
+         |}
+         |""".stripMargin
+      )
+      .map(deploy => SignDeployment.sign(privateKey, deploy))
+}

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -64,6 +64,10 @@ message IsFinalizedQuery {
   string hash = 1;
 }
 
+message BondStatusQuery {
+  bytes publicKey = 1;
+}
+
 message LightBlockInfo {
   string blockHash = 1;
   string blockSize = 2;

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -50,6 +50,9 @@ service DeployService {
   rpc lastFinalizedBlock(LastFinalizedBlockQuery) returns (LastFinalizedBlockResponse) {}
   // Check if a given block is finalized.
   rpc isFinalized(IsFinalizedQuery) returns (IsFinalizedResponse) {}
+  // Check if a given validator is bonded.
+  // Returns on success BondStatusResponse
+  rpc bondStatus(BondStatusQuery) returns (BondStatusResponse) {}
 }
 
 // doDeploy
@@ -151,5 +154,12 @@ message IsFinalizedResponse {
   oneof message {
     ServiceError error = 1;
     bool isFinalized   = 2;
+  }
+}
+
+message BondStatusResponse {
+  oneof message {
+    ServiceError error = 1;
+    bool isBonded   = 2;
   }
 }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -134,6 +134,7 @@ object Main {
       case Keygen(algorithm, privateKeyPath) => generateKey(conf, algorithm, privateKeyPath)
       case LastFinalizedBlock                => DeployRuntime.lastFinalizedBlock[Task]
       case IsFinalized(hash)                 => DeployRuntime.isFinalized[Task](hash)
+      case BondStatus(publicKey)             => DeployRuntime.bondStatus[Task](publicKey)
       case Run                               => nodeProgram(conf)
       case _                                 => conf.printHelp()
     }

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -204,5 +204,12 @@ object DeployGrpcServiceV1 {
           import IsFinalizedResponse.Message._
           IsFinalizedResponse(r.fold[Message](Error, IsFinalized))
         }
+
+      def bondStatus(request: BondStatusQuery): Task[BondStatusResponse] =
+        defer(BlockAPI.bondStatus[F](request.publicKey)) { r =>
+          import BondStatusResponse.Message
+          import BondStatusResponse.Message._
+          BondStatusResponse(r.fold[Message](Error, IsBonded))
+        }
     }
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -230,6 +230,7 @@ object Configuration {
         Keygen(options.keygen.algorithm(), options.keygen.privateKeyPath())
       case Some(options.lastFinalizedBlock) => LastFinalizedBlock
       case Some(options.isFinalized)        => IsFinalized(options.isFinalized.hash())
+      case Some(options.bondStatus)         => BondStatus(options.bondStatus.validatorPublicKey())
       case Some(options.dataAtName)         => DataAtName(options.dataAtName.name())
       case Some(options.contAtName)         => ContAtName(options.contAtName.name())
       case _                                => Help

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import coop.rchain.casper.util.comm.ListenAtName.{Name, PrivName, PubName}
 import coop.rchain.comm.PeerNode
 import coop.rchain.crypto.signatures.Ed25519
-import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.node.BuildInfo
 import org.rogach.scallop._
 
@@ -531,6 +531,18 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val printUnmatchedSends = opt[Boolean](required = false)
   }
   addSubcommand(propose)
+
+  val bondStatus = new Subcommand("bond-status") {
+    val validatorPublicKey = trailArg[PublicKey](
+      descr = "Base16 encoding of the public key to check for bond status.",
+      required = true
+    )(
+      Base16Converter
+        .flatMap(validateLength(Ed25519.keyLength))
+        .map(PublicKey.apply)
+    )
+  }
+  addSubcommand(bondStatus)
 
   verify()
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration.FiniteDuration
 
 import coop.rchain.casper.util.comm.ListenAtName.Name
 import coop.rchain.comm.PeerNode
-import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 
 final case class Server(
     networkId: String,
@@ -79,6 +79,7 @@ final case object Run                                                      exten
 final case class Keygen(algorithm: String, privateKeyPath: Path)           extends Command
 final case object LastFinalizedBlock                                       extends Command
 final case class IsFinalized(hash: String)                                 extends Command
+final case class BondStatus(publicKey: PublicKey)                          extends Command
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command
 final case class ContAtName(names: List[Name])                             extends Command


### PR DESCRIPTION
## Overview
Adds a command `rnode bond-status <publickey>` for checking whether a given validator is bonded or not in the last finalized block.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3066


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
