### PR TITLE
RCHAIN-4107: Remove redundant delays in genesis ceremony + logging

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -132,8 +132,7 @@ object CasperLaunch {
         // TODO track fiber
         _ <- Concurrent[F].start(
               GenesisCeremonyMaster
-                .approveBlockInterval[F](
-                  conf.genesisCeremony.approveInterval,
+                .waitingForApprovedBlockLoop[F](
                   conf.shardName,
                   conf.finalizationRate,
                   validatorId

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -73,7 +73,7 @@ class GenesisCeremonyMasterSpec extends WordSpec {
         lastApprovedBlock <- LastApprovedBlock[Task].get
         _                 = assert(lastApprovedBlock.isDefined)
         _                 <- EngineCell[Task].read >>= (_.handle(local, blockApproval))
-        head              = transportLayer.requests(1)
+        head              = transportLayer.requests(0)
         proto             = ApprovedBlockProto.parseFrom(head.msg.message.packet.get.content.toByteArray)
         _ = assert(
           ApprovedBlock

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -48,8 +48,7 @@ class GenesisCeremonyMasterSpec extends WordSpec {
         _  <- EngineCell[Task].set(new GenesisCeremonyMaster[Task](abp))
         c1 = abp.run().startAndForget.runToFuture
         c2 = GenesisCeremonyMaster
-          .approveBlockInterval[Task](
-            interval,
+          .waitingForApprovedBlockLoop[Task](
             shardId,
             finalizationRate,
             Some(validatorId)


### PR DESCRIPTION
https://rchain.atlassian.net/browse/RCHAIN-4107
This PR adds more logging to genesis ceremony and removes one unnecessary delay between genesis approval and adding of this block.



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
