### PR TITLE
Fix default use of post-state hash for exploratory deploy

### DIFF
--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -126,7 +126,7 @@ object WebApiRoutes {
 
       case req @ POST -> Root / "explore-deploy" =>
         req.handle[String, ExploratoryDeployResponse](
-          term => webApi.exploratoryDeploy(term, none[String], true)
+          term => webApi.exploratoryDeploy(term, none[String], usePreStateHash = false)
         )
 
       case req @ POST -> Root / "explore-deploy-by-block-hash" =>


### PR DESCRIPTION
## Overview
By accident we switched to use of pre-state hash for exploratory deploy so this PR fixes this to correct post-state hash.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
