### PR TITLE
Remove defaults CLI options for FCT update

### DIFF
--- a/node/src/main/resources/reference.conf
+++ b/node/src/main/resources/reference.conf
@@ -188,10 +188,10 @@ rnode {
     genesis-validator = false
 
     # Interval at which condition for creating ApprovedBlock will be checked
-    genesis-approve-interval = 5 seconds
+    genesis-approve-interval = 10 seconds
 
     # Time window in which BlockApproval messages will be accumulated before checking conditions
-    genesis-approve-duration = 5 minutes
+    genesis-approve-duration = 10 seconds
 
     # Genesis data folder
     # genesis-path = ${data-dir}/genesis
@@ -206,10 +206,10 @@ rnode {
     max-number-of-parents = 2147483647 # Unlimited number of parents by default
 
     # Node will request for fork choice tips if the latest FCT is more then this value
-    fork-choice-stale-threshold = 5 minutes
+    fork-choice-stale-threshold = 10 minutes
 
     # Interval for check if fork choice tip is stale
-    fork-choice-check-if-stale-interval = 1 minutes
+    fork-choice-check-if-stale-interval = 11 minutes
 
   }
 

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -830,8 +830,8 @@ object NodeRuntime {
         implicit val ec = engineCell
         implicit val bs = blockStore
         for {
-          _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChoiceStaleThreshold)
           _ <- Time[F].sleep(conf.casper.forkChoiceCheckIfStaleInterval)
+          _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChoiceStaleThreshold)
         } yield ()
       }
       engineInit     = engineCell.read >>= (_.init)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -376,16 +376,14 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val forkChoiceStaleThreshold =
       opt[FiniteDuration](
-        default = Option(FiniteDuration(5, scala.concurrent.duration.MINUTES)),
         descr =
           "Node will request for fork choice tips if the latest FCT is more then " +
-            "forkChoiceStaleThreshold old. Default 5 min."
+            "forkChoiceStaleThreshold old. Default 10 min."
       )
 
     val forkChoiceCheckIfStaleInterval =
       opt[FiniteDuration](
-        default = Option(FiniteDuration(1, scala.concurrent.duration.MINUTES)),
-        descr = "Interval for check if fork choice tip is stale. Default 1 min."
+        descr = "Interval for check if fork choice tip is stale. Default 11 min."
       )
 
     val apiMaxBlocksLimit = opt[Int](


### PR DESCRIPTION
It turned out that setting default value for CLI options is a bad idea, as they overwrite values set in config file.




### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
