### PR TITLE
Rspace/simplify main rspace algorithm

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -14,7 +14,7 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.implicits._
 import coop.rchain.rspace.history.{Branch, HistoryRepository}
-import coop.rchain.rspace.internal.{DataCandidate, _}
+import coop.rchain.rspace.internal.{ConsumeCandidate, _}
 import coop.rchain.rspace.trace._
 import coop.rchain.shared.{Cell, Log, Serialize}
 import coop.rchain.shared.SyncVarOps._
@@ -166,13 +166,7 @@ class RSpace[F[_], C, P, A, K](
   ): F[MaybeActionResult] = {
     val ProduceCandidate(
       channels,
-      wk @ WaitingContinuation(
-        _,
-        _,
-        persistK,
-        peeks,
-        consumeRef
-      ),
+      wk @ WaitingContinuation(_, _, persistK, peeks, consumeRef),
       continuationIndex,
       dataCandidates
     ) = pc
@@ -192,7 +186,7 @@ class RSpace[F[_], C, P, A, K](
   }
 
   protected override def logComm(
-      dataCandidates: Seq[DataCandidate[C, A]],
+      dataCandidates: Seq[ConsumeCandidate[C, A]],
       channels: Seq[C],
       wk: WaitingContinuation[P, K],
       comm: COMM,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -205,8 +205,6 @@ class RSpace[F[_], C, P, A, K](
    * Find produce candidate
    */
 
-  type MaybeProduceCandidate = Option[ProduceCandidate[C, P, A, K]]
-
   type CandidateChannels = Seq[C]
 
   private[this] def extractProduceCandidate(
@@ -313,18 +311,6 @@ class RSpace[F[_], C, P, A, K](
       _               <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
     } yield constructResult
   }
-
-  private[this] def storeData(
-      channel: C,
-      data: A,
-      persist: Boolean,
-      produceRef: Produce
-  ): F[MaybeActionResult] =
-    for {
-      _ <- logF.debug(s"produce: no matching continuation found")
-      _ <- store.putDatum(channel, Datum(data, persist, produceRef))
-      _ <- logF.debug(s"produce: persisted <data: $data> at <channel: $channel>")
-    } yield None
 
   private[this] def logComm(
       consumeRef: Consume,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -157,13 +157,13 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
     } yield None
 
   protected[this] def storePersistentData(
-      dataCandidates: Seq[DataCandidate[C, A]],
+      dataCandidates: Seq[ConsumeCandidate[C, A]],
       peeks: SortedSet[Int]
   ): F[List[Unit]] =
     dataCandidates.toList
       .sortBy(_.datumIndex)(Ordering[Int].reverse)
       .traverse {
-        case DataCandidate(
+        case ConsumeCandidate(
             candidateChannel,
             Datum(_, persistData, _),
             _,
@@ -369,7 +369,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       channels: Seq[C],
       wk: WaitingContinuation[P, K],
       consumeRef: Consume,
-      dataCandidates: Seq[DataCandidate[C, A]]
+      dataCandidates: Seq[ConsumeCandidate[C, A]]
   ): MaybeActionResult =
     Some(
       (
@@ -387,12 +387,12 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
 
   def removeMatchedDatumAndJoin(
       channels: Seq[C],
-      dataCandidates: Seq[DataCandidate[C, A]]
+      dataCandidates: Seq[ConsumeCandidate[C, A]]
   ): F[Seq[Unit]] =
     dataCandidates
       .sortBy(_.datumIndex)(Ordering[Int].reverse)
       .traverse {
-        case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) => {
+        case ConsumeCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) => {
           store
             .removeDatum(candidateChannel, dataIndex)
             .whenA(dataIndex >= 0 && !persistData) >>
@@ -431,7 +431,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
   }
 
   protected def logComm(
-      dataCandidates: Seq[DataCandidate[C, A]],
+      dataCandidates: Seq[ConsumeCandidate[C, A]],
       channels: Seq[C],
       wk: WaitingContinuation[P, K],
       comm: COMM,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -3,9 +3,9 @@ package coop.rchain.rspace
 import cats.Applicative
 
 import scala.collection.SortedSet
-import scala.concurrent.SyncVar
+import scala.concurrent.{ExecutionContext, SyncVar}
 import scala.util.Random
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.implicits._
 import coop.rchain.catscontrib._
 import coop.rchain.metrics.{Metrics, Span}
@@ -13,7 +13,7 @@ import coop.rchain.metrics.implicits._
 import coop.rchain.rspace.concurrent.{ConcurrentTwoStepLockF, TwoStepLock}
 import coop.rchain.rspace.history._
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.trace.{Consume, Produce, Log => EventLog}
+import coop.rchain.rspace.trace.{COMM, Consume, Produce, Log => EventLog}
 import coop.rchain.shared.{Cell, Log, Serialize}
 import coop.rchain.shared.SyncVarOps._
 import com.typesafe.scalalogging.Logger
@@ -28,12 +28,17 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
     implicit
     serializeC: Serialize[C],
     serializeP: Serialize[P],
+    serializeA: Serialize[A],
     serializeK: Serialize[K],
     logF: Log[F],
-    spanF: Span[F]
+    spanF: Span[F],
+    contextShift: ContextShift[F],
+    scheduler: ExecutionContext
 ) extends SpaceMatcher[F, C, P, A, K] {
 
   type MaybeProduceCandidate = Option[ProduceCandidate[C, P, A, K]]
+  type MaybeActionResult     = Option[(ContResult[C, P, K], Seq[Result[C, A]])]
+  type CandidateChannels     = Seq[C]
 
   implicit class MapOps(underlying: Map[Produce, Int]) {
     def putAndIncrementCounter(elem: Produce): Map[Produce, Int] =
@@ -54,12 +59,17 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
   protected[this] val produceCounter: SyncVar[Map[Produce, Int]] =
     create[Map[Produce, Int]](Map.empty.withDefaultValue(0))
 
-  protected[this] def produceCounters(produceRefs: Seq[Produce]) =
+  protected[this] def produceCounters(produceRefs: Seq[Produce]): Map[Produce, Int] =
     produceRefs
       .map(
         p => (p -> produceCounter.get(p))
       )
       .toMap
+
+  implicit val codecC = serializeC.toCodec
+  val syncF: Sync[F]  = Concurrent[F]
+
+  private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF(MetricsSource)
 
   private[this] val installSpanLabel         = Metrics.Source(MetricsSource, "install")
   private[this] val restoreInstallsSpanLabel = Metrics.Source(MetricsSource, "restore-installs")
@@ -69,10 +79,23 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
     Metrics.Source(MetricsSource, "revert-soft-checkpoint")
   private[this] val resetSpanLabel = Metrics.Source(MetricsSource, "reset")
 
+  protected[this] val consumeCommLabel     = "comm.consume"
+  protected[this] val consumeTimeCommLabel = "comm.consume-time"
+  protected[this] val produceCommLabel     = "comm.produce"
+  protected[this] val produceTimeCommLabel = "comm.produce-time"
+
   //TODO close in some F state abstraction
   protected val historyRepositoryAtom: AtomicAny[HistoryRepository[F, C, P, A, K]] = AtomicAny(
     historyRepository
   )
+
+  protected[this] val logger: Logger
+
+  private[this] val installs: SyncVar[Installs[F, C, P, A, K]] = {
+    val installs = new SyncVar[Installs[F, C, P, A, K]]()
+    installs.put(Map.empty)
+    installs
+  }
 
   def store: HotStore[F, C, P, A, K]
 
@@ -82,14 +105,6 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
   def getWaitingContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
     store.getContinuations(channels)
 
-  implicit val codecC = serializeC.toCodec
-
-  val syncF: Sync[F] = Concurrent[F]
-
-  private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF(MetricsSource)
-
-  type MaybeActionResult = Option[(ContResult[C, P, K], Seq[Result[C, A]])]
-
   protected[this] def consumeLockF(
       channels: Seq[C]
   )(
@@ -98,6 +113,15 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
     val hashes = channels.map(ch => StableHashProvider.hash(ch))
     lockF.acquire(hashes)(() => hashes.pure[F])(thunk)
   }
+
+  protected[this] def produceLockF(
+      channel: C
+  )(
+      thunk: => F[MaybeActionResult]
+  ): F[MaybeActionResult] =
+    lockF.acquire(Seq(StableHashProvider.hash(channel)))(
+      () => store.getJoins(channel).map(_.flatten.map(StableHashProvider.hash(_)))
+    )(thunk)
 
   protected[this] def installLockF(
       channels: Seq[C]
@@ -132,26 +156,6 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       _ <- logF.debug(s"produce: persisted <data: $data> at <channel: $channel>")
     } yield None
 
-  protected[this] def produceLockF(
-      channel: C
-  )(
-      thunk: => F[MaybeActionResult]
-  ): F[MaybeActionResult] =
-    lockF.acquire(Seq(StableHashProvider.hash(channel)))(
-      () =>
-        for {
-          groupedChannels <- store.getJoins(channel)
-        } yield (groupedChannels.flatten.map(StableHashProvider.hash(_)))
-    )(thunk)
-
-  protected[this] val logger: Logger
-
-  private[this] val installs: SyncVar[Installs[F, C, P, A, K]] = {
-    val installs = new SyncVar[Installs[F, C, P, A, K]]()
-    installs.put(Map.empty)
-    installs
-  }
-
   protected[this] def restoreInstalls(): F[Unit] = spanF.trace(restoreInstallsSpanLabel) {
     installs.get.toList
       .traverse {
@@ -159,6 +163,77 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
           install(channels, patterns, continuation)
       }
       .as(())
+  }
+
+  override def consume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int] = SortedSet.empty
+  ): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      if (channels.isEmpty) {
+        val msg = "channels can't be empty"
+        logF.error(msg) >> syncF.raiseError(new IllegalArgumentException(msg))
+      } else if (channels.length =!= patterns.length) {
+        val msg = "channels.length must equal patterns.length"
+        logF.error(msg) >> syncF.raiseError(new IllegalArgumentException(msg))
+      } else
+        (for {
+          consumeRef <- Consume.createF(channels, patterns, continuation, persist)
+          result <- consumeLockF(channels) {
+                     lockedConsume(
+                       channels,
+                       patterns,
+                       continuation,
+                       persist,
+                       peeks,
+                       consumeRef
+                     )
+                   }
+        } yield result).timer(consumeTimeCommLabel)(Metrics[F], MetricsSource)
+    }
+
+  protected[this] def lockedConsume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int],
+      consumeRef: Consume
+  ): F[MaybeActionResult]
+
+  override def produce(
+      channel: C,
+      data: A,
+      persist: Boolean
+  ): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      (for {
+        produceRef <- Produce.createF(channel, data, persist)
+        result <- produceLockF(channel)(
+                   lockedProduce(channel, data, persist, produceRef)
+                 )
+      } yield result).timer(produceTimeCommLabel)(Metrics[F], MetricsSource)
+    }
+
+  protected[this] def lockedProduce(
+      channel: C,
+      data: A,
+      persist: Boolean,
+      produceRef: Produce
+  ): F[MaybeActionResult]
+
+  override def install(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K
+  ): F[Option[(K, Seq[A])]] = spanF.trace(installSpanLabel) {
+    installLockF(channels) {
+      implicit val ms = MetricsSource
+      lockedInstall(channels, patterns, continuation).timer("install-time")
+    }
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -183,8 +258,9 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
        */
 
       for {
-        _          <- logF.debug(s"""|install: searching for data matching <patterns: $patterns>
-                                  |at <channels: $channels>""".stripMargin.replace('\n', ' '))
+        _ <- logF.debug(
+              s"install: searching for data matching <patterns: $patterns> at <channels: $channels>"
+            )
         consumeRef = Consume.create(channels, patterns, continuation, true)
         channelToIndexedData <- channels
                                  .traverse { c =>
@@ -214,8 +290,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
                              store.installJoin(channel, channels)
                            }
                        _ <- logF.debug(
-                             s"""|storing <(patterns, continuation): ($patterns, $continuation)>
-                              |at <channels: $channels>""".stripMargin.replace('\n', ' ')
+                             s"storing <(patterns, continuation): ($patterns, $continuation)> at <channels: $channels>"
                            )
                      } yield None
                    case Some(_) =>
@@ -223,17 +298,6 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
                  }
       } yield result
     }
-
-  override def install(
-      channels: Seq[C],
-      patterns: Seq[P],
-      continuation: K
-  ): F[Option[(K, Seq[A])]] = spanF.trace(installSpanLabel) {
-    installLockF(channels) {
-      implicit val ms = MetricsSource
-      lockedInstall(channels, patterns, continuation).timer("install-time")
-    }
-  }
 
   def toMap: F[Map[Seq[C], Row[P, A, K]]] = storeAtom.get().toMap
 
@@ -307,4 +371,76 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
           .map(dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist))
       )
     )
+
+  def removeMatchedDatumAndJoin(
+      channels: Seq[C],
+      dataCandidates: Seq[DataCandidate[C, A]]
+  ): F[Seq[Unit]] =
+    dataCandidates
+      .sortBy(_.datumIndex)(Ordering[Int].reverse)
+      .traverse {
+        case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) => {
+          store
+            .removeDatum(candidateChannel, dataIndex)
+            .whenA(dataIndex >= 0 && !persistData) >>
+            store.removeJoin(candidateChannel, channels)
+        }
+      }
+
+  protected[this] def runMatcherForChannels(
+      groupedChannels: Seq[CandidateChannels],
+      fetchMatchingContinuations: (CandidateChannels) => F[Seq[(WaitingContinuation[P, K], Int)]],
+      fetchMatchingData: C => F[(C, Seq[(Datum[A], Int)])]
+  ): F[MaybeProduceCandidate] = {
+    def go(
+        acc: Seq[CandidateChannels]
+    ): F[Either[Seq[CandidateChannels], MaybeProduceCandidate]] =
+      acc match {
+        case Nil =>
+          none[ProduceCandidate[C, P, A, K]].asRight[Seq[CandidateChannels]].pure[F]
+        case channels :: remaining =>
+          for {
+            matchCandidates <- fetchMatchingContinuations(channels)
+            channelToIndexedDataList <- channels.traverse { c: C =>
+                                         fetchMatchingData(c)
+                                       }
+            firstMatch <- extractFirstMatch(
+                           channels,
+                           matchCandidates,
+                           channelToIndexedDataList.toMap
+                         )
+          } yield firstMatch match {
+            case None             => remaining.asLeft[MaybeProduceCandidate]
+            case produceCandidate => produceCandidate.asRight[Seq[CandidateChannels]]
+          }
+      }
+    groupedChannels.tailRecM(go)
+  }
+
+  protected def logComm(
+      dataCandidates: Seq[DataCandidate[C, A]],
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int],
+      comm: COMM,
+      label: String
+  ): F[COMM]
+
+  protected def logConsume(
+      consumeRef: Consume,
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int]
+  ): F[Consume]
+
+  protected def logProduce(
+      produceRef: Produce,
+      channel: C,
+      data: A,
+      persist: Boolean
+  ): F[Produce]
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -53,6 +53,406 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
   private[this] val produceCommLabel     = "comm.produce"
   private[this] val produceTimeCommLabel = "comm.produce-time"
 
+  def consume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int] = SortedSet.empty
+  ): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      if (channels.length =!= patterns.length) {
+        val msg = "channels.length must equal patterns.length"
+        logF.error(msg) >> syncF.raiseError(new IllegalArgumentException(msg))
+      } else
+        (for {
+          result <- consumeLockF(channels) {
+                     lockedConsume(
+                       channels,
+                       patterns,
+                       continuation,
+                       persist,
+                       peeks
+                     )
+                   }
+        } yield result).timer(consumeTimeCommLabel)
+    }
+
+  private[this] def lockedConsume(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      peeks: SortedSet[Int]
+  ): F[MaybeActionResult] =
+    for {
+      _ <- logF.debug(
+            s"consume: searching for data matching <patterns: $patterns> at <channels: $channels>"
+          )
+      consumeRef <- markConsume(channels, patterns, continuation, persist, peeks)
+      r <- replayData
+            .get(consumeRef)
+            .fold(
+              storeWaitingContinuation(
+                channels,
+                WaitingContinuation(patterns, continuation, persist, peeks, consumeRef)
+              )
+            )(
+              comms =>
+                getCommAndDataCandidates(channels, patterns, comms.iterator().asScala.toList)
+                  .flatMap {
+                    _.fold(
+                      storeWaitingContinuation(
+                        channels,
+                        WaitingContinuation(patterns, continuation, persist, peeks, consumeRef)
+                      )
+                    ) {
+                      case (comm, dataCandidates) =>
+                        val channelsToIndex = channels.zipWithIndex.toMap
+                        handleMatches(
+                          channels,
+                          patterns,
+                          continuation,
+                          persist,
+                          dataCandidates,
+                          consumeRef,
+                          comms,
+                          comm,
+                          peeks,
+                          channelsToIndex
+                        )
+                    }
+                  }
+            )
+    } yield r
+
+  def handleMatches(
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persist: Boolean,
+      mats: Seq[DataCandidate[C, A]],
+      consumeRef: Consume,
+      comms: Multiset[COMM],
+      comm: COMM,
+      peeks: SortedSet[Int],
+      channelsToIndex: Map[C, Int]
+  ): F[MaybeActionResult] =
+    for {
+      commRef <- markComm(
+                  consumeRef,
+                  mats,
+                  channels,
+                  patterns,
+                  continuation,
+                  persist,
+                  peeks,
+                  comm,
+                  consumeCommLabel
+                )
+      _ <- assertF(
+            comms.contains(commRef),
+            s"COMM Event $commRef was not contained in the trace $comms"
+          )
+      r <- for {
+            _ <- mats.toList
+                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                  .traverse {
+                    case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) =>
+                      store.removeDatum(candidateChannel, dataIndex).unlessA(persistData)
+                  }
+            _ <- logF.debug(
+                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
+                )
+            _ <- removeBindingsFor(commRef)
+
+          } yield wrapResult(channels, patterns, continuation, persist, peeks, consumeRef, mats)
+    } yield r
+
+// TODO: refactor this monster
+  def getCommAndDataCandidates(
+      channels: Seq[C],
+      patterns: Seq[P],
+      comms: Seq[COMM]
+  ): F[Option[(COMM, Seq[DataCandidate[C, A]])]] = {
+    type COMMOrData = Either[COMM, (COMM, Seq[DataCandidate[C, A]])]
+    def go(
+        comms: Seq[COMM]
+    ): F[Either[Seq[COMM], COMMOrData]] =
+      comms match {
+        case Nil =>
+          val msg = "List comms must not be empty"
+          logger.error(msg)
+          Sync[F].raiseError(new IllegalArgumentException(msg))
+        case commRef :: Nil =>
+          runMatcherC(channels, patterns, commRef).map {
+            case Some(dataCandidates) =>
+              (commRef, dataCandidates).asRight[COMM].asRight[Seq[COMM]]
+            case None => commRef.asLeft[(COMM, Seq[DataCandidate[C, A]])].asRight[Seq[COMM]]
+          }
+        case commRef :: rem =>
+          runMatcherC(channels, patterns, commRef).map {
+            case Some(dataCandidates) =>
+              (commRef, dataCandidates).asRight[COMM].asRight[Seq[COMM]]
+            case None => rem.asLeft[COMMOrData]
+          }
+      }
+    comms.tailRecM(go).map(_.toOption)
+  }
+
+  def runMatcherC(
+      channels: Seq[C],
+      patterns: Seq[P],
+      comm: COMM
+  ): F[Option[Seq[DataCandidate[C, A]]]] =
+    for {
+      channelToIndexedDataList <- channels.traverse { c: C =>
+                                   store
+                                     .getData(c)
+                                     .map(_.zipWithIndex.filter(matches(comm)))
+                                     .map(v => c -> v)
+                                 }
+      result <- extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
+                 .map(_.sequence)
+    } yield result
+
+  def produce(channel: C, data: A, persist: Boolean): F[MaybeActionResult] =
+    contextShift.evalOn(scheduler) {
+      (for {
+        result <- produceLockF(channel) {
+                   lockedProduce(channel, data, persist)
+                 }
+      } yield result).timer(produceTimeCommLabel)
+    }
+
+  private[this] def lockedProduce(
+      channel: C,
+      data: A,
+      persist: Boolean
+  ): F[MaybeActionResult] =
+    for {
+      groupedChannels <- store.getJoins(channel)
+      _ <- logF.debug(
+            s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>"
+          )
+      produceRef <- markProduce(channel, data, persist)
+      result <- replayData.get(produceRef) match {
+                 case None =>
+                   storeDatum(channel, data, persist, produceRef, None)
+                 case Some(comms) =>
+                   val commOrProduceCandidate
+                       : F[Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]] =
+                     getCommOrProduceCandidate(
+                       channel,
+                       data,
+                       persist,
+                       comms.iterator().asScala.toList,
+                       produceRef,
+                       groupedChannels
+                     )
+                   val r: F[MaybeActionResult] = commOrProduceCandidate.flatMap {
+                     case Left(comm) =>
+                       storeDatum(channel, data, persist, produceRef, Some(comm))
+                     case Right((comm, produceCandidate)) =>
+                       val indexedChannels = produceCandidate.channels.zipWithIndex.toMap
+                       handleMatch(
+                         produceCandidate,
+                         produceRef,
+                         persist,
+                         comms,
+                         comm,
+                         indexedChannels
+                       )
+                   }
+                   r
+               }
+    } yield result
+
+  private[this] def storeDatum(
+      channel: C,
+      data: A,
+      persist: Boolean,
+      produceRef: Produce,
+      maybeCommRef: Option[COMM]
+  ): F[MaybeActionResult] =
+    for {
+      _ <- store.putDatum(channel, Datum(data, persist, produceRef))
+      _ <- logF.debug(
+            s"produce: no matching continuation found storing <data: $data> at <channel: $channel>"
+          )
+    } yield None
+
+  type MaybeProduceCandidate = Option[ProduceCandidate[C, P, A, K]]
+
+  private[this] def getCommOrProduceCandidate(
+      channel: C,
+      data: A,
+      persist: Boolean,
+      comms: Seq[COMM],
+      produceRef: Produce,
+      groupedChannels: Seq[Seq[C]]
+  ): F[Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]] = {
+    type COMMOrProduce = Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]
+    def go(comms: Seq[COMM]): F[Either[Seq[COMM], COMMOrProduce]] =
+      comms match {
+        case Nil =>
+          val msg = "comms must not be empty"
+          logger.error(msg)
+          Sync[F].raiseError(new IllegalArgumentException(msg))
+        case commRef :: Nil =>
+          runMatcherP(channel, data, persist, commRef, produceRef, groupedChannels) map {
+            case Some(x) => (commRef, x).asRight[COMM].asRight[Seq[COMM]]
+            case None    => commRef.asLeft[(COMM, ProduceCandidate[C, P, A, K])].asRight[Seq[COMM]]
+          }
+        case commRef :: rem =>
+          runMatcherP(channel, data, persist, commRef, produceRef, groupedChannels) map {
+            case Some(x) => (commRef, x).asRight[COMM].asRight[Seq[COMM]]
+            case None    => rem.asLeft[COMMOrProduce]
+          }
+      }
+    comms.tailRecM(go)
+  }
+
+  private[this] def runMatcherP(
+      channel: C,
+      data: A,
+      persist: Boolean,
+      comm: COMM,
+      produceRef: Produce,
+      groupedChannels: Seq[Seq[C]]
+  ): F[MaybeProduceCandidate] = {
+
+    def go(groupedChannels: Seq[Seq[C]]): F[Either[Seq[Seq[C]], MaybeProduceCandidate]] =
+      groupedChannels match {
+        case Nil => none[ProduceCandidate[C, P, A, K]].asRight[Seq[Seq[C]]].pure[F]
+        case channels :: remaining =>
+          for {
+            continuations <- store.getContinuations(channels)
+            matchCandidates = continuations.zipWithIndex.filter {
+              case (WaitingContinuation(_, _, _, _, source), _) =>
+                comm.consume == source
+            }
+            channelToIndexedDataList <- channels.traverse { c: C =>
+                                         store
+                                           .getData(c)
+                                           .map(_.zipWithIndex)
+                                           .map(
+                                             as =>
+                                               c -> {
+                                                 if (c == channel)
+                                                   Seq((Datum(data, persist, produceRef), -1))
+                                                 else as
+                                               }.filter { matches(comm) }
+                                           )
+                                       }
+            firstMatch <- extractFirstMatch(
+                           channels,
+                           matchCandidates,
+                           channelToIndexedDataList.toMap
+                         )
+          } yield firstMatch match {
+            case None             => remaining.asLeft[MaybeProduceCandidate]
+            case produceCandidate => produceCandidate.asRight[Seq[Seq[C]]]
+          }
+      }
+    groupedChannels.tailRecM(go)
+  }
+
+  private[this] def handleMatch(
+      mat: ProduceCandidate[C, P, A, K],
+      produceRef: Produce,
+      persist: Boolean,
+      comms: Multiset[COMM],
+      comm: COMM,
+      channelsToIndex: Map[C, Int]
+  ): F[MaybeActionResult] =
+    mat match {
+      case ProduceCandidate(
+          channels,
+          WaitingContinuation(patterns, continuation, persistK, peeks, consumeRef),
+          continuationIndex,
+          dataCandidates
+          ) =>
+        for {
+          commRef <- markComm(
+                      consumeRef,
+                      dataCandidates,
+                      channels,
+                      patterns,
+                      continuation,
+                      persist,
+                      peeks,
+                      comm,
+                      produceCommLabel
+                    )
+          _ <- assertF(
+                comms.contains(commRef),
+                s"COMM Event $commRef was not contained in the trace $comms"
+              )
+          _ <- store.removeContinuation(channels, continuationIndex).unlessA(persistK)
+          _ <- dataCandidates.toList
+                .sortBy(_.datumIndex)(Ordering[Int].reverse)
+                .traverse {
+                  case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) =>
+                    store
+                      .removeDatum(candidateChannel, dataIndex)
+                      .whenA((dataIndex >= 0 && !persistData)) >>
+                      store.removeJoin(candidateChannel, channels)
+                }
+          _ <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
+          _ <- removeBindingsFor(commRef)
+          r <- syncF.delay {
+                Some(
+                  (
+                    ContResult(
+                      continuation,
+                      persistK,
+                      channels,
+                      patterns,
+                      peeks.nonEmpty
+                    ),
+                    dataCandidates.map(
+                      dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist)
+                    )
+                  )
+                )
+              }
+        } yield r
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
+  private def removeBindingsFor(
+      commRef: COMM
+  ): F[Unit] = Sync[F].delay {
+    commRef.produces.foldLeft(replayData.removeBinding(commRef.consume, commRef)) {
+      case (updatedReplays, produceRef) =>
+        updatedReplays.removeBinding(produceRef, commRef)
+    }
+  }
+
+  override def createCheckpoint(): F[Checkpoint] = checkReplayData >> syncF.defer {
+    for {
+      changes     <- storeAtom.get().changes()
+      nextHistory <- historyRepositoryAtom.get().checkpoint(changes.toList)
+      _           = historyRepositoryAtom.set(nextHistory)
+      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+      _           <- restoreInstalls()
+    } yield (Checkpoint(nextHistory.history.root, Seq.empty))
+  }
+
+  override def clear(): F[Unit] = syncF.delay { replayData.clear() } >> super.clear()
+
+  private[this] def matches(comm: COMM)(datumWithIndex: (Datum[A], _)) = {
+    val (datum, _) = datumWithIndex
+    def wasRepeatedEnoughTimes =
+      (if (!datum.persist) {
+         comm.timesRepeated(datum.source) === produceCounter.get(
+           datum.source
+         )
+       } else true)
+    comm.produces.contains(datum.source) && wasRepeatedEnoughTimes
+  }
+
   protected def markComm(
       consumeRef: Consume,
       dataCandidates: Seq[DataCandidate[C, A]],
@@ -92,380 +492,6 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
       if (!persist) produceCounter.update(_.putAndIncrementCounter(ref))
       ref
     }
-
-  def consume(
-      channels: Seq[C],
-      patterns: Seq[P],
-      continuation: K,
-      persist: Boolean,
-      peeks: SortedSet[Int] = SortedSet.empty
-  ): F[MaybeActionResult] =
-    contextShift.evalOn(scheduler) {
-      if (channels.length =!= patterns.length) {
-        val msg = "channels.length must equal patterns.length"
-        logF.error(msg) >> syncF.raiseError(new IllegalArgumentException(msg))
-      } else
-        (for {
-          result <- consumeLockF(channels) {
-                     lockedConsume(
-                       channels,
-                       patterns,
-                       continuation,
-                       persist,
-                       peeks
-                     )
-                   }
-        } yield result).timer(consumeTimeCommLabel)
-    }
-
-  private[this] def lockedConsume(
-      channels: Seq[C],
-      patterns: Seq[P],
-      continuation: K,
-      persist: Boolean,
-      peeks: SortedSet[Int]
-  ): F[MaybeActionResult] = {
-    def runMatcher(comm: COMM): F[Option[Seq[DataCandidate[C, A]]]] =
-      for {
-        channelToIndexedDataList <- channels.traverse { c: C =>
-                                     store
-                                       .getData(c)
-                                       .map(_.zipWithIndex.filter(matches(comm)))
-                                       .map(v => c -> v)
-                                   }
-        result <- extractDataCandidates(channels.zip(patterns), channelToIndexedDataList.toMap, Nil)
-                   .map(_.sequence)
-      } yield result
-
-    def handleMatches(
-        mats: Seq[DataCandidate[C, A]],
-        consumeRef: Consume,
-        comms: Multiset[COMM],
-        comm: COMM,
-        peeks: SortedSet[Int],
-        channelsToIndex: Map[C, Int]
-    ): F[MaybeActionResult] =
-      for {
-        commRef <- markComm(
-                    consumeRef,
-                    mats,
-                    channels,
-                    patterns,
-                    continuation,
-                    persist,
-                    peeks,
-                    comm,
-                    consumeCommLabel
-                  )
-        _ <- assertF(
-              comms.contains(commRef),
-              s"COMM Event $commRef was not contained in the trace $comms"
-            )
-        r <- mats.toList
-              .sortBy(_.datumIndex)(Ordering[Int].reverse)
-              .traverse {
-                case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) =>
-                  store.removeDatum(candidateChannel, dataIndex).unlessA(persistData)
-              }
-              .flatMap { _ =>
-                logF.debug(
-                  s"consume: data found for <patterns: $patterns> at <channels: $channels>"
-                )
-              }
-              .flatMap { _ =>
-                removeBindingsFor(commRef)
-              }
-              .map { _ =>
-                wrapResult(channels, patterns, continuation, persist, peeks, consumeRef, mats)
-              }
-      } yield r
-
-    // TODO: refactor this monster
-    def getCommAndDataCandidates(
-        comms: Seq[COMM]
-    ): F[Option[(COMM, Seq[DataCandidate[C, A]])]] = {
-      type COMMOrData = Either[COMM, (COMM, Seq[DataCandidate[C, A]])]
-      def go(
-          comms: Seq[COMM]
-      ): F[Either[Seq[COMM], COMMOrData]] =
-        comms match {
-          case Nil =>
-            val msg = "List comms must not be empty"
-            logger.error(msg)
-            Sync[F].raiseError(new IllegalArgumentException(msg))
-          case commRef :: Nil =>
-            runMatcher(commRef).map {
-              case Some(dataCandidates) =>
-                (commRef, dataCandidates).asRight[COMM].asRight[Seq[COMM]]
-              case None => commRef.asLeft[(COMM, Seq[DataCandidate[C, A]])].asRight[Seq[COMM]]
-            }
-          case commRef :: rem =>
-            runMatcher(commRef).map {
-              case Some(dataCandidates) =>
-                (commRef, dataCandidates).asRight[COMM].asRight[Seq[COMM]]
-              case None => rem.asLeft[COMMOrData]
-            }
-        }
-      comms.tailRecM(go).map(_.toOption)
-    }
-
-    for {
-      _ <- logF.debug(
-            s"consume: searching for data matching <patterns: $patterns> at <channels: $channels>"
-          )
-      consumeRef <- markConsume(channels, patterns, continuation, persist, peeks)
-      r <- replayData
-            .get(consumeRef)
-            .fold(
-              storeWaitingContinuation(
-                channels,
-                WaitingContinuation(patterns, continuation, persist, peeks, consumeRef)
-              )
-            )(
-              comms =>
-                getCommAndDataCandidates(comms.iterator().asScala.toList).flatMap {
-                  _.fold(
-                    storeWaitingContinuation(
-                      channels,
-                      WaitingContinuation(patterns, continuation, persist, peeks, consumeRef)
-                    )
-                  ) {
-                    case (comm, dataCandidates) =>
-                      val channelsToIndex = channels.zipWithIndex.toMap
-                      handleMatches(
-                        dataCandidates,
-                        consumeRef,
-                        comms,
-                        comm,
-                        peeks,
-                        channelsToIndex
-                      )
-                  }
-                }
-            )
-    } yield r
-  }
-
-  def produce(channel: C, data: A, persist: Boolean): F[MaybeActionResult] =
-    contextShift.evalOn(scheduler) {
-      (for {
-        result <- produceLockF(channel) {
-                   lockedProduce(channel, data, persist)
-                 }
-      } yield result).timer(produceTimeCommLabel)
-    }
-
-  private[this] def lockedProduce(
-      channel: C,
-      data: A,
-      persist: Boolean
-  ): F[MaybeActionResult] = {
-
-    type MaybeProduceCandidate = Option[ProduceCandidate[C, P, A, K]]
-
-    def runMatcher(
-        comm: COMM,
-        produceRef: Produce,
-        groupedChannels: Seq[Seq[C]]
-    ): F[MaybeProduceCandidate] = {
-
-      def go(groupedChannels: Seq[Seq[C]]): F[Either[Seq[Seq[C]], MaybeProduceCandidate]] =
-        groupedChannels match {
-          case Nil => none[ProduceCandidate[C, P, A, K]].asRight[Seq[Seq[C]]].pure[F]
-          case channels :: remaining =>
-            for {
-              continuations <- store.getContinuations(channels)
-              matchCandidates = continuations.zipWithIndex.filter {
-                case (WaitingContinuation(_, _, _, _, source), _) =>
-                  comm.consume == source
-              }
-              channelToIndexedDataList <- channels.traverse { c: C =>
-                                           store
-                                             .getData(c)
-                                             .map(_.zipWithIndex)
-                                             .map(
-                                               as =>
-                                                 c -> {
-                                                   if (c == channel)
-                                                     Seq((Datum(data, persist, produceRef), -1))
-                                                   else as
-                                                 }.filter { matches(comm) }
-                                             )
-                                         }
-              firstMatch <- extractFirstMatch(
-                             channels,
-                             matchCandidates,
-                             channelToIndexedDataList.toMap
-                           )
-            } yield firstMatch match {
-              case None             => remaining.asLeft[MaybeProduceCandidate]
-              case produceCandidate => produceCandidate.asRight[Seq[Seq[C]]]
-            }
-        }
-      groupedChannels.tailRecM(go)
-    }
-
-    def getCommOrProduceCandidate(
-        comms: Seq[COMM],
-        produceRef: Produce,
-        groupedChannels: Seq[Seq[C]]
-    ): F[Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]] = {
-      type COMMOrProduce = Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]
-      def go(comms: Seq[COMM]): F[Either[Seq[COMM], COMMOrProduce]] =
-        comms match {
-          case Nil =>
-            val msg = "comms must not be empty"
-            logger.error(msg)
-            Sync[F].raiseError(new IllegalArgumentException(msg))
-          case commRef :: Nil =>
-            runMatcher(commRef, produceRef, groupedChannels) map {
-              case Some(x) => (commRef, x).asRight[COMM].asRight[Seq[COMM]]
-              case None    => commRef.asLeft[(COMM, ProduceCandidate[C, P, A, K])].asRight[Seq[COMM]]
-            }
-          case commRef :: rem =>
-            runMatcher(commRef, produceRef, groupedChannels) map {
-              case Some(x) => (commRef, x).asRight[COMM].asRight[Seq[COMM]]
-              case None    => rem.asLeft[COMMOrProduce]
-            }
-        }
-      comms.tailRecM(go)
-    }
-
-    def storeDatum(
-        produceRef: Produce,
-        maybeCommRef: Option[COMM]
-    ): F[MaybeActionResult] =
-      for {
-        _ <- store.putDatum(channel, Datum(data, persist, produceRef))
-        _ <- logF.debug(s"""|produce: no matching continuation found
-                            |storing <data: $data> at <channel: $channel>""".stripMargin)
-      } yield None
-
-    def handleMatch(
-        mat: ProduceCandidate[C, P, A, K],
-        produceRef: Produce,
-        comms: Multiset[COMM],
-        comm: COMM,
-        channelsToIndex: Map[C, Int]
-    ): F[MaybeActionResult] =
-      mat match {
-        case ProduceCandidate(
-            channels,
-            WaitingContinuation(patterns, continuation, persistK, peeks, consumeRef),
-            continuationIndex,
-            dataCandidates
-            ) =>
-          for {
-            commRef <- markComm(
-                        consumeRef,
-                        dataCandidates,
-                        channels,
-                        patterns,
-                        continuation,
-                        persist,
-                        peeks,
-                        comm,
-                        produceCommLabel
-                      )
-            _ <- assertF(
-                  comms.contains(commRef),
-                  s"COMM Event $commRef was not contained in the trace $comms"
-                )
-            _ <- store.removeContinuation(channels, continuationIndex).unlessA(persistK)
-            _ <- dataCandidates.toList
-                  .sortBy(_.datumIndex)(Ordering[Int].reverse)
-                  .traverse {
-                    case DataCandidate(candidateChannel, Datum(_, persistData, _), _, dataIndex) =>
-                      store
-                        .removeDatum(candidateChannel, dataIndex)
-                        .whenA((dataIndex >= 0 && !persistData)) >>
-                        store.removeJoin(candidateChannel, channels)
-                  }
-            _ <- logF.debug(s"produce: matching continuation found at <channels: $channels>")
-            _ <- removeBindingsFor(commRef)
-            r <- syncF.delay {
-                  Some(
-                    (
-                      ContResult(
-                        continuation,
-                        persistK,
-                        channels,
-                        patterns,
-                        peeks.nonEmpty
-                      ),
-                      dataCandidates.map(
-                        dc => Result(dc.channel, dc.datum.a, dc.removedDatum, dc.datum.persist)
-                      )
-                    )
-                  )
-                }
-          } yield r
-      }
-
-    for {
-      groupedChannels <- store.getJoins(channel)
-      _ <- logF.debug(
-            s"produce: searching for matching continuations at <groupedChannels: $groupedChannels>"
-          )
-      produceRef <- markProduce(channel, data, persist)
-      result <- replayData.get(produceRef) match {
-                 case None =>
-                   storeDatum(produceRef, None)
-                 case Some(comms) =>
-                   val commOrProduceCandidate
-                       : F[Either[COMM, (COMM, ProduceCandidate[C, P, A, K])]] =
-                     getCommOrProduceCandidate(
-                       comms.iterator().asScala.toList,
-                       produceRef,
-                       groupedChannels
-                     )
-                   val r: F[MaybeActionResult] = commOrProduceCandidate.flatMap {
-                     case Left(comm) =>
-                       storeDatum(produceRef, Some(comm))
-                     case Right((comm, produceCandidate)) =>
-                       val indexedChannels = produceCandidate.channels.zipWithIndex.toMap
-                       handleMatch(produceCandidate, produceRef, comms, comm, indexedChannels)
-                   }
-                   r
-               }
-    } yield result
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
-  private def removeBindingsFor(
-      commRef: COMM
-  ): F[Unit] = Sync[F].delay {
-    commRef.produces.foldLeft(replayData.removeBinding(commRef.consume, commRef)) {
-      case (updatedReplays, produceRef) =>
-        updatedReplays.removeBinding(produceRef, commRef)
-    }
-  }
-
-  override def createCheckpoint(): F[Checkpoint] = checkReplayData >> syncF.defer {
-    for {
-      changes     <- storeAtom.get().changes()
-      nextHistory <- historyRepositoryAtom.get().checkpoint(changes.toList)
-      _           = historyRepositoryAtom.set(nextHistory)
-      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
-      _           <- restoreInstalls()
-    } yield (Checkpoint(nextHistory.history.root, Seq.empty))
-  }
-
-  override def clear(): F[Unit] = syncF.delay { replayData.clear() } >> super.clear()
-
-  protected[rspace] def isDirty(root: Blake2b256Hash): F[Boolean] = true.pure[F]
-
-  private[this] def matches(comm: COMM)(datumWithIndex: (Datum[A], _)) = {
-    val (datum, _) = datumWithIndex
-    def wasRepeatedEnoughTimes =
-      (if (!datum.persist) {
-         comm.timesRepeated(datum.source) === produceCounter.get(
-           datum.source
-         )
-       } else true)
-    comm.produces.contains(datum.source) && wasRepeatedEnoughTimes
-  }
-
 }
 
 object ReplayRSpace {

--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -68,8 +68,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
 
   def getReport: F[Seq[ReportingEvent]] = Sync[F].delay(report.get)
 
-  protected override def markComm(
-      consumeRef: Consume,
+  protected override def logComm(
       dataCandidates: Seq[DataCandidate[C, A]],
       channels: Seq[C],
       patterns: Seq[P],
@@ -80,8 +79,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
       label: String
   ): F[COMM] =
     for {
-      commRef <- super.markComm(
-                  consumeRef,
+      commRef <- super.logComm(
                   dataCandidates,
                   channels,
                   patterns,
@@ -98,7 +96,8 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
           )
     } yield commRef
 
-  protected override def markConsume(
+  protected override def logConsume(
+      consumeRef: Consume,
       channels: Seq[C],
       patterns: Seq[P],
       continuation: K,
@@ -106,25 +105,27 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
       peeks: SortedSet[Int]
   ): F[Consume] =
     for {
-      consumeRef <- super.markConsume(
-                     channels,
-                     patterns,
-                     continuation,
-                     persist,
-                     peeks
-                   )
+      _ <- super.logConsume(
+            consumeRef,
+            channels,
+            patterns,
+            continuation,
+            persist,
+            peeks
+          )
       reportingConsume = ReportingConsume(channels, patterns, continuation, peeks.toSeq)
       _                <- Sync[F].delay(report.update(s => s :+ reportingConsume))
     } yield consumeRef
 
-  protected override def markProduce(
+  protected override def logProduce(
+      produceRef: Produce,
       channel: C,
       data: A,
       persist: Boolean
   ): F[Produce] =
     for {
-      produceRef <- super.markProduce(channel, data, persist)
-      _          <- Sync[F].delay(report.update(s => s :+ ReportingProduce(channel, data)))
+      _ <- super.logProduce(produceRef, channel, data, persist)
+      _ <- Sync[F].delay(report.update(s => s :+ ReportingProduce(channel, data)))
     } yield produceRef
 
   /** Creates a checkpoint.

--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -69,7 +69,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
   def getReport: F[Seq[ReportingEvent]] = Sync[F].delay(report.get)
 
   protected override def logComm(
-      dataCandidates: Seq[DataCandidate[C, A]],
+      dataCandidates: Seq[ConsumeCandidate[C, A]],
       channels: Seq[C],
       wk: WaitingContinuation[P, K],
       comm: COMM,

--- a/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala
@@ -23,11 +23,11 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
 
   /* Consume */
 
-  type MatchingDataCandidate = (DataCandidate[C, A], Seq[(Datum[A], Int)])
+  type MatchingDataCandidate = (ConsumeCandidate[C, A], Seq[(Datum[A], Int)])
 
   /** Searches through data, looking for a match with a given pattern.
     *
-    * If there is a match, we return the matching [[DataCandidate]],
+    * If there is a match, we return the matching [[ConsumeCandidate]],
     * along with the remaining unmatched data. If an illegal state is reached
     * during searching for a match we short circuit and return the state.
     */
@@ -48,7 +48,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
                   case Some(mat) =>
                     val indexedDatums = if (persist) data else prefix ++ remaining
                     (
-                      DataCandidate(
+                      ConsumeCandidate(
                         channel,
                         Datum(mat, persist, produceRef),
                         matchCandidate,
@@ -72,8 +72,8 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
   private[rspace] final def extractDataCandidates(
       channelPatternPairs: Seq[(C, P)],
       channelToIndexedData: Map[C, Seq[(Datum[A], Int)]],
-      acc: Seq[Option[DataCandidate[C, A]]]
-  )(implicit m: Match[F, P, A]): F[Seq[Option[DataCandidate[C, A]]]] =
+      acc: Seq[Option[ConsumeCandidate[C, A]]]
+  )(implicit m: Match[F, P, A]): F[Seq[Option[ConsumeCandidate[C, A]]]] =
     for {
       res <- channelPatternPairs match {
               case (channel, pattern) +: tail =>
@@ -82,7 +82,7 @@ private[rspace] trait SpaceMatcher[F[_], C, P, A, K] extends ISpace[F, C, P, A, 
                                  case Some(indexedData) =>
                                    findMatchingDataCandidate(channel, indexedData, pattern, Nil)
                                  case None =>
-                                   none[(DataCandidate[C, A], Seq[(Datum[A], Int)])].pure[F]
+                                   none[(ConsumeCandidate[C, A], Seq[(Datum[A], Int)])].pure[F]
                                }
                   dataCandidates <- maybeTuple match {
                                      case Some((cand, rem)) =>

--- a/rspace/src/main/scala/coop/rchain/rspace/internal.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/internal.scala
@@ -24,13 +24,6 @@ object internal {
       Datum(a, persist, Produce.create(channel, a, persist))
   }
 
-  final case class DataCandidate[C, A](
-      channel: C,
-      datum: Datum[A],
-      removedDatum: A,
-      datumIndex: Int
-  )
-
   final case class WaitingContinuation[P, K](
       patterns: Seq[P],
       continuation: K,
@@ -61,11 +54,18 @@ object internal {
       )
   }
 
+  final case class ConsumeCandidate[C, A](
+      channel: C,
+      datum: Datum[A],
+      removedDatum: A,
+      datumIndex: Int
+  )
+
   final case class ProduceCandidate[C, P, A, K](
       channels: Seq[C],
       continuation: WaitingContinuation[P, K],
       continuationIndex: Int,
-      dataCandidates: Seq[DataCandidate[C, A]]
+      dataCandidates: Seq[ConsumeCandidate[C, A]]
   )
 
   final case class Row[P, A, K](data: Seq[Datum[A]], wks: Seq[WaitingContinuation[P, K]])

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -48,6 +48,15 @@ final case class COMM(
 ) extends Event
 
 object COMM {
+  def apply[C, A](
+      dataCandidates: Seq[DataCandidate[C, A]],
+      consumeRef: Consume,
+      peeks: SortedSet[Int],
+      produceCounters: (Seq[Produce]) => Map[Produce, Int]
+  ): COMM = {
+    val produceRefs = dataCandidates.map(_.datum.source)
+    COMM(consumeRef, produceRefs, peeks, produceCounters(produceRefs))
+  }
   implicit val codecInt = int32
   implicit val codecCOMM: Codec[COMM] =
     (Codec[Consume] :: Codec[Seq[Produce]] :: sortedSet(uint8) :: Codec[Map[Produce, Int]]).as[COMM]

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -49,7 +49,7 @@ final case class COMM(
 
 object COMM {
   def apply[C, A](
-      dataCandidates: Seq[DataCandidate[C, A]],
+      dataCandidates: Seq[ConsumeCandidate[C, A]],
       consumeRef: Consume,
       peeks: SortedSet[Int],
       produceCounters: (Seq[Produce]) => Map[Produce, Int]

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -144,6 +144,18 @@ object Consume {
     )
   }
 
+  def createF[F[_]: Sync, C, P, K](
+      channels: Seq[C],
+      patterns: Seq[P],
+      continuation: K,
+      persistent: Boolean
+  )(
+      implicit
+      serializeC: Serialize[C],
+      serializeP: Serialize[P],
+      serializeK: Serialize[K]
+  ): F[Consume] = Sync[F].delay(create(channels, patterns, continuation, persistent))
+
   def fromHash(
       channelsHashes: Seq[Blake2b256Hash],
       hash: Blake2b256Hash,

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -1,5 +1,6 @@
 package coop.rchain.rspace.trace
 
+import cats.effect.Sync
 import coop.rchain.rspace.StableHashProvider._
 import coop.rchain.rspace.internal._
 import cats.implicits._
@@ -84,6 +85,12 @@ object Produce {
       hash(channel, datum, persistent),
       persistent
     )
+
+  def createF[F[_]: Sync, C, A](channel: C, datum: A, persistent: Boolean)(
+      implicit
+      serializeC: Serialize[C],
+      serializeA: Serialize[A]
+  ): F[Produce] = Sync[F].delay(create(channel, datum, persistent))
 
   def fromHash(
       channelsHash: Blake2b256Hash,


### PR DESCRIPTION
## Overview
<sup>_What this PR does, and why it's needed_</sup>
As part of handoff of RSpace it makes sense to simplify the methods and streamline their usages.
RSpace and ReplayRSpace have a lot in common,  but it's obfuscated by implementation details.
This PRs goal is to make it obvious which parts are the same and which parts differ.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>
https://rchain.atlassian.net/browse/RCHAIN-3874
https://rchain.atlassian.net/browse/RCHAIN-3875


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
