### PR TITLE
RCHAIN-3895: Make `NormalizerEnv` more type safe

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -153,8 +153,15 @@ message New {
     Par p = 2 [(scalapb.field).no_box = true];
     // For normalization, uri-referenced variables come at the end, and in lexicographical order.
     repeated string uri = 3;
-    map<string, Par> injections = 4;
+    map<string, Injection> injections = 4;
     bytes locallyFree = 5 [(scalapb.field).type = "coop.rchain.models.AlwaysEqual[scala.collection.immutable.BitSet]"];
+}
+
+message Injection {
+    oneof inj_instance {
+        Expr expr_body = 1;
+        GUnforgeable unf_body = 2;
+    }
 }
 
 message MatchCase {

--- a/models/src/main/scala/coop/rchain/models/NormalizerEnv.scala
+++ b/models/src/main/scala/coop/rchain/models/NormalizerEnv.scala
@@ -4,22 +4,27 @@ import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.DeployDataProto
 import coop.rchain.crypto.PublicKey
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.Injection.InjInstance._
 
 object NormalizerEnv {
   type UriString     = String
-  type NormalizerEnv = Map[UriString, Par]
+  type NormalizerEnv = Map[UriString, Injection]
 
-  val Empty: NormalizerEnv = Map[UriString, Par]()
+  val Empty: NormalizerEnv = Map[UriString, Injection]()
 
   def apply(deployId: Array[Byte]): NormalizerEnv =
-    Map("rho:rchain:deployId" -> GDeployId(ByteString.copyFrom(deployId)))
+    Map("rho:rchain:deployId" -> Injection(UnfBody(GDeployId(ByteString.copyFrom(deployId)))))
 
   def apply(deployerPk: PublicKey): NormalizerEnv =
-    Map("rho:rchain:deployerId" -> GDeployerId(ByteString.copyFrom(deployerPk.bytes)))
+    Map(
+      "rho:rchain:deployerId" -> Injection(
+        UnfBody(GDeployerId(ByteString.copyFrom(deployerPk.bytes)))
+      )
+    )
 
   def apply(deploy: DeployDataProto): NormalizerEnv =
     Map(
-      "rho:rchain:deployId"   -> GDeployId(deploy.sig),
-      "rho:rchain:deployerId" -> GDeployerId(deploy.deployer)
+      "rho:rchain:deployId"   -> Injection(UnfBody(GDeployId(deploy.sig))),
+      "rho:rchain:deployerId" -> Injection(UnfBody(GDeployerId(deploy.deployer)))
     )
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -13,6 +13,7 @@ import coop.rchain.metrics.Span
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.GUnforgeable.UnfInstance
 import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
+import coop.rchain.models.Injection.InjInstance.{ExprBody, UnfBody}
 import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
@@ -405,10 +406,10 @@ class DebruijnInterpreter[M[_], F[_]](
           neu.injections
             .get(urn)
             .map {
-              case RhoType.Unforgeable(GUnforgeable(unfInstance)) if unfInstance.isDefined =>
+              case Injection(UnfBody(GUnforgeable(unfInstance))) if unfInstance.isDefined =>
                 newEnv.put(unfInstance).asRight[InterpreterError]
 
-              case RhoType.Expression(Expr(exprInstance)) if exprInstance.isDefined =>
+              case Injection(ExprBody(Expr(exprInstance))) if exprInstance.isDefined =>
                 newEnv.put(exprInstance).asRight[InterpreterError]
 
               case _ =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/normalize.scala
@@ -957,12 +957,17 @@ object ProcNormalizeMatcher {
         val newCount           = newEnv.count - input.env.count
         val requiresDeployId   = uris.contains(deployIdUri)
         val requiresDeployerId = uris.contains(deployerIdUri)
+        val containsDeployId =
+          env.get(deployIdUri).exists(_.injInstance.unfBody.exists(_.unfInstance.isGDeployIdBody))
+        val containsDeployerId = env
+          .get(deployerIdUri)
+          .exists(_.injInstance.unfBody.exists(_.unfInstance.isGDeployerIdBody))
 
         def missingEnvElement(name: String, uri: String) =
           NormalizerError(s"`$uri` was used in rholang usage context where $name is not available.")
-        if (requiresDeployId && env.get(deployIdUri).forall(_.singleDeployId().isEmpty))
+        if (requiresDeployId && !containsDeployId)
           missingEnvElement("DeployId", deployIdUri).raiseError[M, ProcVisitOutputs]
-        else if (requiresDeployerId && env.get(deployerIdUri).forall(_.singleDeployerId().isEmpty))
+        else if (requiresDeployerId && !containsDeployerId)
           missingEnvElement("DeployerId", deployerIdUri).raiseError[M, ProcVisitOutputs]
         else {
           normalizeMatch[M](p.proc_, ProcVisitInputs(VectorPar(), newEnv, input.knownFree)).map {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -15,6 +15,7 @@ import coop.rchain.models.rholang.sorter.ordering._
 import scala.collection.immutable.BitSet
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
+import coop.rchain.models.Injection.InjInstance.ExprBody
 import coop.rchain.models.NormalizerEnv.NormalizerEnv
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.Var.WildcardMsg
@@ -990,13 +991,13 @@ class ProcMatcherSpec extends FlatSpec with Matchers {
 
   "PNew" should "raise a NormalizerError when deployerId uri does not point to a DeployerId" in {
     val uri                                   = "rho:rchain:deployerId"
-    implicit val normalizerEnv: NormalizerEnv = Map(uri -> GInt(42))
+    implicit val normalizerEnv: NormalizerEnv = Map(uri -> Injection(ExprBody(Expr(GInt(42)))))
     checkNormalizerError(uri, "DeployerId")
   }
 
   "PNew" should "raise a NormalizerError when deployId uri does not point to a DeployId" in {
     val uri                                   = "rho:rchain:deployId"
-    implicit val normalizerEnv: NormalizerEnv = Map(uri -> GInt(42))
+    implicit val normalizerEnv: NormalizerEnv = Map(uri -> Injection(ExprBody(Expr(GInt(42)))))
     checkNormalizerError(uri, "DeployId")
   }
 


### PR DESCRIPTION
## Overview
See discussion here: https://github.com/rchain/rchain/pull/2763#discussion_r336118087

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
