### PR TITLE
Fix Initializing engine test

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -88,9 +88,6 @@ class Initializing[F[_]
               _ <- Log[F].info(
                     s"Valid Last Finalized Block received ${PrettyPrinter.buildString(approvedBlock)}"
                   )
-              _ <- Log[F].warn(
-                    s"JUSTIF: ${approvedBlock.justifications.map(_.latestBlockHash).map(PrettyPrinter.buildString).mkString(", ")}"
-                  )
 
               _ <- EventLog[F].publish(
                     shared.Event.ApprovedBlockReceived(

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -469,12 +469,20 @@ class Running[F[_]
                           lfBlock <- LastFinalizedStorage[F]
                                       .get(approvedBlock.candidate.block)
                                       .flatMap(BlockStore[F].getUnsafe)
+                          // Each approved block should be justified by validators signatures
+                          // ATM we have signatures only for genesis approved block - we also have to have a procedure
+                          // for gathering signatures for each approved block post genesis.
+                          // Now new node have to trust bootstrap if it wants to trim state when connecting to the network.
+                          // TODO We need signatures of Validators supporting this block
                           lastApprovedBlock = ApprovedBlock(
                             ApprovedBlockCandidate(lfBlock, 0),
                             List.empty
                           )
                         } yield lastApprovedBlock
                         else
+                          // Respond with approved block that this node is started from.
+                          // The very first one is genesis, but this node still might start from later block,
+                          // so it will not necessary be genesis.
                           approvedBlock.pure[F]
         _ <- handleApprovedBlockRequest(peer, approvedBlock)
       } yield ()

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -8,7 +8,7 @@ import cats.effect.concurrent.Ref
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.rspace.state.instances.RSpaceStateManagerDummyImpl
+import coop.rchain.casper.helper.RSpaceStateManagerTestImpl
 import coop.rchain.shared.{Cell, EventPublisher}
 import monix.eval.Task
 import org.scalatest.WordSpec
@@ -31,7 +31,7 @@ class GenesisCeremonyMasterSpec extends WordSpec {
       val startTime = System.currentTimeMillis()
 
       implicit val engineCell = Cell.unsafe[Task, Engine[Task]](Engine.noop)
-      implicit val rspaceMan  = RSpaceStateManagerDummyImpl[Task]()
+      implicit val rspaceMan  = RSpaceStateManagerTestImpl[Task]()
 
       def waitUtilCasperIsDefined: Task[MultiParentCasper[Task]] =
         EngineCell[Task].read >>= (_.withCasper(

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisValidatorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisValidatorSpec.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.protocol.{NoApprovedBlockAvailable, _}
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.rp.ProtocolHelper._
-import coop.rchain.rspace.state.instances.RSpaceStateManagerDummyImpl
+import coop.rchain.casper.helper.RSpaceStateManagerTestImpl
 import coop.rchain.shared.{Cell, EventPublisher}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -24,7 +24,7 @@ class GenesisValidatorSpec extends WordSpec {
 
       implicit val engineCell: EngineCell[Task] =
         Cell.unsafe[Task, Engine[Task]](Engine.noop)
-      implicit val rspaceMan = RSpaceStateManagerDummyImpl[Task]()
+      implicit val rspaceMan = RSpaceStateManagerTestImpl[Task]()
 
       val expectedCandidate = ApprovedBlockCandidate(genesis, requiredSigs)
       val unapprovedBlock   = BlockApproverProtocolTest.createUnapproved(requiredSigs, genesis)
@@ -54,7 +54,7 @@ class GenesisValidatorSpec extends WordSpec {
 
       implicit val engineCell: EngineCell[Task] =
         Cell.unsafe[Task, Engine[Task]](Engine.noop)
-      implicit val rspaceMan = RSpaceStateManagerDummyImpl[Task]()
+      implicit val rspaceMan = RSpaceStateManagerTestImpl[Task]()
 
       val approvedBlockRequest = ApprovedBlockRequest("test")
       val test = for {

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -9,7 +9,7 @@ import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.comm.rp.ProtocolHelper._
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
-import coop.rchain.rspace.state.instances.RSpaceStateManagerDummyImpl
+import coop.rchain.casper.helper.RSpaceStateManagerTestImpl
 import coop.rchain.shared.{Cell, EventPublisher}
 import fs2.concurrent.Queue
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -6,10 +6,15 @@ import coop.rchain.catscontrib.ski._
 import coop.rchain.casper._
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.comm.CommError.CommErr
+import coop.rchain.comm.{CommError, PeerNode}
+import coop.rchain.comm.protocol.routing.Protocol
 import coop.rchain.comm.rp.ProtocolHelper._
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.models.rholang.implicits.fromVar
 import coop.rchain.casper.helper.RSpaceStateManagerTestImpl
+import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.shared.{Cell, EventPublisher}
 import fs2.concurrent.Queue
 import monix.eval.Task
@@ -27,7 +32,6 @@ class InitializingSpec extends WordSpec {
       val theInit = Task.unit
 
       implicit val engineCell = Cell.unsafe[Task, Engine[Task]](Engine.noop)
-      implicit val rspaceMan  = RSpaceStateManagerDummyImpl[Task]()
 
       val blockResponseQueue = Queue.unbounded[Task, BlockMessage].runSyncUnsafe()
       val stateResponseQueue = Queue.unbounded[Task, StoreItemsMessage].runSyncUnsafe()
@@ -59,9 +63,32 @@ class InitializingSpec extends WordSpec {
         )
       )
 
+      val postStateHashBs = approvedBlock.candidate.block.body.state.postStateHash
+      val postStateHash   = Blake2b256Hash.fromByteString(postStateHashBs)
+      val startPath       = Seq((postStateHash, none))
+
+      // Store request message
+      val storeRequestMessage =
+        StoreItemsMessageRequest(startPath, 0, LastFinalizedStateTupleSpaceRequester.pageSize)
+      // Store response message
+      val storeResponseMessage =
+        StoreItemsMessage(startPath = startPath, lastPath = startPath, Seq(), Seq())
+
+      // Send two response messages to end signal the end
+      val enqueResponses = stateResponseQueue.enqueue1(storeResponseMessage) *>
+        stateResponseQueue.enqueue1(storeResponseMessage)
+      enqueResponses.unsafeRunSync
+
+      val expectedRequests = Seq(
+        packet(local, networkId, storeRequestMessage.toProto),
+        packet(local, networkId, ForkChoiceTipRequestProto())
+      )
+
       val test = for {
-        _               <- EngineCell[Task].set(initializingEngine)
-        _               <- initializingEngine.handle(local, approvedBlock)
+        _ <- EngineCell[Task].set(initializingEngine)
+        // Send approved block
+        _ <- initializingEngine.handle(local, approvedBlock)
+
         engine          <- EngineCell[Task].read
         casperDefined   <- engine.withCasper(kp(true.pure[Task]), false.pure[Task])
         _               = assert(casperDefined)
@@ -70,20 +97,24 @@ class InitializingSpec extends WordSpec {
         _               = assert(blockO.contains(genesis))
         handlerInternal <- EngineCell[Task].read
         _               = assert(handlerInternal.isInstanceOf[Running[Task]])
-        _ = assert(
-          transportLayer.requests.head.msg == packet(
-            local,
-            networkId,
-            ForkChoiceTipRequestProto()
-          )
-        )
+
+        // Assert requested messages for the state and fork choice tip
+        messages = transportLayer.requests.map(_.msg)
+        _ = messages.zip(expectedRequests).map {
+          case (msg1, msg2) => assert(msg1 == msg2)
+        }
         _ = transportLayer.reset()
+
         // assert that we really serve last approved block
         lastApprovedBlockO <- LastApprovedBlock[Task].get
         _                  = assert(lastApprovedBlockO.isDefined)
-        _                  <- EngineCell[Task].read >>= (_.handle(local, ApprovedBlockRequest("test")))
-        head               = transportLayer.requests.head
-        _                  = assert(head.msg.message.packet.get.content == approvedBlock.toProto.toByteString)
+        _ <- EngineCell[Task].read >>= (_.handle(
+              local,
+              ApprovedBlockRequest("test", trimState = false)
+            ))
+        head = transportLayer.requests.head
+        // TODO: fix missing signature in received approved block
+        _ = assert(head.msg.message.packet.get.content == approvedBlock.toProto.toByteString)
       } yield ()
 
       test.unsafeRunSync

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -74,7 +74,7 @@ class InitializingSpec extends WordSpec {
       val storeResponseMessage =
         StoreItemsMessage(startPath = startPath, lastPath = startPath, Seq(), Seq())
 
-      // Send two response messages to end signal the end
+      // Send two response messages to signal the end
       val enqueResponses = stateResponseQueue.enqueue1(storeResponseMessage) *>
         stateResponseQueue.enqueue1(storeResponseMessage)
       enqueResponses.unsafeRunSync
@@ -99,6 +99,7 @@ class InitializingSpec extends WordSpec {
         _               = assert(handlerInternal.isInstanceOf[Running[Task]])
 
         // Assert requested messages for the state and fork choice tip
+        _        = assert(transportLayer.requests.size == expectedRequests.size)
         messages = transportLayer.requests.map(_.msg)
         _ = messages.zip(expectedRequests).map {
           case (msg1, msg2) => assert(msg1 == msg2)

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
@@ -10,7 +10,7 @@ import coop.rchain.comm.rp.ProtocolHelper._
 import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.blockImplicits.getRandomBlock
-import coop.rchain.rspace.state.instances.RSpaceStateManagerDummyImpl
+import coop.rchain.casper.helper.RSpaceStateManagerTestImpl
 import monix.eval.Task
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 
@@ -44,7 +44,7 @@ class RunningSpec extends WordSpec with BeforeAndAfterEach with Matchers {
     )
 
     implicit val casper    = NoOpsCasperEffect[Task]().unsafeRunSync
-    implicit val rspaceMan = RSpaceStateManagerDummyImpl[Task]()
+    implicit val rspaceMan = RSpaceStateManagerTestImpl[Task]()
 
     val engine = new Running[Task](casper, approvedBlock, None, Task.unit)
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -29,6 +29,7 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rholang.interpreter.util.RevAddress
+import coop.rchain.rspace.state.instances.RSpaceStateManagerImpl
 import coop.rchain.shared.Cell
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
@@ -43,10 +44,16 @@ object Setup {
     val networkId                 = "test"
     val scheduler                 = Scheduler.io("test")
     val runtimeDir                = BlockDagStorageTestFixture.blockStorageDir
-    val (space, replay, _) = {
+    val (space, replay, historyRepo) = {
       implicit val s = scheduler
       Runtime.setupRSpace[Task](runtimeDir, 1024L * 1024 * 1024L).unsafeRunSync
     }
+    val (exporter, importer) = {
+      implicit val s = scheduler
+      (historyRepo.exporter.unsafeRunSync, historyRepo.importer.unsafeRunSync)
+    }
+    implicit val rspaceStateManager = RSpaceStateManagerImpl(exporter, importer)
+
     val activeRuntime =
       Runtime
         .createWithEmptyCost[Task]((space, replay))(

--- a/casper/src/test/scala/coop/rchain/casper/helper/RSpaceStateManagerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RSpaceStateManagerTestImpl.scala
@@ -1,0 +1,13 @@
+package coop.rchain.casper.helper
+
+import cats.syntax.all._
+import cats.effect.Sync
+import coop.rchain.rspace.state.{RSpaceExporter, RSpaceImporter, RSpaceStateManager}
+
+final case class RSpaceStateManagerTestImpl[F[_]: Sync]() extends RSpaceStateManager[F] {
+  override def exporter: RSpaceExporter[F] = ???
+
+  override def importer: RSpaceImporter[F] = ???
+
+  override def isEmpty: F[Boolean] = ???
+}

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -38,7 +38,6 @@ import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.rholang.interpreter.Runtime.RhoHistoryRepository
-import coop.rchain.rspace.state.instances.RSpaceStateManagerDummyImpl
 import coop.rchain.shared._
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -128,7 +127,7 @@ class TestNode[F[_]](
     blocksInProcessing
   )
 
-  implicit val rspaceMan                 = RSpaceStateManagerDummyImpl()
+  implicit val rspaceMan                 = RSpaceStateManagerTestImpl()
   val engine                             = new Running(casperEff, approvedBlock, validatorId, ().pure[F])
   implicit val engineCell: EngineCell[F] = Cell.unsafe[F, Engine[F]](engine)
   implicit val packetHandlerEff          = CasperPacketHandler[F]

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -592,7 +592,7 @@ final case class StoreItemsMessageRequest(
     skip: Int,
     take: Int
 ) extends CasperMessage {
-  override def toProto: CasperMessageProto = StoreItemsMessageRequest.toProto(this)
+  override def toProto: StoreItemsMessageRequestProto = StoreItemsMessageRequest.toProto(this)
 }
 
 object StoreItemsMessageRequest {

--- a/rspace/src/main/scala/coop/rchain/rspace/state/exporters/RSpaceExporterItems.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/exporters/RSpaceExporterItems.scala
@@ -25,7 +25,7 @@ object RSpaceExporterItems {
   ): F[StoreItems[Blake2b256Hash, Value]] =
     for {
       // Traverse and collect tuple space nodes
-      nodes <- time("IMPL READ TRIE NODES")(exporter.getNodes(startPath, skip, take))
+      nodes <- time("TRAVERSE TRIE FOR HISTORY")(exporter.getNodes(startPath, skip, take))
 
       // Get last entry / raise exception if empty (partial function)
       lastEntry <- nodes.lastOption.liftTo(EmptyHistoryException)
@@ -33,7 +33,7 @@ object RSpaceExporterItems {
       // Load all history items / without leafs
       historyKeys = nodes.filterNot(_.isLeaf)
       keys        = historyKeys.distinct.map(_.hash)
-      items       <- time("GET HISTORY NODES")(exporter.getHistoryItems(keys, fromBuffer))
+      items       <- time("GET HISTORY BY KEYS")(exporter.getHistoryItems(keys, fromBuffer))
 
       // TEMP: print exported tries
 //      tries <- time("GET HISTORY NODES")(exporter.getHistoryItems(keys, { buf =>
@@ -52,7 +52,7 @@ object RSpaceExporterItems {
   ): F[StoreItems[Blake2b256Hash, Value]] =
     for {
       // Traverse and collect tuple space nodes
-      nodes <- time("GET DATA NODES")(exporter.getNodes(startPath, skip, take))
+      nodes <- time("TRAVERSE TRIE FOR DATA")(exporter.getNodes(startPath, skip, take))
 
       // Get last entry / raise exception if empty (partial function)
       lastEntry <- nodes.lastOption.liftTo(EmptyHistoryException)
@@ -60,6 +60,6 @@ object RSpaceExporterItems {
       // Load all data items / without history
       dataKeys = nodes.filter(_.isLeaf)
       keys     = dataKeys.distinct.map(_.hash)
-      items    <- time("DATA LOADED")(exporter.getDataItems(keys, fromBuffer))
+      items    <- time("GET DATA BY KEYS")(exporter.getDataItems(keys, fromBuffer))
     } yield StoreItems(items, lastEntry.path :+ (lastEntry.hash, none))
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/state/instances/RSpaceStateManagerImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/instances/RSpaceStateManagerImpl.scala
@@ -28,12 +28,3 @@ object RSpaceStateManagerImpl {
       }
   }
 }
-
-// TODO: move it to test project
-final case class RSpaceStateManagerDummyImpl[F[_]: Sync]() extends RSpaceStateManager[F] {
-  override def exporter: RSpaceExporter[F] = ???
-
-  override def importer: RSpaceImporter[F] = ???
-
-  override def isEmpty: F[Boolean] = ???
-}


### PR DESCRIPTION
## Overview
Fix for Initializing Engine to work with RSpace state manager which contains import and export features used for Last Finalized State. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
