### PR TITLE
Make block propagation aware of block store

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -85,7 +85,6 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
 
     def add: F[ValidBlockProcessing] = spanF.trace(AddBlockMetricsSource) {
       for {
-        _      <- BlockStore[F].put(b)
         _      <- spanF.mark("block-store-put")
         dag    <- blockDag
         status <- internalAddBlock(b, dag)

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -85,7 +85,6 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
 
     def add: F[ValidBlockProcessing] = spanF.trace(AddBlockMetricsSource) {
       for {
-        _      <- spanF.mark("block-store-put")
         dag    <- blockDag
         status <- internalAddBlock(b, dag)
         _      <- spanF.mark("block-added-status")

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -197,10 +197,10 @@ object Running {
     )
 
   def handleBlockMessage[F[_]: Monad: Log: RequestedBlocks](peer: PeerNode, b: BlockMessage)(
-      casperContains: BlockHash => F[Boolean],
+      blockStoreContains: BlockHash => F[Boolean],
       casperAdd: BlockMessage => F[ValidBlockProcessing]
   ): F[Unit] =
-    casperContains(b.blockHash)
+    blockStoreContains(b.blockHash)
       .ifM(
         Log[F].info(s"Received block ${PrettyPrinter.buildString(b.blockHash)} again."),
         Log[F].info(s"Received ${PrettyPrinter.buildString(b)}.") >> casperAdd(b) >>= (
@@ -299,7 +299,7 @@ class Running[F[_]: Sync: BlockStore: CommUtil: TransportLayer: ConnectionsCell:
 
   override def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = msg match {
     case blockHash: BlockHashMessage => handleBlockHashMessage(peer, blockHash)(casper.contains)
-    case b: BlockMessage             => handleBlockMessage(peer, b)(casper.contains, casperAdd(peer))
+    case b: BlockMessage             => handleBlockMessage(peer, b)(BlockStore[F].contains, casperAdd(peer))
     case br: BlockRequest            => handleBlockRequest(peer, br)
     case hbr: HasBlockRequest        => handleHasBlockRequest(peer, hbr)(casper.contains)
     case hb: HasBlock                => handleHasBlock(peer, hb)(casper.contains)

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
@@ -1,10 +1,7 @@
 package coop.rchain.casper.engine
 
 import cats.implicits._
-
 import Running.{Requested, RequestedBlocks}
-import coop.rchain.catscontrib.ski._
-import coop.rchain.casper.{BlockStatus}
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm._
@@ -15,15 +12,22 @@ import coop.rchain.comm.rp.RPConf
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.{LogStub, TransportLayerStub}
 import coop.rchain.shared._
-
 import com.google.protobuf.ByteString
 import monix.eval.Coeval
+import coop.rchain.blockstorage.InMemBlockStore
+import cats.effect.concurrent.Ref
+import coop.rchain.metrics.Metrics.MetricsNOP
 import org.scalatest._
 
 class RunningHandleBlockMessageSpec extends FunSpec with BeforeAndAfterEach with Matchers {
 
   val hash = ByteString.copyFrom("hash", "UTF-8")
   val bm   = Dummies.createBlockMessage(blockHash = hash)
+
+  implicit val metrics          = new MetricsNOP[Coeval]()
+  implicit val blockMap         = Ref.unsafe[Coeval, Map[BlockHash, BlockMessageProto]](Map.empty)
+  implicit val approvedBlockRef = Ref.unsafe[Coeval, Option[ApprovedBlock]](None)
+  implicit val blockStore       = InMemBlockStore.create[Coeval]
 
   override def beforeEach(): Unit = {
     transport.reset()

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningMaintainRequestedBlocksSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningMaintainRequestedBlocksSpec.scala
@@ -15,14 +15,22 @@ import coop.rchain.models.BlockHash.BlockHash
 import com.google.protobuf.ByteString
 import coop.rchain.metrics.Metrics
 import monix.eval.Coeval
+import cats.effect.concurrent.Ref
+import coop.rchain.blockstorage.InMemBlockStore
+import coop.rchain.metrics.Metrics.MetricsNOP
+
 import concurrent.duration._
 import org.scalatest._
 
 class RunningMaintainRequestedBlocksSpec extends FunSpec with BeforeAndAfterEach with Matchers {
 
-  val hash             = ByteString.copyFrom("hash", "UTF-8")
-  implicit val metrics = new Metrics.MetricsNOP[Coeval]
-  val timeout: Int     = 240
+  val hash         = ByteString.copyFrom("hash", "UTF-8")
+  val timeout: Int = 240
+
+  implicit val metrics          = new MetricsNOP[Coeval]()
+  implicit val blockMap         = Ref.unsafe[Coeval, Map[BlockHash, BlockMessageProto]](Map.empty)
+  implicit val approvedBlockRef = Ref.unsafe[Coeval, Option[ApprovedBlock]](None)
+  implicit val blockStore       = InMemBlockStore.create[Coeval]
 
   override def beforeEach(): Unit = {
     transport.reset()

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -806,15 +806,17 @@ object NodeRuntime {
       casperLoop = for {
         engine <- engineCell.read
         _      <- engine.withCasper(_.fetchDependencies, Applicative[F].unit)
-        _ <- Running.maintainRequestedBlocks[F](conf.casper.requestedBlocksTimeout)(
-              Monad[F],
-              rpConfAsk,
-              requestedBlocks,
-              TransportLayer[F],
-              Log[F],
-              Time[F],
-              Metrics[F]
-            )
+        _ <- Running
+              .maintainRequestedBlocks[F](conf.casper.requestedBlocksTimeout)(
+                Monad[F],
+                rpConfAsk,
+                requestedBlocks,
+                TransportLayer[F],
+                Log[F],
+                Time[F],
+                Metrics[F],
+                blockStore
+              )
         _ <- Time[F].sleep(conf.casper.casperLoopInterval.seconds)
       } yield ()
       // Broadcast fork choice tips request if current fork choice is more then `forkChoiceStaleThreshold` minutes old.


### PR DESCRIPTION
Liveness of the protocol is supported by casper loop https://github.com/rchain/rchain/blob/ab3edcca40cf0c80eb6f6da31ee9271edc95ca37/casper/src/main/scala/coop/rchain/casper/engine/Running.scala#L105
which maintains queue of blocks that casper needs to get from another peers. Node adds to that queue when requesting block
https://github.com/rchain/rchain/blob/ab3edcca40cf0c80eb6f6da31ee9271edc95ca37/casper/src/main/scala/coop/rchain/casper/engine/Running.scala#L62-L65
and removes after block is added to the DAG.
https://github.com/rchain/rchain/blob/ab3edcca40cf0c80eb6f6da31ee9271edc95ca37/casper/src/main/scala/coop/rchain/casper/engine/Running.scala#L199-L211

So atm block request is removed from the queue only when it is in the DAG which causes faulty rerequests.
Node might actually receive block, put in the block store and send it to casper to add, where it will wait for `blockProcessingLock` to be released https://github.com/rchain/rchain/blob/a8ace3b28430f5af323bd0710eec0628cef297d2/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala#L98 
If there are lots of block being processed, or a single big block occupied lock for a long time - as we are unable to process blocks in parallel, on the next casper loop invocation this block still won't be in the DAG. This will trigger rerequest, which is redundant.

To disable this we can check for block store instead of dag store for hash presence on block message arrival.



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
