### PR TITLE
RCHAIN-3989 Use TreeHashMap in RevVault contract

### DIFF
--- a/casper/src/main/resources/Either.rho
+++ b/casper/src/main/resources/Either.rho
@@ -118,8 +118,8 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
     // Composes two eithers `a: A` and `b: B` using the function `f`. See cats.Apply.map2 for details.`
     contract Either(@"map2", @a, @b, @f, return) = {
       match (a, b) {
-        ((false, _), _)               => return!(a)
-        (_, (false, _))               => return!(b)
+        ((false, _), _)          => return!(a)
+        (_, (false, _))          => return!(b)
         ((true, va), (true, vb)) => {
           new ret in {
             match f {
@@ -139,8 +139,8 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
     // Like map2, but allows passing state to f instead of making f close over it.
     contract Either(@"map2Clean", @a, @b, @f, @state, return) = {
       match (a, b) {
-        ((false, _), _)               => return!(a)
-        (_, (false, _))               => return!(b)
+        ((false, _), _)          => return!(a)
+        (_, (false, _))          => return!(b)
         ((true, va), (true, vb)) => {
           new ret in {
             match f {
@@ -175,7 +175,7 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
     contract Either(@"flatMap", @either, f, return) = {
       match either {
         (true, value) => { f!(value, *return) }
-        (false, _)      => { return!(either) }
+        (false, _)    => { return!(either) }
       }
     } |
 
@@ -183,7 +183,7 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
     contract Either(@"flatMapClean", @either, f, @state, return) = {
       match either {
         (true, value) => { f!(state, value, *return) }
-        (false, _)      => { return!(either) }
+        (false, _)    => { return!(either) }
       }
     } |
 

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -105,7 +105,7 @@ in {
           pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
           // Initializes pending rewards TreeHashMap.
           // - each key in pending rewards state is Map[PublicKey, Int] accumulated by calling "refundDeploy".
-          TreeHashMap!("init", 3, *pendingRewardsMapCh) |
+          TreeHashMap!("init", 1, *pendingRewardsMapCh) |
           for (@(true, posVault)  <- posVaultCh;
                @initialActive     <- initialActiveCh;
                @pendingRewardsMap <- pendingRewardsMapCh) {

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -122,7 +122,7 @@ in {
                   "activeValidators": initialActive,
                   // Map[PublicKey, Int] - are moved from pendingRewards on epoch change or slashing
                   "committedRewards": {},
-                  // Map[PublicKey, Int] - the validators wishing to withdraw and the blocknumber when their quarantine ends
+                  // Map[PublicKey, Int] - the validators wishing to withdraw and the block number when their quarantine ends
                   //                       This begins at the start of the next epoch + quarantineLength.
                   "withdrawers"     : {},
                   "randomImages"    : {},

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -166,6 +166,10 @@ in {
                   returnCh!(coopVault)
                 }
               } |
+              // Exposes initial PoS vault on returnCh.
+              contract PoS(@"getInitialPosVault", returnCh) = {
+                returnCh!(posVault)
+              } |
               // Exposes epochLength parameter to PoSTest.
               contract PoS(@"getEpochLength", returnCh) = {
                 returnCh!($$epochLength$$)

--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -86,7 +86,7 @@ in {
         } |
 
         contract TreeHashMapGetter(@map, @nybList, @n, @len, @suffix, ret) = {
-          // Look up the value of the node at [map, nybList.slice(0, n + 1)]
+          // Look up the value of the node at (map, nybList.slice(0, n + 1))
           new valCh in {
             nodeGet!((map, nybList.slice(0, n)), *valCh) |
             for (@val <- valCh) {
@@ -150,7 +150,7 @@ in {
         } |
 
         contract TreeHashMapSetter(@map, @nybList, @n, @len, @newVal, @suffix, ret) = {
-          // Look up the value of the node at [map, nybList.slice(0, n + 1)
+          // Look up the value of the node at (map, nybList.slice(0, n + 1))
           new valCh, restCh in {
             match (map, nybList.slice(0, n)) {
               node => {

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -16,10 +16,11 @@
  */
 new
   RevVault, rs(`rho:registry:insertSigned:secp256k1`), uriOut,
-  rl(`rho:registry:lookup`), RevAddress(`rho:rev:address`), MakeMintCh, AuthKeyCh, EitherCh,
+  rl(`rho:registry:lookup`), RevAddress(`rho:rev:address`),
+  MakeMintCh, AuthKeyCh, EitherCh, TreeHashMapCh,
   _makeVault,
   _newVault,
-  _getOrCreate,
+  _create,
   _revVault,
   _transferTemplate,
   _depositTemplate
@@ -27,255 +28,247 @@ in {
   rl!(`rho:rchain:makeMint`, *MakeMintCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
   rl!(`rho:lang:either`, *EitherCh) |
-  for(@(_, MakeMint) <- MakeMintCh) {
-    for (@(_, AuthKey) <- AuthKeyCh) {
-      for (@(_, Either) <- EitherCh) {
-        new mintCh, vaultMapStore, initVault in {
+  rl!(`rho:lang:treeHashMap`, *TreeHashMapCh) |
+  for (@(_, MakeMint) <- MakeMintCh;
+       @(_, AuthKey)  <- AuthKeyCh;
+       @(_, Either)   <- EitherCh;
+       TreeHashMap    <- TreeHashMapCh) {
+    // Each invocation of the RevVault contract uses a different mint.
+    new mintCh, vaultMapStore, initVault in {
+      // Initializes the vaultMapStore.
+      TreeHashMap!("init", 2, *vaultMapStore) |
+      for (@vaultMap <- vaultMapStore) {
+        // Called from RevGenerator:
+        //   RevVault!("init", *ret)
+        for (@"init", ret <- RevVault) {
+          ret!(*TreeHashMap, vaultMap, *initVault)
+        } |
+        @MakeMint!(*mintCh) |
+        for (mint <- mintCh) {
+          // Initializes a vault with given name, address, and purse containing the amount.
+          contract initVault(name, @address, @initialAmount) = {
+            new purseCh in {
+              mint!("makePurse", initialAmount, *purseCh) |
+              for (purse <- purseCh) {
+                _newVault!(*name, address, *purse)
+              }
+            }
+          } |
 
-          @MakeMint!(*mintCh) |
-          for (mint <- mintCh) {
-
-            contract initVault(name, @address, @initialAmount) = {
-              new purseCh in {
-                mint!("makePurse", initialAmount, *purseCh) |
-                for (purse <- purseCh) {
-                  _newVault!(*name, address, *purse)
+          contract RevVault(@"deployerAuthKey", deployerId, ret) = {
+            new RevAddress(`rho:rev:address`), DeployerIdOps(`rho:rchain:deployerId:ops`),
+                revAddrCh, deployerPubKeyBytesCh
+            in {
+              DeployerIdOps!("pubKeyBytes", *deployerId, *deployerPubKeyBytesCh) |
+              for (@deployerPubKeyBytes <- deployerPubKeyBytesCh) {
+                RevAddress!("fromPublicKey", deployerPubKeyBytes, *revAddrCh) |
+                for (@deployerRevAddress <- revAddrCh) {
+                  @AuthKey!("make", (*_revVault, deployerRevAddress), *ret)
                 }
               }
-            } |
-
-            for (@"init", ret <- RevVault) {
-              ret!(*vaultMapStore, *initVault)
-            } |
-
-            contract RevVault(@"deployerAuthKey", deployerId, ret) = {
-
-              new RevAddress(`rho:rev:address`), DeployerIdOps(`rho:rchain:deployerId:ops`), revAddrCh, deployerPubKeyBytesCh in {
-                DeployerIdOps!("pubKeyBytes", *deployerId, *deployerPubKeyBytesCh) |
-                for (@deployerPubKeyBytes <- deployerPubKeyBytesCh) {
-
-                  RevAddress!("fromPublicKey", deployerPubKeyBytes, *revAddrCh) |
-                  for (@deployerRevAddress <- revAddrCh) {
-
-                    @AuthKey!("make", (*_revVault, deployerRevAddress), *ret)
+            }
+          } |
+          // Creates authKey from Rev vault name.
+          contract RevVault(@"unforgeableAuthKey", unf, ret) = {
+            new RevAddress(`rho:rev:address`), revAddrCh in {
+              RevAddress!("fromUnforgeable", *unf, *revAddrCh) |
+              for (@unfRevAddress <- revAddrCh) {
+                @AuthKey!("make", (*_revVault, unfRevAddress), *ret)
+              }
+            }
+          } |
+          // Either retrieves or creates corresponding Rev vault either.
+          contract RevVault(@"findOrCreate", @revAddress, retCh) = {
+            new revAddressValidCh, revAddressValidEitherCh in {
+              // Validate Rev address first.
+              RevAddress!("validate", revAddress, *revAddressValidCh) |
+              @Either!("fromNillableError <-", *revAddressValidCh, *revAddressValidEitherCh) |
+              for (@revAddressEither <- revAddressValidEitherCh) {
+                match revAddressEither {
+                  // Invalid Rev address returns Left.
+                  (false, _) => {
+                    retCh!(revAddressEither)
                   }
-                }
-              }
-            } |
-
-            contract RevVault(@"unforgeableAuthKey", unf, ret) = {
-
-              new RevAddress(`rho:rev:address`), revAddrCh in {
-                RevAddress!("fromUnforgeable", *unf, *revAddrCh) |
-                for (@unfRevAddress <- revAddrCh) {
-
-                  @AuthKey!("make", (*_revVault, unfRevAddress), *ret)
-                }
-              }
-            } |
-
-            contract RevVault(@"findOrCreate", @ownerRevAddress, ret) = {
-              new createVault in {
-                _getOrCreate!(ownerRevAddress, *createVault, *ret) |
-                for (retCh <- createVault) {
-
-                  _makeVault!(ownerRevAddress, 0, *retCh)
-                }
-              }
-            } |
-            // Used during genesis to create PoS vault with initial balance = sum of initial bonds.
-            for (@"createWithBalance", @ownerRevAddress, @amount, ret <- RevVault) {
-              new createVault in {
-                _getOrCreate!(ownerRevAddress, *createVault, *ret) |
-                for (retCh <- createVault) {
-                  _makeVault!(ownerRevAddress, amount, *retCh)
-                }
-              }
-            } |
-
-            contract _getOrCreate(@revAddress, constructor, retCh) = {
-              new revAddressValidCh,
-                  revAddressValidEitherCh,
-                  getOrCreate
-              in {
-                RevAddress!("validate", revAddress, *revAddressValidCh) |
-                @Either!("fromNillableError <-", *revAddressValidCh, *revAddressValidEitherCh) |
-                @Either!("flatMap <-", *revAddressValidEitherCh, *getOrCreate, *retCh) |
-                for (_, ret <- getOrCreate) {
-                  // At first peek for `vaultMap` to check if vault (address) exists
-                  // - peek ensures that for existing vaults we don't have a block conflict
-                  for (@vaultMap <<- vaultMapStore) {
-                    match vaultMap.get(revAddress) {
-                      Nil => {
-                        // Vault is not found, create new and save it in the `vaultMap`
-                        // - this means two blocks with new vaults cannot be merged
-                        for (@vaultMap <- vaultMapStore) {
-                          // We need to check again because `vaultMap` is not locked with peek
-                          match vaultMap.get(revAddress) {
-                            Nil => {
-                              new resCh in {
-                                constructor!(*resCh) |
-                                for (@eitherVault <- resCh) {
-                                  ret!(eitherVault) |
-                                  match eitherVault {
-                                    (true, vault) => vaultMapStore!(vaultMap.set(revAddress, vault))
-                                    (false, _)    => vaultMapStore!(vaultMap)
-                                  }
-                                }
-                              }
-                            }
-                            // Return already existing vault
-                            // - we can get here only if vault is created between
-                            // peek and consume on `vaultMapStore`
-                            vault => {
-                              ret!((true, vault)) |
-                              vaultMapStore!(vaultMap)
+                  // Valid Rev address returns Right and we proceed with creation/search.
+                  _ => {
+                    new createVault, vaultCh, getVaultCh in {
+                      TreeHashMap!("get", vaultMap, revAddress, *getVaultCh) |
+                      for (@vault <- getVaultCh) {
+                        if (vault != Nil) {
+                          // If vault is in the store, return (true, vault).
+                          retCh!((true, vault))
+                        } else {
+                          // If vault was not found in store, create it and put it in the store.
+                          _create!(revAddress, *createVault, *vaultCh) |
+                          for (vaultRetCh <- createVault) {
+                            // Creates Rev vault and returns on vaultRetCh, consumed within _create contract.
+                            _makeVault!(revAddress, 0, *vaultRetCh) |
+                            // Blocks until both the vault is created and set in the store.
+                            for (@eitherVault <- vaultCh) {
+                              retCh!(eitherVault)
                             }
                           }
                         }
-                      }
-                      // Return already existing vault
-                      // - no changes to `vaultMap`
-                      vault => {
-                        ret!((true, vault))
                       }
                     }
                   }
                 }
               }
-            } |
-
-            contract _makeVault(@ownerRevAddress, @initialAmount, ret) = {
-
-              new revAddrCh, eitherRevAddrCh, purseCh, eitherPurseCh, mkVault in {
-                @Either!("fromNillable", ownerRevAddress, "Required `revAddress` parameter was Nil", *eitherRevAddrCh) |
-                mint!("makePurse", initialAmount, *purseCh) |
-                @Either!("fromNillable <-", *purseCh, "Couldn't create purse", *eitherPurseCh) |
-                @Either!("map2 <-", *eitherRevAddrCh, *eitherPurseCh, for (@addr, purse, r <- mkVault) {
+            }
+          } |
+          // Used during genesis to create PoS vault with initial balance = sum of initial bonds.
+          // Can only be used to create the PoS vault, i.e. Rev address = "1111gW5kkGxHg7xDg6dRkZx2f7qxTizJzaCH9VEM1oJKWRvSX9Sk5".
+          for (@"createWithBalance", @"1111gW5kkGxHg7xDg6dRkZx2f7qxTizJzaCH9VEM1oJKWRvSX9Sk5", @amount, retCh <- RevVault) {
+            new createVault, vaultCh in {
+              _create!("1111gW5kkGxHg7xDg6dRkZx2f7qxTizJzaCH9VEM1oJKWRvSX9Sk5", *createVault, *vaultCh) |
+              for (vaultRetCh <- createVault) {
+                _makeVault!("1111gW5kkGxHg7xDg6dRkZx2f7qxTizJzaCH9VEM1oJKWRvSX9Sk5", amount, *vaultRetCh) |
+                for (@eitherVault <- vaultCh) {
+                  retCh!(eitherVault)
+                }
+              }
+            }
+          } |
+          // Retrieves vault corresponding to revAddress if one exists, creates a vault otherwise.
+          // Returns either (true, vault) or (false, _) on retCh.
+          contract _create(@revAddress, constructor, retCh) = {
+            // The vault was not found, create a new one and set it in the vaultMap.
+            new resCh, ackCh in {
+              constructor!(*resCh) |
+              for (@eitherVault <- resCh) {
+                match eitherVault {
+                  (true, vault) => {
+                    TreeHashMap!("set", vaultMap, revAddress, vault, *ackCh) |
+                    for (_ <- ackCh) {
+                      retCh!(eitherVault)
+                    }
+                  }
+                  (false, _)    => {
+                    retCh!(eitherVault)
+                  }
+                }
+              }
+            }
+          } |
+          // Creates a Rev vault and returns Either on ret.
+          contract _makeVault(@ownerRevAddress, @initialAmount, ret) = {
+            new revAddrCh, eitherRevAddrCh, purseCh, eitherPurseCh, mkVault in {
+              @Either!("fromNillable", ownerRevAddress, "Required `revAddress` parameter was Nil", *eitherRevAddrCh) |
+              mint!("makePurse", initialAmount, *purseCh) |
+              @Either!("fromNillable <-", *purseCh, "Couldn't create purse", *eitherPurseCh) |
+              @Either!("map2 <-", *eitherRevAddrCh, *eitherPurseCh,
+                for (@addr, purse, r <- mkVault) {
                   new revVault in {
                     _newVault!(*revVault, addr, *purse) |
                     r!(bundle+{*revVault})
                   }
-                }, *ret)
-              }
-
-            } |
-
-            contract _newVault(revVault, @ownRevAddress, purse) = {
-
-              new logStore in {
-
-                logStore!(Nil) |
-
-                contract revVault(@"balance", ret) = {
-                  purse!("getBalance", *ret)
-                } |
-
-                contract revVault(@"transfer", @revAddress, @amount, authKey, ret) = {
-                  new ret2 in {
-                    _transferTemplate!(ownRevAddress, *purse, revAddress, amount, *authKey, *ret2) |
-                    for (@result <- ret2) {
-                      ret!(result) |
-                      for (logCh <<- logStore) {
-                        if (Nil != *logCh) {
-                          new bd(`rho:block:data`), bdCh in {
-                            bd!(*bdCh) |
-                            for (@blockNumber, @timestamp, @sender <- bdCh) {
-                              logCh!(["transfer", revAddress, amount, result, blockNumber, timestamp, sender])
-                            }
+                },
+                *ret
+              )
+            }
+          } |
+          // Supplies balance, transfer, and setLog methods on revVault.
+          contract _newVault(revVault, @ownRevAddress, purse) = {
+            new logStore in {
+              logStore!(Nil) |
+              contract revVault(@"balance", ret) = {
+                purse!("getBalance", *ret)
+              } |
+              // Transfers from vault at revAddress to revVault.
+              contract revVault(@"transfer", @revAddress, @amount, authKey, ret) = {
+                new ret2 in {
+                  _transferTemplate!(ownRevAddress, *purse, revAddress, amount, *authKey, *ret2) |
+                  for (@result <- ret2) {
+                    ret!(result) |
+                    for (logCh <<- logStore) {
+                      if (Nil != *logCh) {
+                        new bd(`rho:block:data`), bdCh in {
+                          bd!(*bdCh) |
+                          for (@blockNumber, @timestamp, @sender <- bdCh) {
+                            logCh!(["transfer", revAddress, amount, result, blockNumber, timestamp, sender])
                           }
                         }
                       }
                     }
                   }
-                } |
-
-                // Set to Nil to disable logging
-                contract revVault(@"setLog", logCh, authKey, ret) = {
-                  new authKeyValidCh in {
-                    @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
-                    for (@result <- authKeyValidCh) {
-                      if (result) {
-                        new ack in {
-                          for (_ <- logStore) {
-                            logStore!(*logCh) |
-                            // Set logging on the purse so that we also see deposits into the vault
-                            purse!("setLog", *logCh, *ack) |
-                            for (_ <- ack) {
-                              ret!(true)
-                            }
-                          }
-                        }
-                      } else {
-                        ret!(false)
-                      }
-                    }
-                  }
-                } |
-
-                contract @{ownRevAddress | bundle0{*_revVault}}(@"_deposit", depositPurse, retCh) = {
-                  _depositTemplate!(*purse, *depositPurse, *retCh)
                 }
-
+              } |
+              // Set to Nil to disable logging
+              contract revVault(@"setLog", logCh, authKey, ret) = {
+                new authKeyValidCh in {
+                  @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
+                  for (@result <- authKeyValidCh) {
+                    if (result) {
+                      new ack in {
+                        for (_ <- logStore) {
+                          logStore!(*logCh) |
+                          // Set logging on the purse so that we also see deposits into the vault
+                          purse!("setLog", *logCh, *ack) |
+                          for (_ <- ack) {
+                            ret!(true)
+                          }
+                        }
+                      }
+                    } else {
+                      ret!(false)
+                    }
+                  }
+                }
+              } |
+              // Internal RevVault method for making deposits between purses.
+              contract @{ownRevAddress | bundle0{*_revVault}}(@"_deposit", depositPurse, retCh) = {
+                _depositTemplate!(*purse, *depositPurse, *retCh)
               }
-
-            } |
-
-            contract _transferTemplate(@ownRevAddress, purse, @revAddress, @amount, authKey, ret) = {
-              new
-                revAddressValid, revAddressValidEither, amountNonNegative,
+            }
+          } |
+          // Checks all necessary validation and authentication prerequisites. If everything checks out,
+          // amount is transferred from vault at revAddress to vault at ownRevAddress.
+          contract _transferTemplate(@ownRevAddress, purse, @revAddress, @amount, authKey, ret) = {
+            new revAddressValid, revAddressValidEither, amountNonNegative,
                 authKeyValidCh, authKeyValidEitherCh,
                 parametersOkCh, parametersAndAuthOkCh,
                 split, eitherPurseCh, doDeposit
-              in {
-                RevAddress!("validate", revAddress, *revAddressValid) |
-                @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
-
-                @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
-
-                @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
-                @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
-
-                @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
-                @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
-
-                @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
-                for (_, retCh <- split) {
-                  new amountPurseCh in {
-                    purse!("split", amount, *amountPurseCh) |
-                    @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
-                  }
-                } |
-
-                @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
-                for (@p, retCh <- doDeposit) {
-                  @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
+            in {
+              RevAddress!("validate", revAddress, *revAddressValid) |
+              @Either!("fromNillableError <-", *revAddressValid, *revAddressValidEither) |
+              @Either!("fromBoolean", amount >= 0, "Amount must be non-negative", *amountNonNegative) |
+              @AuthKey!("check", *authKey, (*_revVault, ownRevAddress), *authKeyValidCh) |
+              @Either!("fromBoolean <-", *authKeyValidCh, "Invalid AuthKey", *authKeyValidEitherCh) |
+              @Either!("productR <-", *revAddressValidEither, *amountNonNegative, *parametersOkCh) |
+              @Either!("productR <-", *parametersOkCh, *authKeyValidEitherCh, *parametersAndAuthOkCh) |
+              @Either!("flatMap <-", *parametersAndAuthOkCh, *split, *eitherPurseCh) |
+              for (_, retCh <- split) {
+                new amountPurseCh in {
+                  purse!("split", amount, *amountPurseCh) |
+                  @Either!("fromSingletonList <-", *amountPurseCh, "Insufficient funds", *retCh)
                 }
+              } |
+              @Either!("flatMap <-", *eitherPurseCh, *doDeposit, *ret) |
+              for (@p, retCh <- doDeposit) {
+                @{revAddress | bundle0{*_revVault}}!("_deposit", p, *retCh)
               }
-            } |
-
-            contract _depositTemplate(purse, depositPurse, retCh) = {
-              new amountCh, depositSuccessCh in {
-                depositPurse!("getBalance", *amountCh) |
-                for (@amount <- amountCh) {
-
-                  purse!("deposit", amount, *depositPurse, *depositSuccessCh) |
-                  @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
-                }
+            }
+          } |
+          // Deposits the entire balance in the fromPurse to the toPurse.
+          contract _depositTemplate(toPurse, fromPurse, retCh) = {
+            new amountCh, depositSuccessCh in {
+              fromPurse!("getBalance", *amountCh) |
+              for (@amount <- amountCh) {
+                // Calls purse deposit method in MakeMint contract; adds amount to toPurse and subtracts from fromPurse.
+                toPurse!("deposit", amount, *fromPurse, *depositSuccessCh) |
+                @Either!("fromBoolean <-", *depositSuccessCh, "BUG FOUND: purse deposit failed", *retCh)
               }
-            } |
+            }
+          } |
 
-            rs!(
-              "040f035630a5d2199184890b4b6b83440c842da0b6becca539f788f7b35d6e873561f673cd6ebe2e32236398a86f29dad992e8fba32534734300fcc5104bcfea0e".hexToBytes(),
-              (9223372036854775807, bundle+{*RevVault}),
-              "30450221008af89d676c4cd6b3d41e90da89b03a1e83f161fc8c4ad22c9edc903db3a9f4c402204e35e29e40a5f2b2f431d3cc63b87fb52c33716b3ce331a2a19b9660c3690c18".hexToBytes(),
-              *uriOut
-            )
-          }
+          rs!(
+            "040f035630a5d2199184890b4b6b83440c842da0b6becca539f788f7b35d6e873561f673cd6ebe2e32236398a86f29dad992e8fba32534734300fcc5104bcfea0e".hexToBytes(),
+            (9223372036854775807, bundle+{*RevVault}),
+            "30450221008af89d676c4cd6b3d41e90da89b03a1e83f161fc8c4ad22c9edc903db3a9f4c402204e35e29e40a5f2b2f431d3cc63b87fb52c33716b3ce331a2a19b9660c3690c18".hexToBytes(),
+            *uriOut
+          )
         }
       }
     }
   }
 }
-
-

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -40,8 +40,16 @@ in {
       for (@vaultMap <- vaultMapStore) {
         // Called from RevGenerator:
         //   RevVault!("init", *ret)
-        for (@"init", ret <- RevVault) {
-          ret!(*TreeHashMap, vaultMap, *initVault)
+        new initContinue in {
+          // REV vault initialization in genesis is done in batches.
+          // In the last batch `initContinue` channel will not receive
+          // anything so further access to `RevVault(@"init", _)` is impossible.
+          initContinue!() |
+          contract RevVault(@"init", ret) = {
+            for (<- initContinue) {
+              ret!(*TreeHashMap, vaultMap, *initVault, *initContinue)
+            }
+          }
         } |
         @MakeMint!(*mintCh) |
         for (mint <- mintCh) {

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -26,21 +26,32 @@ object Genesis {
       posParams: ProofOfStake,
       vaults: Seq[Vault],
       supply: Long
-  ): Seq[Signed[DeployData]] =
+  ): Seq[Signed[DeployData]] = {
+    // Splits initial vaults creation in multiple deploys (batches)
+    val vaultBatches = vaults.grouped(100).toSeq
+    val vaultDeploys = vaultBatches.zipWithIndex.map {
+      case (batchVaults, idx) =>
+        StandardDeploys.revGenerator(
+          batchVaults,
+          supply,
+          timestamp = 1565818101792L + idx,
+          isLastBatch = 1 + idx == vaultBatches.size
+        )
+    }
+
     // Order of deploys is important for Registry to work correctly
     // - dependencies must be defined first in the list
-    Seq(
-      StandardDeploys.registry,
-      StandardDeploys.listOps,
-      StandardDeploys.either,
-      StandardDeploys.nonNegativeNumber,
-      StandardDeploys.makeMint,
-      StandardDeploys.authKey,
-      StandardDeploys.revVault,
-      StandardDeploys.multiSigRevVault,
-      StandardDeploys.revGenerator(vaults, supply),
+    StandardDeploys.registry +:
+      StandardDeploys.listOps +:
+      StandardDeploys.either +:
+      StandardDeploys.nonNegativeNumber +:
+      StandardDeploys.makeMint +:
+      StandardDeploys.authKey +:
+      StandardDeploys.revVault +:
+      StandardDeploys.multiSigRevVault +:
+      vaultDeploys :+
       StandardDeploys.poSGenerator(posParams)
-    )
+  }
 
   def createGenesisBlock[F[_]: Concurrent](
       runtimeManager: RuntimeManager[F],

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/RevGenerator.scala
@@ -30,9 +30,10 @@ object RevGenerator {
          #             new iter in {
          #               contract iter(@[(addr, initialBalance) ... tail]) = {
          #                  iter!(tail) |
-         #                  new vault in {
+         #                  new vault, setDoneCh in {
          #                    initVault!(*vault, addr, initialBalance) |
-         #                    TreeHashMap!("set", vaultMap, addr, *vault, Nil)
+         #                    TreeHashMap!("set", vaultMap, addr, *vault, *setDoneCh) |
+         #                    for (_ <- setDoneCh) { Nil }
          #                  }
          #               } |
          #               iter!(vaults) ${if (!isLastBatch) "| initContinue!()" else ""}

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -86,11 +86,16 @@ object StandardDeploys {
       1559156420651L
     )
 
-  def revGenerator(vaults: Seq[Vault], supply: Long): Signed[DeployData] =
+  def revGenerator(
+      vaults: Seq[Vault],
+      supply: Long,
+      timestamp: Long,
+      isLastBatch: Boolean
+  ): Signed[DeployData] =
     toDeploy(
-      RevGenerator(vaults, supply),
+      RevGenerator(vaults, supply, isLastBatch),
       "a06959868e39bb3a8502846686a23119716ecd001700baf9e2ecfa0dbf1a3247",
-      1565818101792L
+      timestamp
     )
 
 }

--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -45,9 +45,9 @@ match (
           @posRevAddress <- posRevAddressCh;
           @(_, ListOps)  <- ListOpsCh;
           @sysAuthToken  <- sysAuthTokenCh) {
-        stdlog!("info", {"posRevAddress":posRevAddress}) |
-        @RevVault!("findOrCreate", posRevAddress, *posVaultCh) |
-        for (@(true, posVault) <- posVaultCh) {
+        stdlog!("info", {"posRevAddress" : posRevAddress}) |
+        @PoS!("getInitialPosVault", *posVaultCh) |
+        for (@posVault <- posVaultCh) {
           @RhoSpec!("testSuite", *setup,
             [
               ("PoS is created with empty rewards", *test_make_pos_succeeds),
@@ -693,7 +693,6 @@ match (
                   }
                 }
               } |
-
               @posVault!("balance", *posVaultBalanceCh) |
               for (@posVaultBalance <- posVaultBalanceCh) {
                 @PoS!("getActiveValidatorVaults", *vaultsCh) |

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -62,8 +62,8 @@ class GenesisCeremonyMasterSpec extends WordSpec {
           validatorPk
         )
         _ <- EngineCell[Task].read >>= (_.handle(local, blockApproval))
-        //wait until casper is defined, with 1 minute timeout (indicating failure)
-        possiblyCasper  <- Task.racePair(Task.sleep(1.minute), waitUtilCasperIsDefined)
+        //wait until casper is defined, with a timeout (indicating failure)
+        possiblyCasper  <- Task.racePair(Task.sleep(3.minute), waitUtilCasperIsDefined)
         _               = assert(possiblyCasper.isRight)
         blockO          <- blockStore.get(genesis.blockHash)
         _               = assert(blockO.isDefined)

--- a/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
@@ -2,6 +2,8 @@ package coop.rchain.casper.util
 
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.{DeployData, DeployDataProto}
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1, Secp256k1Eth, SignaturesAlg, Signed}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -15,8 +17,14 @@ class DeployValidationSpec extends FlatSpec with Matchers {
       phloPrice = 1,
       validAfterBlockNumber = 0L
     )
-    val (privKey, _) = alg.newKeyPair
-    val signed       = Signed(deploy, alg, privKey)
+
+    // TODO: fixed key is used because Secp256k1Eth sign/verify is unstable with some generated keys ???
+    // - check CertificateHelper.{encodeSignatureRStoDER, decodeSignatureDERtoRS}
+    val privKeyHex = "6a42f5941bdaec35fdfa93d735c04f58d5d51ca3529d9a2fe753b818f1fa32e1"
+    val privKey    = PrivateKey(Base16.unsafeDecode(privKeyHex))
+//    val (privKey, _) = alg.newKeyPair
+
+    val signed = Signed(deploy, alg, privKey)
     val deployProto = DeployDataProto()
       .withSigAlgorithm(alg.name)
       .withSig(signed.sig)

--- a/integration-tests/test/test_wallets.py
+++ b/integration-tests/test/test_wallets.py
@@ -120,13 +120,13 @@ def test_transfer_failed_with_insufficient_funds(command_line_options: CommandLi
         bob_rev_address = BOB_KEY.get_public_key().get_rev_address()
         alice_rev_address = ALICE_KEY.get_public_key().get_rev_address()
 
-        bob_balance = get_vault_balance(context, bootstrap, bob_rev_address, CHARLIE_KEY, 100000, 1)
-        alice_balance = get_vault_balance(context, bootstrap, alice_rev_address, CHARLIE_KEY, 100000, 1)
+        bob_balance = get_vault_balance(context, bootstrap, bob_rev_address, CHARLIE_KEY, 1000000, 1)
+        alice_balance = get_vault_balance(context, bootstrap, alice_rev_address, CHARLIE_KEY, 1000000, 1)
         assert bob_balance == 0
         assert alice_balance < 2000000
 
         with pytest.raises(TransderFundsError) as e:
-            transfer_funds(context, bootstrap, alice_rev_address, bob_rev_address, 2000000, ALICE_KEY, 200000, 1)
+            transfer_funds(context, bootstrap, alice_rev_address, bob_rev_address, 2000000, ALICE_KEY, 1000000, 1)
         assert e.value.reason == "Insufficient funds"
-        bob_balance = get_vault_balance(context, bootstrap, bob_rev_address, CHARLIE_KEY, 100000, 1)
+        bob_balance = get_vault_balance(context, bootstrap, bob_rev_address, CHARLIE_KEY, 1000000, 1)
         assert bob_balance == 0


### PR DESCRIPTION
## Overview
Uses TreeHashMap in the RevVault contract instead of an ordinary Rholang map.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-3989



### Notes



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
