### PR TITLE
RCHAIN-4005 Fix block data order in block-data.rho

### DIFF
--- a/rholang/examples/block-data.rho
+++ b/rholang/examples/block-data.rho
@@ -1,6 +1,6 @@
 new blockData(`rho:block:data`), stdout(`rho:io:stdout`), retCh in {
   blockData!(*retCh) |
-  for(@timestamp, @blockNumber, @sender <- retCh) {
+  for(@blockNumber, @timestamp, @sender <- retCh) {
       stdout!({"block number": blockNumber}) |
       stdout!({"block time": timestamp})|
       stdout!({"block sender": sender})


### PR DESCRIPTION
## Overview
Order of block data was incorrect.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4005



### Notes
N/A



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
