### PR TITLE
RCHAIN-3925: DeployData print end of the signature and add valid after block number

### DIFF
--- a/models/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
+++ b/models/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
@@ -45,10 +45,18 @@ object PrettyPrinter {
   def buildString(b: ByteString): String =
     limit(Base16.encode(b.toByteArray), 10)
 
+  def buildStringSig(b: ByteString): String = {
+    val bytes = b.toByteArray
+    val str1  = Base16.encode(bytes.take(10))
+    val str2  = Base16.encode(bytes.takeRight(10))
+    s"${str1}...${str2}"
+  }
+
   def buildString(sd: Signed[DeployData]): String =
-    s"${buildString(sd.data)}, SigAlgorithm: ${sd.sigAlgorithm.name}, Sig: ${buildString(sd.sig)}"
+    s"${buildString(sd.data)}, Sig: ${buildStringSig(sd.sig)}, SigAlgorithm: ${sd.sigAlgorithm.name}, ValidAfterBlockNumber: ${sd.data.validAfterBlockNumber}"
+
   def buildString(d: DeployData): String =
-    s"DeployData #${d.timestamp} -- ${d.term}}"
+    s"DeployData #${d.timestamp} -- ${d.term}"
 
   def buildString(r: RChainState): String =
     buildString(r.postStateHash)


### PR DESCRIPTION
## Overview
DeployData pretty prints 10 chars of the signature from the beginning and the end. Also prints valid after block number.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3925

### Notes
Sample
```
Sig: 304402202295240e2ea9...60d195cb0fadc2967b89, SigAlgorithm: secp256k1, ValidAfterBlockNumber: 40
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
