### PR TITLE
Add BlockIsInProcessing ignore reason

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockRetriever.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockRetriever.scala
@@ -329,7 +329,9 @@ object BlockRetriever {
         } yield ()
       }
 
-      /** Blocks that are received but still not in Casper */
+      /** Blocks that are received and
+        * have all dependencies filled, so not put in casperBuffer,
+        * but were not accepted by Casper, so processing is postponed*/
       override def getEnqueuedToCasper: F[List[BlockHash]] =
         for {
           state         <- RequestedBlocks[F].get

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -33,7 +33,9 @@ object Running {
   trait CasperMessageStatus
   final case object BlockIsInDag            extends CasperMessageStatus
   final case object BlockIsInCasperBuffer   extends CasperMessageStatus
+  final case object BlockIsReceived         extends CasperMessageStatus
   final case object BlockIsWaitingForCasper extends CasperMessageStatus
+  final case object BlockIsInProcessing     extends CasperMessageStatus
   final case object DoNotIgnore             extends CasperMessageStatus
 
   final case class IgnoreCasperMessageStatus(doIgnore: Boolean, status: CasperMessageStatus)
@@ -281,32 +283,53 @@ class Running[F[_]: Concurrent: BlockStore: CasperBufferStorage: BlockRetriever:
   /**
     * Message that relates to a block A (e.g. block message or block hash broadcast message) shall be considered
     * as repeated and ignored if block A is
-    * 1. marked as received in BlocksRetriever and pending adding to CasperBuffer or
-    * 2. added do CasperBuffer and pending adding to DAG or
-    * 3. already added to DAG.
+    * 1. BlockIsWaitingForCasper  -> ready to be replayed but Casper is busy, so processing is postponed
+    * 2. BlockIsInProcessing      -> currently replayed by Casper
+    * 3. BlockIsInCasperBuffer    -> is missing dependencies so added to CasperBuffer
+    *                                and waiting for all dependencies to be filled
+    * 4. BlockIsInDag             -> is already added to the DAG.
+    * 5. BlockIsReceived          -> is received, but BlockRetriever did not process it yet (rare case).
     * Otherwise - that is a new message and shall be processed normal way.
     *
     * @param hash Block hash
     * @return If message should be ignored
     */
   private def ignoreCasperMessage(hash: BlockHash): F[IgnoreCasperMessageStatus] =
-    BlockRetriever[F]
-      .received(hash)
-      .ifM(
-        IgnoreCasperMessageStatus(doIgnore = true, BlockIsWaitingForCasper).pure[F],
-        CasperBufferStorage[F]
-          .contains(hash)
-          .ifM(
-            IgnoreCasperMessageStatus(doIgnore = true, BlockIsInCasperBuffer).pure[F],
-            casper.blockDag.flatMap(
-              _.contains(hash)
+    for {
+      // This long chain of ifM created to minimise computation for ignore check and provide
+      // readable output for each ignore reason
+      received <- BlockRetriever[F].received(hash)
+      r <- BlockRetriever[F].getEnqueuedToCasper
+            .map(_.contains(hash))
+            .ifM(
+              IgnoreCasperMessageStatus(doIgnore = true, BlockIsWaitingForCasper).pure[F],
+              casper.getBlocksInProcessing
+                .map(_.contains(hash))
                 .ifM(
-                  IgnoreCasperMessageStatus(doIgnore = true, BlockIsInDag).pure[F],
-                  IgnoreCasperMessageStatus(doIgnore = false, DoNotIgnore).pure[F]
+                  IgnoreCasperMessageStatus(doIgnore = true, BlockIsInProcessing).pure[F],
+                  CasperBufferStorage[F]
+                    .contains(hash)
+                    .ifM(
+                      IgnoreCasperMessageStatus(doIgnore = true, BlockIsInCasperBuffer).pure[F],
+                      casper.blockDag.flatMap(
+                        _.contains(hash)
+                          .ifM(
+                            IgnoreCasperMessageStatus(doIgnore = true, BlockIsInDag).pure[F],
+                            // If none of the checks above is true, this means that
+                            // thread that received block did not execute Casper code yet.
+                            // So there is still possibility of `received` to be true, that's why
+                            // this check put in place. But the possibility is close to 0.
+                            if (received)
+                              IgnoreCasperMessageStatus(doIgnore = true, BlockIsReceived).pure[F]
+                            else
+                              IgnoreCasperMessageStatus(doIgnore = false, DoNotIgnore).pure[F]
+                          )
+                      )
+                    )
                 )
             )
-          )
-      )
+
+    } yield r
 
   /**
     * Basic block validation before saving block in Blockstore. The intention here is to prevent saving

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -263,4 +263,5 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   override def bufferContains(hash: BlockHash): F[Boolean] = underlying.bufferContains(hash)
   override def getVersion: F[Long]                         = underlying.getVersion
   override def getDeployLifespan: F[Int]                   = underlying.getDeployLifespan
+  override def getBlocksInProcessing: F[Set[BlockHash]]    = underlying.getBlocksInProcessing
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -57,6 +57,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
       _ <- Sync[F].delay(store.update(b.get.blockHash, b.get))
     } yield BlockStatus.valid.asRight
 
+  def getBlocksInProcessing: F[Set[BlockHash]] = Set.empty[BlockHash].pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -117,13 +117,16 @@ class TestNode[F[_]](
   implicit val commUtil: CommUtil[F]             = CommUtil.of[F]
   implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]
 
+  val blocksInProcessing = Ref.unsafe[F, Set[BlockHash]](Set.empty)
+
   implicit val casperEff = new MultiParentCasperImpl[F](
     validatorId,
     genesis,
     postGenesisStateHash,
     shardId,
     finalizationRate,
-    blockProcessingLock
+    blockProcessingLock,
+    blocksInProcessing
   )
 
   val engine                             = new Running(casperEff, approvedBlock, validatorId, ().pure[F])


### PR DESCRIPTION
There is a flaw in message ignoring logic. When block is passed to Casper with all dependencies already filled, it omits casperBuffer, so node is not aware that this block is actually being processed. As block processing can last long, this leads to misleading requests of message that is already being processing.

This PR makes Casper maintaining set of hashes that are currently in processing + adjusts message ignoring logic.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
