### PR TITLE
RCHAIN-4030 skip genesis validation when connecting exist network and have genesis

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -60,7 +60,13 @@ object CasperLaunch {
         validatorId <- ValidatorIdentity.fromConfig[F](conf)
         genesis     = approvedBlock.candidate.block
         casper <- MultiParentCasper
-                   .hashSetCasper[F](validatorId, genesis, conf.shardId, conf.finalizationRate)
+                   .hashSetCasper[F](
+                     validatorId,
+                     genesis,
+                     conf.shardId,
+                     conf.finalizationRate,
+                     skipValidateGenesis = true
+                   )
         _ <- Engine
               .transitionToRunning[F](
                 casper,

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -56,7 +56,13 @@ object GenesisCeremonyMaster {
                  for {
                    _ <- insertIntoBlockAndDagStore[F](genesis, approvedBlock)
                    casper <- MultiParentCasper
-                              .hashSetCasper[F](validatorId, genesis, shardId, finalizationRate)
+                              .hashSetCasper[F](
+                                validatorId,
+                                genesis,
+                                shardId,
+                                finalizationRate,
+                                skipValidateGenesis = false
+                              )
                    _ <- Engine
                          .transitionToRunning[F](casper, approvedBlock, validatorId, ().pure[F])
                    _ <- CommUtil[F].sendForkChoiceTipRequest

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -77,7 +77,8 @@ class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: 
                                      validatorId,
                                      genesis,
                                      shardId,
-                                     finalizationRate
+                                     finalizationRate,
+                                     skipValidateGenesis = false
                                    )
                         _ <- Engine
                               .transitionToRunning[F](


### PR DESCRIPTION
## Overview
The original thoughts in discord was to introduce a flag to skip the genesis validation. After studying the [codes](https://github.com/rchain/rchain/blob/dev/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala#L34-L56), I think we can just skip validation on case of connecting to the existing network with the genesis block stored. @tgrospic @nzpr @Isaac-DeFrain 



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4030



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
