### PR TITLE
RCHAIN-4083: Put limits on listenAtName

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -162,7 +162,8 @@ object BlockAPI {
 
   def getListeningNameDataResponse[F[_]: Concurrent: EngineCell: Log: SafetyOracle: BlockStore](
       depth: Int,
-      listeningName: Par
+      listeningName: Par,
+      maxBlocksLimit: Int
   ): F[ApiErr[(Seq[DataWithBlockInfo], Int)]] = {
 
     val errorMessage = "Could not get listening name data, casper instance was not available yet."
@@ -184,17 +185,23 @@ object BlockAPI {
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield (blocksWithActiveName, blocksWithActiveName.length).asRight
 
-    EngineCell[F].read >>= (_.withCasper[ApiErr[(Seq[DataWithBlockInfo], Int)]](
-      casperResponse(_),
-      Log[F]
-        .warn(errorMessage)
-        .as(s"Error: $errorMessage".asLeft)
-    ))
+    if (depth > maxBlocksLimit)
+      s"Your request on getListeningName depth ${depth} exceed the max limit ${maxBlocksLimit}"
+        .asLeft[(Seq[DataWithBlockInfo], Int)]
+        .pure[F]
+    else
+      EngineCell[F].read >>= (_.withCasper[ApiErr[(Seq[DataWithBlockInfo], Int)]](
+        casperResponse(_),
+        Log[F]
+          .warn(errorMessage)
+          .as(s"Error: $errorMessage".asLeft)
+      ))
   }
 
   def getListeningNameContinuationResponse[F[_]: Concurrent: EngineCell: Log: SafetyOracle: BlockStore](
       depth: Int,
-      listeningNames: Seq[Par]
+      listeningNames: Seq[Par],
+      maxBlocksLimit: Int
   ): F[ApiErr[(Seq[ContinuationsWithBlockInfo], Int)]] = {
     val errorMessage =
       "Could not get listening names continuation, casper instance was not available yet."
@@ -216,12 +223,17 @@ object BlockAPI {
         blocksWithActiveName = maybeBlocksWithActiveName.flatten
       } yield (blocksWithActiveName, blocksWithActiveName.length).asRight
 
-    EngineCell[F].read >>= (_.withCasper[ApiErr[(Seq[ContinuationsWithBlockInfo], Int)]](
-      casperResponse(_),
-      Log[F]
-        .warn(errorMessage)
-        .as(s"Error: $errorMessage".asLeft)
-    ))
+    if (depth > maxBlocksLimit)
+      s"Your request on getListeningNameContinuation depth ${depth} exceed the max limit ${maxBlocksLimit}"
+        .asLeft[(Seq[ContinuationsWithBlockInfo], Int)]
+        .pure[F]
+    else
+      EngineCell[F].read >>= (_.withCasper[ApiErr[(Seq[ContinuationsWithBlockInfo], Int)]](
+        casperResponse(_),
+        Log[F]
+          .warn(errorMessage)
+          .as(s"Error: $errorMessage".asLeft)
+      ))
   }
 
   private def getMainChainFromTip[F[_]: Sync: Log: SafetyOracle: BlockStore](depth: Int)(

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -31,7 +31,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         listeningNameResponse1 <- BlockAPI
                                    .getListeningNameDataResponse[Effect](
                                      Int.MaxValue,
-                                     listeningName
+                                     listeningName,
+                                     Int.MaxValue
                                    )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -65,7 +66,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         resultData    = Par().copy(exprs = Seq(Expr(GInt(0))))
         listeningNameResponse1 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -81,7 +83,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
         listeningNameResponse2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse2) {
           case Right((blockResults, l)) =>
@@ -104,7 +107,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
 
         listeningNameResponse3 <- BlockAPI.getListeningNameDataResponse[Effect](
                                    Int.MaxValue,
-                                   listeningName
+                                   listeningName,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse3) {
           case Right((blockResults, l)) =>
@@ -133,13 +137,18 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
             l should be(7)
         }
         listeningNameResponse3UntilDepth <- BlockAPI
-                                             .getListeningNameDataResponse[Effect](1, listeningName)
+                                             .getListeningNameDataResponse[Effect](
+                                               1,
+                                               listeningName,
+                                               Int.MaxValue
+                                             )
         _ = inside(listeningNameResponse3UntilDepth) {
           case Right((_, l)) => l should be(1)
         }
         listeningNameResponse3UntilDepth2 <- BlockAPI.getListeningNameDataResponse[Effect](
                                               2,
-                                              listeningName
+                                              listeningName,
+                                              Int.MaxValue
                                             )
         _ = inside(listeningNameResponse3UntilDepth2) {
           case Right((_, l)) => l should be(2)
@@ -171,7 +180,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         )
         listeningNameResponse1 <- BlockAPI.getListeningNameContinuationResponse[Effect](
                                    Int.MaxValue,
-                                   listeningNamesShuffled1
+                                   listeningNamesShuffled1,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse1) {
           case Right((blockResults, l)) =>
@@ -187,7 +197,8 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
         )
         listeningNameResponse2 <- BlockAPI.getListeningNameContinuationResponse[Effect](
                                    Int.MaxValue,
-                                   listeningNamesShuffled2
+                                   listeningNamesShuffled2,
+                                   Int.MaxValue
                                  )
         _ = inside(listeningNameResponse2) {
           case Right((blockResults, l)) =>

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -158,7 +158,7 @@ object DeployGrpcServiceV1 {
       def listenForDataAtName(request: DataAtNameQuery): Task[ListeningNameDataResponse] =
         defer(
           BlockAPI
-            .getListeningNameDataResponse[F](request.depth, request.name.get)
+            .getListeningNameDataResponse[F](request.depth, request.name.get, apiMaxBlocksLimit)
         ) { r =>
           import ListeningNameDataResponse.Message
           import ListeningNameDataResponse.Message._
@@ -174,7 +174,11 @@ object DeployGrpcServiceV1 {
       ): Task[ContinuationAtNameResponse] =
         defer(
           BlockAPI
-            .getListeningNameContinuationResponse[F](request.depth, request.names)
+            .getListeningNameContinuationResponse[F](
+              request.depth,
+              request.names,
+              apiMaxBlocksLimit
+            )
         ) { r =>
           import ContinuationAtNameResponse.Message
           import ContinuationAtNameResponse.Message._

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -74,7 +74,7 @@ object WebApi {
 
     def listenForDataAtName(req: DataRequest): F[DataResponse] =
       BlockAPI
-        .getListeningNameDataResponse(req.depth, toPar(req))
+        .getListeningNameDataResponse(req.depth, toPar(req), apiMaxBlocksLimit)
         .flatMap(_.liftToBlockApiErr)
         .map(toDataResponse)
 


### PR DESCRIPTION
## Overview
Adds a limit to number of blocks available to API method `listenForDataAtName`.

Same as https://github.com/rchain/rchain/pull/2931#issue-413637065, but patch on dev branch

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4083

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
