### PR TITLE
Message propagation improvement

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -73,7 +73,9 @@ sealed abstract class SafetyOracleInstances {
           candidateBlockHash: BlockHash
       ): F[Float] = Span[F].trace(SafetyOracleMetricsSource) {
         for {
-          _                      <- Log[F].debug(s"Calculating faultTolearance of block ${candidateBlockHash} ")
+          _ <- Log[F].debug(
+                s"Calculating faultTolearance of block ${PrettyPrinter.buildString(candidateBlockHash)} "
+              )
           maybeCandidateMetadata <- blockDag.lookup(candidateBlockHash)
           faultTolerance <- maybeCandidateMetadata match {
                              case Some(candidateMetadata) =>
@@ -101,7 +103,7 @@ sealed abstract class SafetyOracleInstances {
                              // if the node can to find the block, it would return -1 and regard that block as orphaned
                              case None =>
                                Log[F].info(
-                                 s"calculate faultTolerance blockHash ${candidateBlockHash} failed because it can not be found in store."
+                                 s"calculate faultTolerance blockHash ${PrettyPrinter.buildString(candidateBlockHash)} failed because it can not be found in store."
                                ) >> (-1L).toFloat
                                  .pure[F]
                            }

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.util.comm
 import scala.concurrent.duration._
 
 import cats.effect._
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.tagless.autoFunctorK
@@ -47,9 +46,8 @@ object CommUtil {
     new CommUtil[F] {
 
       def sendBlockHash(hash: BlockHash, blockCreator: ByteString): F[Unit] =
-        sendToPeers(BlockHashMessageProto(hash, blockCreator)) <* Log[F].info(
-          s"Sent hash ${PrettyPrinter.buildString(hash)} to peers"
-        )
+        sendToPeers(BlockHashMessageProto(hash, blockCreator)) >>
+          Log[F].info(s"Sent hash ${PrettyPrinter.buildString(hash)} to peers")
 
       def sendBlockRequest(hash: BlockHash): F[Unit] =
         Running
@@ -58,15 +56,15 @@ object CommUtil {
           .flatMap(
             requested =>
               Applicative[F].unlessA(requested.contains(hash))(
-                Running.addNewEntry(hash) >> sendToPeers(HasBlockRequestProto(hash)) <* Log[F]
-                  .info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
+                Running.addNewEntry(hash) >> sendToPeers(HasBlockRequestProto(hash)) >>
+                  Log[F]
+                    .info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
               )
           )
 
       def sendForkChoiceTipRequest: F[Unit] =
-        sendToPeers(ForkChoiceTipRequest.toProto) <* Log[F].info(
-          s"Requested fork tip from peers"
-        )
+        sendToPeers(ForkChoiceTipRequest.toProto) >>
+          Log[F].info(s"Requested fork tip from peers")
 
       def sendToPeers(message: Packet): F[Unit] =
         for {

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -83,7 +83,10 @@ object GrpcTransportReceiver {
                   .delay(blobBuffer.pushNext(msg))
                   .ifM(
                     List(
-                      logger.debug(s"Enqueued for handling packet ${msg.path}"),
+                      logger.debug(
+                        s"Enqueued for handling packet with message ${msg.typeId} " +
+                          s"from ${msg.sender.endpoint.host} size of ${msg.contentLength}. Packet ${msg.path}"
+                      ),
                       metrics.incrementCounter("enqueued.packets")
                     ).sequence,
                     List(

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -106,7 +106,9 @@ class GrpcTransportServer(
                          .subscribe()(queueScheduler)
                      )
       blobConsumer <- Task.delay(
-                       blobBuffer.mapEval(dispatchBlob).subscribe()(queueScheduler)
+                       blobBuffer
+                         .mapParallelUnordered(parallelism)(dispatchBlob)
+                         .subscribe()(queueScheduler)
                      )
     } yield Cancelable.collection(receiver, tellConsumer, blobConsumer)
   }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -780,7 +780,12 @@ object NodeRuntime {
 
         CasperLaunch.of(conf.casper)
       }
-      packetHandler <- {
+      packetHandler = {
+        implicit val ec = engineCell
+        CasperPacketHandler[F]
+      }
+      // Bypass fair dispatcher
+      /*packetHandler <- {
         implicit val ec = engineCell
         implicit val rb = requestedBlocks
         implicit val sp = span
@@ -789,7 +794,7 @@ object NodeRuntime {
           conf.roundRobinDispatcher.giveUpAfterSkipped,
           conf.roundRobinDispatcher.dropPeerAfterRetries
         )
-      }
+      }*/
       blockApiLock <- Semaphore[F](1)
       apiServers = NodeRuntime.acquireAPIServers[F](runtime, blockApiLock, scheduler)(
         blockStore,


### PR DESCRIPTION
Result of WIP in of https://github.com/rchain/rchain/pull/2897 and https://github.com/rchain/rchain/pull/2891

This PR enable discarding of duplicate messages to lower down load on Casper and system in general.
Moreover, bloat was found in consumption of streamed GRPC messages (blocks) which lead to over a hundred of messages waiting for processing as per `tmp/comm`. It is fixed as well.

As a result, we can see nodes advancing nicely when creating blocks simultaneously (synchrony constraint 0.67).
<img width="712" alt="Screenshot 2020-03-07 at 13 19 11" src="https://user-images.githubusercontent.com/1746367/76141528-5cf21d80-6076-11ea-96b0-0c6bcd8aec54.png">



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
