### PR TITLE
RCHAIN-3866: Add support for Ethereum personal signature format

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -21,6 +21,8 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.bc.BcPEMDecryptorProvider
 import org.bouncycastle.openssl.{PEMEncryptedKeyPair, PEMParser}
 
+// TODO: refactor Signature API to handle exceptions from `NativeSecp256k1` library
+
 object Secp256k1 extends SignaturesAlg {
 
   private val provider        = new BouncyCastleProvider()
@@ -99,6 +101,7 @@ object Secp256k1 extends SignaturesAlg {
       signature: Array[Byte],
       pub: Array[Byte]
   ): Boolean =
+    // WARNING: this code throws Assertion exception if input is not correct length
     NativeSecp256k1.verify(data, signature, pub)
 
   /**
@@ -116,6 +119,7 @@ object Secp256k1 extends SignaturesAlg {
       data: Array[Byte],
       sec: Array[Byte]
   ): Array[Byte] =
+    // WARNING: this code throws Assertion exception if input is not correct length
     NativeSecp256k1.sign(data, sec)
 
   /**
@@ -128,6 +132,7 @@ object Secp256k1 extends SignaturesAlg {
     * Boolean of secret key verification
     */
   def secKeyVerify(seckey: Array[Byte]): Boolean =
+    // WARNING: this code throws Assertion exception if input is not correct length
     NativeSecp256k1.secKeyVerify(seckey)
 
   /**
@@ -139,6 +144,7 @@ object Secp256k1 extends SignaturesAlg {
     * @param pubkey ECDSA Public key, 33 or 65 bytes
     */
   def toPublic(seckey: Array[Byte]): Array[Byte] =
+    // WARNING: this code throws Assertion exception if input is not correct length
     NativeSecp256k1.computePubkey(seckey)
 
   override def toPublic(sec: PrivateKey): PublicKey = PublicKey(toPublic(sec.bytes))

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1Eth.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1Eth.scala
@@ -1,0 +1,73 @@
+package coop.rchain.crypto.signatures
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.crypto.util.CertificateHelper
+
+/*
+ * Ethereum personal signature
+ *
+ * The difference from `Secp256k1` is in signature format
+ */
+object Secp256k1Eth extends SignaturesAlg {
+
+  val name                    = s"${Secp256k1.name}:eth"
+  override val sigLength: Int = Secp256k1.sigLength
+
+  def newKeyPair = Secp256k1.newKeyPair
+
+  def parsePemFile[F[_]: Sync](path: Path, password: String): F[PrivateKey] =
+    Secp256k1.parsePemFile(path, password)
+
+  //TODO: refactor to make use of strongly typed keys
+  /**
+    * Verifies the given secp256k1 signature in native code.
+    *
+    * Input values
+    * @param data The data which was signed, must be exactly 32 bytes
+    * @param signatureRS The signature in raw RS format
+    * @param pub The public key which did the signing
+    *
+    * Return value
+    * boolean value of verification
+    *
+    */
+  def verify(
+      data: Array[Byte],
+      signatureRS: Array[Byte],
+      pub: Array[Byte]
+  ): Boolean = {
+    // Convert signature to DER format
+    val sigDER = CertificateHelper.encodeSignatureRStoDER(signatureRS)
+    Secp256k1.verify(data, sigDER, pub)
+  }
+
+  /**
+    * libsecp256k1 Create an ECDSA signature.
+    *
+    * Input values
+    * @param data Message hash, 32 bytes
+    * @param sec Secret key, 32 bytes
+    *
+    * Return value
+    * byte array of signature in raw RS format
+    *
+    */
+  def sign(
+      data: Array[Byte],
+      sec: Array[Byte]
+  ): Array[Byte] = {
+    val sigDER = Secp256k1.sign(data, sec)
+    // Convert signature to raw RS format
+    CertificateHelper.decodeSignatureDERtoRS(sigDER)
+  }
+
+  def secKeyVerify = Secp256k1.secKeyVerify(_)
+
+  def toPublic(seckey: Array[Byte]): Array[Byte] =
+    Secp256k1.toPublic(seckey)
+
+  override def toPublic(sec: PrivateKey): PublicKey = Secp256k1.toPublic(sec)
+}

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/SignaturesAlg.scala
@@ -18,8 +18,9 @@ trait SignaturesAlg {
 object SignaturesAlg {
   def apply(algorithm: String): Option[SignaturesAlg] =
     algorithm.toLowerCase match {
-      case Ed25519.name   => Some(Ed25519)
-      case Secp256k1.name => Some(Secp256k1)
-      case _              => None
+      case Ed25519.name      => Some(Ed25519)
+      case Secp256k1.name    => Some(Secp256k1)
+      case Secp256k1Eth.name => Some(Secp256k1Eth)
+      case _                 => None
     }
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
@@ -1,8 +1,10 @@
 package coop.rchain.crypto.signatures
 
+import java.nio.charset.StandardCharsets
+
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.{PrivateKey, PublicKey}
-import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.crypto.hash.{Blake2b256, Keccak256}
 import coop.rchain.shared.Serialize
 
 final case class Signed[A] private (
@@ -18,9 +20,9 @@ object Signed {
       sigAlgorithm: SignaturesAlg,
       sk: PrivateKey
   ): Signed[A] = {
-    val toSign = Serialize[A].encode(data).toArray
-    val hash   = Blake2b256.hash(toSign)
-    val sig    = sigAlgorithm.sign(hash, sk)
+    val serializedData = Serialize[A].encode(data).toArray
+    val hash           = signatureHash(sigAlgorithm.name, serializedData)
+    val sig            = sigAlgorithm.sign(hash, sk)
 
     Signed(data, sigAlgorithm.toPublic(sk), ByteString.copyFrom(sig), sigAlgorithm)
   }
@@ -31,11 +33,24 @@ object Signed {
       sig: ByteString,
       sigAlgorithm: SignaturesAlg
   ): Option[Signed[A]] = {
-    val hash = Blake2b256.hash(Serialize[A].encode(data).toArray)
+    val serializedData = Serialize[A].encode(data).toArray
+    val hash           = signatureHash(sigAlgorithm.name, serializedData)
 
     if (sigAlgorithm.verify(hash, sig.toByteArray, pk))
       Some(new Signed(data, pk, sig, sigAlgorithm))
     else
       None
   }
+
+  def signatureHash(sigAlgName: String, serializedData: Array[Byte]) =
+    sigAlgName match {
+      case Secp256k1Eth.name =>
+        Keccak256.hash(ethPrefix(serializedData.length) ++ serializedData)
+      case _ =>
+        Blake2b256.hash(serializedData)
+    }
+
+  private[this] def ethPrefix(msgLength: Int) =
+    s"\u0019Ethereum Signed Message:\n${msgLength}"
+      .getBytes(StandardCharsets.UTF_8)
 }

--- a/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
@@ -138,17 +138,18 @@ object CertificateHelper {
       try {
         seq.addObject(toASN1Int(r))
         seq.addObject(toASN1Int(s))
+        // Close to write the sequence
         seq.close
         bos.toByteArray
       } finally {
-        if (seq != null) seq.close()
         // > Closing a ByteArrayOutputStream has no effect.
         // https://docs.oracle.com/javase/10/docs/api/java/io/ByteArrayOutputStream.html
+        bos.close
       }
     }
 
     if (signatureRS.isEmpty)
-      new Exception("Input array must not be empty.").asLeft
+      new IllegalArgumentException("Input array must not be empty").asLeft
     else
       Try(convert).toEither
   }
@@ -167,16 +168,18 @@ object CertificateHelper {
         val Array(r, s, _*) = asnSeq.toArray
         toBytes(r) ++ toBytes(s)
       } finally {
-        if (asn != null) asn.close()
+        asn.close
         // > Closing a ByteArrayInputStream has no effect.
         // https://docs.oracle.com/javase/10/docs/api/java/io/ByteArrayInputStream.html
+        bis.close
       }
     }
 
     if (signatureDER.isEmpty)
-      new Exception("Input array must not be empty.").asLeft
+      new IllegalArgumentException("Input array must not be empty").asLeft
     else
       Try(convert).toEither
+        .leftMap(new IllegalArgumentException("Input array is not valid DER message format", _))
   }
 
 }

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.crypto.signatures
 
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.crypto.signatures.Signed.{signatureHash}
 import coop.rchain.shared.Serialize
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
@@ -18,7 +18,7 @@ class SignedSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matche
   }
 
   implicit val sigAlgorithmArbitrary: Arbitrary[SignaturesAlg] = Arbitrary(
-    Gen.oneOf(Secp256k1, Ed25519)
+    Gen.oneOf(Secp256k1, Secp256k1Eth, Ed25519)
   )
 
   property("Signed should generate a valid signature") {
@@ -26,8 +26,7 @@ class SignedSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matche
       val (sk, pk) = sigAlgorithm.newKeyPair
 
       val signed = Signed(input, sigAlgorithm, sk)
-
-      val hash = Blake2b256.hash(signed.data)
+      val hash   = signatureHash(sigAlgorithm.name, signed.data)
 
       sigAlgorithm.verify(hash, signed.sig.toByteArray, pk) should be(true)
       signed.pk should be(pk)

--- a/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
@@ -1,20 +1,53 @@
 package coop.rchain.crypto.util
 
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.crypto.signatures.{Secp256k1, Secp256k1Eth}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
-import org.scalacheck.Prop.propBoolean
 
 class DERConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
   implicit val arbBytes: Arbitrary[Array[Byte]] = arbContainer[Array, Byte]
 
-  property("DER converter should work with any non-empty byte array") {
+  property("DER converter check with valid and non-empty input") {
     forAll { (bytes: Array[Byte]) =>
-      !bytes.isEmpty ==> !CertificateHelper.encodeSignatureRStoDER(bytes).right.get.isEmpty
+      if (!bytes.isEmpty) {
+        val (PrivateKey(privKey), _) = Secp256k1.newKeyPair
+        val data                     = Blake2b256.hash(bytes)
+        val sigRS                    = Secp256k1Eth.sign(data, privKey)
 
-      !bytes.isEmpty ==> !CertificateHelper.decodeSignatureDERtoRS(bytes).right.get.isEmpty
+        val sigDER     = CertificateHelper.encodeSignatureRStoDER(sigRS).right.get
+        val expectedRS = CertificateHelper.decodeSignatureDERtoRS(sigDER).right.get
+
+        // Encode / decode should get initial input for valid signature
+        sigRS shouldBe expectedRS
+
+        // Encoder is safe of exception for any input
+        CertificateHelper.encodeSignatureRStoDER(bytes).right.get.isEmpty shouldBe false
+
+        // Decoder should throw exception with invalid DER message format
+        CertificateHelper
+          .decodeSignatureDERtoRS(bytes)
+          .left
+          .get shouldBe a[IllegalArgumentException]
+      }
     }
+  }
+
+  property("encoder should throw exception on empty input") {
+    CertificateHelper
+      .encodeSignatureRStoDER(Array[Byte]())
+      .left
+      .get shouldBe a[IllegalArgumentException]
+  }
+
+  property("decoder should throw exception on empty input") {
+    CertificateHelper
+      .decodeSignatureDERtoRS(Array[Byte]())
+      .left
+      .get shouldBe a[IllegalArgumentException]
   }
 
 }

--- a/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
@@ -1,0 +1,20 @@
+package coop.rchain.crypto.util
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import org.scalacheck.Prop.propBoolean
+
+class DERConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+  implicit val arbBytes: Arbitrary[Array[Byte]] = arbContainer[Array, Byte]
+
+  property("DER converter should work with any non-empty byte array") {
+    forAll { (bytes: Array[Byte]) =>
+      !bytes.isEmpty ==> !CertificateHelper.encodeSignatureRStoDER(bytes).right.get.isEmpty
+
+      !bytes.isEmpty ==> !CertificateHelper.decodeSignatureDERtoRS(bytes).right.get.isEmpty
+    }
+  }
+
+}

--- a/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
@@ -18,19 +18,19 @@ class DERConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with 
         val data                     = Blake2b256.hash(bytes)
         val sigRS                    = Secp256k1Eth.sign(data, privKey)
 
-        val sigDER     = CertificateHelper.encodeSignatureRStoDER(sigRS).right.get
-        val expectedRS = CertificateHelper.decodeSignatureDERtoRS(sigDER).right.get
+        val sigDER     = CertificateHelper.encodeSignatureRStoDER(sigRS).get
+        val expectedRS = CertificateHelper.decodeSignatureDERtoRS(sigDER).get
 
         // Encode / decode should get initial input for valid signature
         sigRS shouldBe expectedRS
 
         // Encoder is safe of exception for any input
-        CertificateHelper.encodeSignatureRStoDER(bytes).right.get.isEmpty shouldBe false
+        CertificateHelper.encodeSignatureRStoDER(bytes).get.isEmpty shouldBe false
 
         // Decoder should throw exception with invalid DER message format
         CertificateHelper
           .decodeSignatureDERtoRS(bytes)
-          .left
+          .failed
           .get shouldBe a[IllegalArgumentException]
       }
     }
@@ -39,14 +39,14 @@ class DERConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with 
   property("encoder should throw exception on empty input") {
     CertificateHelper
       .encodeSignatureRStoDER(Array[Byte]())
-      .left
+      .failed
       .get shouldBe a[IllegalArgumentException]
   }
 
   property("decoder should throw exception on empty input") {
     CertificateHelper
       .decodeSignatureDERtoRS(Array[Byte]())
-      .left
+      .failed
       .get shouldBe a[IllegalArgumentException]
   }
 

--- a/shared/src/main/scala/coop/rchain/shared/TrySyntax.scala
+++ b/shared/src/main/scala/coop/rchain/shared/TrySyntax.scala
@@ -1,0 +1,13 @@
+package coop.rchain.shared
+
+import scala.util.{Failure, Success, Try}
+
+object TrySyntax {
+  implicit final class TryExt[A](val t: Try[A]) extends AnyVal {
+
+    // Wrap exception in failure
+    def mapFailure(f: Throwable => Throwable): Try[A] =
+      t.transform(Success(_), ex => Failure(f(ex)))
+
+  }
+}


### PR DESCRIPTION
## Overview
Allowing for deploys to signed this way would mean we could leverage all the wallet tools that have been built for Ethereum (such as Metamask) to sign RChain deploys.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3866
https://rchain.atlassian.net/browse/RCHAIN-3867

### Notes
The same parameter is used in deploy `sigAlgorithm` but with additional label `eth` to mark additional verification support. `secp256k1:eth` means the same signature algorithm as with `secp256k1` but message is constructed with prefix and different hashing algorithm.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
