### PR TITLE
RCHAIN-4077: Key-value store with manager

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -37,7 +37,7 @@ import org.lmdbjava.{Env, EnvFlags}
 import scala.ref.WeakReference
 import scala.util.matching.Regex
 
-private final case class BlockDagFileStorageState[F[_]: Sync](
+private final case class BlockDagFileStorageState(
     sortOffset: Long,
     checkpoints: List[Checkpoint]
 )
@@ -50,7 +50,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
     deployIndex: PersistentDeployIndex[F],
     invalidBlocksIndex: PersistentInvalidBlocksIndex[F],
     equivocationTrackerIndex: PersistentEquivocationTrackerIndex[F],
-    state: MonadState[F, BlockDagFileStorageState[F]]
+    state: MonadState[F, BlockDagFileStorageState]
 ) extends BlockDagStorage[F] {
   implicit private val logSource: LogSource = LogSource(BlockDagFileStorage.getClass)
 
@@ -499,7 +499,7 @@ object BlockDagFileStorage {
       deployIndex,
       invalidBlocksIndex,
       equivocationTrackerIndex,
-      new AtomicMonadState[F, BlockDagFileStorageState[F]](AtomicAny(state))
+      new AtomicMonadState[F, BlockDagFileStorageState](AtomicAny(state))
     )
   }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -20,7 +20,7 @@ import coop.rchain.shared.Log
 
 import scala.collection.immutable.HashSet
 
-final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log: BlockStore](
+final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
     lock: Semaphore[F],
     latestMessagesRef: Ref[F, Map[Validator, BlockHash]],
     childMapRef: Ref[F, Map[BlockHash, Set[BlockHash]]],
@@ -176,7 +176,7 @@ object InMemBlockDagStorage {
   implicit private val InMemBlockDagStorageMetricsSource: Source =
     Metrics.Source(BlockStorageMetricsSource, "in-mem")
 
-  def create[F[_]: Concurrent: Sync: Log: BlockStore: Metrics]: F[InMemBlockDagStorage[F]] =
+  def create[F[_]: Concurrent: Sync: Log: Metrics]: F[InMemBlockDagStorage[F]] =
     for {
       lock                    <- MetricsSemaphore.single[F]
       latestMessagesRef       <- Ref.of[F, Map[Validator, BlockHash]](Map.empty)

--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
@@ -1,0 +1,90 @@
+package coop.rchain.casper.storage
+
+import java.nio.ByteBuffer
+
+import cats.effect.ExitCase.{Canceled, Completed, Error}
+import cats.effect.Sync
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import coop.rchain.shared.Resources.withResource
+import coop.rchain.store.KeyValueStore
+import org.lmdbjava._
+
+final case class DbEnv[F[_]](env: Env[ByteBuffer], dbi: Dbi[ByteBuffer], done: F[Unit])
+
+final case class LmdbKeyValueStore[F[_]: Sync](
+    getEnvDbi: F[DbEnv[F]]
+) extends KeyValueStore[F] {
+
+  private def withTxn[T](
+      isWrite: Boolean
+  )(op: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
+    for {
+      // Acquire current LMDB environment and DBI interface
+      dbEnv <- getEnvDbi
+      // "Done" must be called to mark finished operation with the environment/dbi
+      DbEnv(env, dbi, done) = dbEnv
+      // Create read or write transaction
+      txnF = Sync[F].delay(if (isWrite) env.txnWrite else env.txnRead)
+      // Execute database operation, commit at the end
+      result <- txnF.bracketCase(
+                 txn =>
+                   for {
+                     // Execute DB operation within transaction
+                     res <- op(txn, dbi)
+                     // Commit transaction (read and write)
+                     _ <- Sync[F].delay(txn.commit())
+                   } yield res
+               ) {
+                 case (txn, Completed) =>
+                   // Close transaction when execution is successful.
+                   Sync[F].delay(txn.close()) *> done
+                 case (txn, Error(_)) =>
+                   // Close transaction on error.
+                   Sync[F].delay(txn.close()) *> done
+                 case (_, Canceled) =>
+                   // When execution is canceled, closing transaction throws NotReadyException
+                   //  in bracket `use` function which is not visible in bracket `release` (?).
+                   done
+               }
+    } yield result
+
+  def withReadTxnF[T](f: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
+    withTxn(isWrite = false)(f)
+
+  def withWriteTxnF[T](f: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
+    withTxn(isWrite = true)(f)
+
+  // GET
+  override def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]] =
+    withReadTxnF { (txn, dbi) =>
+      import cats.instances.vector._
+      keys.toVector
+        .traverse(x => Sync[F].delay(Option(dbi.get(txn, x)).map(fromBuffer)))
+        .map(_.toSeq)
+    }
+
+  // PUT
+  override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
+    withWriteTxnF { (txn, dbi) =>
+      Sync[F].delay(kvPairs.foreach {
+        case (key, value) =>
+          if (dbi.put(txn, key, toBuffer(value))) () else ()
+      })
+    }
+
+  // DELETE
+  override def delete(keys: Seq[ByteBuffer]): F[Int] =
+    withWriteTxnF { (txn, dbi) =>
+      Sync[F].delay(keys.foldLeft(0)((acc, key) => if (dbi.delete(txn, key)) acc + 1 else acc))
+    }
+
+  // ITERATE
+  override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T] =
+    withReadTxnF { (txn, dbi) =>
+      withResource(dbi.iterate(txn)) { iterator =>
+        import scala.collection.JavaConverters._
+        f(iterator.asScala.map(c => (c.key, c.`val`)))
+      }
+    }
+}

--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
@@ -1,0 +1,131 @@
+package coop.rchain.casper.storage
+
+import java.nio.ByteBuffer
+import java.nio.file.{Files, Path}
+
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.shared.Log
+import coop.rchain.store.{KeyValueStore, KeyValueStoreManager}
+import enumeratum.{Enum, EnumEntry}
+import org.lmdbjava.{DbiFlags, Env, EnvFlags}
+
+object LmdbStoreManager {
+  def apply[F[_]: Concurrent: Log](dirPath: Path): F[KeyValueStoreManager[F]] =
+    Deferred[F, Env[ByteBuffer]] map (LmdbStoreManagerImpl(dirPath, _))
+}
+
+private final case class LmdbStoreManagerImpl[F[_]: Concurrent: Log](
+    dirPath: Path,
+    envDefer: Deferred[F, Env[ByteBuffer]]
+) extends KeyValueStoreManager[F] {
+
+  sealed trait EnvRefStatus extends EnumEntry
+  object EnvRefStatus extends Enum[EnvRefStatus] {
+    val values = findValues
+    case object EnvClosed   extends EnvRefStatus
+    case object EnvStarting extends EnvRefStatus
+    case object EnvOpen     extends EnvRefStatus
+    case object EnvClosing  extends EnvRefStatus
+  }
+  import EnvRefStatus._
+
+  private case class DbState(
+      status: EnvRefStatus,
+      inProgress: Int,
+      envDefer: Deferred[F, Env[ByteBuffer]],
+      dbs: Map[String, Deferred[F, DbEnv[F]]] = Map.empty
+  ) {
+    override def toString() = s"DbState(status: $status, inProgress: $inProgress)"
+  }
+
+  // Internal manager state for LMDB databases and environments
+  private val varState = Ref.unsafe(DbState(EnvClosed, 0, envDefer))
+
+  override def database(dbName: String): F[KeyValueStore[F]] =
+    Sync[F].delay(new LmdbKeyValueStore[F](getCurrentEnv(dbName)))
+
+  private def getCurrentEnv(dbName: String): F[DbEnv[F]] =
+    for {
+      // Check if environment is closed
+      isNewEnv <- varState.modify { st =>
+                   if (st.status == EnvClosed) {
+                     val newState = st.copy(status = EnvStarting)
+                     (newState, true)
+                   } else (st, false)
+                 }
+      // Create new environment when it's closed.
+      // IMPORTANT: this can happen only once, all other callers
+      // are blocked on Deferred object until it's completed.
+      _ <- createEnv.whenA(isNewEnv)
+
+      // Block until environment is ready.
+      st  <- varState.get
+      env <- st.envDefer.get
+
+      // Find DB ref / first time create deferred object.
+      newDbDefer <- Deferred[F, DbEnv[F]]
+      action <- varState.modify { st =>
+                 val maybeDbRef = st.dbs.get(dbName)
+                 maybeDbRef.fold {
+                   val newDbs = st.dbs.updated(dbName, newDbDefer)
+                   val newSt  = st.copy(dbs = newDbs)
+                   (newSt, (true, newDbDefer))
+                 }(defer => (st, (false, defer)))
+               }
+
+      // If database is not found, create new Deferred object to block
+      // callers until database is created and Deferred object completed.
+      (isNewDb, dbEnvDefer) = action
+      _ <- (for {
+            _   <- Log[F].debug(s"Creating LMDB database: $dbName, env: $dirPath")
+            dbi <- Sync[F].delay(env.openDbi(dbName, DbiFlags.MDB_CREATE))
+            _   <- dbEnvDefer.complete(DbEnv(env, dbi, decrementDbRefCounter))
+          } yield ()).whenA(isNewDb)
+
+      // Block until database is ready.
+      envDbi <- dbEnvDefer.get
+
+      // Increment request counters to track in unfinished requests.
+      _ <- incrementDbRefCounter
+    } yield envDbi
+
+  // Begin database request
+  private def incrementDbRefCounter: F[Unit] =
+    varState.update { st =>
+      st.copy(inProgress = st.inProgress + 1)
+    }
+
+  // Finish database request
+  private def decrementDbRefCounter: F[Unit] =
+    varState.update { st =>
+      st.copy(inProgress = st.inProgress - 1)
+    }
+
+  // Create LMDB environment and update the state
+  private def createEnv: F[Unit] =
+    for {
+      _     <- Log[F].debug(s"Creating LMDB environment: $dirPath")
+      _     <- Sync[F].delay(Files.createDirectories(dirPath))
+      flags = Seq(EnvFlags.MDB_NOTLS)
+      // Create environment
+      env <- Sync[F].delay(
+              Env
+                .create()
+                .setMapSize(10L * 1024L * 1024L * 1024L)
+                .setMaxDbs(20)
+                // Maximum parallel readers
+                .setMaxReaders(2048)
+                .open(dirPath.toFile, flags: _*)
+            )
+      // Update state to Open
+      envDefer <- varState.modify { st =>
+                   val newState = st.copy(status = EnvOpen)
+                   (newState, newState.envDefer)
+                 }
+      // Complete deferred object
+      _ <- envDefer.complete(env)
+    } yield ()
+      _   <- Log[F].debug(s"Shutdown LMDB environment: $dirPath")
+}

--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
@@ -127,5 +127,12 @@ private final case class LmdbStoreManagerImpl[F[_]: Concurrent: Log](
       // Complete deferred object
       _ <- envDefer.complete(env)
     } yield ()
-      _   <- Log[F].debug(s"Shutdown LMDB environment: $dirPath")
+
+  override def shutdown: F[Unit] =
+    for {
+      // Close LMDB environment
+      st  <- varState.get
+      env <- st.envDefer.get
+      _   <- Sync[F].delay(env.close())
+    } yield ()
 }

--- a/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
@@ -1,0 +1,57 @@
+package coop.rchain.casper.storage
+
+import java.nio.file.Path
+
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.syntax.all._
+import coop.rchain.shared.Log
+import coop.rchain.store.{KeyValueStore, KeyValueStoreManager}
+
+object RNodeKeyValueStoreManager {
+  def apply[F[_]: Concurrent: Log](dirPath: Path): F[KeyValueStoreManager[F]] =
+    Concurrent[F].delay(new RNodeKeyValueStoreManager(dirPath))
+}
+
+// The idea for this class is to manage all instances of key-value databases for RNode.
+// For LMDB this allows control which databases are part of the same environment (file).
+private final case class RNodeKeyValueStoreManager[F[_]: Concurrent: Log](
+    dirPath: Path
+) extends KeyValueStoreManager[F] {
+
+  // Database name to store instance name mapping (subfolder for LMDB store)
+  // - keys with the same instance will be in one LMDB file (environment)
+  val dbInstanceMapping: Map[String, String] = Map[String, String](
+    // Block store
+    ("block-metadata", "dagstorage")
+  )
+
+  private case class StoreState(
+      envs: Map[String, Deferred[F, KeyValueStoreManager[F]]]
+  )
+
+  private val managersState = Ref.unsafe(StoreState(Map.empty))
+
+  // Creates database uniquely defined by the name
+  override def database(dbName: String): F[KeyValueStore[F]] =
+    for {
+      // Find DB ref / first time create deferred object
+      newDefer <- Deferred[F, KeyValueStoreManager[F]]
+      action <- managersState.modify { st =>
+                 val manName        = dbInstanceMapping(dbName)
+                 val (isNew, defer) = st.envs.get(manName).fold((true, newDefer))((false, _))
+                 val newSt          = st.copy(envs = st.envs.updated(manName, defer))
+                 (newSt, (isNew, defer, manName))
+               }
+      (isNew, defer, manName) = action
+      _                       <- createLmdbManger(manName, defer).whenA(isNew)
+      manager                 <- defer.get
+      database                <- manager.database(dbName)
+    } yield database
+
+  private def createLmdbManger(name: String, defer: Deferred[F, KeyValueStoreManager[F]]) =
+    for {
+      manager <- LmdbStoreManager(dirPath.resolve(name))
+      _       <- defer.complete(manager)
+    } yield ()
+}

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -1,0 +1,93 @@
+package coop.rchain.casper.batch2
+
+import java.nio.file.Files
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import coop.rchain.casper.storage.LmdbStoreManager
+import coop.rchain.shared.Log
+import coop.rchain.store.KeyValueStoreSut
+import monix.eval.Task
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.reflect.io.{Directory, Path}
+import scala.util.Random
+
+class LmdbKeyValueStoreSpec
+    extends FlatSpec
+    with Matchers
+    with GeneratorDrivenPropertyChecks
+    with BeforeAndAfterAll {
+  implicit val scheduler = monix.execution.Scheduler.global
+
+  val tempPath = Files.createTempDirectory(s"lmdb-test-")
+  val tempDir  = Directory(Path(tempPath.toFile))
+
+  override def beforeAll: Unit = tempDir.deleteRecursively
+
+  override def afterAll: Unit = tempDir.deleteRecursively
+
+  def withSut[F[_]: Concurrent: Log](f: KeyValueStoreSut[F] => F[Unit]) =
+    for {
+      kvm <- LmdbStoreManager[F](tempPath.resolve(Random.nextString(32)))
+      sut = {
+        implicit val kvm_ = kvm
+        new KeyValueStoreSut[F]
+      }
+      _ <- f(sut)
+      _ <- kvm.shutdown
+    } yield ()
+
+  def genData: Gen[Map[Long, String]] = {
+    val arbKV = Arbitrary.arbitrary[(Long, String)]
+    Gen.listOfN(2000, arbKV).map(_.toMap)
+  }
+
+  implicit val log: Log[Task] = new Log.NOPLog[Task]()
+
+  it should "put and get data from the store" in {
+    forAll(genData) { expected =>
+      val test = withSut[Task] { sut =>
+        for {
+          result <- sut.testPutGet(expected)
+        } yield result shouldBe expected
+      }
+
+      test.runSyncUnsafe()
+    }
+  }
+
+  it should "put and get all data from the store" in {
+    forAll(genData) { expected =>
+      val test = withSut[Task] { sut =>
+        for {
+          result <- sut.testPutIterate(expected)
+        } yield result shouldBe expected
+      }
+
+      test.runSyncUnsafe()
+    }
+  }
+
+  it should "not have deleted keys in the store" in {
+    forAll(genData) { input =>
+      val test = withSut[Task] { sut =>
+        val allKeys = input.keysIterator.toVector
+        // Take some keys for deletion
+        val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
+        val values                = getKeys.map(input.get)
+        // Expected input without deleted keys
+        val expected =
+          getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+        for {
+          result <- sut.testPutDeleteGet(input, deleteKeys)
+        } yield result shouldBe expected
+      }
+
+      test.runSyncUnsafe()
+    }
+  }
+
+}

--- a/rspace/src/main/scala/coop/rchain/rspace/history/StoreFactory.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/StoreFactory.scala
@@ -1,0 +1,50 @@
+package coop.rchain.rspace.history
+
+import java.nio.ByteBuffer
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.rspace.Blake2b256Hash
+import coop.rchain.shared.ByteVectorOps.RichByteVector
+import coop.rchain.store.KeyValueStoreManager
+import scodec.bits.BitVector
+
+// This is helper method to create Store instances with KeyValueStoreManager.
+object StoreFactory {
+  def keyValueStore[F[_]: Sync: KeyValueStoreManager](dbName: String): F[Store[F]] =
+    for {
+      kvStore <- KeyValueStoreManager[F].database(dbName)
+      store   = kvStore
+    } yield new Store[F] {
+
+      override def get(key: ByteBuffer): F[Option[ByteBuffer]] =
+        store.get(Seq(key), identity).map(_.head)
+
+      override def put(key: ByteBuffer, value: ByteBuffer): F[Unit] =
+        store.put[ByteBuffer](Seq((key, value)), identity)
+
+      override def get(key: Blake2b256Hash): F[Option[BitVector]] = {
+        val directKey = key.bytes.toDirectByteBuffer
+        get(directKey).map(v => v.map(BitVector(_)))
+      }
+
+      override def put(key: Blake2b256Hash, value: BitVector): F[Unit] = {
+        val directKey   = key.bytes.toDirectByteBuffer
+        val directValue = value.toByteVector.toDirectByteBuffer
+        put(directKey, directValue)
+      }
+
+      def put[T](
+          data: Seq[(Blake2b256Hash, T)],
+          toBuffer: T => ByteBuffer
+      ): F[Unit] = {
+        val rawData = data.map { case (k, v) => (k.bytes.toDirectByteBuffer, v) }
+        store.put(rawData, toBuffer)
+      }
+
+      override def put(data: Seq[(Blake2b256Hash, BitVector)]): F[Unit] =
+        put(data, (x: BitVector) => x.toByteVector.toDirectByteBuffer)
+
+      override def close(): F[Unit] = ().pure
+    }
+}

--- a/shared/src/main/scala/coop/rchain/shared/AttemptOpsF.scala
+++ b/shared/src/main/scala/coop/rchain/shared/AttemptOpsF.scala
@@ -6,10 +6,12 @@ import scodec.{Attempt, Err}
 
 object AttemptOpsF {
 
-  val ex: Err ⇒ Exception = err => new Exception(err.toString)
-  implicit class RichAttempt[F[_]: Sync, T](a: Attempt[T]) {
+  // Exception in case of failure
+  def ex(err: Err) = new Exception(err.toString)
 
-    def get: F[T] =
+  implicit class RichAttempt[T](a: Attempt[T]) {
+    // Get result or applicative error if failure
+    def get[F[_]](implicit f: Sync[F]): F[T] =
       a match {
         case Attempt.Successful(res) =>
           Applicative[F].pure(res)

--- a/shared/src/main/scala/coop/rchain/shared/package.scala
+++ b/shared/src/main/scala/coop/rchain/shared/package.scala
@@ -1,0 +1,10 @@
+package coop.rchain
+
+import coop.rchain.store.{KeyValueStoreSyntax, KeyValueTypedStoreSyntax}
+
+package object shared {
+  // Syntax for shared project
+  // TODO: unify syntax (extensions) with catscontrib,
+  //  one import per project similar as `import cats.syntax.all._`
+  object syntax extends KeyValueStoreSyntax with KeyValueTypedStoreSyntax
+}

--- a/shared/src/main/scala/coop/rchain/store/InMemoryKeyValueStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/InMemoryKeyValueStore.scala
@@ -1,0 +1,36 @@
+package coop.rchain.store
+
+import java.nio.ByteBuffer
+
+import cats.effect.Sync
+import cats.syntax.all._
+import scodec.bits.ByteVector
+
+import scala.collection.concurrent.TrieMap
+
+final case class InMemoryKeyValueStore[F[_]: Sync]() extends KeyValueStore[F] {
+
+  val state = TrieMap[ByteBuffer, ByteVector]()
+
+  override def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]] =
+    Sync[F].delay(
+      keys.map(state.get).map(_.map(_.toByteBuffer).map(fromBuffer))
+    )
+
+  override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
+    Sync[F].delay(
+      kvPairs
+        .foreach {
+          case (k, v) =>
+            state.put(k, ByteVector(toBuffer(v)))
+        }
+    )
+
+  override def delete(keys: Seq[ByteBuffer]): F[Int] =
+    Sync[F].delay(keys.map(state.remove).count(_.nonEmpty))
+
+  override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T] = {
+    val iter = state.toIterator.map { case (k, v) => (k, v.toByteBuffer) }
+    f(iter)
+  }
+}

--- a/shared/src/main/scala/coop/rchain/store/InMemoryStoreManager.scala
+++ b/shared/src/main/scala/coop/rchain/store/InMemoryStoreManager.scala
@@ -1,6 +1,7 @@
 package coop.rchain.store
 
 import cats.effect.Sync
+import cats.syntax.all._
 
 import scala.collection.concurrent.TrieMap
 
@@ -12,4 +13,6 @@ final case class InMemoryStoreManager[F[_]: Sync]() extends KeyValueStoreManager
   // Creates new database for each unique database name
   override def database(name: String): F[KeyValueStore[F]] =
     Sync[F].delay(state.getOrElseUpdate(name, InMemoryKeyValueStore[F]))
+
+  override def shutdown: F[Unit] = ().pure
 }

--- a/shared/src/main/scala/coop/rchain/store/InMemoryStoreManager.scala
+++ b/shared/src/main/scala/coop/rchain/store/InMemoryStoreManager.scala
@@ -1,0 +1,15 @@
+package coop.rchain.store
+
+import cats.effect.Sync
+
+import scala.collection.concurrent.TrieMap
+
+// Simple in-memory key value store manager
+final case class InMemoryStoreManager[F[_]: Sync]() extends KeyValueStoreManager[F] {
+
+  val state = TrieMap[String, InMemoryKeyValueStore[F]]()
+
+  // Creates new database for each unique database name
+  override def database(name: String): F[KeyValueStore[F]] =
+    Sync[F].delay(state.getOrElseUpdate(name, InMemoryKeyValueStore[F]))
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStore.scala
@@ -1,0 +1,13 @@
+package coop.rchain.store
+
+import java.nio.ByteBuffer
+
+trait KeyValueStore[F[_]] {
+  def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]]
+
+  def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit]
+
+  def delete(keys: Seq[ByteBuffer]): F[Int]
+
+  def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T]
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStoreManager.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStoreManager.scala
@@ -2,6 +2,8 @@ package coop.rchain.store
 
 trait KeyValueStoreManager[F[_]] {
   def database(name: String): F[KeyValueStore[F]]
+
+  def shutdown: F[Unit]
 }
 
 object KeyValueStoreManager {

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStoreManager.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStoreManager.scala
@@ -1,0 +1,9 @@
+package coop.rchain.store
+
+trait KeyValueStoreManager[F[_]] {
+  def database(name: String): F[KeyValueStore[F]]
+}
+
+object KeyValueStoreManager {
+  def apply[F[_]](implicit kvm: KeyValueStoreManager[F]): KeyValueStoreManager[F] = kvm
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
@@ -1,0 +1,19 @@
+package coop.rchain.store
+
+import cats.effect.Sync
+import scodec.Codec
+
+trait KeyValueStoreSyntax {
+  implicit final def sharedSyntaxKeyValueStore[F[_]](store: KeyValueStore[F]): KeyValueStoreOps[F] =
+    new KeyValueStoreOps[F](store)
+}
+
+final class KeyValueStoreOps[F[_]](
+    // KeyValueStore extensions / syntax
+    private val store: KeyValueStore[F]
+) {
+  // From key-value store, with serializers for K and V, typed store can be created
+  def toTypedStore[K, V](kCodec: Codec[K], vCodec: Codec[V])(
+      implicit s: Sync[F]
+  ): KeyValueTypedStore[F, K, V] = new KeyValueTypedStoreCodec[F, K, V](store, kCodec, vCodec)
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStore.scala
@@ -1,0 +1,13 @@
+package coop.rchain.store
+
+trait KeyValueTypedStore[F[_], K, V] {
+  def get(keys: Seq[K]): F[Seq[Option[V]]]
+
+  def put(kvPairs: Seq[(K, V)]): F[Unit]
+
+  def delete(keys: Seq[K]): F[Int]
+
+  def contains(keys: Seq[K]): F[Seq[Boolean]]
+
+  def toMap: F[Map[K, V]]
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreCodec.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreCodec.scala
@@ -1,0 +1,95 @@
+package coop.rchain.store
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.shared.ByteVectorOps.RichByteVector
+import scodec.Codec
+import scodec.bits.BitVector
+
+class KeyValueTypedStoreCodec[F[_]: Sync, K, V](
+    store: KeyValueStore[F],
+    kCodec: Codec[K],
+    vCodec: Codec[V]
+) extends KeyValueTypedStore[F, K, V] {
+  // TODO: create specialized exceptions for Codec errors
+  def encodeKey(key: K): F[BitVector] =
+    kCodec
+      .encode(key)
+      .fold(
+        err => new Exception(err.message).raiseError[F, BitVector],
+        _.pure[F]
+      )
+
+  def decodeKey(bytes: BitVector): F[K] =
+    kCodec
+      .decodeValue(bytes)
+      .fold(
+        err => new Exception(err.message).raiseError[F, K],
+        _.pure[F]
+      )
+
+  def encodeValue(value: V): F[BitVector] =
+    vCodec
+      .encode(value)
+      .fold(
+        err => new Exception(err.message).raiseError[F, BitVector],
+        _.pure[F]
+      )
+
+  def decodeValue(bytes: BitVector): F[V] =
+    vCodec
+      .decodeValue(bytes)
+      .fold(
+        err => new Exception(err.message).raiseError[F, V],
+        _.pure[F]
+      )
+
+  import cats.instances.option._
+  import cats.instances.vector._
+
+  override def get(keys: Seq[K]): F[Seq[Option[V]]] =
+    for {
+      keysBitVector <- keys.toVector.traverse(encodeKey)
+      keysBuf       = keysBitVector.map(_.toByteVector.toDirectByteBuffer)
+      valuesBytes   <- store.get(keysBuf, BitVector(_))
+      values        <- valuesBytes.toVector.traverse(_.traverse(decodeValue))
+    } yield values
+
+  override def put(kvPairs: Seq[(K, V)]): F[Unit] =
+    for {
+      pairsBitVector <- kvPairs.toVector.traverse {
+                         case (k, v) => encodeKey(k).map2(encodeValue(v))((x, y) => (x, y))
+                       }
+      pairs = pairsBitVector.map { case (k, v) => (k.toByteVector.toDirectByteBuffer, v) }
+      _     <- store.put[BitVector](pairs, _.toByteVector.toDirectByteBuffer)
+    } yield ()
+
+  override def delete(keys: Seq[K]): F[Int] =
+    for {
+      keysBitVector <- keys.toVector.traverse(encodeKey)
+      keysBuf       = keysBitVector.map(_.toByteVector.toDirectByteBuffer)
+      deletedCount  <- store.delete(keysBuf)
+    } yield deletedCount
+
+  override def contains(keys: Seq[K]): F[Seq[Boolean]] =
+    for {
+      keysBitVector <- keys.toVector.traverse(encodeKey)
+      keysBuf       = keysBitVector.map(_.toByteVector.toDirectByteBuffer)
+      results       <- store.get(keysBuf, _ => ())
+    } yield results.map(_.nonEmpty)
+
+  override def toMap: F[Map[K, V]] =
+    for {
+      valuesBytes <- store.iterate(
+                      _.map { case (k, v) => (BitVector(k), BitVector(v)) }.toVector.pure[F]
+                    )
+      values <- valuesBytes.traverse {
+                 case (k, v) =>
+                   for {
+                     key   <- decodeKey(k)
+                     value <- decodeValue(v)
+                   } yield (key, value)
+
+               }
+    } yield values.toMap
+}

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
@@ -1,0 +1,23 @@
+package coop.rchain.store
+
+import cats.Functor
+import cats.syntax.all._
+
+trait KeyValueTypedStoreSyntax {
+  implicit final def sharedSyntaxKeyValueTypedStore[F[_]: Functor, K, V](
+      store: KeyValueTypedStore[F, K, V]
+  ): KeyValueTypedStoreOps[F, K, V] = new KeyValueTypedStoreOps[F, K, V](store)
+}
+
+final class KeyValueTypedStoreOps[F[_]: Functor, K, V](
+    // KeyValueTypedStore extensions / syntax
+    private val store: KeyValueTypedStore[F, K, V]
+) {
+  def get(key: K): F[Option[V]] = store.get(Seq(key)).map(_.head)
+
+  def put(key: K, value: V): F[Unit] = store.put(Seq((key, value)))
+
+  def delete(key: K): F[Boolean] = store.delete(Seq(key)).map(_ == 1)
+
+  def contains(key: K): F[Boolean] = store.contains(Seq(key)).map(_.head)
+}

--- a/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
+++ b/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
@@ -1,0 +1,93 @@
+package coop.rchain.store
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.shared.syntax._
+import monix.eval.Task
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import scodec.codecs.{int64, utf8}
+
+class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {
+  def copyToDb(data: Map[Long, String]): F[KeyValueTypedStore[F, Long, String]] =
+    for {
+      db    <- KeyValueStoreManager[F].database("test")
+      store = db.toTypedStore(int64, utf8)
+      _     <- store.put(data.toSeq)
+    } yield store
+
+  def testPutGet(input: Map[Long, String]) =
+    for {
+      store  <- copyToDb(input)
+      keys   = input.keysIterator.toVector
+      values <- store.get(keys)
+      result = keys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+    } yield result
+
+  def testPutDeleteGet(input: Map[Long, String], deleteKeys: Seq[Long]) =
+    for {
+      store  <- copyToDb(input)
+      _      <- store.delete(deleteKeys)
+      result <- store.toMap
+    } yield result
+
+  def testPutIterate(input: Map[Long, String]) =
+    for {
+      store  <- copyToDb(input)
+      result <- store.toMap
+    } yield result
+}
+
+class InMemoryKeyValueStoreSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+  implicit val scheduler = monix.execution.Scheduler.global
+
+  def genData: Gen[Map[Long, String]] = {
+    val arbKV = Arbitrary.arbitrary[(Long, String)]
+    Gen.listOfN(2000, arbKV).map(_.toMap)
+  }
+
+  it should "put and get data from the store" in {
+    forAll(genData) { expected =>
+      implicit val kvm = InMemoryStoreManager[Task]
+      val sut          = new KeyValueStoreSut[Task]
+      val test = for {
+        result <- sut.testPutGet(expected)
+      } yield result shouldBe expected
+
+      test.runSyncUnsafe()
+    }
+  }
+
+  it should "put and get all data from the store" in {
+    forAll(genData) { expected =>
+      implicit val kvm = InMemoryStoreManager[Task]
+      val sut          = new KeyValueStoreSut[Task]
+      val test = for {
+        result <- sut.testPutIterate(expected)
+      } yield result shouldBe expected
+
+      test.runSyncUnsafe()
+    }
+  }
+
+  it should "not have deleted keys in the store" in {
+    forAll(genData) { input =>
+      implicit val kvm = InMemoryStoreManager[Task]
+      val sut          = new KeyValueStoreSut[Task]
+      val allKeys      = input.keysIterator.toVector
+      // Take some keys for deletion
+      val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
+      val values                = getKeys.map(input.get)
+      // Expected input without deleted keys
+      val expected =
+        getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+      val test = for {
+        result <- sut.testPutDeleteGet(input, deleteKeys)
+      } yield result shouldBe expected
+
+      test.runSyncUnsafe()
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR introduces key-value store abstraction with the manager for easier and general use than existing `Store`.
Manager gives more flexibility how implementation deals with database connections and environments. We can manage all store instances in one place (node project) and relief other places (like RSpace) from knowing about implementation details. After migration, LMDB can be removed as dependency from other projects (shared, block-storage and rspace) and can be moved to node project (and main test project).
This will also enable much easier integration and testing with other key-value databases like RocksDB or Badger.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4077

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
