### PR TITLE
RCHAIN-4097: Improved Web API error handling, log response errors

### DIFF
--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -600,7 +600,7 @@ class NodeRuntime private[node] (
         reportingCasper,
         webApi,
         nodeConf.apiServer.maxConnectionIdle
-      )(nodeDiscovery, connectionsCell, concurrent, rPConfAsk, consumer, s)
+      )(nodeDiscovery, connectionsCell, concurrent, rPConfAsk, consumer, s, log)
       httpFiber <- httpServerFiber.start
       _ <- Task.delay {
             Kamon.reconfigure(kamonConf.withFallback(Kamon.config()))

--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -8,6 +8,7 @@ import coop.rchain.node.NodeRuntime.TaskEnv
 import coop.rchain.node.api.WebApi
 import coop.rchain.node.diagnostics.NewPrometheusReporter
 import coop.rchain.node.effects.EventConsumer
+import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.http4s.implicits._
@@ -33,7 +34,8 @@ package object web {
       concurrent: Concurrent[Task],
       rPConfAsk: RPConfAsk[Task],
       consumer: EventConsumer[Task],
-      scheduler: Scheduler
+      scheduler: Scheduler,
+      log: Log[Task]
   ): Task[Unit] =
     for {
       event <- EventsInfo.service[Task]

--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -57,7 +57,7 @@ package object web {
       else
         Map.empty
       allRoutes = baseRoutes ++ extraRoutes
-      httpServerFiber <- BlazeServerBuilder[Task]
+      httpServerFiber <- BlazeServerBuilder[Task](scheduler)
                           .bindHttp(httpPort, host)
                           .withHttpApp(Router(allRoutes.toList: _*).orNotFound)
                           .withIdleTimeout(connectionIdleTimeout)

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -15,6 +15,7 @@ import coop.rchain.casper.protocol.{BlockInfo, BondInfo, DeployData, DeployInfo,
 import coop.rchain.node.NodeRuntime.TaskEnv
 import coop.rchain.node.api.WebApi
 import coop.rchain.node.api.WebApi._
+import coop.rchain.shared.Log
 import io.circe.Decoder.Result
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -180,6 +181,7 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
   implicit val decodePrepareResponse: Decoder[PrepareResponse]   = deriveDecoder[PrepareResponse]
   implicit val encodePrepareRequest: Encoder[PrepareRequest]     = deriveEncoder[PrepareRequest]
   implicit val et                                                = NodeRuntime.envToTask
+  implicit val log                                               = new Log.NOPLog[Task]
 
   val api   = genWebApi
   val route = WebApiRoutes.service[Task, TaskEnv](api)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ object Dependencies {
 
   val osClassifier: String = Detector.detect(Seq("fedora")).osClassifier
 
-  val circeVersion      = "0.12.0-M4"
+  val circeVersion      = "0.13.0"
   val enumeratumVersion = "1.5.13"
-  val http4sVersion     = "0.21.0-M2"
+  val http4sVersion     = "0.21.4"
   val kamonVersion      = "1.1.5"
   val catsVersion       = "2.1.0"
   val catsEffectVersion = "2.0.0"


### PR DESCRIPTION
## Overview
This PR updates dependencies of `http4s` and `circe` libraries which seems to resolve some errors that we see in our logs. This error was thrown when HTTP connection is cancelled due to timeout.
`ERROR o.h.blaze.channel.nio1.NIO1HeadStage - Abnormal NIO1HeadStage termination`

Fixes the case when _message_ in exception is `null` and correct error is not reported to the client. And writes all response errors to the log.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4097

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
