### PR TITLE
RCHAIN-4029: fix Web API prepare-deploy to return correct sequence number

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -778,7 +778,12 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
   def playExploratoryDeploy(term: String, hash: StateHash): F[Seq[Par]] = {
     // Create a deploy with newly created private key
     val (privKey, _) = Secp256k1.newKeyPair
-    val deploy       = ConstructDeploy.sourceDeployNow(term, sec = privKey)
+    val deploy = ConstructDeploy.sourceDeploy(
+      term,
+      timestamp = System.currentTimeMillis,
+      phloLimit = Long.MaxValue,
+      sec = privKey
+    )
     // Create return channel as first private name created in deploy term
     val rand = Tools.unforgeableNameRng(deploy.pk, deploy.data.timestamp)
     import coop.rchain.models.rholang.implicits._

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -20,7 +20,6 @@ class ApiStatus:
 @dataclass
 class PrepareResponse:
     names: List[str]
-    block_number: int
     seq_number: int
 
 
@@ -61,7 +60,7 @@ class HttpClient():
             rep = requests.get(prepare_deploy_url)
         _check_reponse(rep)
         message = rep.json()
-        return PrepareResponse(names=message['names'], block_number=message['blockNumber'], seq_number=message['seqNumber'])
+        return PrepareResponse(names=message['names'], seq_number=message['seqNumber'])
 
     def deploy(self, term: str, phlo_limit: int, phlo_price: int, valid_after_block_number: int, deployer: PrivateKey) -> str:
         timestamp = int(time.time()* 1000)

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -30,10 +30,8 @@ def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
     status = client.status()
     assert status.version
     prepare_rep = client.prepare_deploy()
-    assert prepare_rep.block_number == 3
     assert prepare_rep.seq_number == 3
     prepare_rep_2 = client.prepare_deploy(STANDALONE_KEY.get_public_key().to_hex(), 1, 1)
-    assert prepare_rep_2.block_number == 3
     assert prepare_rep_2.seq_number == 3
 
     data_at_name = client.data_at_name(deploy_hash[0], 1, "UnforgDeploy")

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -91,12 +91,11 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
     deploys = deploys
   )
 
-  val prepareBlockNumber = 1L
-  val prepareSeqNumber   = 11L
-  val prepareNames       = List[String]("a", "b", "c")
-  val exPRS              = ExprBool(true)
-  val deployRet          = "Success!\\nDeployId is: 111111111111"
-  val dataAtLength       = 5
+  val prepareSeqNumber = 11
+  val prepareNames     = List[String]("a", "b", "c")
+  val exPRS            = ExprBool(true)
+  val deployRet        = "Success!\\nDeployId is: 111111111111"
+  val dataAtLength     = 5
 
   implicit class RichTask[A](t: Task[A]) {
     def toReaderT: TaskEnv[A] =
@@ -118,10 +117,9 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
     ): TaskEnv[WebApi.PrepareResponse] =
       Task
         .delay({
-          val names       = prepareNames
-          val blockNumber = prepareBlockNumber
-          val seqNumber   = prepareSeqNumber
-          WebApi.PrepareResponse(names, blockNumber, seqNumber)
+          val names     = prepareNames
+          val seqNumber = prepareSeqNumber
+          WebApi.PrepareResponse(names, seqNumber)
         })
         .toReaderT
 
@@ -226,7 +224,7 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
       res  <- act_resp
       _    = res.status should be(Status.Ok)
       body = res.decodeJson[PrepareResponse].runSyncUnsafe()
-      _    = body.blockNumber should be(prepareBlockNumber)
+      _    = body.seqNumber should be(prepareSeqNumber)
       _    = body.names should be(prepareNames)
     } yield ()
   }
@@ -242,7 +240,7 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
       res  <- act_resp
       _    = res.status should be(Status.Ok)
       body = res.decodeJson[PrepareResponse].runSyncUnsafe()
-      _    = body.blockNumber should be(prepareBlockNumber)
+      _    = body.seqNumber should be(prepareSeqNumber)
       _    = body.names should be(prepareNames)
     } yield ()
   }


### PR DESCRIPTION
## Overview
Web API `prepare-deploy` should return `seqNum` for the last block created by the validator. For read-only node it returns `-1`.

NOTE: Also I removed `blockNumber` from `prepare-deploy` so it can be more lightweight (BlockAPI.getBlocks is overhead for that).
The latest block number can be retrieved with `/blocks/1`.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4029

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
