### PR TITLE
RCHAIN-4032: disable receives on the same channel

### DIFF
--- a/casper/src/test/resources/RhoSpecContractTest.rho
+++ b/casper/src/test/resources/RhoSpecContractTest.rho
@@ -101,9 +101,9 @@ in {
   } |
 
   contract testAssertEqualsForVariables(rhoSpec, self, ackCh) = {
-    new ch in {
-      ch !! (1) |
-      for (x <- ch; y <- ch) {
+    new ch1, ch2 in {
+      ch1 ! (1) | ch2 ! (1) |
+      for (x <- ch1; y <- ch2) {
         rhoSpec ! ("assertMany",
           [
             ((*x, "==", *y), "assert var equals var"),

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -117,4 +117,12 @@ object errors {
         s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getFullStackTrace).mkString}"
       )
 
+  // Current implementation of SpaceMatcher (extractDataCandidates) causes unmatched comms
+  // with the same binding channels and overlapping patterns.
+  // Temporarily these kind of joins `for (<- @2; <- @2)` are not allowed.
+  // https://rchain.atlassian.net/browse/RCHAIN-4032
+  final case class ReceiveOnSameChannelsError(line: Int, col: Int)
+      extends InterpreterError(
+        s"Receiving on the same channels is currently not allowed (at $line:$col). Ref. RCHAIN-4032."
+      )
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -289,27 +289,28 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
     listBindings1.add(new NameVar("z"))
     val listLinearBinds = new ListLinearBind()
     listLinearBinds.add(
-      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x"))
+      new LinearBindImpl(listBindings, new NameRemainderEmpty(), new NameVar("x0"))
     )
     listLinearBinds.add(
-      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x"))
+      new LinearBindImpl(listBindings1, new NameRemainderEmpty(), new NameVar("x1"))
     )
     val linearSimple = new LinearSimple(listLinearBinds)
     val receipt      = new ReceiptLinear(linearSimple)
     val cont         = new PPar(new PEval(new NameVar("y")), new PEval(new NameVar("z")))
     val receive      = new PInput(receipt, cont)
     val nameDec      = new ListNameDecl()
-    nameDec.add(new NameDeclSimpl("x"))
+    nameDec.add(new NameDeclSimpl("x0"))
+    nameDec.add(new NameDeclSimpl("x1"))
     val source = new PNew(nameDec, receive)
     val result =
       PrettyPrinter().buildString(
         ProcNormalizeMatcher.normalizeMatch[Coeval](source, inputs).value.par
       )
     val target =
-      """new x0 in {
-        |  for( @{x1} <- x0 ; @{x2} <- x0 ) {
+      """new x0, x1 in {
+        |  for( @{x2} <- x1 ; @{x3} <- x0 ) {
         |    x2 |
-        |    x1
+        |    x3
         |  }
         |}""".stripMargin
     result shouldBe target

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
@@ -27,7 +27,10 @@ class ReplaySpec extends FlatSpec with Matchers {
   //  with in-memory version used here.
   // https://github.com/rchain/rchain/blob/1f9554f68a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala#L231
 
-  "multi joins (2/2)" should "execute successfully in replay" in {
+  // Temporarily disabled tests with joins on the same channels
+  // https://rchain.atlassian.net/browse/RCHAIN-4032
+
+  "multi joins (2/2)" should "execute successfully in replay" ignore {
     val term =
       """
         |new x in {
@@ -37,7 +40,7 @@ class ReplaySpec extends FlatSpec with Matchers {
     testRholangTerm(term, 500, 30.seconds)
   }
 
-  "multi joins (4/2)" should "execute successfully in replay" in {
+  "multi joins (4/2)" should "execute successfully in replay" ignore {
     val term =
       """
         |new x in {


### PR DESCRIPTION
## Overview
Because current implementation of [SpaceMatcher](https://github.com/rchain/rchain/blob/dcd5ee6/rspace/src/main/scala/coop/rchain/rspace/SpaceMatcher.scala#L72-L104) does not work well with receives on the same channels, we need to disallow these kind of joins `for (<- @2; <- @2)`.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4032

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
