### PR TITLE
Rewrite ReplayRSpace matching

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -170,7 +170,7 @@ private class InMemHotStore[F[_]: Sync, C, P, A, K](
     for {
       cached <- internalGetJoins(channel)
       state  <- S.get
-    } yield (state.installedJoins.get(channel).getOrElse(Seq.empty) ++: cached)
+    } yield (state.installedJoins.getOrElse(channel, Seq.empty) ++: cached)
 
   private[this] def internalGetJoins(channel: C): F[Seq[Seq[C]]] =
     for {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -52,7 +52,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       t.map(d => Random.shuffle(d.zipWithIndex))
   }
 
-  def assertF(predicate: Boolean, errorMsg: String): F[Unit] =
+  def assertF(predicate: Boolean, errorMsg: => String): F[Unit] =
     Sync[F].raiseError(new IllegalStateException(errorMsg)).unlessA(predicate)
 
   protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Seq.empty)

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -45,7 +45,10 @@ final case class COMM(
     produces: Seq[Produce],
     peeks: SortedSet[Int],
     timesRepeated: Map[Produce, Int]
-) extends Event
+) extends Event {
+  def matches(datum: Datum[_], produceCounter: => Int): Boolean =
+    timesRepeated.get(datum.source).exists(count => datum.persist || count == produceCounter)
+}
 
 object COMM {
   def apply[C, A](


### PR DESCRIPTION
Flamegraphs shown that it is very slow. Reference: https://cdn.discordapp.com/attachments/476150978555674644/646102858651009027/cpu_test8.svg

This PR is for now in Draft mode till performance tests we're conducting show that it is useful

## Overview
<sup>_What this PR does, and why it's needed_</sup>
Based on the flamegraph above we can conclude three things:
- Amount of time spent on preparing strings is quite significant. These come from calls to `Log[F]` (but these are lazy) and calls to `assertF` - fixed by making string argument passed to `assertF` lazy
- quite a lot of time spending on looping through sequences, mostly from `zipWithIndex` which is used extensively everywhere!! (this is a sign of really bad design tbh). It made sense to introduce iterated version instead (`seq.iterator.zipWithIndex...toSeq` instead of `seq.zipWithIndex...`) to at least eliminate creation of intermediate collections
- the biggest offender seemed to be `match` call. More specifically it spent a lot of time checking if elements are contained within sequence of `Produce`. Rewritten to make use of `Map` for faster containment check.


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>

Don't think there is any

### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
