### PR TITLE
Fix closing LMDB environment only if open

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbStoreManager.scala
@@ -140,8 +140,7 @@ private final case class LmdbStoreManagerImpl[F[_]: Concurrent: Log](
   override def shutdown: F[Unit] =
     for {
       // Close LMDB environment
-      st  <- varState.get
-      env <- st.envDefer.get
-      _   <- Sync[F].delay(env.close())
+      st <- varState.get
+      _  <- st.envDefer.get.map(_.close()).whenA(st.status == EnvOpen)
     } yield ()
 }


### PR DESCRIPTION
## Overview
Fix when node shutdown key-value store manager. Close is now called only on open environments.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
