### PR TITLE
RCHAIN-4082 add isFinalized function call in http API

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -43,6 +43,8 @@ trait WebApi[F[_]] {
   def exploratoryDeploy(term: String): F[ExploratoryDeployResponse]
 
   def getBlocksByHeights(startBlockNumber: Long, endBlockNumber: Long): F[List[LightBlockInfo]]
+
+  def isFinalized(hash: String): F[Boolean]
 }
 
 object WebApi {
@@ -108,6 +110,9 @@ object WebApi {
       BlockAPI
         .getBlocksByHeights(startBlockNumber, endBlockNumber, apiMaxBlocksLimit)
         .flatMap(_.liftToBlockApiErr)
+
+    def isFinalized(hash: String): F[Boolean] =
+      BlockAPI.isFinalized(hash).flatMap(_.liftToBlockApiErr)
   }
 
   // Rholang terms interesting for translation to JSON

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -89,6 +89,7 @@ object WebApiRoutes {
     implicit val encodeBlockInfo: Encoder[BlockInfo] = deriveEncoder[BlockInfo]
     // Encoders
     implicit val stringEncoder     = jsonEncoderOf[F, String]
+    implicit val booleanEncode     = jsonEncoderOf[F, Boolean]
     implicit val apiStatusEncoder  = jsonEncoderOf[F, ApiStatus]
     implicit val blockInfoEncoder  = jsonEncoderOf[F, BlockInfo]
     implicit val lightBlockEncoder = jsonEncoderOf[F, LightBlockInfo]
@@ -145,6 +146,9 @@ object WebApiRoutes {
 
       case GET -> Root / "deploy" / deployId =>
         webApi.findDeploy(deployId).handle
+
+      case GET -> Root / "is-finalized" / hash =>
+        webApi.isFinalized(hash).handle
     }
   }
 

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -153,6 +153,8 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
         startBlockNumber: Long,
         endBlockNumber: Long
     ): TaskEnv[List[LightBlockInfo]] = ???
+
+    override def isFinalized(hash: String): TaskEnv[Boolean] = ???
   }
 
   implicit val decodeByteString: Decoder[ByteString] = new Decoder[ByteString] {


### PR DESCRIPTION
## Overview
isFinalized api is not exposed in http. Make it exposed.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4082



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
