### PR TITLE
RCHAIN-4081: Specify a starting point to visualize dag 

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -220,7 +220,7 @@ class TestNode[F[_]](
 
   def shutoff() = transportLayerEff.clear(local)
 
-  def visualizeDag(): F[String] = {
+  def visualizeDag(startBlockNumber: Int): F[String] = {
 
     type G[A] = State[StringBuffer, A]
     import cats.mtl.implicits._
@@ -232,6 +232,7 @@ class TestNode[F[_]](
     val result: F[Either[String, String]] = BlockAPI.visualizeDag[F, G, String](
       Int.MaxValue,
       apiMaxBlocksLimit,
+      startBlockNumber,
       (ts, lfb) =>
         GraphzGenerator.dagAsCluster[F, G](
           ts,
@@ -247,9 +248,9 @@ class TestNode[F[_]](
     * Prints a uri on stdout that, when clicked, visualizes the current dag state using ttps://dreampuf.github.io.
     * The dag's shape is passed as Graphviz's dot source code, encoded in the URI's hash.
     */
-  def printVisualizeDagUrl(): F[Unit] =
+  def printVisualizeDagUrl(startBlockNumber: Int): F[Unit] =
     for {
-      dot <- visualizeDag()
+      dot <- visualizeDag(startBlockNumber)
       // Java's URLEncode encodes ' ' as '+' instead of '%20', see https://stackoverflow.com/a/5330239/52142
       urlEncoded = URLEncoder.encode(dot, "UTF-8").replaceAll("\\+", "%20")
       _ <- Sync[F].delay {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -52,6 +52,7 @@ message ContinuationAtNameQuery {
 message VisualizeDagQuery {
   int32 depth                 = 1;
   bool showJustificationLines = 2;
+  int32 startBlockNumber      = 3;
 }
 
 message MachineVerifyQuery {

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -99,8 +99,9 @@ object DeployGrpcServiceV1 {
         implicit val ser: GraphSerializer[Effect]             = new ListSerializer[Effect]
         val serialize: Effect[Graphz[Effect]] => List[String] = _.runS(Vector.empty).value.toList
 
-        val depth  = if (request.depth <= 0) apiMaxBlocksLimit else request.depth
-        val config = GraphConfig(request.showJustificationLines)
+        val depth            = if (request.depth <= 0) apiMaxBlocksLimit else request.depth
+        val config           = GraphConfig(request.showJustificationLines)
+        val startBlockNumber = request.startBlockNumber
 
         Observable
           .fromTask(
@@ -109,6 +110,7 @@ object DeployGrpcServiceV1 {
                 .visualizeDag[F, Effect, List[String]](
                   depth,
                   apiMaxBlocksLimit,
+                  startBlockNumber,
                   (ts, lfb) => GraphzGenerator.dagAsCluster[F, Effect](ts, lfb, config),
                   serialize
                 )


### PR DESCRIPTION
## Overview
Right now, the start point of the vdag is the latest block. It would be better that we can visualize the dag from anywhere we want for debugging.


### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4081



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
