### PR TITLE
 fix latest message problem in 0.9.25.1

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -287,7 +287,6 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
 
   def insert(
       block: BlockMessage,
-      genesis: BlockMessage,
       invalid: Boolean
   ): F[BlockDagRepresentation[F]] =
     lock.withPermit(
@@ -306,7 +305,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
                   .map(_.validator)
                   .toSet
                   .diff(block.justifications.map(_.validator).toSet)
-                newValidatorsLatestMessages = newValidators.map(v => (v, genesis.blockHash))
+                newValidatorsLatestMessages = newValidators.map(v => (v, block.blockHash))
                 newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
                                                           // Ignore empty sender for special cases such as genesis block
                                                           Log[F].warn(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -132,7 +132,6 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
 
   def insert(
       block: BlockMessage,
-      genesis: BlockMessage,
       invalid: Boolean
   ): F[BlockDagRepresentation[F]] =
     lock.withPermit(
@@ -152,7 +151,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
                   .map(_.validator)
                   .toSet
                   .diff(block.justifications.map(_.validator).toSet)
-                newValidatorsLatestMessages = newValidators.map(v => (v, genesis.blockHash))
+                newValidatorsLatestMessages = newValidators.map(v => (v, block.blockHash))
                 newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
                                                           // Ignore empty sender for special cases such as genesis block
                                                           Log[F].warn(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -11,7 +11,6 @@ trait BlockDagStorage[F[_]] {
   def getRepresentation: F[BlockDagRepresentation[F]]
   def insert(
       block: BlockMessage,
-      genesis: BlockMessage,
       invalid: Boolean
   ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -112,7 +112,6 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
 
   override def insert(
       block: BlockMessage,
-      genesis: BlockMessage,
       invalid: Boolean
   ): F[BlockDagRepresentation[F]] =
     lock.withPermit(
@@ -132,7 +131,7 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
           .map(_.validator)
           .toSet
           .diff(block.justifications.map(_.validator).toSet)
-        newValidatorsLatestMessages = newValidators.map(v => (v, genesis.blockHash))
+        newValidatorsLatestMessages = newValidators.map(v => (v, block.blockHash))
         newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
                                                   // Ignore empty sender for special cases such as genesis block
                                                   Log[F].warn(

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
@@ -121,7 +121,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { storage =>
         for {
-          _      <- blockElements.traverse_(storage.insert(_, genesis, false))
+          _      <- blockElements.traverse_(storage.insert(_, false))
           result <- lookupElements(blockElements, storage)
         } yield testLookupElementsResult(result, blockElements)
       }
@@ -139,7 +139,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
       }
       withDagStorage { storage =>
         for {
-          _      <- blockElementsWithGenesis.traverse_(storage.insert(_, genesis, false))
+          _      <- blockElementsWithGenesis.traverse_(storage.insert(_, false))
           result <- lookupElements(blockElementsWithGenesis, storage)
         } yield testLookupElementsResult(result, blockElementsWithGenesis)
       }
@@ -152,8 +152,8 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         secondBlockElements =>
           withDagStorage { storage =>
             for {
-              _      <- firstBlockElements.traverse_(storage.insert(_, genesis, false))
-              _      <- secondBlockElements.traverse_(storage.insert(_, genesis, false))
+              _      <- firstBlockElements.traverse_(storage.insert(_, false))
+              _      <- secondBlockElements.traverse_(storage.insert(_, false))
               result <- lookupElements(firstBlockElements ++ secondBlockElements, storage)
             } yield testLookupElementsResult(result, firstBlockElements ++ secondBlockElements)
           }
@@ -167,9 +167,9 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         (secondBlockElements, thirdBlockElements) =>
           withDagStorage { storage =>
             for {
-              _      <- blockElements.traverse_(storage.insert(_, genesis, false))
-              _      <- secondBlockElements.traverse_(storage.insert(_, genesis, false))
-              _      <- thirdBlockElements.traverse_(storage.insert(_, genesis, false))
+              _      <- blockElements.traverse_(storage.insert(_, false))
+              _      <- secondBlockElements.traverse_(storage.insert(_, false))
+              _      <- thirdBlockElements.traverse_(storage.insert(_, false))
               result <- lookupElements(blockElements, storage)
             } yield testLookupElementsResult(
               result,
@@ -186,7 +186,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         forAll(blockHashGen) { blockHash =>
           withDagStorage { storage =>
             for {
-              _ <- blockElements.traverse_(storage.insert(_, genesis, false))
+              _ <- blockElements.traverse_(storage.insert(_, false))
               record = EquivocationRecord(
                 equivocator,
                 0,
@@ -229,7 +229,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { storage =>
         for {
-          _             <- blockElements.traverse_(storage.insert(_, genesis, true))
+          _             <- blockElements.traverse_(storage.insert(_, true))
           dag           <- storage.getRepresentation
           invalidBlocks <- dag.invalidBlocks
         } yield invalidBlocks shouldBe blockElements.map(BlockMetadata.fromBlock(_, true)).toSet
@@ -241,7 +241,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { storage =>
         for {
-          _   <- blockElements.traverse_(storage.insert(_, genesis, true))
+          _   <- blockElements.traverse_(storage.insert(_, true))
           dag <- storage.getRepresentation
           (deploys, blockHashes) = blockElements
             .flatMap(b => b.body.deploys.map(_ -> b.blockHash))
@@ -258,8 +258,8 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         val invalidBlock = block.copy(
           body = block.body.copy(state = block.body.state.copy(blockNumber = 1000))
         )
-        storage.insert(genesis, genesis, false) >>
-          storage.insert(invalidBlock, genesis, true)
+        storage.insert(genesis, false) >>
+          storage.insert(invalidBlock, true)
       }
     }
   }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -45,7 +45,7 @@ trait BlockDagStorageTest
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { dagStorage =>
         for {
-          _   <- blockElements.traverse_(dagStorage.insert(_, genesis, false))
+          _   <- blockElements.traverse_(dagStorage.insert(_, false))
           dag <- dagStorage.getRepresentation
           blockElementLookups <- blockElements.traverse { b =>
                                   for {
@@ -265,7 +265,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { dagDataDir =>
         for {
           firstStorage  <- createAtDefaultLocation(dagDataDir)
-          _             <- blockElements.traverse_(firstStorage.insert(_, genesis, false))
+          _             <- blockElements.traverse_(firstStorage.insert(_, false))
           _             <- firstStorage.close()
           secondStorage <- createAtDefaultLocation(dagDataDir)
           result        <- lookupElements(blockElements, secondStorage)
@@ -287,7 +287,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { dagDataDir =>
         for {
           firstStorage  <- createAtDefaultLocation(dagDataDir)
-          _             <- blockElementsWithGenesis.traverse_(firstStorage.insert(_, genesis, false))
+          _             <- blockElementsWithGenesis.traverse_(firstStorage.insert(_, false))
           _             <- firstStorage.close()
           secondStorage <- createAtDefaultLocation(dagDataDir)
           result        <- lookupElements(blockElementsWithGenesis, secondStorage)
@@ -304,10 +304,10 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           withDagStorageLocation { dagDataDir =>
             for {
               firstStorage  <- createAtDefaultLocation(dagDataDir)
-              _             <- firstBlockElements.traverse_(firstStorage.insert(_, genesis, false))
+              _             <- firstBlockElements.traverse_(firstStorage.insert(_, false))
               _             <- firstStorage.close()
               secondStorage <- createAtDefaultLocation(dagDataDir)
-              _             <- secondBlockElements.traverse_(secondStorage.insert(_, genesis, false))
+              _             <- secondBlockElements.traverse_(secondStorage.insert(_, false))
               _             <- secondStorage.close()
               thirdStorage  <- createAtDefaultLocation(dagDataDir)
               result        <- lookupElements(firstBlockElements ++ secondBlockElements, thirdStorage)
@@ -323,7 +323,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { dagDataDir =>
         for {
           firstStorage <- createAtDefaultLocation(dagDataDir)
-          _            <- blockElements.traverse_(firstStorage.insert(_, genesis, false))
+          _            <- blockElements.traverse_(firstStorage.insert(_, false))
           _            <- firstStorage.close()
           garbageBytes = Array.fill[Byte](Validator.Length + BlockHash.Length)(0)
           _            <- Sync[Task].delay { Random.nextBytes(garbageBytes) }
@@ -348,7 +348,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         withDagStorageLocation { dagDataDir =>
           for {
             firstStorage                  <- createAtDefaultLocation(dagDataDir)
-            _                             <- blockElements.traverse_(firstStorage.insert(_, genesis, invalid = false))
+            _                             <- blockElements.traverse_(firstStorage.insert(_, invalid = false))
             _                             <- firstStorage.close()
             garbageBlockMetadata          = BlockMetadata.fromBlock(garbageBlock, invalid = false)
             keyValueCodec                 = (codecBlockHash ~ codecBlockMetadata)
@@ -387,9 +387,9 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           withDagStorageLocation { dagDataDir =>
             for {
               firstStorage  <- createAtDefaultLocation(dagDataDir, 2)
-              _             <- blockElements.traverse_(firstStorage.insert(_, genesis, false))
-              _             <- secondBlockElements.traverse_(firstStorage.insert(_, genesis, false))
-              _             <- thirdBlockElements.traverse_(firstStorage.insert(_, genesis, false))
+              _             <- blockElements.traverse_(firstStorage.insert(_, false))
+              _             <- secondBlockElements.traverse_(firstStorage.insert(_, false))
+              _             <- thirdBlockElements.traverse_(firstStorage.insert(_, false))
               _             <- firstStorage.close()
               secondStorage <- createAtDefaultLocation(dagDataDir)
               result        <- lookupElements(blockElements, secondStorage)
@@ -410,7 +410,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           withDagStorageLocation { dagDataDir =>
             for {
               firstStorage <- createAtDefaultLocation(dagDataDir)
-              _            <- blockElements.traverse_(firstStorage.insert(_, genesis, false))
+              _            <- blockElements.traverse_(firstStorage.insert(_, false))
               record = EquivocationRecord(
                 equivocator,
                 0,
@@ -462,7 +462,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           withDagStorageLocation { dagDataDir =>
             for {
               firstStorage <- createAtDefaultLocation(dagDataDir)
-              _            <- blockElements.traverse_(firstStorage.insert(_, genesis, false))
+              _            <- blockElements.traverse_(firstStorage.insert(_, false))
               record = EquivocationRecord(
                 equivocator,
                 0,
@@ -512,7 +512,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { dagDataDir =>
         for {
           firstStorage  <- createAtDefaultLocation(dagDataDir)
-          _             <- blockElements.traverse_(firstStorage.insert(_, genesis, true))
+          _             <- blockElements.traverse_(firstStorage.insert(_, true))
           _             <- firstStorage.close()
           secondStorage <- createAtDefaultLocation(dagDataDir)
           dag           <- secondStorage.getRepresentation
@@ -528,7 +528,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorageLocation { dagDataDir =>
         for {
           firstStorage  <- createAtDefaultLocation(dagDataDir)
-          _             <- blockElements.traverse_(firstStorage.insert(_, genesis, true))
+          _             <- blockElements.traverse_(firstStorage.insert(_, true))
           _             <- firstStorage.close()
           secondStorage <- createAtDefaultLocation(dagDataDir)
           dag           <- secondStorage.getRepresentation
@@ -548,7 +548,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
         for {
           firstStorage <- createAtDefaultLocation(dagDataDir)
           _ <- blockElements.traverse_(
-                b => firstStorage.insert(b, genesis, false)
+                b => firstStorage.insert(b, false)
               )
           _ <- firstStorage.close()
           _ <- Sync[Task].delay {
@@ -574,8 +574,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
       withDagStorage { dagStorage =>
         val invalidBlock =
           block.copy(body = block.body.copy(state = block.body.state.copy(blockNumber = 1000)))
-        dagStorage.insert(genesis, genesis, false) >>
-          dagStorage.insert(invalidBlock, genesis, true)
+        dagStorage.insert(genesis, false) >>
+          dagStorage.insert(invalidBlock, true)
       }
     }
   }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -435,7 +435,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
       .map { _ =>
         // Add successful! Send block hash to peers, log success, try to add other blocks
         for {
-          updatedDag <- BlockDagStorage[F].insert(block, approvedBlock, invalid = false)
+          updatedDag <- BlockDagStorage[F].insert(block, invalid = false)
           _ <- Log[F].info(
                 s"Added ${PrettyPrinter.buildString(block, true)}"
               )
@@ -549,7 +549,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
   ): F[BlockDagRepresentation[F]] =
     Log[F].warn(
       s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}."
-    ) >> BlockDagStorage[F].insert(block, approvedBlock, invalid = true)
+    ) >> BlockDagStorage[F].insert(block, invalid = true)
 
   def getRuntimeManager: F[RuntimeManager[F]] = syncF.pure(runtimeManager)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -61,7 +61,7 @@ object Engine {
   ): F[Unit] =
     for {
       _ <- BlockStore[F].put(genesis.blockHash, genesis)
-      _ <- BlockDagStorage[F].insert(genesis, genesis, invalid = false)
+      _ <- BlockDagStorage[F].insert(genesis, invalid = false)
       _ <- BlockStore[F].putApprovedBlock(approvedBlock)
     } yield ()
 

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -278,8 +278,8 @@ class BlockQueryResponseAPITest
   ): Task[(LogStub[Task], EngineCell[Task], SafetyOracle[Task])] =
     runtimeManagerResource.use { implicit runtimeManager =>
       for {
-        _ <- blockDagStorage.insert(genesisBlock, genesisBlock, false)
-        _ <- blockDagStorage.insert(secondBlock, genesisBlock, false)
+        _ <- blockDagStorage.insert(genesisBlock, false)
+        _ <- blockDagStorage.insert(secondBlock, false)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap[BlockHash, BlockMessage](
                            (genesisBlock.blockHash, genesisBlock),

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -276,7 +276,7 @@ class ValidateTest
           )
 
           _ <- blockStore.put(block.blockHash, block)
-          _ <- blockDagStorage.insert(block, genesis, false)
+          _ <- blockDagStorage.insert(block, false)
         } yield block
 
       for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -82,7 +82,7 @@ object BlockGenerator {
       b.body.copy(state = updatedBlockPostState, deploys = processedDeploys.toList)
     val updatedBlock = b.copy(body = updatedBlockBody)
     BlockStore[F].put(b.blockHash, updatedBlock) >>
-      BlockDagStorage[F].insert(updatedBlock, genesis, invalid = false).void
+      BlockDagStorage[F].insert(updatedBlock, invalid = false).void
   }
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -124,7 +124,7 @@ object GenesisBuilder {
         implicit val kvm = storeManager
         BlockDagKeyValueStorage.create[Task]
       }
-      _ <- blockDagStorage.insert(genesis, genesis, invalid = false)
+      _ <- blockDagStorage.insert(genesis, invalid = false)
     } yield GenesisContext(genesis, validavalidatorKeyPairs, storageDirectory)).unsafeRunSync
   }
 


### PR DESCRIPTION
when new validators bonded, the latest message for the new validator is genesis block which causes problems for calculating the estimator. The estimator would traverse until genesis.

## Overview
<!-- What this PR does, and why it's needed -->


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
