### PR TITLE
Rchain 4095 slashed validator record

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -17,6 +17,7 @@ trait BlockDagStorage[F[_]] {
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
   def checkpoint(): F[Unit]
   def close(): F[Unit]
+  def recordSlasedValidator(validator: Validator): F[Unit]
 }
 
 object BlockDagStorage {
@@ -40,6 +41,7 @@ trait BlockDagRepresentation[F[_]] {
   def latestMessageHashes: F[Map[Validator, BlockHash]]
   def latestMessages: F[Map[Validator, BlockMetadata]]
   def invalidBlocks: F[Set[BlockMetadata]]
+  def slashedInvalidValidators: F[Set[Validator]]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/SlashedMessagePersistentIndex.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/SlashedMessagePersistentIndex.scala
@@ -1,0 +1,25 @@
+package coop.rchain.blockstorage.dag
+
+import java.nio.file.Path
+
+import cats.effect.Sync
+import coop.rchain.blockstorage.LatestMessagesLogIsCorrupted
+import coop.rchain.blockstorage.dag.codecs._
+import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
+import coop.rchain.models.Validator.Validator
+import coop.rchain.shared.Log
+import scodec.codecs._
+
+object SlashedMessagePersistentIndex {
+  type SlashedMessagePersistentIndex[F[_]] = PersistentIndex[F, Validator, Unit]
+
+  def load[F[_]: Sync: Log: RaiseIOError](
+      logPath: Path,
+      crcPath: Path
+  ): F[SlashedMessagePersistentIndex[F]] =
+    PersistentIndex.load[F, Validator, Unit](
+      logPath,
+      crcPath,
+      LatestMessagesLogIsCorrupted
+    )(Sync[F], Log[F], RaiseIOError[F], codecValidator, ignore(0))
+}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -116,6 +116,11 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         _          <- dagStorage.close()
       } yield result
     }
+  private def defaultSlashedInvalidValidatorCrc(dagDataDir: Path): Path =
+    dagDataDir.resolve("slashed-invalid-validator-checksum")
+
+  private def defaultSlashedInvalidValidatorLog(dagDataDir: Path): Path =
+    dagDataDir.resolve("slashed-invalid-validator-data")
 
   private def defaultLatestMessagesLog(dagDataDir: Path): Path =
     dagDataDir.resolve("latest-messsages-data")
@@ -171,6 +176,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         defaultInvalidBlocksCrc(dagDataDir),
         defaultBlockHasesByDeploy(dagDataDir),
         defaultBlockHasesByDeployCrc(dagDataDir),
+        defaultSlashedInvalidValidatorLog(dagDataDir),
+        defaultSlashedInvalidValidatorCrc(dagDataDir),
         defaultCheckpointsDir(dagDataDir),
         defaultBlockNumberIndex(dagDataDir),
         100L * 1024L * 1024L * 4096L,

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -10,6 +10,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
+import coop.rchain.models.Validator.Validator
 
 final class IndexedBlockDagStorage[F[_]: Monad](
     lock: Semaphore[F],
@@ -68,6 +69,9 @@ final class IndexedBlockDagStorage[F[_]: Monad](
   def checkpoint(): F[Unit] = underlying.checkpoint()
 
   def close(): F[Unit] = underlying.close()
+
+  def recordSlasedValidator(validator: Validator): F[Unit] =
+    underlying.recordSlasedValidator(validator)
 
   def lookupById(id: Int): F[Option[BlockMessage]] =
     idToBlocksRef.get.map(_.get(id.toLong))

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -66,14 +66,18 @@ object BlockCreator {
       import cats.instances.list._
       for {
         tipHashes             <- Estimator[F].tips(dag, genesis)
+        _ <- Log[F].info(s"Creating block with tip hashes ${tipHashes.map(PrettyPrinter.buildString)}")
         _                     <- spanF.mark("after-estimator")
         parentMetadatas       <- EstimatorHelper.chooseNonConflicting(tipHashes, dag)
+        _ <- Log[F].info(s"Creating block with parents ${parentMetadatas.map(b => PrettyPrinter.buildString(b.blockHash))}")
         maxBlockNumber        = ProtoUtil.maxBlockNumberMetadata(parentMetadatas)
+        _ <- Log[F].info(s"Creating block with maxBlockNumber ${maxBlockNumber}")
         invalidLatestMessages <- ProtoUtil.invalidLatestMessages(dag)
         deploys               <- extractDeploys(dag, parentMetadatas, maxBlockNumber, expirationThreshold)
         sender                = ByteString.copyFrom(validatorIdentity.publicKey.bytes)
         latestMessageOpt      <- dag.latestMessage(sender)
         seqNum                = latestMessageOpt.fold(0)(_.seqNum) + 1
+        _ <- Log[F].info(s"Creating block with seqNum ${seqNum}")
         // TODO: Add `slashingDeploys` to DeployStorage
         slashingDeploys = invalidLatestMessages.values.toList.map(
           invalidBlockHash =>
@@ -96,6 +100,7 @@ object BlockCreator {
         isActive = parents
           .traverse(b => isActiveValidator(b, runtimeManager, validatorIdentity))
           .map(_.forall(identity))
+        _ <- Log[F].info(s"Check isActive:${isActive} for creating block")
         justifications   <- computeJustifications(dag, parents)
         now              <- Time[F].currentMillis
         invalidBlocksSet <- dag.invalidBlocks

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -487,4 +487,8 @@ object ProtoUtil {
         case (_, blockHash) => invalidBlocks.map(_.blockHash).contains(blockHash)
       }
     }
+
+  def slashedInvalidValidators[F[_]: Monad](
+      dag: BlockDagRepresentation[F]
+  ): F[Set[Validator]] = dag.slashedInvalidValidators
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -134,6 +134,8 @@ object BlockDagStorageTestFixture {
         blockDagStorageDir.resolve("invalid-blocks-crc"),
         blockDagStorageDir.resolve("block-hashes-by-deploy-data"),
         blockDagStorageDir.resolve("block-hashes-by-deploy-crc"),
+        blockDagStorageDir.resolve("slashed-invalid-validator-data"),
+        blockDagStorageDir.resolve("slashed-invalid-validator-crc"),
         blockDagStorageDir.resolve("checkpoints"),
         blockDagStorageDir.resolve("block-number-index"),
         mapSize

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -438,6 +438,8 @@ object TestNode {
       blockDagDir.resolve("invalid-blocks-crc"),
       blockDagDir.resolve("block-hashes-by-deploy-data"),
       blockDagDir.resolve("block-hashes-by-deploy-crc"),
+      blockDagDir.resolve("slashed-invalid-validator-data"),
+      blockDagDir.resolve("slashed-invalid-validator-crc"),
       blockDagDir.resolve("checkpoints"),
       blockDagDir.resolve("block-number-index"),
       mapSize

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -183,6 +183,8 @@ class NodeRuntime private[node] (
       invalidBlocksCrcPath = blockdagStoragePath.resolve("invalidBlocksCrcPath"),
       blockHashesByDeployLogPath = blockdagStoragePath.resolve("blockHashesByDeployLogPath"),
       blockHashesByDeployCrcPath = blockdagStoragePath.resolve("blockHashesByDeployCrcPath"),
+      slashedInvalidValidatorLogPath = blockdagStoragePath.resolve("slashedInvalidValidatorLogPath"),
+      slashedInvalidValidatorCrcPath = blockdagStoragePath.resolve("slashedInvalidValidatorCrcPath"),
       checkpointsDirPath = blockdagStoragePath.resolve("checkpointsDirPath"),
       blockNumberIndexPath = blockdagStoragePath.resolve("blockNumberIndexPath"),
       mapSize = nodeConf.storage.lmdbMapSizeBlockdagstore,


### PR DESCRIPTION
## Overview
Once an invalid block is existed, the normal validator would keep slashing the validator in every block. This  slashed validator should be recorded.



### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4095


### Notes
<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
