### PR TITLE
Get rid of toposort ordering

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -162,11 +162,6 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
       val startBlockNumber = Math.max(0L, sortOffset - (tailLength - topoSortVector.length))
       topoSort(startBlockNumber)
     }
-    def deriveOrdering(startBlockNumber: Long): F[Ordering[BlockMetadata]] =
-      topoSort(startBlockNumber).map { topologicalSorting =>
-        val order = topologicalSorting.flatten.zipWithIndex.toMap
-        Ordering.by(b => order(b.blockHash))
-      }
     def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
       latestMessagesMap.get(validator).pure[F]
     def latestMessage(validator: Validator): F[Option[BlockMetadata]] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -32,7 +32,6 @@ trait BlockDagRepresentation[F[_]] {
   def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]]
   def topoSort(startBlockNumber: Long): F[Vector[Vector[BlockHash]]]
   def topoSortTail(tailLength: Int): F[Vector[Vector[BlockHash]]]
-  def deriveOrdering(startBlockNumber: Long): F[Ordering[BlockMetadata]]
   def latestMessageHash(validator: Validator): F[Option[BlockHash]]
   def latestMessage(validator: Validator): F[Option[BlockMetadata]]
   def latestMessageHashes: F[Map[Validator, BlockHash]]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -50,11 +50,6 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
       topoSortVector.drop(startBlockNumber.toInt).pure[F]
     def topoSortTail(tailLength: Int): F[Vector[Vector[BlockHash]]] =
       topoSortVector.takeRight(tailLength).pure[F]
-    def deriveOrdering(startBlockNumber: Long): F[Ordering[BlockMetadata]] =
-      topoSort(startBlockNumber).map { topologicalSorting =>
-        val order = topologicalSorting.flatten.zipWithIndex.toMap
-        Ordering.by(b => order(b.blockHash))
-      }
     def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
       latestMessagesMap.get(validator).pure[F]
     def latestMessage(validator: Validator): F[Option[BlockMetadata]] =

--- a/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/DagOperations.scala
@@ -37,16 +37,12 @@ object DagOperations {
     * B contains i.
     * @param blocks indexed sequence of blocks to determine uncommon ancestors of
     * @param dag the DAG
-    * @param topoSort topological sort of the DAG, ensures ancestor computation is
-    *                 done correctly
     * @return A map from uncommon ancestor blocks to BitSets, where a block B is
     *         and ancestor of starting block with index i if B's BitSet contains i.
     */
   def uncommonAncestors[F[_]: Monad](
       blocks: IndexedSeq[BlockMetadata],
       dag: BlockDagRepresentation[F]
-  )(
-      implicit topoSort: Ordering[BlockMetadata]
   ): F[Map[BlockMetadata, BitSet]] = {
     val commonSet = BitSet(0 until blocks.length: _*)
     def parents(b: BlockMetadata): F[List[BlockMetadata]] =
@@ -54,7 +50,7 @@ object DagOperations {
     def isCommon(set: BitSet): Boolean = set == commonSet
 
     val initMap = blocks.zipWithIndex.map { case (b, i) => b -> BitSet(i) }.toMap
-    val q       = new mutable.PriorityQueue[BlockMetadata]()
+    val q       = new mutable.PriorityQueue[BlockMetadata]()(BlockMetadata.orderingByNum)
     q.enqueue(blocks: _*)
 
     def loop(
@@ -101,22 +97,6 @@ object DagOperations {
       b2: BlockMetadata,
       dag: BlockDagRepresentation[F]
   ): F[BlockMetadata] = {
-    val iterableByteOrdering = Ordering.Iterable[Byte]
-
-    implicit val blockMetadataByNumDecreasing: Ordering[BlockMetadata] =
-      (l: BlockMetadata, r: BlockMetadata) => {
-        def compareByteString(l: ByteString, r: ByteString): Int =
-          iterableByteOrdering.compare(l.toByteArray, r.toByteArray)
-
-        val ln = l.blockNum
-        val rn = r.blockNum
-        // Notice the inverted order of compared items, which makes the ordering descending
-        rn.compare(ln) match {
-          case 0 => compareByteString(l.blockHash, r.blockHash)
-          case v => v
-        }
-      }
-
     def getParents(p: BlockMetadata): F[Set[BlockMetadata]] =
       p.parents.traverse(dag.lookup).map(_.toSet.flatten)
 
@@ -130,7 +110,7 @@ object DagOperations {
     if (b1 == b2) {
       b1.pure[F]
     } else {
-      val start = SortedSet.empty[BlockMetadata] + b1 + b2
+      val start = SortedSet.empty[BlockMetadata](BlockMetadata.orderingByNum.reverse) + b1 + b2
       Monad[F]
         .iterateWhileM(start)(extractParentsFromHighestNumBlock)(
           _.size != 1

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -116,21 +116,20 @@ class DagOperationsTest
 
           dag <- blockDagStorage.getRepresentation
 
-          ordering <- dag.deriveOrdering(0L)
-          _ <- DagOperations.uncommonAncestors(Vector(b6, b7), dag)(Monad[Task], ordering) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b6, b7), dag)(Monad[Task]) shouldBeF Map(
                 toMetadata(b6) -> BitSet(0),
                 toMetadata(b4) -> BitSet(0),
                 toMetadata(b7) -> BitSet(1),
                 toMetadata(b2) -> BitSet(1)
               )
 
-          _ <- DagOperations.uncommonAncestors(Vector(b6, b3), dag)(Monad[Task], ordering) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b6, b3), dag)(Monad[Task]) shouldBeF Map(
                 toMetadata(b6) -> BitSet(0),
                 toMetadata(b4) -> BitSet(0),
                 toMetadata(b5) -> BitSet(0)
               )
 
-          _ <- DagOperations.uncommonAncestors(Vector(b2, b4, b5), dag)(Monad[Task], ordering) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b2, b4, b5), dag)(Monad[Task]) shouldBeF Map(
                 toMetadata(b2) -> BitSet(0),
                 toMetadata(b4) -> BitSet(1),
                 toMetadata(b5) -> BitSet(2),
@@ -138,7 +137,7 @@ class DagOperationsTest
                 toMetadata(b1) -> BitSet(1, 2)
               )
 
-          result <- DagOperations.uncommonAncestors(Vector(b1), dag)(Monad[Task], ordering) shouldBeF Map
+          result <- DagOperations.uncommonAncestors(Vector(b1), dag)(Monad[Task]) shouldBeF Map
                      .empty[BlockMetadata, BitSet]
         } yield result
   }

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -42,6 +42,17 @@ object BlockMetadata {
     )
   }
 
+  private val byteStringOrdering =
+    Ordering.by[ByteString, Iterable[Byte]](_.toByteArray)(Ordering.Iterable[Byte])
+
+  val orderingByNum: Ordering[BlockMetadata] =
+    (l: BlockMetadata, r: BlockMetadata) => {
+      l.blockNum.compare(r.blockNum) match {
+        case 0 => byteStringOrdering.compare(l.blockHash, r.blockHash)
+        case v => v
+      }
+    }
+
   def fromBytes(bytes: Array[Byte]): BlockMetadata =
     typeMapper.toCustom(BlockMetadataInternal.parseFrom(bytes))
 


### PR DESCRIPTION
## Overview
Deriving toposort ordering is a very expensive operation which can be easily avoided as we can just sort blocks by their block numbers first and by their hashes lexicographically second.

According to my runs on devnet2 this change improves Estimator performance but does not solve the LPT problem.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3870


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
