### PR TITLE
Fix UnusedCOMM caused by system deploys execution

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -133,7 +133,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
           case Right(PlaySucceeded(finalPlayStateHash, processedSystemDeploy, playResult)) =>
             assert(resultAssertion(playResult))
             runtimeManager
-              .replaySystemDeploy(startState)(replaySystemDeploy, processedSystemDeploy)
+              .replaySystemDeploy(startState)(replaySystemDeploy, processedSystemDeploy, runtime)
               .attempt
               .map {
                 case Right(Right(systemDeployReplayResult)) =>

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -70,10 +70,11 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
     for {
       res <- runtimeManager.computeState(stateHash)(
               deploy :: Nil,
+               Nil,
               BlockData(deploy.data.timestamp, 0, genesisContext.validatorPks.head, Array[Byte]()),
               Map.empty[BlockHash, Validator]
             )
-      (hash, Seq(result)) = res
+      (hash, Seq(result), _) = res
     } yield (hash, result)
 
   private def replayComputeState[F[_]: Functor](runtimeManager: RuntimeManager[F])(


### PR DESCRIPTION
## Overview
DeploysResult computed under runtimeLock (inside computeState method), and all system deploys are calculated separately. And if RSpace is modified between, e.g. if node receives block from a peer - this corrupts calculation.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
