### PR TITLE
RCHAIN-3967: Fix sorting for New

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/NewSortMatcher.scala
@@ -1,33 +1,36 @@
 package coop.rchain.models.rholang.sorter
 
 import cats.effect.Sync
-import cats.implicits._
-import coop.rchain.models.New
+import cats.syntax.all._
+import cats.instances.list._
+import coop.rchain.models.{New, Par}
 
 private[sorter] object NewSortMatcher extends Sortable[New] {
   def sortMatch[F[_]: Sync](n: New): F[ScoredTerm[New]] =
-    Sortable
-      .sortMatch(n.p)
-      .map {
-        val sortedUri = n.uri.sorted
-        val uriScore =
-          if (sortedUri.nonEmpty)
-            sortedUri.map(Leaf.apply)
-          else
-            List(Leaf(Score.ABSENT))
-
-        sortedPar =>
-          ScoredTerm(
-            New(
-              bindCount = n.bindCount,
-              p = sortedPar.term,
-              uri = sortedUri,
-              injections = n.injections,
-              locallyFree = n.locallyFree
-            ),
-            new Node(
-              Leaf(Score.NEW) +: (Leaf(n.bindCount.toLong) +: uriScore :+ sortedPar.score)
-            )
-          )
-      }
+    for {
+      sortedPar      <- Sortable.sortMatch(n.p)
+      sortedUri      = n.uri.sorted
+      uriScore       = if (sortedUri.nonEmpty) sortedUri.map(Leaf.apply) else List(Leaf(Score.ABSENT))
+      injectionsList = n.injections.toList
+      injectionsScore <- if (injectionsList.nonEmpty)
+                          injectionsList.traverse {
+                            case (k, v) =>
+                              Sortable[Par]
+                                .sortMatch[F](v)
+                                .map(
+                                  scoredTerm => Node(k, scoredTerm.score)
+                                )
+                          } else List(Leaf(Score.ABSENT)).pure[F]
+    } yield ScoredTerm(
+      New(
+        bindCount = n.bindCount,
+        p = sortedPar.term,
+        uri = sortedUri,
+        injections = n.injections,
+        locallyFree = n.locallyFree
+      ),
+      new Node(
+        Leaf(Score.NEW) +: ((Leaf(n.bindCount.toLong) +: uriScore) ++ injectionsScore :+ sortedPar.score)
+      )
+    )
 }

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
@@ -85,6 +85,9 @@ trait ScoreTree {
     // Shortcut to write Node(1, Leaf(1)) instead of Node(Seq(Leaf(ScoreAtom(1)), Leaf(ScoreAtom(1))))
     def apply(left: Int, right: Tree[ScoreAtom]*): Tree[ScoreAtom] =
       new Node(Seq(Leaf(left.toLong)) ++ right)
+
+    def apply(left: String, right: Tree[ScoreAtom]*): Tree[ScoreAtom] =
+      new Node(Seq(Leaf(left)) ++ right)
   }
 
   object ScoredTerm {

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -114,6 +114,24 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     checkScoreEquality[Send]
     checkScoreEquality[Var]
   }
+  it should "sort so that unequal New have unequal scores" in {
+    val new1 = New(
+      bindCount = 1,
+      injections = Map(
+        "" -> Par(
+          bundles = Vector(
+            Bundle(
+              Par(),
+              writeFlag = true
+            )
+          )
+        )
+      )
+    )
+    val new2 = New(bindCount = 1)
+    assert(new1 != new2)
+    assert(sort(new1).score != sort(new2).score)
+  }
   it should "sort so that unequal EMethod have unequal scores" in {
     val method1 = Expr(EMethodBody(EMethod(connectiveUsed = true)))
     val method2 = Expr(EMethodBody(EMethod(connectiveUsed = false)))


### PR DESCRIPTION
## Overview
Injections where previously not considered when calculating the score of a `New`.
Therefore the situation could occur where two `New`s are not equal but have the same score (see test case for an example).

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3967


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
