### PR TITLE
RCHAIN-4048: Limit the execution of exploratory deploy with phloLimit

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -778,16 +778,21 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
   def playExploratoryDeploy(term: String, hash: StateHash): F[Seq[Par]] = {
     // Create a deploy with newly created private key
     val (privKey, _) = Secp256k1.newKeyPair
+
+    // Creates signed deploy
     val deploy = ConstructDeploy.sourceDeploy(
       term,
       timestamp = System.currentTimeMillis,
-      phloLimit = Long.MaxValue,
+      // Hardcoded phlogiston limit / 1 REV if phloPrice=1
+      phloLimit = 100 * 1000 * 1000,
       sec = privKey
     )
+
     // Create return channel as first private name created in deploy term
     val rand = Tools.unforgeableNameRng(deploy.pk, deploy.data.timestamp)
     import coop.rchain.models.rholang.implicits._
     val returnName: Par = GPrivate(ByteString.copyFrom(rand.next()))
+
     // Execute deploy on top of specified block hash
     captureResultsWithErrors(hash, deploy, returnName)
   }


### PR DESCRIPTION
## Overview
Execution of exploratory deploy in v0.9.24 not limited and potentially can put presure on read-only node. In this PR execution is limited to 1e8 phlogistons which corresponds to 1 REV is phlo price is 1.
With refactoring of RuntimeManager we should introduce configuration parameter for this.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4048

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
