### PR TITLE
Optimization of loading partial block data (BlockStore)

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -3,12 +3,11 @@ package coop.rchain.blockstorage
 import java.nio.ByteBuffer
 import java.nio.file._
 
-import cats.Monad
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.mtl.MonadState
-
+import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.FileLMDBIndexBlockStore.Checkpoint
 import coop.rchain.blockstorage.StorageError.StorageErr
@@ -22,18 +21,16 @@ import coop.rchain.casper.protocol.{
   BlockMessageProto
 }
 import coop.rchain.lmdb.LMDBStore
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.ByteStringOps._
-import coop.rchain.shared.Language.ignore
 import coop.rchain.shared.{AtomicMonadState, Log}
-
 import monix.execution.atomic.AtomicAny
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava._
-import scala.util.matching.Regex
 
-import coop.rchain.metrics.{Metrics, MetricsSemaphore}
-import coop.rchain.metrics.Metrics.Source
+import scala.util.matching.Regex
 
 private final case class FileLMDBIndexBlockStoreState[F[_]: Sync](
     blockMessageRandomAccessFile: RandomAccessIO[F],
@@ -140,6 +137,11 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
                      .map(block => List(blockHash -> BlockMessage.from(block).right.get)) // TODO FIX-ME
                })
     } yield result
+
+  // Default implementation will use `get` to load the whole block so
+  //  this is optimization to only look at the index.
+  override def contains(blockHash: BlockHash)(implicit ap: Applicative[F]): F[Boolean] =
+    index.get(blockHash.toDirectByteBuffer).map(_.nonEmpty)
 
   override def put(f: => (BlockHash, BlockMessage)): F[Unit] =
     lock.withPermit(


### PR DESCRIPTION
## Overview
1. Implements `contains` on file implementation of BlockStore to use LMDB index instead of loading the whole block.
2. Use DAG storage to load finalized block number instead of loading the whole block.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
