### PR TITLE
RCHAIN-3935: WebAPI - http endpoint to BlockAPI

### DIFF
--- a/integration-tests/Pipfile
+++ b/integration-tests/Pipfile
@@ -17,6 +17,7 @@ cryptography = "*"
 eth-hash = "*"
 pycryptodome = "*"
 pyrchain = {git = "https://github.com/rchain/pyrchain.git"}
+requests = "*"
 
 [dev-packages]
 python-language-server = "*"

--- a/integration-tests/Pipfile.lock
+++ b/integration-tests/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "522fbf8cea4a412501d2a3f2e672dca92dcaaf58f784efc31c48617aa31e52db"
+            "sha256": "9d1352f8ad891b26f48a0734db7bae58c76e8bf78500f343db5e13122b2f1442"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,73 +14,64 @@
         ]
     },
     "default": {
-        "asn1crypto": {
-            "hashes": [
-                "sha256:0b199f211ae690df3db4fd6c1c4ff976497fb1da689193e368eedbadc53d9292",
-                "sha256:bca90060bd995c3f62c4433168eab407e44bdbdb567b3f3a396a676c1a4c4a3f"
-            ],
-            "version": "==1.0.1"
-        },
         "astroid": {
             "hashes": [
-                "sha256:98c665ad84d10b18318c5ab7c3d203fe11714cbad2a4aef4f44651f415392754",
-                "sha256:b7546ffdedbf7abcfbff93cd1de9e9980b1ef744852689decc5aeada324238c6"
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "version": "==2.3.1"
-        },
-        "atomicwrites": {
-            "hashes": [
-                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
-                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
-            ],
-            "version": "==1.3.0"
+            "version": "==2.3.3"
         },
         "attrs": {
             "hashes": [
-                "sha256:ec20e7a4825331c1b5ebf261d111e16fa9612c1f7a5e1f884f12bd53a664dfd2",
-                "sha256:f913492e1663d3c36f502e5e9ba6cd13cf19d7fab50aa13239e420fef95e1396"
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
-            "version": "==19.2.0"
+            "version": "==19.3.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "cffi": {
             "hashes": [
-                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
-                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
-                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
-                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
-                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
-                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
-                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
-                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
-                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
-                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
-                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
-                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
-                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
-                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
-                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
-                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
-                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
-                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
-                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
-                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
-                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
-                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
-                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
-                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
-                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
-                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
-                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
-                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
+                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
+                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
+                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
+                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
+                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
+                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
+                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
+                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
+                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
+                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
+                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
+                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
+                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
+                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
+                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
+                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
+                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
+                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
+                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
+                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
+                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
+                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
+                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
+                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
+                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
+                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
+                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
+                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
+                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
+                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
+                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
+                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
             ],
-            "version": "==1.12.3"
+            "version": "==1.13.2"
         },
         "chardet": {
             "hashes": [
@@ -91,25 +82,30 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
-                "sha256:25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643",
-                "sha256:3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216",
-                "sha256:41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799",
-                "sha256:5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a",
-                "sha256:5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9",
-                "sha256:72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc",
-                "sha256:7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8",
-                "sha256:961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53",
-                "sha256:96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1",
-                "sha256:ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609",
-                "sha256:b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292",
-                "sha256:cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e",
-                "sha256:e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6",
-                "sha256:f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed",
-                "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
+                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
+                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
+                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
+                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
+                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
+                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
+                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
+                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
+                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
+                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
+                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
+                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
+                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
+                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
+                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
+                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
+                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
+                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
+                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
+                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
+                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
             ],
             "index": "pypi",
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "dataclasses": {
             "hashes": [
@@ -121,19 +117,19 @@
         },
         "docker": {
             "hashes": [
-                "sha256:acf51b5e3e0d056925c3b780067a6f753c915fffaa46c5f2d79eb0fc1cbe6a01",
-                "sha256:cc5b2e94af6a2b1e1ed9d7dcbdc77eff56c36081757baf9ada6e878ea0213164"
+                "sha256:6e06c5e70ba4fad73e35f00c55a895a448398f3ada7faae072e2bb01348bafc1",
+                "sha256:8f93775b8bdae3a2df6bc9a5312cce564cade58d6555f2c2570165a1270cd8a7"
             ],
             "index": "pypi",
-            "version": "==4.0.2"
+            "version": "==4.1.0"
         },
         "ecdsa": {
             "hashes": [
-                "sha256:163c80b064a763ea733870feb96f9dd9b92216cfcacd374837af18e4e8ec3d4d",
-                "sha256:9814e700890991abeceeb2242586024d4758c8fc18445b194a49bd62d85861db"
+                "sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e",
+                "sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe"
             ],
             "index": "pypi",
-            "version": "==0.13.3"
+            "version": "==0.14.1"
         },
         "eth-hash": {
             "hashes": [
@@ -152,11 +148,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
-                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
+                "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45",
+                "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.23"
+            "version": "==1.3.0"
         },
         "isort": {
             "hashes": [
@@ -167,26 +163,29 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf",
-                "sha256:18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3",
-                "sha256:1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce",
-                "sha256:2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f",
-                "sha256:616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f",
-                "sha256:63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0",
-                "sha256:77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e",
-                "sha256:83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905",
-                "sha256:84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8",
-                "sha256:874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2",
-                "sha256:9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009",
-                "sha256:a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a",
-                "sha256:a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512",
-                "sha256:ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5",
-                "sha256:ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e",
-                "sha256:b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4",
-                "sha256:c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f",
-                "sha256:fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "mccabe": {
             "hashes": [
@@ -197,34 +196,37 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
-                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==7.2.0"
+            "version": "==8.0.2"
         },
         "mypy": {
             "hashes": [
-                "sha256:0107bff4f46a289f0e4081d59b77cef1c48ea43da5a0dbf0005d54748b26df2a",
-                "sha256:07957f5471b3bb768c61f08690c96d8a09be0912185a27a68700f3ede99184e4",
-                "sha256:10af62f87b6921eac50271e667cc234162a194e742d8e02fc4ddc121e129a5b0",
-                "sha256:11fd60d2f69f0cefbe53ce551acf5b1cec1a89e7ce2d47b4e95a84eefb2899ae",
-                "sha256:15e43d3b1546813669bd1a6ec7e6a11d2888db938e0607f7b5eef6b976671339",
-                "sha256:352c24ba054a89bb9a35dd064ee95ab9b12903b56c72a8d3863d882e2632dc76",
-                "sha256:437020a39417e85e22ea8edcb709612903a9924209e10b3ec6d8c9f05b79f498",
-                "sha256:49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4",
-                "sha256:6724fcd5777aa6cebfa7e644c526888c9d639bd22edd26b2a8038c674a7c34bd",
-                "sha256:7a17613f7ea374ab64f39f03257f22b5755335b73251d0d253687a69029701ba",
-                "sha256:cdc1151ced496ca1496272da7fc356580e95f2682be1d32377c22ddebdf73c91"
+                "sha256:02d9bdd3398b636723ecb6c5cfe9773025a9ab7f34612c1cde5c7f2292e2d768",
+                "sha256:088f758a50af31cf8b42688118077292370c90c89232c783ba7979f39ea16646",
+                "sha256:28e9fbc96d13397a7ddb7fad7b14f373f91b5cff538e0772e77c270468df083c",
+                "sha256:30e123b24931f02c5d99307406658ac8f9cd6746f0d45a3dcac2fe5fbdd60939",
+                "sha256:3294821b5840d51a3cd7a2bb63b40fc3f901f6a3cfb3c6046570749c4c7ef279",
+                "sha256:41696a7d912ce16fdc7c141d87e8db5144d4be664a0c699a2b417d393994b0c2",
+                "sha256:4f42675fa278f3913340bb8c3371d191319704437758d7c4a8440346c293ecb2",
+                "sha256:54d205ccce6ed930a8a2ccf48404896d456e8b87812e491cb907a355b1a9c640",
+                "sha256:6992133c95a2847d309b4b0c899d7054adc60481df6f6b52bb7dee3d5fd157f7",
+                "sha256:6ecbd0e8e371333027abca0922b0c2c632a5b4739a0c61ffbd0733391e39144c",
+                "sha256:83fa87f556e60782c0fc3df1b37b7b4a840314ba1ac27f3e1a1e10cb37c89c17",
+                "sha256:c87ac7233c629f305602f563db07f5221950fe34fe30af072ac838fa85395f78",
+                "sha256:de9ec8dba773b78c49e7bec9a35c9b6fc5235682ad1fc2105752ae7c22f4b931",
+                "sha256:f385a0accf353ca1bca4bbf473b9d83ed18d923fdb809d3a70a385da23e25b6a"
             ],
             "index": "pypi",
-            "version": "==0.720"
+            "version": "==0.750"
         },
         "mypy-extensions": {
             "hashes": [
-                "sha256:37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812",
-                "sha256:b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
             ],
-            "version": "==0.4.1"
+            "version": "==0.4.3"
         },
         "packaging": {
             "hashes": [
@@ -235,10 +237,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
-                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "py": {
             "hashes": [
@@ -255,51 +257,55 @@
         },
         "pycryptodome": {
             "hashes": [
-                "sha256:0281dc6a65a4d0d9e439f54e0ad5faf27bfdc2ebe9ead36912bac74a0920fa2e",
-                "sha256:02af9b284f5c9a55f06f5e4532c16c9b7bd958e293e93969934d864ef7bd87ee",
-                "sha256:09da99372fb69762e4b9690291176a166cc351793e2e1c9405d29ca291503aa8",
-                "sha256:0c2400ccfc049c3f24e65d4f02bb4208d86e408011019e455fab7f50d2b226c9",
-                "sha256:2081dd6dce6b21bf3596427edaedd4f2561dce616893b162ed2c674f3a3ca70a",
-                "sha256:28b86ec9fdb005a2a18e4862a3a7277046738825ee8dc89cda5657e75a396089",
-                "sha256:2d790c0d4c0d5edcf5fbab4e2af7b03757e40c5ae8d217f0dfe9ddea37fe130f",
-                "sha256:2f24906153dca16528cf5515b1afa9ef635423d5a654904e861765f88ca667b6",
-                "sha256:30d283939896fa4bacbdb9fa86e6fd51e9a5b953a511e210b38481f697f289f5",
-                "sha256:31f78b67f97830d137f74813c0502a181a03b43a32ed124049bb20428176c307",
-                "sha256:33c1f3a380fd38ab4dd4372bef17e98002b360b52814bb1b077693b1bd06ec87",
-                "sha256:34091e9a6650c44e25339f22fc821396f19f152f65be2546edd823a093fb5a04",
-                "sha256:567fb73951ab6865a2eb1a0060b54be1e27302574f6c65879525bdf53fab49e1",
-                "sha256:5bc40f8aa7ba8ca7f833ad2477b9d84e1bfd2630b22a46d9bbd221982f8c3ac0",
-                "sha256:6b0a0ccf33c7a6100c569667c888335a4aaf0d22218cb97b4963a65d70f6c343",
-                "sha256:71b93157f1ce93fc7cfff9359b76def2b4826a7ef7a7f95e070161368e7f584a",
-                "sha256:7d939d511b7dac29b2d936706786771ecb8256e43fade5cdb0e8bc58f02b86cf",
-                "sha256:7fbc5a93d52e4c51487f4648b00dc41700adb144d10fc567b05f852e76c243ad",
-                "sha256:9cb94b8f9c915a5d2b273d612a25a8e5d67b49543f8eb6bcec0275ac46cda421",
-                "sha256:a585ea1722f9731e75881d5ffcc51d11c794d244ac57e7c2a9cbb8d5ac729302",
-                "sha256:a6458dd7a10ae51f6fce56bdfc79bf6d3b54556237045d09e77fbda9d6d37864",
-                "sha256:a9fb92e948128bce0239b87c6efcf2cb1c5a703d0b41dd6835211e6fafd1c5df",
-                "sha256:b0b6b4ca1c53e7d6ca9f2720919f63837f05e7a5f92912a2bc29bfd03ed3b54f",
-                "sha256:b7d22c8d648aaa3a7ec785eda544402141eb78ac5ffbba4cbe2c3a1f52276870",
-                "sha256:bc9560574a868cfa2ba781b7bb0b4685b08ea251697abfc49070ffc05e1cbee6",
-                "sha256:c0c5a576f3f7b7de3f86889cb47eb51b59dc11db9cf1e2a0f51eb4d988010ea4",
-                "sha256:e1c91c2fa942a71c98a7a1f462de6dbbe82f34b9267eb8131314d97bd13bf0d4",
-                "sha256:ec936361ad78aa95382c313df95777795b8185aac5dd3ec5463363ea94b556fc"
+                "sha256:042ae873baadd0c33b4d699a5c5b976ade3233a979d972f98ca82314632d868c",
+                "sha256:0502876279772b1384b660ccc91563d04490d562799d8e2e06b411e2d81128a9",
+                "sha256:2de33ed0a95855735d5a0fc0c39603314df9e78ee8bbf0baa9692fb46b3b8bbb",
+                "sha256:319e568baf86620b419d53063b18c216abf924875966efdfe06891b987196a45",
+                "sha256:4372ec7518727172e1605c0843cdc5375d4771e447b8148c787b860260aae151",
+                "sha256:48821950ffb9c836858d8fa09d7840b6df52eadd387a3c5acece55cb387743f9",
+                "sha256:4b9533d4166ca07abdd49ce9d516666b1df944997fe135d4b21ac376aa624aff",
+                "sha256:54456cf85130e01674d21fb1ab89ffccacb138a8ade88d72fa2b0ac898d2798b",
+                "sha256:56fdd0e425f1b8fd3a00b6d96351f86226674974814c50534864d0124d48871f",
+                "sha256:57b1b707363490c495ad0eeb38bd1b0e1697c497af25fad78d3a1ebf0477fd5b",
+                "sha256:5c485ed6e9718ebcaa81138fa70ace9c563d202b56a8cee119b4085b023931f5",
+                "sha256:63c103a22cbe9752f6ea9f1a0de129995bad91c4d03a66c67cffcf6ee0c9f1e1",
+                "sha256:68fab8455efcbfe87c5d75015476f9b606227ffe244d57bfd66269451706e899",
+                "sha256:6c2720696b10ae356040e888bde1239b8957fe18885ccf5e7b4e8dec882f0856",
+                "sha256:72166c2ac520a5dbd2d90208b9c279161ec0861662a621892bd52fb6ca13ab91",
+                "sha256:7c52308ac5b834331b2f107a490b2c27de024a229b61df4cdc5c131d563dfe98",
+                "sha256:87d8d85b4792ca5e730fb7a519fbc3ed976c59dcf79c5204589c59afd56b9926",
+                "sha256:896e9b6fd0762aa07b203c993fbbee7a1f1a4674c6886afd7bfa86f3d1be98a8",
+                "sha256:8a799bea3c6617736e914a2e77c409f52893d382f619f088f8a80e2e21f573c1",
+                "sha256:9d9945ac8375d5d8e60bd2a2e1df5882eaa315522eedf3ca868b1546dfa34eba",
+                "sha256:9ef966c727de942de3e41aa8462c4b7b4bca70f19af5a3f99e31376589c11aac",
+                "sha256:a168e73879619b467072509a223282a02c8047d932a48b74fbd498f27224aa04",
+                "sha256:a30f501bbb32e01a49ef9e09ca1260e5ab49bf33a257080ec553e08997acc487",
+                "sha256:a8ca2450394d3699c9f15ef25e8de9a24b401933716a1e39d37fa01f5fe3c58b",
+                "sha256:aec4d42deb836b8fb3ba32f2ba1ef0d33dd3dc9d430b1479ee7a914490d15b5e",
+                "sha256:b4af098f2a50f8d048ab12cabb59456585c0acf43d90ee79782d2d6d0ed59dba",
+                "sha256:b55c60c321ac91945c60a40ac9896ac7a3d432bb3e8c14006dfd82ad5871c331",
+                "sha256:c53348358408d94869059e16fba5ff3bef8c52c25b18421472aba272b9bb450f",
+                "sha256:cbfd97f9e060f0d30245cd29fa267a9a84de9da97559366fca0a3f7655acc63f",
+                "sha256:d3fe3f33ad52bf0c19ee6344b695ba44ffbfa16f3c29ca61116b48d97bd970fb",
+                "sha256:e3a79a30d15d9c7c284a7734036ee8abdb5ca3a6f5774d293cdc9e1358c1dc10",
+                "sha256:eec0689509389f19875f66ae8dedd59f982240cdab31b9f78a8dc266011df93a"
             ],
             "index": "pypi",
-            "version": "==3.8.2"
+            "version": "==3.9.4"
         },
         "pylint": {
             "hashes": [
-                "sha256:7edbae11476c2182708063ac387a8f97c760d9cfe36a5ede0ca996f90cf346c8",
-                "sha256:844ce067788028c1a35086a5c66bc5e599ddd851841c41d6ee1623b36774d9f2"
+                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
+                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.4"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pyrchain": {
             "git": "https://github.com/rchain/pyrchain.git",
@@ -307,11 +313,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6ef6d06de77ce2961156013e9dff62f1b2688aa04d0dc244299fe7d67e09370d",
-                "sha256:a736fed91c12681a7b34617c8fcefe39ea04599ca72c608751c31d89579a3f77"
+                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
+                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
+            "version": "==5.3.2"
         },
         "pytest-json": {
             "hashes": [
@@ -334,31 +340,37 @@
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
+            "index": "pypi",
             "version": "==2.22.0"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "typed-ast": {
             "hashes": [
+                "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161",
                 "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
                 "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
                 "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
                 "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47",
                 "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
                 "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
                 "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
                 "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2",
+                "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e",
                 "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
                 "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
                 "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
                 "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
                 "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
                 "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66",
                 "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
             ],
             "markers": "implementation_name == 'cpython' and python_version < '3.8'",
@@ -366,20 +378,20 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95",
-                "sha256:b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87",
-                "sha256:d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"
+                "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2",
+                "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d",
+                "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"
             ],
             "index": "pypi",
-            "version": "==3.7.4"
+            "version": "==3.7.4.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
             ],
             "index": "pypi",
-            "version": "==1.25.3"
+            "version": "==1.25.7"
         },
         "wcwidth": {
             "hashes": [
@@ -412,58 +424,64 @@
     "develop": {
         "future": {
             "hashes": [
-                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "version": "==0.17.1"
+            "version": "==0.18.2"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
-                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
+                "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45",
+                "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.23"
+            "version": "==1.3.0"
         },
         "jedi": {
             "hashes": [
-                "sha256:2bb0603e3506f708e792c7f4ad8fc2a7a9d9c2d292a358fbbd58da531695595b",
-                "sha256:2c6bcd9545c7d6440951b12b44d373479bf18123a401a52025cf98563fbd826c"
+                "sha256:786b6c3d80e2f06fd77162a07fed81b8baa22dde5d62896a790a331d6ac21a27",
+                "sha256:ba859c74fa3c966a22f2aeebe1b74ee27e2a462f56d3f5f7ca4a59af61bfe42e"
             ],
-            "version": "==0.13.3"
+            "version": "==0.15.1"
         },
         "more-itertools": {
             "hashes": [
-                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
-                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
             ],
-            "version": "==7.2.0"
+            "version": "==8.0.2"
         },
         "parso": {
             "hashes": [
-                "sha256:63854233e1fadb5da97f2744b6b24346d2750b85965e7e399bec1620232797dc",
-                "sha256:666b0ee4a7a1220f65d367617f2cd3ffddff3e205f3f16a0284df30e774c2a9c"
+                "sha256:55cf25df1a35fd88b878715874d2c4dc1ad3f0eebd1e0266a67e1f55efccfbe1",
+                "sha256:5c1f7791de6bd5dbbeac8db0ef5594b36799de198b3f7f7014643b0c5536b9d3"
             ],
-            "version": "==0.5.1"
+            "version": "==0.5.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
-                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "python-jsonrpc-server": {
             "hashes": [
-                "sha256:59ce9c9523c14c493a327b3a27ee37464a36dc2b9d8ab485ecbcedd38840380a"
+                "sha256:05bcf26eac4c98c96afec266acdf563d8f454e12612da9a3f9aabb66c46daf35"
             ],
-            "version": "==0.2.0"
+            "version": "==0.3.2"
         },
         "python-language-server": {
             "hashes": [
-                "sha256:77c6d043bd4bc7c32f56d80ff12bcd93d341043da89a76bffe3b6fd263ebb165"
+                "sha256:b8c5540d66afdda64c0811f008d93a79fb847920301681bdcb117a17184f06c7"
             ],
             "index": "pypi",
-            "version": "==0.27.0"
+            "version": "==0.31.2"
+        },
+        "ujson": {
+            "hashes": [
+                "sha256:f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86"
+            ],
+            "version": "==1.35"
         },
         "zipp": {
             "hashes": [

--- a/integration-tests/test/conftest.py
+++ b/integration-tests/test/conftest.py
@@ -189,9 +189,12 @@ def testing_context(command_line_options: CommandLineOptions,
 
 testing_context.__test__ = False # type: ignore
 
-
+STANDALONE_KEY = PrivateKey.from_hex("ff2ba092524bafdbc85fa0c7eddb2b41c69bc9bf066a4711a8a16f749199e5be")
 @pytest.yield_fixture(scope='module')
 def started_standalone_bootstrap_node(command_line_options: CommandLineOptions, random_generator: Random, docker_client: DockerClient) -> Generator[Node, None, None]:
-    with testing_context(command_line_options, random_generator, docker_client) as context:
+    wallet_dict = {
+        STANDALONE_KEY: 100000000
+    }
+    with testing_context(command_line_options, random_generator, docker_client, wallets_dict=wallet_dict) as context:
         with ready_bootstrap_with_network(context=context) as bootstrap_node:
             yield bootstrap_node

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -1,0 +1,118 @@
+import time
+from dataclasses import dataclass
+from typing import Optional, List, Union, Dict
+import requests
+from rchain.crypto import PrivateKey
+from rchain.pb.CasperMessage_pb2 import DeployDataProto
+from rchain.util import sign_deploy_data
+
+class HttpRequestException(Exception):
+   def __init__(self, status_code: int, content: str):
+       super(HttpRequestException, self).__init__()
+       self.status_code = status_code
+       self.content = content
+
+@dataclass
+class ApiStatus:
+    version: int
+    message: str
+
+@dataclass
+class PrepareResponse:
+    names: List[str]
+    block_number: int
+
+
+@dataclass
+class DataResponse:
+    exprs: List[Union[str, int]]
+    length: int
+
+def _check_reponse(response: requests.Response) -> None:
+    if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+        raise HttpRequestException(response.status_code, response.text)
+
+class HttpClient():
+    def __init__(self, host: str, port: int):
+        super().__init__()
+        self.host = host
+        self.port = port
+        self.url = "http://{}:{}/api".format(host, port)
+
+
+    def status(self) -> ApiStatus:
+        status_url = self.url+'/status'
+        rep = requests.get(status_url)
+        _check_reponse(rep)
+        message = rep.json()
+        return ApiStatus(version=message['version'], message=message['message'])
+
+    def prepare_deploy(self, deployer: Optional[str] =None, timestamp: Optional[int] = None, name_qty: Optional[int] = None) -> PrepareResponse:
+        prepare_deploy_url = self.url + '/prepare-deploy'
+        if deployer and timestamp and name_qty:
+            data = {
+                "deployer":deployer,
+                "timestamp": timestamp,
+                "nameQty": name_qty
+            }
+            rep = requests.post(prepare_deploy_url,json=data)
+        else:
+            rep = requests.get(prepare_deploy_url)
+        _check_reponse(rep)
+        message = rep.json()
+        return PrepareResponse(names=message['names'], block_number=message['blockNumber'])
+
+    def deploy(self, term: str, phlo_limit: int, phlo_price: int, valid_after_block_number: int, deployer: PrivateKey) -> str:
+        timestamp = int(time.time()* 1000)
+        deploy_data = {
+            "term": term,
+            "timestamp": timestamp,
+            "phloLimit": phlo_limit,
+            "phloPrice": phlo_price,
+            "validAfterBlockNumber": valid_after_block_number
+        }
+        deploy_proto = DeployDataProto(term=term, timestamp=timestamp, phloLimit=phlo_limit, phloPrice=phlo_price, validAfterBlockNumber=valid_after_block_number)
+        deploy_req = {
+            "data": deploy_data,
+            "deployer": deployer.get_public_key().to_hex(),
+            "signature": sign_deploy_data(deployer, deploy_proto).hex(),
+            "sigAlgorithm": "secp256k1"
+        }
+        deploy_url = self.url + '/deploy'
+        rep = requests.post(deploy_url, json=deploy_req)
+        _check_reponse(rep)
+        return rep.text
+
+    def data_at_name(self, name: str, depth: int, name_type: str) -> DataResponse:
+        data_at_name_url = self.url + '/data-at-name'
+        rep =requests.post(data_at_name_url, json={"name": {name_type: {"data": name}}, "depth": depth})
+        _check_reponse(rep)
+        message = rep.json()
+        return DataResponse(exprs=message['exprs'], length=message['length'])
+
+    def last_finalized_block(self) -> Dict:
+        last_finalized_block_url = self.url + '/last-finalized-block'
+        rep = requests.get(last_finalized_block_url)
+        _check_reponse(rep)
+        return rep.json()
+
+    def get_block(self, block_hash: str) -> Dict:
+        block_url = self.url + '/block/' + block_hash
+        rep = requests.get(block_url)
+        _check_reponse(rep)
+        return rep.json()
+
+    def get_blocks(self, depth: Optional[int]) -> List[Dict]:
+        if depth:
+            blocks_url = self.url + "/blocks/{}".format(depth)
+        else:
+            blocks_url = self.url + "/blocks"
+        rep = requests.get(blocks_url)
+        _check_reponse(rep)
+        return rep.json()
+
+    def get_deploy(self, deploy_id: str) -> Dict:
+        deploy_url = self.url + "/deploy/{}".format(deploy_id)
+        rep = requests.get(deploy_url)
+        _check_reponse(rep)
+        return rep.json()

--- a/integration-tests/test/node_client.py
+++ b/integration-tests/test/node_client.py
@@ -4,8 +4,6 @@ from concurrent import futures
 from contextlib import contextmanager
 from queue import Queue, Empty
 from typing import Generator, Iterator
-import os
-import subprocess
 from pathlib import Path
 import grpc
 from cryptography.hazmat.backends import default_backend
@@ -31,6 +29,7 @@ from rchain.pb.routing_pb2_grpc import (
 )
 from docker import DockerClient
 
+from .utils import get_node_ip_of_network
 from .rnode import Node as RNode
 from .common import TestingContext
 
@@ -67,43 +66,6 @@ def get_free_tcp_port() -> int:
         tcp.close()
     return port
 
-@contextmanager
-def get_node_ip_of_network(docker_client: DockerClient, network_name: str) -> Generator[str, None, None]:
-    """
-    In a drone mode, the current pytest process is within a docker container.In order
-    to create the connection with the node, we have to attach the current pytest container
-    to the node network.
-
-    In a local linux mode, the current pytest process is a normal system process which is
-    running in the host machine. So as for the container, the gateway ip is the host
-    machine ip.
-
-    WARNING: For Windows and MacOS, you can not connect to the container from host
-    without any other configuration. For more info, see https://github.com/docker/for-mac/issues/2670.
-    """
-    if os.environ.get("DRONE") == 'true':
-        current_container_id = get_current_container_id()
-        current_container = docker_client.containers.get(current_container_id)
-        network = docker_client.networks.get(network_name)
-        try:
-            network.connect(current_container)
-            network.reload()
-            container_network_config =network.attrs['Containers'][current_container.id]
-            ip, _ = container_network_config['IPv4Address'].split('/')
-            yield ip
-        finally:
-            network.disconnect(current_container)
-    else:
-        network_attr = docker_client.networks.get(network_name).attrs
-        ipam_attr = network_attr.get("IPAM")
-        assert ipam_attr is not None
-        ip = ipam_attr['Config'][0]['Gateway']
-        yield ip
-
-
-def get_current_container_id() -> str:
-    hostname = subprocess.run(['hostname'], check=True, stdout=subprocess.PIPE)
-    return hostname.stdout.decode('utf8').strip("\n")
 
 
 class TransportServer(TransportLayerServicer):
@@ -163,10 +125,7 @@ class NodeClient:
         return Header(sender=self.node_pb, networkId=self.network_id)
 
     def get_peer_node_ip(self, rnode: RNode) -> str:
-        rnode.container.reload()
-        network_config = rnode.container.attrs['NetworkSettings']['Networks'][self.network_name]
-        assert network_config is not None
-        return network_config['IPAddress']
+        return rnode.get_peer_node_ip(self.network_name)
 
     def _start_transport_server(self) -> grpc.Server:
         server_credential = grpc.ssl_server_credentials([(self.node_pem_key, self.node_pem_cert)])

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -129,6 +129,12 @@ class Node:
                 return ''
             raise
 
+    def get_peer_node_ip(self, network_name: str) -> str:
+        self.container.reload()
+        network_config = self.container.attrs['NetworkSettings']['Networks'][network_name]
+        assert network_config is not None
+        return network_config['IPAddress']
+
     def cleanup(self) -> None:
         self.container.remove(force=True, v=True)
         self.terminate_background_logging_event.set()

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -1,0 +1,57 @@
+from typing import Generator, Tuple, List
+import pytest
+from docker import DockerClient
+from .rnode import Node
+from .conftest import STANDALONE_KEY
+from .utils import get_node_ip_of_network
+from .http_client import HttpClient
+
+@pytest.fixture(scope="module")
+def node_with_blocks(started_standalone_bootstrap_node: Node, docker_client: DockerClient) -> Generator[Tuple[Node, List[str], List[str]], None, None]:
+    deploy_hash = []
+    block_hash = []
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    block_hash.append(started_standalone_bootstrap_node.propose())
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    block_hash.append(started_standalone_bootstrap_node.propose())
+    deploy_hash.append(started_standalone_bootstrap_node.deploy('/opt/docker/examples/tut-hello.rho', STANDALONE_KEY, 100000, 1))
+    block_hash.append(started_standalone_bootstrap_node.propose())
+    with get_node_ip_of_network(docker_client, started_standalone_bootstrap_node.network):
+        yield (started_standalone_bootstrap_node, deploy_hash, block_hash)
+
+
+def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
+    node = node_with_blocks[0]
+    deploy_hash = node_with_blocks[1]
+    block_hash = node_with_blocks[2]
+    ip = node.get_peer_node_ip(node.network)
+    client = HttpClient(ip, 40403)
+
+    status = client.status()
+    assert status.version
+    prepare_rep = client.prepare_deploy()
+    assert prepare_rep.block_number == 3
+    prepare_rep_2 = client.prepare_deploy(STANDALONE_KEY.get_public_key().to_hex(), 1, 1)
+    assert prepare_rep_2.block_number == 3
+
+    data_at_name = client.data_at_name(deploy_hash[0], 1, "UnforgDeploy")
+    assert data_at_name.length == 0
+    assert data_at_name.exprs == []
+
+    last_finalized = client.last_finalized_block()
+    assert "blockInfo" in last_finalized
+    assert "deploys" in last_finalized
+
+    block = client.get_block(block_hash[0])
+    assert "blockInfo" in block
+    assert "deploys" in block
+
+    assert len(client.get_blocks(10)) == 4
+
+    deploy_block = client.get_deploy(deploy_hash[0])
+    assert "blockHash" in deploy_block
+    assert "seqNum" in deploy_block
+
+    ret = client.deploy("@2!(1)", 100000, 1, 5, STANDALONE_KEY)
+    assert ret is not None
+

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -404,6 +404,11 @@ class NodeRuntime private[node] (
           )
       _ <- servers.kademliaRPCServer.start.toReaderT
 
+      // HTTP server is started immediately on `acquireServers`
+      _ <- Log[TaskEnv].info(
+            s"HTTP API server started at $host:${conf.server.httpPort}"
+          )
+
       _ <- Log[TaskEnv].info(
             s"Kademlia RPC server started at $host:${servers.kademliaRPCServer.port}"
           )

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -1,0 +1,340 @@
+package coop.rchain.node.api
+
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.BlockStore
+import coop.rchain.casper.SafetyOracle
+import coop.rchain.casper.api.BlockAPI
+import coop.rchain.casper.engine.EngineCell.EngineCell
+import coop.rchain.casper.protocol.{
+  BondInfo,
+  DataWithBlockInfo,
+  DeployData,
+  DeployInfo,
+  BlockInfo => BlockInfoProto,
+  LightBlockInfo => LightBlockInfoProto
+}
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.{SignaturesAlg, Signed}
+import coop.rchain.metrics.Span
+import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
+import coop.rchain.models._
+import coop.rchain.node.api.WebApi._
+import coop.rchain.shared.Log
+
+trait WebApi[F[_]] {
+  def status: F[ApiStatus]
+
+  // Get data to create deploy
+  def prepareDeploy(request: Option[PrepareRequest]): F[PrepareResponse]
+
+  // Write data (deploy)
+  def deploy(request: Signed[DeployData]): F[String]
+
+  // Read data (listen)
+  def listenForDataAtName(request: DataRequest): F[DataResponse]
+
+  // Blocks info
+
+  def lastFinalizedBlock: F[BlockInfo]
+
+  def getBlock(hash: String): F[BlockInfo]
+
+  def getBlocks(depth: Option[Int]): F[List[LightBlockInfo]]
+}
+
+object WebApi {
+
+  class WebApiImpl[F[_]: Sync: Concurrent: EngineCell: Log: Span: SafetyOracle: BlockStore]
+      extends WebApi[F] {
+    import WebApiSyntax._
+
+    def prepareDeploy(req: Option[PrepareRequest]): F[PrepareResponse] = {
+      val blockNumber = BlockAPI
+        .getBlocks[F](1.some)
+        .flatMap(_.leftToError)
+        .map(_.headOption.map(_.blockNumber).getOrElse(-1L))
+
+      val previewNames = req.fold(List[String]().pure) { r =>
+        BlockAPI
+          .previewPrivateNames[F](toByteString(r.deployer), r.timestamp, r.nameQty)
+          .flatMap(_.leftToError)
+          .map(_.map(toHex).toList)
+      }
+
+      previewNames.map2(blockNumber)(PrepareResponse)
+    }
+
+    def deploy(request: Signed[DeployData]): F[String] =
+      BlockAPI.deploy(request).flatMap(_.leftToError)
+
+    def listenForDataAtName(req: DataRequest): F[DataResponse] =
+      BlockAPI
+        .getListeningNameDataResponse(req.depth, toPar(req))
+        .flatMap(_.leftToError)
+        .map(toDataResponse)
+
+    def lastFinalizedBlock: F[BlockInfo] =
+      BlockAPI.lastFinalizedBlock[F].flatMap(_.leftToError).map(toBlockInfo)
+
+    def getBlock(hash: String): F[BlockInfo] =
+      BlockAPI.getBlock[F](hash).flatMap(_.leftToError).map(toBlockInfo)
+
+    def getBlocks(depth: Option[Int]): F[List[LightBlockInfo]] =
+      BlockAPI.getBlocks[F](depth).flatMap(_.leftToError).map(_.map(toLightBlockInfo))
+
+    def status: F[ApiStatus] =
+      ApiStatus(
+        version = 1,
+        message = "OK"
+      ).pure
+  }
+
+  // API request & response types
+
+  final case class SignedDeploy(
+      data: DeployData,
+      deployer: String,
+      signature: String,
+      sigAlgorithm: String
+  )
+
+  // Rholang terms interesting for translation to JSON
+
+  sealed trait RhoExpr
+  // Nested expressions
+  final case class ExprPar(data: List[RhoExpr])        extends RhoExpr
+  final case class ExprList(data: List[RhoExpr])       extends RhoExpr
+  final case class ExprTuple(data: List[RhoExpr])      extends RhoExpr
+  final case class ExprMap(data: Map[String, RhoExpr]) extends RhoExpr
+  // Terminal expressions (here is the data)
+  final case class ExprBool(data: Boolean)  extends RhoExpr
+  final case class ExprInt(data: Long)      extends RhoExpr
+  final case class ExprString(data: String) extends RhoExpr
+  final case class ExprUri(data: String)    extends RhoExpr
+  // Binary data is encoded as base16 string
+  final case class ExprBytes(data: String)     extends RhoExpr
+  final case class ExprUnforg(data: RhoUnforg) extends RhoExpr
+
+  // Unforgeable name
+  sealed trait RhoUnforg
+  final case class UnforgPrivate(data: String)  extends RhoUnforg
+  final case class UnforgDeploy(data: String)   extends RhoUnforg
+  final case class UnforgDeployer(data: String) extends RhoUnforg
+
+  final case class DataRequest(
+      // For simplicity only one Unforgeable name is allowed
+      // instead of the whole RhoExpr (proto Par)
+      name: RhoUnforg,
+      // Number of blocks in the past to search for data
+      depth: Int
+  )
+
+  final case class DataResponse(
+      exprs: List[RhoExprWithBlock],
+      length: Int
+  )
+
+  final case class RhoExprWithBlock(
+      expr: RhoExpr,
+      block: LightBlockInfo
+  )
+
+  final case class LightBlockInfo(
+      blockHash: String,
+      sender: String,
+      seqNum: Long,
+      sig: String,
+      sigAlgorithm: String,
+      shardId: String,
+      extraBytes: String,
+      version: Long,
+      timestamp: Long,
+      headerExtraBytes: String,
+      parentsHashList: List[String],
+      blockNumber: Long,
+      preStateHash: String,
+      postStateHash: String,
+      bodyExtraBytes: String,
+      bonds: List[BondInfo],
+      blockSize: String,
+      deployCount: Int,
+      faultTolerance: Float
+  )
+
+  final case class BlockInfo(
+      blockInfo: LightBlockInfo,
+      deploys: List[DeployInfo]
+  )
+
+  final case class PrepareRequest(
+      deployer: String,
+      timestamp: Long,
+      nameQty: Int
+  )
+
+  final case class PrepareResponse(
+      names: List[String],
+      blockNumber: Long
+  )
+
+  final case class ApiStatus(
+      version: Int,
+      message: String
+  )
+
+  // Exception thrown by BlockAPI
+  final class BlockApiException(message: String) extends Exception(message)
+
+  // Conversion functions for protobuf generated types
+
+  import WebApiSyntax._
+
+  def toSigned[F[_]: Sync](
+      sd: SignedDeploy
+  ): F[Signed[DeployData]] =
+    for {
+      pkBytes  <- Base16.decode(sd.deployer).noneToError("Public key is not valid base16 format.")
+      sigBytes <- Base16.decode(sd.signature).noneToError("Signature is not valid base16 format.")
+      sig      = ByteString.copyFrom(sigBytes)
+      pk       = PublicKey(pkBytes)
+      sigAlg   <- SignaturesAlg(sd.sigAlgorithm).noneToError("Signature algorithm not supported.")
+      sigData  <- Signed.fromSignedData(sd.data, pk, sig, sigAlg).noneToError("Invalid signature.")
+    } yield sigData
+
+  // Binary converters - protobuf uses ByteString and in JSON is base16 string
+
+  private def toHex(bs: ByteString) = Base16.encode(bs.toByteArray)
+
+  private def toByteString(hexStr: String) = ByteString.copyFrom(Base16.unsafeDecode(hexStr))
+
+  // RhoExpr from protobuf
+
+  private def exprFromParProto(par: Par): Option[RhoExpr] = {
+    val exprs = par.exprs.flatMap(exprFromExprProto) ++ par.unforgeables.flatMap(unforgFromProto)
+    // Implements semantic of Par with Unit: P | Nil ==> P
+    if (exprs.size == 1) exprs.head.some
+    else if (exprs.isEmpty) none
+    else ExprPar(exprs.toList).some
+  }
+
+  private def exprFromExprProto(exp: Expr): Option[RhoExpr] =
+    // Primitive types
+    if (exp.exprInstance.isGBool)
+      ExprBool(exp.getGBool).some
+    else if (exp.exprInstance.isGInt)
+      ExprInt(exp.getGInt).some
+    else if (exp.exprInstance.isGString)
+      ExprString(exp.getGString).some
+    else if (exp.exprInstance.isGUri)
+      ExprUri(exp.getGUri).some
+    else if (exp.exprInstance.isGByteArray)
+      // Binary data as base16 string
+      ExprBytes(toHex(exp.getGByteArray)).some
+    // Tuple
+    else if (exp.exprInstance.isETupleBody)
+      ExprTuple(exp.getETupleBody.ps.flatMap(exprFromParProto).toList).some
+    // List
+    else if (exp.exprInstance.isEListBody)
+      ExprList(exp.getEListBody.ps.flatMap(exprFromParProto).toList).some
+    // Map
+    else if (exp.exprInstance.isEMapBody) {
+      val fields = for {
+        (k, v) <- exp.getEMapBody.ps
+        expr   <- k.exprs.headOption
+        // Only String keys are accepted
+        ExprString(key) <- exprFromExprProto(expr)
+        value           <- exprFromParProto(v)
+      } yield (key, value)
+      ExprMap(fields.toMap).some
+    } else none
+
+  private def unforgFromProto(un: GUnforgeable): Option[ExprUnforg] =
+    if (un.unfInstance.isGPrivateBody)
+      mkUnforgExpr(UnforgPrivate, un.unfInstance.gPrivateBody.get.id).some
+    else if (un.unfInstance.isGDeployIdBody)
+      mkUnforgExpr(UnforgDeploy, un.unfInstance.gDeployIdBody.get.sig).some
+    else if (un.unfInstance.isGDeployerIdBody)
+      mkUnforgExpr(UnforgDeployer, un.unfInstance.gDeployerIdBody.get.publicKey).some
+    else none
+
+  private def mkUnforgExpr(f: String => RhoUnforg, bs: ByteString): ExprUnforg =
+    ExprUnforg(f(toHex(bs)))
+
+  // RhoExpr to protobuf
+
+  private def unforgToUnforgProto(unforg: RhoUnforg): GUnforgeable.UnfInstance = unforg match {
+    case UnforgPrivate(name)  => GPrivateBody(GPrivate(toByteString(name)))
+    case UnforgDeploy(name)   => GDeployIdBody(GDeployId(toByteString(name)))
+    case UnforgDeployer(name) => GDeployerIdBody(GDeployerId(toByteString(name)))
+  }
+
+  // Data request/response protobuf wrappers
+
+  private def toPar(req: DataRequest): Par =
+    Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(req.name))))
+
+  private def toDataResponse(req: (Seq[DataWithBlockInfo], Int)): DataResponse = {
+    val (dbs, length) = req
+    val exprsWithBlock = dbs.foldLeft(List[RhoExprWithBlock]()) { (acc, data) =>
+      val exprs = data.postBlockData.flatMap(exprFromParProto)
+      // Implements semantic of Par with Unit: P | Nil ==> P
+      val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
+      val block = toLightBlockInfo(data.block.get)
+      RhoExprWithBlock(expr, block) +: acc
+    }
+    DataResponse(exprsWithBlock, length)
+  }
+
+  private def toLightBlockInfo(b: LightBlockInfoProto): LightBlockInfo =
+    LightBlockInfo(
+      blockHash = b.blockHash,
+      sender = b.sender,
+      seqNum = b.seqNum,
+      sig = b.sig,
+      sigAlgorithm = b.sigAlgorithm,
+      shardId = b.shardId,
+      extraBytes = toHex(b.extraBytes),
+      version = b.version,
+      timestamp = b.timestamp,
+      headerExtraBytes = toHex(b.headerExtraBytes),
+      parentsHashList = b.parentsHashList.toList,
+      blockNumber = b.blockNumber,
+      preStateHash = b.preStateHash,
+      postStateHash = b.postStateHash,
+      bodyExtraBytes = toHex(b.bodyExtraBytes),
+      bonds = b.bonds.toList,
+      blockSize = b.blockSize,
+      deployCount = b.deployCount,
+      faultTolerance = b.faultTolerance
+    )
+
+  private def toBlockInfo(b: BlockInfoProto): BlockInfo =
+    BlockInfo(
+      blockInfo = toLightBlockInfo(b.blockInfo.get),
+      deploys = b.deploys.toList
+    )
+
+  object WebApiSyntax {
+    implicit final class OptionExt[A](val x: Option[A]) extends AnyVal {
+      def noneToError[F[_]: Sync](error: String): F[A] =
+        x.noneToError(new BlockApiException(error))
+
+      def noneToError[F[_]: Sync](error: Throwable): F[A] =
+        x.fold(Sync[F].raiseError[A](error))(Sync[F].pure)
+    }
+
+    implicit final class EitherStringExt[A](val x: Either[String, A]) extends AnyVal {
+      def leftToError[F[_]: Sync]: F[A] =
+        x.fold(error => Sync[F].raiseError(new BlockApiException(error)), Sync[F].pure)
+    }
+
+    implicit final class EitherThrowExt[A](val x: Either[Throwable, A]) extends AnyVal {
+      def leftToError[F[_]: Sync]: F[A] =
+        x.fold(error => Sync[F].raiseError(error), Sync[F].pure)
+    }
+  }
+
+}

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -43,6 +43,8 @@ trait WebApi[F[_]] {
   def getBlock(hash: String): F[BlockInfo]
 
   def getBlocks(depth: Option[Int]): F[List[LightBlockInfo]]
+
+  def findDeploy(deployId: String): F[LightBlockInfo]
 }
 
 object WebApi {
@@ -84,6 +86,9 @@ object WebApi {
 
     def getBlocks(depth: Option[Int]): F[List[LightBlockInfo]] =
       BlockAPI.getBlocks[F](depth).flatMap(_.leftToError).map(_.map(toLightBlockInfo))
+
+    def findDeploy(deployId: String): F[LightBlockInfo] =
+      BlockAPI.findDeploy[F](toByteString(deployId)).flatMap(_.leftToError).map(toLightBlockInfo)
 
     def status: F[ApiStatus] =
       ApiStatus(

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -44,7 +44,7 @@ object WebApiRoutes {
 
     implicit class MEx[A](val ma: M[A]) {
       // Handle GET requests
-      //   case GET -> Root / "lastFinalizedBlock" =>
+      //   case GET -> Root / "last-finalized-block" =>
       //     webApi.lastFinalizedBlock.handle
       def handle(implicit encoder: EntityEncoder[F, A]): F[Response[F]] =
         mf(ma)
@@ -55,14 +55,14 @@ object WebApiRoutes {
     implicit class RequestEx(val req: Request[F]) {
       // Handle POST requests
       //   case req @ POST -> Root / "deploy" =>
-      //     req.handle[SignedDeploy, String](WebApi.toSigned[M](_) >>= webApi.deploy)
+      //     req.handle[DeployRequest, String](webApi.deploy)
       def handle[A, B](
           f: A => M[B]
       )(implicit decoder: EntityDecoder[F, A], encoder: EntityEncoder[F, B]): F[Response[F]] =
         handleRequest[A, B](req, f)
 
       // Handle POST requests without input parameters
-      //   case req @ POST -> Root / "lastFinalizedBlock" =>
+      //   case req @ POST -> Root / "last-finalized-block" =>
       //     req.handle_(webApi.lastFinalizedBlock)
       def handle_[B](
           f: M[B]
@@ -82,9 +82,9 @@ object WebApiRoutes {
     implicit val dataRespEncoder   = jsonEncoderOf[F, DataResponse]
     implicit val prepareEncoder    = jsonEncoderOf[F, PrepareResponse]
     // Decoders
-    implicit val signedDeployDecoder = jsonOf[F, SignedDeploy]
-    implicit val dataRequestDecoder  = jsonOf[F, DataRequest]
-    implicit val prepareDecoder      = jsonOf[F, PrepareRequest]
+    implicit val deployRequestDecoder = jsonOf[F, DeployRequest]
+    implicit val dataRequestDecoder   = jsonOf[F, DataRequest]
+    implicit val prepareDecoder       = jsonOf[F, PrepareRequest]
 
     HttpRoutes.of[F] {
       case GET -> Root / "status" =>
@@ -101,7 +101,7 @@ object WebApiRoutes {
       // Deploy
 
       case req @ POST -> Root / "deploy" =>
-        req.handle[SignedDeploy, String](WebApi.toSigned[M](_) >>= webApi.deploy)
+        req.handle[DeployRequest, String](webApi.deploy)
 
       // Get data
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -28,7 +28,7 @@ object WebApiRoutes {
       req
         .attemptAs[A]
         .value
-        .flatMap(_.leftToError[F])
+        .flatMap(_.liftTo[F])
         .flatMap(a => mf(f(a)))
         .flatMap(Ok(_))
         .handleErrorWith {

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -1,0 +1,126 @@
+package coop.rchain.node.web
+
+import cats.effect.Sync
+import cats.syntax.all._
+import cats.~>
+import coop.rchain.node.api.WebApi
+import coop.rchain.node.api.WebApi._
+import org.http4s.{HttpRoutes, Response}
+
+object WebApiRoutes {
+  import WebApiSyntax._
+
+  def service[F[_]: Sync, M[_]: Sync](
+      webApi: WebApi[M]
+  )(implicit mf: M ~> F): HttpRoutes[F] = {
+    import io.circe.generic.auto._
+    import io.circe.syntax._
+    import org.http4s.circe._
+    import org.http4s.{EntityDecoder, EntityEncoder, InvalidMessageBodyFailure, Request}
+
+    val dsl = org.http4s.dsl.Http4sDsl[F]
+    import dsl._
+
+    def handleRequest[A, B](req: Request[F], f: A => M[B])(
+        implicit decoder: EntityDecoder[F, A],
+        encoder: EntityEncoder[F, B]
+    ): F[Response[F]] =
+      req
+        .attemptAs[A]
+        .value
+        .flatMap(_.leftToError[F])
+        .flatMap(a => mf(f(a)))
+        .flatMap(Ok(_))
+        .handleErrorWith {
+          // The place where all API errors are handled
+          // TODO: introduce error codes
+          // Request JSON parse errors
+          case err: InvalidMessageBodyFailure =>
+            BadRequest(s"${err.getMessage.take(250)}...".asJson)
+          // Errors from BlockAPI
+          case err: BlockApiException => BadRequest(err.getMessage.asJson)
+          case err: Throwable         => BadRequest(err.getMessage.asJson)
+        }
+
+    implicit class MEx[A](val ma: M[A]) {
+      // Handle GET requests
+      //   case GET -> Root / "lastFinalizedBlock" =>
+      //     webApi.lastFinalizedBlock.handle
+      def handle(implicit encoder: EntityEncoder[F, A]): F[Response[F]] =
+        mf(ma)
+          .flatMap(Ok(_))
+          .handleErrorWith(err => BadRequest(err.getMessage.asJson))
+    }
+
+    implicit class RequestEx(val req: Request[F]) {
+      // Handle POST requests
+      //   case req @ POST -> Root / "deploy" =>
+      //     req.handle[SignedDeploy, String](WebApi.toSigned[M](_) >>= webApi.deploy)
+      def handle[A, B](
+          f: A => M[B]
+      )(implicit decoder: EntityDecoder[F, A], encoder: EntityEncoder[F, B]): F[Response[F]] =
+        handleRequest[A, B](req, f)
+
+      // Handle POST requests without input parameters
+      //   case req @ POST -> Root / "lastFinalizedBlock" =>
+      //     req.handle_(webApi.lastFinalizedBlock)
+      def handle_[B](
+          f: M[B]
+      )(implicit encoder: EntityEncoder[F, B]): F[Response[F]] =
+        handleRequest[Unit, B](req, _ => f)
+    }
+
+    // TODO: Create generic encoders/decoders for
+    // ADT's with discriminator field
+
+    // Encoders
+    implicit val stringEncoder     = jsonEncoderOf[F, String]
+    implicit val apiStatusEncoder  = jsonEncoderOf[F, ApiStatus]
+    implicit val blockInfoEncoder  = jsonEncoderOf[F, BlockInfo]
+    implicit val lightBlockEncoder = jsonEncoderOf[F, List[LightBlockInfo]]
+    implicit val dataRespEncoder   = jsonEncoderOf[F, DataResponse]
+    implicit val prepareEncoder    = jsonEncoderOf[F, PrepareResponse]
+    // Decoders
+    implicit val signedDeployDecoder = jsonOf[F, SignedDeploy]
+    implicit val dataRequestDecoder  = jsonOf[F, DataRequest]
+    implicit val prepareDecoder      = jsonOf[F, PrepareRequest]
+
+    HttpRoutes.of[F] {
+      case GET -> Root / "status" =>
+        webApi.status.handle
+
+      // Prepare deploy
+
+      case GET -> Root / "prepare-deploy" =>
+        webApi.prepareDeploy(none).handle
+
+      case req @ POST -> Root / "prepare-deploy" =>
+        req.handle[PrepareRequest, PrepareResponse](x => webApi.prepareDeploy(x.some))
+
+      // Deploy
+
+      case req @ POST -> Root / "deploy" =>
+        req.handle[SignedDeploy, String](WebApi.toSigned[M](_) >>= webApi.deploy)
+
+      // Get data
+
+      case req @ POST -> Root / "data-at-name" =>
+        req.handle[DataRequest, DataResponse](webApi.listenForDataAtName)
+
+      // Blocks
+
+      case GET -> Root / "last-finalized-block" =>
+        webApi.lastFinalizedBlock.handle
+
+      case GET -> Root / "block" / hash =>
+        webApi.getBlock(hash).handle
+
+      case GET -> Root / "blocks" =>
+        webApi.getBlocks(none).handle
+
+      case GET -> Root / "blocks" / IntVar(depth) =>
+        webApi.getBlocks(depth.some).handle
+    }
+  }
+
+}

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -77,7 +77,8 @@ object WebApiRoutes {
     implicit val stringEncoder     = jsonEncoderOf[F, String]
     implicit val apiStatusEncoder  = jsonEncoderOf[F, ApiStatus]
     implicit val blockInfoEncoder  = jsonEncoderOf[F, BlockInfo]
-    implicit val lightBlockEncoder = jsonEncoderOf[F, List[LightBlockInfo]]
+    implicit val lightBlockEncoder = jsonEncoderOf[F, LightBlockInfo]
+    implicit val lightBlockListEnc = jsonEncoderOf[F, List[LightBlockInfo]]
     implicit val dataRespEncoder   = jsonEncoderOf[F, DataResponse]
     implicit val prepareEncoder    = jsonEncoderOf[F, PrepareResponse]
     // Decoders
@@ -120,6 +121,9 @@ object WebApiRoutes {
 
       case GET -> Root / "blocks" / IntVar(depth) =>
         webApi.getBlocks(depth.some).handle
+
+      case GET -> Root / "deploy" / deployId =>
+        webApi.findDeploy(deployId).handle
     }
   }
 

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -1,0 +1,322 @@
+package coop.rchain.node.web
+
+import cats.data.ReaderT
+import io.circe.generic.semiauto._
+import io.circe._
+import io.circe.syntax._
+import org.http4s.circe._
+import com.google.protobuf.ByteString
+import org.http4s.{EntityBody, _}
+import org.scalatest._
+import coop.rchain.crypto.codec._
+import coop.rchain.crypto.signatures.Signed
+import coop.rchain.node.NodeRuntime
+import coop.rchain.casper.protocol.{BlockInfo, BondInfo, DeployData, DeployInfo, LightBlockInfo}
+import coop.rchain.node.NodeRuntime.TaskEnv
+import coop.rchain.node.api.WebApi
+import coop.rchain.node.api.WebApi._
+import io.circe.Decoder.Result
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+
+class WebApiRoutesTest extends FlatSpec with Matchers {
+  val blockHash        = "blockhash"
+  val sender           = "sender"
+  val seqNum           = 1L
+  val sig              = "sig_str"
+  val sigAlgorithm     = "secp256k1"
+  val shardId          = "rchain"
+  val extraBytes       = ByteString.EMPTY
+  val version          = 1L
+  val timestamp        = 123L
+  val headerExtraBytes = ByteString.EMPTY
+  val parentsList      = List("genesis")
+  val blockNumber      = 1L
+  val preStateHash     = "preHash"
+  val postStateHash    = "postHash"
+  val bodyExtraBytes   = ByteString.EMPTY
+  val bonds            = List[BondInfo](BondInfo("validator_a", 100))
+  val blockSize        = "100"
+  val deployCount      = 1
+  val faultTolerance   = 0.2.toFloat
+  val lightBlock = LightBlockInfo(
+    blockHash,
+    sender,
+    seqNum,
+    sig,
+    sigAlgorithm,
+    shardId,
+    extraBytes,
+    version,
+    timestamp,
+    headerExtraBytes,
+    parentsList,
+    blockNumber,
+    preStateHash,
+    postStateHash,
+    bodyExtraBytes,
+    bonds,
+    blockSize,
+    deployCount,
+    faultTolerance
+  )
+  val deployer              = "a"
+  val term                  = "@2!(1)"
+  val deployTimestamp       = 1000000L
+  val deploySig             = "asdf32ascwef"
+  val deploySigAlgorithm    = "asd"
+  val phloLimit             = 100000L
+  val phloPrice             = 1L
+  val validAfterBlockNumber = 1L
+  val cost                  = 100L
+  val errored               = false
+  val systemDeployError     = ""
+  val deploys = List(
+    DeployInfo(
+      deployer = deployer,
+      term = term,
+      timestamp = deployTimestamp,
+      sig = deploySig,
+      sigAlgorithm = deploySigAlgorithm,
+      phloLimit = phloLimit,
+      phloPrice = phloPrice,
+      validAfterBlockNumber = validAfterBlockNumber,
+      cost = cost,
+      errored = errored,
+      systemDeployError = systemDeployError
+    )
+  )
+  val blockInfo = BlockInfo(
+    blockInfo = Some(lightBlock),
+    deploys = deploys
+  )
+
+  val prepareBlockNumber = 1L
+  val prepareNames       = List[String]("a", "b", "c")
+  val exPRS              = ExprBool(true)
+  val deployRet          = "Success!\\nDeployId is: 111111111111"
+  val dataAtLength       = 5
+
+  implicit class RichTask[A](t: Task[A]) {
+    def toReaderT: TaskEnv[A] =
+      ReaderT.liftF(t)
+  }
+  def genWebApi: WebApi[TaskEnv] = new WebApi[TaskEnv] {
+    override def status: TaskEnv[WebApi.ApiStatus] =
+      Task
+        .delay(
+          ApiStatus(
+            version = 1,
+            message = "OK"
+          )
+        )
+        .toReaderT
+
+    override def prepareDeploy(
+        request: Option[WebApi.PrepareRequest]
+    ): TaskEnv[WebApi.PrepareResponse] =
+      Task
+        .delay({
+          val names       = prepareNames
+          val blockNumber = prepareBlockNumber
+          WebApi.PrepareResponse(names, blockNumber)
+        })
+        .toReaderT
+
+    override def deploy(request: DeployRequest): TaskEnv[String] =
+      Task.delay(deployRet).toReaderT
+
+    override def listenForDataAtName(request: WebApi.DataRequest): TaskEnv[WebApi.DataResponse] =
+      Task
+        .delay({
+          val exprs = exPRS
+          //        List[RhoExpr](ExprBool(true), ExprInt(1), ExprBytes("a"), ExprString("b"), ExprUri("c"))
+          val exprsWithBlock = WebApi.RhoExprWithBlock(exprs, lightBlock)
+          val data           = List[WebApi.RhoExprWithBlock](exprsWithBlock)
+          WebApi.DataResponse(data, dataAtLength)
+        })
+        .toReaderT
+
+    override def lastFinalizedBlock: TaskEnv[BlockInfo] = Task.delay(blockInfo).toReaderT
+
+    override def getBlock(hash: String): TaskEnv[BlockInfo] = Task.delay(blockInfo).toReaderT
+
+    override def getBlocks(depth: Option[Int]): TaskEnv[List[LightBlockInfo]] =
+      Task.delay(List(lightBlock)).toReaderT
+
+    override def findDeploy(deployId: String): TaskEnv[LightBlockInfo] =
+      Task.delay(lightBlock).toReaderT
+  }
+
+  implicit val decodeByteString: Decoder[ByteString] = new Decoder[ByteString] {
+    override def apply(c: HCursor): Result[ByteString] =
+      if (c.value.isString)
+        Right(
+          Base16
+            .decode(c.value.asString.getOrElse(""))
+            .map(ByteString.copyFrom)
+            .getOrElse(ByteString.EMPTY)
+        )
+      else Left(DecodingFailure("error", List[CursorOp]()))
+  }
+  implicit val decodeBondInfo: Decoder[BondInfo]                 = deriveDecoder[BondInfo]
+  implicit val decodeLightBlockInfo: Decoder[LightBlockInfo]     = deriveDecoder[LightBlockInfo]
+  implicit val decodeDeployInfo: Decoder[DeployInfo]             = deriveDecoder[DeployInfo]
+  implicit val decodeBlockInfo: Decoder[BlockInfo]               = deriveDecoder[BlockInfo]
+  implicit val decodeApiStatus: Decoder[ApiStatus]               = deriveDecoder[ApiStatus]
+  implicit val decodeRhoExpr: Decoder[RhoExpr]                   = deriveDecoder[RhoExpr]
+  implicit val decodeRhoUnforg: Decoder[RhoUnforg]               = deriveDecoder[RhoUnforg]
+  implicit val decodeRhoExprWithBlock: Decoder[RhoExprWithBlock] = deriveDecoder[RhoExprWithBlock]
+  implicit val decodeDataResponse: Decoder[DataResponse]         = deriveDecoder[DataResponse]
+  implicit val decodePrepareResponse: Decoder[PrepareResponse]   = deriveDecoder[PrepareResponse]
+  implicit val encodePrepareRequest: Encoder[PrepareRequest]     = deriveEncoder[PrepareRequest]
+  implicit val et                                                = NodeRuntime.envToTask
+
+  val api   = genWebApi
+  val route = WebApiRoutes.service[Task, TaskEnv](api)
+
+  "GET getBlock" should "detailed block info" in {
+    val resp     = route.run(Request[Task](method = Method.GET, uri = Uri(path = "block/" + blockHash)))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res            <- act_resp
+      _              = res.status should be(Status.Ok)
+      blockInfo      = res.decodeJson[BlockInfo].runSyncUnsafe()
+      lightBlockInfo = blockInfo.blockInfo.get
+      _              = lightBlockInfo should be(lightBlock)
+      deployInfo     = blockInfo.deploys.head
+      _              = deployInfo should be(deploys.head)
+
+    } yield ()
+  }
+
+  "GET getBlocks" should "return a list of LightBlockInfo" in {
+    val resp     = route.run(Request[Task](method = Method.GET, uri = Uri(path = "blocks")))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res    <- act_resp
+      _      = res.status should be(Status.Ok)
+      blocks = res.decodeJson[List[LightBlockInfo]].runSyncUnsafe()
+      block  <- blocks.headOption
+      _      = block should be(lightBlock)
+    } yield ()
+  }
+
+  "GET getApiStatus" should "return api status" in {
+    val resp     = route.run(Request[Task](method = Method.GET, uri = Uri(path = "status")))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[ApiStatus].runSyncUnsafe()
+      _    = body.message should be("OK")
+      _    = body.version should be(1)
+    } yield ()
+  }
+
+  "GET prepareDeploy" should "return latest block number info" in {
+    val resp     = route.run(Request[Task](method = Method.GET, uri = Uri(path = "prepare-deploy")))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[PrepareResponse].runSyncUnsafe()
+      _    = body.blockNumber should be(prepareBlockNumber)
+      _    = body.names should be(prepareNames)
+    } yield ()
+  }
+  "POST prepareDeploy" should "return latest block number info" in {
+    import org.http4s.circe._
+    val b = """{"deployer":"a", "timestamp":10000000, "nameQty":1}"""
+    val resp = route.run(
+      Request[Task](method = Method.POST, uri = Uri(path = "prepare-deploy"))
+        .withEntity(b)
+    )
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[PrepareResponse].runSyncUnsafe()
+      _    = body.blockNumber should be(prepareBlockNumber)
+      _    = body.names should be(prepareNames)
+    } yield ()
+  }
+  "POST deploy" should "return deploy message" in {
+    val deployReq =
+      """{"deployer":"a", "signature":"1sda", "sigAlgorithm":"algorithm",""" +
+        """ "data":{"term":"@2!(1)", "timestamp":1000, "phloPrice":1, "phloLimit":10000, "validAfterBlockNumber":1} }"""
+    val resp = route.run(
+      Request[Task](method = Method.POST, uri = Uri(path = "deploy")).withEntity(deployReq)
+    )
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[String].runSyncUnsafe()
+      _    = body should be(deployRet)
+    } yield ()
+  }
+
+  "POST listenForDataAtName" should "return data at the name" in {
+    val requestBody = """{"name": {"UnforgDeploy":{"data":"a"}}, "depth":1}"""
+    val resp = route.run(
+      Request[Task](method = Method.POST, uri = Uri(path = "data-at-name")).withEntity(requestBody)
+    )
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[DataResponse].runSyncUnsafe()
+      _    = body.length should be(dataAtLength)
+      _    = body.exprs.head.expr should be(exPRS)
+      _    = body.exprs.head.block should be(lightBlock)
+    } yield ()
+  }
+
+  "GET lastFinalizedBlock" should "return BlockInfo" in {
+    val resp =
+      route.run(Request[Task](method = Method.GET, uri = Uri(path = "last-finalized-block")))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[BlockInfo].runSyncUnsafe()
+      _    = body.blockInfo.get should be(lightBlock)
+      _    = body.deploys should be(deploys)
+    } yield ()
+  }
+
+  "GET findDeploy" should "return deployed blockInfo" in {
+    val resp =
+      route.run(Request[Task](method = Method.GET, uri = Uri(path = "deploy/" + deploySig)))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res  <- act_resp
+      _    = res.status should be(Status.Ok)
+      body = res.decodeJson[LightBlockInfo].runSyncUnsafe()
+      _    = body should be(lightBlock)
+    } yield ()
+  }
+
+  "GET unknown uri" should "return 404" in {
+    val resp =
+      route.run(Request[Task](method = Method.GET, uri = Uri(path = "unknown")))
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res <- act_resp
+      _   = res.status should be(Status.NotFound)
+    } yield ()
+  }
+
+  "POST with incorrect data" should "return 400" in {
+    val resp =
+      route.run(
+        Request[Task](method = Method.POST, uri = Uri(path = "deploy")).withEntity("errorData")
+      )
+    val act_resp = resp.value.runSyncUnsafe()
+    for {
+      res <- act_resp
+      _   = res.status should be(Status.BadRequest)
+    } yield ()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.0-M2"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "1.5.0"
+  val catsVersion       = "1.6.1"
   val catsEffectVersion = "1.2.0"
   val catsMtlVersion    = "0.4.0"
   val slf4jVersion      = "1.7.25"


### PR DESCRIPTION
## Overview
Web API should enable much easier use for dApp developers and also connection to RNode from the browser directly.

This PR is introduction of HTTP API. It's missing streaming endpoint now available on WebSockets Events API.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3935

### Notes
Tests will be written in another ticket.
https://rchain.atlassian.net/browse/RCHAIN-3948

### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
