### PR TITLE
RCHAIN-4087: GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_ask_question.md
+++ b/.github/ISSUE_TEMPLATE/10_ask_question.md
@@ -1,0 +1,12 @@
+---
+name: Ask a question
+about: Asking a question related to RNode software
+labels: question
+---
+
+<!-- For questions related to RChain platform improvement process please open an issue on
+     RChain Improvement Proposals repository https://github.com/rchain/rchip-proposals/issues. -->
+
+<!-- Make sure you include information that can help us understand your question. -->
+
+<!-- Your question below this line. -->

--- a/.github/ISSUE_TEMPLATE/20_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/20_bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Report a bug
+about: Create a bug report to help us improve RNode software
+labels: bug
+---
+
+<!-- Please answer these questions before submitting a bug report. -->
+
+### What did you expect to see?
+
+### What did you see instead?
+
+### Steps to reproduce the bug
+<!-- Make sure you include information that can help us debug (code example, error messages, logs, ...). -->
+
+### What version of RNode are you using?
+
+### What is your environment?
+<!-- Operating system (Linux, Windows,...) and version, Docker, jdk version, etc. -->
+<!-- Blocks info and deploy related data if the bug is specific to the blockchain network. -->

--- a/.github/ISSUE_TEMPLATE/30_documentation.md
+++ b/.github/ISSUE_TEMPLATE/30_documentation.md
@@ -1,0 +1,20 @@
+---
+name: Request documentation improvement
+about: Suggest an enhancement related to documentation in RChain repository
+labels: enhancement
+---
+
+<!-- Thank you very much for your feedback. -->
+
+<!-- Please answer these questions before submitting a request. -->
+
+### If this relates to existing RChain documentation, please provide the complete, specific URL and location in the page
+
+
+### Please describe the problem including, missing, unclear or incorrect documentation
+
+
+### Please provide the improvement suggestion, including links to any reference material and examples
+
+
+### Please describe what if any part of this you can work on

--- a/.github/ISSUE_TEMPLATE/40_dev_template.md
+++ b/.github/ISSUE_TEMPLATE/40_dev_template.md
@@ -1,0 +1,26 @@
+---
+name: Developer team template (internal)
+about: Task planning and estimation
+---
+
+## Overview
+<!-- Describe the task or solution. -->
+
+### Impact
+<!-- Describe which part of the code will be impacted. -->
+
+### Dependencies
+<!-- To provide this solution, is any other work required in another component or by another team? -->
+
+### Design
+<!-- Describe the issues which need to be addressed or resolved before attempting implementation. -->
+
+### Steps to implement the solution
+<!-- Provide a list of steps needed to implement the solution. -->
+
+### Steps for integration testing
+<!-- If applicable, describe the steps for an integration test. -->
+
+### Resource estimation
+<!-- How many developers?
+Estimation of time required? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Propose RChain platform improvement (RCHIP)
     url: https://github.com/rchain/rchip-proposals/issues
     about: For RChain platform feature requests, you can consider open an issue on RChain Improvement Proposals repository
-  - name: Report security bug
-    url: https://developer.rchain.coop
-    about: Please report security related bugs here
+  # - name: Report security bug
+  #   url: https://developer.rchain.coop
+  #   about: Please report security related bugs here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Propose RChain platform improvement (RCHIP)
+    url: https://github.com/rchain/rchip-proposals/issues
+    about: For RChain platform feature requests, you can consider open an issue on RChain Improvement Proposals repository
+  - name: Report security bug
+    url: https://developer.rchain.coop
+    about: Please report security related bugs here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,13 @@
 ## Overview
-<sup>_What this PR does, and why it's needed_</sup>
+<!-- What this PR does, and why it's needed -->
 
 
-
-### JIRA ticket:
-<sup>_Create it if there isn't one already._</sup>
-
+### GitHub issue:
+<!-- Create it if there isn't one already. -->
 
 
 ### Notes
-<sup>_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._</sup>
-
+<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->
 
 
 ### Please make sure that this PR:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RChain
 
-[![Build Status](https://drone.rchain-dev.tk/api/badges/rchain/rchain/status.svg)](https://drone.rchain-dev.tk/rchain/rchain)
+[![Build Status](https://github.com/rchain/rchain/workflows/CI/badge.svg)](https://github.com/rchain/rchain/actions?query=workflow%3ACI+branch%3Astaging)
 [![codecov](https://codecov.io/gh/rchain/rchain/branch/master/graph/badge.svg)](https://codecov.io/gh/rchain/rchain)
 
 The open-source RChain project is building a decentralized, economic,


### PR DESCRIPTION
## Overview
Initial set of GitHub issue templates for users and developers. This is part of the effort to use GitHub for managing tickets instead of Jira.

Build badge in README file is updated to GitHub CI.

**NOTE: We still need a web page (Google form) for security bugs. This is commented out in this PR until the page is not created.**
Example of Ethereum site https://bounty.ethereum.org.

Example: https://github.com/tgrospic/rchain/issues/new/choose

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4087

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
