### PR TITLE
RCHAIN-4111: provide block hash on exploratory deploy 

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
@@ -68,7 +68,9 @@ class ExploratoryDeployAPITest
           _              <- n2.propagateBlock(produceDeploys(1))(nodes: _*)
 
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
-          result <- exploratoryDeploy("new return in { for (@data <- @\"store\") {return!(data)}}")(
+          result <- exploratoryDeploy(
+                     "new return in { for (@data <- @\"store\") {return!(data)}}"
+                   )(
                      engineCell
                    ).map(_.right.value)
           (par, lastFinalizedBlock) = result

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -77,6 +77,8 @@ message BondStatusQuery {
 
 message ExploratoryDeployQuery{
   string term = 1;
+  string blockHash = 2;
+  bool usePreStateHash = 3;
 }
 
 message BondInfo{

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -235,7 +235,10 @@ object DeployGrpcServiceV1 {
         }
 
       def exploratoryDeploy(request: ExploratoryDeployQuery): Task[ExploratoryDeployResponse] =
-        defer(BlockAPI.exploratoryDeploy[F](request.term)) { r =>
+        defer(
+          BlockAPI
+            .exploratoryDeploy[F](request.term, Some(request.blockHash), request.usePreStateHash)
+        ) { r =>
           import ExploratoryDeployResponse.Message
           import ExploratoryDeployResponse.Message._
           ExploratoryDeployResponse(r.fold[Message](Error, {

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -40,7 +40,11 @@ trait WebApi[F[_]] {
 
   def findDeploy(deployId: String): F[LightBlockInfo]
 
-  def exploratoryDeploy(term: String): F[ExploratoryDeployResponse]
+  def exploratoryDeploy(
+      term: String,
+      blockHash: Option[String],
+      usePreStateHash: Boolean
+  ): F[ExploratoryDeployResponse]
 
   def getBlocksByHeights(startBlockNumber: Long, endBlockNumber: Long): F[List[LightBlockInfo]]
 
@@ -94,9 +98,13 @@ object WebApi {
         .findDeploy[F](toByteString(deployId))
         .flatMap(_.liftToBlockApiErr)
 
-    def exploratoryDeploy(term: String): F[ExploratoryDeployResponse] =
+    def exploratoryDeploy(
+        term: String,
+        blockHash: Option[String],
+        usePreStateHash: Boolean
+    ): F[ExploratoryDeployResponse] =
       BlockAPI
-        .exploratoryDeploy(term)
+        .exploratoryDeploy(term, blockHash, usePreStateHash)
         .flatMap(_.liftToBlockApiErr)
         .map(toExploratoryResponse)
 
@@ -145,6 +153,12 @@ object WebApi {
       deployer: String,
       signature: String,
       sigAlgorithm: String
+  )
+
+  final case class ExploreDeployRequest(
+      term: String,
+      blockHash: String,
+      usePreStateHash: Boolean
   )
 
   final case class DataRequest(

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -105,6 +105,7 @@ object WebApiRoutes {
     implicit val deployRequestDecoder = jsonOf[F, DeployRequest]
     implicit val dataRequestDecoder   = jsonOf[F, DataRequest]
     implicit val prepareDecoder       = jsonOf[F, PrepareRequest]
+    implicit val ExploreDeployRequest = jsonOf[F, ExploreDeployRequest]
 
     HttpRoutes.of[F] {
       case GET -> Root / "status" =>
@@ -124,7 +125,14 @@ object WebApiRoutes {
         req.handle[DeployRequest, String](webApi.deploy)
 
       case req @ POST -> Root / "explore-deploy" =>
-        req.handle[String, ExploratoryDeployResponse](webApi.exploratoryDeploy)
+        req.handle[String, ExploratoryDeployResponse](
+          term => webApi.exploratoryDeploy(term, none[String], true)
+        )
+
+      case req @ POST -> Root / "explore-deploy-by-block-hash" =>
+        req.handle[ExploreDeployRequest, ExploratoryDeployResponse](
+          req => webApi.exploratoryDeploy(req.term, Some(req.blockHash), req.usePreStateHash)
+        )
 
       // Get data
 

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -151,7 +151,12 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
       Task.delay(lightBlock).toReaderT
 
     // TODO: https://rchain.atlassian.net/browse/RCHAIN-4018
-    override def exploratoryDeploy(term: String): TaskEnv[ExploratoryDeployResponse] = ???
+    override def exploratoryDeploy(
+        term: String,
+        blockHash: Option[String],
+        usePreStateHash: Boolean
+    ): TaskEnv[ExploratoryDeployResponse] = ???
+
     override def getBlocksByHeights(
         startBlockNumber: Long,
         endBlockNumber: Long


### PR DESCRIPTION
make explore deploy api can be configured by blockHash and isPostStateHash

## Overview
https://rchain.atlassian.net/browse/RCHAIN-4111

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
