### PR TITLE
RCHAIN-4087: Update issue templates for security bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/20_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/20_bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Report a bug
-about: Create a bug report to help us improve RNode software
+about: Create a bug report to help us improve RChain platform
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Propose RChain platform improvement (RCHIP)
     url: https://github.com/rchain/rchip-proposals/issues
     about: For RChain platform feature requests, you can consider open an issue on RChain Improvement Proposals repository
-  # - name: Report security bug
-  #   url: https://developer.rchain.coop
-  #   about: Please report security related bugs here
+  - name: Report security bug
+    url: https://docs.google.com/forms/d/1HzG8R0ex122YFYZsmb6QTOv4a0C9i_vwHjB9cpQGjBE
+    about: Please report security related bugs here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,6 @@
 <!-- What this PR does, and why it's needed -->
 
 
-### GitHub issue:
-<!-- Create it if there isn't one already. -->
-
-
 ### Notes
 <!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->
 


### PR DESCRIPTION
## Overview
Added security bug report template (link) to Google Form.

Also from PR template ticket info is removed.

First PR where issue templates are introduced: #2953.

Example: https://github.com/tgrospic/rchain/issues/new/choose

### JIRA ticket:
https://rchain.atlassian.net/browse/RCHAIN-4087

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
