### PR TITLE
RCHAIN-4056 make ReportingCasper work with cost accounting

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/MultiParentCasperReportingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/MultiParentCasperReportingSpec.scala
@@ -18,7 +18,7 @@ class MultiParentCasperReportingSpec extends FlatSpec with Matchers with Inspect
 
   val genesis = buildGenesis()
 
-  "ReportingCasper" should "behave the same way as MultiParentCasper" ignore effectTest {
+  "ReportingCasper" should "behave the same way as MultiParentCasper" in effectTest {
     val correctRholang =
       """ for(@x <- @"x"; @y <- @"y"){ @"xy"!(x + y) | @"x"!(1) | @"y"!(2) } | @"x"!("x") | @"y"!("y")  """
     TestNode.standaloneEff(genesis).use { node =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -11,7 +11,12 @@ import coop.rchain.models._
 import scalapb.GeneratedMessage
 import coop.rchain.shared.StringOps._
 import cats.implicits._
-import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
+import coop.rchain.models.GUnforgeable.UnfInstance.{
+  GDeployIdBody,
+  GDeployerIdBody,
+  GPrivateBody,
+  GSysAuthTokenBody
+}
 import coop.rchain.shared.Printer
 import monix.eval.Coeval
 
@@ -57,6 +62,8 @@ final case class PrettyPrinter(
         pure("DeployId(0x" + Base16.encode(id.sig.toByteArray) + ")")
       case GDeployerIdBody(id) =>
         pure("DeployerId(0x" + Base16.encode(id.publicKey.toByteArray) + ")")
+      case GSysAuthTokenBody(value) =>
+        pure(s"GSysAuthTokenBody(${value})")
       case _ => throw new Error(s"Attempted to print unknown GUnforgeable type: $u")
     }
   }


### PR DESCRIPTION
## Overview
makes ReportingCasper work with cost accounting.
Almost all the codes are duplicated from `RuntimeManager` which is not very good. 
would refactor in the later pr



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4056
sub task of
https://rchain.atlassian.net/browse/RCHAIN-4055



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
