### PR TITLE
Use one gRPC channel per peer

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -3,11 +3,12 @@ package coop.rchain.comm.transport
 import java.io.ByteArrayInputStream
 import java.nio.file.Path
 
+import cats.Applicative
+import cats.effect.concurrent.{Deferred, Ref}
+
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util._
-
 import cats.implicits._
-
 import coop.rchain.catscontrib.ski.kp
 import coop.rchain.comm._
 import coop.rchain.comm.protocol.routing._
@@ -16,7 +17,6 @@ import coop.rchain.grpc.implicits._
 import coop.rchain.metrics.Metrics
 import coop.rchain.shared.{Log, UncaughtExceptionLogger}
 import coop.rchain.shared.PathOps.PathDelete
-
 import io.grpc.ManagedChannel
 import io.grpc.netty._
 import io.netty.handler.ssl.SslContext
@@ -31,7 +31,8 @@ class GrpcTransportClient(
     maxMessageSize: Int,
     packetChunkSize: Int,
     tempFolder: Path,
-    clientQueueSize: Int
+    clientQueueSize: Int,
+    channelsMap: Ref[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]]
 )(
     implicit scheduler: Scheduler,
     val log: Log[Task],
@@ -77,7 +78,7 @@ class GrpcTransportClient(
         case Left(t)           => Task.raiseError[SslContext](t)
       }
 
-  private def clientChannel(peer: PeerNode): Task[ManagedChannel] =
+  private def createChannel(peer: PeerNode): Task[ManagedChannel] =
     for {
       clientSslContext <- clientSslContextTask
       c <- Task.delay {
@@ -93,18 +94,41 @@ class GrpcTransportClient(
           }
     } yield c
 
-  def disconnect(peer: PeerNode): Task[Unit] = Task.unit
+  def getChannel(peer: PeerNode): Task[ManagedChannel] =
+    for {
+      cDefNew <- Deferred[Task, ManagedChannel]
+      ret <- channelsMap.modify[(Deferred[Task, ManagedChannel], Boolean)] { chMap =>
+              val noCh = !chMap.exists(c => c._1 equals peer)
+              if (noCh) {
+                (chMap + (peer -> cDefNew), (cDefNew, true))
+              } else {
+                (chMap, (chMap(peer), false))
+              }
+            }
+      (cDef, newChannel) = ret
+      _ <- Applicative[Task].whenA(newChannel)(
+            log.info(s"Creating new channel to peer ${peer.toAddress}") >>
+              createChannel(peer) >>= cDef.complete
+          )
+      c <- cDef.get
+      // In case channel is terminated - remove current record and try one more time
+      r <- if (c.isTerminated)
+            log.info(
+              s"Channel to peer ${peer.toAddress} is terminated, removing from connections map"
+            ) >>
+              channelsMap.update(_ - peer) >> getChannel(peer)
+          else
+            c.pure[Task]
+    } yield r
 
   private def withClient[A](peer: PeerNode, timeout: FiniteDuration)(
       request: GrpcTransport.Request[A]
   ): Task[CommErr[A]] =
     (for {
-      //_       <- log.debug(s"Creating new channel to peer ${peer.toAddress}")
-      channel <- clientChannel(peer)
+      channel <- getChannel(peer)
       stub    <- Task.delay(RoutingGrpcMonix.stub(channel).withDeadlineAfter(timeout))
-      result  <- request(stub).doOnFinish(kp(Task.delay(channel.shutdown()).attempt.void))
-      //_       <- log.debug(s"Send request to peer ${peer.toAddress} done")
-      _ <- Task.unit.asyncBoundary // return control to caller thread
+      result  <- request(stub)
+      _       <- Task.unit.asyncBoundary // return control to caller thread
     } yield result).attempt.map(_.fold(e => Left(protocolException(e)), identity))
 
   def send(peer: PeerNode, msg: Protocol): Task[CommErr[Unit]] =

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -2,8 +2,9 @@ package coop.rchain.comm.transport
 
 import java.nio.file._
 
-import scala.concurrent.duration.Duration
+import cats.effect.concurrent.{Deferred, Ref}
 
+import scala.concurrent.duration.Duration
 import coop.rchain.comm._
 import coop.rchain.comm.rp.Connect.RPConfAsk
 import coop.rchain.crypto.codec.Base16
@@ -11,7 +12,7 @@ import coop.rchain.crypto.util.{CertificateHelper, CertificatePrinter}
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared.Log
-
+import io.grpc.ManagedChannel
 import monix.catnap.MVar
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -59,7 +60,8 @@ class TcpTransportLayerSpec
         maxMessageSize,
         maxMessageSize,
         tempFolder,
-        100
+        100,
+        Ref.unsafe[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]](Map.empty)
       )
     )
 


### PR DESCRIPTION
Attempt to address this issue https://github.com/rchain/rchain/issues/3005
ATM each p2p call opens new gRPC connection, which does TLS handshake, allocates TCP port and so on. 
This PR makes transport client open a single gRPC connection per peer and use it for all subsequent calls.

Also as per https://github.com/grpc/grpc/issues/7058 `channels are intended to be shared among stubs.`

For now it's not clear if we can/should go even further and use a single stub to execute all requests, that needs some research.
https://github.com/rchain/rchain/blob/ff17c3988c43ce7d038c30e20fb7da511634dd39/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala#L128-L131

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
