### PR TITLE
RCHAIN-4014 add SystemDeployUtil, change closeBlockDeploy random seed, remove

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployUtil.scala
@@ -1,0 +1,41 @@
+package coop.rchain.casper.util.rholang
+
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.crypto.signatures.Signed
+
+object SystemDeployUtil {
+  // Currently we have 4 system deploys -> refund, preCharge, closeBlock, Slashing
+  // In every user deploy, the rnode would do the preCharge first, then execute the
+  // user deploy and do the refund at last.
+  //
+  // The refund and preCharge system deploy
+  // would use user deploy signature to generate the system deploy. The random seed of
+  // the refund and preCharge has to be exactly the same to make sure replay the user
+  // deploy would come out the exact same result.
+  //
+  // As for closeBlock and slashing, the rnode would execute closeBlock system deploy in every block.
+  // The closeBlock system deploy would use the signature of the all user deploys in the block.
+
+  def generateSystemDeployRandomSeed(deploys: Seq[Signed[DeployData]]): Blake2b512Random =
+    Tools.rng(
+      deploys
+        .map(s => s.sig.toByteArray)
+        .foldLeft(Array[Byte]())(_ ++ _)
+    )
+
+  // splitByte here to make sure random seed is not the same as precharge deploy when there
+  // is only one user deploy in a block
+  def generateCloseDeployRandomSeed(deploys: Seq[Signed[DeployData]]): Blake2b512Random =
+    generateSystemDeployRandomSeed(deploys).splitByte(1)
+
+  def generateSlashDeployRandomSeed(deploys: Seq[Signed[DeployData]]): Blake2b512Random =
+    generateSystemDeployRandomSeed(deploys).splitByte(2)
+
+  def generatePreChargeDeployRandomSeed(deploy: Signed[DeployData]): Blake2b512Random =
+    Tools.rng(deploy.sig.toByteArray)
+
+  def generateRefundDeployRandomSeed(deploy: Signed[DeployData]): Blake2b512Random =
+    Tools.rng(deploy.sig.toByteArray).splitByte(64)
+
+}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployUtil.scala
@@ -48,7 +48,7 @@ object SystemDeployUtil {
 
   def generateCloseDeployRandomSeed(pk: PublicKey, seqNum: Int): Blake2b512Random = {
     val sender = ByteString.copyFrom(pk.bytes)
-    generateCloseDeployRandomSeed(sender, seqNum).splitByte(0)
+    generateCloseDeployRandomSeed(sender, seqNum)
   }
 
   def generateSlashDeployRandomSeed(sender: Validator, seqNum: Int): Blake2b512Random =

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -60,7 +60,8 @@ class InterpreterUtilTest
       deploys: Seq[Signed[DeployData]],
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager[F],
-      seqNum: Long = 0L
+      blockNumber: Long = 0L,
+      seqNum: Int = 0
   ): F[
     Either[Throwable, (StateHash, StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])]
   ] =
@@ -75,8 +76,10 @@ class InterpreterUtilTest
               runtimeManager,
               BlockData(
                 now,
-                seqNum,
-                genesisContext.validatorPks.head
+                // TODO this should be blockNumber
+                blockNumber,
+                genesisContext.validatorPks.head,
+                seqNum
               ),
               Map.empty[BlockHash, Validator]
             )
@@ -585,7 +588,8 @@ class InterpreterUtilTest
                                 deploys,
                                 dag1,
                                 runtimeManager,
-                                (i + 1).toLong
+                                (i + 1).toLong,
+                                (i + 1)
                               )
           Right((preStateHash, computedTsHash, processedDeploys, _)) = deploysCheckpoint
           block <- createBlock[Task](
@@ -667,7 +671,8 @@ class InterpreterUtilTest
                                 deploys,
                                 dag1,
                                 runtimeManager,
-                                seqNum = (i + 1).toLong
+                                (i + 1).toLong,
+                                (i + 1)
                               )
           Right((preStateHash, computedTsHash, processedDeploys, _)) = deploysCheckpoint
           block <- createBlock[Task](

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -76,8 +76,7 @@ class InterpreterUtilTest
               BlockData(
                 now,
                 seqNum,
-                genesisContext.validatorPks.head,
-                parents.head.blockHash.toByteArray
+                genesisContext.validatorPks.head
               ),
               Map.empty[BlockHash, Validator]
             )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -81,23 +81,18 @@ object Runtime {
   type Remainder = Option[Var]
   type BodyRef   = Long
 
-  // parentHash in side the BlockData is only used for closeBlock system deploy random initial
-  // parentHash is not exposed in the rholang contract `rho:block:data`
-  // maybe future we will refactor this into a better way
   final case class BlockData private (
       timeStamp: Long,
       blockNumber: Long,
-      sender: PublicKey,
-      parentHash: Array[Byte]
+      sender: PublicKey
   )
   object BlockData {
-    def empty: BlockData = BlockData(0, 0, PublicKey(Base16.unsafeDecode("00")), Array[Byte]())
+    def empty: BlockData = BlockData(0, 0, PublicKey(Base16.unsafeDecode("00")))
     def fromBlock(template: BlockMessage) =
       BlockData(
         template.header.timestamp,
         template.body.state.blockNumber,
-        PublicKey(template.sender),
-        template.header.parentsHashList.headOption.getOrElse(ByteString.EMPTY).toByteArray
+        PublicKey(template.sender)
       )
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -81,18 +81,21 @@ object Runtime {
   type Remainder = Option[Var]
   type BodyRef   = Long
 
+  // seqNum is not exposed to rholang api contract currently
   final case class BlockData private (
       timeStamp: Long,
       blockNumber: Long,
-      sender: PublicKey
+      sender: PublicKey,
+      seqNum: Int
   )
   object BlockData {
-    def empty: BlockData = BlockData(0, 0, PublicKey(Base16.unsafeDecode("00")))
+    def empty: BlockData = BlockData(0, 0, PublicKey(Base16.unsafeDecode("00")), 0)
     def fromBlock(template: BlockMessage) =
       BlockData(
         template.header.timestamp,
         template.body.state.blockNumber,
-        PublicKey(template.sender)
+        PublicKey(template.sender),
+        template.seqNum
       )
   }
 


### PR DESCRIPTION
## Overview
1. add SystemDeployUtil to generate random seed for systemDeploy. The logic of `PreCharge` and `Refund` doesn't change. I only change `CloseBlock` and `Slashing`
2. replace the `parentHash` with `seqNum`  in the `BlockData`. 



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4014



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
