### PR TITLE
RCHAIN-4026: fix RSpace replay - sorted produces in COMM event log, match joins on the same channels

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/EventConverter.scala
@@ -90,7 +90,7 @@ object EventConverter {
           consume.hash,
           consume.persistent
         ),
-        rspaceProduceCounts.keys.toSeq,
+        rspaceProduceCounts.keys.toSeq.sortBy(p => (p.channelsHash, p.hash, p.persistent)),
         SortedSet(peeks.map(_.channelIndex): _*),
         rspaceProduceCounts
       )

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
@@ -1,0 +1,140 @@
+package coop.rchain.rholang.interpreter
+
+import cats.effect.Resource
+import cats.syntax.all._
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.rholang.Resources
+import coop.rchain.rholang.interpreter.accounting.utils.costLog
+import coop.rchain.rholang.interpreter.accounting.{_cost, Cost, CostAccounting}
+import coop.rchain.rspace.SoftCheckpoint
+import coop.rchain.shared.Log
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class ReplaySpec extends FlatSpec with Matchers {
+
+  // TODO: these tests are temporary and specific to bugs found in replay.
+  // Testing execution for many iteration doesn't make sense.
+  // In tests, nondeterministic execution of Par in tuple space should be replaced with deterministic version
+  // so that we can test tuple space access in all possible states (and not guess and wait).
+
+  // TODO: fuzzer test now creates complete on-disk tuple space for each execution, this can be replaced
+  //  with in-memory version used here.
+  // https://github.com/rchain/rchain/blob/1f9554f68a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala#L231
+
+  "multi joins (2/2)" should "execute successfully in replay" in {
+    val term =
+      """
+        |new x in {
+        |  x!() | for(<- x; <- x) { 0 } | x!()
+        |}
+        |""".stripMargin
+    testRholangTerm(term, 500, 30.seconds)
+  }
+
+  "multi joins (4/2)" should "execute successfully in replay" in {
+    val term =
+      """
+        |new x in {
+        |  x!() | x!() | for(<- x; <- x) { 0 } | x!() | x!()
+        |}
+        |""".stripMargin
+    testRholangTerm(term, 500, 30.seconds)
+  }
+
+  def testRholangTerm(term: String, iterations: Int, timeout: Duration) =
+    withRSpaceAndRuntime { runtime =>
+      for (i <- 1 to iterations) {
+        val (playRes, replayRes) = evaluateWithRuntime(runtime)(term, Cost(Integer.MAX_VALUE))
+          .onError {
+            case _: Throwable =>
+              println(s"Test retry count: $i").pure[Task]
+          }
+          .runSyncUnsafe(1.seconds)
+
+        assert(playRes.errors.isEmpty)
+        assert(replayRes.errors.isEmpty)
+      }
+      ().pure[Task]
+    }.runSyncUnsafe(timeout)
+
+  def evaluateWithRuntime(runtime: Runtime[Task])(term: String, initialPhlo: Cost) = {
+    implicit val c: _cost[Task]         = runtime.cost
+    implicit def rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
+    for {
+      // Save revert checkpoints
+      startState       <- runtime.space.createSoftCheckpoint()
+      startReplayState <- runtime.replaySpace.createSoftCheckpoint()
+
+      // Execute play
+      playResult <- Interpreter[Task]
+                     .injAttempt(
+                       runtime.reducer,
+                       term,
+                       initialPhlo,
+                       Map.empty
+                     )(rand)
+
+      // Create play snapshot (diff)
+      playSnapshot              <- runtime.space.createSoftCheckpoint()
+      SoftCheckpoint(_, log, _) = playSnapshot
+
+      // Prepare replay with events log from play
+      _ <- runtime.replaySpace.rig(log)
+
+      // Execute replay
+      replayResult <- Interpreter[Task]
+                       .injAttempt(
+                         runtime.replayReducer,
+                         term,
+                         initialPhlo,
+                         Map.empty
+                       )(rand)
+                       .onError {
+                         case _: Throwable =>
+                           println(s"Executed term: $term")
+                           println(s"Event log: $log").pure[Task]
+                       }
+      _ <- runtime.replaySpace.checkReplayData().onError {
+            case _: Throwable =>
+              println(s"Executed term: $term")
+              println(s"Event log: $log")
+              println(s"Replay result: $replayResult").pure[Task]
+          }
+
+      // Revert all changes / reset to initial state
+      _ <- runtime.space.revertToSoftCheckpoint(startState)
+      _ <- runtime.replaySpace.revertToSoftCheckpoint(startReplayState)
+    } yield (playResult, replayResult)
+  }
+
+  def withRSpaceAndRuntime(op: Runtime[Task] => Task[Unit]) = {
+    implicit val logF: Log[Task]           = new Log.NOPLog[Task]
+    implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+    implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
+    implicit val ms: Metrics.Source        = Metrics.BaseSource
+
+    val resources = for {
+      dir     <- Resources.mkTempDir[Task]("cost-accounting-spec-")
+      costLog <- Resource.liftF(costLog[Task]())
+      cost    <- Resource.liftF(CostAccounting.emptyCost[Task](implicitly, metricsEff, costLog, ms))
+      sar     <- Resource.liftF(Runtime.setupRSpace[Task](dir, 1024L * 1024 * 1024))
+      runtime <- {
+        implicit val c: _cost[Task] = cost
+        Resource.make(Runtime.create[Task]((sar._1, sar._2), Nil))(_.close())
+      }
+    } yield (runtime, costLog)
+
+    resources.use {
+      case (runtime, _) =>
+        // Execute operation
+        op(runtime)
+    }
+  }
+
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -192,7 +192,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
           .map { as =>
             val d = Datum(data, persist, produceRef)
             val matching = if (c == channel) {
-              if (comm.matches(d, produceCounter.get(produceRef))) Seq(d -> -1) //WTF?
+              if (comm.matches(d, produceCounter.get(produceRef))) (d -> -1) +: as.zipWithIndex
               else Seq.empty
             } else filterMatching(comm)(as)
             c -> matching

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -189,7 +189,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
             as => {
               c -> {
                 if (c == channel)
-                  Seq((Datum(data, persist, produceRef), -1))
+                  (Datum(data, persist, produceRef), -1) +: as
                 else as
               }.filter {
                 matches(comm)

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -57,7 +57,9 @@ object COMM {
       peeks: SortedSet[Int],
       produceCounters: (Seq[Produce]) => Map[Produce, Int]
   ): COMM = {
-    val produceRefs = dataCandidates.map(_.datum.source)
+    val produceRefs =
+      dataCandidates.map(_.datum.source).sortBy(p => (p.channelsHash, p.hash, p.persistent))
+
     COMM(consumeRef, produceRefs, peeks, produceCounters(produceRefs))
   }
   implicit val codecInt = int32

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -45,10 +45,7 @@ final case class COMM(
     produces: Seq[Produce],
     peeks: SortedSet[Int],
     timesRepeated: Map[Produce, Int]
-) extends Event {
-  def matches(datum: Datum[_], produceCounter: => Int): Boolean =
-    timesRepeated.get(datum.source).exists(count => datum.persist || count == produceCounter)
-}
+) extends Event
 
 object COMM {
   def apply[C, A](


### PR DESCRIPTION
## Overview
- Fixes bug in replay with joins on the same channels. Order of produces in COMM event log is now sorted.
- Fixes bug with missing produce when getting data on matching joins.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4026

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
