### PR TITLE
RCHAIN-4108: Fix comm event bug on reportingCasper

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -153,7 +153,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
   /** ReportingCasper would reset(empty) the report data in every createCheckpoint.
     *
     */
-  override def createCheckpoint(): F[Checkpoint] = checkReplayData >> syncF.defer {
+  override def createCheckpoint(): F[Checkpoint] = syncF.defer {
     val historyRepository = historyRepositoryAtom.get()
     for {
       _ <- createNewHotStore(historyRepository)(serializeK.toCodec)


### PR DESCRIPTION


## Overview
don't check data before createCheckpoit, this can fix the unused comm event happened in reportinRspace


### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
