### PR TITLE
Fix to prevent deploys with keys used for blessed (standard) contracts

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/StandardDeploys.scala
@@ -1,11 +1,10 @@
 package coop.rchain.casper.genesis.contracts
 
-import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.util.ProtoUtil.stringToByteString
-import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
-import coop.rchain.models.NormalizerEnv
 import coop.rchain.rholang.build.CompiledRholangSource
 import coop.rchain.rholang.interpreter.accounting
 
@@ -28,61 +27,90 @@ object StandardDeploys {
     Signed(deployData, Secp256k1, sk)
   }
 
+  // Private keys used to sign blessed (standard) contracts
+  val registryPk          = "5a0bde2f5857124b1379c78535b07a278e3b9cefbcacc02e62ab3294c02765a1"
+  val listOpsPk           = "867c21c6a3245865444d80e49cac08a1c11e23b35965b566bbe9f49bb9897511"
+  val eitherPk            = "5248f8913f8572d8227a3c7787b54bd8263389f7209adc1422e36bb2beb160dc"
+  val nonNegativeNumberPk = "e33c9f1e925819d04733db4ec8539a84507c9e9abd32822059349449fe03997d"
+  val makeMintPk          = "de19d53f28d4cdee74bad062342d8486a90a652055f3de4b2efa5eb2fccc9d53"
+  val authKeyPk           = "f450b26bac63e5dd9343cd46f5fae1986d367a893cd21eedd98a4cb3ac699abc"
+  val revVaultPk          = "27e5718bf55dd673cc09f13c2bcf12ed7949b178aef5dcb6cd492ad422d05e9d"
+  val multiSigRevVaultPk  = "2a2eaa76d6fea9f502629e32b0f8eea19b9de8e2188ec0d589fcafa98fb1f031"
+  val poSGeneratorPk      = "a9585a0687761139ab3587a4938fb5ab9fcba675c79fefba889859674046d4a5"
+  val revGeneratorPk      = "a06959868e39bb3a8502846686a23119716ecd001700baf9e2ecfa0dbf1a3247"
+
+  // Public keys used to sign blessed (standard) contracts
+  val systemPublicKeys: Seq[PublicKey] = Seq(
+    registryPk,
+    listOpsPk,
+    eitherPk,
+    nonNegativeNumberPk,
+    makeMintPk,
+    authKeyPk,
+    revVaultPk,
+    multiSigRevVaultPk,
+    poSGeneratorPk,
+    revGeneratorPk
+  ).map(Base16.unsafeDecode).map(PrivateKey(_)).map(Secp256k1.toPublic)
+
   def registry: Signed[DeployData] = toDeploy(
     CompiledRholangSource("Registry.rho"),
-    "5a0bde2f5857124b1379c78535b07a278e3b9cefbcacc02e62ab3294c02765a1",
+    registryPk,
     1559156071321L
   )
 
   def listOps: Signed[DeployData] = toDeploy(
     CompiledRholangSource("ListOps.rho"),
-    "867c21c6a3245865444d80e49cac08a1c11e23b35965b566bbe9f49bb9897511",
+    listOpsPk,
     1559156082324L
   )
+
   def either: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("Either.rho"),
-      "5248f8913f8572d8227a3c7787b54bd8263389f7209adc1422e36bb2beb160dc",
+      eitherPk,
       1559156217509L
     )
+
   def nonNegativeNumber: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("NonNegativeNumber.rho"),
-      "e33c9f1e925819d04733db4ec8539a84507c9e9abd32822059349449fe03997d",
+      nonNegativeNumberPk,
       1559156251792L
     )
+
   def makeMint: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("MakeMint.rho"),
-      "de19d53f28d4cdee74bad062342d8486a90a652055f3de4b2efa5eb2fccc9d53",
+      makeMintPk,
       1559156452968L
     )
 
   def authKey: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("AuthKey.rho"),
-      "f450b26bac63e5dd9343cd46f5fae1986d367a893cd21eedd98a4cb3ac699abc",
+      authKeyPk,
       1559156356769L
     )
 
   def revVault: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("RevVault.rho"),
-      "27e5718bf55dd673cc09f13c2bcf12ed7949b178aef5dcb6cd492ad422d05e9d",
+      revVaultPk,
       1559156183943L
     )
 
   def multiSigRevVault: Signed[DeployData] =
     toDeploy(
       CompiledRholangSource("MultiSigRevVault.rho"),
-      "2a2eaa76d6fea9f502629e32b0f8eea19b9de8e2188ec0d589fcafa98fb1f031",
+      multiSigRevVaultPk,
       1571408470880L
     )
 
   def poSGenerator(poS: ProofOfStake): Signed[DeployData] =
     toDeploy(
       poS,
-      "a9585a0687761139ab3587a4938fb5ab9fcba675c79fefba889859674046d4a5",
+      poSGeneratorPk,
       1559156420651L
     )
 
@@ -94,7 +122,7 @@ object StandardDeploys {
   ): Signed[DeployData] =
     toDeploy(
       RevGenerator(vaults, supply, isLastBatch),
-      "a06959868e39bb3a8502846686a23119716ecd001700baf9e2ecfa0dbf1a3247",
+      revGeneratorPk,
       timestamp
     )
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/StandardDeploysSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/StandardDeploysSpec.scala
@@ -1,0 +1,16 @@
+package coop.rchain.casper.genesis.contracts
+
+import coop.rchain.crypto.codec.Base16
+import org.scalatest.FlatSpec
+
+class StandardDeploysSpec extends FlatSpec {
+  it should "print public keys used for signing standard (blessed) contracts" in {
+    println(s"Public keys used to sign standard (blessed) contracts")
+    println(s"=====================================================")
+
+    StandardDeploys.systemPublicKeys.zipWithIndex.foreach {
+      case (pubKey, idx) =>
+        println(s"${idx + 1}. ${Base16.encode(pubKey.bytes)}")
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This is security fix already applied to main net validators as v0.9.25.2 release.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
