### PR TITLE
Persistent storage for last finalized block

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/PersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/PersistentIndex.scala
@@ -27,9 +27,6 @@ class PersistentIndex[F[_]: Sync: Log: RaiseIOError, K: Codec, V: Codec](
     private val keyValueCodec: Codec[(K, V)],
     private val outputStream: FileOutputStreamIO[F]
 ) {
-  private def replaceFile(from: Path, to: Path): F[Path] =
-    moveFile[F](from, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-
   private def updateCrcFile: F[Unit] =
     for {
       newCrcBytes <- crc.bytes

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/errors.scala
@@ -19,6 +19,7 @@ final case object LatestMessagesLogIsCorrupted                                ex
 final case object DataLookupIsCorrupted                                       extends StorageError
 final case object InvalidBlocksIsCorrupted                                    extends StorageError
 final case object BlockHashesByDeployLogIsCorrupted                           extends StorageError
+final case object LastFinalizedBlockIsCorrupted                               extends StorageError
 
 object StorageError {
   type StorageErr[A]        = Either[StorageError, A]
@@ -48,6 +49,8 @@ object StorageError {
         "Invalid blocks log is corrupted"
       case BlockHashesByDeployLogIsCorrupted =>
         "Block hashes by deploy log is corrupted"
+      case LastFinalizedBlockIsCorrupted =>
+        "Last finalized block file is corrupted"
     }
 
   implicit class StorageErrorToMessage(storageError: StorageError) {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorage.scala
@@ -1,0 +1,67 @@
+package coop.rchain.blockstorage.finality
+
+import java.nio.file.{Path, StandardCopyOption}
+
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.option._
+import cats.effect.{Concurrent, Sync}
+import cats.effect.concurrent.Semaphore
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.LastFinalizedBlockIsCorrupted
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.blockstorage.util.io._
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.Cell
+
+class LastFinalizedFileStorage[F[_]: Sync: RaiseIOError] private (
+    lock: Semaphore[F],
+    lastFinalizedPath: Path,
+    lastFinalizedBlockHashState: Cell[F, Option[BlockHash]]
+) extends LastFinalizedStorage[F] {
+  override def put(blockHash: BlockHash): F[Unit] =
+    lock.withPermit(
+      for {
+        _ <- lastFinalizedBlockHashState.set(blockHash.some)
+
+        tmpPath <- createSameDirectoryTemporaryFile(lastFinalizedPath)
+        _       <- writeToFile(tmpPath, blockHash.toByteArray)
+        _       <- replaceFile(tmpPath, lastFinalizedPath)
+      } yield ()
+    )
+
+  override def get(genesis: BlockMessage): F[BlockHash] =
+    lock.withPermit(
+      lastFinalizedBlockHashState.read.map(_.getOrElse(genesis.blockHash))
+    )
+}
+
+object LastFinalizedFileStorage {
+  private def readLastFinalizedBlockHash[F[_]: Sync: RaiseIOError](
+      lastFinalizedPath: Path
+  ): F[Option[BlockHash]] =
+    createNewFile[F](lastFinalizedPath) >>
+      readAllBytesFromFile(lastFinalizedPath).flatMap {
+        case bytes if bytes.isEmpty =>
+          none[BlockHash].pure[F]
+        case bytes if bytes.length == BlockHash.Length =>
+          ByteString.copyFrom(bytes).some.pure[F]
+        case _ =>
+          Sync[F].raiseError[Option[BlockHash]](LastFinalizedBlockIsCorrupted)
+      }
+
+  def make[F[_]: Sync: Concurrent](
+      lastFinalizedPath: Path
+  ): F[LastFinalizedStorage[F]] = {
+    implicit val raiseIOError: RaiseIOError[F] = IOError.raiseIOErrorThroughSync[F]
+
+    for {
+      lock                      <- Semaphore[F](1)
+      lastFinalizedBlockHashOpt <- readLastFinalizedBlockHash(lastFinalizedPath)
+      state                     <- Cell.mvarCell[F, Option[BlockHash]](lastFinalizedBlockHashOpt)
+    } yield new LastFinalizedFileStorage[F](lock, lastFinalizedPath, state)
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
@@ -1,0 +1,26 @@
+package coop.rchain.blockstorage.finality
+
+import cats.Functor
+import cats.syntax.functor._
+import cats.syntax.option._
+import cats.effect.Concurrent
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.Cell
+
+class LastFinalizedMemoryStorage[F[_]: Functor](
+    lastFinalizedBlockHashState: Cell[F, Option[BlockHash]]
+) extends LastFinalizedStorage[F] {
+  override def put(blockHash: BlockHash): F[Unit] =
+    lastFinalizedBlockHashState.set(blockHash.some)
+
+  override def get(genesis: BlockMessage): F[BlockHash] =
+    lastFinalizedBlockHashState.read.map(_.getOrElse(genesis.blockHash))
+}
+
+object LastFinalizedMemoryStorage {
+  def make[F[_]: Concurrent]: F[LastFinalizedStorage[F]] =
+    for {
+      state <- Cell.mvarCell[F, Option[BlockHash]](none[BlockHash])
+    } yield new LastFinalizedMemoryStorage[F](state)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
@@ -1,0 +1,13 @@
+package coop.rchain.blockstorage.finality
+
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
+
+trait LastFinalizedStorage[F[_]] {
+  def put(blockHash: BlockHash): F[Unit]
+  def get(genesis: BlockMessage): F[BlockHash]
+}
+
+object LastFinalizedStorage {
+  def apply[F[_]](implicit ev: LastFinalizedStorage[F]): LastFinalizedStorage[F] = ev
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/util/io/package.scala
@@ -57,6 +57,9 @@ package object io {
       }
     )
 
+  def replaceFile[F[_]: Sync: RaiseIOError](from: Path, to: Path): F[Path] =
+    moveFile[F](from, to, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+
   def isDirectory[F[_]: Sync: RaiseIOError](path: Path): F[Boolean] =
     handleIo(Files.isDirectory(path), UnexpectedIOError.apply)
 

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorageTest.scala
@@ -1,0 +1,60 @@
+package coop.rchain.blockstorage.finality
+
+import java.nio.file.Path
+
+import cats.implicits._
+import cats.effect.Sync
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.blockstorage.util.io._
+import coop.rchain.catscontrib.TaskContrib.TaskOps
+import coop.rchain.models.blockImplicits._
+import coop.rchain.shared.scalatestcontrib._
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{BeforeAndAfterAll, EitherValues, FlatSpecLike, Matchers, OptionValues}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class LastFinalizedFileStorageTest
+    extends FlatSpecLike
+    with Matchers
+    with OptionValues
+    with EitherValues
+    with GeneratorDrivenPropertyChecks
+    with BeforeAndAfterAll {
+  implicit val raiseIOError: RaiseIOError[Task] = IOError.raiseIOErrorThroughSync[Task]
+
+  def withLfbStorageFile[R](f: Path => Task[R]): R =
+    Sync[Task].bracket {
+      createTemporaryFile[Task]("lfb-storage-file", "")
+    } { tmpFile =>
+      f(tmpFile)
+    } { _ =>
+      Task.unit
+    }.unsafeRunSync
+
+  def withLfbStorage[R](f: LastFinalizedStorage[Task] => Task[R]): R =
+    withLfbStorageFile { lfbStorageFile =>
+      LastFinalizedFileStorage.make[Task](lfbStorageFile) >>= f
+    }
+
+  "Last finalized file storage" should "return genesis on empty state" in {
+    forAll(blockElementGen) { genesis =>
+      withLfbStorage {
+        _.get(genesis) shouldBeF genesis.blockHash
+      }
+    }
+  }
+
+  it should "be able to restore saved last finalized block on restart" in {
+    forAll(blockElementGen, blockHashGen) { (genesis, blockHash) =>
+      withLfbStorageFile { lfbStorageFile =>
+        for {
+          lfbStorage1 <- LastFinalizedFileStorage.make[Task](lfbStorageFile)
+          _           <- lfbStorage1.put(blockHash)
+          lfbStorage2 <- LastFinalizedFileStorage.make[Task](lfbStorageFile)
+          _           <- lfbStorage2.get(genesis) shouldBeF blockHash
+        } yield ()
+      }
+    }
+  }
+}

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -6,6 +6,7 @@ import cats.{Applicative, Show}
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.engine.Running
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil
@@ -84,7 +85,7 @@ sealed abstract class MultiParentCasperInstances {
     Metrics.Source(CasperMetricsSource, "casper")
   private[this] val genesisLabel = Metrics.Source(MetricsSource, "genesis")
 
-  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: Span: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
+  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
       shardId: String

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
@@ -25,7 +26,7 @@ trait CasperLaunch[F[_]] {
 
 object CasperLaunch {
 
-  def of[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
+  def of[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: LastFinalizedStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
       conf: CasperConf
   ): CasperLaunch[F] = new CasperLaunch[F] {
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -18,6 +18,7 @@ import coop.rchain.shared
 import coop.rchain.shared._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.util.comm.CommUtil
 
 trait Engine[F[_]] {
@@ -86,7 +87,7 @@ object Engine {
 
     } yield ()
 
-  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
+  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
       shardId: String,
       validatorId: Option[ValidatorIdentity],
       init: F[Unit]

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -7,6 +7,7 @@ import cats.Applicative
 import EngineCell._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.protocol._
@@ -37,7 +38,7 @@ class GenesisCeremonyMaster[F[_]: Sync: BlockStore: CommUtil: TransportLayer: RP
 
 object GenesisCeremonyMaster {
   import Engine._
-  def approveBlockInterval[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker](
+  def approveBlockInterval[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker](
       interval: FiniteDuration,
       shardId: String,
       validatorId: Option[ValidatorIdentity]

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -16,9 +16,10 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.shared._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.util.comm.CommUtil
 
-class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: EngineCell: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
+class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker](
     validatorId: ValidatorIdentity,
     shardId: String,
     blockApprover: BlockApproverProtocol

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -8,6 +8,7 @@ import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import EngineCell._
+import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -24,7 +25,7 @@ import scala.language.higherKinds
   * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
   * `F[None]` to all other message types.
     **/
-class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker](
+class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker](
     shardId: String,
     validatorId: Option[ValidatorIdentity],
     theInit: F[Unit]

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -7,6 +7,7 @@ import cats.effect.{Concurrent, ContextShift}
 import cats.temp.par
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, InMemBlockDagStorage}
+import coop.rchain.blockstorage.finality.LastFinalizedMemoryStorage
 import coop.rchain.casper._
 import coop.rchain.casper.genesis.contracts.{Validator, Vault}
 import coop.rchain.casper.helper.BlockDagStorageTestFixture
@@ -109,6 +110,9 @@ object Setup {
     implicit val blockStore       = InMemBlockStore.create[Task]
     implicit val blockDagStorage = InMemBlockDagStorage
       .create[Task]
+      .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
+    implicit val lastFinalizedStorage = LastFinalizedMemoryStorage
+      .make[Task]
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
     implicit val safetyOracle = new SafetyOracle[Task] {
       override def normalizedFaultTolerance(


### PR DESCRIPTION
## Overview
Introduces persistent storage for last finalized block using which we won't be losing our finalization progress on node restart.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3894


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
