### PR TITLE
CI update workflow with release artifacts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ on:
     branches:
       - dev
       - 'feature/**'
-    
+
 env:
   # This is read by every new JVM. Every JVM thinks it can use up to 80% of
   # total memory available to the system (used or unused). This may not be
@@ -216,7 +216,7 @@ jobs:
 
 
   # Get RNode Docker image and run integration tests.
-  # 
+  #
   # These steps are run directly on runner's host (note there's no container key
   # in the job configuration). That is because bind mounting in container runner
   # is broken[1] and we need to mount host's /tmp onto container's /tmp (see
@@ -385,57 +385,29 @@ jobs:
           docker push "$image_name:latest"
 
 
-  # Upload built packages to https://build.rchain-dev.tk.
+  # GitHub (create) release and packages
   release_packages:
     name: Release Packages
     needs:
       - run_unit_tests
       - run_integration_tests
       - build_packages
-    if: "false && github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/staging')"
+    if: "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
     runs-on: ubuntu-latest
-    container:
-      image: rchain/buildenv
-      options: --privileged # Needed for gcsfuse
     steps:
       - name: Load Packages
         uses: actions/download-artifact@v1
         with:
           name: artifacts-packages
-
-      - name: Publish Packages
-        env:
-          SERVICE_ACCOUNT_KEY: ${{ secrets.SERVICE_ACCOUNT_KEY }}
-          UPLOAD_BUCKET: ${{ secrets.UPLOAD_BUCKET }}
-        shell: bash
-        run: |
-          set -eu -o pipefail
-
-          for var in SERVICE_ACCOUNT_KEY UPLOAD_BUCKET; do
-              if [[ ! -v $var || -z ${!var} ]]; then
-                  echo "Required variable $var is not set." >&2
-                  exit 1
-              fi
-          done
-
-          version=$(cat artifacts-packages/version.txt)
-          dest_dir=release/$version
-
-          if [[ $GITHUB_REF == refs/heads/* ]]; then
-              dest_dir=staging/$version
-          fi
-
-          GOOGLE_APPLICATION_CREDENTIALS=$HOME/service_account_key.json
-          touch $GOOGLE_APPLICATION_CREDENTIALS
-          chmod 600 $_
-          builtin echo "$SERVICE_ACCOUNT_KEY" >$_
-          export GOOGLE_APPLICATION_CREDENTIALS
-
-          mkdir /tmp/upload
-          gcsfuse $UPLOAD_BUCKET /tmp/upload
-
-          mkdir -p /tmp/upload/$dest_dir
-          cp -av artifacts-packages/* /tmp/upload/$dest_dir/
+      - name: Update release and release artifacts
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: artifacts-packages/*
+          prerelease: true
+          draft: true
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
 
   # The following is for Bors to work. It's copied almost verbatim from
@@ -456,7 +428,7 @@ jobs:
 
   bors_try_success:
     name: bors build finished
-    needs: 
+    needs:
       - run_unit_tests
       - run_integration_tests
     if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
@@ -466,7 +438,7 @@ jobs:
 
   bors_try_failure:
     name: bors build finished
-    needs: 
+    needs:
       - run_unit_tests
       - run_integration_tests
     if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
@@ -479,7 +451,7 @@ jobs:
 
   bors_merge_success:
     name: bors build finished
-    needs: 
+    needs:
       - release_docker_image
       #- release_packages
     if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
@@ -489,7 +461,7 @@ jobs:
 
   bors_merge_failure:
     name: bors build finished
-    needs: 
+    needs:
       - release_docker_image
       #- release_packages
     if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"


### PR DESCRIPTION
## Overview
Update CI workflow to publish draft release with attached artifacts. To update existing release the tag should match.

~Also memory limit is configured separately for integration tests with lower value and with more memory for unit tests.~
This is moved to #2964.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
