### PR TITLE
Enable per peer outbound streaming queue

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -21,8 +21,19 @@ import io.grpc.ManagedChannel
 import io.grpc.netty._
 import io.netty.handler.ssl.SslContext
 import monix.eval.Task
-import monix.execution.Scheduler
+import monix.execution.Ack.Continue
+import monix.execution.{CancelableFuture, Scheduler}
 import monix.reactive.Observable
+
+/**
+  * GRPC channel with a message buffer protecting it from resource exhaustion
+  * @param grpcTransport underlying gRPC channel
+  * @param buffer buffer implementing some kind of overflow policy
+  */
+final case class BufferedGrpcStreamChannel(
+    grpcTransport: ManagedChannel,
+    buffer: StreamObservable
+)
 
 class GrpcTransportClient(
     networkId: String,
@@ -32,7 +43,7 @@ class GrpcTransportClient(
     packetChunkSize: Int,
     tempFolder: Path,
     clientQueueSize: Int,
-    channelsMap: Ref[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]]
+    channelsMap: Ref[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel]]]
 )(
     implicit scheduler: Scheduler,
     val log: Log[Task],
@@ -44,25 +55,8 @@ class GrpcTransportClient(
   implicit val metricsSource: Metrics.Source =
     Metrics.Source(CommMetricsSource, "rp.transport")
 
-  private def certInputStream  = new ByteArrayInputStream(cert.getBytes())
-  private def keyInputStream   = new ByteArrayInputStream(key.getBytes())
-  private val streamObservable = new StreamObservable(clientQueueSize, tempFolder)
-  private val parallelism      = Math.max(Runtime.getRuntime.availableProcessors(), 2)
-  private val streamQueue =
-    streamObservable
-      .flatMap { s =>
-        Observable
-          .fromIterable(s.peers)
-          .mapParallelUnordered(parallelism)(
-            streamBlobFile(s.path, _, s.sender)
-          )
-          .guarantee(s.path.deleteSingleFile[Task]())
-      }
-
-  // Start to consume the stream queue immediately
-  private val _ = streamQueue.subscribe()(
-    Scheduler.fixedPool("tl-client-stream-queue", parallelism, reporter = UncaughtExceptionLogger)
-  )
+  private def certInputStream = new ByteArrayInputStream(cert.getBytes())
+  private def keyInputStream  = new ByteArrayInputStream(key.getBytes())
 
   private val clientSslContextTask: Task[SslContext] =
     Task
@@ -78,26 +72,34 @@ class GrpcTransportClient(
         case Left(t)           => Task.raiseError[SslContext](t)
       }
 
-  private def createChannel(peer: PeerNode): Task[ManagedChannel] =
+  private def createChannel(peer: PeerNode): Task[BufferedGrpcStreamChannel] =
     for {
       clientSslContext <- clientSslContextTask
-      c <- Task.delay {
-            NettyChannelBuilder
-              .forAddress(peer.endpoint.host, peer.endpoint.tcpPort)
-              .executor(scheduler)
-              .maxInboundMessageSize(maxMessageSize)
-              .negotiationType(NegotiationType.TLS)
-              .sslContext(clientSslContext)
-              .intercept(new SslSessionClientInterceptor(networkId))
-              .overrideAuthority(peer.id.toString)
-              .build()
-          }
-    } yield c
+      grpcChannel = NettyChannelBuilder
+        .forAddress(peer.endpoint.host, peer.endpoint.tcpPort)
+        .executor(scheduler)
+        .maxInboundMessageSize(maxMessageSize)
+        .negotiationType(NegotiationType.TLS)
+        .sslContext(clientSslContext)
+        .intercept(new SslSessionClientInterceptor(networkId))
+        .overrideAuthority(peer.id.toString)
+        .build()
+      buffer = new StreamObservable(peer, clientQueueSize, tempFolder)
 
-  def getChannel(peer: PeerNode): Task[ManagedChannel] =
+      channel = BufferedGrpcStreamChannel(grpcChannel, buffer)
+
+      _ = buffer.subscribe(
+        sMsg =>
+          streamBlobFile(sMsg.path, peer, sMsg.sender)
+            .guarantee(sMsg.path.deleteSingleFile[Task])
+            .runToFuture >> Continue.pure[CancelableFuture]
+      )
+    } yield channel
+
+  private def getChannel(peer: PeerNode): Task[BufferedGrpcStreamChannel] =
     for {
-      cDefNew <- Deferred[Task, ManagedChannel]
-      ret <- channelsMap.modify[(Deferred[Task, ManagedChannel], Boolean)] { chMap =>
+      cDefNew <- Deferred[Task, BufferedGrpcStreamChannel]
+      ret <- channelsMap.modify[(Deferred[Task, BufferedGrpcStreamChannel], Boolean)] { chMap =>
               val noCh = !chMap.exists(c => c._1 equals peer)
               if (noCh) {
                 (chMap + (peer -> cDefNew), (cDefNew, true))
@@ -111,14 +113,13 @@ class GrpcTransportClient(
               createChannel(peer) >>= cDef.complete
           )
       c <- cDef.get
-      // In case channel is terminated - remove current record and try one more time
-      r <- if (c.isTerminated)
+      // In case underlying gRPC transport is terminated - remove current record and try one more time
+      r <- if (c.grpcTransport.isTerminated)
             log.info(
               s"Channel to peer ${peer.toAddress} is terminated, removing from connections map"
             ) >>
               channelsMap.update(_ - peer) >> getChannel(peer)
-          else
-            c.pure[Task]
+          else c.pure[Task]
     } yield r
 
   private def withClient[A](peer: PeerNode, timeout: FiniteDuration)(
@@ -126,7 +127,7 @@ class GrpcTransportClient(
   ): Task[CommErr[A]] =
     (for {
       channel <- getChannel(peer)
-      stub    <- Task.delay(RoutingGrpcMonix.stub(channel).withDeadlineAfter(timeout))
+      stub    <- Task.delay(RoutingGrpcMonix.stub(channel.grpcTransport).withDeadlineAfter(timeout))
       result  <- request(stub)
       _       <- Task.unit.asyncBoundary // return control to caller thread
     } yield result).attempt.map(_.fold(e => Left(protocolException(e)), identity))
@@ -138,10 +139,10 @@ class GrpcTransportClient(
     Task.gatherUnordered(peers.map(send(_, msg)))
 
   def stream(peer: PeerNode, blob: Blob): Task[Unit] =
-    stream(Seq(peer), blob)
+    getChannel(peer).flatMap(_.buffer.enque(blob))
 
   def stream(peers: Seq[PeerNode], blob: Blob): Task[Unit] =
-    streamObservable.stream(peers, blob)
+    Task.gatherUnordered(peers.map(stream(_, blob))).void
 
   private def streamBlobFile(
       path: Path,
@@ -154,18 +155,20 @@ class GrpcTransportClient(
 
     PacketOps.restore[Task](path) >>= {
       case Right(packet) =>
-        withClient(peer, timeout(packet))(
-          GrpcTransport.stream(networkId, peer, Blob(sender, packet), packetChunkSize)
-        ).flatMap {
-          case Left(error) =>
-            log.debug(
-              s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
-            )
-          case Right(_) => log.debug(s"Streamed packet $path to $peer")
-        }
+        log.debug(
+          s"Attempting to stream packet to $peer with timeout: ${timeout(packet).toMillis}ms"
+        ) >>
+          withClient(peer, timeout(packet))(
+            GrpcTransport.stream(networkId, peer, Blob(sender, packet), packetChunkSize)
+          ).flatMap {
+            case Left(error) =>
+              log.debug(
+                s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
+              )
+            case Right(_) => log.debug(s"Streamed packet $path to $peer")
+          }
       case Left(error) =>
         log.error(s"Error while streaming packet $path to $peer: ${error.message}")
     }
   }
-
 }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -61,7 +61,7 @@ class TcpTransportLayerSpec
         maxMessageSize,
         tempFolder,
         100,
-        Ref.unsafe[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]](Map.empty)
+        Ref.unsafe[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel]]](Map.empty)
       )
     )
 

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -128,7 +128,9 @@ class NodeRuntime private[node] (
           .toReaderT
 
     clientChannelsCache <- Ref
-                            .of[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]](Map.empty)
+                            .of[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel]]](
+                              Map.empty
+                            )
                             .toReaderT
     transport <- effects
                   .transportClient(

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -61,7 +61,7 @@ package object effects {
       maxMessageSize: Int,
       packetChunkSize: Int,
       folder: Path,
-      channels: Ref[Task, Map[PeerNode, Deferred[Task, ManagedChannel]]]
+      channels: Ref[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel]]]
   )(
       implicit scheduler: Scheduler,
       log: Log[Task],


### PR DESCRIPTION
ATM all outbound block messages go through single queue with fixed length. If queue is overflown, messages are dropped. So different p2p connections can influence each other.  This PR creates introduces separate queues er each P2P connection.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
