### PR TITLE
Remove propose service from external port

### DIFF
--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -551,8 +551,7 @@ class NodeRuntime private[node] (
                             .acquireExternalServer[Task](
                               conf.grpcServer.portExternal,
                               grpcScheduler,
-                              apiServers.deploy,
-                              apiServers.propose
+                              apiServers.deploy
                             )
       internalApiServer <- api
                             .acquireInternalServer(

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -45,8 +45,7 @@ package object api {
   def acquireExternalServer[F[_]: Concurrent: Log: Taskable](
       port: Int,
       grpcExecutor: Scheduler,
-      deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
-      proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService
+      deployGrpcService: DeployServiceV1GrpcMonix.DeployService
   ): F[Server[F]] =
     GrpcServer[F](
       NettyServerBuilder
@@ -56,10 +55,6 @@ package object api {
         .addService(
           DeployServiceV1GrpcMonix
             .bindService(deployGrpcService, grpcExecutor)
-        )
-        .addService(
-          ProposeServiceV1GrpcMonix
-            .bindService(proposeGrpcService, grpcExecutor)
         )
         .addService(ProtoReflectionService.newInstance())
         .build


### PR DESCRIPTION
We should not allow triggering proposals via public port (40401) and should expose propose service only on internal port (40402).



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
