### PR TITLE
RCHAIN-4093: split casper tests by folders [v0.9.23LTS]

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ env:
   # However, setting this value too low or leaving it at default value, 25% on
   # OpenJDK 11, makes some unit tests occasionally fail on OutOfMemoryError on
   # GitHub runners which have only 7GB of RAM.
-  _JAVA_OPTIONS: -XX:MaxRAMPercentage=60.0 -XX:MaxDirectMemorySize=128M
+  _JAVA_OPTIONS: -XX:MaxRAMPercentage=65.0 -XX:MaxDirectMemorySize=128M
 
 jobs:
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ env:
   # However, setting this value too low or leaving it at default value, 25% on
   # OpenJDK 11, makes some unit tests occasionally fail on OutOfMemoryError on
   # GitHub runners which have only 7GB of RAM.
-  _JAVA_OPTIONS: -XX:MaxRAMPercentage=80.0
+  _JAVA_OPTIONS: -XX:MaxRAMPercentage=60.0 -XX:MaxDirectMemorySize=128M
 
 jobs:
 
@@ -86,7 +86,13 @@ jobs:
         #
         # To learn about REMAINDER, see .github/run-unit-test-selection.
         tests:
-          - casper/test
+          - "'casper/test:testOnly coop.rchain.casper.addblock.*'"
+          - "'casper/test:testOnly coop.rchain.casper.api.*'"
+          - "'casper/test:testOnly coop.rchain.casper.batch1.*'"
+          - "'casper/test:testOnly coop.rchain.casper.batch2.*'"
+          - "'casper/test:testOnly coop.rchain.casper.engine.*'"
+          - "'casper/test:testOnly coop.rchain.casper.genesis.*'"
+          - "'casper/test:testOnly coop.rchain.casper.util.*'"
           - REMAINDER # Do not modify/remove!
     env:
       TESTS: ${{ matrix.tests }}

--- a/casper/src/test/scala/coop/rchain/casper/README.md
+++ b/casper/src/test/scala/coop/rchain/casper/README.md
@@ -1,0 +1,9 @@
+# Casper unit tests
+
+To parallelize execution of tests with CI, tests were grouped into folders.
+
+This enables to run tests in specific folder with wildcard e.g.  
+`sbt 'casper/test:testOnly coop.rchain.casper.addblock.*'`.
+
+ Main tests for multi parent casper are in these 3 folders: `addblock`, `batch1` and `batch2`.  
+ The idea is to equalize the duration per group (folder). Adding a block takes long enough to be alone in one folder. 

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.addblock
 
 import cats.effect.Sync
 import cats.implicits._
@@ -8,9 +8,9 @@ import coop.rchain.casper.helper.{BlockUtil, TestNode}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.RegistrySigGen
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
+import coop.rchain.casper._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.comm.rp.ProtocolHelper.packet
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -3,9 +3,11 @@ package coop.rchain.casper.api
 import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.casper.engine._
+import EngineCell._
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.engine._, EngineCell._
+import coop.rchain.casper.engine._
+import EngineCell._
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
@@ -13,6 +15,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Cell

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -13,6 +13,7 @@ import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.LogStub

--- a/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
@@ -9,9 +9,9 @@ import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.helper._
 import coop.rchain.casper.util.GenesisBuilder._
-import coop.rchain.casper.EngineWithCasper
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.ConstructDeploy.basicDeployData
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics.Metrics

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -16,6 +16,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.util._
 import coop.rchain.casper.util.ConstructDeploy.basicDeployData
 import coop.rchain.casper.util.rholang._
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}

--- a/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator, TestNo
 import coop.rchain.casper.util.GenesisBuilder.{buildGenesis, buildGenesisParameters}
 import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.casper.engine.Engine
-import coop.rchain.casper.{EngineWithCasper, SafetyOracle}
+import coop.rchain.casper.SafetyOracle
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.util.ConstructDeploy.{basicDeployData, sourceDeployNowF}
 import coop.rchain.metrics.Metrics
@@ -15,6 +15,7 @@ import coop.rchain.shared.{Cell, Log}
 import coop.rchain.models._
 import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.batch2.EngineWithCasper
 import monix.eval.Task
 import org.scalatest.{EitherValues, FlatSpec, Matchers}
 import monix.execution.Scheduler.Implicits.global

--- a/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
@@ -5,13 +5,14 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.engine.Engine
-import coop.rchain.casper.{EngineWithCasper, SafetyOracle}
+import coop.rchain.casper.SafetyOracle
 import coop.rchain.casper.helper._
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.GenesisBuilder._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.ConstructDeploy.basicDeployData
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.{Cell, Log}

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
@@ -1,20 +1,21 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
-import scala.util.Random._
-import cats.{Applicative, Functor, Monad}
 import cats.implicits._
+import coop.rchain.casper._
 import coop.rchain.casper.helper.TestNode
-import coop.rchain.casper.helper.TestNode._
+import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.protocol.DeployData
-import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.scalatestcontrib.{assert, fail, succeed, _}
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.exceptions.TestFailedException
+import org.scalactic.source
 import org.scalatest.Assertion
-import org.scalactic._
+import org.scalatest.exceptions.TestFailedException
+
+import scala.util.Random.shuffle
 
 trait MergeabilityRules {
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperBondingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperBondingSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperCommunicationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperCommunicationSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import cats.implicits._
 import coop.rchain.casper.helper.TestNode

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -1,10 +1,9 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
-import com.google.protobuf.ByteString
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.util.ConstructDeploy
-import coop.rchain.crypto.signatures.{Secp256k1, Signed}
+import coop.rchain.casper.{MultiParentCasper, NoNewDeploys}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperFinalizationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperFinalizationSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import cats.implicits._
 import coop.rchain.casper.helper.TestNode

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import cats.implicits._
 import coop.rchain.casper.helper.TestNode

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
@@ -1,5 +1,6 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
+import coop.rchain.casper.ReportingCasper
 import coop.rchain.casper.ReportingCasperData.BlockTracesReport
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
@@ -7,8 +8,8 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.models.BlockHash._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib.effectTest
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
 import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
 class MultiParentCasperReportingSpec extends FlatSpec with Matchers with Inspectors {
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
@@ -1,13 +1,14 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
-import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.util.rholang.{RegistrySigGen, RuntimeManager}
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
+import coop.rchain.casper.{Created, MultiParentCasper, MultiParentCasperImpl}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperSmokeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperSmokeSpec.scala
@@ -1,11 +1,11 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch1
 
 import cats.implicits._
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
-import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
@@ -1,19 +1,21 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
-import scala.collection.immutable.HashMap
-import scala.collection.mutable
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
+import coop.rchain.casper.SafetyOracle
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
-import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.immutable.HashMap
+import scala.collection.mutable
 
 class CliqueOracleTest
     extends FlatSpec

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EngineWithCasper.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EngineWithCasper.scala
@@ -1,7 +1,8 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
-import coop.rchain.casper.engine._, EngineCell._
-import cats._, cats.data._, cats.implicits._
+import cats._
+import coop.rchain.casper.MultiParentCasper
+import coop.rchain.casper.engine._
 import coop.rchain.casper.protocol.CasperMessage
 import coop.rchain.comm.PeerNode
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorHelperTest.scala
@@ -1,10 +1,11 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.{BlockDagStorage, IndexedBlockDagStorage}
+import coop.rchain.casper.EstimatorHelper
 import coop.rchain.casper.EstimatorHelper.conflicts
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator, TestNode}
 import coop.rchain.casper.protocol._

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorTest.scala
@@ -1,8 +1,6 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
-import scala.collection.immutable.HashMap
-import coop.rchain.casper.protocol.Bond
-import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.casper.Estimator
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{
@@ -10,12 +8,13 @@ import coop.rchain.casper.helper.{
   BlockGenerator,
   UnlimitedParentsEstimatorFixture
 }
+import coop.rchain.casper.protocol.Bond
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
-import com.google.protobuf.ByteString
-import coop.rchain.shared.Log
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.immutable.HashMap
 
 class EstimatorTest
     extends FlatSpec

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LimitedParentDepthSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LimitedParentDepthSpec.scala
@@ -1,7 +1,7 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
-import cats.syntax.traverse._
 import cats.instances.list._
+import cats.syntax.traverse._
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.util.ConstructDeploy.basicDeployData
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
@@ -1,30 +1,29 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
 import cats.Monad
 import cats.effect.{Resource, Sync}
 import com.google.protobuf.ByteString
-import coop.rchain.casper.engine._
-import EngineCell._
 import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
 import coop.rchain.casper.api.BlockAPI
+import coop.rchain.casper.engine._
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager
-import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.casper.{Estimator, SafetyOracle}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
-import coop.rchain.shared.{Cell, Log, Time}
+import coop.rchain.shared.{Cell, Time}
 import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 import monix.execution.schedulers.CanBlock
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.HashMap
 import scala.concurrent.duration._
 import scala.util.Random
-import monix.execution.Scheduler.Implicits.global
 
 class ManyValidatorsTest
     extends FlatSpec

--- a/casper/src/test/scala/coop/rchain/casper/batch2/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/RholangBuildTest.scala
@@ -1,20 +1,18 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
 import cats.implicits._
-import coop.rchain.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import coop.rchain.casper.genesis.contracts.Vault
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
-import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder._
 import coop.rchain.casper.util.RSpaceUtil._
 import coop.rchain.casper.util.rholang.RegistrySigGen
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.RChainScheduler
+import coop.rchain.shared.scalatestcontrib._
 import org.scalatest.{FlatSpec, Matchers}
 
 class RholangBuildTest extends FlatSpec with Matchers {

--- a/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
@@ -1,19 +1,20 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
-import cats.syntax.traverse._
-import cats.syntax.flatMap._
-import cats.syntax.either._
 import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
-import coop.rchain.casper.protocol.{DeployData, Justification}
+import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
+import coop.rchain.casper.{BlockStatus, ValidBlock, Validate}
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib.effectTest
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
 import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
 class SingleParentCasperSpec extends FlatSpec with Matchers with Inspectors {
   implicit val timeEff = new LogicalTime[Effect]

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -1,37 +1,38 @@
-package coop.rchain.casper
+package coop.rchain.casper.batch2
 
 import java.nio.file.Files
 
-import scala.collection.immutable.HashMap
 import cats.Monad
 import cats.implicits._
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.IndexedBlockDagStorage
+import coop.rchain.casper.helper.BlockGenerator._
+import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{
   BlockDagStorageFixture,
   BlockGenerator,
   UnlimitedParentsEstimatorFixture
 }
-import coop.rchain.casper.helper.BlockGenerator._
-import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.protocol._
-import coop.rchain.casper.util._
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
+import coop.rchain.casper.util._
 import coop.rchain.casper.util.rholang.{InterpreterUtil, RuntimeManager}
-import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.casper.{InvalidBlock, ValidBlock, Validate}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
-import coop.rchain.metrics._
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.shared.Time
 import coop.rchain.shared.scalatestcontrib._
-import com.google.protobuf.ByteString
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+
+import scala.collection.immutable.HashMap
 
 class ValidateTest
     extends FlatSpec

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
@@ -270,9 +270,9 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
   "A merge with many children" should "group by 255's until a single internal node is reached." in {
     val builder      = Vector.newBuilder[Blake2b512Random]
     val b2RandomBase = Blake2b512Random(emptyMsg)
-    for (i <- 0 until 20) {
+    for (i <- 0 until (20, 5)) {
       val splitOnce = b2RandomBase.splitByte(i.toByte)
-      for (j <- 0 until 255) {
+      for (j <- 0 until (255, 5)) {
         val splitTwice = splitOnce.splitByte(j.toByte)
         for (k <- 0 until 255) {
           val splitThrice = splitTwice.splitByte(k.toByte)
@@ -284,10 +284,10 @@ class Blake2b512RandomSpec extends FlatSpec with Matchers with Checkers with Con
     val res1   = merged.next()
     val res2   = merged.next()
     Base16.encode(res1) should be(
-      "1af9db74651a8aa5e667311151d6b556939d0eb478980cce2ebd0b2cbc7183a8"
+      "ceff4f6065e6b508b46f4c7b687c3b67eb3bcdcbb52a4ad098e481876b745156"
     )
     Base16.encode(res2) should be(
-      "e6015287968435ef7b9656daf52083619aeb237db24bf09b2f878575d616572a"
+      "d30832a104feffed4502542768e8f3b05d12593ba29aacdc086c4d1db405e4e6"
     )
   }
 }


### PR DESCRIPTION
## Overview
Copy of changes from dev branch PR #2936 and #2939.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4093

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
