### PR TITLE
Add new termination condition for isInMainChain

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -28,20 +28,19 @@ object ProtoUtil {
   /*
    * c is in the blockchain of b iff c == b or c is in the blockchain of the main parent of b
    */
-  // TODO: Move into BlockDAG and remove corresponding param once that is moved over from simulator
   def isInMainChain[F[_]: Monad](
       dag: BlockDagRepresentation[F],
-      candidateBlockHash: BlockHash,
+      candidateMetadata: BlockMetadata,
       targetBlockHash: BlockHash
   ): F[Boolean] = {
     import coop.rchain.catscontrib.Catscontrib.ToBooleanF
     import cats.instances.option._
 
-    (candidateBlockHash == targetBlockHash).pure[F] ||^ {
+    (candidateMetadata.blockHash == targetBlockHash).pure[F] ||^ {
       for {
         targetBlockOpt       <- dag.lookup(targetBlockHash)
         mainParentOpt        = targetBlockOpt >>= (_.parents.headOption)
-        inMainParentChainOpt <- mainParentOpt.traverse(isInMainChain(dag, candidateBlockHash, _))
+        inMainParentChainOpt <- mainParentOpt.traverse(isInMainChain(dag, candidateMetadata, _))
       } yield inMainParentChainOpt.getOrElse(false)
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
@@ -3,8 +3,10 @@ package coop.rchain.casper.util
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
+import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.util.ProtoUtil._
+import coop.rchain.models.BlockMetadata
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -13,6 +15,9 @@ class CasperUtilTest
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture {
+  implicit private def blockMessageToBlockMetadata(block: BlockMessage): BlockMetadata =
+    BlockMetadata.fromBlock(block, invalid = false)
+
   "isInMainChain" should "classify appropriately" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
@@ -22,10 +27,10 @@ class CasperUtilTest
 
         dag <- blockDagStorage.getRepresentation
 
-        _      <- isInMainChain(dag, genesis.blockHash, b3.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b2.blockHash, b3.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b3.blockHash, b2.blockHash) shouldBeF false
-        result <- isInMainChain(dag, b3.blockHash, genesis.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, genesis, b3.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b2, b3.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b3, b2.blockHash) shouldBeF false
+        result <- isInMainChain(dag, b3, genesis.blockHash) shouldBeF false
       } yield result
   }
 
@@ -39,11 +44,11 @@ class CasperUtilTest
 
         dag <- blockDagStorage.getRepresentation
 
-        _      <- isInMainChain(dag, genesis.blockHash, b2.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, genesis.blockHash, b3.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, genesis.blockHash, b4.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b2.blockHash, b4.blockHash) shouldBeF true
-        result <- isInMainChain(dag, b3.blockHash, b4.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, genesis, b2.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, genesis, b3.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, genesis, b4.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b2, b4.blockHash) shouldBeF true
+        result <- isInMainChain(dag, b3, b4.blockHash) shouldBeF false
       } yield result
   }
 
@@ -65,16 +70,16 @@ class CasperUtilTest
 
         dag <- blockDagStorage.getRepresentation
 
-        _      <- isInMainChain(dag, genesis.blockHash, b2.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b2.blockHash, b3.blockHash) shouldBeF false
-        _      <- isInMainChain(dag, b3.blockHash, b4.blockHash) shouldBeF false
-        _      <- isInMainChain(dag, b4.blockHash, b5.blockHash) shouldBeF false
-        _      <- isInMainChain(dag, b5.blockHash, b6.blockHash) shouldBeF false
-        _      <- isInMainChain(dag, b6.blockHash, b7.blockHash) shouldBeF false
-        _      <- isInMainChain(dag, b7.blockHash, b8.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b2.blockHash, b6.blockHash) shouldBeF true
-        _      <- isInMainChain(dag, b2.blockHash, b8.blockHash) shouldBeF true
-        result <- isInMainChain(dag, b4.blockHash, b2.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, genesis, b2.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b2, b3.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, b3, b4.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, b4, b5.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, b5, b6.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, b6, b7.blockHash) shouldBeF false
+        _      <- isInMainChain(dag, b7, b8.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b2, b6.blockHash) shouldBeF true
+        _      <- isInMainChain(dag, b2, b8.blockHash) shouldBeF true
+        result <- isInMainChain(dag, b4, b2.blockHash) shouldBeF false
       } yield result
   }
 }


### PR DESCRIPTION
## Overview
While looking at the [flamegraph](https://storage.googleapis.com/heapdumps.bucket.rchain-dev.tk/testnet.rchain-dev.tk/2019-10-06T20-04-12.testnet2-1.node0/ap/finalization.svg), I noticed that `isInMainChain` is responsible for 50% of the CPU time. Although there were some talks about DAG storage being the bottleneck here (and ways how to improve it), I don't think that `isInMainChain` should make as many calls to DAG storage anyway.

My conclusion is that `isInMainChain` was lacking a very important termination condition. It should not try to continue looking for candidate block once target block's number becomes lower or equal than the candidate block's number.

Imagine a block A with two children B and C. If we call `isInMainChain(B, C)`, the current implementation will start looking through C's ancestors trying to find block B but never actually finding it. Eventually it will reach genesis and stop concluding that C is not in the main chain of B. This is critically inefficient when we are talking about 100k ancestors.

### JIRA ticket:
<https://rchain.atlassian.net/browse/RCHAIN-3890>


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
