### PR TITLE
Persistent deploys

### DIFF
--- a/block-storage/src/main/resources/db/migration/V1__Initial_Setup.sql
+++ b/block-storage/src/main/resources/db/migration/V1__Initial_Setup.sql
@@ -1,0 +1,10 @@
+CREATE TABLE deploys
+(
+    signature                BLOB PRIMARY KEY NOT NULL,
+    public_key               BLOB             NOT NULL,
+    term                     VARCHAR          NOT NULL,
+    timestamp                INTEGER          NOT NULL,
+    phlo_price               INTEGER          NOT NULL,
+    phlo_limit               INTEGER          NOT NULL,
+    valid_after_block_number INTEGER          NOT NULL
+);

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/DeployStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/DeployStorage.scala
@@ -1,0 +1,14 @@
+package coop.rchain.blockstorage.deploy
+
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.signatures.Signed
+
+trait DeployStorage[F[_]] {
+  def put(deploys: List[Signed[DeployData]]): F[Unit]
+  def remove(deploys: List[Signed[DeployData]]): F[Int]
+  def getUnfinalized: F[Set[Signed[DeployData]]]
+}
+
+object DeployStorage {
+  def apply[F[_]](implicit ev: DeployStorage[F]): DeployStorage[F] = ev
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/InMemDeployStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/InMemDeployStorage.scala
@@ -1,0 +1,30 @@
+package coop.rchain.blockstorage.deploy
+
+import cats.Monad
+import cats.effect.Concurrent
+import cats.effect.concurrent.Ref
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.signatures.Signed
+
+class InMemDeployStorage[F[_]: Monad](
+    deployRef: Ref[F, Set[Signed[DeployData]]]
+) extends DeployStorage[F] {
+  def put(deploys: List[Signed[DeployData]]): F[Unit] = deployRef.update(_ ++ deploys)
+
+  def remove(deploys: List[Signed[DeployData]]): F[Int] =
+    deployRef.modify { oldDeploys =>
+      val newDeploys = oldDeploys -- deploys
+      (newDeploys, oldDeploys.size - newDeploys.size)
+    }
+
+  def getUnfinalized: F[Set[Signed[DeployData]]] = deployRef.get
+}
+
+object InMemDeployStorage {
+  def make[F[_]: Concurrent]: F[DeployStorage[F]] =
+    for {
+      ref <- Ref.of[F, Set[Signed[DeployData]]](Set.empty)
+    } yield new InMemDeployStorage[F](ref)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/SQLiteDeployStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/deploy/SQLiteDeployStorage.scala
@@ -1,0 +1,61 @@
+package coop.rchain.blockstorage.deploy
+
+import cats.effect.Sync
+import cats.instances.list._
+import cats.syntax.functor._
+import cats.syntax.applicative._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.signatures.{Secp256k1, Signed}
+import doobie._
+import doobie.implicits._
+
+class SQLiteDeployStorage[F[_]: Sync](transactor: Transactor[F]) extends DeployStorage[F] {
+  implicit protected val readDeployData: Read[Signed[DeployData]] =
+    Read[(Array[Byte], Array[Byte], String, Long, Long, Long, Long)].map {
+      case (signature, pk, term, timestamp, phloPrice, phloLimit, validAfterBlockNumber) =>
+        val deployData = DeployData(term, timestamp, phloPrice, phloLimit, validAfterBlockNumber)
+        Signed
+          .fromSignedData(deployData, PublicKey(pk), ByteString.copyFrom(signature), Secp256k1)
+          .get
+    }
+
+  implicit protected val writeDeployData: Write[Signed[DeployData]] =
+    Write[(Array[Byte], Array[Byte], String, Long, Long, Long, Long)].contramap { deploy =>
+      (
+        deploy.sig.toByteArray,
+        deploy.pk.bytes,
+        deploy.data.term,
+        deploy.data.timestamp,
+        deploy.data.phloPrice,
+        deploy.data.phloLimit,
+        deploy.data.validAfterBlockNumber
+      )
+    }
+
+  def put(deploys: List[Signed[DeployData]]): F[Unit] =
+    Update[Signed[DeployData]](
+      """INSERT OR IGNORE INTO deploys
+        |(signature, public_key, term, timestamp, phlo_price, phlo_limit, valid_after_block_number)
+        |VALUES (?, ?, ?, ?, ?, ?, ?)
+        |""".stripMargin
+    ).updateMany(deploys).transact(transactor).void
+
+  def remove(deploys: List[Signed[DeployData]]): F[Int] =
+    Update[Array[Byte]](
+      "DELETE FROM deploys WHERE signature=?"
+    ).updateMany(deploys.map(d => d.sig.toByteArray))
+      .transact(transactor)
+
+  def getUnfinalized: F[Set[Signed[DeployData]]] =
+    sql"SELECT * FROM deploys"
+      .query[Signed[DeployData]]
+      .to[Set]
+      .transact(transactor)
+}
+
+object SQLiteDeployStorage {
+  def make[F[_]: Sync](transactor: Transactor[F]): F[DeployStorage[F]] =
+    new SQLiteDeployStorage[F](transactor).pure[F].widen
+}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/deploy/SQLiteDeployStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/deploy/SQLiteDeployStorageTest.scala
@@ -1,0 +1,67 @@
+package coop.rchain.blockstorage.deploy
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import cats.syntax.applicative._
+import cats.syntax.functor._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.blockstorage.util.io._
+import coop.rchain.catscontrib.TaskContrib.TaskOps
+import coop.rchain.models.blockImplicits.signedDeployDataGen
+import doobie.Transactor
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.flywaydb.core.Flyway
+import org.flywaydb.core.api.Location
+import org.scalacheck.Gen
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class SQLiteDeployStorageTest
+    extends FlatSpecLike
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with BeforeAndAfterAll {
+
+  val scheduler = Scheduler.fixedPool("sqlite-deploy-storage-test-scheduler", 4)
+
+  implicit val raiseIOError: RaiseIOError[Task] = IOError.raiseIOErrorThroughSync[Task]
+
+  def withDBLocation[R](f: Path => Task[R]): R = {
+    val testProgram = Sync[Task].bracket {
+      createTemporaryFile[Task]("sqlite-deploy-storage", "test")
+    } { dbPath =>
+      f(dbPath)
+    } { dbPath =>
+      deleteIfExists[Task](dbPath).void
+    }
+    testProgram.unsafeRunSync(scheduler)
+  }
+
+  def createDeployStorage(dbPath: Path): Task[DeployStorage[Task]] = {
+    val dataSource = s"jdbc:sqlite:$dbPath"
+    val conf =
+      Flyway
+        .configure()
+        .dataSource(dataSource, "", "")
+        .locations(new Location("classpath:/db/migration"))
+    val flyway = conf.load()
+    flyway.migrate()
+    val transactor = Transactor.fromDriverManager[Task]("org.sqlite.JDBC", dataSource)
+    SQLiteDeployStorage.make[Task](transactor)
+  }
+
+  "SQLiteDeployStorage" should "be able to restore deploys after restart" in {
+    forAll(Gen.listOf(signedDeployDataGen), minSize(0), sizeRange(10)) { deploys =>
+      withDBLocation { dbPath =>
+        for {
+          deployStorage1 <- createDeployStorage(dbPath)
+          _              <- deployStorage1.put(deploys)
+          deployStorage2 <- createDeployStorage(dbPath)
+          result         <- deployStorage2.getUnfinalized
+        } yield result shouldBe deploys.toSet
+      }
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -451,7 +451,11 @@ lazy val blockStorage = (project in file("block-storage"))
       lmdbjava,
       catsCore,
       catsEffect,
-      catsMtl
+      catsMtl,
+      doobieCore,
+      doobieHikari,
+      flyway,
+      sqlLite
     )
   )
   .dependsOn(shared, models % "compile->compile;test->test")

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -6,6 +6,7 @@ import cats.{Applicative, Show}
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.engine.Running
 import coop.rchain.casper.protocol._
@@ -80,7 +81,7 @@ sealed abstract class MultiParentCasperInstances {
     Metrics.Source(CasperMetricsSource, "casper")
   private[this] val genesisLabel = Metrics.Source(MetricsSource, "genesis")
 
-  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator](
+  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
       shardId: String,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
@@ -26,7 +27,7 @@ trait CasperLaunch[F[_]] {
 
 object CasperLaunch {
 
-  def of[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: LastFinalizedStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator](
+  def of[F[_]: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: LastFinalizedStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
       conf: CasperConf
   ): CasperLaunch[F] = new CasperLaunch[F] {
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -18,6 +18,7 @@ import coop.rchain.shared
 import coop.rchain.shared._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.util.comm.CommUtil
 
@@ -87,7 +88,7 @@ object Engine {
 
     } yield ()
 
-  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator](
+  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
       shardId: String,
       finalizationRate: Int,
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -7,6 +7,7 @@ import cats.Applicative
 import EngineCell._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
@@ -38,7 +39,7 @@ class GenesisCeremonyMaster[F[_]: Sync: BlockStore: CommUtil: TransportLayer: RP
 
 object GenesisCeremonyMaster {
   import Engine._
-  def approveBlockInterval[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: Estimator](
+  def approveBlockInterval[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
       interval: FiniteDuration,
       shardId: String,
       finalizationRate: Int,

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -16,10 +16,11 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.shared._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.util.comm.CommUtil
 
-class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator](
+class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: Running.RequestedBlocks: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
     validatorId: ValidatorIdentity,
     shardId: String,
     finalizationRate: Int,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -8,6 +8,7 @@ import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import EngineCell._
+import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.comm.CommUtil
@@ -25,7 +26,7 @@ import scala.language.higherKinds
   * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
   * `F[None]` to all other message types.
     **/
-class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: Estimator](
+class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Running.RequestedBlocks: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: Estimator: DeployStorage](
     shardId: String,
     finalizationRate: Int,
     validatorId: Option[ValidatorIdentity],

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -7,6 +7,7 @@ import cats.effect.{Concurrent, ContextShift}
 import cats.temp.par
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, InMemBlockDagStorage}
+import coop.rchain.blockstorage.deploy.InMemDeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedMemoryStorage
 import coop.rchain.casper._
 import coop.rchain.casper.genesis.contracts.{Validator, Vault}
@@ -115,6 +116,9 @@ object Setup {
       .create[Task]
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
     implicit val lastFinalizedStorage = LastFinalizedMemoryStorage
+      .make[Task]
+      .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
+    implicit val deployStorage = InMemDeployStorage
       .make[Task]
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
     implicit val safetyOracle = new SafetyOracle[Task] {

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -10,6 +10,7 @@ import cats.effect.{Concurrent, Resource, Sync}
 import cats.implicits._
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage}
+import coop.rchain.blockstorage.deploy.{DeployStorage, InMemDeployStorage}
 import coop.rchain.blockstorage.finality.{LastFinalizedFileStorage, LastFinalizedStorage}
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
@@ -63,6 +64,7 @@ class TestNode[F[_]](
     implicit val blockStore: BlockStore[F],
     implicit val blockDagStorage: BlockDagStorage[F],
     implicit val lastFinalizedStorage: LastFinalizedStorage[F],
+    implicit val deployStorage: DeployStorage[F],
     val metricEff: Metrics[F],
     val span: Span[F],
     val casperState: CasperStateCell[F],
@@ -368,6 +370,7 @@ object TestNode {
       node <- Resource.liftF(
                for {
                  lastFinalizedStorage <- LastFinalizedFileStorage.make[F](paths.lastFinalizedFile)
+                 deployStorage        <- InMemDeployStorage.make[F]
                  _                    <- TestNetwork.addPeer(currentPeerNode)
                  blockProcessingLock  <- Semaphore[F](1)
                  casperState          <- Cell.mvarCell[F, CasperState](CasperState())
@@ -389,6 +392,7 @@ object TestNode {
                    blockStore,
                    blockDagStorage,
                    lastFinalizedStorage,
+                   deployStorage,
                    metricEff,
                    spanEff,
                    casperState,

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -38,12 +38,11 @@ object blockImplicits {
 
   implicit val arbitraryJustification: Arbitrary[Justification] = Arbitrary(justificationGen)
 
-  val processedDeployGen: Gen[ProcessedDeploy] =
+  val signedDeployDataGen: Gen[Signed[DeployData]] =
     for {
-      term        <- listOfN(32, Gen.alphaNumChar).map(_.mkString)
-      timestamp   <- arbitrary[Long]
-      (sec, pub)  = Secp256k1.newKeyPair
-      bytesLength <- Gen.chooseNum(128, 256)
+      term      <- listOfN(32, Gen.alphaNumChar).map(_.mkString)
+      timestamp <- arbitrary[Long]
+      (sec, _)  = Secp256k1.newKeyPair
       deployData = Signed(
         DeployData(
           term = term,
@@ -55,6 +54,11 @@ object blockImplicits {
         signatures.Secp256k1,
         sec
       )
+    } yield deployData
+
+  val processedDeployGen: Gen[ProcessedDeploy] =
+    for {
+      deployData <- signedDeployDataGen
     } yield ProcessedDeploy(
       deploy = deployData,
       cost = PCost(0L),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
   val catsEffectVersion = "1.4.0"
   val catsMtlVersion    = "0.6.0"
   val slf4jVersion      = "1.7.25"
+  val doobieVersion     = "0.7.1"
 
   // format: off
   val bouncyProvCastle    = "org.bouncycastle"           % "bcprov-jdk15on"             % "1.61"
@@ -81,6 +82,12 @@ object Dependencies {
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
   val julToSlf4j          = "org.slf4j"                   % "jul-to-slf4j"              % slf4jVersion
+  val sqlLite             = "org.xerial"                  % "sqlite-jdbc"               % "3.28.0"
+  val flyway              = "org.flywaydb"                % "flyway-core"               % "5.2.4"
+  val doobieCore = ("org.tpolecat" %% "doobie-core" % doobieVersion)
+    .exclude("co.fs2", s"fs2-core_2.12")
+  val doobieHikari = ("org.tpolecat" %% "doobie-hikari" % doobieVersion)
+    .exclude("co.fs2", s"fs2-core_2.12")
   // format: on
 
   val overrides = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.0-M2"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "1.5.0"
-  val catsEffectVersion = "1.2.0"
-  val catsMtlVersion    = "0.4.0"
+  val catsVersion       = "1.6.0"
+  val catsEffectVersion = "1.4.0"
+  val catsMtlVersion    = "0.6.0"
   val slf4jVersion      = "1.7.25"
 
   // format: off


### PR DESCRIPTION
## Overview
Implements persistent storage for deploys. I made a few decisions while working on this:

- SQLite is used as a lightweight embeded RDBMS
- Doobie is used as a functional JDBC layer
- Flyway is used as a database migration control system



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3840


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
