### PR TITLE
RCHAIN-4109: Alignment + colors for logs

### DIFF
--- a/integration-tests/test/wait.py
+++ b/integration-tests/test/wait.py
@@ -45,7 +45,7 @@ class LogsContainMessage:
 
 class NodeStarted(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'coop.rchain.node.NodeRuntime - Listening for traffic on rnode')
+        super().__init__(node, 'Listening for traffic on rnode')
 
 
 class RunningStateEntered(LogsContainMessage):
@@ -60,17 +60,17 @@ class ApprovedBlockReceived(LogsContainMessage):
 
 class SentUnapprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Broadcasting UnapprovedBlock')
+        super().__init__(node, 'Broadcasting UnapprovedBlock')
 
 
 class BlockApproval(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Received block approval from')
+        super().__init__(node, 'Received block approval from')
 
 
 class SentApprovedBlock(LogsContainMessage):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'c.r.c.e.ApproveBlockProtocol$ApproveBlockProtocolImpl - Sending ApprovedBlock')
+        super().__init__(node, 'Sending ApprovedBlock')
 
 
 class LogsReMatch:

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
     <file>${rnode.data.dir}/rnode.log</file>
     <append>true</append>
     <encoder>
-      <pattern>%d{ISO8601, UTC} [%highlight(%-5level{5})] [%cyan(%-20.20thread{30})] [%cyan(%-29.29logger{29})]- %msg%n </pattern>
+      <pattern>%d{ISO8601, UTC} [%-5level{5}] [%-20.20thread{30}] [%-29.29logger{29}]- %msg%n </pattern>
     </encoder>
   </appender>
 

--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
     </filter>
     <!-- encoders are  by default assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%highlight(%-5level{5})] [%cyan(%-20.20thread{20})] [%cyan(%-29.29logger{29})] - %msg%n </pattern>
     </encoder>
   </appender>
 
@@ -20,7 +20,7 @@
     <file>${rnode.data.dir}/rnode.log</file>
     <append>true</append>
     <encoder>
-      <pattern>%d{ISO8601, UTC} [%thread] %-5level %logger - %msg%n</pattern>
+      <pattern>%d{ISO8601, UTC} [%highlight(%-5level{5})] [%cyan(%-20.20thread{30})] [%cyan(%-29.29logger{29})]- %msg%n </pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
This PR adds colors and alignment to logs for better readability to node console output. On logfile appender coloring is disabled - the only change is formatting.

<img width="1411" alt="Screenshot 2020-06-15 at 17 50 53" src="https://user-images.githubusercontent.com/1746367/84672063-c4025680-af30-11ea-8e8d-1cf563a5e9df.png">

https://rchain.atlassian.net/browse/RCHAIN-4109



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
