### PR TITLE
Prioritise pendant block when picking the next bock to add

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -274,9 +274,12 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
                           } yield !missingDep
                         }
       enqueued <- BlockRetriever[F].getEnqueuedToCasper
-      all      = enqueued ++ depFreePendants
-      _ <- Log[F].info(s"Blocks ready to be added: enqueued to Casper ${PrettyPrinter
-            .buildString(enqueued)}, buffer pendants ${PrettyPrinter.buildString(depFreePendants)}.")
+      all      = depFreePendants ++ enqueued
+      _ <- Log[F].info(
+            s"Blocks ready to be added: " +
+              s"dependency free buffer pendants ${PrettyPrinter.buildString(depFreePendants)}, " +
+              s"enqueued to Casper ${PrettyPrinter.buildString(enqueued)}"
+          )
     } yield all.headOption
   }
 


### PR DESCRIPTION
## Overview
In rare cases in while catching up node can stuck adding blocks and requires restart to continue.

This is because node prioritise blocks that are in BlockRetriever but not in Casper yet (enqueued to Casper), over CasperBuffer dependency free pendants. In general case enqueued to Casper list should be empty when node is catching up, but when node is under load, this might lead to blocking.

This PR is a fix for https://github.com/rchain/rchain/pull/2943, to prioritise dependency free blocks.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
