### PR TITLE
RCHAIN-4043 add test_transfer_to_not_exist_vault

### DIFF
--- a/integration-tests/test/conftest.py
+++ b/integration-tests/test/conftest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addoption("--startup-timeout", type=int, action="store", default=60 * 30, help="timeout in seconds for starting a node")
     parser.addoption("--converge-timeout", type=int, action="store", default=60 * 30, help="timeout in seconds for network converge")
     parser.addoption("--receive-timeout", type=int, action="store", default=30, help="timeout in seconds for receiving a single block")
-    parser.addoption("--command-timeout", type=int, action="store", default=60 * 30, help="timeout in seconds for executing a rnode call")
+    parser.addoption("--command-timeout", type=int, action="store", default=60 * 3, help="timeout in seconds for executing a rnode call")
     parser.addoption("--random-seed", type=int, action="store", default=None, help="seed for the random numbers generator used in integration tests")
 
 def pytest_terminal_summary(terminalreporter:TerminalReporter) -> None:

--- a/integration-tests/test/wait.py
+++ b/integration-tests/test/wait.py
@@ -291,6 +291,11 @@ def wait_for_log_match_result(context: TestingContext, node: 'Node', pattern: Pa
     wait_using_wall_clock_time_or_fail(predicate, context.command_timeout)
     return predicate.result
 
+def wait_for_log_match_result_raise(context: TestingContext, node: 'Node', pattern: Pattern) -> Match:
+    predicate = LogsReMatchWithResult(node, pattern)
+    wait_using_wall_clock_time(predicate, context.command_timeout)
+    return predicate.result
+
 
 def wait_for_block_finalized(context: TestingContext, node: 'Node', *, block_hash_prefix: str) -> None:
     predicate = BlockFinalized(node, block_hash_prefix)

--- a/rholang/examples/vault_demo/3.transfer_funds.rho
+++ b/rholang/examples/vault_demo/3.transfer_funds.rho
@@ -16,10 +16,12 @@ in {
     ) {
       (from, to, amount) => {
 
-        new vaultCh, revVaultkeyCh, deployerId(`rho:rchain:deployerId`) in {
+        new vaultCh, targetVaultCh, revVaultkeyCh, deployerId(`rho:rchain:deployerId`) in {
           @RevVault!("findOrCreate", from, *vaultCh) |
+          // make sure the target vault it created and the transfer would be done
+          @RevVault!("findOrCreate", to, *targetVaultCh) |
           @RevVault!("deployerAuthKey", *deployerId, *revVaultkeyCh) |
-          for (@(true, vault) <- vaultCh; key <- revVaultkeyCh) {
+          for (@(true, vault) <- vaultCh; key <- revVaultkeyCh; @(true, _) <- targetVaultCh) {
 
             stdout!(("Beginning transfer of ", amount, "REV from", from, "to", to)) |
 


### PR DESCRIPTION
## Overview
This PR adds integration test for REV transfer when REV target REV vault does not exists and transfer result is not returned until is created.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4043

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
