### PR TITLE
RCHAIN-4008: fix errors from parallel execution (part 2)

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -740,7 +740,7 @@ class InterpreterUtilTest
       |  }
       |""".stripMargin
 
-  "replay" should "match in case of Out of Phlo error" ignore effectTest {
+  "replay" should "match in case of Out of Phlo error" in effectTest {
     val deploy =
       ConstructDeploy.sourceDeploy(
         multiBranchSampleTermWithError,
@@ -758,7 +758,7 @@ class InterpreterUtilTest
     }
   }
 
-  "replay" should "match in case of user execution error" ignore effectTest {
+  "replay" should "match in case of user execution error" in effectTest {
     val deploy =
       ConstructDeploy.sourceDeploy(
         multiBranchSampleTermWithError,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -118,7 +118,8 @@ class DebruijnInterpreter[M[_], F[_]](
       continuation: TaggedContinuation,
       dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
   )(ops: M[Unit]*) =
-    (dispatch(continuation, dataList) :: ops.toList).parSequence_
+    // Collect errors from all parallel execution paths (pars)
+    parTraverseSafe(dispatch(continuation, dataList) +: ops.toVector)(identity)
 
   private[this] def dispatch(
       continuation: TaggedContinuation,


### PR DESCRIPTION
## Overview
This is the same fix for handling errors from parallel executions but on the second place where `cats.Parallel[F]` is used.
First PR #2853.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4008

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
