### PR TITLE
Update fork-choice tips when node is supposedly stuck

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -39,6 +39,8 @@ final case class CasperConf(
     deployTimestamp: Option[Long],
     finalizationRate: Int,
     maxNumberOfParents: Int,
+    forkChioceStaleThreshold: FiniteDuration,
+    forkChioceCheckIfStaleInterval: FiniteDuration,
     maxParentDepthOpt: Option[Int]
 )
 

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -39,8 +39,8 @@ final case class CasperConf(
     deployTimestamp: Option[Long],
     finalizationRate: Int,
     maxNumberOfParents: Int,
-    forkChioceStaleThreshold: FiniteDuration,
-    forkChioceCheckIfStaleInterval: FiniteDuration,
+    forkChoiceStaleThreshold: FiniteDuration,
+    forkChoiceCheckIfStaleInterval: FiniteDuration,
     maxParentDepthOpt: Option[Int]
 )
 

--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -201,6 +201,13 @@ rnode {
     
     # Maximum number of block parents
     max-number-of-parents = 2147483647 # Unlimited number of parents by default
+
+    # Node will request for fork choice tips if the latest FCT is more then this value
+    fork-choice-stale-threshold = 5 minutes
+
+    # Interval for check if fork choice tip is stale
+    fork-choice-check-if-stale-interval = 1 minutes
+
   }
 
   influxdb {

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -817,15 +817,15 @@ object NodeRuntime {
             )
         _ <- Time[F].sleep(conf.casper.casperLoopInterval.seconds)
       } yield ()
-      // Broadcast fork choice tips request if current fork choice is more then `forkChioceStaleThreshold` minutes old.
+      // Broadcast fork choice tips request if current fork choice is more then `forkChoiceStaleThreshold` minutes old.
       // For why - look at updateForkChoiceTipsIfStuck method description.
       updateForkChoiceLoop = {
         implicit val cu = commUtil
         implicit val ec = engineCell
         implicit val bs = blockStore
         for {
-          _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChioceStaleThreshold)
-          _ <- Time[F].sleep(conf.casper.forkChioceCheckIfStaleInterval)
+          _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChoiceStaleThreshold)
+          _ <- Time[F].sleep(conf.casper.forkChoiceCheckIfStaleInterval)
         } yield ()
       }
       engineInit     = engineCell.read >>= (_.init)

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -251,6 +251,7 @@ class NodeRuntime private[node] (
       packetHandler,
       apiServers,
       casperLoop,
+      updateForkChoiceLoop,
       engineInit,
       casperLaunch,
       reportingCasper,
@@ -264,6 +265,7 @@ class NodeRuntime private[node] (
     program = nodeProgram(
       apiServers,
       casperLoop,
+      updateForkChoiceLoop,
       engineInit,
       runtimeCleanup,
       reportingCasper,
@@ -313,6 +315,7 @@ class NodeRuntime private[node] (
   private def nodeProgram(
       apiServers: APIServers,
       casperLoop: CasperLoop[TaskEnv],
+      updateForkChoiceLoop: CasperLoop[TaskEnv],
       engineInit: EngineInit[TaskEnv],
       runtimeCleanup: Cleanup[TaskEnv],
       reportingCasper: ReportingCasper[TaskEnv],
@@ -445,6 +448,11 @@ class NodeRuntime private[node] (
       _ <- Concurrent[TaskEnv].start(engineInit)
       _ <- Task
             .defer(casperLoop.forever.run(NodeCallCtx.init))
+            .executeOn(loopScheduler)
+            .start
+            .toReaderT
+      _ <- Task
+            .defer(updateForkChoiceLoop.forever.run(NodeCallCtx.init))
             .executeOn(loopScheduler)
             .toReaderT
     } yield ()
@@ -665,6 +673,7 @@ object NodeRuntime {
         PacketHandler[F],
         APIServers,
         CasperLoop[F],
+        CasperLoop[F],
         EngineInit[F],
         CasperLaunch[F],
         ReportingCasper[F],
@@ -743,6 +752,7 @@ object NodeRuntime {
         implicit val sp = span
         RuntimeManager.fromRuntime[F](casperRuntime)
       }
+
       engineCell   <- EngineCell.init[F]
       envVars      = EnvVars.envVars[F]
       raiseIOError = IOError.raiseIOErrorThroughSync[F]
@@ -807,6 +817,17 @@ object NodeRuntime {
             )
         _ <- Time[F].sleep(conf.casper.casperLoopInterval.seconds)
       } yield ()
+      // Broadcast fork choice tips request if current fork choice is more then `forkChioceStaleThreshold` minutes old.
+      // For why - look at updateForkChoiceTipsIfStuck method description.
+      updateForkChoiceLoop = {
+        implicit val cu = commUtil
+        implicit val ec = engineCell
+        implicit val bs = blockStore
+        for {
+          _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChioceStaleThreshold)
+          _ <- Time[F].sleep(conf.casper.forkChioceCheckIfStaleInterval)
+        } yield ()
+      }
       engineInit     = engineCell.read >>= (_.init)
       runtimeCleanup = NodeRuntime.cleanup(runtime, casperRuntime, deployStorageCleanup)
       webApi = {
@@ -823,6 +844,7 @@ object NodeRuntime {
       packetHandler,
       apiServers,
       casperLoop,
+      updateForkChoiceLoop,
       engineInit,
       casperLaunch,
       reportingCasper,

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -113,6 +113,8 @@ object ConfigMapper {
         add(keys.FinalizationRate, run.finalizationRate)
         add(keys.MaxNumberOfParents, run.maxNumberOfParents)
         add(keys.MaxParentDepth, run.maxParentDepth)
+        add(keys.forkChoiceStaleThreshold, run.forkChoiceStaleThreshold)
+        add(keys.forkChoiceCheckIfStaleInterval, run.forkChoiceCheckIfStaleInterval)
       }
     }
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -373,6 +373,20 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val maxParentDepth = opt[Int](
       descr = "Maximum depth of block parents."
     )
+
+    val forkChoiceStaleThreshold =
+      opt[FiniteDuration](
+        default = Option(FiniteDuration(5, scala.concurrent.duration.MINUTES)),
+        descr =
+          "Node will request for fork choice tips if the latest FCT is more then " +
+            "forkChoiceStaleThreshold old. Default 5 min."
+      )
+
+    val forkChoiceCheckIfStaleInterval =
+      opt[FiniteDuration](
+        default = Option(FiniteDuration(1, scala.concurrent.duration.MINUTES)),
+        descr = "Interval for check if fork choice tip is stale. Default 1 min."
+      )
   }
   addSubcommand(run)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/hocon/model.scala
@@ -265,30 +265,32 @@ object Casper {
   val Keys: List[String] = keys.all.map(k => s"$Key.$k")
 
   object keys {
-    val ValidatorPrivateKey      = "validator-private-key"
-    val ValidatorPrivateKeyPath  = "validator-private-key-path"
-    val ValidatorPublicKey       = "validator-public-key"
-    val BondsFile                = "bonds-file"
-    val KnownValidatorsFile      = "known-validators-file"
-    val Validators               = "validators"
-    val WalletsFile              = "wallets-file"
-    val BondMinimum              = "bond-minimum"
-    val BondMaximum              = "bond-maximum"
-    val QuarantineLength         = "quarantine-length"
-    val NumberOfActiveValidators = "number-of-active-validators"
-    val CasperLoopInterval       = "casper-loop-interval"
-    val RequestedBlocksTimeout   = "requested-blocks-timeout"
-    val EpochLength              = "epoch-length"
-    val RequiredSignatures       = "required-signatures"
-    val Shard                    = "shard"
-    val GenesisValidator         = "genesis-validator"
-    val GenesisApproveInterval   = "genesis-approve-interval"
-    val GenesisApproveDuration   = "genesis-approve-duration"
-    val DeployTimestamp          = "deploy-timestamp"
-    val GenesisPath              = "genesis-path"
-    val FinalizationRate         = "finalization-rate"
-    val MaxNumberOfParents       = "max-number-of-parents"
-    val MaxParentDepth           = "max-parent-depth"
+    val ValidatorPrivateKey            = "validator-private-key"
+    val ValidatorPrivateKeyPath        = "validator-private-key-path"
+    val ValidatorPublicKey             = "validator-public-key"
+    val BondsFile                      = "bonds-file"
+    val KnownValidatorsFile            = "known-validators-file"
+    val Validators                     = "validators"
+    val WalletsFile                    = "wallets-file"
+    val BondMinimum                    = "bond-minimum"
+    val BondMaximum                    = "bond-maximum"
+    val QuarantineLength               = "quarantine-length"
+    val NumberOfActiveValidators       = "number-of-active-validators"
+    val CasperLoopInterval             = "casper-loop-interval"
+    val RequestedBlocksTimeout         = "requested-blocks-timeout"
+    val EpochLength                    = "epoch-length"
+    val RequiredSignatures             = "required-signatures"
+    val Shard                          = "shard"
+    val GenesisValidator               = "genesis-validator"
+    val GenesisApproveInterval         = "genesis-approve-interval"
+    val GenesisApproveDuration         = "genesis-approve-duration"
+    val DeployTimestamp                = "deploy-timestamp"
+    val GenesisPath                    = "genesis-path"
+    val FinalizationRate               = "finalization-rate"
+    val MaxNumberOfParents             = "max-number-of-parents"
+    val MaxParentDepth                 = "max-parent-depth"
+    val forkChoiceStaleThreshold       = "fork-choice-stale-threshold"
+    val forkChoiceCheckIfStaleInterval = "fork-choice-check-if-stale-interval"
 
     val all =
       List(
@@ -315,6 +317,8 @@ object Casper {
         GenesisPath,
         FinalizationRate,
         MaxNumberOfParents,
+        forkChoiceStaleThreshold,
+        forkChoiceCheckIfStaleInterval,
         MaxParentDepth
       )
   }
@@ -350,6 +354,8 @@ object Casper {
       createGenesis = false,
       finalizationRate = casper.getInt(keys.FinalizationRate),
       maxNumberOfParents = casper.getInt(keys.MaxNumberOfParents),
+      forkChoiceStaleThreshold = casper.getFiniteDuration(keys.forkChoiceStaleThreshold),
+      forkChoiceCheckIfStaleInterval = casper.getFiniteDuration(keys.forkChoiceCheckIfStaleInterval),
       maxParentDepthOpt = casper.getIntOpt(keys.MaxParentDepth)
     )
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -212,6 +212,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--deploy-timestamp 333",
         "--finalization-rate 4",
         "--max-number-of-parents 1",
+        "--fork-choice-stale-threshold 3h",
+        "--fork-choice-check-if-stale-interval 3h",
         "--max-parent-depth 7"
       ).mkString(" ")
 
@@ -246,6 +248,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         deployTimestamp = Some(333),
         finalizationRate = 4,
         maxNumberOfParents = 1,
+        forkChoiceStaleThreshold = 3.hour,
+        forkChoiceCheckIfStaleInterval = 3.hour,
         maxParentDepthOpt = Some(7)
       )
 

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -219,6 +219,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         |    deploy-timestamp = 333
         |    finalization-rate = 4
         |    max-number-of-parents = 1
+        |    fork-choice-stale-threshold = 3h
+        |    fork-choice-check-if-stale-interval = 3h
         |    max-parent-depth = 7
         |  }
         |}
@@ -249,6 +251,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         deployTimestamp = Some(333),
         finalizationRate = 4,
         maxNumberOfParents = 1,
+        forkChoiceStaleThreshold = 3.hour,
+        forkChoiceCheckIfStaleInterval = 3.hour,
         maxParentDepthOpt = Some(7)
       )
 


### PR DESCRIPTION
## Overview
As we introduced synchrony constraint - there might be situation when node is stuck.
As an edge case with `sync = 0.99`, if node misses the block that is the last one to meet sync constraint, it has no way to request it after it was broadcasted. So it will never meet synchrony constraint. To mitigate this issue we can update fork choice tips if current fork-choice tip has old timestamp, which means node does not propose new blocks and no new blocks were received recently.

### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
