### PR TITLE
RCHAIN-4089: Add configs for api server

### DIFF
--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -123,6 +123,27 @@ api-server {
 
   # Enable reporting API
   enable-reporting = false
+
+  # Sets a custom keepalive time, the delay time for sending next keepalive ping
+  keep-alive-time = 2 hours
+
+  # Sets a custom keepalive timeout, the timeout for keepalive ping requests
+  keep-alive-timeout = 20 seconds
+
+  # The most aggressive keep-alive time clients are permitted to configure.
+  # The server would close the connection if clients exceeding this rate
+  permit-keep-alive-time = 5 minutes
+
+  # Sets a custom max connection idle time, connection being idle for longer than which will be gracefully terminated
+  max-connection-idle = 1 hours
+
+  # Sets a custom max connection age, connection lasting longer than which will be gracefully terminated
+  max-connection-age = 1 hours
+
+  # Sets a custom grace time for the graceful connection termination. Once the max connection age
+  # is reached, RPCs have the grace time to complete. RPCs that do not complete in time will be
+  # cancelled, allowing the connection to terminate
+  max-connection-age-grace = 1 hours
 }
 
 storage {

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -566,7 +566,13 @@ class NodeRuntime private[node] (
                               nodeConf.apiServer.portGrpcExternal,
                               grpcScheduler,
                               apiServers.deploy,
-                              nodeConf.apiServer.grpcMaxRecvMessageSize.toInt
+                              nodeConf.apiServer.grpcMaxRecvMessageSize.toInt,
+                              nodeConf.apiServer.keepAliveTime,
+                              nodeConf.apiServer.keepAliveTimeout,
+                              nodeConf.apiServer.permitKeepAliveTime,
+                              nodeConf.apiServer.maxConnectionIdle,
+                              nodeConf.apiServer.maxConnectionAge,
+                              nodeConf.apiServer.maxConnectionAgeGrace
                             )
       internalApiServer <- api
                             .acquireInternalServer(
@@ -576,7 +582,13 @@ class NodeRuntime private[node] (
                               apiServers.repl,
                               apiServers.deploy,
                               apiServers.propose,
-                              nodeConf.apiServer.grpcMaxRecvMessageSize.toInt
+                              nodeConf.apiServer.grpcMaxRecvMessageSize.toInt,
+                              nodeConf.apiServer.keepAliveTime,
+                              nodeConf.apiServer.keepAliveTimeout,
+                              nodeConf.apiServer.permitKeepAliveTime,
+                              nodeConf.apiServer.maxConnectionIdle,
+                              nodeConf.apiServer.maxConnectionAge,
+                              nodeConf.apiServer.maxConnectionAgeGrace
                             )
 
       prometheusReporter = new NewPrometheusReporter()

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -598,7 +598,8 @@ class NodeRuntime private[node] (
         nodeConf.apiServer.portHttp,
         prometheusReporter,
         reportingCasper,
-        webApi
+        webApi,
+        nodeConf.apiServer.maxConnectionIdle
       )(nodeDiscovery, connectionsCell, concurrent, rPConfAsk, consumer, s)
       httpFiber <- httpServerFiber.start
       _ <- Task.delay {

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -1,6 +1,7 @@
 package coop.rchain.node
 
 import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
 
 import cats.effect.Concurrent
 import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
@@ -15,6 +16,8 @@ import io.netty.channel.local.LocalAddress
 import monix.eval.Task
 import monix.execution.Scheduler
 
+import scala.concurrent.duration.FiniteDuration
+
 package object api {
 
   def acquireInternalServer(
@@ -24,7 +27,13 @@ package object api {
       replGrpcService: ReplGrpcMonix.Repl,
       deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
       proposeGrpcService: ProposeServiceV1GrpcMonix.ProposeService,
-      maxMessageSize: Int
+      maxMessageSize: Int,
+      keepAliveTime: FiniteDuration,
+      keepAliveTimeout: FiniteDuration,
+      permitKeepAliveTime: FiniteDuration,
+      maxConnectionIdle: FiniteDuration,
+      maxConnectionAge: FiniteDuration,
+      maxConnectionAgeGrace: FiniteDuration
   ): Task[Server[Task]] =
     GrpcServer[Task](
       NettyServerBuilder
@@ -42,6 +51,12 @@ package object api {
           DeployServiceV1GrpcMonix
             .bindService(deployGrpcService, grpcExecutor)
         )
+        .keepAliveTime(keepAliveTime.length, keepAliveTime.unit)
+        .keepAliveTimeout(keepAliveTimeout.length, keepAliveTimeout.unit)
+        .permitKeepAliveTime(permitKeepAliveTime.length, permitKeepAliveTime.unit)
+        .maxConnectionIdle(maxConnectionIdle.length, maxConnectionIdle.unit)
+        .maxConnectionAge(maxConnectionAge.length, maxConnectionAge.unit)
+        .maxConnectionAgeGrace(maxConnectionAgeGrace.length, maxConnectionAgeGrace.unit)
         .addService(ProtoReflectionService.newInstance())
         .compressorRegistry(null)
         .build
@@ -52,7 +67,13 @@ package object api {
       port: Int,
       grpcExecutor: Scheduler,
       deployGrpcService: DeployServiceV1GrpcMonix.DeployService,
-      maxMessageSize: Int
+      maxMessageSize: Int,
+      keepAliveTime: FiniteDuration,
+      keepAliveTimeout: FiniteDuration,
+      permitKeepAliveTime: FiniteDuration,
+      maxConnectionIdle: FiniteDuration,
+      maxConnectionAge: FiniteDuration,
+      maxConnectionAgeGrace: FiniteDuration
   ): F[Server[F]] =
     GrpcServer[F](
       NettyServerBuilder
@@ -64,6 +85,12 @@ package object api {
             .bindService(deployGrpcService, grpcExecutor)
         )
         .compressorRegistry(null)
+        .keepAliveTime(keepAliveTime.length, keepAliveTime.unit)
+        .keepAliveTimeout(keepAliveTimeout.length, keepAliveTimeout.unit)
+        .permitKeepAliveTime(permitKeepAliveTime.length, permitKeepAliveTime.unit)
+        .maxConnectionIdle(maxConnectionIdle.length, maxConnectionIdle.unit)
+        .maxConnectionAge(maxConnectionAge.length, maxConnectionAge.unit)
+        .maxConnectionAgeGrace(maxConnectionAgeGrace.length, maxConnectionAgeGrace.unit)
         .addService(ProtoReflectionService.newInstance())
         .build
     )

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -99,6 +99,12 @@ object ConfigMapper {
       add("api-server.port-http", run.apiPortHttp)
       add("api-server.enable-reporting", run.apiEnableReporting)
       add("api-server.max-blocks-limit", run.apiMaxBlocksLimit)
+      add("api-server.keep-alive-time", run.apiKeepAliveTime)
+      add("api-server.keep-alive-timeout", run.apiKeepAliveTimeout)
+      add("api-server.permit-keep-alive-time", run.apiPermitKeepAliveTime)
+      add("api-server.max-connection-idle", run.apiMaxConnectionIdle)
+      add("api-server.max-connection-age", run.apiMaxConnectionAge)
+      add("api-server.max-connection-age-grace", run.apiMaxConnectionAgeGrace)
 
       add("tls.key-path", run.tlsKeyPath)
       add("tls.certificate-path", run.tlsCertificatePath)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -300,6 +300,35 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Use this flag to enable reporting endpoints."
     )
 
+    val apiKeepAliveTime = opt[FiniteDuration](
+      descr = "Sets a custom keepalive time, the delay time for sending next keepalive ping"
+    )
+
+    val apiKeepAliveTimeout = opt[FiniteDuration](
+      descr = "Sets a custom keepalive timeout, the timeout for keepalive ping requests"
+    )
+
+    val apiPermitKeepAliveTime = opt[FiniteDuration](
+      descr = "The most aggressive keep-alive time clients are permitted to configure.The server would close" +
+        "the connection if clients exceeding this rate "
+    )
+
+    val apiMaxConnectionIdle = opt[FiniteDuration](
+      descr =
+        "Sets a custom max connection idle time, connection being idle for longer than which will be gracefully terminated"
+    )
+
+    val apiMaxConnectionAge = opt[FiniteDuration](
+      descr =
+        "Sets a custom max connection age, connection lasting longer than which will be gracefully terminated"
+    )
+
+    val apiMaxConnectionAgeGrace = opt[FiniteDuration](
+      descr = "Sets a custom grace time for the graceful connection termination. Once the max connection age" +
+        " is reached, RPCs have the grace time to complete. RPCs that do not complete in time will be" +
+        " cancelled, allowing the connection to terminate"
+    )
+
     val dataDir = opt[Path](
       required = false,
       descr = "Path to data directory. Defaults to $HOME/.rnode"

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -71,7 +71,13 @@ final case class ApiServer(
     grpcMaxRecvMessageSize: Long,
     portHttp: Int,
     maxBlocksLimit: Int,
-    enableReporting: Boolean
+    enableReporting: Boolean,
+    keepAliveTime: FiniteDuration,
+    keepAliveTimeout: FiniteDuration,
+    permitKeepAliveTime: FiniteDuration,
+    maxConnectionIdle: FiniteDuration,
+    maxConnectionAge: FiniteDuration,
+    maxConnectionAgeGrace: FiniteDuration
 )
 
 final case class Storage(

--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -15,6 +15,8 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.CORS
 
+import scala.concurrent.duration.FiniteDuration
+
 package object web {
   def aquireHttpServer(
       reporting: Boolean,
@@ -22,7 +24,8 @@ package object web {
       httpPort: Int,
       prometheusReporter: NewPrometheusReporter,
       reportingCasper: ReportingCasper[TaskEnv],
-      webApiRoutes: WebApi[TaskEnv]
+      webApiRoutes: WebApi[TaskEnv],
+      connectionIdleTimeout: FiniteDuration
   )(
       implicit
       nodeDiscovery: NodeDiscovery[Task],
@@ -57,6 +60,7 @@ package object web {
       httpServerFiber <- BlazeServerBuilder[Task]
                           .bindHttp(httpPort, host)
                           .withHttpApp(Router(allRoutes.toList: _*).orNotFound)
+                          .withIdleTimeout(connectionIdleTimeout)
                           .resource
                           .use(_ => Task.never[Unit])
     } yield httpServerFiber

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -59,6 +59,12 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--api-grpc-max-recv-message-size 111111",
         "--api-max-blocks-limit 111111",
         "--api-enable-reporting",
+        "--api-keep-alive-time 111111seconds",
+        "--api-keep-alive-timeout 111111seconds",
+        "--api-permit-keep-alive-time 111111seconds",
+        "--api-max-connection-idle 111111seconds",
+        "--api-max-connection-age 111111seconds",
+        "--api-max-connection-age-grace 111111seconds",
         "--data-dir /var/lib/rnode",
         "--lmdb-map-size-rspace 111111",
         "--lmdb-map-size-blockdagstore 111111",
@@ -172,7 +178,13 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         portHttp = 111111,
         grpcMaxRecvMessageSize = 111111,
         maxBlocksLimit = 111111,
-        enableReporting = true
+        enableReporting = true,
+        keepAliveTime = 111111L.seconds,
+        keepAliveTimeout = 111111L.seconds,
+        permitKeepAliveTime = 111111L.seconds,
+        maxConnectionAge = 111111L.seconds,
+        maxConnectionIdle = 111111L.seconds,
+        maxConnectionAgeGrace = 111111L.seconds
       ),
       storage = Storage(
         dataDir = Paths.get("/var/lib/rnode"),

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -89,7 +89,13 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         grpcMaxRecvMessageSize = 16777216,
         portHttp = 40403,
         maxBlocksLimit = 50,
-        enableReporting = false
+        enableReporting = false,
+        keepAliveTime = 2.hours,
+        keepAliveTimeout = 20.seconds,
+        permitKeepAliveTime = 5.minutes,
+        maxConnectionAge = 1.hours,
+        maxConnectionIdle = 1.hours,
+        maxConnectionAgeGrace = 1.hours
       ),
       storage = Storage(
         dataDir = Paths.get("/var/lib/rnode"),


### PR DESCRIPTION
## Overview
This PR adds additional config for gRPC API servers to control connection timeout.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4089

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
