### PR TITLE
Do not traverse the whole DAG on unseenBlock

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -362,43 +362,47 @@ object ProtoUtil {
     import cats.instances.stream._
 
     for {
-      latestMessages        <- dag.latestMessages
-      latestMessagesOfBlock <- toLatestMessage(block.justifications, dag)
-      unseenBlockHashesAndLatestMessages <- latestMessages.toStream
-                                             .traverse {
-                                               case (validator, latestMessage) =>
-                                                 getJustificationChainFromLatestMessageToBlock(
-                                                   dag,
-                                                   latestMessagesOfBlock,
-                                                   validator,
-                                                   latestMessage
-                                                 )
-                                             }
-                                             .map(_.flatten.toSet)
-    } yield unseenBlockHashesAndLatestMessages -- latestMessagesOfBlock.values.map(_.blockHash) - block.blockHash
+      dagsLatestMessages   <- dag.latestMessages
+      blocksLatestMessages <- toLatestMessage(block.justifications, dag)
+
+      unseenLatestMessages = dagsLatestMessages.filter(
+        dlm =>
+          !blocksLatestMessages.contains(dlm._1) ||
+            (blocksLatestMessages.contains(dlm._1) &&
+              dlm._2.seqNum > blocksLatestMessages.toList.find(_._1 == dlm._1).get._2.seqNum)
+      )
+
+      unseenBlockHashes <- unseenLatestMessages.toStream
+                            .traverse { ulm =>
+                              getCreatorBlocksBetween(
+                                dag,
+                                ulm._2,
+                                blocksLatestMessages.get(ulm._1)
+                              )
+                            }
+                            .map(_.flatten.toSet)
+    } yield unseenBlockHashes -- blocksLatestMessages.values.map(_.blockHash) - block.blockHash
   }
 
-  private def getJustificationChainFromLatestMessageToBlock[F[_]: Sync: BlockStore](
+  private def getCreatorBlocksBetween[F[_]: Sync: BlockStore](
       dag: BlockDagRepresentation[F],
-      latestMessagesOfBlock: Map[Validator, BlockMetadata],
-      validator: Validator,
-      latestMessage: BlockMetadata
+      topBlock: BlockMetadata,
+      bottomBlock: Option[BlockMetadata]
   ): F[Set[BlockHash]] =
-    latestMessagesOfBlock.get(validator) match {
-      case Some(latestMessageOfBlockByValidator) =>
+    bottomBlock match {
+      case None => Set(topBlock.blockHash).pure[F]
+      case Some(bottomBlock) =>
         DagOperations
-          .bfTraverseF(List(latestMessage))(
-            block =>
+          .bfTraverseF(List(topBlock))(
+            nextCreatorBlock =>
               getCreatorJustificationUnlessGoal(
                 dag,
-                block,
-                latestMessageOfBlockByValidator
+                nextCreatorBlock,
+                bottomBlock
               )
           )
           .map(_.blockHash)
           .toSet
-      case None =>
-        Set.empty[BlockHash].pure
     }
 
   private def getCreatorJustificationUnlessGoal[F[_]: Sync: BlockStore](
@@ -417,7 +421,10 @@ object ProtoUtil {
             }
           case None =>
             Sync[F].raiseError[List[BlockMetadata]](
-              new RuntimeException(s"Missing block hash $hash in block dag.")
+              new RuntimeException(
+                s"BlockDAG is missing justification ${PrettyPrinter
+                  .buildString(hash)} for ${PrettyPrinter.buildString(block.blockHash)}."
+              )
             )
         }
       case None =>


### PR DESCRIPTION
On each replay node have to find invalid blocks that are in the scope of block being replayed. By `scope` I mean that there is a path in DAG between block replayed and invalid block. Also, node maintains only a single set of invalid blocks without any metadata. Therefore, before replaying new block node have to find out which invalid blocks are in the scope of that block. To do this node perform traversing on the DAG. 

ATM this traversing includes the whole DAG due to the bug. So takes the more time, the bigger DAG become. On testnet it is about 20-30 seconds. So we waste this time replaying each block.
This PR fixes it.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
