### PR TITLE
Fix hash mismatch when joins are not sorted

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
@@ -236,15 +236,6 @@ object HistoryRepositoryImpl {
       .get
       .toByteVector
 
-  private def encodeUnsorted[D](data: Seq[D])(implicit codec: Codec[D]): ByteVector =
-    codecSeqByteVector
-      .encode(
-        data
-          .map(d => Codec.encode[D](d).get.toByteVector)
-      )
-      .get
-      .toByteVector
-
   def encodeData[A](data: Seq[internal.Datum[A]])(implicit codec: Codec[Datum[A]]): ByteVector =
     encodeSorted(data)
 
@@ -267,8 +258,9 @@ object HistoryRepositoryImpl {
       .encode(
         joins
           .map(
-            channels => encodeUnsorted(channels)
+            channels => encodeSorted(channels)
           )
+          .sorted(util.ordByteVector)
       )
       .get
       .toByteVector

--- a/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
@@ -43,14 +43,14 @@ class EncodingSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyCh
       Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes3)
   }
 
-  "Joins list encode" should "preserve channel orderings" in forAll { (j1: Join, j2: Join) =>
-    whenever(j1 != j2) {
-      val joins         = j1 :: j2 :: Nil
-      val bytes         = HistoryRepositoryImpl.encodeJoins(joins)
-      val reversedBytes = HistoryRepositoryImpl.encodeJoins(joins.reverse)
-
-      HistoryRepositoryImpl.decodeJoins(bytes)(codecChannel) shouldBe (joins)
-      HistoryRepositoryImpl.decodeJoins(reversedBytes)(codecChannel) shouldBe (joins.reverse)
-    }
+  "Joins list encode" should "return same hash for different orderings of each channel list" in forAll {
+    (j1: Join, j2: Join, j3: Join) =>
+      val bytes1 = HistoryRepositoryImpl.encodeJoins(j1 :: j2 :: j3 :: Nil)
+      val bytes2 = HistoryRepositoryImpl.encodeJoins(j3 :: j2 :: j1 :: Nil)
+      val bytes3 = HistoryRepositoryImpl.encodeJoins(j2 :: j3 :: j1 :: Nil)
+      val bytes4 = HistoryRepositoryImpl.encodeJoins(j1 :: j3 :: j2 :: Nil)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes2)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes3)
+      Blake2b256Hash.create(bytes1) shouldBe Blake2b256Hash.create(bytes4)
   }
 }


### PR DESCRIPTION
## Overview
Revert of this PR #2436 which allows unsorted joins and join channels.

[Bonding tests](https://github.com/ArturGajowy/rchain/blob/a2aeaf0d8/casper/src/test/scala/coop/rchain/casper/MultiParentCasperBondingSpec.scala) that were failing, mentioned in #2436, are removed in PR #2518.

TODO: Add details.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
