### PR TITLE
Limit listen at name [v0.9.23LTS]

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -31,7 +31,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         listeningNameResponse1 <- BlockAPI
                                    .getListeningNameDataResponse[Effect](
                                      Int.MaxValue,
-                                     listeningName
+                                     listeningName,
+                                     Int.MaxValue
                                    )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -65,7 +66,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         resultData    = Par().copy(exprs = Seq(Expr(GInt(0))))
         listeningNameResponse1 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -81,7 +83,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
         listeningNameResponse2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse2) {
           case Right((blockResults, l)) =>
@@ -104,7 +107,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
         listeningNameResponse3 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse3) {
           case Right((blockResults, l)) =>
@@ -133,13 +137,18 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
             l should be(7)
         }
         listeningNameResponse3UntilDepth <- BlockAPI
-                                             .getListeningNameDataResponse[Effect](1, listeningName)
+                                             .getListeningNameDataResponse[Effect](
+                                               1,
+                                               listeningName,
+                                               Int.MaxValue
+                                             )
         _ = inside(listeningNameResponse3UntilDepth) {
           case Right((_, l)) => l should be(1)
         }
         listeningNameResponse3UntilDepth2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                               2,
-                                              listeningName
+                                              listeningName,
+                                              Int.MaxValue
                                             )
         _ = inside(listeningNameResponse3UntilDepth2) {
           case Right((_, l)) => l should be(2)
@@ -171,7 +180,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         )
         listeningNameResponse1 <- BlockAPI.getListeningNameContinuationResponse[Effect](
                                    Int.MaxValue,
-                                   listeningNamesShuffled1
+                                   listeningNamesShuffled1,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -187,7 +197,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         )
         listeningNameResponse2 <- BlockAPI.getListeningNameContinuationResponse[Effect](
                                    Int.MaxValue,
-                                   listeningNamesShuffled2
+                                   listeningNamesShuffled2,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse2) {
           case Right((blockResults, l)) =>

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -157,7 +157,7 @@ object DeployGrpcServiceV1 {
       def listenForDataAtName(request: DataAtNameQuery): Task[ListeningNameDataResponse] =
         defer(
           BlockAPI
-            .getListeningNameDataResponse[F](request.depth, request.name.get)
+            .getListeningNameDataResponse[F](request.depth, request.name.get, apiMaxBlocksLimit)
         ) { r =>
           import ListeningNameDataResponse.Message
           import ListeningNameDataResponse.Message._
@@ -173,7 +173,11 @@ object DeployGrpcServiceV1 {
       ): Task[ContinuationAtNameResponse] =
         defer(
           BlockAPI
-            .getListeningNameContinuationResponse[F](request.depth, request.names)
+            .getListeningNameContinuationResponse[F](
+              request.depth,
+              request.names,
+              apiMaxBlocksLimit
+            )
         ) { r =>
           import ContinuationAtNameResponse.Message
           import ContinuationAtNameResponse.Message._

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -74,7 +74,7 @@ object WebApi {
 
     def listenForDataAtName(req: DataRequest): F[DataResponse] =
       BlockAPI
-        .getListeningNameDataResponse(req.depth, toPar(req))
+        .getListeningNameDataResponse(req.depth, toPar(req), apiMaxBlocksLimit)
         .flatMap(_.liftToBlockApiErr)
         .map(toDataResponse)
 


### PR DESCRIPTION
Listen at name is not limited. And it can be possible that it would iterate the whole chain which cause performance issue



### JIRA ticket:
<sup>_Create it if there isn't one already._</sup>



### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
