### PR TITLE
RCHAIN-4078 Stop using blockstore.find in get report, for better performance

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -16,7 +16,13 @@ trait BlockStore[F[_]] {
 
   def get(blockHash: BlockHash): F[Option[BlockMessage]]
 
-  def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]]
+  /**
+    * Iterates over BlockStore and loads first n blocks according to predicate
+    * @param p predicate
+    * @param n limit for number of blocks to load
+    * @return Sequence of [(BlockHash, BlockMessage)]
+    */
+  def find(p: BlockHash => Boolean, n: Int = 10000): F[Seq[(BlockHash, BlockMessage)]]
 
   def put(f: => (BlockHash, BlockMessage)): F[Unit]
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -124,24 +124,22 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
     )
 
   override def find(p: BlockHash => Boolean, n: Int): F[Seq[(BlockHash, BlockMessage)]] =
-    lock.withPermit(
-      for {
-        filteredIndex <- index.iterate { iterator =>
-                          iterator
-                            .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
-                            .withFilter { case (key, _) => p(key) }
-                            .map { case (key, value) => (key, IndexEntry.load(value)) }
-                            // Return only the first n result / stop iteration
-                            .take(n)
-                            .toList
-                        }
-        result <- filteredIndex.flatTraverse {
-                   case (blockHash, indexEntry) =>
-                     readBlockMessage(indexEntry)
-                       .map(block => List(blockHash -> BlockMessage.from(block).right.get)) // TODO FIX-ME
-                 }
-      } yield result
-    )
+    for {
+      filteredIndex <- index.iterate { iterator =>
+                        iterator
+                          .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
+                          .withFilter { case (key, _) => p(key) }
+                          .map { case (key, value) => (key, IndexEntry.load(value)) }
+                          // Return only the first n result / stop iteration
+                          .take(n)
+                          .toList
+                      }
+      result <- lock.withPermit(filteredIndex.flatTraverse {
+                 case (blockHash, indexEntry) =>
+                   readBlockMessage(indexEntry)
+                     .map(block => List(blockHash -> BlockMessage.from(block).right.get)) // TODO FIX-ME
+               })
+    } yield result
 
   override def put(f: => (BlockHash, BlockMessage)): F[Unit] =
     lock.withPermit(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/InMemBlockStore.scala
@@ -27,7 +27,7 @@ class InMemBlockStore[F[_]] private ()(
       state <- refF.get
     } yield state.get(blockHash) >>= (bmp => BlockMessage.from(bmp).toOption)
 
-  override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMessage)]] =
+  override def find(p: BlockHash => Boolean, n: Int): F[Seq[(BlockHash, BlockMessage)]] =
     for {
       _     <- metricsF.incrementCounter("find")
       state <- refF.get

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -624,7 +624,7 @@ object BlockAPI {
       hash: String
   ): F[Option[BlockMessage]] =
     for {
-      findResult <- BlockStore[F].find(h => Base16.encode(h.toByteArray).startsWith(hash))
+      findResult <- BlockStore[F].find(h => Base16.encode(h.toByteArray).startsWith(hash), 1)
     } yield findResult.headOption match {
       case Some((_, block)) => Some(block)
       case None             => none[BlockMessage]

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -479,7 +479,7 @@ object BlockAPI {
                                         ByteString.copyFrom(Base16.unsafeDecode(hash))
                                       )
                        mayberesult = createBlockReportResponse(reportResult)
-                       block       <- getBlockFromStore[F](hash)
+                       block       <- BlockStore[F].get(ByteString.copyFrom(Base16.unsafeDecode(hash)))
                        lightBlock  <- block.traverse(getLightBlockInfo[F](_))
 
                        res = mayberesult.map(BlockEventInfo(lightBlock, _))


### PR DESCRIPTION
## Overview
stop using blockstore.find in get report because of the performance

The `find` method is slow if the nodes has so many blocks.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4078



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
