### PR TITLE
RCHAIN-4063 replace hardcoded api maxMessageSize to a parameter

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -116,7 +116,7 @@ rnode {
     port-internal = 40402
 
     # Maximum size of message that can be sent via gRPC API
-    max-message-size = 4M
+    max-message-size = 16M
   }
 
   # Casper configuration

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -559,7 +559,8 @@ class NodeRuntime private[node] (
                             .acquireExternalServer[Task](
                               conf.grpcServer.portExternal,
                               grpcScheduler,
-                              apiServers.deploy
+                              apiServers.deploy,
+                              conf.grpcServer.maxMessageSize
                             )
       internalApiServer <- api
                             .acquireInternalServer(
@@ -567,7 +568,8 @@ class NodeRuntime private[node] (
                               grpcScheduler,
                               apiServers.repl,
                               apiServers.deploy,
-                              apiServers.propose
+                              apiServers.propose,
+                              conf.grpcServer.maxMessageSize
                             )
 
       prometheusReporter = new NewPrometheusReporter()

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -16,16 +16,13 @@ import monix.execution.Scheduler
 
 package object api {
 
-  // 16 MB is max message size allowed by HTTP2 RFC 7540
-  // grpc and netty can however work with bigger values
-  val maxMessageSize: Int = 16 * 1024 * 1024
-
   def acquireInternalServer(
       port: Int,
       grpcExecutor: Scheduler,
       replGrpcService: ReplGrpcMonix.Repl,
       deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
-      proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService
+      proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService,
+      maxMessageSize: Int
   ): Task[Server[Task]] =
     GrpcServer[Task](
       NettyServerBuilder
@@ -50,7 +47,8 @@ package object api {
   def acquireExternalServer[F[_]: Concurrent: Log: Taskable](
       port: Int,
       grpcExecutor: Scheduler,
-      deployGrpcService: DeployServiceV1GrpcMonix.DeployService
+      deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
+      maxMessageSize: Int
   ): F[Server[F]] =
     GrpcServer[F](
       NettyServerBuilder


### PR DESCRIPTION
## Overview
replace hardcoded api maxMessageSize to a parameter



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4063



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
