### PR TITLE
RCHAIN-4106: Update keygen routine + fix for running with keyfile

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -1,6 +1,6 @@
 package coop.rchain.node.configuration.commandline
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 import coop.rchain.casper.util.comm.ListenAtName.{Name, PrivName, PubName}
 import coop.rchain.comm.PeerNode
@@ -495,23 +495,18 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   addSubcommand(run)
 
   val keygen = new Subcommand("keygen") {
-    descr("Generate a public/private key pair.")
+    descr(
+      "Generates a public/private key pair. Files created are: \n" +
+        "- password protected private key in PEM format, \n" +
+        "- public key in PEM format, \n" +
+        "- public key in as a HEX string"
+    )
     helpWidth(width)
 
-    val algorithm = opt[String](
-      descr = "Algorithm to be used for key generation. Must be one of ed25519 or secp256k1.",
-      validate = (s: String) => { s == "ed25519" || s == "secp256k1" },
-      required = true
-    )
-
-    val privateKeyPath = opt[Path](
-      descr = "Path to the file where the encoded private key will be written to.",
-      required = true
-    )
-
-    val publicKeyPath = opt[Path](
-      descr = "Path to the file where the encoded public key will be written to.",
-      required = true
+    val location = trailArg[Path](
+      descr = "Folder to save keyfies. Defaults to './' ",
+      default = Some(Paths.get("")),
+      required = false
     )
   }
   addSubcommand(keygen)

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -108,11 +108,10 @@ final case class ShowBlocks(depth: Int)                                    exten
 final case class VisualizeDag(depth: Int, showJustificationLines: Boolean) extends Command
 final case object MachineVerifiableDag                                     extends Command
 final case object Run                                                      extends Command
-final case class Keygen(algorithm: String, privateKeyPath: Path, publicKeyPath: Path)
-    extends Command
-final case object LastFinalizedBlock              extends Command
-final case class IsFinalized(hash: String)        extends Command
-final case class BondStatus(publicKey: PublicKey) extends Command
-final case object Help                            extends Command
-final case class DataAtName(name: Name)           extends Command
-final case class ContAtName(names: List[Name])    extends Command
+final case class Keygen(path: Path)                                        extends Command
+final case object LastFinalizedBlock                                       extends Command
+final case class IsFinalized(hash: String)                                 extends Command
+final case class BondStatus(publicKey: PublicKey)                          extends Command
+final case object Help                                                     extends Command
+final case class DataAtName(name: Name)                                    extends Command
+final case class ContAtName(names: List[Name])                             extends Command


### PR DESCRIPTION
https://rchain.atlassian.net/browse/RCHAIN-4106

We have a problem running node with a keyfile - it does not read encryption password from environment and keeps asking even if `RNODE_VALIDATOR_PASSWORD` is set. 
This PR fixes this.

Additionally, `keygen` routine is adjusted. Ed25519 option is removed, CLI option is refactored according to convention over configuration. 3 files with fix names are generated to configurable folder. In addition, hex string of public is written to file.

```
➜  rchain git:(keygen) node/target/docker/stage/opt/docker/bin/rnode keygen
Enter password for keyfile: ***
Repeat password: ***

Success!
Private key file (encrypted PEM format):  /Users/nzpr/rchain/rchain/rnode.key
Public  key file (PEM format):            /Users/nzpr/rchain/rchain/rnode.pub.pem
Public  key file (HEX format):            /Users/nzpr/rchain/rchain/rnode.pub.hex
```



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
