### PR TITLE
RCHIP-01: Add bytesToHex method

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -65,6 +65,9 @@ trait Costs {
   // decoding to bytes is linear with respect to the length of the string
   def hexToBytesCost(str: String): Cost = Cost(str.size, "hex to bytes")
 
+  // encoding to hex is linear with respect to the length of the byte array
+  def bytesToHexCost(bytes: Array[Byte]): Cost = Cost(bytes.size, "bytes to hex")
+
   // Both Set#remove and Map#remove have complexity of eC
   def diffCost(numElements: Int): Cost =
     Cost(REMOVE_COST * numElements, s"$numElements elements diff cost")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -173,6 +173,32 @@ class RholangMethodsCostsSpec
     }
   }
 
+  "bytesToHex" when {
+    "called on byte array" should {
+      "charge proportionally to the length of the bytes" in {
+        val byteArrays = Table[Array[Byte]](
+          ("Bytes"),
+          Array.ofDim[Byte](1),
+          Array.ofDim[Byte](3),
+          Array.ofDim[Byte](7),
+          Array.ofDim[Byte](10)
+        )
+        val base     = Array.ofDim[Byte](1)
+        val baseCost = bytesToHexCost(base)
+        forAll(byteArrays) { bytes =>
+          val decodedBytes = GByteArray(ByteString.copyFrom(bytes))
+          val method       = methodCall("bytesToHex", decodedBytes, List.empty)
+          val factor       = bytes.length.toDouble / base.length
+          testProportional(
+            baseCost,
+            factor,
+            method
+          )
+        }
+      }
+    }
+  }
+
   "toUtf8Bytes" when {
     "called on String" should {
       "charge proportionally to the length of the String" in {


### PR DESCRIPTION
## Overview
Adds bytesToHex method to convert a byte array to a hexadecimal string.

### RCHIP proposal:
RCHIP-01:  https://github.com/rchain/rchip-proposals/issues/11

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
