### PR TITLE
fix explore deploy backward not compatible

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -237,7 +237,11 @@ object DeployGrpcServiceV1 {
       def exploratoryDeploy(request: ExploratoryDeployQuery): Task[ExploratoryDeployResponse] =
         defer(
           BlockAPI
-            .exploratoryDeploy[F](request.term, Some(request.blockHash), request.usePreStateHash)
+            .exploratoryDeploy[F](
+              request.term,
+              if (request.blockHash.isEmpty) none[String] else Some(request.blockHash),
+              request.usePreStateHash
+            )
         ) { r =>
           import ExploratoryDeployResponse.Message
           import ExploratoryDeployResponse.Message._

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -131,7 +131,11 @@ object WebApiRoutes {
 
       case req @ POST -> Root / "explore-deploy-by-block-hash" =>
         req.handle[ExploreDeployRequest, ExploratoryDeployResponse](
-          req => webApi.exploratoryDeploy(req.term, Some(req.blockHash), req.usePreStateHash)
+          req =>
+            if (req.blockHash.isEmpty)
+              webApi.exploratoryDeploy(req.term, none[String], req.usePreStateHash)
+            else
+              webApi.exploratoryDeploy(req.term, Some(req.blockHash), req.usePreStateHash)
         )
 
       // Get data


### PR DESCRIPTION
## Overview
https://github.com/rchain/rchain/pull/2967 introduce new form api of explore deploy.
But the old version grpc api doesn't compatible with it.
Fix the incompatible of it.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
