### PR TITLE
RCHAIN-3993 Transfer slashed funds to Coop vault

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -20,13 +20,13 @@
  8.  | 7, 1,      | secp256k1          | sig = 3044022054ff4bae3984252b116e41e28d98bb5533eaa39aec2729228159166e2784f641022066a0fd99e7ea33df812fab095cbe61250f9548bce6da3ec4c6a90c741b94087f
  9.  | 4,         | registry           | uri = rho:id:m3xk7h8r54dtqtwsrnxqzhe81baswey66nzw6m533nyd45ptyoybqr
  ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
- */
-new  PoS,
+*/
+
+new PoS,
     registryLookup(`rho:registry:lookup`),
     revAddressOps(`rho:rev:address`),
     revVaultCh, listOpsCh,
     getUser,
-    getCurrentUserAddress,
     pickActiveValidators,
     runMVar,
     fst,
@@ -37,20 +37,22 @@ new  PoS,
     posId(`rho:rchain:deployerId`),
     PendingRewards, MergeIntMaps, treeHashMapCh,
     sysAuthTokenOps(`sys:authToken:ops`),
-    uriOut
+    multiSigRevVaultCh, coopVaultCh,
+    uriOut, sumFromPair
 in {
+  // Simultaneously retrieves RevVault, ListOps, TreeHashMap, and MultiSigRevVault contracts from the registry.
   registryLookup!(`rho:rchain:revVault`, *revVaultCh) |
   registryLookup!(`rho:lang:listOps`, *listOpsCh) |
   registryLookup!(`rho:lang:treeHashMap`, *treeHashMapCh) |
-
-  for(@(_, RevVault) <- revVaultCh;
-      @(_, ListOps) <- listOpsCh;
-      TreeHashMap <- treeHashMapCh) {
-    new posRevAddressCh, posAuthKeyCh, posVaultCh, initialActiveCh, pendingRewardsMapCh in {
-
-      @RevVault!("deployerAuthKey", *posId, *posAuthKeyCh) |
-      getCurrentUserAddress!(*posId, *posRevAddressCh) |
-
+  registryLookup!(`rho:rchain:multiSigRevVault`, *multiSigRevVaultCh) |
+  for (@(_, RevVault)         <- revVaultCh;
+       @(_, ListOps)          <- listOpsCh;
+       TreeHashMap            <- treeHashMapCh;
+       @(_, MultiSigRevVault) <- multiSigRevVaultCh) {
+    new posRevAddressCh, posAuthKeyCh, posVaultCh,
+        initialActiveCh, pendingRewardsMapCh
+    in {
+      // Creates a Rev vault for each active validator, in parallel.
       new rangeCh, makeVault in {
         contract makeVault(_, returnCh) = {
           new unf, revAddressCh, vaultCh in {
@@ -63,626 +65,675 @@ in {
             }
           }
         } |
-
         @ListOps!("range", 0, $$numberOfActiveValidators$$, *rangeCh) |
         for (@range <- rangeCh) {
           @ListOps!("parMap", range, *makeVault, *perActiveValidatorPosVaultsCh)
         }
       } |
-
-      for(@posRevAddress <- posRevAddressCh;
-          @posAuthKey <- posAuthKeyCh) {
-
-        @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
-        pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
-
-        // Initialize pending rewards Tree Hash map
-        // - each key in pending rewards state is Map[PublickKey, Int] accummulated by calling "refundDeploy"
-        TreeHashMap!("init", 3, *pendingRewardsMapCh) |
-
-        for (@(true, posVault) <- posVaultCh;
-             @initialActive <- initialActiveCh;
-             @pendingRewardsMap <- pendingRewardsMapCh) {
-          new stateCh, pendingRewardsInitializedCh in {
-            // Initialize empty pending rewards state for each validator
-            // - states must be initialized to prevent conflicts when are "set" (only lookup can be conflict free)
-            PendingRewards!("init", initialActive, *pendingRewardsInitializedCh) |
-            for (_ <- pendingRewardsInitializedCh) {
-              // Initialize PoS state structure
-              stateCh!({
-                // Map[PublickKey, Int] - each validator stake
-                "allBonds"        : $$initialBonds$$,
-                // List[PublicKey] - the active validators
-                "activeValidators": initialActive,
-                // Map[PublickKey, Int] - are moved from pendingRewards on epoch change or slashing
-                "committedRewards": {},
-                // Map[PublicKey, Int] - the validators willing to withdraw and the blocknumber when their quarantine ends
-                //                       This is the beggining of the next epoch after their withdrawal + quarantineLength
-                "withdrawers"     : {},
-                "randomImages"    : {},
-                "randomNumbers"   : {},
-              })
-            } |
-
-            contract PoS (@"getBonds", returnCh) = {
-              for (@state <<- stateCh) {
-                returnCh!(state.get("allBonds"))
-              }
-            } |
-
-            contract PoS (@"getActiveValidators", returnCh) = {
-              for (@state <<- stateCh) {
-                returnCh!(state.get("activeValidators"))
-              }
-            } |
-
-            contract PoS (@"getActiveValidatorVaults", returnCh) = {
-              for(@vaults <<- perActiveValidatorPosVaultsCh) {
-                returnCh!(vaults)
-              }
-            } |
-
-            /**
-             * Returns a Map[PublidKey, Int] containing the rewards accumulated for each validator.
-             * The returned map contains only the committed rewards after the last closeBlock
-             */
-            contract PoS (@"getRewards", returnCh) = {
-              for (@state <<- stateCh) {
-                returnCh!(state.get("committedRewards"))
-              }
-            } |
-
-            contract PoS (@"bond", @deployerId, @amount, returnCh) = {
-              new userCh, depositCh, processCh in {
-                runMVar!(*stateCh, *processCh, *returnCh) |
-                getUser!(deployerId, *userCh) |
-                for(@state, resultCh <- processCh;
-                    @userPk <- userCh) {
-                  if (state.get("allBonds").contains(userPk)) {
-                    resultCh!(state, (false, "Public key is already bonded."))
-                  } else if (amount < $$minimumBond$$) {
-                    resultCh!(state, (false, "Bond is less than minimum!"))
-                  } else if (amount > $$maximumBond$$) {
-                    resultCh!(state, (false, "Bond is greater than maximum!"))
-                  } else {
-                    deposit!(deployerId, amount, state.get("activeValidators"), *depositCh) |
-                    for(@depositResult <- depositCh) {
-                      match depositResult {
-                        (true, _) => {
-                          resultCh!(
-                            state.set(
-                              "allBonds",
-                              state.get("allBonds").set(userPk,amount)),
-                            depositResult
-                          )
-                        }
-                        (false, errorMsg) => {
-                          resultCh!(state, (false, "Bond deposit failed: " ++ errorMsg))
-                        }
-                      }
-                    }
-                  }
+      // Creates the auth key and Rev vault associated with the PoS contract.
+      new posPkCh in {
+        @RevVault!("deployerAuthKey", *posId, *posAuthKeyCh) |
+        getUser!(*posId, *posPkCh) |
+        for (@posPk <- posPkCh) {
+          revAddressOps!("fromPublicKey", posPk, *posRevAddressCh) |
+          // Creates Coop multisig vault for slashed funds.
+          // Either (false, errorMsg) or (true, (multiSigVault, revAddress, revVault)) are returned on coopVaultCh.
+          // TODO: supply real publicKeys, unsealers, and quorumSize
+          @MultiSigRevVault!("create", [posPk], [], 1, *coopVaultCh)
+        }
+      } |
+      for (@posRevAddress <- posRevAddressCh;
+           @posAuthKey    <- posAuthKeyCh) {
+        for (@(true, coopVault) <<- coopVaultCh) {
+          // Creates PoS Rev vault with sum of initial bonds.
+          new bondSumCh in {
+            @ListOps!("fold", $$initialBonds$$.toList(), 0, *sumFromPair, *bondSumCh) |
+            for (@bondSum <- bondSumCh) {
+              @RevVault!("createWithBalance", posRevAddress, bondSum, *posVaultCh)
+            }
+          } |
+          // Selects the initial active validators.
+          pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
+          // Initializes pending rewards TreeHashMap.
+          // - each key in pending rewards state is Map[PublicKey, Int] accumulated by calling "refundDeploy".
+          TreeHashMap!("init", 3, *pendingRewardsMapCh) |
+          for (@(true, posVault)  <- posVaultCh;
+               @initialActive     <- initialActiveCh;
+               @pendingRewardsMap <- pendingRewardsMapCh) {
+            new stateCh, pendingRewardsInitializedCh in {
+              // Initializes empty pending rewards state for each validator.
+              // - states must be initialized to prevent conflicts during "set" (only lookup can be conflict free)
+              PendingRewards!("init", initialActive, *pendingRewardsInitializedCh) |
+              for (_ <- pendingRewardsInitializedCh) {
+                // Initializes PoS state structure.
+                stateCh!({
+                  // Map[PublicKey, Int] - each validator stake
+                  "allBonds"        : $$initialBonds$$,
+                  // List[PublicKey]     - the active validators
+                  "activeValidators": initialActive,
+                  // Map[PublicKey, Int] - are moved from pendingRewards on epoch change or slashing
+                  "committedRewards": {},
+                  // Map[PublicKey, Int] - the validators wishing to withdraw and the blocknumber when their quarantine ends
+                  //                       This begins at the start of the next epoch + quarantineLength.
+                  "withdrawers"     : {},
+                  "randomImages"    : {},
+                  "randomNumbers"   : {},
+                })
+              } |
+              // Peeks at bonds map.
+              contract PoS(@"getBonds", returnCh) = {
+                for (@state <<- stateCh) {
+                  returnCh!(state.get("allBonds"))
                 }
-              }
-            } |
-
-            contract PoS (@"withdraw", @deployerId, returnCh) = {
-              new userCh, processCh,
-                  getBlockData(`rho:block:data`),
-                  blockDataCh
-              in {
-                runMVar!(*stateCh, *processCh, *returnCh) |
-
-                getBlockData!(*blockDataCh) |
-                getUser!(deployerId, *userCh) |
-                for(@state, resultCh <- processCh;
-                    @userPk <- userCh;
-                    @blockNumber, _, _ <- blockDataCh) {
-                  if (state.get("allBonds").contains(userPk)) {
-                    // the withdwal is in effect starting from the next epoch
-                    resultCh!(
-                      state.set("withdrawers",
-                                state.get("withdrawers")
-                                     .set(userPk,
-                                       $$quarantineLength$$ + $$epochLength$$ * (1 + blockNumber / $$epochLength$$))),
-                      (true, Nil))
-                  } else {
-                    resultCh!(state, (false, "User is not bonded"))
-                  }
+              } |
+              // Peeks at active validator list.
+              contract PoS(@"getActiveValidators", returnCh) = {
+                for (@state <<- stateCh) {
+                  returnCh!(state.get("activeValidators"))
                 }
-              }
-            } |
-
-            new currentDeployerData in {
-              contract PoS (@"chargeDeploy", @deployerId, @amount, @sysAuthToken, return) = {
-                new isValidTokenCh in {
-                  sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
-                  for (@isValid <- isValidTokenCh) {
-                    if (isValid) {
-                      new depositCh in {
-                        for (@state <<- stateCh) {
-                          deposit!(deployerId, amount, state.get("activeValidators"), *depositCh) |
-                          for(@depositResult <- depositCh){
-                            match depositResult {
-                              (true, _) => {
-                                currentDeployerData!((deployerId, amount)) |
-                                return!(depositResult)
-                              }
-                              (_, errorMessage) => {
-                                return!((false, "Deploy payment failed: " ++ errorMessage))
-                              }
-                            }
+              } |
+              // Peeks at active validator list.
+              contract PoS(@"getWithdrawers", returnCh) = {
+                for (@state <<- stateCh) {
+                  returnCh!(state.get("withdrawers"))
+                }
+              } |
+              // Peeks at active validator vaults.
+              contract PoS(@"getActiveValidatorVaults", returnCh) = {
+                for (@vaults <<- perActiveValidatorPosVaultsCh) {
+                  returnCh!(vaults)
+                }
+              } |
+              // Peeks at the accumulated rewards map, i.e. "committed rewards".
+              // The returned map contains only the rewards committed up to the last closeBlock.
+              contract PoS(@"getRewards", returnCh) = {
+                for (@state <<- stateCh) {
+                  returnCh!(state.get("committedRewards"))
+                }
+              } |
+              // Exposes Coop multisig vault on returnCh.
+              contract PoS(@"getCoopVault", returnCh) = {
+                for (@(_, coopVault) <<- coopVaultCh) {
+                  returnCh!(coopVault)
+                }
+              } |
+              // Exposes epochLength parameter to PoSTest.
+              contract PoS(@"getEpochLength", returnCh) = {
+                returnCh!($$epochLength$$)
+              } |
+              // Exposes quarantineLength parameter to PoSTest.
+              contract PoS(@"getQuarantineLength", returnCh) = {
+                returnCh!($$quarantineLength$$)
+              } |
+              // Public method allowing users to bond and become validators.
+              contract PoS(@"bond", @deployerId, @amount, returnCh) = {
+                new userCh, depositCh,
+                    processCh
+                in {
+                  runMVar!(*stateCh, *processCh, *returnCh) |
+                  getUser!(deployerId, *userCh) |
+                  for (@state, resultCh <- processCh;
+                       @userPk          <- userCh) {
+                    if (state.get("allBonds").contains(userPk)) {
+                      resultCh!(state, (false, "Public key is already bonded."))
+                    } else if (amount < $$minimumBond$$) {
+                      resultCh!(state, (false, "Bond is less than minimum!"))
+                    } else if (amount > $$maximumBond$$) {
+                      resultCh!(state, (false, "Bond is greater than maximum!"))
+                    } else {
+                      // Transfers user's bond amount to the block sender's per validator vault.
+                      deposit!(deployerId, amount, state.get("activeValidators"), *depositCh) |
+                      for (@depositResult <- depositCh) {
+                        match depositResult {
+                          // If deposit is successful, the user becomes a bonded validator.
+                          (true, _) => {
+                            resultCh!(state.set("allBonds", state.get("allBonds").set(userPk, amount)), depositResult)
+                          }
+                          // If deposit is unsuccessful, the user is not bonded.
+                          (false, errorMsg) => {
+                            resultCh!(state, (false, "Bond deposit failed: " ++ errorMsg))
                           }
                         }
                       }
-                    } else {
-                      return!((false, "Invalid system auth token"))
                     }
                   }
                 }
               } |
-
-              contract transferFromBlockSender(@deployerRevAddress, @refundAmount, returnCh) = {
-                new getBlockData(`rho:block:data`),
-                    blockDataCh,
-                    indexSender,
-                    unfAuthKeyCh,
-                    tmpCh in {
+              // Public method allowing validators to withdraw their bonded and accumulated funds.
+              contract PoS(@"withdraw", @deployerId, returnCh) = {
+                new userCh, processCh, blockDataCh,
+                    getBlockData(`rho:block:data`)
+                in {
+                  // Consumes state and updates withdrawers map.
+                  runMVar!(*stateCh, *processCh, *returnCh) |
                   getBlockData!(*blockDataCh) |
-                  for (_, _, @sender <- blockDataCh) {
-                    for (@state <<- stateCh) {
-                      @ListOps!("indexOf", state.get("activeValidators"), sender, *indexSender) |
-                      for (@idx <- indexSender) {
-                        for (@vaults <<- perActiveValidatorPosVaultsCh) {
-                          if (idx == -1) {
-                            returnCh!((false, "Sender is not an active validator"))
-                          } else {
-                            match vaults.nth(idx) {
-                              (unf, _, activeValidatorVault) => {
-                                @RevVault!("unforgeableAuthKey", unf, *unfAuthKeyCh) |
-                                for (@authKey <- unfAuthKeyCh) {
-                                  @activeValidatorVault!("transfer", deployerRevAddress, refundAmount, authKey, *returnCh)
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
+                  getUser!(deployerId, *userCh) |
+                  for (@state, resultCh   <- processCh;
+                       @userPk            <- userCh;
+                       @blockNumber, _, _ <- blockDataCh) {
+                    if (state.get("allBonds").contains(userPk)) {
+                      // The withdrawal goes into effect at the start of the next epoch.
+                      resultCh!(
+                        state.set("withdrawers",
+                                  state.get("withdrawers")
+                                       .set(userPk,
+                                         $$quarantineLength$$ + $$epochLength$$ * (1 + blockNumber / $$epochLength$$))),
+                        (true, Nil))
+                    } else {
+                      resultCh!(state, (false, "User is not bonded"))
                     }
                   }
                 }
               } |
-
-              contract PoS (@"refundDeploy", @refundAmount, @sysAuthToken, return) = {
-                new isValidTokenCh in {
-                  sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
-                  for (@isValid <- isValidTokenCh) {
-                    if (isValid) {
-                      for(@(deployerId, initialPaymentAmount) <- currentDeployerData){
-                        new revAddressCh in {
-                          revAddressOps!("fromDeployerId", deployerId, *revAddressCh) |
-                          for(@deployerRevAddress <- revAddressCh){
-                            new transferCh in {
-                              transferFromBlockSender!(deployerRevAddress, refundAmount, *transferCh) |
-                              for(@transferResult <- transferCh){
-                                match transferResult {
-                                  (true, _) => {
-                                    new newRewardsCh, pendingUpdatedCh, blockDataCh, getBlockData(`rho:block:data`) in {
-                                      for (@state <<- stateCh) {
-                                        distributeRewards!(
-                                          initialPaymentAmount - refundAmount,
-                                          state.get("activeValidators"),
-                                          state.get("allBonds"),
-                                          *newRewardsCh)
-                                      } |
-                                      getBlockData!(*blockDataCh) |
-                                      for(@newRewards <- newRewardsCh;
-                                          _, _, @sender <- blockDataCh) {
-                                        // Add new pending rewards to validator pending rewards state
-                                        PendingRewards!("append", sender, newRewards, *pendingUpdatedCh) |
-                                        for (_ <- pendingUpdatedCh) {
-                                          return!((true, Nil))
-                                        }
-                                      }
-                                    }
-                                  }
-                                  (_, errorMessage) => {
-                                    return!((false, "(Bug found) Deploy refund failed: " ++ errorMessage))
-                                  }
+              // Private method which charges a deployer for a deploy.
+              // Deployer's funds are deposited into the block sender's vault.
+              // Return expects (Boolean, Either[Nil, String])
+              new currentDeployerData in {
+                contract PoS(@"chargeDeploy", @deployerId, @amount, @sysAuthToken, return) = {
+                  new isValidTokenCh in {
+                    sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
+                    for (@isValid <- isValidTokenCh) {
+                      if (isValid) {
+                        new depositCh in {
+                          for (@state <<- stateCh) {
+                            deposit!(deployerId, amount, state.get("activeValidators"), *depositCh) |
+                            for (@depositResult <- depositCh){
+                              match depositResult {
+                                (true, _) => {
+                                  currentDeployerData!((deployerId, amount)) |
+                                  return!(depositResult)
+                                }
+                                (_, errorMessage) => {
+                                  return!((false, "Deploy payment failed: " ++ errorMessage))
                                 }
                               }
                             }
                           }
                         }
-                      }
-                    } else {
-                      return!((false, "Invalid system auth token"))
-                    }
-                  }
-                }
-              }
-            } |
-
-            contract PoS(@"slash", @deployerId, @blockHash, @sysAuthToken, returnCh) = {
-              new isValidTokenCh in {
-                sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
-                for (@isValid <- isValidTokenCh) {
-                  if (isValid) {
-                    new userCh, invalidBlocksCh, doSlashCh,
-                        getInvalidBlocks(`rho:casper:invalidBlocks`) in {
-                      getInvalidBlocks!(*invalidBlocksCh) |
-                      getUser!(deployerId, *userCh) |
-
-                      runMVar!(*stateCh, *doSlashCh, *returnCh) |
-                      for (@invalidBlocks <- invalidBlocksCh;
-                           @userPk <- userCh;
-                           @state, slashResultCh <- doSlashCh) {
-                        new toBeSlashed in {
-                          toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
-                          for (@validator <- toBeSlashed) {
-                            new valPendingRewardsCh in {
-                              // Collect and reset slashed validator pending rewards (from per validator states)
-                              PendingRewards!("collectValue", validator, state.get("activeValidators"), *valPendingRewardsCh) |
-                              for (@validatorPendingRewards <- valPendingRewardsCh) {
-                                // TODO: Transfer to coop wallet instead of just simply setting bonds to 0
-                                // Slashed rewards:
-                                // + validatorPendingRewards
-                                // + state.get("committedRewards")
-                                slashResultCh!(
-                                  state.set("committedRewards",
-                                            state.get("committedRewards").set(validator, 0))
-                                      .set("allBonds",
-                                            state.get("allBonds").set(validator, 0)),
-                                  true)
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  } else {
-                    returnCh!((false, "Invalid system auth token"))
-                  }
-                }
-              }
-            } |
-
-            contract PoS(@"closeBlock", @sysAuthToken, ackCh) = {
-              new isValidTokenCh in {
-                sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
-                for (@isValid <- isValidTokenCh) {
-                  if (isValid) {
-                    new accumulateDeposits,
-                        commitRewards,
-                        changeEpoch,
-                        removeQuarantinedWithdrawers,
-                        payValidators
-                    in {
-                      new blockDataCh, mvarProcessCh,
-                          getBlockData(`rho:block:data`),
-                          accDepositsDoneCh,
-                          commitRewardsCh,
-                          newValidatorsCh, removeQuarantinedCh, paymentDoneCh
-                      in {
-                        getBlockData!(*blockDataCh) |
-
-                        runMVar!(*stateCh, *mvarProcessCh, *ackCh) |
-                        for(@blockNumber, _, _ <- blockDataCh;
-                            @state, mvarResultCh <- mvarProcessCh) {
-                          // Before choosing new active validators and paying out any withdrawers,
-                          // deposits have to be accumulated into one vault for now.
-                          accumulateDeposits!(posRevAddress, *accDepositsDoneCh) |
-
-                          changeEpoch!(
-                            blockNumber,
-                            state.get("allBonds"),
-                            state.get("activeValidators"),
-                            state.get("withdrawers"),
-                            *newValidatorsCh)|
-
-                          new pendingRewardsAllCh in {
-                            // Collect pending rewards from all validators and reset state to zero
-                            PendingRewards!("collect", state.get("activeValidators"), *pendingRewardsAllCh) |
-                            for (@pendingRewards <- pendingRewardsAllCh) {
-                              for (@newValidatorKeys <<- newValidatorsCh) {
-                                new ackInitCh in {
-                                  // Initialize empty pending rewards state with new set of validators
-                                  PendingRewards!("init", newValidatorKeys, *ackInitCh) |
-                                  for (_ <- ackInitCh) {
-                                    // Sum of pending rewards to committed rewards
-                                    commitRewards!(pendingRewards, state.get("committedRewards"), *commitRewardsCh)
-                                  }
-                                }
-                              }
-                            }
-                          } |
-
-                          for (@committedRewards <- commitRewardsCh) {
-
-                            removeQuarantinedWithdrawers!(
-                              blockNumber,
-                              state.get("allBonds"),
-                              state.get("withdrawers"),
-                              committedRewards,
-                              *removeQuarantinedCh)
-                          } |
-
-                          for(@newValidators <- newValidatorsCh;
-                              @(payments, newBonds, newWithdrawers, newRewards) <- removeQuarantinedCh;
-                              _ <- accDepositsDoneCh) {
-
-                            payValidators!(payments, *paymentDoneCh) |
-
-                            for (_ <- paymentDoneCh) {
-
-                              mvarResultCh!({
-                                "allBonds"        : newBonds,
-                                "activeValidators": newValidators,
-                                "committedRewards": newRewards,
-                                "withdrawers"     : newWithdrawers,
-                                "randomImages"    : {},
-                                "randomNumbers"   : {},
-                              }, (true, Nil))
-                            }
-                          }
-                        }
-                      } |
-
-                      new moveFunds in {
-                        contract moveFunds(@(unf, _, vault), returnCh) = {
-                          new balanceCh, unfAuthKeyCh, transferDoneCh in {
-                            @vault!("balance", *balanceCh) |
-                            for (@balance <- balanceCh) {
-                              if (balance > 0) {
-                                @RevVault!("unforgeableAuthKey", unf, *unfAuthKeyCh) |
-                                for (@authKey <- unfAuthKeyCh) {
-                                  @vault!("transfer", posRevAddress, balance, authKey, *transferDoneCh) |
-                                  for (@(true, Nil) <- transferDoneCh) {
-                                    returnCh!(true)
-                                  }
-                                }
-                              } else {
-                                returnCh!(true)
-                              }
-                            }
-                          }
-                        } |
-
-                        contract accumulateDeposits(destRevAddress, ackCh) = {
-                          for(@vaults <<- perActiveValidatorPosVaultsCh) {
-                            @ListOps!("parMap", vaults, *moveFunds, *ackCh)
-                          }
-                        }
-                      } |
-
-                      new payValidator in {
-                        contract payValidator (@(pk, amount), returnCh) = {
-                          new vaultCh, revAddressCh in {
-                            revAddressOps!("fromPublicKey", pk, *revAddressCh) |
-                            for (@toRevAddress <- revAddressCh) {
-                              @posVault!("transfer", toRevAddress, amount, posAuthKey, *returnCh)
-                            }
-                          }
-                        } |
-                        contract payValidators(@payments, ackCh) = {
-                          @ListOps!("unorderedParMap", payments, *payValidator, *ackCh)
-                        }
-                      } |
-
-                      new commitReward in {
-                        contract commitReward(@(pk, pending), @acc, resultCh) = {
-                          resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
-                        } |
-                        contract commitRewards(@pendingRewards, @rewards, newRewardsCh) = {
-                          @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *newRewardsCh)
-                        }
-                      } |
-
-                      contract changeEpoch(@currentBlockNumber, @allBonds, @activeValidators, @withdrawers, resultCh) = {
-                        if (currentBlockNumber % $$epochLength$$ == 0) {
-                          pickActiveValidators!(allBonds, withdrawers, *resultCh)
-                        } else {
-                          resultCh!(activeValidators)
-                        }
-                      } |
-
-                      contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, @rewards, returnCh) = {
-                        new quarantinedValidatorsCh,
-                            validatorsToWithdrawListCh,
-                            isQuarantineFinished,
-                            notWithdrawn,
-                            newBondsListCh,
-                            newWithdrawersListCh,
-                            newRewardsListCh,
-                            paymentsCh, computePay
-                        in {
-                          @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
-                          for (@quarantinedValidators <- quarantinedValidatorsCh) {
-                            @ListOps!("map", quarantinedValidators, *fst, *validatorsToWithdrawListCh) |
-                            for (@validatorsToWithdrawList <- validatorsToWithdrawListCh) {
-                              @ListOps!("map", validatorsToWithdrawList, *computePay, *paymentsCh) |
-                              contract computePay(@pk, resultCh) = {
-                                resultCh!((pk, allBonds.get(pk) + rewards.getOrElse(pk, 0)))
-                              } |
-
-                              match validatorsToWithdrawList.toSet() {
-                                validatorsToWithdrawSet => {
-                                  @ListOps!("filter", allBonds.toList(), *notWithdrawn, *newBondsListCh) |
-                                  @ListOps!("filter", withdrawers.toList(), *notWithdrawn, *newWithdrawersListCh) |
-                                  @ListOps!("filter", rewards.toList(), *notWithdrawn, *newRewardsListCh) |
-
-                                  for (@newWithdrawersList <- newWithdrawersListCh;
-                                       @newBondsList <- newBondsListCh;
-                                       @newRewardsList <- newRewardsListCh;
-                                       @payments <- paymentsCh) {
-                                    returnCh!((payments, newBondsList.toMap(), newWithdrawersList.toMap(), newRewardsList.toMap()))
-                                  } |
-
-                                  contract notWithdrawn(@(pk, _), resultCh) = { resultCh!(not validatorsToWithdrawSet.contains(pk))}
-                                }
-                              }
-                            }
-                          } |
-
-                          contract isQuarantineFinished(@(_, blockNumber), resultCh) = {
-                            resultCh!(blockNumber >= currentBlockNumber)
-                          }
-                        }
-                      }
-                    }
-                  } else {
-                    ackCh!((false, "Invalid system auth token"))
-                  }
-                }
-              }
-            } |
-
-            contract PoS(@"commitRandomImage", @deployerId, @hash, ackCh) = {
-              new userCh, mvarCh in {
-                getUser!(deployerId, *userCh) |
-
-                runMVar!(*stateCh, *mvarCh, *ackCh) |
-                for (@validator <- userCh;
-                     @state, resultCh <- mvarCh) {
-                  if (state.get("randomImages").contains(validator)) {
-                    resultCh!(state, (false, "Image already committed"))
-                  }
-                  else {
-                    resultCh!(
-                      state.set("randomImages",
-                               state.get("randomImages").set(validator, hash)),
-                      true)
-                  }
-               }
-             }
-            } |
-
-            contract PoS(@"revealRandom", @deployerId, @random, ackCh) = {
-              new userCh, mvarCh, computeHash(`rho:crypto:keccak256Hash`), hashCh in {
-                getUser!(deployerId, *userCh) |
-
-                runMVar!(*stateCh, *mvarCh, *ackCh) |
-                computeHash!(random, *hashCh) |
-                for (@validator <- userCh;
-                     @state, resultCh <- mvarCh;
-                     @hash <- hashCh) {
-                  if (state.get("randomImages").contains(validator)) {
-                    if (hash == state.get("randomImages").get(validator))
-                    {
-                      resultCh!(
-                        state.set("randomNumbers",
-                          state.get("randomNumbers").set(validator, random)),
-                        true)
-                    } else
-                    {
-                      resultCh!(state, (false, "Previously committed image doesn't match the random number"))
-                    }
-                  }
-                  else {
-                      resultCh! (state, (false, "Previously committed random image not found"))
-                  }
-               }
-             }
-            } |
-
-            // Initialize pending rewards state for each validator
-            contract PendingRewards(@"init", @validatorKeys, @return) = {
-              new createStateKeyCh in {
-                @ListOps!("map", validatorKeys, *createStateKeyCh, return) |
-                contract createStateKeyCh(@key, @ackCh) = {
-                  TreeHashMap!("set", pendingRewardsMap, key, {}, ackCh)
-                }
-              }
-            } |
-
-            // Sum of new pending rewards with existing state
-            contract PendingRewards(@"append", @validatorKey, @newRewards, @return) = {
-              new currentRewardsCh in {
-                // Get existing pending rewards (per validator)
-                // - validator key is always initialized so here we can use unsafe get
-                TreeHashMap!("fastUnsafeGet", pendingRewardsMap, validatorKey, *currentRewardsCh) |
-                for (@currentRewards <- currentRewardsCh) {
-                  new mergeResultCh in {
-                    // Merge (sum) current pending rewards with new pending rewards
-                    MergeIntMaps!(currentRewards, newRewards, *mergeResultCh) |
-                    for (@mergeResult <- mergeResultCh) {
-                      // Update pending rewards state
-                      TreeHashMap!("set", pendingRewardsMap, validatorKey, mergeResult, return)
-                    }
-                  }
-                }
-              }
-            } |
-
-            // Collect pending rewards from all validators (in a map) / reset state to zero
-            contract PendingRewards(@"collect", @validatorKeys, @return) = {
-              new collectMaps, mapsListCh in {
-                // Get pending rewards (maps) for list of validators (public keys)
-                @ListOps!("fold", validatorKeys, [], *collectMaps, *mapsListCh) |
-                contract collectMaps(@validatorKey, @acc, mergeRet) = {
-                  new updateCh, updateAckCh in {
-                    // Update (per validator) pending rewards
-                    // - collect existing values and reset to empty map
-                    TreeHashMap!("update", pendingRewardsMap, validatorKey, *updateCh, *updateAckCh) |
-                    for (@rewardsMap, rewardsRet <- updateCh) {
-                      // Reset per validator pending rewards state
-                      rewardsRet!({}) |
-                      // Accumulate all reward maps
-                      for (_ <- updateAckCh) {
-                        mergeRet!(acc ++ [rewardsMap])
+                      } else {
+                        return!((false, "Invalid system auth token"))
                       }
                     }
                   }
                 } |
-
-                // Merge pending rewards (maps) to one map of pending rewards
-                for (@mapsList <- mapsListCh) {
-                  @ListOps!("fold", mapsList, {}, *MergeIntMaps, return)
-                }
-              }
-            } |
-
-            // Collect rewards for one validator from all validators / reset this validator state to zero
-            contract PendingRewards(@"collectValue", @collectValidatorKey, @validatorKeys, @return) = {
-              new collectRewards in {
-                // Get pending rewards (maps) for list of validators (public keys)
-                @ListOps!("fold", validatorKeys, 0, *collectRewards, return) |
-                contract collectRewards(@validatorKey, @acc, sumReturn) = {
-                  new updateCh, updateAckCh in {
-                    // Update validator pending rewards
-                    // - collect existing values and reset to zero
-                    TreeHashMap!("update", pendingRewardsMap, validatorKey, *updateCh, *updateAckCh) |
-                    for (@rewardsMap, rewardsRet <- updateCh) {
-                      // Reset validator pending rewards state
-                      rewardsRet!(rewardsMap.set(collectValidatorKey, 0)) |
-                      // Sum of validator pending rewards from all validators states
-                      for (_ <- updateAckCh) {
-                        match rewardsMap.get(collectValidatorKey) {
-                          Nil => sumReturn!(acc)
-                          val => sumReturn!(acc + rewardsMap.get(collectValidatorKey))
+                // Private method which refunds a deployer if too much was charged in chargeDeploy.
+                // Funds are transferred from the block sender's vault to the deployer.
+                // Return expects (Boolean, Either[Nil, String])
+                contract PoS(@"refundDeploy", @refundAmount, @sysAuthToken, return) = {
+                  new isValidTokenCh in {
+                    sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
+                    for (@isValid <- isValidTokenCh) {
+                      if (isValid) {
+                        for (@(deployerId, initialPaymentAmount) <- currentDeployerData){
+                          new revAddressCh in {
+                            revAddressOps!("fromDeployerId", deployerId, *revAddressCh) |
+                            for (@deployerRevAddress <- revAddressCh){
+                              new transferCh in {
+                                transferFromBlockSender!(deployerRevAddress, refundAmount, *transferCh) |
+                                for (@transferResult <- transferCh){
+                                  match transferResult {
+                                    (true, _) => {
+                                      new newRewardsCh, pendingUpdatedCh, blockDataCh,
+                                          getBlockData(`rho:block:data`)
+                                      in {
+                                        for (@state <<- stateCh) {
+                                          distributeRewards!(
+                                            initialPaymentAmount - refundAmount,
+                                            state.get("activeValidators"),
+                                            state.get("allBonds"),
+                                            *newRewardsCh)
+                                        } |
+                                        getBlockData!(*blockDataCh) |
+                                        for (@newRewards  <- newRewardsCh;
+                                            _, _, @sender <- blockDataCh) {
+                                          // Add new pending rewards to validator pending rewards state
+                                          PendingRewards!("append", sender, newRewards, *pendingUpdatedCh) |
+                                          for (_ <- pendingUpdatedCh) {
+                                            return!((true, Nil))
+                                          }
+                                        }
+                                      }
+                                    }
+                                    (_, errorMessage) => {
+                                      return!((false, "(Bug found) Deploy refund failed: " ++ errorMessage))
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      } else {
+                        return!((false, "Invalid system auth token"))
+                      }
+                    }
+                  }
+                } |
+                // Transfer (from sender to deployer) called in refundDeploy.
+                contract transferFromBlockSender(@deployerRevAddress, @refundAmount, returnCh) = {
+                  new getBlockData(`rho:block:data`),
+                      blockDataCh, indexSender,
+                      unfAuthKeyCh, tmpCh
+                  in {
+                    getBlockData!(*blockDataCh) |
+                    for (_, _, @sender <- blockDataCh) {
+                      for (@state <<- stateCh) {
+                        @ListOps!("indexOf", state.get("activeValidators"), sender, *indexSender) |
+                        for (@idx <- indexSender) {
+                          if (idx == -1) {
+                            returnCh!((false, "Sender is not an active validator"))
+                          } else {
+                            for (@vaults <<- perActiveValidatorPosVaultsCh) {
+                              match vaults.nth(idx) {
+                                (unf, _, activeValidatorVault) => {
+                                  @RevVault!("unforgeableAuthKey", unf, *unfAuthKeyCh) |
+                                  for (@authKey <- unfAuthKeyCh) {
+                                    @activeValidatorVault!("transfer", deployerRevAddress, refundAmount, authKey, *returnCh)
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }
                   }
                 }
+              } |
+              new accumulateDeposits, commitRewards, moveFunds in {
+                // Private method which transfers all of a validator's rewards + bond to the Coop vault.
+                // Slash expects (Boolean, Either[Nil, String]) on returnCh.
+                contract PoS(@"slash", @deployerId, @blockHash, @sysAuthToken, returnCh) = {
+                  new isValidTokenCh in {
+                    sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
+                    for (@isValid <- isValidTokenCh) {
+                      if (isValid) {
+                        new invalidBlocksCh, stateProcessCh, userCh,
+                            getInvalidBlocks(`rho:casper:invalidBlocks`)
+                        in {
+                          getInvalidBlocks!(*invalidBlocksCh) |
+                          getUser!(deployerId, *userCh) |
+                          runMVar!(*stateCh, *stateProcessCh, *returnCh) |
+                          for (@invalidBlocks        <- invalidBlocksCh;
+                               @userPk               <- userCh;
+                               @state, stateUpdateCh <- stateProcessCh) {
+                            match coopVault {
+                              (_, coopRevAddress, _) => {
+                                new toBeSlashed, valBondCh, valRewardCh in {
+                                  // Flow of logic:
+                                  // 0. check if blockHash is the hash of an invalid block
+                                  // 1. accumulateDeposits
+                                  // 2. commitRewards
+                                  // 3. transfer slashed funds to Coop
+                                  // 4. update state
+                                  // Retrieves either public key of sender of invalid block or the deployer public key.
+                                  toBeSlashed!(invalidBlocks.getOrElse(blockHash, userPk)) |
+                                  for (@validator <- toBeSlashed) {
+                                    new commitRewardsCh, accDepositsDoneCh in {
+                                      // Slashed funds:
+                                      // + valPendingRewards
+                                      // + state.get("committedRewards").get(validator)
+                                      // + state.get("allBonds").get(validator)
+                                      // Collects all deposits from per validator vaults.
+                                      accumulateDeposits!(*accDepositsDoneCh) |
+                                      for (_ <- accDepositsDoneCh) {
+                                        new pendingRewardsAllCh in {
+                                          // Collects pending rewards from each validator and resets to zero.
+                                          PendingRewards!("collect", state.get("activeValidators"), *pendingRewardsAllCh) |
+                                          for (@pendingRewards <- pendingRewardsAllCh) {
+                                            new ackInitCh in {
+                                              // Initialize empty pending rewards state with current set of validators.
+                                              PendingRewards!("init", state.get("activeValidators"), *ackInitCh) |
+                                              for (_ <- ackInitCh) {
+                                                // Add all pending rewards to global committed rewards.
+                                                commitRewards!(pendingRewards, state.get("committedRewards"), *commitRewardsCh)
+                                              }
+                                            }
+                                          }
+                                        } |
+                                        for (@committedRewardsList <- commitRewardsCh) {
+                                          // Collects slashed validator's committed rewards and bond.
+                                          valRewardCh!(committedRewardsList.toMap().getOrElse(validator, 0)) |
+                                          valBondCh!(state.get("allBonds").get(validator)) |
+                                          for (@valReward <- valRewardCh;
+                                               @valBond   <- valBondCh) {
+                                            // Transfers slashed funds from PoS vault to Coop vault, then updates state.
+                                            new transferDoneCh in {
+                                              @posVault!(
+                                                "transfer",
+                                                coopRevAddress,
+                                                valReward + valBond,
+                                                posAuthKey,
+                                                *transferDoneCh
+                                              ) |
+                                              for (_ <- transferDoneCh) {
+                                                // Moves slashed validator to withdrawers map to unbond at next epoch change.
+                                                new blockDataCh,
+                                                    getBlockData(`rho:block:data`)
+                                                in {
+                                                  getBlockData!(*blockDataCh) |
+                                                  for (@blockNumber, _, _ <- blockDataCh) {
+                                                    // Sets slashed validator's committed rewards and bond to 0 in state.
+                                                    // Moves slashed validator to withdrawers map with no quarantine period.
+                                                    stateUpdateCh!({
+                                                      "allBonds"        : state.get("allBonds").set(validator, 0),
+                                                      "committedRewards": committedRewardsList.toMap().set(validator, 0),
+                                                      "activeValidators": state.get("activeValidators"),
+                                                      "withdrawers"     : state.get("withdrawers")
+                                                                                .set(validator,
+                                                                                  $$quarantineLength$$ + $$epochLength$$ * (1 + blockNumber / $$epochLength$$)),
+                                                      "randomImages"    : state.get("randomImages"),
+                                                      "randomNumbers"   : state.get("randomNumbers")
+                                                    },
+                                                    (true, Nil))
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      } else {
+                        returnCh!((false, "Invalid system auth token"))
+                      }
+                    }
+                  }
+                } |
+                // Private method which signals the end of block processing.
+                contract PoS(@"closeBlock", @sysAuthToken, ackCh) = {
+                  new isValidTokenCh in {
+                    sysAuthTokenOps!("check", sysAuthToken, *isValidTokenCh) |
+                    for (@isValid <- isValidTokenCh) {
+                      if (isValid) {
+                        new blockDataCh, getBlockData(`rho:block:data`) in {
+                          getBlockData!(*blockDataCh) |
+                          for (@blockNumber, _, _ <- blockDataCh) {
+                            if (blockNumber % $$epochLength$$ != 0) {
+                              // Epoch change does not occur.
+                              ackCh!((true, Nil))
+                            } else {
+                              // Epoch change occurs.
+                              new payWithdrawers, removeQuarantinedWithdrawers,
+                                  stateProcessCh, paymentDoneCh,
+                                  accDepositsDoneCh, commitRewardsCh,
+                                  newValidatorsCh, removeQuarantinedCh
+                              in {
+                                runMVar!(*stateCh, *stateProcessCh, *ackCh) |
+                                for (@state, stateUpdateCh <- stateProcessCh) {
+                                  // Before choosing new active validators and paying out any withdrawers (i.e. updating the state),
+                                  // per validator vaults are accumulated into the PoS vault.
+                                  accumulateDeposits!(*accDepositsDoneCh) |
+                                  // New active validators will be choosen from set of bonded validators who have not withdrawn.
+                                  pickActiveValidators!(state.get("allBonds"), state.get("withdrawers"), *newValidatorsCh) |
+                                  new pendingRewardsAllCh in {
+                                    // Collects pending rewards from all validators and resets to zero.
+                                    PendingRewards!("collect", state.get("activeValidators"), *pendingRewardsAllCh) |
+                                    for (@pendingRewards <- pendingRewardsAllCh) {
+                                      for (@newValidatorKeys <<- newValidatorsCh) {
+                                        new ackInitCh in {
+                                          // Initialize empty pending rewards state with new set of validators.
+                                          PendingRewards!("init", newValidatorKeys, *ackInitCh) |
+                                          for (_ <- ackInitCh) {
+                                            // Add all pending rewards to global committed rewards.
+                                            commitRewards!(pendingRewards, state.get("committedRewards"), *commitRewardsCh)
+                                          }
+                                        }
+                                      }
+                                    }
+                                  } |
+                                  // After pending rewards are committed, quarantined withdrawers are removed
+                                  // from the bonds and withdrawers maps.
+                                  for (@committedRewards <- commitRewardsCh) {
+                                    removeQuarantinedWithdrawers!(
+                                      blockNumber,
+                                      state.get("allBonds"),
+                                      state.get("withdrawers"),
+                                      committedRewards,
+                                      *removeQuarantinedCh)
+                                  } |
+                                  // After new active validators are selected, deposits are accumulated, and
+                                  // quarantined withdrawers are removed from the bonds map,
+                                  // these withdrawing validators are paid out, then the state is updated.
+                                  for (@newValidators                                    <- newValidatorsCh;
+                                       @(payments, newBonds, newWithdrawers, newRewards) <- removeQuarantinedCh;
+                                       _                                                 <- accDepositsDoneCh) {
+                                    payWithdrawers!(payments, *paymentDoneCh) |
+                                    for (_ <- paymentDoneCh) {
+                                      stateUpdateCh!({
+                                        "allBonds"        : newBonds,
+                                        "activeValidators": newValidators,
+                                        "committedRewards": newRewards,
+                                        "withdrawers"     : newWithdrawers,
+                                        "randomImages"    : {},
+                                        "randomNumbers"   : {},
+                                      },
+                                      (true, Nil))
+                                    }
+                                  }
+                                } |
+                                // Transfers withdrawing validator's bond + accumulated (committed) rewards from PoS vault to their vault.
+                                new payWithdrawer in {
+                                  contract payWithdrawer(@(pk, amount), returnCh) = {
+                                    new vaultCh, revAddressCh in {
+                                      revAddressOps!("fromPublicKey", pk, *revAddressCh) |
+                                      for (@toRevAddress <- revAddressCh) {
+                                        @posVault!("transfer", toRevAddress, amount, posAuthKey, *returnCh)
+                                      }
+                                    }
+                                  } |
+                                  contract payWithdrawers(@payments, returnCh) = {
+                                    @ListOps!("unorderedParMap", payments, *payWithdrawer, *returnCh)
+                                  }
+                                } |
+                                // Checks withdrawer's quarantine period against current block number,
+                                // then computes their payment, removes them from the bonds and withdrawers maps, and
+                                // updates the committed rewards map.
+                                contract removeQuarantinedWithdrawers(@currentBlockNumber, @allBonds, @withdrawers, @rewards, returnCh) = {
+                                  new quarantinedValidatorsCh, validatorsToWithdrawListCh,
+                                      isQuarantineFinished, notWithdrawn,
+                                      paymentsCh, computePay,
+                                      newBondsListCh, newWithdrawersListCh,
+                                      newRewardsListCh
+                                  in {
+                                    @ListOps!("filter", withdrawers.toList(), *isQuarantineFinished, *quarantinedValidatorsCh) |
+                                    for (@quarantinedValidators <- quarantinedValidatorsCh) {
+                                      @ListOps!("map", quarantinedValidators, *fst, *validatorsToWithdrawListCh) |
+                                      for (@validatorsToWithdrawList <- validatorsToWithdrawListCh) {
+                                        @ListOps!("map", validatorsToWithdrawList, *computePay, *paymentsCh) |
+                                        contract computePay(@pk, resultCh) = {
+                                          resultCh!((pk, allBonds.get(pk) + rewards.getOrElse(pk, 0)))
+                                        } |
+                                        match validatorsToWithdrawList.toSet() {
+                                          validatorsToWithdrawSet => {
+                                            @ListOps!("filter", allBonds.toList(), *notWithdrawn, *newBondsListCh) |
+                                            @ListOps!("filter", withdrawers.toList(), *notWithdrawn, *newWithdrawersListCh) |
+                                            @ListOps!("filter", rewards.toList(), *notWithdrawn, *newRewardsListCh) |
+                                            for (@newWithdrawersList <- newWithdrawersListCh;
+                                                 @newBondsList       <- newBondsListCh;
+                                                 @newRewardsList     <- newRewardsListCh;
+                                                 @payments           <- paymentsCh) {
+                                              returnCh!((
+                                                payments,
+                                                newBondsList.toMap(),
+                                                newWithdrawersList.toMap(),
+                                                newRewardsList.toMap()
+                                              ))
+                                            } |
+                                            // Checks that the validator is not a withdrawer.
+                                            contract notWithdrawn(@(pk, _), resultCh) = {
+                                              resultCh!(not validatorsToWithdrawSet.contains(pk))
+                                            }
+                                          }
+                                        }
+                                      }
+                                    } |
+                                    // Check whether quarantine period is finished.
+                                    contract isQuarantineFinished(@(_, blockNumber), resultCh) = {
+                                      resultCh!(currentBlockNumber >= blockNumber)
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      } else {
+                        ackCh!((false, "Invalid system auth token"))
+                      }
+                    }
+                  }
+                } |
+                // Adds pending rewards to global committed rewards for bookkeeping.
+                new commitReward in {
+                  contract commitReward(@(pk, pending), @acc, resultCh) = {
+                    resultCh!(acc.set(pk, acc.getOrElse(pk, 0) + pending))
+                  } |
+                  contract commitRewards(@pendingRewards, @rewards, newRewardsCh) = {
+                    @ListOps!("fold", pendingRewards.toList(), rewards, *commitReward, *newRewardsCh)
+                  }
+                } |
+                // Moves the entire contents of a validator's vault to the PoS vault.
+                contract moveFunds(@(unf, revAddr, vault), returnCh) = {
+                  new balanceCh, unfAuthKeyCh, transferDoneCh in {
+                    @vault!("balance", *balanceCh) |
+                    for (@balance <- balanceCh) {
+                      if (balance > 0) {
+                        @RevVault!("unforgeableAuthKey", unf, *unfAuthKeyCh) |
+                        for (@authKey <- unfAuthKeyCh) {
+                          // Transfer funds from validator vault to the PoS vault.
+                          @vault!("transfer", posRevAddress, balance, authKey, *transferDoneCh) |
+                          for (@(true, _) <- transferDoneCh) {
+                            returnCh!(true)
+                          }
+                        }
+                      } else {
+                        returnCh!(true)
+                      }
+                    }
+                  }
+                } |
+                // Transfers all accumulated funds to the PoS vault.
+                contract accumulateDeposits(returnCh) = {
+                  for (@vaults <<- perActiveValidatorPosVaultsCh) {
+                    @ListOps!("parMap", vaults, *moveFunds, *returnCh)
+                  }
+                }
+              } |
+              //
+              contract PoS(@"commitRandomImage", @deployerId, @hash, ackCh) = {
+                new userCh, mvarCh in {
+                  getUser!(deployerId, *userCh) |
+                  runMVar!(*stateCh, *mvarCh, *ackCh) |
+                  for (@validator       <- userCh;
+                       @state, resultCh <- mvarCh) {
+                    if (state.get("randomImages").contains(validator)) {
+                      resultCh!(state, (false, "Image already committed"))
+                    } else {
+                      resultCh!(
+                        state.set("randomImages", state.get("randomImages").set(validator, hash)), true)
+                    }
+                  }
+                }
+              } |
+              //
+              contract PoS(@"revealRandom", @deployerId, @random, ackCh) = {
+                new userCh, mvarCh, computeHash(`rho:crypto:keccak256Hash`), hashCh in {
+                  getUser!(deployerId, *userCh) |
+                  runMVar!(*stateCh, *mvarCh, *ackCh) |
+                  computeHash!(random, *hashCh) |
+                  for (@validator       <- userCh;
+                       @state, resultCh <- mvarCh;
+                       @hash            <- hashCh) {
+                    if (state.get("randomImages").contains(validator)) {
+                      if (hash == state.get("randomImages").get(validator)) {
+                        resultCh!(
+                          state.set("randomNumbers",state.get("randomNumbers").set(validator, random)), true)
+                      } else {
+                        resultCh!(state, (false, "Previously committed image doesn't match the random number"))
+                      }
+                    } else {
+                      resultCh!(state, (false, "Previously committed random image not found"))
+                    }
+                  }
+                }
+              } |
+              // Initialize pending rewards state for each validator
+              contract PendingRewards(@"init", @validatorKeys, @return) = {
+                new createStateKeyCh in {
+                  @ListOps!("map", validatorKeys, *createStateKeyCh, return) |
+                  contract createStateKeyCh(@key, @ackCh) = {
+                    TreeHashMap!("set", pendingRewardsMap, key, {}, ackCh)
+                  }
+                }
+              } |
+              // Sum of new pending rewards with existing state
+              contract PendingRewards(@"append", @validatorKey, @newRewards, @return) = {
+                new currentRewardsCh in {
+                  // Get existing pending rewards (per validator)
+                  // - validator key is always initialized so here we can use unsafe get
+                  TreeHashMap!("fastUnsafeGet", pendingRewardsMap, validatorKey, *currentRewardsCh) |
+                  for (@currentRewards <- currentRewardsCh) {
+                    new mergeResultCh in {
+                      // Merge (sum) current pending rewards with new pending rewards
+                      MergeIntMaps!(currentRewards, newRewards, *mergeResultCh) |
+                      for (@mergeResult <- mergeResultCh) {
+                        // Update pending rewards state
+                        TreeHashMap!("set", pendingRewardsMap, validatorKey, mergeResult, return)
+                      }
+                    }
+                  }
+                }
+              } |
+              // Collect pending rewards from all validators (in a map) / reset state to zero.
+              contract PendingRewards(@"collect", @validatorKeys, @return) = {
+                new collectMaps, mapsListCh in {
+                  // Get pending rewards (maps) for list of validators (public keys).
+                  @ListOps!("fold", validatorKeys, [], *collectMaps, *mapsListCh) |
+                  contract collectMaps(@validatorKey, @acc, mergeRet) = {
+                    new updateCh, updateAckCh in {
+                      // Update (per validator) pending rewards.
+                      // - collect existing values and reset to empty map
+                      TreeHashMap!("update", pendingRewardsMap, validatorKey, *updateCh, *updateAckCh) |
+                      for (@rewardsMap, rewardsRet <- updateCh) {
+                        // Reset per validator pending rewards state.
+                        rewardsRet!({}) |
+                        // Accumulate all rewards maps.
+                        for (_ <- updateAckCh) {
+                          mergeRet!(acc ++ [rewardsMap])
+                        }
+                      }
+                    }
+                  } |
+                  // Merge all pending rewards maps into one map.
+                  for (@mapsList <- mapsListCh) {
+                    @ListOps!("fold", mapsList, {}, *MergeIntMaps, return)
+                  }
+                }
               }
             }
-
           }
         } |
-
-        contract deposit (@deployerId, @amount, @activeValidators, returnCh) = {
-          new vaultCh,
-              revAddressCh,
-              indexSender,
-              getBlockData(`rho:block:data`), blockDataCh,
-              authKeyCh in {
+        // Transfers funds from deployer to block sender.
+        contract deposit(@deployerId, @amount, @activeValidators, returnCh) = {
+          new vaultCh, revAddressCh,
+              indexSender, authKeyCh,
+              getBlockData(`rho:block:data`), blockDataCh
+          in {
             @RevVault!("deployerAuthKey", deployerId, *authKeyCh) |
             revAddressOps!("fromDeployerId", deployerId, *revAddressCh) |
-            for (@authKey <- authKeyCh; @fromRevAddress <- revAddressCh) {
+            for (@authKey        <- authKeyCh;
+                 @fromRevAddress <- revAddressCh) {
               @RevVault!("findOrCreate", fromRevAddress, *vaultCh) |
               getBlockData!(*blockDataCh) |
-              for (@(true, fromVault) <- vaultCh; _, _, @sender <- blockDataCh) {
+              for (@(true, fromVault) <- vaultCh;
+                   _, _, @sender      <- blockDataCh) {
                 @ListOps!("indexOf", activeValidators, sender, *indexSender) |
                 for (@idx <- indexSender) {
                   for (@vaults <<- perActiveValidatorPosVaultsCh) {
@@ -701,16 +752,17 @@ in {
             }
           }
         } |
-
+        // Stake-weighted distribution of final deployment cost for bookkeeping in validator state.
         contract distributeRewards(@amount, @activeValidators, @bonds, returnCh) = {
           new computeSum, computeDelta, totalActiveStakeCh in {
             @ListOps!("fold", activeValidators, 0, *computeSum, *totalActiveStakeCh) |
             contract computeSum(@pk, @acc, resultCh) = {
               resultCh!(acc + bonds.get(pk))
             } |
-
-            for(@totalActiveStake <- totalActiveStakeCh) {
+            // Computes the rewards delta for each active validator.
+            for (@totalActiveStake <- totalActiveStakeCh) {
               @ListOps!("fold", activeValidators, {}, *computeDelta, *returnCh) |
+              // Stake-weighted rewards delta map.
               contract computeDelta(@pk, @acc, resultCh) = {
                 resultCh!(acc.set(pk, (amount * bonds.get(pk)) / totalActiveStake))
               }
@@ -718,7 +770,7 @@ in {
           }
         }
       } |
-
+      // Updates value stored on varCh and sends (Bool) acknowledgement on returnCh.
       contract runMVar(varCh, processCh, returnCh) = {
         new resultCh in {
           for (@v <- varCh) {
@@ -730,31 +782,29 @@ in {
           }
         }
       } |
-
+      // Discards second element of a pair.
       contract fst(@(first, _), resultCh) = {
         resultCh!(first)
       } |
-
-      contract getUser (@deployerId, returnCh) = {
+      // For computing some of initial validator bonds.
+      contract sumFromPair(@(_, a), @b, resultCh) = {
+        resultCh!(a + b)
+      } |
+      // Retrieves deployer's public key.
+      contract getUser(@deployerId, returnCh) = {
         new deployerIdOps(`rho:rchain:deployerId:ops`) in {
           deployerIdOps!("pubKeyBytes", deployerId, *returnCh)
         }
       } |
-
-      contract getCurrentUserAddress(@deployerId, returnCh) = {
-        new userCh in {
-          getUser!(deployerId, *userCh) |
-          for (@userPk <- userCh) {
-            revAddressOps!("fromPublicKey", userPk, *returnCh)
-          }
-        }
-      } |
-
+      // Selects set of active validators from the set of available validators.
       contract pickActiveValidators(@allBonds, @withdrawers, returnCh) = {
-        new availableValidatorsCh, isAvailable, pksCh in {
+        new availableValidatorsCh,
+            isAvailable, pksCh
+        in {
           @ListOps!("filter", allBonds.toList(), *isAvailable, *availableValidatorsCh) |
-          contract isAvailable(@(pk, _), resultCh) = { resultCh!(not withdrawers.contains(pk))} |
-
+          contract isAvailable(@(pk, _), resultCh) = {
+            resultCh!(not withdrawers.contains(pk))
+          } |
           for (@availableValidators <- availableValidatorsCh) {
             @ListOps!("map", availableValidators, *fst, *pksCh) |
             for (@pks <- pksCh) {
@@ -765,7 +815,6 @@ in {
         }
       }
     } |
-
     // Merge (sum) maps with integer values
     // MergeIntMaps({"a": 1, "b": 4}, {"a": 2, "c": 5, "d": Nil})
     //            = {"a": 3, "b": 4, "c": 5}
@@ -782,10 +831,11 @@ in {
         }
       }
     } |
-
-    rs!("047b43d6548b72813b89ac1b9f9ca67624a8b372feedd71d4e2da036384a3e1236812227e524e6f237cde5f80dbb921cac12e6500791e9a9ed1254a745a816fe1f".hexToBytes(),
-    (9223372036854775807, bundle+{*PoS}),
-    "3044022054ff4bae3984252b116e41e28d98bb5533eaa39aec2729228159166e2784f641022066a0fd99e7ea33df812fab095cbe61250f9548bce6da3ec4c6a90c741b94087f".hexToBytes(),
-    *uriOut)
+    // Registers signed write-only PoS contract bundle.
+    rs!(
+      "047b43d6548b72813b89ac1b9f9ca67624a8b372feedd71d4e2da036384a3e1236812227e524e6f237cde5f80dbb921cac12e6500791e9a9ed1254a745a816fe1f".hexToBytes(),
+      (9223372036854775807, bundle+{*PoS}),
+      "3044022054ff4bae3984252b116e41e28d98bb5533eaa39aec2729228159166e2784f641022066a0fd99e7ea33df812fab095cbe61250f9548bce6da3ec4c6a90c741b94087f".hexToBytes(),
+      *uriOut)
   }
 }

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -83,6 +83,15 @@ in {
                 }
               }
             } |
+            // Used during genesis to create PoS vault with initial balance = sum of initial bonds.
+            for (@"createWithBalance", @ownerRevAddress, @amount, ret <- RevVault) {
+              new createVault in {
+                _getOrCreate!(ownerRevAddress, *createVault, *ret) |
+                for (retCh <- createVault) {
+                  _makeVault!(ownerRevAddress, amount, *retCh)
+                }
+              }
+            } |
 
             contract _getOrCreate(@revAddress, constructor, retCh) = {
               new revAddressValidCh,

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -73,12 +73,10 @@ object BlockCreator {
         invalidBlocksSet <- dag.invalidBlocks
         invalidBlocks    = invalidBlocksSet.map(block => (block.blockHash, block.sender)).toMap
         // make sure closeBlock is the last system Deploy
-        systemDeploys = if (slashingDeploys.nonEmpty)
-          slashingDeploys ++ Seq(
-            CloseBlockDeploy(Tools.rng(parents.head.blockHash.toByteArray))
-          )
-        else List.empty[SystemDeploy]
-        unsignedBlock <- if (deploys.nonEmpty || systemDeploys.nonEmpty) {
+        systemDeploys = slashingDeploys :+ CloseBlockDeploy(
+          Tools.rng(parents.head.blockHash.toByteArray)
+        )
+        unsignedBlock <- if (deploys.nonEmpty || slashingDeploys.nonEmpty) {
                           SynchronyConstraintChecker[F]
                             .check(dag, runtimeManager, genesis, validator)
                             .ifM(

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -40,7 +40,7 @@ final case class ProofOfStake(
 }
 
 object ProofOfStake {
-  // TODO: Determine how the "intial bonds" map can simulate transferring stake into the PoS contract
+  // TODO: Determine how the "initial bonds" map can simulate transferring stake into the PoS contract
   //       when this must be done during genesis, under the authority of the genesisPk, which calls the
   //       linear receive in PoS.rho
   def initialBonds(validators: Seq[Validator]): String = {

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
@@ -19,7 +19,7 @@ final case class SlashDeploy(
   import record._
   import syntax.singleton._
 
-  type Output = RhoBoolean
+  type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit
 
   val `sys:casper:invalidBlockHash` = Witness("sys:casper:invalidBlockHash")
@@ -51,7 +51,13 @@ final case class SlashDeploy(
 
   protected override val extractor = Extractor.derive
 
-  protected def processResult(value: Boolean): Either[SystemDeployFailure, Unit] =
-    Either.cond(value, (), SystemDeployUserError("Slashing failed unexpectedly"))
+  protected def processResult(
+      value: (Boolean, Either[String, Unit])
+  ): Either[SystemDeployFailure, Unit] =
+    value match {
+      case (true, _)               => Right(())
+      case (false, Left(errorMsg)) => Left(SystemDeployUserError(errorMsg))
+      case _                       => Left(SystemDeployUserError("Slashing failed unexpectedly"))
+    }
 
 }

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -29,6 +29,7 @@ match (
       test_commit_random,
       test_dont_pay_inactive_validators,
       test_bonding_failure,
+      test_slashing_vaults_and_state,
       getPosBalance,
       closeBlock
     in {
@@ -38,12 +39,12 @@ match (
       rl!(`rho:lang:listOps`, *ListOpsCh) |
       rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
       makeSysAuthToken!(*sysAuthTokenCh) |
-      for(@(_, RhoSpec) <- RhoSpecCh;
-          @(_, PoS) <- PoSCh;
+      for(@(_, RhoSpec)  <- RhoSpecCh;
+          @(_, PoS)      <- PoSCh;
           @(_, RevVault) <- RevVaultCh;
           @posRevAddress <- posRevAddressCh;
-          @(_, ListOps) <- ListOpsCh;
-          @sysAuthToken <- sysAuthTokenCh) {
+          @(_, ListOps)  <- ListOpsCh;
+          @sysAuthToken  <- sysAuthTokenCh) {
         stdlog!("info", {"posRevAddress":posRevAddress}) |
 
         @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
@@ -60,9 +61,10 @@ match (
               ("payment works", *test_pay_succeeds),
               ("payment refund works", *test_refund_succeeds),
               ("bonding fails if already bonded", *test_bonding_fails_if_already_bonded),
-              ("bonding fails is bond is too small", *test_bonding_fails_if_bond_too_small),
+              ("bonding fails if bond is too small", *test_bonding_fails_if_bond_too_small),
               ("payment is not distributed to inactive validators", *test_dont_pay_inactive_validators),
-              ("commited random matches its image", *test_commit_random)
+              ("commited random matches its image", *test_commit_random),
+              ("Slashing transfers funds appropriately", *test_slashing_vaults_and_state)
             ]) |
 
           contract setup(_, retCh) = {
@@ -165,47 +167,70 @@ match (
               }
             }
           } |
-
+          // Tests that when a user requests to bond, they are added to the bond map with the appropriate bond stake.
+          // Rewards shouldn't change with a bond request because these funds are just accumulated into the PoS vault during closeBlock.
+          // The user's balance should decrease by the bond amount after their bonding request is processed.
+          // After withdrawing, the validator should be moved to the withdrawers map with the appropriate quarantine period.
+          // Caution: there is interaction between this test and test_withdraw_succeeds because block numbers are manipulated.
           contract test_withdraw_succeeds(rhoSpec, _, ackCh) = {
-            new setupCh, retCh,
+            new setupCh, bondCh,
                 initialPosBalanceCh, finalPosBalanceCh,
                 initialUserBalanceCh, finalUserBalanceCh,
                 initialRewardsCh, finalRewardsCh,
                 initialBondsCh, finalBondsCh,
-                withdrawCh, closeBlockCh in {
+                withdrawCh, closeBlockCh, quarantineCh, epochCh, quarantinePeriodCh,
+                withdrawersCh, setBlockData(`rho:test:block:data:set`), blockDataCh
+            in {
               prepareUser!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", *setupCh) |
-              for (@user1PubKey, _, @user1Vault, @user1DeployerId <- setupCh) {
+              for (@userPubKey, _, @userVault, @userDeployerId <- setupCh) {
                 getPosBalance!(*initialPosBalanceCh) |
-                @user1Vault!("balance", *initialUserBalanceCh) |
+                @userVault!("balance", *initialUserBalanceCh) |
                 @PoS!("getBonds", *initialBondsCh) |
                 @PoS!("getRewards", *initialRewardsCh) |
-                for(@initialPosBalance <- initialPosBalanceCh;
-                    @initialUserBalance <- initialUserBalanceCh;
-                    @initialBonds <- initialBondsCh;
-                    @initialRewards <- initialRewardsCh) {
-                  @PoS!("bond", user1DeployerId, 100, *retCh) |
-                  for ( @(true, _) <- retCh) {
-                    @PoS!("withdraw", user1DeployerId, *withdrawCh) |
-                    for (_ <- withdrawCh) {
-                      closeBlock!(*closeBlockCh) |
-                      for (_ <- closeBlockCh) {
-                        @PoS!("getBonds", *finalBondsCh) |
-                        getPosBalance!(*finalPosBalanceCh) |
-                        @user1Vault!("balance", *finalUserBalanceCh) |
-                        @PoS!("getRewards", *finalRewardsCh) |
-                        for(@finalPosBalance <- finalPosBalanceCh;
-                            @finalUserBalance <- finalUserBalanceCh;
-                            @finalBonds <- finalBondsCh;
-                            @finalRewards <- finalRewardsCh) {
-                          rhoSpec!("assertMany",
-                            [
-                              ((finalBonds, "==", initialBonds), "bonds don't change"),
-                              ((finalRewards, "==", initialRewards), "rewards don't change"),
-                              ((finalUserBalance, "==", initialUserBalance), "user balancs doesn't change"),
-                              ((finalPosBalance, "==", initialPosBalance), "pos balance doesn't change")
-                            ],
-                            *ackCh
-                          )
+                @PoS!("getQuarantineLength", *quarantineCh) |
+                @PoS!("getEpochLength", *epochCh) |
+                for (@initialPosBalance  <- initialPosBalanceCh;
+                     @initialUserBalance <- initialUserBalanceCh;
+                     @initialBonds       <- initialBondsCh;
+                     @initialRewards     <- initialRewardsCh;
+                     @epochLength        <- epochCh;
+                     @quarantineLength   <- quarantineCh) {
+                  // block number is set for after a quarantine period so this validator will appear in the initial and final bonds map in test_validator_is_paid_after_withdraw
+                  match (100, 2 * epochLength * quarantineLength) {
+                    (bondAmt, blockNumber) => {
+                      @PoS!("bond", userDeployerId, bondAmt, *bondCh) |
+                      setBlockData!("blockNumber", blockNumber, *blockDataCh) |
+                      for (@(true, _) <- bondCh;
+                           _          <- blockDataCh) {
+                        @PoS!("withdraw", userDeployerId, *withdrawCh) |
+                        for (_ <- withdrawCh) {
+                          closeBlock!(*closeBlockCh) |
+                          for (_ <- closeBlockCh) {
+                            @PoS!("getBonds", *finalBondsCh) |
+                            getPosBalance!(*finalPosBalanceCh) |
+                            @userVault!("balance", *finalUserBalanceCh) |
+                            @PoS!("getRewards", *finalRewardsCh) |
+                            @PoS!("getWithdrawers", *withdrawersCh) |
+                            quarantinePeriodCh!(quarantineLength + epochLength * (1 + blockNumber / epochLength)) |
+                            for (@finalPosBalance  <- finalPosBalanceCh;
+                                 @finalUserBalance <- finalUserBalanceCh;
+                                 @finalBonds       <- finalBondsCh;
+                                 @finalRewards     <- finalRewardsCh;
+                                 @withdrawers      <- withdrawersCh;
+                                 @quarantinePeriod <- quarantinePeriodCh) {
+                              rhoSpec!("assertMany",
+                                [
+                                  ((finalBonds, "==", initialBonds.set(userPubKey, bondAmt)), "user is correctly added to the bond map"),
+                                  ((finalRewards, "==", initialRewards), "rewards don't change for bonding"),
+                                  ((finalUserBalance, "==", initialUserBalance - bondAmt), "user balance should change by bond amount"),
+                                  ((finalPosBalance, "==", initialPosBalance + bondAmt), "pos balance should change by bond amount"),
+                                  ((true, "==", withdrawers.contains(userPubKey)), "withdrawer is moved to withdrawers map"),
+                                  ((quarantinePeriod, "==", withdrawers.get(userPubKey)), "withdrawer has correct quarantine finish block")
+                                ],
+                                *ackCh
+                              )
+                            }
+                          }
                         }
                       }
                     }
@@ -214,44 +239,96 @@ match (
               }
             }
           } |
-
+          // Tests that a withdrawing validator is only paid after their quarantine period finishes and that when they are paid,
+          // their bond is returned to their vault and they are paid the rewards they have accumulated.
+          // Caution: there is interaction between this test and test_withdraw_succeeds because block numbers are manipulated.
           contract test_validator_is_paid_after_withdraw(rhoSpec, _, ackCh) = {
-            new setupCh, retCh0, retCh1,
+            new setupCh, bondCh, chargeCh, refundCh,
                 initialValidatorBalanceCh, finalValidatorBalanceCh,
                 initialBondsCh, finalBondsCh,
-                withdrawCh, closeBlockCh in {
+                withdrawCh, closeBlockCh, epochCh, quarantineCh,
+                setBlockData(`rho:test:block:data:set`),
+                blockDataCh, rewardsCh, validatorRewardCh,
+                intermediateValidatorBalanceCh, withdrawersCh
+            in {
               prepareUser!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", *setupCh) |
               for (@validatorPubKey, _, @validatorVault, @validatorDeployerId <- setupCh) {
                 @validatorVault!("balance", *initialValidatorBalanceCh) |
                 @PoS!("getBonds", *initialBondsCh) |
-                for(@initialValidatorBalance <- initialValidatorBalanceCh;
-                    @initialBonds <- initialBondsCh) {
-                  @PoS!("bond", validatorDeployerId, 100, *retCh0) |
-                  for ( @(true, _) <- retCh0) {
-                    closeBlock!(*closeBlockCh) |
-                    for (_ <- closeBlockCh) {
-                      prepareUser!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", *setupCh) |
-                      for (@userPubKey, _, @userVault, @userDeployerId <- setupCh) {
-                        @PoS!("chargeDeploy", userDeployerId, 100, sysAuthToken, *retCh0) |
-                        @PoS!("refundDeploy", 0, sysAuthToken, *retCh1) |
-                        for ( @(true, _) <- retCh0; @(true, _) <- retCh1){
-                          closeBlock!(*closeBlockCh) |
-                          for (_ <- closeBlockCh) {
-                            @PoS!("withdraw", validatorDeployerId, *withdrawCh) |
-                            for (_ <- withdrawCh) {
+                @PoS!("getQuarantineLength", *quarantineCh) |
+                @PoS!("getEpochLength", *epochCh) |
+                for (@initialValidatorBalance <- initialValidatorBalanceCh;
+                     @initialBonds            <- initialBondsCh;
+                     @epochLength             <- epochCh;
+                     @quarantineLength        <- quarantineCh) {
+                  match (100, 100, 0, 1) {
+                    (bondAmt, chargeAmt, refundAmt, blockNumber) => {
+                      @PoS!("bond", validatorDeployerId, bondAmt, *bondCh) |
+                      for (@(true, _) <- bondCh) {
+                        closeBlock!(*closeBlockCh) |
+                        for (_ <- closeBlockCh) {
+                          prepareUser!("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", *setupCh) |
+                          for (@userPubKey, _, @userVault, @userDeployerId <- setupCh) {
+                            @PoS!("chargeDeploy", userDeployerId, chargeAmt, sysAuthToken, *chargeCh) |
+                            @PoS!("refundDeploy", refundAmt, sysAuthToken, *refundCh) |
+                            for (@(true, _) <- chargeCh;
+                                 @(true, _) <- refundCh){
                               closeBlock!(*closeBlockCh) |
                               for (_ <- closeBlockCh) {
-                                @validatorVault!("balance", *finalValidatorBalanceCh) |
-                                @PoS!("getBonds", *finalBondsCh) |
-                                for(@finalBonds <- finalBondsCh;
-                                    @finalValidatorBalance <- finalValidatorBalanceCh) {
-                                  rhoSpec!("assertMany",
-                                    [
-                                      ((finalBonds, "==", initialBonds), "bonds don't change"),
-                                      ((46, "==", finalValidatorBalance-initialValidatorBalance ), "user balance changes accordingly")
-                                    ],
-                                    *ackCh
-                                  )
+                                @PoS!("getRewards", *rewardsCh) |
+                                for (@rewards <- rewardsCh) {
+                                  validatorRewardCh!(rewards.getOrElse(validatorPubKey, 0)) |
+                                  for (@validatorReward <- validatorRewardCh) {
+                                    setBlockData!("blockNumber", blockNumber, *blockDataCh) |
+                                    @PoS!("getWithdrawers", *withdrawersCh) |
+                                    for (_                   <- blockDataCh;
+                                         @initialWithdrawers <- withdrawersCh) {
+                                      @PoS!("withdraw", validatorDeployerId, *withdrawCh) |
+                                      for (_ <- withdrawCh) {
+                                        match quarantineLength + epochLength * (1 + blockNumber / epochLength) {
+                                          quarantinePeriod => {
+                                            setBlockData!("blockNumber", quarantinePeriod - 1, *blockDataCh) |
+                                            for (_ <- blockDataCh) {
+                                              @PoS!("getWithdrawers", *withdrawersCh) |
+                                              @validatorVault!("balance", *intermediateValidatorBalanceCh) |
+                                              for (@intermediateWithdrawers      <- withdrawersCh;
+                                                   @intermediateValidatorBalance <- intermediateValidatorBalanceCh) {
+                                                // Sets blockNumber to the soonest epoch change after quarantine period is finished.
+                                                if (quarantineLength % epochLength == 0) {
+                                                  setBlockData!("blockNumber", quarantinePeriod, *blockDataCh)
+                                                } else {
+                                                  setBlockData!("blockNumber", quarantinePeriod + epochLength - (quarantineLength % epochLength), *blockDataCh)
+                                                } |
+                                                for (_ <- blockDataCh) {
+                                                  closeBlock!(*closeBlockCh) |
+                                                  for (_ <- closeBlockCh) {
+                                                    @validatorVault!("balance", *finalValidatorBalanceCh) |
+                                                    @PoS!("getBonds", *finalBondsCh) |
+                                                    @PoS!("getWithdrawers", *withdrawersCh) |
+                                                    for (@finalBonds            <- finalBondsCh;
+                                                         @finalWithdrawers      <- withdrawersCh;
+                                                         @finalValidatorBalance <- finalValidatorBalanceCh) {
+                                                      rhoSpec!("assertMany",
+                                                        [
+                                                          ((finalBonds, "==", initialBonds), "bonds don't change after the same user bonds and withdraws successfully"),
+                                                          ((intermediateValidatorBalance, "==", initialValidatorBalance - bondAmt), "withdrawer is not paid before quarantine period is over"),
+                                                          ((validatorReward, "==", finalValidatorBalance - initialValidatorBalance), "after payment, validator's balance only changes by their accumulated rewards"),
+                                                          ((false, "==", initialWithdrawers.contains(validatorPubKey)), "before validator withdraws, they should not be in withdrawers map"),
+                                                          ((true, "==", intermediateWithdrawers.contains(validatorPubKey)), "after validator requests to withdraw and before quarantine is finished, they should be in withdrawers map"),
+                                                          ((false, "==", finalWithdrawers.contains(validatorPubKey)), "after quarantine is finished, validator should not be in withdrawers map")
+                                                        ],
+                                                        *ackCh
+                                                      )
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             }
@@ -274,36 +351,39 @@ match (
                 @user1Vault!("balance", *initialUser1BalanceCh) |
                 for(@initialPosBalance <- initialPosBalanceCh;
                     @initialUser1Balance <- initialUser1BalanceCh) {
-                  @PoS!("bond", user1DeployerId, 100, *retCh) |
-                  for ( @(true, _) <- retCh) {
-                    stdlog!("info", "first bond") |
-                    prepareUser!("3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", *setupCh) |
-                    for(@user2PubKey, _, @user2Vault, @user2DeployerId <- setupCh) {
-                      @user2Vault!("balance", *initialUser2BalanceCh) |
-                      for (@initialUser2Balance <- initialUser2BalanceCh) {
-                        @PoS!("bond", user2DeployerId, 200, *retCh) |
-                        for ( @(true, _) <- retCh) {
-
-                          @PoS!("getBonds", *retCh) |
-                          getPosBalance!(*finalPosBalanceCh) |
-                          @user1Vault!("balance", *finalUser1BalanceCh) |
-                          @user2Vault!("balance", *finalUser2BalanceCh) |
-                          for(@finalPosBalance <- finalPosBalanceCh;
-                              @finalUser1Balance <- finalUser1BalanceCh;
-                              @finalUser2Balance <- finalUser2BalanceCh;
-                              @bonds <- retCh) {
-                            match (bonds.get(user1PubKey), bonds.get(user2PubKey)) {
-                              (bondAmount1, bondAmount2) => {
-                                rhoSpec!("assertMany",
-                                  [
-                                    ((100, "==", bondAmount1), "the user1 bond is expected in the final map"),
-                                    ((200, "==", bondAmount2), "the user2 bond is expected in the final map"),
-                                    ((100, "==", initialUser1Balance - finalUser1Balance), "the user1 account decreases"),
-                                    ((200, "==", initialUser2Balance - finalUser2Balance), "the user2 account decreases"),
-                                    ((300, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
-                                  ],
-                                  *ackCh
-                                )
+                  match (100, 200) {
+                    (user1Bond, user2Bond) => {
+                      @PoS!("bond", user1DeployerId, user1Bond, *retCh) |
+                      for (@(true, _) <- retCh) {
+                        stdlog!("info", "first bond") |
+                        prepareUser!("3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333", *setupCh) |
+                        for(@user2PubKey, _, @user2Vault, @user2DeployerId <- setupCh) {
+                          @user2Vault!("balance", *initialUser2BalanceCh) |
+                          for (@initialUser2Balance <- initialUser2BalanceCh) {
+                            @PoS!("bond", user2DeployerId, user2Bond, *retCh) |
+                            for (@(true, _) <- retCh) {
+                              @PoS!("getBonds", *retCh) |
+                              getPosBalance!(*finalPosBalanceCh) |
+                              @user1Vault!("balance", *finalUser1BalanceCh) |
+                              @user2Vault!("balance", *finalUser2BalanceCh) |
+                              for(@finalPosBalance <- finalPosBalanceCh;
+                                  @finalUser1Balance <- finalUser1BalanceCh;
+                                  @finalUser2Balance <- finalUser2BalanceCh;
+                                  @bonds <- retCh) {
+                                match (bonds.get(user1PubKey), bonds.get(user2PubKey)) {
+                                  (bondAmount1, bondAmount2) => {
+                                    rhoSpec!("assertMany",
+                                      [
+                                        ((user1Bond, "==", bondAmount1), "the user1 bond is expected in the final map"),
+                                        ((user2Bond, "==", bondAmount2), "the user2 bond is expected in the final map"),
+                                        ((user1Bond, "==", initialUser1Balance - finalUser1Balance), "the user1 account decreases"),
+                                        ((user2Bond, "==", initialUser2Balance - finalUser2Balance), "the user2 account decreases"),
+                                        ((user1Bond + user2Bond, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
+                                      ],
+                                      *ackCh
+                                    )
+                                  }
+                                }
                               }
                             }
                           }
@@ -315,7 +395,6 @@ match (
               }
             }
           } |
-
           contract test_pay_succeeds(rhoSpec, _, ackCh) = {
             new setupCh, closeBlockCh, retCh0, retCh1, initialPosBalanceCh, finalPosBalanceCh,
                 initialUser1BalanceCh, finalUser1BalanceCh,
@@ -325,53 +404,58 @@ match (
             in {
               prepareUser!("4444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444", *setupCh) |
               for (@validatorPubKey, _, _, @validatorDeployerId <- setupCh) {
-                @PoS!("bond", validatorDeployerId, 100, *setupCh) |
-                for (@(true, _) <- setupCh) {
-                  closeBlock!(*closeBlockCh) |
-                  prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", *setupCh) |
-                  for (@user1PubKey, _, @user1Vault, @user1DeployerId <- setupCh;
-                       _ <- closeBlockCh) {
-                    getPosBalance!(*initialPosBalanceCh) |
-                    @user1Vault!("balance", *initialUser1BalanceCh) |
-                    @PoS!("getRewards", *initialRewardsCh) |
-                    for(@initialPosBalance <- initialPosBalanceCh;
-                        @initialUser1Balance <- initialUser1BalanceCh;
-                        @initialRewards <- initialRewardsCh) {
-                      @PoS!("chargeDeploy", user1DeployerId, 100, sysAuthToken, *retCh0) |
-                      @PoS!("refundDeploy", 0, sysAuthToken, *retCh1) |
-                      for ( @(true, _) <- retCh0; @(true, _) <- retCh1) {
-                        closeBlock!(*closeBlockCh) |
-                        for (_ <- closeBlockCh) {
-                          getPosBalance!(*finalPosBalanceCh) |
-                          @user1Vault!("balance", *finalUser1BalanceCh) |
-                          @PoS!("getRewards", *finalRewardsCh) |
-                          for(@finalPosBalance <- finalPosBalanceCh;
-                              @finalUser1Balance <- finalUser1BalanceCh;
-                              @finalRewards <- finalRewardsCh) {
-                            @ListOps!("fold", finalRewards.toList(), {}, *computeDelta, *deltaRewardsCh) |
-                            contract computeDelta(@(pk, finalReward), @acc, resultCh) = {
-                              resultCh!(acc.set(pk, finalReward - initialRewards.getOrElse(pk, 0)))
-                            } |
-                            for (@deltaRewards <- deltaRewardsCh) {
-                              @ListOps!("forall", deltaRewards, *isPositive, *allRewardsPositiveCh) |
-                              contract isPositive(@n, resultCh) = { resultCh!(n > 0)} |
+                match (100, 100, 0) {
+                  (validatorBond, user1Charge, user1Refund) => {
+                    @PoS!("bond", validatorDeployerId, validatorBond, *setupCh) |
+                    for (@(true, _) <- setupCh) {
+                      closeBlock!(*closeBlockCh) |
+                      prepareUser!("5555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555", *setupCh) |
+                      for (@user1PubKey, _, @user1Vault, @user1DeployerId <- setupCh;
+                           _                                              <- closeBlockCh) {
+                        getPosBalance!(*initialPosBalanceCh) |
+                        @user1Vault!("balance", *initialUser1BalanceCh) |
+                        @PoS!("getRewards", *initialRewardsCh) |
+                        for (@initialPosBalance   <- initialPosBalanceCh;
+                             @initialUser1Balance <- initialUser1BalanceCh;
+                             @initialRewards      <- initialRewardsCh) {
+                          @PoS!("chargeDeploy", user1DeployerId, user1Charge, sysAuthToken, *retCh0) |
+                          @PoS!("refundDeploy", user1Refund, sysAuthToken, *retCh1) |
+                          for (@(true, _) <- retCh0;
+                               @(true, _) <- retCh1) {
+                            closeBlock!(*closeBlockCh) |
+                            for (_ <- closeBlockCh) {
+                              getPosBalance!(*finalPosBalanceCh) |
+                              @user1Vault!("balance", *finalUser1BalanceCh) |
+                              @PoS!("getRewards", *finalRewardsCh) |
+                              for (@finalPosBalance   <- finalPosBalanceCh;
+                                   @finalUser1Balance <- finalUser1BalanceCh;
+                                   @finalRewards      <- finalRewardsCh) {
+                                @ListOps!("fold", finalRewards.toList(), {}, *computeDelta, *deltaRewardsCh) |
+                                contract computeDelta(@(pk, finalReward), @acc, resultCh) = {
+                                  resultCh!(acc.set(pk, finalReward - initialRewards.getOrElse(pk, 0)))
+                                } |
+                                for (@deltaRewards <- deltaRewardsCh) {
+                                  @ListOps!("forall", deltaRewards, *isPositive, *allRewardsPositiveCh) |
+                                  contract isPositive(@n, resultCh) = { resultCh!(n > 0)} |
 
-                              @ListOps!("fold", deltaRewards.toList(), 0, *sumDelta, *deltaSumCh) |
-                              contract sumDelta(@(_, delta), @acc, resultCh) = {
-                                resultCh!(acc + delta)
-                              } |
+                                  @ListOps!("fold", deltaRewards.toList(), 0, *sumDelta, *deltaSumCh) |
+                                  contract sumDelta(@(_, delta), @acc, resultCh) = {
+                                    resultCh!(acc + delta)
+                                  } |
 
-                              rhoSpec!("assertMany",
-                                [
-                                  ((100, "==", initialUser1Balance - finalUser1Balance), "the user account decreases"),
-                                  ((100, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
-                                  ((19, "==", finalRewards.get(validatorPubKey)), "the validator's finalRewards is as expected"),
-                                  //TODO use arbitrary precision numbers instead of long ints
-                                  ((96, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
-                                  ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")
-                                ],
-                                *ackCh
-                              )
+                                  rhoSpec!("assertMany",
+                                    [
+                                      ((user1Charge, "==", initialUser1Balance - finalUser1Balance), "the user account decreases"),
+                                      ((user1Charge - user1Refund, "==", finalPosBalance - initialPosBalance), "the pos account increases"),
+                                      ((19, "==", finalRewards.get(validatorPubKey)), "the validator's finalRewards is as expected"),
+                                      //TODO use arbitrary precision numbers instead of long ints
+                                      ((96, "== <-", *deltaSumCh), "the sum difference should equal the payment"),
+                                      ((true, "== <-", *allRewardsPositiveCh), "the rewards can only grow")
+                                    ],
+                                    *ackCh
+                                  )
+                                }
+                              }
                             }
                           }
                         }
@@ -408,8 +492,8 @@ match (
                     for(@initialPosBalance <- posBalanceCh;
                         @initialUserBalance <- userBalanceCh;
                         @initialRewards <- rewardsCh) {
-                      @PoS!("chargeDeploy", userDeployerId, 100, sysAuthToken, *chargeDeployAck) |
-                      @PoS!("refundDeploy", 50, sysAuthToken, *refundDeployAck) |
+                        @PoS!("chargeDeploy", userDeployerId, 100, sysAuthToken, *chargeDeployAck) |
+                        @PoS!("refundDeploy", 50, sysAuthToken, *refundDeployAck) |
                       for ( @(true, _) <- chargeDeployAck; @(true, _) <- refundDeployAck) {
                         closeBlock!(*closeBlockAck) |
                         for (_ <- closeBlockAck) {
@@ -623,6 +707,89 @@ match (
                         }
                       }
                     }
+                  }
+                }
+              }
+            }
+          } |
+          // Checks that the slashed validator's bond and rewards are moved from the PoS vault to the Coop vault and
+          // reduced to 0 in the bond and committedRewards maps and that they are immediately moved to the withdrawers map.
+          contract test_slashing_vaults_and_state(rhoSpec, _, ackCh) = {
+            new setInvalidBlocks(`rho:test:casper:invalidBlocks:set`),
+                computeHash(`rho:crypto:keccak256Hash`), hashCh, invalidBlocksSetCh,
+                initialBondSumCh, chargeCh, refundCh, initialCoopBalanceCh, finalCoopBalanceCh,
+                setupCh, slashCh, activeValidatorsCh, withdrawersCh, getCoopBalance,
+                initialPosBalanceCh, finalPosBalanceCh,
+                initialUserBalanceCh, finalUserBalanceCh,
+                initialRewardsCh, finalRewardsCh,
+                initialBondsCh, finalBondsCh
+            in {
+              prepareUser!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", *setupCh) |
+              for (_, _, @userVault, @userDeployerId <- setupCh) {
+                @PoS!("getActiveValidators", *activeValidatorsCh) |
+                @PoS!("getBonds", *initialBondsCh) |
+                getCoopBalance!(*initialCoopBalanceCh) |
+                for (@activeValidators   <- activeValidatorsCh;
+                     @initialBonds       <- initialBondsCh;
+                     @initialCoopBalance <- initialCoopBalanceCh) {
+                  match (100, 0) {
+                    (chargeAmt, refundAmt) => {
+                      @PoS!("chargeDeploy", userDeployerId, chargeAmt, sysAuthToken, *chargeCh) |
+                      @PoS!("refundDeploy", refundAmt, sysAuthToken, *refundCh) |
+                      for (@(true, _) <- chargeCh;
+                           @(true, _) <- refundCh) {
+                        match activeValidators.nth(1) {
+                          slashedValidator => {
+                            computeHash!(slashedValidator, *hashCh) |
+                            for (@hash <- hashCh) {
+                              getPosBalance!(*initialPosBalanceCh) |
+                              @PoS!("getRewards", *initialRewardsCh) |
+                              @userVault!("balance", *initialUserBalanceCh) |
+                              setInvalidBlocks!({hash : slashedValidator}, *invalidBlocksSetCh) |
+                              for (_                   <- invalidBlocksSetCh;
+                                   @initialUserBalance <- initialUserBalanceCh;
+                                   @initialRewards     <- initialRewardsCh;
+                                   @initialPosBalance  <- initialPosBalanceCh) {
+                                @PoS!("slash", userDeployerId, hash, sysAuthToken, *slashCh) |
+                                for (@(true, _) <- slashCh) {
+                                  @PoS!("getBonds", *finalBondsCh) |
+                                  getPosBalance!(*finalPosBalanceCh) |
+                                  @userVault!("balance", *finalUserBalanceCh) |
+                                  @PoS!("getRewards", *finalRewardsCh) |
+                                  @PoS!("getWithdrawers", *withdrawersCh) |
+                                  getCoopBalance!(*finalCoopBalanceCh) |
+                                  for (@finalPosBalance  <- finalPosBalanceCh;
+                                       @finalUserBalance <- finalUserBalanceCh;
+                                       @finalBonds       <- finalBondsCh;
+                                       @finalRewards     <- finalRewardsCh;
+                                       @withdrawers      <- withdrawersCh;
+                                       @finalCoopBalance <- finalCoopBalanceCh) {
+                                    rhoSpec!("assertMany",
+                                      [
+                                        ((finalBonds, "==", initialBonds.set(slashedValidator, 0)), "Slashed validator's bond is reduced to 0"),
+                                        ((0, "==", finalRewards.get(slashedValidator)), "Slashed validator's rewards are reduced to 0"),
+                                        ((true, "==", withdrawers.contains(slashedValidator)), "Slashed validator is immediately moved to withdrawers map"),
+                                        ((finalPosBalance, "==", initialPosBalance - initialBonds.get(slashedValidator) - initialRewards.get(slashedValidator)), "Slashed validator's funds are transferred out of the PoS vault"),
+                                        ((finalCoopBalance, "==", initialCoopBalance + initialBonds.get(slashedValidator) + initialRewards.get(slashedValidator)), "Slashed validator's funds are transferred to the Coop vault")
+                                      ],
+                                      *ackCh
+                                    )
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              } |
+              contract getCoopBalance(returnCh) = {
+                new retCh in {
+                  @PoS!("getCoopVault", *retCh) |
+                  for (@(_, _, coopVault) <- retCh) {
+                    @coopVault!("balance", *returnCh)
                   }
                 }
               }

--- a/casper/src/test/scala/coop/rchain/casper/helper/CasperInvalidBlocksContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/CasperInvalidBlocksContract.scala
@@ -7,7 +7,7 @@ import coop.rchain.models.{ListParWithRandom, Par}
 import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
 import coop.rchain.rholang.interpreter.Runtime.SystemProcess
 
-object BlockDataContract {
+object CasperInvalidBlocksContract {
   import cats.implicits._
 
   def set[F[_]: Concurrent: Span](
@@ -18,21 +18,13 @@ object BlockDataContract {
     message match {
       case isContractCall(
           produce,
-          Seq(RhoType.String("sender"), RhoType.ByteArray(pk), ackCh)
+          Seq(newInvalidBlocks, ackCh)
           ) =>
         for {
-          _ <- ctx.blockData.update(_.copy(sender = PublicKey(pk)))
-          _ <- produce(Seq(Par()), ackCh)
-        } yield ()
-
-      case isContractCall(
-          produce,
-          Seq(RhoType.String("blockNumber"), RhoType.Number(n), ackCh)
-          ) =>
-        for {
-          _ <- ctx.blockData.update(_.copy(blockNumber = n))
+          _ <- ctx.invalidBlocks.setParams(newInvalidBlocks)
           _ <- produce(Seq(Par()), ackCh)
         } yield ()
     }
   }
+
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -121,6 +121,13 @@ class RhoSpec(
           3,
           107L,
           ctx => BlockDataContract.set(ctx)(_)
+        ),
+        SystemProcess.Definition[F](
+          "rho:test:casper:invalidBlocks:set",
+          Runtime.byteName(108),
+          2,
+          108L,
+          ctx => CasperInvalidBlocksContract.set(ctx)(_)
         )
       )
     testResultCollectorService

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -51,15 +51,16 @@ object GenesisBuilder {
         proofOfStake = ProofOfStake(
           minimumBond = 0L,
           maximumBond = Long.MaxValue,
-          epochLength = 1,
+          epochLength = 1, // TODO: change to proper quantity
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq
         ),
         vaults = Seq(defaultPub, defaultPub2).map(predefinedVault) ++
           bonds.toList.map {
-            case (pk, stake) =>
-              RevAddress.fromPublicKey(pk).map(Vault(_, stake))
+            case (pk, _) =>
+              // Initial validator vaults contain 0 Rev
+              RevAddress.fromPublicKey(pk).map(Vault(_, 0))
           }.flattenOption,
         supply = Long.MaxValue
       )

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -51,7 +51,10 @@ object GenesisBuilder {
         proofOfStake = ProofOfStake(
           minimumBond = 0L,
           maximumBond = Long.MaxValue,
-          epochLength = 1, // TODO: change to proper quantity
+          // Epoch length is set to large number to prevent trigger of epoch change
+          // in PoS close block method, which causes block merge conflicts
+          // - epoch change can be set as a parameter in Rholang tests (e.g. PoSSpec)
+          epochLength = 1000,
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq


### PR DESCRIPTION
### Overview
Add Coop multiSig Rev vault to PoS

Create PoS vault with initial balance = sum of initial bonds

Remove getCurrentUserAddress contract from PoS

Slash method returns Either (SlashDeploy)

Short-circuit closeBlock if no epoch change occurs

Slashed validator moved to withdrawers map with correct block number

Add comments to PoS

Add linear consume for PoS vault creation to RevVault

Add CasperInvalidBlocksContract to create invalid blocks for PoSTest

Add slashing test to PoSTest

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3993



### Notes



### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
