### PR TITLE
RCHAIN-4092: DAG storage implementation with key-value store (LMDB)

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -497,4 +497,38 @@ object BlockDagFileStorage {
     )
   }
 
+  def createStores[F[_]: Concurrent: Sync: Log: Metrics](config: Config) = {
+    implicit val raiseIOError: RaiseIOError[F] = IOError.raiseIOErrorThroughSync[F]
+    for {
+      blockNumberIndex <- loadBlockNumberIndexLmdbStore(config)
+      latestMessagesIndex <- LatestMessagesPersistentIndex.load[F](
+                              config.latestMessagesLogPath,
+                              config.latestMessagesCrcPath
+                            )
+      blockMetadataIndex <- BlockMetadataPersistentIndex.load[F](
+                             config.blockMetadataLogPath,
+                             config.blockMetadataCrcPath
+                           )
+      equivocationTrackerIndex <- EquivocationTrackerPersistentIndex.load[F](
+                                   config.equivocationsTrackerLogPath,
+                                   config.equivocationsTrackerCrcPath
+                                 )
+      invalidBlocksIndex <- InvalidBlocksPersistentIndex.load[F](
+                             config.invalidBlocksLogPath,
+                             config.invalidBlocksCrcPath
+                           )
+      deployIndex <- DeployPersistentIndex.load[F](
+                      config.blockHashesByDeployLogPath,
+                      config.blockHashesByDeployCrcPath
+                    )
+    } yield (
+      blockNumberIndex,
+      latestMessagesIndex,
+      blockMetadataIndex,
+      deployIndex,
+      invalidBlocksIndex,
+      equivocationTrackerIndex
+    )
+  }
+
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -204,16 +204,10 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
 
     def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
       latestMessagesMap.get(validator).pure[F]
-    def latestMessage(validator: Validator): F[Option[BlockMetadata]] =
-      latestMessagesMap.get(validator).flatTraverse(lookup)
+
     def latestMessageHashes: F[Map[Validator, BlockHash]] =
       latestMessagesMap.pure[F]
-    def latestMessages: F[Map[Validator, BlockMetadata]] =
-      latestMessagesMap.toList
-        .traverse {
-          case (validator, hash) => lookup(hash).map(validator -> _.get)
-        }
-        .map(_.toMap)
+
     def invalidBlocks: F[Set[BlockMetadata]] =
       invalidBlocksSet.pure[F]
   }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -1,0 +1,252 @@
+package coop.rchain.blockstorage.dag
+
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage._
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
+import coop.rchain.blockstorage.dag.BlockMetadataStore.BlockMetadataStore
+import coop.rchain.blockstorage.dag.EquivocationTrackerStore.EquivocationTrackerStore
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.BlockMessageUtil._
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, MetricsSemaphore}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.EquivocationRecord.SequenceNumber
+import coop.rchain.models.Validator.Validator
+import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
+import coop.rchain.shared.syntax._
+import coop.rchain.shared.{Log, LogSource}
+import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
+import scodec.Codec
+import scodec.bits.ByteVector
+
+import scala.collection.immutable.SortedMap
+
+final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
+    lock: Semaphore[F],
+    latestMessagesIndex: KeyValueTypedStore[F, Validator, BlockHash],
+    blockMetadataIndex: BlockMetadataStore[F],
+    deployIndex: KeyValueTypedStore[F, DeployId, BlockHash],
+    invalidBlocksIndex: KeyValueTypedStore[F, BlockHash, BlockMetadata],
+    equivocationTrackerIndex: EquivocationTrackerStore[F]
+) extends BlockDagStorage[F] {
+  implicit private val logSource: LogSource = LogSource(BlockDagKeyValueStorage.getClass)
+
+  private case class KeyValueDagRepresentation(
+      dagSet: Set[BlockHash],
+      latestMessagesMap: Map[Validator, BlockHash],
+      childMap: Map[BlockHash, Set[BlockHash]],
+      heightMap: SortedMap[Long, Set[BlockHash]],
+      invalidBlocksSet: Set[BlockMetadata]
+  ) extends BlockDagRepresentation[F] {
+
+    def lookup(blockHash: BlockHash): F[Option[BlockMetadata]] =
+      if (dagSet.contains(blockHash)) blockMetadataIndex.get(blockHash)
+      else none[BlockMetadata].pure[F]
+
+    def contains(blockHash: BlockHash): F[Boolean] =
+      (blockHash.size == BlockHash.Length && dagSet.contains(blockHash)).pure[F]
+
+    def children(blockHash: BlockHash): F[Option[Set[BlockHash]]] =
+      childMap.get(blockHash).pure[F]
+
+    def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+      latestMessagesMap.get(validator).pure[F]
+
+    def latestMessageHashes: F[Map[Validator, BlockHash]] = latestMessagesMap.pure[F]
+
+    def invalidBlocks: F[Set[BlockMetadata]] = invalidBlocksSet.pure[F]
+
+    // latestBlockNumber, topoSort and lookupByDeployId are only used in BlockAPI.
+    // Do they need to be part of the DAG current state or they can be moved to DAG storage directly?
+
+    private def getMaxHeight = if (heightMap.nonEmpty) heightMap.last._1 + 1L else 0L
+
+    def latestBlockNumber: F[Long] =
+      getMaxHeight.pure[F]
+
+    def topoSort(
+        startBlockNumber: Long,
+        maybeEndBlockNumber: Option[Long]
+    ): F[Vector[Vector[BlockHash]]] = {
+      val endBlockNumber = maybeEndBlockNumber.getOrElse(getMaxHeight)
+      if (startBlockNumber >= 0 && startBlockNumber <= endBlockNumber) {
+        Sync[F].delay(
+          heightMap
+            .filterKeys(h => h >= startBlockNumber && h <= endBlockNumber)
+            .map { case (_, v) => v.toVector }
+            .toVector
+        )
+      } else {
+        Sync[F].raiseError(
+          TopoSortFragmentParameterError(startBlockNumber, endBlockNumber)
+        )
+      }
+    }
+
+    def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
+      deployIndex.get(deployId)
+  }
+
+  private object KeyValueStoreEquivocationsTracker extends EquivocationsTracker[F] {
+    override def equivocationRecords: F[Set[EquivocationRecord]] =
+      equivocationTrackerIndex.data
+
+    override def insertEquivocationRecord(record: EquivocationRecord): F[Unit] =
+      equivocationTrackerIndex.add(record)
+
+    override def updateEquivocationRecord(
+        record: EquivocationRecord,
+        blockHash: BlockHash
+    ): F[Unit] = {
+      val updatedEquivocationDetectedBlockHashes =
+        record.equivocationDetectedBlockHashes + blockHash
+      val newRecord =
+        record.copy(equivocationDetectedBlockHashes = updatedEquivocationDetectedBlockHashes)
+      equivocationTrackerIndex.add(newRecord)
+    }
+  }
+
+  private def representation: F[BlockDagRepresentation[F]] =
+    for {
+      // Take current DAG state / view of the DAG
+      latestMessages <- latestMessagesIndex.toMap
+      dagSet         <- blockMetadataIndex.dagSet
+      childMap       <- blockMetadataIndex.childMapData
+      heightMap      <- blockMetadataIndex.heightMap
+      invalidBlocks  <- invalidBlocksIndex.toMap.map(_.toSeq.map(_._2).toSet)
+    } yield KeyValueDagRepresentation(
+      dagSet,
+      latestMessages,
+      childMap,
+      heightMap,
+      invalidBlocks
+    )
+
+  def getRepresentation: F[BlockDagRepresentation[F]] =
+    lock.withPermit(representation)
+
+  def insert(
+      block: BlockMessage,
+      genesis: BlockMessage,
+      invalid: Boolean
+  ): F[BlockDagRepresentation[F]] =
+    lock.withPermit(
+      for {
+        alreadyStored <- blockMetadataIndex.contains(block.blockHash)
+        _ <- if (alreadyStored) {
+              Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} is already stored")
+            } else {
+              val blockMetadata = BlockMetadata.fromBlock(block, invalid)
+              assert(block.blockHash.size == BlockHash.Length)
+              for {
+                _ <- if (invalid) invalidBlocksIndex.put(blockMetadata.blockHash, blockMetadata)
+                    else ().pure[F]
+                //Block which contains newly bonded validators will not
+                //have those validators in its justification
+                newValidators = bonds(block)
+                  .map(_.validator)
+                  .toSet
+                  .diff(block.justifications.map(_.validator).toSet)
+                newValidatorsLatestMessages = newValidators.map(v => (v, genesis.blockHash))
+                newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
+                                                          // Ignore empty sender for special cases such as genesis block
+                                                          Log[F].warn(
+                                                            s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
+                                                          ) >> newValidatorsLatestMessages.pure[F]
+                                                        } else if (block.sender
+                                                                     .size() == Validator.Length) {
+                                                          (newValidatorsLatestMessages + (
+                                                            (
+                                                              block.sender,
+                                                              block.blockHash
+                                                            )
+                                                          )).pure[F]
+                                                        } else {
+                                                          Sync[F].raiseError[Set[
+                                                            (ByteString, ByteString)
+                                                          ]](
+                                                            BlockSenderIsMalformed(block)
+                                                          )
+                                                        }
+                deployHashes = deployData(block).map(_.sig).toList
+                // Add deploys to deploy index storage
+                _ <- deployIndex.put(deployHashes.map(_ -> block.blockHash))
+                // Add/update validators latest messages
+                _ <- latestMessagesIndex.put(newValidatorsWithSenderLatestMessages.toList)
+                // Add block metadata
+                _ <- blockMetadataIndex.add(blockMetadata)
+              } yield ()
+            }
+        dag <- representation
+      } yield dag
+    )
+
+  override def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A] =
+    lock.withPermit(f(KeyValueStoreEquivocationsTracker))
+
+  def checkpoint(): F[Unit] = ().pure[F]
+
+  def close(): F[Unit] = ().pure[F]
+}
+
+object BlockDagKeyValueStorage {
+  implicit private val BlockDagKeyValueStorage_FromFileMetricsSource: Source =
+    Metrics.Source(BlockStorageMetricsSource, "dag-key-value-store")
+
+//  implicit private val logSource = LogSource(BlockDagKeyValueStorage.getClass)
+
+  def create[F[_]: Concurrent: KeyValueStoreManager: Log: Metrics]: F[BlockDagStorage[F]] = {
+
+    def createDB[K, V](name: String, kCodec: Codec[K], vCodec: Codec[V]) =
+      KeyValueStoreManager[F].database(name).map(_.toTypedStore(kCodec, vCodec))
+
+    for {
+      lock <- MetricsSemaphore.single[F]
+      // Block metadata map
+      blockMetadataDb <- createDB[BlockHash, BlockMetadata](
+                          "block-metadata",
+                          codecBlockHash,
+                          codecBlockMetadata
+                        )
+      blockMetadataStore <- BlockMetadataStore[F](blockMetadataDb)
+      // Equivocation tracker map
+      equivocationTrackerDb <- createDB[(Validator, SequenceNumber), Set[BlockHash]](
+                                "equivocation-tracker",
+                                codecValidator ~ codecSeqNum,
+                                codecBlockHashSet
+                              )
+      equivocationTrackerIndex <- EquivocationTrackerStore[F](equivocationTrackerDb)
+      // Latest messages map
+      latestMessagesDb <- createDB[Validator, BlockHash](
+                           "latest-messages",
+                           codecValidator,
+                           codecBlockHash
+                         )
+      // Invalid blocks map
+      invalidBlocksDb <- createDB[BlockHash, BlockMetadata](
+                          "invalid-blocks",
+                          codecBlockHash,
+                          codecBlockMetadata
+                        )
+      // Deploy map
+      deployIndexDb <- createDB[DeployId, BlockHash](
+                        "deploy-index",
+                        codecDeployId,
+                        codecBlockHash
+                      )
+    } yield new BlockDagKeyValueStorage[F](
+      lock,
+      latestMessagesDb,
+      blockMetadataStore,
+      deployIndexDb,
+      invalidBlocksDb,
+      equivocationTrackerIndex
+    )
+  }
+
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -1,0 +1,41 @@
+package coop.rchain.blockstorage.dag
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
+import coop.rchain.models.Validator.Validator
+
+trait BlockDagRepresentationSyntax {
+  implicit final def blockStorageSyntaxBlockDagRepresentation[F[_]: Sync](
+      dag: BlockDagRepresentation[F]
+  ): BlockDagRepresentationOps[F] = new BlockDagRepresentationOps[F](dag)
+}
+
+final case class BlockDagInconsistencyError(message: String) extends Exception(message)
+
+final class BlockDagRepresentationOps[F[_]: Sync](
+    // BlockDagRepresentation extensions / syntax
+    private val dag: BlockDagRepresentation[F]
+) {
+  // Get block metadata, "unsafe" because method expects block already in the DAG.
+  def lookupUnsafe(hash: BlockHash): F[BlockMetadata] = {
+    def errMsg = s"Block hash ${PrettyPrinter.buildString(hash)} not found in the DAG."
+    dag.lookup(hash) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
+  }
+
+  def latestMessage(validator: Validator): F[Option[BlockMetadata]] = {
+    import cats.instances.option._
+    dag.latestMessageHash(validator) >>= (_.traverse(lookupUnsafe))
+  }
+
+  def latestMessages: F[Map[Validator, BlockMetadata]] = {
+    import cats.instances.vector._
+    dag.latestMessageHashes >>= (
+      _.toVector
+        .traverse { case (validator, hash) => lookupUnsafe(hash).map(validator -> _) }
+        .map(_.toMap)
+      )
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -29,17 +29,16 @@ trait BlockDagRepresentation[F[_]] {
   def children(blockHash: BlockHash): F[Option[Set[BlockHash]]]
   def lookup(blockHash: BlockHash): F[Option[BlockMetadata]]
   def contains(blockHash: BlockHash): F[Boolean]
+  def latestMessageHash(validator: Validator): F[Option[BlockHash]]
+  def latestMessageHashes: F[Map[Validator, BlockHash]]
+  def invalidBlocks: F[Set[BlockMetadata]]
+  // For BlockAPI
+  def latestBlockNumber: F[Long]
   def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]]
   def topoSort(
       startBlockNumber: Long,
       maybeEndBlockNumber: Option[Long]
   ): F[Vector[Vector[BlockHash]]]
-  def latestBlockNumber: F[Long]
-  def latestMessageHash(validator: Validator): F[Option[BlockHash]]
-  def latestMessage(validator: Validator): F[Option[BlockMetadata]]
-  def latestMessageHashes: F[Map[Validator, BlockHash]]
-  def latestMessages: F[Map[Validator, BlockMetadata]]
-  def invalidBlocks: F[Set[BlockMetadata]]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
@@ -17,12 +17,7 @@ object BlockMetadataStore {
   def apply[F[_]: Sync: Log](
       blockMetadataStore: KeyValueTypedStore[F, BlockHash, BlockMetadata]
   ): F[BlockMetadataStore[F]] =
-//    implicit val raiseIOError: RaiseIOError[F] = IOError.raiseIOErrorThroughSync[F]
     for {
-      // Migrating data from previous metadata index
-//      result <- BlockMetadataPersistentIndex.read(Paths.get("index_path"))
-//      (oldMetadaatMap, _, _) = result
-//      _ <- blockMetadataStore.put(oldMetadaatMap.toSeq)
       blockMetadataMap <- blockMetadataStore.toMap
       dagState         = recreateInMemoryState(blockMetadataMap)
     } yield new BlockMetadataStore[F](

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
@@ -1,0 +1,105 @@
+package coop.rchain.blockstorage.dag
+
+import cats.Monad
+import cats.effect.Sync
+import cats.mtl.MonadState
+import cats.syntax.all._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
+import coop.rchain.shared.syntax._
+import coop.rchain.shared.{AtomicMonadState, Log}
+import coop.rchain.store.KeyValueTypedStore
+import monix.execution.atomic.AtomicAny
+
+import scala.collection.immutable.SortedMap
+
+object BlockMetadataStore {
+  def apply[F[_]: Sync: Log](
+      blockMetadataStore: KeyValueTypedStore[F, BlockHash, BlockMetadata]
+  ): F[BlockMetadataStore[F]] =
+//    implicit val raiseIOError: RaiseIOError[F] = IOError.raiseIOErrorThroughSync[F]
+    for {
+      // Migrating data from previous metadata index
+//      result <- BlockMetadataPersistentIndex.read(Paths.get("index_path"))
+//      (oldMetadaatMap, _, _) = result
+//      _ <- blockMetadataStore.put(oldMetadaatMap.toSeq)
+      blockMetadataMap <- blockMetadataStore.toMap
+      dagState         = recreateInMemoryState(blockMetadataMap)
+    } yield new BlockMetadataStore[F](
+      blockMetadataStore,
+      new AtomicMonadState(AtomicAny(dagState))
+    )
+
+  private final case class DagState(
+      dagSet: Set[BlockHash],
+      childMap: Map[BlockHash, Set[BlockHash]],
+      heightMap: SortedMap[Long, Set[BlockHash]]
+  )
+
+  class BlockMetadataStore[F[_]: Monad](
+      private val store: KeyValueTypedStore[F, BlockHash, BlockMetadata],
+      private val dagState: MonadState[F, DagState]
+  ) {
+    def add(block: BlockMetadata): F[Unit] =
+      for {
+        // Update DAG state with new block
+        _ <- dagState.modify(st => validateDagState(addBlockToDagState(block)(st)))
+
+        // Update persistent block metadata store
+        _ <- store.put(block.blockHash, block)
+      } yield ()
+
+    def get(hash: BlockHash): F[Option[BlockMetadata]] = store.get(hash)
+
+    // DAG state operations
+
+    def dagSet: F[Set[BlockHash]] = dagState.get.map(_.dagSet)
+
+    def contains(hash: BlockHash): F[Boolean] = dagState.get.map(_.dagSet.contains(hash))
+
+    def childMapData: F[Map[BlockHash, Set[BlockHash]]] =
+      dagState.get.map(_.childMap)
+
+    def heightMap: F[SortedMap[Long, Set[BlockHash]]] =
+      dagState.get.map(_.heightMap)
+  }
+
+  private def addBlockToDagState(block: BlockMetadata)(state: DagState): DagState = {
+    // Update dag set / all blocks in the DAG
+    val newDagSet = state.dagSet + block.blockHash
+
+    // Update children relation map
+    val blockChilds = block.parents.map((_, Set(block.blockHash))) :+ (block.blockHash, Set())
+    val newChildMap = blockChilds.foldLeft(state.childMap) {
+      case (acc, (key, newChildren)) =>
+        val currChildren = acc.getOrElse(key, Set.empty[BlockHash])
+        acc.updated(key, currChildren ++ newChildren)
+    }
+
+    // Update block height map
+    val newHeightMap = if (!block.invalid) {
+      val currSet = state.heightMap.getOrElse(block.blockNum, Set())
+      state.heightMap.updated(block.blockNum, currSet + block.blockHash)
+    } else state.heightMap
+
+    state.copy(dagSet = newDagSet, childMap = newChildMap, heightMap = newHeightMap)
+  }
+
+  private def validateDagState(state: DagState): DagState = {
+    // Validate height map index (block numbers) are in sequence without holes
+    val m          = state.heightMap
+    val (min, max) = if (m.nonEmpty) (m.firstKey, m.lastKey + 1) else (0L, 0L)
+    assert(max - min == m.size.toLong, "DAG store height map has numbers not in sequence.")
+    state
+  }
+
+  private def recreateInMemoryState(
+      blockMetadataMap: Map[BlockHash, BlockMetadata]
+  ): DagState = {
+    val emptyState = DagState(dagSet = Set(), childMap = Map(), heightMap = SortedMap())
+    val dagState = blockMetadataMap.foldLeft(emptyState) {
+      case (state, (_, block)) => addBlockToDagState(block)(state)
+    }
+    validateDagState(dagState)
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/EquivocationTrackerStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/EquivocationTrackerStore.scala
@@ -1,0 +1,43 @@
+package coop.rchain.blockstorage.dag
+
+import cats.Monad
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.EquivocationRecord
+import coop.rchain.models.EquivocationRecord.SequenceNumber
+import coop.rchain.models.Validator.Validator
+import coop.rchain.shared.Log
+import coop.rchain.shared.syntax._
+import coop.rchain.store.KeyValueTypedStore
+
+object EquivocationTrackerStore {
+  def apply[F[_]: Sync: Log](
+      store: KeyValueTypedStore[F, (Validator, SequenceNumber), Set[BlockHash]]
+  ): F[EquivocationTrackerStore[F]] =
+    Sync[F].delay(new EquivocationTrackerStore(store))
+
+  class EquivocationTrackerStore[F[_]: Monad](
+      private val store: KeyValueTypedStore[F, (Validator, SequenceNumber), Set[BlockHash]]
+  ) {
+    def add(record: EquivocationRecord): F[Unit] =
+      store.put(
+        (record.equivocator, record.equivocationBaseBlockSeqNum),
+        record.equivocationDetectedBlockHashes
+      )
+
+    def addAll(records: List[EquivocationRecord]): F[Unit] =
+      store.put(
+        records.map {
+          case EquivocationRecord(equivocator, seqNum, blockHashes) =>
+            (equivocator, seqNum) -> blockHashes
+        }
+      )
+
+    def data: F[Set[EquivocationRecord]] =
+      store.toMap.map(_.map {
+        case ((equivocator, seqNum), blockHashes) =>
+          EquivocationRecord(equivocator, seqNum, blockHashes)
+      }.toSet)
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -1,8 +1,12 @@
 package coop.rchain
 
+import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
 import coop.rchain.metrics.Metrics
 
 package object blockstorage {
   val BlockStorageMetricsSource: Metrics.Source =
     Metrics.Source(Metrics.BaseSource, "block-storage")
+
+  // Block storage syntax
+  object syntax extends BlockDagRepresentationSyntax
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
@@ -1,0 +1,265 @@
+package coop.rchain.blockstorage.dag
+
+import cats.instances.list._
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.protocol._
+import coop.rchain.catscontrib.TaskContrib.TaskOps
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+import coop.rchain.models.blockImplicits._
+import coop.rchain.models.{BlockMetadata, EquivocationRecord}
+import coop.rchain.shared
+import coop.rchain.store.InMemoryStoreManager
+import monix.eval.Task
+import scodec.bits.ByteVector
+
+class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
+
+  private def createDagStorage: Task[BlockDagStorage[Task]] = {
+    implicit val log     = new shared.Log.NOPLog[Task]()
+    implicit val metrics = new Metrics.MetricsNOP[Task]
+    implicit val kvm     = InMemoryStoreManager[Task]
+    BlockDagKeyValueStorage.create[Task]
+  }
+
+  override def withDagStorage[R](f: BlockDagStorage[Task] => Task[R]): R =
+    (createDagStorage >>= f).unsafeRunSync(scheduler)
+
+  type LookupResult =
+    (
+        List[
+          (
+              Option[BlockMetadata],
+              Option[BlockHash],
+              Option[BlockMetadata],
+              Option[Set[BlockHash]],
+              Boolean
+          )
+        ],
+        Map[Validator, BlockHash],
+        Map[Validator, BlockMetadata],
+        Vector[Vector[BlockHash]],
+        Long
+    )
+
+  private def lookupElements(
+      blockElements: List[BlockMessage],
+      storage: BlockDagStorage[Task],
+      topoSortStartBlockNumber: Long = 0
+  ): Task[LookupResult] = {
+    import cats.instances.list._
+    for {
+      dag <- storage.getRepresentation
+      list <- blockElements.traverse { b =>
+               for {
+                 blockMetadata     <- dag.lookup(b.blockHash)
+                 latestMessageHash <- dag.latestMessageHash(b.sender)
+                 latestMessage     <- dag.latestMessage(b.sender)
+                 children          <- dag.children(b.blockHash)
+                 contains          <- dag.contains(b.blockHash)
+               } yield (blockMetadata, latestMessageHash, latestMessage, children, contains)
+             }
+      latestMessageHashes <- dag.latestMessageHashes
+      latestMessages      <- dag.latestMessages
+      topoSort            <- dag.topoSort(topoSortStartBlockNumber, none)
+      latestBlockNumber   <- dag.latestBlockNumber
+    } yield (list, latestMessageHashes, latestMessages, topoSort, latestBlockNumber)
+  }
+
+  private def testLookupElementsResult(
+      lookupResult: LookupResult,
+      blockElements: List[BlockMessage]
+  ): Unit = {
+    val (list, latestMessageHashes, latestMessages, topoSort, latestBlockNumber) = lookupResult
+    val realLatestMessages = blockElements.foldLeft(Map.empty[Validator, BlockMetadata]) {
+      case (lm, b) =>
+        // Ignore empty sender for genesis block
+        if (b.sender != ByteString.EMPTY)
+          lm.updated(b.sender, BlockMetadata.fromBlock(b, false))
+        else
+          lm
+    }
+    list.zip(blockElements).foreach {
+      case ((blockMetadata, latestMessageHash, latestMessage, children, contains), b) =>
+        blockMetadata shouldBe Some(BlockMetadata.fromBlock(b, false))
+        latestMessageHash shouldBe realLatestMessages.get(b.sender).map(_.blockHash)
+        latestMessage shouldBe realLatestMessages.get(b.sender)
+        children shouldBe
+          Some(
+            blockElements
+              .filter(_.header.parentsHashList.contains(b.blockHash))
+              .map(_.blockHash)
+              .toSet
+          )
+        contains shouldBe true
+    }
+    latestMessageHashes shouldBe realLatestMessages.mapValues(_.blockHash)
+    latestMessages shouldBe realLatestMessages
+
+    def normalize(topoSort: Vector[Vector[BlockHash]]): Vector[Vector[BlockHash]] =
+      if (topoSort.size == 1 && topoSort.head.isEmpty)
+        Vector.empty
+      else
+        topoSort
+
+    val realTopoSort = normalize(Vector(blockElements.map(_.blockHash).toVector))
+    for ((topoSortLevel, realTopoSortLevel) <- topoSort.zipAll(
+                                                realTopoSort,
+                                                Vector.empty,
+                                                Vector.empty
+                                              )) {
+      topoSortLevel.toSet shouldBe realTopoSortLevel.toSet
+      latestBlockNumber shouldBe topoSort.length
+    }
+
+  }
+
+  it should "be able to restore state on startup" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      withDagStorage { storage =>
+        for {
+          _      <- blockElements.traverse_(storage.insert(_, genesis, false))
+          result <- lookupElements(blockElements, storage)
+        } yield testLookupElementsResult(result, blockElements)
+      }
+    }
+  }
+
+  it should "be able to restore latest messages with genesis with empty sender field" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      val blockElementsWithGenesis = blockElements match {
+        case x :: xs =>
+          val genesis = x.copy(sender = ByteString.EMPTY)
+          genesis :: xs
+        case Nil =>
+          Nil
+      }
+      withDagStorage { storage =>
+        for {
+          _      <- blockElementsWithGenesis.traverse_(storage.insert(_, genesis, false))
+          result <- lookupElements(blockElementsWithGenesis, storage)
+        } yield testLookupElementsResult(result, blockElementsWithGenesis)
+      }
+    }
+  }
+
+  it should "be able to restore state from the previous two instances" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { firstBlockElements =>
+      forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { secondBlockElements =>
+        withDagStorage { storage =>
+          for {
+            _      <- firstBlockElements.traverse_(storage.insert(_, genesis, false))
+            _      <- secondBlockElements.traverse_(storage.insert(_, genesis, false))
+            result <- lookupElements(firstBlockElements ++ secondBlockElements, storage)
+          } yield testLookupElementsResult(result, firstBlockElements ++ secondBlockElements)
+        }
+      }
+    }
+  }
+
+  it should "be able to restore after squashing latest messages" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      forAll(blockWithNewHashesGen(blockElements), blockWithNewHashesGen(blockElements)) {
+        (secondBlockElements, thirdBlockElements) =>
+          withDagStorage { storage =>
+            for {
+              _      <- blockElements.traverse_(storage.insert(_, genesis, false))
+              _      <- secondBlockElements.traverse_(storage.insert(_, genesis, false))
+              _      <- thirdBlockElements.traverse_(storage.insert(_, genesis, false))
+              result <- lookupElements(blockElements, storage)
+            } yield testLookupElementsResult(
+              result,
+              blockElements ++ secondBlockElements ++ thirdBlockElements
+            )
+          }
+      }
+    }
+  }
+
+  it should "be able to restore equivocations tracker on startup" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      forAll(validatorGen) { equivocator =>
+        forAll(blockHashGen) { blockHash =>
+          withDagStorage { storage =>
+            for {
+              _ <- blockElements.traverse_(storage.insert(_, genesis, false))
+              record = EquivocationRecord(
+                equivocator,
+                0,
+                Set(blockHash)
+              )
+              _ <- storage.accessEquivocationsTracker { tracker =>
+                    tracker.insertEquivocationRecord(record)
+                  }
+              _       <- storage.close()
+              records <- storage.accessEquivocationsTracker(_.equivocationRecords)
+              _       = records shouldBe Set(record)
+              result  <- lookupElements(blockElements, storage)
+            } yield testLookupElementsResult(result, blockElements)
+          }
+        }
+      }
+    }
+  }
+
+  it should "be able to modify equivocation records" in {
+    forAll(validatorGen, blockHashGen, blockHashGen) { (equivocator, blockHash1, blockHash2) =>
+      withDagStorage { storage =>
+        val record = EquivocationRecord(equivocator, 0, Set(blockHash1))
+        for {
+          _ <- storage.accessEquivocationsTracker { tracker =>
+                tracker.insertEquivocationRecord(record)
+              }
+          _ <- storage.accessEquivocationsTracker { tracker =>
+                tracker.updateEquivocationRecord(record, blockHash2)
+              }
+          updatedRecord = EquivocationRecord(equivocator, 0, Set(blockHash1, blockHash2))
+          records       <- storage.accessEquivocationsTracker(_.equivocationRecords)
+          _             = records shouldBe Set(updatedRecord)
+        } yield ()
+      }
+    }
+  }
+
+  it should "be able to restore invalid blocks on startup" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      withDagStorage { storage =>
+        for {
+          _             <- blockElements.traverse_(storage.insert(_, genesis, true))
+          dag           <- storage.getRepresentation
+          invalidBlocks <- dag.invalidBlocks
+        } yield invalidBlocks shouldBe blockElements.map(BlockMetadata.fromBlock(_, true)).toSet
+      }
+    }
+  }
+
+  it should "be able to restore deploy index on startup" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      withDagStorage { storage =>
+        for {
+          _   <- blockElements.traverse_(storage.insert(_, genesis, true))
+          dag <- storage.getRepresentation
+          (deploys, blockHashes) = blockElements
+            .flatMap(b => b.body.deploys.map(_ -> b.blockHash))
+            .unzip
+          deployLookups <- deploys.traverse(d => dag.lookupByDeployId(d.deploy.sig))
+        } yield deployLookups shouldBe blockHashes.map(_.some)
+      }
+    }
+  }
+
+  it should "handle blocks with invalid numbers" in {
+    forAll(blockElementGen, blockElementGen) { (genesis, block) =>
+      withDagStorage { storage =>
+        val invalidBlock = block.copy(
+          body = block.body.copy(state = block.body.state.copy(blockNumber = 1000))
+        )
+        storage.insert(genesis, genesis, false) >>
+          storage.insert(invalidBlock, genesis, true)
+      }
+    }
+  }
+}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.LatestMessagesLogIsCorrupted
 import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
 import coop.rchain.casper.protocol._

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -1,17 +1,16 @@
 package coop.rchain.blockstorage.dag
 
-import cats.Monad
-import cats.effect.Concurrent
 import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStorageMetricsSource
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 
-final class IndexedBlockDagStorage[F[_]: Monad](
+final class IndexedBlockDagStorage[F[_]: Sync](
     lock: Semaphore[F],
     underlying: BlockDagStorage[F],
     idToBlocksRef: Ref[F, Map[Long, BlockMessage]],

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.deploy.DeployStorage
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
@@ -196,7 +197,7 @@ object BlockCreator {
    * any latest message not from a bonded validator will not change the
    * final fork-choice.
    */
-  private def computeJustifications[F[_]: Monad](
+  private def computeJustifications[F[_]: Sync](
       dag: BlockDagRepresentation[F],
       parents: Seq[BlockMessage]
   ): F[Seq[Justification]] = {

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
@@ -1,12 +1,13 @@
 package coop.rchain.casper
 
 import cats.effect.Sync
-import cats.syntax.flatMap._
 import cats.syntax.applicative._
+import cats.syntax.flatMap._
 import cats.syntax.functor._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.models.Validator.Validator

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -3,11 +3,12 @@ package coop.rchain.casper
 import cats.Monad
 import cats.syntax.all._
 import cats.instances.list._
-
 import coop.rchain.catscontrib._
 import Catscontrib._
 import cats.data.OptionT
+import cats.effect.Sync
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.Justification
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, DagOperations, ProtoUtil}
@@ -57,7 +58,7 @@ object SafetyOracle extends SafetyOracleInstances {
 }
 
 sealed abstract class SafetyOracleInstances {
-  def cliqueOracle[F[_]: Monad: Log: Metrics: Span]: SafetyOracle[F] =
+  def cliqueOracle[F[_]: Sync: Log: Metrics: Span]: SafetyOracle[F] =
     new SafetyOracle[F] {
       private val SafetyOracleMetricsSource: Metrics.Source =
         Metrics.Source(CasperMetricsSource, "safety-oracle")

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -7,10 +7,11 @@ import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
-import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.bonds
 import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -1,43 +1,37 @@
 package coop.rchain.casper.api
 
-import scala.collection.immutable
 import cats.Monad
-import cats.effect.{Concurrent, Sync}
 import cats.effect.concurrent.Semaphore
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.engine._
-import EngineCell._
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
-import coop.rchain.casper._
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.DeployError._
+import coop.rchain.casper.{ReportingCasper, ReportingProtoTransformer, _}
+import coop.rchain.casper.engine.EngineCell._
+import coop.rchain.casper.engine._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util._
-import coop.rchain.casper.util.rholang.{ReplayFailure, RuntimeManager, Tools}
+import coop.rchain.casper.util.rholang.{RuntimeManager, Tools}
+import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.Signed
 import coop.rchain.graphz._
-import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.metrics.implicits._
-import coop.rchain.models.{BindPattern, BlockMetadata, ListParWithRandom, Par, TaggedContinuation}
-import coop.rchain.casper.ReportingCasper
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.models.BlockHash.{BlockHash, _}
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
-import coop.rchain.models.BlockHash.{BlockHash, _}
+import coop.rchain.models.{BlockMetadata, Par}
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rspace.{ReportingRspace, ReportingTransformer, StableHashProvider}
+import coop.rchain.rspace.ReportingRspace.ReportingEvent
+import coop.rchain.rspace.StableHashProvider
 import coop.rchain.rspace.trace._
 import coop.rchain.shared.Log
-import com.google.protobuf.ByteString
-import coop.rchain.crypto.PublicKey
-import coop.rchain.crypto.signatures.Signed
-import coop.rchain.rspace.ReportingRspace.{
-  ReportingComm,
-  ReportingConsume,
-  ReportingEvent,
-  ReportingProduce
-}
-import coop.rchain.casper.ReportingProtoTransformer
+
+import scala.collection.immutable
 
 object BlockAPI {
   type Error     = String

--- a/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
@@ -25,11 +25,19 @@ private final case class RNodeKeyValueStoreManager[F[_]: Concurrent: Log](
       maxEnvSize: Long = 100L * 1024L * 1024L * 1024L
   )
 
-  private val reportingEnvConfig = LmdbEnvConfig("reporting")
+  // Config name is used as a subfolder for LMDB files
+  private val dagStorageEnvConfig = LmdbEnvConfig(name = "dagstorage")
+  private val reportingEnvConfig  = LmdbEnvConfig(name = "reporting")
 
   // Database name to store instance name mapping (subfolder for LMDB store)
   // - keys with the same instance will be in one LMDB file (environment)
   private val dbInstanceMapping: Map[String, LmdbEnvConfig] = Map[String, LmdbEnvConfig](
+    // Block storage
+    ("block-metadata", dagStorageEnvConfig),
+    ("equivocation-tracker", dagStorageEnvConfig),
+    ("latest-messages", dagStorageEnvConfig),
+    ("invalid-blocks", dagStorageEnvConfig),
+    ("deploy-index", dagStorageEnvConfig),
     // Reporting (trace) cache
     ("reporting-cache", reportingEnvConfig)
   )

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -9,6 +9,7 @@ import cats.{Applicative, Monad}
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.{DeployData, _}
 import coop.rchain.casper.util.implicits._
@@ -468,7 +469,7 @@ object ProtoUtil {
         List.empty[BlockMetadata].pure
     }
 
-  def invalidLatestMessages[F[_]: Monad](
+  def invalidLatestMessages[F[_]: Sync](
       dag: BlockDagRepresentation[F]
   ): F[Map[Validator, BlockHash]] =
     dag.latestMessages.flatMap(

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper.addblock
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.helper.{BlockUtil, TestNode}
 import coop.rchain.casper.protocol._

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -10,7 +10,7 @@ import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{ETuple, Par}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
-import coop.rchain.rholang.interpreter.storage
+import coop.rchain.rholang.interpreter.storage.serializePar
 import coop.rchain.shared.ByteArrayOps._
 import coop.rchain.shared.Serialize
 import coop.rchain.shared.scalatestcontrib._
@@ -26,8 +26,7 @@ class MultiParentCasperMergeSpec
   import RSpaceUtil._
   import coop.rchain.casper.util.GenesisBuilder._
 
-  implicit val timeEff                      = new LogicalTime[Effect]
-  implicit val serializePar: Serialize[Par] = storage.serializePar
+  implicit val timeEff = new LogicalTime[Effect]
 
   val genesis = buildGenesis()
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{


### PR DESCRIPTION
## Overview
This PR introduces new implementation of DAG storage that uses `KeyValueStore` to persist data.
In separate PR will be the migration logic to transfer data from existing DAG file storage.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4092

### CPU and memory usage with main net state (including #2943)

Start with DAG storage migration (catch up phase).
![rnode-start-with-migration](https://user-images.githubusercontent.com/5306205/84882306-528cea00-b08f-11ea-8c38-50111ba682fd.png)

Start with migrated storage (catch up phase).
![rnode-start-normal](https://user-images.githubusercontent.com/5306205/84882366-6df7f500-b08f-11ea-8b17-90ab0b3fb3ea.png)

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
