### PR TITLE
Transport layer optimisations

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -88,8 +88,8 @@ class GrpcTransportServer(
 
     for {
       serverSslContext <- serverSslContextTask
-      tellBuffer       <- Task.delay(buffer.LimitedBufferObservable.dropNew[Send](4096))
-      blobBuffer       <- Task.delay(buffer.LimitedBufferObservable.dropNew[StreamMessage](1024))
+      tellBuffer       <- Task.delay(buffer.LimitedBufferObservable.dropNew[Send](1024))
+      blobBuffer       <- Task.delay(buffer.LimitedBufferObservable.dropNew[StreamMessage](100))
       receiver <- GrpcTransportReceiver.create(
                    networkId: String,
                    port,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -67,7 +67,7 @@ package object effects {
     Task.delay {
       val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
       val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
-      new GrpcTransportClient(networkId, cert, key, maxMessageSize, packetChunkSize, folder, 1000)
+      new GrpcTransportClient(networkId, cert, key, maxMessageSize, packetChunkSize, folder, 100)
     }
 
   def consoleIO(consoleReader: ConsoleReader): ConsoleIO[Task] = new JLineConsoleIO(consoleReader)


### PR DESCRIPTION
## Overview
1. When Casper wants to stream a block to a remote peer and the outgoing message queue is full then comm should drop the block. Currently, Casper waits (forever) until it can enqueue the block.

2. When streaming of a block to a remote peer fails then don't retry. Currently, we have 3 retries with a 1-second delay.

3. Make the outgoing and the incoming message queues much shorter (f.e. 100). Currently, we allow a node to fall 1000 messages (blocks) behind before we start dropping messages.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3858
