### PR TITLE
Update default.nix because BNFC was not working

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,32 +2,16 @@ let
 
   pkgs = import <nixpkgs> {};
 
-  bnfcSrc = pkgs.fetchFromGitHub {
-              owner = "BNFC";
-              repo = "bnfc";
-              rev = "7c9e8591902c806c17cc5617db228e5f3e02a2ad";
-              sha256 = "18rr41kabb9dabmaz58k1iyv1ijv9aq0gzg1jyal3nicpmm9159a";
-              postFetch = ''
-                tar --strip-components=1 -xvzf $downloadedFile
-                mkdir $out
-                cp -r source/* $out
-              '';
-            };
-
-  bnfcHEAD = pkgs.haskellPackages.callCabal2nix "bnfc-HEAD" bnfcSrc {};
-
   jdk = pkgs.openjdk8;
 
   sbt = pkgs.sbt.override { jre = jdk.jre; };
 
 in rec {
 
-  bnfc = bnfcHEAD;
-
   rchainEnv = pkgs.buildFHSUserEnv {
     name = "rchain";
     targetPkgs = ps: rchainPackages;
   };
 
-  rchainPackages = with pkgs; [ bnfcHEAD git jflex sbt jdk ];
+  rchainPackages = with pkgs; [ haskellPackages.BNFC git jflex sbt jdk ];
 }


### PR DESCRIPTION
## Overview
This PR fixes nix configuration to build and install _bnfc_ dependency used as part of RNode build. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [ ] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
