### PR TITLE
RCHAIN-4052: make higher AND and OR combinators lazy in second argument

### DIFF
--- a/shared/src/main/scala/coop/rchain/catscontrib/BooleanF.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/BooleanF.scala
@@ -1,19 +1,22 @@
 package coop.rchain.catscontrib
 
-import cats._, cats.data._, cats.implicits._
+import cats._, cats.syntax.all._
 
 final class BooleanF[F[_]: FlatMap](val self: F[Boolean]) {
-  def &&^(other: F[Boolean]): F[Boolean] =
+  def &&^(other: => F[Boolean]): F[Boolean] =
     BooleanF.&&^[F](self, other)
-  def ||^(other: F[Boolean]): F[Boolean] =
+
+  def ||^(other: => F[Boolean]): F[Boolean] =
     BooleanF.||^[F](self, other)
+
+  def not: F[Boolean] = BooleanF.~^(self)
 }
 
 object BooleanF {
-  def &&^[F[_]: FlatMap](m1: F[Boolean], m2: F[Boolean]): F[Boolean] =
+  def &&^[F[_]: FlatMap](m1: F[Boolean], m2: => F[Boolean]): F[Boolean] =
     FlatMap[F].ifM(m1)(m2, m1)
 
-  def ||^[F[_]: FlatMap](m1: F[Boolean], m2: F[Boolean]): F[Boolean] =
+  def ||^[F[_]: FlatMap](m1: F[Boolean], m2: => F[Boolean]): F[Boolean] =
     FlatMap[F].ifM(m1)(m1, m2)
 
   def ~^[F[_]: FlatMap](m: F[Boolean]): F[Boolean] =


### PR DESCRIPTION
## Overview
Arguments for boolean higher kinded combinators `&&^` and `||^` should be lazy when evaluate second argument. In case of AND, if first is `false` second should not be evaluated, and in case of OR, if first is `true` second should be evaluated.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4052

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
