### PR TITLE
Set fault tolerance as 1 for valid old blocks (temp solution) for 0.9.23LTS

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -537,8 +537,16 @@ object BlockAPI {
   )(implicit casper: MultiParentCasper[F]): F[A] =
     for {
       dag <- casper.blockDag
-      normalizedFaultTolerance <- SafetyOracle[F]
-                                   .normalizedFaultTolerance(dag, block.blockHash) // TODO: Warn about parent block finalization
+      // TODO this is temporary solution to not calculate fault tolerance for old blocks which is costly
+      oldBlock  = dag.latestBlockNumber.map(_ - block.body.state.blockNumber).map(_ > 100)
+      isInvalid = dag.lookup(block.blockHash).map(_.get.invalid)
+      // Old block fault tolerance / invalid block has -1.0 fault tolerance
+      oldBlockFaultTolerance = isInvalid.map(if (_) -1f else 1f)
+      normalizedFaultTolerance <- oldBlock.ifM(
+                                   oldBlockFaultTolerance,
+                                   SafetyOracle[F]
+                                     .normalizedFaultTolerance(dag, block.blockHash)
+                                 )
       initialFault   <- casper.normalizedInitialFault(ProtoUtil.weightMap(block))
       faultTolerance = normalizedFaultTolerance - initialFault
       blockInfo      <- constructor(block, faultTolerance)


### PR DESCRIPTION
Apply https://github.com/rchain/rchain/pull/2947 to 0.9.23LTS


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
