### PR TITLE
RCHAIN-3981 - introduction of exploratory deploy

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -39,7 +39,7 @@ object BlockCreator {
    *  3. Extract all valid deploys that aren't already in all ancestors of S (the parents).
    *  4. Create a new block that contains the deploys from the previous step.
    */
-  def createBlock[F[_]: Sync: Log: Time: BlockStore: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: Metrics](
+  def createBlock[F[_]: Sync: Log: Time: BlockStore: Estimator: DeployStorage: Metrics](
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage,
       validatorIdentity: ValidatorIdentity,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -42,7 +42,7 @@ object CasperState {
   type CasperStateCell[F[_]] = Cell[F, CasperState]
 }
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: CommUtil: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: CommUtil: EventPublisher: Estimator: DeployStorage](
     validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,
     postGenesisStateHash: StateHash,

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -21,7 +21,7 @@ import coop.rchain.crypto.codec.Base16
 import coop.rchain.casper.util.{ConstructDeploy, EventConverter}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.crypto.signatures.Signed
+import coop.rchain.crypto.signatures.{Secp256k1, Signed}
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
@@ -681,8 +681,9 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
   }
 
   def computeBonds(hash: StateHash): F[Seq[Bond]] = {
-    // Create a deploy with built-in private key
-    val deploy = ConstructDeploy.sourceDeployNow(bondsQuerySource)
+    // Create a deploy with newly created private key
+    val (privKey, _) = Secp256k1.newKeyPair
+    val deploy       = ConstructDeploy.sourceDeployNow(bondsQuerySource, sec = privKey)
     captureResults(hash, deploy)
       .ensureOr(
         bondsPar =>

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -21,6 +21,7 @@ class ApiStatus:
 class PrepareResponse:
     names: List[str]
     block_number: int
+    seq_number: int
 
 
 @dataclass
@@ -60,7 +61,7 @@ class HttpClient():
             rep = requests.get(prepare_deploy_url)
         _check_reponse(rep)
         message = rep.json()
-        return PrepareResponse(names=message['names'], block_number=message['blockNumber'])
+        return PrepareResponse(names=message['names'], block_number=message['blockNumber'], seq_number=message['seqNumber'])
 
     def deploy(self, term: str, phlo_limit: int, phlo_price: int, valid_after_block_number: int, deployer: PrivateKey) -> str:
         timestamp = int(time.time()* 1000)

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -31,8 +31,10 @@ def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
     assert status.version
     prepare_rep = client.prepare_deploy()
     assert prepare_rep.block_number == 3
+    assert prepare_rep.seq_number == 3
     prepare_rep_2 = client.prepare_deploy(STANDALONE_KEY.get_public_key().to_hex(), 1, 1)
     assert prepare_rep_2.block_number == 3
+    assert prepare_rep_2.seq_number == 3
 
     data_at_name = client.data_at_name(deploy_hash[0], 1, "UnforgDeploy")
     assert data_at_name.length == 0

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -89,6 +89,7 @@ object WebApiRoutes {
     implicit val lightBlockListEnc = jsonEncoderOf[F, List[LightBlockInfo]]
     implicit val dataRespEncoder   = jsonEncoderOf[F, DataResponse]
     implicit val prepareEncoder    = jsonEncoderOf[F, PrepareResponse]
+    implicit val explRespEncoder   = jsonEncoderOf[F, ExploratoryDeployResponse]
     // Decoders
     implicit val deployRequestDecoder = jsonOf[F, DeployRequest]
     implicit val dataRequestDecoder   = jsonOf[F, DataRequest]
@@ -110,6 +111,9 @@ object WebApiRoutes {
 
       case req @ POST -> Root / "deploy" =>
         req.handle[DeployRequest, String](webApi.deploy)
+
+      case req @ POST -> Root / "explore-deploy" =>
+        req.handle[String, ExploratoryDeployResponse](webApi.exploratoryDeploy)
 
       // Get data
 

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -92,6 +92,7 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
   )
 
   val prepareBlockNumber = 1L
+  val prepareSeqNumber   = 11L
   val prepareNames       = List[String]("a", "b", "c")
   val exPRS              = ExprBool(true)
   val deployRet          = "Success!\\nDeployId is: 111111111111"
@@ -119,7 +120,8 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
         .delay({
           val names       = prepareNames
           val blockNumber = prepareBlockNumber
-          WebApi.PrepareResponse(names, blockNumber)
+          val seqNumber   = prepareSeqNumber
+          WebApi.PrepareResponse(names, blockNumber, seqNumber)
         })
         .toReaderT
 
@@ -146,6 +148,9 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
 
     override def findDeploy(deployId: String): TaskEnv[LightBlockInfo] =
       Task.delay(lightBlock).toReaderT
+
+    // TODO: https://rchain.atlassian.net/browse/RCHAIN-4018
+    override def exploratoryDeploy(term: String): TaskEnv[ExploratoryDeployResponse] = ???
   }
 
   implicit val decodeByteString: Decoder[ByteString] = new Decoder[ByteString] {


### PR DESCRIPTION
## Overview
Exploratory deploy allows clients to get data from the blockchain. Exploratory deploy is executed on top of the last finalized block. Future versions will support custom block hash and other nice features.
**Method can be executed only on read-only RNode**.

Also `prepare-deploy` now returns not only block number but also sequence number which is needed  for deploy as parameter _valid after block number_.

**TODO**: exploratory deploy is for now only exposed on Web API. gRPC endpoint and tests will be done in an additional ticket.
https://rchain.atlassian.net/browse/RCHAIN-4018

The sample JS code to make exploratory deploy through Web API:
**Return channel is the first created unforgeable name**.
```js
const url = 'http://localhost:40403/api/explore-deploy'
const req = {
  method: 'POST',
  body: `new return in { return!(42) }`
}
fetch(url, req).then(r => r.json()).then(console.log)
// Returns `42` as Rholang AST (Seq[Par])
```
### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3981

### Notes
Epic
https://rchain.atlassian.net/browse/RCHAIN-3979
Design document
https://rchain.atlassian.net/wiki/spaces/CORE/pages/492732472/Obtaining+Data

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
