### PR TITLE
RCHAIN-3881: Prohibit terms wider than Short.MAX_VALUE splits/terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ integration-tests/report.json
 integration-tests.log
 *.log
 .virtualenv
+.metals


### PR DESCRIPTION
## Overview
Bulletproof unforgeable-name namespace uniqueness by prohibiting terms wider than Short.MAX_VALUE splits/terms

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3881

### Notes
~Test of eval with max split size takes almost 30 seconds, with just empty sends, so it's not included.~
Test of eval with max split size is included and it takes about 10 seconds.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
