### PR TITLE
RCHAIN-4035: temp solution to handle hash mismatch error when replaying a block

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -219,7 +219,7 @@ object Running {
     ) >>= (
         tip =>
           streamToPeer(peer)(ToPacket(tip.toProto)) <* Log[F].info(
-            s"Sending Block ${tip.blockHash} to $peer"
+            s"Sending Block ${PrettyPrinter.buildString(tip.blockHash)} to $peer"
           )
       )
 

--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperDeploySpec.scala
@@ -66,4 +66,115 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
       } yield assert(!block.body.deploys.head.isFailed)
     }
   }
+
+  val term =
+    """
+      |new return, rl(`rho:registry:lookup`), RevVaultCh, vaultCh,
+      |  deployId(`rho:rchain:deployId`)
+      |   in {
+      |    rl!(`rho:rchain:revVault`, *RevVaultCh) |
+      |    for (@(_, RevVault) <- RevVaultCh) {
+      |      @RevVault!("findOrCreate", "1111LZ6wp2EkfiFhbMqVZpjVEGaxGYB8rt6uLgdTBUKBcGzVMo1jk", *vaultCh) |
+      |      for (@maybeVault <- vaultCh) {
+      |        match maybeVault {
+      |          (true, vault) => @vault!("balance", *deployId)
+      |          (false, err)  => deployId!(err)
+      |        }
+      |      }
+      |    }
+      |  }
+      |""".stripMargin
+
+  val termNzpr =
+    """
+      |new
+      |    rl(`rho:registry:lookup`), RevVaultCh,
+      |    vaultCh, balanceCh,
+      |    deployId(`rho:rchain:deployId`),
+      |    stdout(`rho:io:stdout`)
+      |  in {
+      |
+      |    rl!(`rho:rchain:revVault`, *RevVaultCh) |
+      |    for (@(_, RevVault) <- RevVaultCh) {
+      |
+      |      stdout!(("MyRChainWallet.CheckBalance.rho")) |
+      |
+      |      match "1111wz8Ga8b6pPnDgKarjMeFBYr1Fsor8CUfpXfaNcD3D2328sbfv" {
+      |        revAddress => {
+      |
+      |          stdout!(("Accessing vault at RevAddress", revAddress)) |
+      |
+      |          // most RevVault methods return an `Either[String, A] = (false, String) / (true, A)`
+      |          @RevVault!("findOrCreate", revAddress, *vaultCh) |
+      |          for (@(true, vault) <- vaultCh) {
+      |
+      |            stdout!("Obtained vault, checking balance") |
+      |
+      |            @vault!("balance", *balanceCh) |
+      |            for (@balance <- balanceCh) {
+      |
+      |              stdout!(("Balance is", balance)) |
+      |
+      |              deployId!(balance)
+      |            }
+      |          }
+      |
+      |        }
+      |      }
+      |    }
+      |  }
+      |""".stripMargin
+
+  it should "replay the block with hundreds of deploys" in effectTest {
+    implicit val timeEff = new LogicalTime[Effect]
+    TestNode.networkEff(genesis, networkSize = 10).use {
+      case n0 +: n1 +: n2 +: n3 +: n4 +: n5 +: n6 +: n7 +: n8 +: n9 +: Seq() =>
+        val deploys = Seq.fill(100)(
+          ConstructDeploy
+            .sourceDeploy(termNzpr, phloLimit = 500000L, timestamp = System.currentTimeMillis)
+        )
+//        val terms = Seq.fill(100)(termNzpr).mkString(" |\n")
+//        println(s"$terms")
+//        val deploysBig = Seq.fill(1)(
+//          ConstructDeploy
+//            .sourceDeploy(terms, phloLimit = 50000000L, timestamp = System.currentTimeMillis)
+//        )
+        for {
+          b   <- n0.propagateBlock(deploys: _*)(n1, n2, n3, n4, n5, n6, n7, n8, n9)
+          ok1 <- n1.casperEff.contains(b.blockHash)
+          ok2 <- n2.casperEff.contains(b.blockHash)
+          ok3 <- n3.casperEff.contains(b.blockHash)
+          ok4 <- n4.casperEff.contains(b.blockHash)
+          ok5 <- n5.casperEff.contains(b.blockHash)
+          ok6 <- n5.casperEff.contains(b.blockHash)
+          ok7 <- n5.casperEff.contains(b.blockHash)
+          ok8 <- n5.casperEff.contains(b.blockHash)
+          ok9 <- n5.casperEff.contains(b.blockHash)
+//          _                  <- casper1.deploy(deploy)
+//          createBlockResult2 <- casper1.createBlock
+        } yield (ok1, ok2, ok3, ok4, ok5, ok6, ok7, ok8, ok9) shouldBe (true, true, true, true, true, true, true, true, true)
+    }
+  }
+
+  it should "replay the block with hundreds of deploys 2" in effectTest {
+    implicit val timeEff = new LogicalTime[Effect]
+    TestNode.networkEff(genesis, networkSize = 5).use {
+      case n0 +: n1 +: n2 +: n3 +: n4 +: Seq() =>
+        val deploys = Seq.fill(1000)(
+          ConstructDeploy
+            .sourceDeploy(termNzpr, phloLimit = 500000L, timestamp = System.currentTimeMillis)
+        )
+        for {
+          b   <- n0.propagateBlock(deploys: _*)(n1, n2, n3, n4)
+//          b <- n0.createBlock(deploys: _*)
+//          _ <- n0.syncWith(n1, n2, n3, n4)
+//          _   <- n0.syncWith(n4)
+          ok1 <- n1.casperEff.contains(b.blockHash)
+          ok2 <- n2.casperEff.contains(b.blockHash)
+          ok3 <- n3.casperEff.contains(b.blockHash)
+          ok4 <- n4.casperEff.contains(b.blockHash)
+        } yield (ok1, ok2, ok3, ok4) shouldBe (true, true, true, true)
+    }
+  }
+
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -31,7 +31,7 @@ object GenesisBuilder {
   def createGenesis(): BlockMessage =
     buildGenesis().genesisBlock
 
-  val defaultValidatorKeyPairs                   = (1 to 4).map(_ => Secp256k1.newKeyPair)
+  val defaultValidatorKeyPairs                   = (1 to 20).map(_ => Secp256k1.newKeyPair)
   val (defaultValidatorSks, defaultValidatorPks) = defaultValidatorKeyPairs.unzip
 
   def buildGenesisParameters(
@@ -70,7 +70,8 @@ object GenesisBuilder {
     )
 
   private def predefinedVault(pub: PublicKey): Vault =
-    Vault(RevAddress.fromPublicKey(pub).get, 9000000)
+//    Vault(RevAddress.fromPublicKey(pub).get, 90000000000L)
+    Vault(RevAddress.fromPublicKey(pub).get, 0L)
 
   type GenesisParameters = (Iterable[(PrivateKey, PublicKey)], Genesis)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -89,7 +89,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
             Map.empty
           )(rand) >>= { playResult =>
             runtime.space.createCheckpoint() >>= {
-              case Checkpoint(root, log) =>
+              case Checkpoint(root, log, _) =>
                 runtime.replaySpace.rigAndReset(root, log) >>
                   Interpreter[Task].injAttempt(
                     runtime.replayReducer,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ISpaceStub.scala
@@ -40,6 +40,7 @@ class ISpaceStub[F[_]: Applicative, C, P, A, K] extends ISpace[F, C, P, A, K] {
   ): F[Option[(ContResult[C, P, K], Seq[Result[C, A]])]] = ???
 
   override def createCheckpoint(): F[Checkpoint] = ???
+  override def createCheckpointWithRetry(root: Blake2b256Hash): F[Checkpoint] = ???
 
   override def reset(root: Blake2b256Hash): F[Unit] = ???
 

--- a/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
@@ -7,4 +7,8 @@ final case class SoftCheckpoint[C, P, A, K](
     log: trace.Log,
     produceCounter: Map[Produce, Int]
 )
-final case class Checkpoint(root: Blake2b256Hash, log: trace.Log)
+final case class Checkpoint(
+    root: Blake2b256Hash,
+    log: trace.Log,
+    changes: Seq[HotStoreAction] = Seq.empty
+)

--- a/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ISpace.scala
@@ -31,6 +31,7 @@ trait ISpace[F[_], C, P, A, K] extends Tuplespace[F, C, P, A, K] {
     * @return A [[Checkpoint]]
     */
   def createCheckpoint(): F[Checkpoint]
+  def createCheckpointWithRetry(postRoot: Blake2b256Hash): F[Checkpoint]
 
   /** Resets the store to the given root.
     *

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
@@ -9,6 +9,10 @@ import scodec.Codec
 
 trait HistoryRepository[F[_], C, P, A, K] extends HistoryReader[F, C, P, A, K] {
   def checkpoint(actions: List[HotStoreAction]): F[HistoryRepository[F, C, P, A, K]]
+  def checkpointWithRetry(
+      actions: List[HotStoreAction],
+      postRoot: Blake2b256Hash
+  ): F[HistoryRepository[F, C, P, A, K]]
 
   def reset(root: Blake2b256Hash): F[HistoryRepository[F, C, P, A, K]]
 


### PR DESCRIPTION
## Overview
Because of a bug reported by @nzpr, replay block can fail with tuple space hash mismatch error. It's not reproducible in tests and and conditions are not completely clear.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4035

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
