### PR TITLE
RCHAIN-1117/2927 Resolve MakeMint bugs

### DIFF
--- a/casper/src/main/resources/MakeMint.rho
+++ b/casper/src/main/resources/MakeMint.rho
@@ -23,7 +23,8 @@ in {
       new thisMint, internalMakePurse, decr in {
         contract thisMint(@"makePurse", @init, return) = {
           new balanceCh in {
-            @NonNegativeNumber!(init, *balanceCh) | for(@balance <- balanceCh) {
+            @NonNegativeNumber!(init, *balanceCh) |
+            for(@balance <- balanceCh) {
               internalMakePurse!(balance, *return)
             }
           }
@@ -35,23 +36,48 @@ in {
             new letCh in { // let thisDecr = ...
               letCh!(bundle0{bundle0{*thisPurse}|*decr}) |
               for (thisDecr <- letCh) {
+                // Checks mint and either decreases the balance of this purse by the given amount and returns true or
+                // doesn't not decrease and returns false.
                 contract thisPurse(@=*thisDecr, @amount, return) = {
-                  new success in {
-                    balance!("sub", amount, *success) |
-                    for (@subOk <- success) {
-                      return!(subOk, *decr) |
+                  new success, thisPurseDecrCh, decrCh,
+                      bd(`rho:block:data`), bdCh
+                  in {
+                    // Checks that this purse has been provided with the correct decr.
+                    decrCh!(bundle0{*decr}) |
+                    thisPurse!("decr", *thisPurseDecrCh) |
+                    for (@thisPurseDecr <- thisPurseDecrCh;
+                         @decrBundle    <- decrCh) {
                       for (logCh <<- logStore) {
-                        if (Nil != *logCh) {
-                          new bd(`rho:block:data`), bdCh in {
+                        if (thisPurseDecr == decrBundle) {
+                          // Correct mint.
+                          // Calls "sub" method on balance in the NonNegativeNumber contract.
+                          balance!("sub", amount, *success) |
+                          for (@subOk <- success) {
+                            return!(subOk) |
+                            if (Nil != *logCh) {
+                              bd!(*bdCh) |
+                              for (@blockNumber, @timestamp, @sender <- bdCh) {
+                                logCh!(["*decr", amount, subOk, blockNumber, timestamp, sender])
+                              }
+                            }
+                          }
+                        } else {
+                          // Incorrect mint.
+                          return!(false) |
+                          if (Nil != *logCh) {
                             bd!(*bdCh) |
                             for (@blockNumber, @timestamp, @sender <- bdCh) {
-                              logCh!(["*decr", amount, subOk, blockNumber, timestamp, sender])
+                              logCh!(["*decr", amount, false, blockNumber, timestamp, sender])
                             }
                           }
                         }
                       }
                     }
                   }
+                } |
+                // Used to compare mints. The name decr cannot be exposed, but is needed to check equality with other mints.
+                contract thisPurse(@"decr", return) = {
+                  return!(bundle0{*decr})
                 }
               }
             } |
@@ -63,9 +89,10 @@ in {
             contract thisPurse(@"sprout", return) = { thisMint!("makePurse", 0, *return) } |
             contract thisPurse(@"split", @amount, return) = {
               new destPurseCh, successCh in {
-                thisPurse!("sprout", *destPurseCh) | for(@destPurse <- destPurseCh) {
+                thisPurse!("sprout", *destPurseCh) |
+                for (@destPurse <- destPurseCh) {
                   @destPurse!("deposit", amount, *thisPurse, *successCh) |
-                  for(@success <- successCh) {
+                  for (@success <- successCh) {
                     if (success) {
                       return!([destPurse])
                     } else {
@@ -76,27 +103,65 @@ in {
               }
             } |
             contract thisPurse(@"deposit", @amount, @src, success) = {
-              new result in {
-                @src!(bundle0{bundle0{src}|*decr}, amount, *result) | //call src decr function.
-                for(@decrSuccess, @auth <- result) {
+              new result, addSuccessCh, thisDecrCh, srcDecrCh in {
+                // Checks if mints match.
+                thisPurse!("decr", *thisDecrCh) |
+                @src!("decr", *srcDecrCh) |
+                for (@thisDecr <- thisDecrCh;
+                     @srcDecr  <- srcDecrCh) {
                   for (logCh <<- logStore) {
-                    if (decrSuccess and auth == *decr) {
-                      // add transferred amount to this purse
-                      balance!("add", amount, *success) |
-                      // log
-                      if (Nil != *logCh) {
-                        new bd(`rho:block:data`), bdCh in {
-                          bd!(*bdCh) |
-                          for (@blockNumber, @timestamp, @sender <- bdCh) {
-                            logCh!(["deposit", amount, src.toByteArray(), true, blockNumber, timestamp, sender])
+                    new bd(`rho:block:data`), bdCh in {
+                      if (thisDecr == srcDecr) {
+                        // Adds amount to this purse if same mint.
+                        // Checks balance of this purse after adding amount to it to make sure an overflow did not occur.
+                        balance!("add", amount, *addSuccessCh) |
+                        for (@addSuccess <- addSuccessCh) {
+                          if (addSuccess) {
+                            // No overflow occurred.
+                            @src!(bundle0{bundle0{src}|*decr}, amount, *result) | //call src decr function.
+                            for (@decrSuccess <- result) {
+                              if (decrSuccess) {
+                                // Proper authority to subtract amount from src, amount subtracted from src.
+                                success!(true) |
+                                // log
+                                if (Nil != *logCh) {
+                                  bd!(*bdCh) |
+                                  for (@blockNumber, @timestamp, @sender <- bdCh) {
+                                    logCh!(["deposit", amount, src.toByteArray(), true, blockNumber, timestamp, sender])
+                                  }
+                                }
+                              } else {
+                                // Insufficient funds in src purse.
+                                // The amount must now be subtracted from this purse.
+                                new subCh in {
+                                  balance!("sub", amount, *subCh) |
+                                  for (_ <- subCh) {
+                                    success!(false)
+                                  }
+                                } |
+                                if (Nil != *logCh) {
+                                  bd!(*bdCh) |
+                                  for (@blockNumber, @timestamp, @sender <- bdCh) {
+                                    logCh!(["deposit", amount, src.toByteArray(), false, blockNumber, timestamp, sender])
+                                  }
+                                }
+                              }
+                            }
+                          } else {
+                            // Failed to add funds to this purse due to overflow or negative amount.
+                            success!(false) |
+                            if (Nil != *logCh) {
+                              bd!(*bdCh) |
+                              for (@blockNumber, @timestamp, @sender <- bdCh) {
+                                logCh!(["deposit", amount, src.toByteArray(), false, blockNumber, timestamp, sender])
+                              }
+                            }
                           }
                         }
-                      }
-                    } else {
-                      success!(false) |
-                      // log
-                      if (Nil != *logCh) {
-                        new bd(`rho:block:data`), bdCh in {
+                      } else {
+                        // Mint mismatch. No transfer occurs.
+                        success!(false) |
+                        if (Nil != *logCh) {
                           bd!(*bdCh) |
                           for (@blockNumber, @timestamp, @sender <- bdCh) {
                             logCh!(["deposit", amount, src.toByteArray(), false, blockNumber, timestamp, sender])

--- a/casper/src/test/resources/MakeMintTest.rho
+++ b/casper/src/test/resources/MakeMintTest.rho
@@ -6,7 +6,7 @@ new
   stdlog(`rho:io:stdlog`),
   setup,
   test_create_purse, test_cross_currency_deposit, test_deposit, test_split,
-  test_log_set,
+  test_log_set, test_overflow_deposit,
   roguePurse1,
   split, getBalance, deposit
 in {
@@ -16,11 +16,12 @@ in {
       @RhoSpec!("testSuite", *setup,
         [
           ("Purses should be created with the given balance", *test_create_purse),
-          // ("Cross-currency deposits should fail.", *test_cross_currency_deposit)
+          ("Cross-currency deposits should fail.", *test_cross_currency_deposit),
           ("Fake purses should not be able to forge payment.", *roguePurse1),
           ("Deposit should work as expected", *test_deposit),
           ("Split should work as expected", *test_split),
-          ("be able to set a log channel and receive notifications", *test_log_set)
+          ("be able to set a log channel and receive notifications", *test_log_set),
+          ("In case of overflow, no tranfer occurs", *test_overflow_deposit)
         ])
     }
   } |
@@ -28,27 +29,35 @@ in {
   contract setup(_, retCh) = {
     new MakeMintCh, mintACh, mintBCh in {
       rl!(`rho:rchain:makeMint`, *MakeMintCh) |
-      for(@(_, MakeMint) <- MakeMintCh) {
-        @MakeMint!(*mintACh) | @MakeMint!(*mintBCh) |
-        for(mintA <- mintACh; mintB <- mintBCh) {
-          retCh ! ((*mintA, *mintB))
+      for (@(_, MakeMint) <- MakeMintCh) {
+        @MakeMint!(*mintACh) |
+        @MakeMint!(*mintBCh) |
+        for (mintA <- mintACh;
+             mintB <- mintBCh) {
+          retCh!((*mintA, *mintB))
         }
       }
     }
   } |
 
   contract test_create_purse(rhoSpec, @(mintA, mintB), ackCh) = {
-    new aliceAPurse, bobBPurse, aliceAPurseBalance, bobBPurseBalance in {
-      @mintA!("makePurse", 100, *aliceAPurse) |
-      @mintB!("makePurse", 50, *bobBPurse) |
-      for(aliceAPurse <- aliceAPurse; bobBPurse <- bobBPurse) {
-        aliceAPurse!("getBalance", *aliceAPurseBalance) |
-        bobBPurse!("getBalance", *bobBPurseBalance) |
-        rhoSpec!("assertMany",
-          [
-            ((100, "== <-", *aliceAPurseBalance), "alice should have the initial balance"),
-            ((50, "== <-", *bobBPurseBalance), "bob should have the initial balance")
-          ], *ackCh)
+    new aliceAPurse, bobBPurse,
+        aliceAPurseBalance, bobBPurseBalance
+    in {
+      match (100, 50) {
+        (aliceAmt, bobAmt) => {
+          @mintA!("makePurse", aliceAmt, *aliceAPurse) |
+          @mintB!("makePurse", bobAmt, *bobBPurse) |
+          for(aliceAPurse <- aliceAPurse; bobBPurse <- bobBPurse) {
+            aliceAPurse!("getBalance", *aliceAPurseBalance) |
+            bobBPurse!("getBalance", *bobBPurseBalance) |
+            rhoSpec!("assertMany",
+              [
+                ((aliceAmt, "== <-", *aliceAPurseBalance), "alice should have the initial balance"),
+                ((bobAmt, "== <-", *bobBPurseBalance), "bob should have the initial balance")
+              ], *ackCh)
+          }
+        }
       }
     }
   } |
@@ -57,15 +66,20 @@ in {
     new aliceAPurse, bobBPurse, ccDep1, ccDep2 in {
       @mintA!("makePurse", 100, *aliceAPurse) |
       @mintB!("makePurse", 50, *bobBPurse) |
-      for(aliceAPurse <- aliceAPurse;
-          bobBPurse <- bobBPurse) {
+      for (aliceAPurse <- aliceAPurse;
+           bobBPurse   <- bobBPurse) {
         aliceAPurse!("deposit", 10, *bobBPurse, *ccDep1) |
         bobBPurse!("deposit", 10, *aliceAPurse, *ccDep2) |
-        rhoSpec!("assertMany",
-          [
-            ((false, *ccDep1), "deposit from bob to alice should fail"),
-            ((false, *ccDep2), "deposit from alice to bob should fail")
-          ], *ackCh)
+        for (@success1 <- ccDep1;
+             @success2 <- ccDep2) {
+          rhoSpec!("assertMany",
+            [
+              ((false, "==", success1), "deposit from bob to alice should fail"),
+              ((false, "==", success2), "deposit from alice to bob should fail")
+            ],
+            *ackCh
+          )
+        }
       }
     }
   } |
@@ -154,6 +168,9 @@ in {
 
   contract roguePurse1(rhoSpec, @(*mint1, _), ackCh) = {
     new fakePurse in {
+      contract fakePurse(@"decr", decrCh) = {
+        decrCh!("fakeDecr")
+      } |
       contract fakePurse(@stolenDecr, @amount, success) = {
         success!(true, "fakeDecr")
       } |
@@ -163,6 +180,47 @@ in {
           purse1!("deposit", 5, *fakePurse, *depositCh) | for (@depositOk <- depositCh) {
             purse1!("getBalance", *let3) | for (@bal <- let3) {
               rhoSpec!("assert", (bal, "==", 10), "real purse balance should not increase", *ackCh)
+            }
+          }
+        }
+      }
+    }
+  } |
+  // In case of an overflow during a deposit, no funds should be transferred.
+  contract test_overflow_deposit(rhoSpec, @(*mint, _), ackCh) = {
+    new alicePurseCh, bobPurseCh, successCh,
+        initialAlicePurseBalanceCh, initialBobPurseBalanceCh,
+        finalAlicePurseBalanceCh, finalBobPurseBalanceCh
+    in {
+      match (9223372036854775807, 1000) {
+        (aliceAmt, bobAmt) => {
+          // Alice's purse has maximum balance.
+          mint!("makePurse", aliceAmt, *alicePurseCh) |
+          mint!("makePurse", bobAmt, *bobPurseCh) |
+          for (alicePurse <- alicePurseCh;
+               bobPurse   <- bobPurseCh) {
+            alicePurse!("getBalance", *initialAlicePurseBalanceCh) |
+            bobPurse!("getBalance", *initialBobPurseBalanceCh) |
+            for (@initialAlicePurseBalance <- initialAlicePurseBalanceCh;
+                 @initialBobPurseBalance   <- initialBobPurseBalanceCh) {
+              // Depositing any funds to Alice results in overflow.
+              alicePurse!("deposit", 1, *bobPurse, *successCh) |
+              for (@false <- successCh) {
+                alicePurse!("getBalance", *finalAlicePurseBalanceCh) |
+                bobPurse!("getBalance", *finalBobPurseBalanceCh) |
+                for (@finalAlicePurseBalance <- finalAlicePurseBalanceCh;
+                     @finalBobPurseBalance   <- finalBobPurseBalanceCh) {
+                  rhoSpec!("assertMany",
+                    [
+                      ((aliceAmt, "==", initialAlicePurseBalance), "Alice should have the initial balance"),
+                      ((bobAmt, "==", initialBobPurseBalance), "Bob should have the initial balance"),
+                      ((finalAlicePurseBalance, "==", initialAlicePurseBalance), "Alice's balance should not change"),
+                      ((finalBobPurseBalance, "==", initialBobPurseBalance), "Bob's balance should not change")
+                    ],
+                    *ackCh
+                  )
+                }
+              }
             }
           }
         }

--- a/integration-tests/test/test_wallets.py
+++ b/integration-tests/test/test_wallets.py
@@ -126,7 +126,7 @@ def test_transfer_failed_with_insufficient_funds(command_line_options: CommandLi
         assert alice_balance < 2000000
 
         with pytest.raises(TransderFundsError) as e:
-            transfer_funds(context, bootstrap, alice_rev_address, bob_rev_address, 2000000, ALICE_KEY, 100000, 1)
+            transfer_funds(context, bootstrap, alice_rev_address, bob_rev_address, 2000000, ALICE_KEY, 200000, 1)
         assert e.value.reason == "Insufficient funds"
         bob_balance = get_vault_balance(context, bootstrap, bob_rev_address, CHARLIE_KEY, 100000, 1)
         assert bob_balance == 0


### PR DESCRIPTION
Resolve MakeMint overflow bug

Resolve cross-currency deposits

## Overview
A deposit of funds which resulted in an overflow was destroying the transferred funds. Also, no value was being returned for deposits between different mints. This PR makes it so that neither purse's balance changes in the case of an overflow and deposits between different mints return `false`.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-1117
https://rchain.atlassian.net/browse/RCHAIN-2927



### Notes




### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
