### PR TITLE
Protect Signed data to be copied (shadow copy method)

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
@@ -12,7 +12,13 @@ final case class Signed[A] private (
     pk: PublicKey,
     sig: ByteString,
     sigAlgorithm: SignaturesAlg
-)
+) {
+  // Protect Signed data to be copied (shadow generated copy function)
+  // - hack is to prevent `unused error`
+  // https://contributors.scala-lang.org/t/removing-copy-operation-from-case-classes-with-private-constructors/2605/2
+  private def copy(): Unit = hack
+  private def hack(): Unit = copy
+}
 
 object Signed {
   def apply[A: Serialize](


### PR DESCRIPTION
## Overview
Signed type has private constructor but generated `copy` method allows to create invalid (with wrong signatures) instances. Creating private `copy` method disables creating generated version.
https://contributors.scala-lang.org/t/removing-copy-operation-from-case-classes-with-private-constructors/2605/2 

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3907

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
