### PR TITLE
Fix LMDB commit transaction when execution freezes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ env:
   # However, setting this value too low or leaving it at default value, 25% on
   # OpenJDK 11, makes some unit tests occasionally fail on OutOfMemoryError on
   # GitHub runners which have only 7GB of RAM.
-  _JAVA_OPTIONS: -XX:MaxRAMPercentage=65.0 -XX:MaxDirectMemorySize=128M
+  _JAVA_OPTIONS: -XX:MaxRAMPercentage=80.0 -XX:MaxDirectMemorySize=128M
 
 jobs:
 
@@ -267,6 +267,9 @@ jobs:
       # We don't use $CACHE_ROOT in host because it may not be (it is not)
       # writeable by host runner unprivileged account. See note above.
       HOST_CACHE_ROOT: /tmp/rchain-build-cache
+      # In integration tests multiple RNode instances are created so memory
+      # limit in lower to prevent sporadic crashes.
+      _JAVA_OPTIONS: -XX:MaxRAMPercentage=35.0
     steps:
       - name: Clone Repository
         uses: actions/checkout@v1

--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
@@ -10,22 +10,22 @@ import coop.rchain.shared.Resources.withResource
 import coop.rchain.store.KeyValueStore
 import org.lmdbjava._
 
+import scala.util.control.NonFatal
+
 final case class DbEnv[F[_]](env: Env[ByteBuffer], dbi: Dbi[ByteBuffer], done: F[Unit])
 
 final case class LmdbKeyValueStore[F[_]: Sync](
     getEnvDbi: F[DbEnv[F]]
 ) extends KeyValueStore[F] {
 
-  private def withTxn[T](
-      isWrite: Boolean
-  )(op: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
+  private def withReadTxn[T](op: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
     for {
       // Acquire current LMDB environment and DBI interface
       dbEnv <- getEnvDbi
       // "Done" must be called to mark finished operation with the environment/dbi
       DbEnv(env, dbi, done) = dbEnv
-      // Create read or write transaction
-      txnF = Sync[F].delay(if (isWrite) env.txnWrite else env.txnRead)
+      // Create read transaction
+      txnF = Sync[F].delay(env.txnRead)
       // Execute database operation, commit at the end
       result <- txnF.bracketCase(
                  txn =>
@@ -49,39 +49,68 @@ final case class LmdbKeyValueStore[F[_]: Sync](
                }
     } yield result
 
-  def withReadTxnF[T](f: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
-    withTxn(isWrite = false)(f)
+  // Ensures transaction is used only on one thread.
+  // > A write Transaction may only be used from the thread it was created on.
+  // https://lmdb.readthedocs.io/en/release/#threads
+  private def withTxnSingleThread[T](
+      isWrite: Boolean
+  )(op: (Txn[ByteBuffer], Dbi[ByteBuffer]) => T): F[T] =
+    for {
+      // Acquire current LMDB environment and DBI interface
+      dbEnv <- getEnvDbi
+      // "Done" must be called to mark finished operation with the environment/dbi
+      DbEnv(env, dbi, done) = dbEnv
+      // Create read or write transaction
+      txn = if (isWrite) env.txnWrite else env.txnRead
+      // Execute database operation, commit at the end
+      result <- try {
+                 // Execute DB operation within transaction
+                 val res = op(txn, dbi)
+                 // Commit transaction (read and write)
+                 txn.commit()
+                 // DB result
+                 res.pure[F]
+               } catch {
+                 case NonFatal(ex) =>
+                   // Ack done and rethrow error.
+                   done *> ex.raiseError[F, T]
+               } finally {
+                 // Close transaction at the end.
+                 txn.close()
+               }
+      // Ack done
+      _ <- done
+    } yield result
 
-  def withWriteTxnF[T](f: (Txn[ByteBuffer], Dbi[ByteBuffer]) => F[T]): F[T] =
-    withTxn(isWrite = true)(f)
+  def withWriteTxn[T](f: (Txn[ByteBuffer], Dbi[ByteBuffer]) => T): F[T] =
+    withTxnSingleThread(isWrite = true)(f)
 
   // GET
   override def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]] =
-    withReadTxnF { (txn, dbi) =>
-      import cats.instances.vector._
-      keys.toVector
-        .traverse(x => Sync[F].delay(Option(dbi.get(txn, x)).map(fromBuffer)))
-        .map(_.toSeq)
+    withReadTxn { (txn, dbi) =>
+      Sync[F].delay {
+        keys.map(x => Option(dbi.get(txn, x)).map(fromBuffer))
+      }
     }
 
   // PUT
   override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
-    withWriteTxnF { (txn, dbi) =>
-      Sync[F].delay(kvPairs.foreach {
+    withWriteTxn { (txn, dbi) =>
+      kvPairs.foreach {
         case (key, value) =>
           if (dbi.put(txn, key, toBuffer(value))) () else ()
-      })
+      }
     }
 
   // DELETE
   override def delete(keys: Seq[ByteBuffer]): F[Int] =
-    withWriteTxnF { (txn, dbi) =>
-      Sync[F].delay(keys.foldLeft(0)((acc, key) => if (dbi.delete(txn, key)) acc + 1 else acc))
+    withWriteTxn { (txn, dbi) =>
+      keys.foldLeft(0)((acc, key) => if (dbi.delete(txn, key)) acc + 1 else acc)
     }
 
   // ITERATE
   override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T] =
-    withReadTxnF { (txn, dbi) =>
+    withReadTxn { (txn, dbi) =>
       withResource(dbi.iterate(txn)) { iterator =>
         import scala.collection.JavaConverters._
         f(iterator.asScala.map(c => (c.key, c.`val`)))

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -742,7 +742,7 @@ object NodeRuntime {
         for {
           // Check if migration from DAG file storage to LMDB should be executed
           blockMetadataDb  <- casperStoreManager.database("block-metadata")
-          dagStrageIsEmpty <- blockMetadataDb.iterate(_.isEmpty.pure[F])
+          dagStrageIsEmpty <- blockMetadataDb.iterate(_.isEmpty)
           // TODO: remove `dagConfig`, it's not used anymore (after migration)
           _ <- BlockDagKeyValueStorage.importFromFileStorage(dagConfig).whenA(dagStrageIsEmpty)
           // Create DAG store

--- a/shared/src/main/scala/coop/rchain/store/InMemoryKeyValueStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/InMemoryKeyValueStore.scala
@@ -29,8 +29,9 @@ final case class InMemoryKeyValueStore[F[_]: Sync]() extends KeyValueStore[F] {
   override def delete(keys: Seq[ByteBuffer]): F[Int] =
     Sync[F].delay(keys.map(state.remove).count(_.nonEmpty))
 
-  override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T] = {
-    val iter = state.toIterator.map { case (k, v) => (k, v.toByteBuffer) }
-    f(iter)
-  }
+  override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => T): F[T] =
+    Sync[F].delay {
+      val iter = state.toIterator.map { case (k, v) => (k, v.toByteBuffer) }
+      f(iter)
+    }
 }

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStore.scala
@@ -9,5 +9,5 @@ trait KeyValueStore[F[_]] {
 
   def delete(keys: Seq[ByteBuffer]): F[Int]
 
-  def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => F[T]): F[T]
+  def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => T): F[T]
 }

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreCodec.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreCodec.scala
@@ -81,7 +81,7 @@ class KeyValueTypedStoreCodec[F[_]: Sync, K, V](
   override def toMap: F[Map[K, V]] =
     for {
       valuesBytes <- store.iterate(
-                      _.map { case (k, v) => (BitVector(k), BitVector(v)) }.toVector.pure[F]
+                      _.map { case (k, v) => (BitVector(k), BitVector(v)) }.toVector
                     )
       values <- valuesBytes.traverse {
                  case (k, v) =>


### PR DESCRIPTION
## Overview
LMDB has limitation for write transactions to be used on a single thread. 
https://lmdb.readthedocs.io/en/release/#threads

This PR fixes the implementation of LMDB store to not use suspended execution (Sync.delay) which can cause changing threads. This applies to read and write transactions because freezing of execution was noticed in both cases.

For the reference this was the buggy code.
https://github.com/rchain/rchain/blob/899954e422/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala#L21-L50

---

In this PR is also fix for CI to pass tests. Memory limit is set separately for integration tests with lower value and with more memory for unit tests.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
