### PR TITLE
Remove ad-hoc parallelism bound on Pars.

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2512,7 +2512,17 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
     task.runSyncUnsafe(timeout)
   }
 
-  "term split size max" should "be evaluated (Int16/2 - 1)" in {
+  /**
+    * I chose to ignore this test for reasons mentioned in
+    * https://github.com/rchain/rchain/pull/2814
+    * To quote it here:
+    *   it doesn't matter if this test executes longer or shorter.
+    *   In this particular case the cost of thread pool management is likely much higher than the cost of evaluating terms.
+    *   The test is misguided in this sense.
+    *   The actual parallelism level is function of term complexity which is very low here, so it does not matter if it executes longer or not.
+    *   If it bothers anyone, please change the scheduler used in tests from global to TestScheduler and see the difference.
+    */
+  "term split size max" should "be evaluated (Int16/2 - 1)" ignore {
     implicit val errorLog = new ErrorLog[Task]()
     val p                 = New(bindCount = 1)
     val news              = Seq.fill(Short.MaxValue)(p)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2552,7 +2552,7 @@ class ReduceSpec extends FlatSpec with Matchers with AppendedClues with Persiste
     }
 
     result should be(
-      ReduceError("The number of Pars in the term is 32768, which exceeds the limit of 32767.")
+      ReduceError("The number of terms in the Par is 32768, which exceeds the limit of 32767.")
     )
   }
 }


### PR DESCRIPTION
## Overview
The existing `parallelism` value assumes a 2-to-1 mapping from sub-terms 
of a Par to processors. This assumption is far too strong, since the Par 
evaluation strategy depends entirely on the instance of `Parallel` 
passed to `DebruijnInterpreter`.

Monix discourages users from making assumptions about the evaluation order 
that `parTraverse` chooses, so shuffling terms to increase fairness is
superfluous.

This one slipped by me, but this change includes a comment, "Verify if using 
traverse-per-batch inside parTraverse means that less tasks are spawned
at once". The performance benefits of this change should have been verified
before this PR was merged.

### JIRA ticket:
Unticketed