### PR TITLE
RCHAIN-4101: Add LMDB cache to Reporting API

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/codecs.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/codecs.scala
@@ -35,4 +35,6 @@ object codecs {
     byteVector => DeployData.from(DeployDataProto.parseFrom(byteVector.toArray)).right.get,
     signedDeployData => ByteVector(DeployData.toProto(signedDeployData).toByteArray)
   )
+
+  val codecByteString = xmapToByteString(variableSizeBytes(uint8, bytes))
 }

--- a/casper/src/main/scala/coop/rchain/casper/ReportMemStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ReportMemStore.scala
@@ -43,8 +43,8 @@ class ReportMemStoreImpl[F[_]: Sync](
 
   override def put(hash: ByteString, data: Seq[Seq[ReportingEvent]]): F[Unit] =
     for {
-      encoded <- Sync[F].delay(coder.encode(data).get)
-      _       <- encoded.map(b => store.put(hash, b))
+      encoded <- coder.encode(data).get
+      _       <- store.put(hash, encoded)
     } yield ()
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
@@ -1,11 +1,13 @@
 package coop.rchain.casper.batch1
 
-import coop.rchain.casper.ReportingCasper
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.util.ConstructDeploy
+import coop.rchain.casper.{ReportMemStore, ReportingCasper}
+import coop.rchain.models.{BindPattern, ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib.effectTest
+import coop.rchain.store.InMemoryStoreManager
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
@@ -22,19 +24,21 @@ class MultiParentCasperReportingSpec extends FlatSpec with Matchers with Inspect
       """ for(@a <- @"1"){ Nil } | @"1"!("x") """
     TestNode.standaloneEff(genesis).use { node =>
       import node._
+      import coop.rchain.rholang.interpreter.storage._
       implicit val timeEff = new LogicalTime[Effect]
-
-      val reportingCasper: ReportingCasper[Effect] =
-        ReportingCasper.rhoReporter(node.rhoHistoryRepository)
+      implicit val kvm     = InMemoryStoreManager[Effect]
 
       for {
-        deploy      <- ConstructDeploy.sourceDeployNowF(correctRholang)
-        signedBlock <- node.addBlock(deploy)
-        _           = logEff.warns.isEmpty should be(true)
-        dag         <- node.casperEff.blockDag
-        estimate    <- node.casperEff.estimator(dag)
-        _           = estimate shouldBe IndexedSeq(signedBlock.blockHash)
-        trace       <- reportingCasper.trace(signedBlock.blockHash)
+        reportingStore <- ReportMemStore
+                           .store[Effect, Par, BindPattern, ListParWithRandom, TaggedContinuation]
+        reportingCasper = ReportingCasper.rhoReporter(node.rhoHistoryRepository, reportingStore)
+        deploy          <- ConstructDeploy.sourceDeployNowF(correctRholang)
+        signedBlock     <- node.addBlock(deploy)
+        _               = logEff.warns.isEmpty should be(true)
+        dag             <- node.casperEff.blockDag
+        estimate        <- node.casperEff.estimator(dag)
+        _               = estimate shouldBe IndexedSeq(signedBlock.blockHash)
+        trace           <- reportingCasper.trace(signedBlock.blockHash)
         result = trace match {
           case Right(value) => value.head._2.foldLeft(0)(_ + _.length)
           case Left(_)      => 0

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -31,7 +31,7 @@ class LmdbKeyValueStoreSpec
 
   def withSut[F[_]: Concurrent: Log](f: KeyValueStoreSut[F] => F[Unit]) =
     for {
-      kvm <- LmdbStoreManager[F](tempPath.resolve(Random.nextString(32)))
+      kvm <- LmdbStoreManager[F](tempPath.resolve(Random.nextString(32)), 1024 * 1024 * 1024)
       sut = {
         implicit val kvm_ = kvm
         new KeyValueStoreSut[F]


### PR DESCRIPTION
## Overview
Currently reporting API uses in-memory cache for EventLog for a block that is replayed. This PR introduces LMDB store for this cache.
This should decrease the use of heap memory which is needed for nodes supporting exchanges.

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4101

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
