### PR TITLE
Do not consume repeated genesis candidate block

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -158,15 +158,15 @@ object ApproveBlockProtocol {
             (before, after) = modifyResult
 
             _ <- if (after > before)
-                  Log[F].info("APPROVAL: New signature received") >>
+                  Log[F].info("New signature received") >>
                     Metrics[F].incrementCounter("genesis")
                 else
-                  Log[F].info("APPROVAL: No new sigs received")
+                  Log[F].info("No new sigs received")
 
-            _ <- Log[F].info(s"APPROVAL: received block approval from $sender")
+            _ <- Log[F].info(s"Received block approval from $sender")
 
             _ <- Log[F].info(
-                  s"APPROVAL: ${after.size} approvals received: ${after
+                  s"${after.size} approvals received: ${after
                     .map(s => PrettyPrinter.buildString(s.publicKey))
                     .mkString(", ")}"
                 )
@@ -179,8 +179,8 @@ object ApproveBlockProtocol {
                 )
 
           } yield ()
-        } else Log[F].warn(s"APPROVAL: ignoring invalid block approval from $sender")
-      } else Log[F].warn(s"APPROVAL: Received BlockApproval from untrusted validator.")
+        } else Log[F].warn(s"Ignoring invalid block approval from $sender")
+      } else Log[F].warn(s"Received BlockApproval from untrusted validator.")
     }
 
     private def signedByTrustedValidator(a: BlockApproval): Boolean =
@@ -204,9 +204,8 @@ object ApproveBlockProtocol {
     //      received a valid signature from yet
     private def sendUnapprovedBlock: F[Unit] =
       for {
-        _ <- Log[F].info(s"APPROVAL: Beginning send of UnapprovedBlock $candidateHash to peers...")
+        _ <- Log[F].info(s"Broadcasting UnapprovedBlock $candidateHash...")
         _ <- CommUtil[F].streamToPeers(serializedUnapprovedBlock)
-        _ <- Log[F].info(s"APPROVAL: Sent UnapprovedBlock $candidateHash to peers.")
         _ <- EventLog[F].publish(shared.Event.SentUnapprovedBlock(candidateHash))
       } yield ()
 
@@ -229,15 +228,14 @@ object ApproveBlockProtocol {
         apbO <- LastApprovedBlock[F].get
         _ <- apbO match {
               case None =>
-                Log[F].warn(s"APPROVAL: Expected ApprovedBlock but was None.")
+                Log[F].warn(s"Expected ApprovedBlock but was None.")
               case Some(b) =>
                 val serializedApprovedBlock = ToPacket(b.toProto)
                 for {
                   _ <- Log[F].info(
-                        s"APPROVAL: Beginning send of ApprovedBlock $candidateHash to peers..."
+                        s"Sending ApprovedBlock $candidateHash to peers..."
                       )
                   _ <- CommUtil[F].streamToPeers(serializedApprovedBlock)
-                  _ <- Log[F].info(s"APPROVAL: Sent ApprovedBlock $candidateHash to peers.")
                   _ <- EventLog[F].publish(shared.Event.SentApprovedBlock(candidateHash))
                 } yield ()
             }

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -256,7 +256,7 @@ object Running {
     ) >>= (
         tip =>
           Log[F].info(
-            s"Streaming block ${PrettyPrinter.buildString(tip.blockHash} to $peer"
+            s"Streaming block ${PrettyPrinter.buildString(tip.blockHash)} to $peer"
           ) >> streamToPeer(peer)(ToPacket(tip.toProto))
       )
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -256,7 +256,7 @@ object Running {
     ) >>= (
         tip =>
           Log[F].info(
-            s"Streaming block ${tip.blockHash} to $peer"
+            s"Streaming block ${PrettyPrinter.buildString(tip.blockHash} to $peer"
           ) >> streamToPeer(peer)(ToPacket(tip.toProto))
       )
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/ApproveBlockProtocolTest.scala
@@ -245,8 +245,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     // I know that testing the logs is not the best way but I comparing messages sent won't work
     // because we attach `System.currentMillis` to every message.
     ctx.tick(4.millisecond)
-    infosContain("Sent UnapprovedBlock", 1)
-    infosContain("received block approval from", 0)
+    infosContain("Broadcasting UnapprovedBlock", 1)
+    infosContain("Received block approval from", 0)
     metricsTest.counters.get(METRICS_APPROVAL_COUNTER_NAME) should be(None)
 
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
@@ -255,8 +255,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     ctx.tick(1.millisecond)
     sigsF.get.unsafeRunSync.size should be(1)
     metricsTest.counters(METRICS_APPROVAL_COUNTER_NAME) should be(1)
-    infosContain("received block approval from", 1)
-    infosContain("Sent UnapprovedBlock", 2)
+    infosContain("Received block approval from", 1)
+    infosContain("Broadcasting UnapprovedBlock", 2)
     cancelToken.cancel()
   }
 
@@ -275,8 +275,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
 
     // I know that testing the logs is not the best way but I comparing messages sent won't work
     // because we attach `System.currentMillis` to every message.
-    logStub.infos.filter(_.startsWith("received block approval from")).size should be(0)
-    logStub.infos.filter(_.startsWith("Sent ApprovedBlock")).size should be(0)
+    logStub.infos.filter(_.startsWith("Received block approval from")).size should be(0)
+    logStub.infos.filter(_.startsWith("Sending ApprovedBlock")).size should be(0)
     metricsTest.counters.get(METRICS_APPROVAL_COUNTER_NAME) should be(None)
 
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
@@ -286,10 +286,10 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     ctx.tick(1.millisecond)
 
     sigsF.get.unsafeRunSync.size should be(1)
-    logStub.infos.filter(_.startsWith("received block approval from")).size should be(1)
+    logStub.infos.filter(_.startsWith("Received block approval from")).size should be(1)
     metricsTest.counters(METRICS_APPROVAL_COUNTER_NAME) should be(1)
     ctx.tick(1.millisecond)
-    logStub.infos.filter(_.startsWith("Sent ApprovedBlock")).size should be(1)
+    logStub.infos.filter(_.startsWith("Sending ApprovedBlock")).size should be(1)
     cancelToken.cancel()
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/engine/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/ApproveBlockProtocolTest.scala
@@ -245,8 +245,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     // I know that testing the logs is not the best way but I comparing messages sent won't work
     // because we attach `System.currentMillis` to every message.
     ctx.tick(4.millisecond)
-    infosContain("APPROVAL: Sent UnapprovedBlock", 1)
-    infosContain("APPROVAL: received block approval from", 0)
+    infosContain("Sent UnapprovedBlock", 1)
+    infosContain("received block approval from", 0)
     metricsTest.counters.get(METRICS_APPROVAL_COUNTER_NAME) should be(None)
 
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
@@ -255,8 +255,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     ctx.tick(1.millisecond)
     sigsF.get.unsafeRunSync.size should be(1)
     metricsTest.counters(METRICS_APPROVAL_COUNTER_NAME) should be(1)
-    infosContain("APPROVAL: received block approval from", 1)
-    infosContain("APPROVAL: Sent UnapprovedBlock", 2)
+    infosContain("received block approval from", 1)
+    infosContain("Sent UnapprovedBlock", 2)
     cancelToken.cancel()
   }
 
@@ -275,8 +275,8 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
 
     // I know that testing the logs is not the best way but I comparing messages sent won't work
     // because we attach `System.currentMillis` to every message.
-    logStub.infos.filter(_.startsWith("APPROVAL: received block approval from")).size should be(0)
-    logStub.infos.filter(_.startsWith("APPROVAL: Sent ApprovedBlock")).size should be(0)
+    logStub.infos.filter(_.startsWith("received block approval from")).size should be(0)
+    logStub.infos.filter(_.startsWith("Sent ApprovedBlock")).size should be(0)
     metricsTest.counters.get(METRICS_APPROVAL_COUNTER_NAME) should be(None)
 
     val a = ApproveBlockProtocolTest.approval(candidate, validatorSk, validatorPk)
@@ -286,10 +286,10 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
     ctx.tick(1.millisecond)
 
     sigsF.get.unsafeRunSync.size should be(1)
-    logStub.infos.filter(_.startsWith("APPROVAL: received block approval from")).size should be(1)
+    logStub.infos.filter(_.startsWith("received block approval from")).size should be(1)
     metricsTest.counters(METRICS_APPROVAL_COUNTER_NAME) should be(1)
     ctx.tick(1.millisecond)
-    logStub.infos.filter(_.startsWith("APPROVAL: Sent ApprovedBlock")).size should be(1)
+    logStub.infos.filter(_.startsWith("Sent ApprovedBlock")).size should be(1)
     cancelToken.cancel()
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -58,7 +58,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 differentUnapproved2
               )
 
-          _ = node.logEff.warns.count(_.contains("Received unexpected candidate")) should be(2)
+          _ = node.logEff.warns
+            .count(_.contains("Received unexpected genesis block candidate")) should be(2)
           queue <- {
             implicit val network = node.transportLayerEff.testNetworkF
             TestNetwork.peerQueue(node.local)

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -148,12 +148,12 @@ object Connect {
     (
       for {
         address <- peer.toAddress.pure[F]
-        _       <- Log[F].debug(s"Connecting to $address")
-        _       <- Metrics[F].incrementCounter("connect")
-        _       <- Log[F].debug(s"Initialize protocol handshake to $address")
-        conf    <- RPConfAsk[F].ask
-        ph      = protocolHandshake(conf.local, conf.networkId)
-        res     <- TransportLayer[F].send(peer, ph)
+        //_       <- Log[F].debug(s"Connecting to $address")
+        _ <- Metrics[F].incrementCounter("connect")
+        //_       <- Log[F].debug(s"Initialize protocol handshake to $address")
+        conf <- RPConfAsk[F].ask
+        ph   = protocolHandshake(conf.local, conf.networkId)
+        res  <- TransportLayer[F].send(peer, ph)
       } yield res
     ).timer("connect-time")
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -99,12 +99,12 @@ class GrpcTransportClient(
       request: GrpcTransport.Request[A]
   ): Task[CommErr[A]] =
     (for {
-      _       <- log.debug(s"Creating new channel to peer ${peer.toAddress}")
+      //_       <- log.debug(s"Creating new channel to peer ${peer.toAddress}")
       channel <- clientChannel(peer)
       stub    <- Task.delay(RoutingGrpcMonix.stub(channel).withDeadlineAfter(timeout))
       result  <- request(stub).doOnFinish(kp(Task.delay(channel.shutdown()).attempt.void))
-      _       <- log.debug(s"Send request to peer ${peer.toAddress} done")
-      _       <- Task.unit.asyncBoundary // return control to caller thread
+      //_       <- log.debug(s"Send request to peer ${peer.toAddress} done")
+      _ <- Task.unit.asyncBoundary // return control to caller thread
     } yield result).attempt.map(_.fold(e => Left(protocolException(e)), identity))
 
   def send(peer: PeerNode, msg: Protocol): Task[CommErr[Unit]] =
@@ -137,7 +137,7 @@ class GrpcTransportClient(
             log.debug(
               s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
             )
-          case Right(_) => log.info(s"Streamed packet $path to $peer")
+          case Right(_) => log.debug(s"Streamed packet $path to $peer")
         }
       case Left(error) =>
         log.error(s"Error while streaming packet $path to $peer: ${error.message}")

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
@@ -25,7 +25,7 @@ class StreamObservable(bufferSize: Int, folder: Path)(implicit log: Log[Task], s
   def stream(peers: Seq[PeerNode], blob: Blob): Task[Unit] = {
 
     val logStreamInformation =
-      log.info(s"Streaming packet (type = ${blob.packet.typeId}) to peers ${peers.mkString(", ")}")
+      log.debug(s"Streaming packet (type = ${blob.packet.typeId}) to peers ${peers.mkString(", ")}")
 
     val storeBlob: Task[Option[Path]] =
       blob.packet.store[Task](folder) >>= {

--- a/integration-tests/test/wait.py
+++ b/integration-tests/test/wait.py
@@ -60,17 +60,17 @@ class ApprovedBlockReceived(LogsContainMessage):
 
 class SentUnapprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sent UnapprovedBlock')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Broadcasting UnapprovedBlock')
 
 
 class BlockApproval(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - received block approval from')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Received block approval from')
 
 
 class SentApprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sent ApprovedBlock')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sending ApprovedBlock')
 
 
 class LogsReMatch:

--- a/integration-tests/test/wait.py
+++ b/integration-tests/test/wait.py
@@ -60,17 +60,17 @@ class ApprovedBlockReceived(LogsContainMessage):
 
 class SentUnapprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: Sent UnapprovedBlock')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sent UnapprovedBlock')
 
 
 class BlockApproval(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: received block approval from')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - received block approval from')
 
 
 class SentApprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - APPROVAL: Sent ApprovedBlock')
+        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sent ApprovedBlock')
 
 
 class LogsReMatch:


### PR DESCRIPTION
ATM during genesis ceremony Ceremony master repeatedly broadcasts candidate block to all known peers. Each of this block triggers new validation routine on peers, even if that block is already being validated. This PR introduces check for duplicate.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
