### PR TITLE
Reorganize TransportLayer, CommUtil, BlockStore helpers

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStoreSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStoreSyntax.scala
@@ -1,0 +1,35 @@
+package coop.rchain.blockstorage
+
+import cats.effect.Sync
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
+
+trait BlockStoreSyntax {
+  implicit final def syntaxBlockStore[F[_]: Sync](
+      blockStore: BlockStore[F]
+  ): BlockStoreOps[F] =
+    new BlockStoreOps[F](blockStore)
+}
+
+/**
+  * This kind of error should be in a group of fatal errors.
+  * E.g. for unsafe `get` we are expecting the message to be in the store and if it's not, node should stop.
+  *
+  * The point is to have the syntax to recognize these places, categorize errors and have meaningful error messages
+  * instead of generic text e.g. for Option - NoSuchElementException: None.get.
+  */
+final case class BlockStoreInconsistencyError(message: String) extends Exception(message)
+
+final class BlockStoreOps[F[_]: Sync](
+    // BlockStore extensions / syntax
+    private val blockStore: BlockStore[F]
+) {
+  // Get block, "unsafe" because method expects block already in the block store.
+  def getUnsafe(hash: BlockHash): F[BlockMessage] = {
+    def errMsg = s"BlockStore is missing hash ${PrettyPrinter.buildString(hash)}"
+    blockStore.get(hash) >>= (_.liftTo(BlockStoreInconsistencyError(errMsg)))
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -21,7 +21,7 @@ final class BlockDagRepresentationOps[F[_]: Sync](
 ) {
   // Get block metadata, "unsafe" because method expects block already in the DAG.
   def lookupUnsafe(hash: BlockHash): F[BlockMetadata] = {
-    def errMsg = s"Block hash ${PrettyPrinter.buildString(hash)} not found in the DAG."
+    def errMsg = s"DAG storage is missing hash ${PrettyPrinter.buildString(hash)}"
     dag.lookup(hash) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
   }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -1,5 +1,6 @@
 package coop.rchain
 
+import coop.rchain.blockstorage.BlockStoreSyntax
 import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
 import coop.rchain.metrics.Metrics
 
@@ -7,6 +8,9 @@ package object blockstorage {
   val BlockStorageMetricsSource: Metrics.Source =
     Metrics.Source(Metrics.BaseSource, "block-storage")
 
-  // Block storage syntax
-  object syntax extends BlockDagRepresentationSyntax
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxBlockStorage
 }
+
+// Block storage syntax
+trait AllSyntaxBlockStorage extends BlockStoreSyntax with BlockDagRepresentationSyntax

--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -96,7 +96,7 @@ object BlockCreator {
               SystemDeployUtil.generateSlashDeployRandomSeed(sender, seqNum)
             )
         )
-        parents <- parentMetadatas.toList.traverse(p => ProtoUtil.getBlock(p.blockHash))
+        parents <- parentMetadatas.toList.traverse(p => BlockStore[F].getUnsafe(p.blockHash))
         // there are 3 situations on judging whether the validator is active
         // 1. it is possible that you are active in some parents but not active in other parents
         // 2. all of the parents are in active state
@@ -179,7 +179,7 @@ object BlockCreator {
                  )
                  .foldLeftF(validDeploys) { (deploys, blockMetadata) =>
                    for {
-                     block        <- ProtoUtil.getBlock(blockMetadata.blockHash)
+                     block        <- BlockStore[F].getUnsafe(blockMetadata.blockHash)
                      blockDeploys = ProtoUtil.deploys(block).map(_.deploy)
                    } yield deploys -- blockDeploys
                  }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -11,6 +11,7 @@ import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.engine.Running
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
@@ -76,7 +77,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
       dag       <- casper.blockDag
       tipHashes <- casper.estimator(dag)
       tipHash   = tipHashes.head
-      tip       <- ProtoUtil.getBlock(tipHash)
+      tip       <- BlockStore[F].getUnsafe(tipHash)
     } yield tip
 }
 

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -7,6 +7,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage, EquivocationsTracker}
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.{DagOperations, DoublyLinkedDag, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.models.BlockHash.BlockHash
@@ -222,7 +223,7 @@ object EquivocationDetector {
       true.pure[F]
     } else {
       for {
-        justificationBlock <- ProtoUtil.getBlock[F](justificationBlockHash)
+        justificationBlock <- BlockStore[F].getUnsafe(justificationBlockHash)
         equivocationDetected <- isEquivocationDetectableThroughChildren[F](
                                  blockDag,
                                  equivocationRecord,
@@ -299,7 +300,7 @@ object EquivocationDetector {
       maybeLatestEquivocatingValidatorBlockHash match {
         case Some(blockHash) =>
           for {
-            latestEquivocatingValidatorBlock <- ProtoUtil.getBlock[F](blockHash)
+            latestEquivocatingValidatorBlock <- BlockStore[F].getUnsafe(blockHash)
             updatedEquivocationChildren <- if (latestEquivocatingValidatorBlock.seqNum > equivocationBaseBlockSeqNum) {
                                             addEquivocationChild[F](
                                               blockDag,
@@ -332,7 +333,7 @@ object EquivocationDetector {
     ).flatMap {
       case Some(equivocationChildHash) =>
         for {
-          equivocationChild <- ProtoUtil.getBlock[F](equivocationChildHash)
+          equivocationChild <- BlockStore[F].getUnsafe(equivocationChildHash)
         } yield equivocationChildren + equivocationChild
       case None =>
         throw new Exception(

--- a/casper/src/main/scala/coop/rchain/casper/Estimator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Estimator.scala
@@ -6,6 +6,7 @@ import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.casper.util.ProtoUtil.weightFromValidatorByDag
 import coop.rchain.catscontrib.ListContrib
@@ -79,8 +80,8 @@ final class Estimator[F[_]: Sync: Log: Metrics: Span](
         val mainHash +: secondaryHashes = rankedLatestHashes
 
         for {
-          maxBlockNumber   <- ProtoUtil.getBlockMetadata[F](mainHash, dag).map(_.blockNum)
-          secondaryParents <- secondaryHashes.traverse(ProtoUtil.getBlockMetadata[F](_, dag))
+          maxBlockNumber   <- dag.lookupUnsafe(mainHash).map(_.blockNum)
+          secondaryParents <- secondaryHashes.traverse(dag.lookupUnsafe)
           shallowParents = secondaryParents.filter(
             p => maxBlockNumber - p.blockNum <= maxParentDepth
           )

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -6,8 +6,7 @@ import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.casper.CasperState.CasperStateCell
-import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.catscontrib.ListContrib
+import coop.rchain.casper.syntax._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Log
 
@@ -35,7 +34,7 @@ final class LastFinalizedBlockCalculator[F[_]: Sync: Log: Concurrent: BlockStore
       finalizedChildHash: BlockHash
   ): F[Unit] =
     for {
-      block          <- ProtoUtil.getBlock[F](finalizedChildHash)
+      block          <- BlockStore[F].getUnsafe(finalizedChildHash)
       deploys        = block.body.deploys.map(_.deploy)
       deploysRemoved <- DeployStorage[F].remove(deploys)
       _ <- Log[F].info(

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -9,6 +9,7 @@ import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.CasperState.CasperStateCell
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util._
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.comm.CommUtil
@@ -238,7 +239,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
               RChainEvent.blockFinalised(updatedLastFinalizedBlockHash.base16String)
             )
             .whenA(lastFinalizedBlockHash != updatedLastFinalizedBlockHash)
-      blockMessage <- ProtoUtil.getBlock(updatedLastFinalizedBlockHash)
+      blockMessage <- BlockStore[F].getUnsafe(updatedLastFinalizedBlockHash)
     } yield blockMessage
 
   def blockDag: F[BlockDagRepresentation[F]] =

--- a/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper.protocol.{BlockMessage, Justification}
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.models.Validator.Validator
@@ -43,7 +44,7 @@ final class SynchronyConstraintChecker[F[_]: Sync: BlockStore: Log](
         true.pure[F]
       case Some(lastProposedBlockHash) =>
         for {
-          lastProposedBlock <- ProtoUtil.getBlock[F](lastProposedBlockHash)
+          lastProposedBlock <- BlockStore[F].getUnsafe(lastProposedBlockHash)
           // Guaranteed to be present since last proposed block was present
           seenSenders            <- calculateSeenSendersSince(lastProposedBlock, dag)
           lastProposedTuplespace = ProtoUtil.postStateHash(lastProposedBlock)

--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -1,19 +1,15 @@
 package coop.rchain.casper.api
 
+import cats.{Monad, _}
+import cats.effect.Sync
+import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.casper._
-import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.graphz._
-import coop.rchain.shared.Log
-
-import cats.Monad
-import cats.effect.Sync
-import cats._, cats.data._, cats.implicits._
-import cats.mtl._
-import cats.mtl.implicits._
+import coop.rchain.casper.syntax._
 import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.ski._
+import coop.rchain.graphz._
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.Log
 
 final case class ValidatorBlock(
     blockHash: String,
@@ -105,7 +101,7 @@ object GraphzGenerator {
       blockHashes: Vector[BlockHash]
   ): F[DagInfo[G]] =
     for {
-      blocks    <- blockHashes.traverse(ProtoUtil.getBlock[F])
+      blocks    <- blockHashes.traverse(BlockStore[F].getUnsafe)
       timeEntry = blocks.head.body.state.blockNumber
       validators = blocks.toList.map { b =>
         val blockHash       = PrettyPrinter.buildString(b.blockHash)

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -13,6 +13,7 @@ import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.casper.engine.EngineCell._
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.comm._
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.{BondsParser, VaultParser}

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -12,6 +12,7 @@ import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper._
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -11,6 +11,7 @@ import EngineCell._
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain
 
-import com.google.protobuf.ByteString
+import coop.rchain.casper.util.comm.CommUtilSyntax
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 
@@ -11,4 +11,9 @@ package object casper {
 
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
 
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxCasper with AllSyntaxComm with AllSyntaxBlockStorage
 }
+
+// Casper syntax
+trait AllSyntaxCasper extends CommUtilSyntax

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -258,7 +258,7 @@ object ProtoUtil {
                             .getOrElse(
                               Sync[F].raiseError(
                                 new RuntimeException(
-                                  s"Could not find a block for $hash in the DAG storage"
+                                  s"Could not find a block for ${PrettyPrinter.buildString(hash)} in the DAG storage"
                                 )
                               )
                             )

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -81,17 +81,6 @@ object ProtoUtil {
     } yield mainChain
   }
 
-  def getBlockMetadata[F[_]: Sync](
-      hash: BlockHash,
-      dag: BlockDagRepresentation[F]
-  ): F[BlockMetadata] =
-    dag.lookup(hash) >>= (
-      Sync[F].fromOption(
-        _,
-        new Exception(s"DAG storage is missing hash ${PrettyPrinter.buildString(hash)}")
-      )
-    )
-
   def creatorJustification(block: BlockMessage): Option[Justification] =
     block.justifications.find(_.validator == block.sender)
 
@@ -197,7 +186,7 @@ object ProtoUtil {
       dag: BlockDagRepresentation[F]
   ): F[List[BlockMetadata]] = {
     import cats.instances.list._
-    b.parents.traverse(getBlockMetadata(_, dag))
+    b.parents.traverse(dag.lookupUnsafe)
   }
 
   def getParentMetadatasAboveBlockNumber[F[_]: Sync](

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -1,13 +1,10 @@
 package coop.rchain.casper.util.comm
 
 import scala.concurrent.duration._
-
 import cats.effect._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
+import cats.syntax.all._
 import cats.tagless.autoFunctorK
-import cats.Applicative
-
+import cats.{Applicative, Monad}
 import coop.rchain.casper._
 import coop.rchain.casper.engine._
 import coop.rchain.casper.engine.Running.RequestedBlocks
@@ -17,54 +14,44 @@ import coop.rchain.comm.protocol.routing.{Packet, Protocol}
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.comm.rp.ProtocolHelper.packet
 import coop.rchain.comm.transport.{Blob, TransportLayer}
-import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared._
-
 import com.google.protobuf.ByteString
+import coop.rchain.casper.util.comm.CommUtil.StandaloneNodeSendToBootstrapError
 
+// TODO: remove CommUtil completely and move to extensions (syntax) on TransportLayer
 @autoFunctorK
 trait CommUtil[F[_]] {
-  def sendBlockHash(hash: BlockHash, blockCreator: ByteString): F[Unit]
-  def sendBlockRequest(hash: BlockHash): F[Unit]
-  def sendForkChoiceTipRequest: F[Unit]
-  def sendToPeers[Msg: ToPacket](message: Msg): F[Unit] = sendToPeers(ToPacket(message))
+  // Broadcast packet (in one piece)
   def sendToPeers(message: Packet): F[Unit]
-  def streamToPeers[Msg: ToPacket](message: Msg): F[Unit] = streamToPeers(ToPacket(message))
+
+  // Broadcast packet in chunks (stream)
   def streamToPeers(packet: Packet): F[Unit]
-  def requestApprovedBlock: F[Unit]
+
+  // Send packet with retry
+  def sendWithRetry(
+      message: Packet,
+      peer: PeerNode,
+      retryAfter: FiniteDuration,
+      messageTypeName: String // Only for log message / should be removed with CommUtil refactor
+  ): F[Unit]
+
+  // Send request for the block to all peers
+  def sendBlockRequest(hash: BlockHash): F[Unit]
 }
 
 object CommUtil {
 
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
+  // Standalone (bootstrap) node should try send messages to bootstrap node
+  final case object StandaloneNodeSendToBootstrapError extends Exception
+
   def apply[F[_]](implicit ev: CommUtil[F]): CommUtil[F] = ev
 
-  def of[F[_]: Concurrent: Log: Time: Metrics: TransportLayer: ConnectionsCell: RPConfAsk: RequestedBlocks]
+  def of[F[_]: Concurrent: TransportLayer: RPConfAsk: ConnectionsCell: RequestedBlocks: Log: Time]
       : CommUtil[F] =
     new CommUtil[F] {
-
-      def sendBlockHash(hash: BlockHash, blockCreator: ByteString): F[Unit] =
-        sendToPeers(BlockHashMessageProto(hash, blockCreator)) >>
-          Log[F].info(s"Sent hash ${PrettyPrinter.buildString(hash)} to peers")
-
-      def sendBlockRequest(hash: BlockHash): F[Unit] =
-        Running
-          .RequestedBlocks[F]
-          .read
-          .flatMap(
-            requested =>
-              Applicative[F].unlessA(requested.contains(hash))(
-                Running.addNewEntry(hash) >> sendToPeers(HasBlockRequestProto(hash)) >>
-                  Log[F]
-                    .info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
-              )
-          )
-
-      def sendForkChoiceTipRequest: F[Unit] =
-        sendToPeers(ForkChoiceTipRequest.toProto) >>
-          Log[F].info(s"Requested fork tip from peers")
 
       def sendToPeers(message: Packet): F[Unit] =
         for {
@@ -82,34 +69,78 @@ object CommUtil {
           _     <- TransportLayer[F].stream(peers, msg)
         } yield ()
 
-      def requestApprovedBlock: F[Unit] = {
-
-        def keepOnRequestingTillRunning(bootstrap: PeerNode, msg: Protocol): F[Unit] =
-          TransportLayer[F].send(bootstrap, msg) >>= {
+      def sendWithRetry(
+          message: Packet,
+          peer: PeerNode,
+          retryAfter: FiniteDuration,
+          msgTypeName: String
+      ): F[Unit] = {
+        def keepOnRequestingTillRunning(peer: PeerNode, msg: Protocol): F[Unit] =
+          TransportLayer[F].send(peer, msg) >>= {
             case Right(_) =>
-              Log[F].info(s"Successfully sent ApprovedBlockRequest to $bootstrap")
+              Log[F].info(s"Successfully sent ${msgTypeName} to $peer")
             case Left(error) =>
               Log[F].warn(
-                s"Failed to send ApprovedBlockRequest to $bootstrap because of ${CommError.errorMessage(error)}. Retrying in 10 seconds..."
-              ) >> Time[F].sleep(10 seconds) >> keepOnRequestingTillRunning(bootstrap, msg)
+                s"Failed to send ${msgTypeName} to $peer because of ${CommError
+                  .errorMessage(error)}. Retrying in $retryAfter..."
+              ) >> Time[F].sleep(retryAfter) >> keepOnRequestingTillRunning(peer, msg)
           }
 
         RPConfAsk[F].ask >>= { conf =>
-          conf.bootstrap match {
-            case Some(bootstrap) =>
-              val msg =
-                packet(
-                  conf.local,
-                  conf.networkId,
-                  ApprovedBlockRequest("PleaseSendMeAnApprovedBlock").toProto
-                )
-              Log[F].info("Starting to request ApprovedBlockRequest") >>
-                Concurrent[F].start(keepOnRequestingTillRunning(bootstrap, msg)).void
-            case None =>
-              Log[F].warn("Cannot request for an approved block as standalone") // TODO we should exit here
-          }
+          val msg = packet(conf.local, conf.networkId, message)
+          Log[F].info(s"Starting to request ${msg.getClass.getName}") >>
+            Concurrent[F].start(keepOnRequestingTillRunning(peer, msg)).void
         }
       }
-    }
 
+      def sendBlockRequest(hash: BlockHash): F[Unit] =
+        // TODO: Running is depending on CommUtil, it should't be used here
+        Running
+          .RequestedBlocks[F]
+          .read
+          .flatMap(
+            requested =>
+              Applicative[F].unlessA(requested.contains(hash))(
+                Running.addNewEntry(hash) >> sendToPeers(ToPacket(HasBlockRequestProto(hash))) >>
+                  Log[F]
+                    .info(s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
+              )
+          )
+
+    }
+}
+
+trait CommUtilSyntax {
+  implicit final def casperSyntaxCommUtil[F[_]](commUtil: CommUtil[F]): CommUtilOps[F] =
+    new CommUtilOps[F](commUtil)
+}
+
+final class CommUtilOps[F[_]](
+    // CommUtil extensions / syntax
+    private val commUtil: CommUtil[F]
+) {
+  def sendToPeers[Msg: ToPacket](message: Msg): F[Unit] =
+    commUtil.sendToPeers(ToPacket(message))
+
+  def streamToPeers[Msg: ToPacket](message: Msg): F[Unit] =
+    commUtil.streamToPeers(ToPacket(message))
+
+  def sendBlockHash(
+      hash: BlockHash,
+      blockCreator: ByteString
+  )(implicit m: Monad[F], log: Log[F]): F[Unit] =
+    sendToPeers(BlockHashMessageProto(hash, blockCreator)) >>
+      Log[F].info(s"Sent hash ${PrettyPrinter.buildString(hash)} to peers")
+
+  def sendForkChoiceTipRequest(implicit m: Monad[F], log: Log[F]): F[Unit] =
+    sendToPeers(ForkChoiceTipRequest.toProto) >>
+      Log[F].info(s"Requested fork tip from peers")
+
+  def requestApprovedBlock(implicit m: Sync[F], r: RPConfAsk[F]): F[Unit] =
+    for {
+      maybeBootstrap <- RPConfAsk[F].reader(_.bootstrap)
+      bootstrap      <- maybeBootstrap.liftTo(StandaloneNodeSendToBootstrapError)
+      msg            = ApprovedBlockRequest("PleaseSendMeAnApprovedBlock").toProto
+      _              <- commUtil.sendWithRetry(ToPacket(msg), bootstrap, 10.seconds, "ApprovedBlockRequest")
+    } yield ()
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -7,6 +7,7 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.rholang.RuntimeManager._
 import coop.rchain.casper.util.{DagOperations, ProtoUtil}
 import coop.rchain.crypto.codec.Base16
@@ -19,8 +20,6 @@ import coop.rchain.rholang.interpreter.ParBuilder
 import coop.rchain.rholang.interpreter.Runtime.BlockData
 import coop.rchain.shared.{Log, LogSource}
 import com.google.protobuf.ByteString
-import coop.rchain.casper.protocol.ProcessedSystemDeploy.Failed
-import coop.rchain.casper.util.rholang.SystemDeployPlayResult.{PlayFailed, PlaySucceeded}
 import coop.rchain.crypto.signatures.Signed
 import monix.eval.Coeval
 
@@ -250,7 +249,7 @@ object InterpreterUtil {
               ReplayIntoMergeBlockMetricsSource
             )
         _             <- Span[F].mark("before-compute-parents-post-state-get-blocks")
-        blocksToApply <- blockMetasToApply.traverse(b => ProtoUtil.getBlock(b.blockHash))
+        blocksToApply <- blockMetasToApply.traverse(b => BlockStore[F].getUnsafe(b.blockHash))
         _             <- Span[F].mark("before-compute-parents-post-state-replay")
         replayResult <- blocksToApply.foldM(initStateHash) { (stateHash, block) =>
                          (for {

--- a/comm/src/main/scala/coop/rchain/comm/package.scala
+++ b/comm/src/main/scala/coop/rchain/comm/package.scala
@@ -3,10 +3,10 @@ package coop.rchain
 import java.net.InetAddress
 
 import cats.effect.Sync
-import cats.implicits._
 import cats.mtl.ApplicativeAsk
-
+import cats.syntax.all._
 import coop.rchain.catscontrib.ski.kp
+import coop.rchain.comm.transport.TransportLayerSyntax
 import coop.rchain.metrics.Metrics
 
 package object comm {
@@ -34,4 +34,10 @@ package object comm {
           a.isMulticastAddress ||
           a.isSiteLocalAddress)
     )
+
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxComm
 }
+
+// Comm syntax
+trait AllSyntaxComm extends TransportLayerSyntax

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayerSyntax.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayerSyntax.scala
@@ -1,0 +1,48 @@
+package coop.rchain.comm.transport
+
+import cats.Monad
+import cats.syntax.all._
+import coop.rchain.casper.protocol.ToPacket
+import coop.rchain.comm.PeerNode
+import coop.rchain.comm.protocol.routing.Packet
+import coop.rchain.comm.rp.Connect.RPConfAsk
+import coop.rchain.comm.rp.ProtocolHelper.packet
+
+trait TransportLayerSyntax {
+  implicit final def commSyntaxTransportLayer[F[_]: Monad: RPConfAsk](
+      transport: TransportLayer[F]
+  ): TransportLayerOps[F] = new TransportLayerOps[F](transport)
+}
+
+final class TransportLayerOps[F[_]: Monad: RPConfAsk](
+    // TransportLayer extensions / syntax
+    private val transport: TransportLayer[F]
+) {
+  // Send packet (in one piece)
+  def sendToPeer(peer: PeerNode, message: Packet): F[Unit] =
+    for {
+      conf <- RPConfAsk[F].ask
+      msg  = packet(conf.local, conf.networkId, message)
+      _    <- transport.send(peer, msg)
+    } yield ()
+
+  // Send message (in one piece)
+  def sendToPeer[Msg: ToPacket](
+      peer: PeerNode,
+      message: Msg
+  ): F[Unit] = sendToPeer(peer, ToPacket(message))
+
+  // Send packet in chunks (stream)
+  def streamToPeer(peer: PeerNode, packet: Packet): F[Unit] =
+    for {
+      local <- RPConfAsk[F].reader(_.local)
+      msg   = Blob(local, packet)
+      _     <- transport.stream(peer, msg)
+    } yield ()
+
+  // Send message in chunks (stream)
+  def streamToPeer[Msg: ToPacket](
+      peer: PeerNode,
+      message: Msg
+  ): F[Unit] = streamToPeer(peer, ToPacket(message))
+}

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -145,13 +145,12 @@ class NodeRuntime private[node] (
     requestedBlocks <- Cell.mvarCell[Task, Map[BlockHash, Running.Requested]](Map.empty).toReaderT
     commUtil = CommUtil.of[Task](
       Concurrent[Task],
-      log,
-      time,
-      metrics,
       transport,
-      rpConnections,
       rpConfAsk,
-      requestedBlocks
+      rpConnections,
+      requestedBlocks,
+      log,
+      time
     )
 
     kademliaRPC = effects.kademliaRPC(
@@ -886,9 +885,9 @@ object NodeRuntime {
         _      <- engine.withCasper(_.fetchDependencies, Applicative[F].unit)
         _ <- Running.maintainRequestedBlocks[F](conf.casper.requestedBlocksTimeout)(
               Monad[F],
+              TransportLayer[F],
               rpConfAsk,
               requestedBlocks,
-              TransportLayer[F],
               Log[F],
               Time[F],
               Metrics[F]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -40,7 +40,7 @@ trait Reduce[M[_]] {
 
 }
 
-class DebruijnInterpreter[M[_], F[_]](
+class DebruijnInterpreter[M[_]](
     space: RhoTuplespace[M],
     dispatcher: => RhoDispatch[M],
     urnMap: Map[String, Par]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -66,7 +66,7 @@ object RholangAndScalaDispatcher {
       new RholangAndScalaDispatcher(dispatchTable)
 
     implicit lazy val reducer: Reduce[M] =
-      new DebruijnInterpreter[M, F](tuplespace, dispatcher, urnMap)
+      new DebruijnInterpreter[M](tuplespace, dispatcher, urnMap)
 
     (dispatcher, reducer)
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 import coop.rchain.shared.PathOps._
 import coop.rchain.rholang.interpreter.storage._
 
-final case class TestFixture(space: RhoISpace[Task], reducer: DebruijnInterpreter[Task, Task.Par])
+final case class TestFixture(space: RhoISpace[Task], reducer: DebruijnInterpreter[Task])
 
 trait PersistentStoreTester {
   implicit val ms: Metrics.Source = Metrics.BaseSource

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RholangOnlyDispatcher.scala
@@ -18,13 +18,13 @@ object RholangOnlyDispatcher {
       cost: _cost[M],
       parallel: Parallel[M],
       s: Sync[M]
-  ): (Dispatch[M, ListParWithRandom, TaggedContinuation], DebruijnInterpreter[M, F]) = {
+  ): (Dispatch[M, ListParWithRandom, TaggedContinuation], DebruijnInterpreter[M]) = {
 
     lazy val dispatcher: Dispatch[M, ListParWithRandom, TaggedContinuation] =
       new RholangOnlyDispatcher
 
-    implicit lazy val reducer: DebruijnInterpreter[M, F] =
-      new DebruijnInterpreter[M, F](
+    implicit lazy val reducer: DebruijnInterpreter[M] =
+      new DebruijnInterpreter[M](
         tuplespace,
         dispatcher,
         urnMap

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -809,7 +809,7 @@ class RholangMethodsCostsSpec
     }
   }
   def withReducer[R](
-      f: DebruijnInterpreter[Task, Task.Par] => Task[R]
+      f: DebruijnInterpreter[Task] => Task[R]
   )(implicit cost: _cost[Task]): R = {
 
     val test = for {

--- a/shared/src/main/scala/coop/rchain/catscontrib/BooleanF.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/BooleanF.scala
@@ -1,15 +1,16 @@
 package coop.rchain.catscontrib
 
-import cats._, cats.syntax.all._
+import cats.FlatMap
+import cats.syntax.all._
 
-final class BooleanF[F[_]: FlatMap](val self: F[Boolean]) {
-  def &&^(other: => F[Boolean]): F[Boolean] =
+final class BooleanF[F[_]](val self: F[Boolean]) extends AnyVal {
+  def &&^(other: => F[Boolean])(implicit f: FlatMap[F]): F[Boolean] =
     BooleanF.&&^[F](self, other)
 
-  def ||^(other: => F[Boolean]): F[Boolean] =
+  def ||^(other: => F[Boolean])(implicit f: FlatMap[F]): F[Boolean] =
     BooleanF.||^[F](self, other)
 
-  def not: F[Boolean] = BooleanF.~^(self)
+  def not(implicit f: FlatMap[F]): F[Boolean] = BooleanF.~^(self)
 }
 
 object BooleanF {

--- a/shared/src/main/scala/coop/rchain/shared/package.scala
+++ b/shared/src/main/scala/coop/rchain/shared/package.scala
@@ -3,8 +3,11 @@ package coop.rchain
 import coop.rchain.store.{KeyValueStoreSyntax, KeyValueTypedStoreSyntax}
 
 package object shared {
-  // Syntax for shared project
-  // TODO: unify syntax (extensions) with catscontrib,
-  //  one import per project similar as `import cats.syntax.all._`
-  object syntax extends KeyValueStoreSyntax with KeyValueTypedStoreSyntax
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxShared
 }
+
+// Syntax for shared project
+// TODO: unify syntax (extensions) with catscontrib,
+//  one import per project similar as `import cats.syntax.all._`
+trait AllSyntaxShared extends KeyValueStoreSyntax with KeyValueTypedStoreSyntax

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
@@ -11,7 +11,7 @@ trait KeyValueStoreSyntax {
 final class KeyValueStoreOps[F[_]](
     // KeyValueStore extensions / syntax
     private val store: KeyValueStore[F]
-) {
+) extends AnyVal {
   // From key-value store, with serializers for K and V, typed store can be created
   def toTypedStore[K, V](kCodec: Codec[K], vCodec: Codec[V])(
       implicit s: Sync[F]

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
@@ -4,20 +4,20 @@ import cats.Functor
 import cats.syntax.all._
 
 trait KeyValueTypedStoreSyntax {
-  implicit final def sharedSyntaxKeyValueTypedStore[F[_]: Functor, K, V](
+  implicit final def sharedSyntaxKeyValueTypedStore[F[_], K, V](
       store: KeyValueTypedStore[F, K, V]
   ): KeyValueTypedStoreOps[F, K, V] = new KeyValueTypedStoreOps[F, K, V](store)
 }
 
-final class KeyValueTypedStoreOps[F[_]: Functor, K, V](
+final class KeyValueTypedStoreOps[F[_], K, V](
     // KeyValueTypedStore extensions / syntax
     private val store: KeyValueTypedStore[F, K, V]
-) {
-  def get(key: K): F[Option[V]] = store.get(Seq(key)).map(_.head)
+) extends AnyVal {
+  def get(key: K)(implicit f: Functor[F]): F[Option[V]] = store.get(Seq(key)).map(_.head)
 
   def put(key: K, value: V): F[Unit] = store.put(Seq((key, value)))
 
-  def delete(key: K): F[Boolean] = store.delete(Seq(key)).map(_ == 1)
+  def delete(key: K)(implicit f: Functor[F]): F[Boolean] = store.delete(Seq(key)).map(_ == 1)
 
-  def contains(key: K): F[Boolean] = store.contains(Seq(key)).map(_.head)
+  def contains(key: K)(implicit f: Functor[F]): F[Boolean] = store.contains(Seq(key)).map(_.head)
 }


### PR DESCRIPTION
## Overview
This PR is not changing any functionality it's just refactoring of CommUtil interface to reduce basic functions which are moved to TransportLayer extensions (syntax).

Also two methods to get block data unsafe (with applicative error) are transformed to extension methods.

Implicit classes for extension methods for KeyValueStore now extends AnyVal for slightly better optimization. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
