### PR TITLE
Use Vector in trie traversal

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -137,12 +137,12 @@ class Initializing[F[_]
                            tupleSpaceQueue
                          )
 
+      // Execute stream until tuple space and all needed blocks are received
+      _ <- fs2.Stream(blockRequestStream, tupleSpaceStream).parJoinUnbounded.compile.drain
+
       // Approved block is saved after the whole state is received
       //  to restart requesting if interrupted with incomplete state.
       _ <- BlockStore[F].put(approvedBlock.candidate.block)
-
-      // Execute stream until tuple space and all needed blocks are received
-      _ <- fs2.Stream(blockRequestStream, tupleSpaceStream).parJoinUnbounded.compile.drain
 
       // Populate DAG with blocks retrieved
       _ <- populateDag(approvedBlock.candidate.block)

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -70,8 +70,9 @@ class Initializing[F[_]
       logNoApprovedBlockAvailable[F](na.nodeIdentifer) >>
         Time[F].sleep(10.seconds) >>
         CommUtil[F].requestApprovedBlock(trimState)
+
     case s: StoreItemsMessage =>
-      tupleSpaceQueue.enqueue1(s)
+      Log[F].info(s"Received ${s.pretty}") *> tupleSpaceQueue.enqueue1(s)
 
     case b: BlockMessage =>
       Log[F].info(s"BlockMessage received ${PrettyPrinter.buildString(b)}") *>

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -1,6 +1,7 @@
 package coop.rchain.casper.engine
 
 import cats.effect.Concurrent
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
@@ -81,46 +82,63 @@ class Initializing[F[_]
     case _ => ().pure
   }
 
+  // TEMP: flag for single call for process approved block
+  val startRequester = Ref.unsafe(true)
+
   private def onApprovedBlock(
       sender: PeerNode,
       approvedBlock: ApprovedBlock,
       enableStateExporter: Boolean
   ): F[Unit] = {
     val senderIsBootstrap = RPConfAsk[F].ask.map(_.bootstrap.exists(_ == sender))
+
+    def handleApprovedBlock = {
+      val block = approvedBlock.candidate.block
+      for {
+        _ <- Log[F].info(
+              s"Valid approved block ${PrettyPrinter
+                .buildString(approvedBlock.candidate.block, short = true)} received. Restoring approved state."
+            )
+
+        // Download approved state and all related blocks
+        _ <- requestApprovedState(approvedBlock)
+
+        _ <- EventLog[F].publish(
+              shared.Event.ApprovedBlockReceived(
+                PrettyPrinter
+                  .buildStringNoLimit(block.blockHash)
+              )
+            )
+
+        _ <- LastApprovedBlock[F].set(approvedBlock)
+
+        // Update last finalized block with received block hash
+        _ <- LastFinalizedStorage[F].put(block.blockHash)
+
+        _ <- Log[F].info(
+              s"Approved state for block ${PrettyPrinter
+                .buildString(approvedBlock.candidate.block, short = true)} is successfully restored."
+            )
+      } yield ()
+    }
+
     for {
       // TODO resolve validation of approved block - we should be sure that bootstrap is not lying
       // Might be Validate.approvedBlock is enough but have to check
       isValid <- senderIsBootstrap &&^ Validate.approvedBlock[F](approvedBlock)
-      block   = approvedBlock.candidate.block
-      _ <- if (isValid) {
-            for {
-              _ <- Log[F].info(
-                    s"Valid approved block ${PrettyPrinter
-                      .buildString(approvedBlock.candidate.block, short = true)} received. Restoring approved state."
-                  )
 
-              // Download approved state and all related blocks
-              _ <- requestApprovedState(approvedBlock)
+      _ <- Log[F].info("Invalid LastFinalizedBlock received; refusing to add.").whenA(!isValid)
 
-              _ <- EventLog[F].publish(
-                    shared.Event.ApprovedBlockReceived(
-                      PrettyPrinter
-                        .buildStringNoLimit(block.blockHash)
-                    )
-                  )
+      // Start only once, when state is true and approved block is valid
+      start <- startRequester.modify {
+                case true if isValid => (false, true)
+                case _               => (false, false)
+              }
 
-              _ <- LastApprovedBlock[F].set(approvedBlock)
+      // HACK: Wait for master transition to Running
+      _ <- Time[F].sleep(3.seconds).whenA(start)
 
-              // Update last finalized block with received block hash
-              _ <- LastFinalizedStorage[F].put(block.blockHash)
-
-              _ <- Log[F].info(
-                    s"Approved state for block ${PrettyPrinter
-                      .buildString(approvedBlock.candidate.block, short = true)} is successfully restored."
-                  )
-            } yield ()
-          } else
-            Log[F].info("Invalid LastFinalizedBlock received; refusing to add.")
+      _ <- handleApprovedBlock.whenA(start)
     } yield ()
   }
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateTupleSpaceRequester.scala
@@ -133,8 +133,6 @@ object LastFinalizedStateTupleSpaceRequester {
 
         StoreItemsMessage(startPath, lastPath, historyItems, dataItems) = msg
 
-        _ <- Stream.eval(Log[F].info(s"Received ${msg.pretty}"))
-
         // Mark chunk as received
         isReceived <- Stream.eval(d.modify(_.received(startPath)))
 

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -88,7 +88,7 @@ object CommUtil {
 
         RPConfAsk[F].ask >>= { conf =>
           val msg = packet(conf.local, conf.networkId, message)
-          Log[F].info(s"Starting to request ${msg.getClass.getName}") >>
+          Log[F].info(s"Starting to request ${msgTypeName}") >>
             Concurrent[F].start(keepOnRequestingTillRunning(peer, msg)).void
         }
       }

--- a/integration-tests/test/test_genesis_ceremony.py
+++ b/integration-tests/test/test_genesis_ceremony.py
@@ -33,15 +33,15 @@ def test_successful_genesis_ceremony(command_line_options: CommandLineOptions, r
     https://docs.google.com/document/d/1Z5Of7OVVeMGl2Fw054xrwpRmDmKCC-nAoIxtIIHD-Tc/
     """
     bootstrap_cli_options = {
-        '--deploy-timestamp':   '1',
-        '--required-signatures':      '2',
-        '--approve-duration':           '5min',
-        '--approve-interval':           '10sec',
+        '--deploy-timestamp'   : '1',
+        '--required-signatures': '2',
+        '--approve-duration'   : '5min',
+        '--approve-interval'   : '10sec',
     }
-    peers_cli_flags = set(['--genesis-validator'])
+    peers_cli_flags = {'--genesis-validator'}
     peers_cli_options = {
-        '--deploy-timestamp':   '1',
-        '--required-signatures':      '2',
+        '--deploy-timestamp'   : '1',
+        '--required-signatures': '2',
     }
     peers_keypairs = [
         VALIDATOR_A_KEYPAIR,

--- a/integration-tests/test/test_genesis_ceremony.py
+++ b/integration-tests/test/test_genesis_ceremony.py
@@ -35,7 +35,7 @@ def test_successful_genesis_ceremony(command_line_options: CommandLineOptions, r
     bootstrap_cli_options = {
         '--deploy-timestamp'   : '1',
         '--required-signatures': '2',
-        '--approve-duration'   : '5min',
+        '--approve-duration'   : '1min',
         '--approve-interval'   : '10sec',
     }
     peers_cli_flags = {'--genesis-validator'}

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -8,6 +8,7 @@ import coop.rchain.models.PCost
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rspace.Blake2b256Hash
+import coop.rchain.rspace.state.RSpaceExporter
 import coop.rchain.shared.Serialize
 import scodec.bits.ByteVector
 
@@ -629,6 +630,14 @@ final case class StoreItemsMessage(
     dataItems: Seq[(Blake2b256Hash, ByteString)]
 ) extends CasperMessage {
   override def toProto: StoreItemsMessageProto = StoreItemsMessage.toProto(this)
+
+  def pretty: String = {
+    val start       = startPath.map(RSpaceExporter.pathPretty).mkString(" ")
+    val last        = lastPath.map(RSpaceExporter.pathPretty).mkString(" ")
+    val historySize = historyItems.size
+    val dataSize    = dataItems.size
+    s"StoreItems(history: $historySize, data: $dataSize, start: [$start], last: [$last])"
+  }
 }
 
 object StoreItemsMessage {

--- a/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
@@ -131,4 +131,11 @@ object RSpaceExporter {
             Vector.empty
         }
     }
+
+  // Pretty printer helpers
+  def pathPretty(path: (Blake2b256Hash, Option[Byte])) = {
+    val (hash, idx) = path
+    val idxStr      = idx.fold("--")(i => String.format("%02x", Integer.valueOf(i & 0xff)))
+    s"$idxStr:${hash.bytes.toHex.take(8)}"
+  }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
@@ -1,10 +1,10 @@
 package coop.rchain.rspace.state
 
 import cats.Monad
+import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.history._
-import coop.rchain.rspace.util.Lib
 import coop.rchain.state.{TrieExporter, TrieNode}
 
 trait RSpaceExporter[F[_]] extends TrieExporter[F] {
@@ -22,14 +22,14 @@ object RSpaceExporter {
 
   type ReadParams[F[_]] = (
       // Keys (tries) to read
-      Seq[TrieNode[Blake2b256Hash]],
+      Vector[TrieNode[Blake2b256Hash]],
       // Offset path
       Seq[(Blake2b256Hash, Option[Byte])],
       // Skip & take counter
       Counter,
       // Result tries as indexed collection
-      Seq[TrieNode[Blake2b256Hash]],
-      // Items traversed (not necessary)
+      Vector[TrieNode[Blake2b256Hash]],
+      // Items traversed (temp for debugging)
       Int
   )
 
@@ -38,31 +38,31 @@ object RSpaceExporter {
       skip: Int,
       take: Int,
       getTrie: Blake2b256Hash => F[Trie]
-  ): F[Seq[TrieNode[Blake2b256Hash]]] =
-    startPath.headOption.fold(Seq.empty[TrieNode[Blake2b256Hash]].pure[F]) {
+  ): F[Vector[TrieNode[Blake2b256Hash]]] =
+    startPath.headOption.fold(Vector.empty[TrieNode[Blake2b256Hash]].pure[F]) {
       case (root, _) =>
         val startParams: ReadParams[F] = (
           // First node is root / start path head
-          Seq(TrieNode(root, isLeaf = false, Nil)),
+          Vector(TrieNode(root, isLeaf = false, Seq.empty)),
           startPath,
           Counter(skip, take),
-          Seq.empty,
+          Vector.empty,
           0
         )
-        Monad[F].tailRecM(startParams)(traverseTrieRec[F](getTrie))
+        startParams.tailRecM(traverseTrieRec[F](getTrie))
     }
 
   private def traverseTrieRec[F[_]: Monad](
       getTrie: Blake2b256Hash => F[Trie]
-  )(params: ReadParams[F]): F[Either[ReadParams[F], Seq[TrieNode[Blake2b256Hash]]]] = {
+  )(params: ReadParams[F]): F[Either[ReadParams[F], Vector[TrieNode[Blake2b256Hash]]]] = {
     val (keys, path, Counter(skip, take), currentNodes, iterations) = params
-    def getCounter(n: Int, items: Seq[TrieNode[Blake2b256Hash]]) =
-      if (skip > 0) (Counter(skip + n, take), Seq.empty) else (Counter(skip, take + n), items)
+    def getCounter(n: Int, items: Vector[TrieNode[Blake2b256Hash]]) =
+      if (skip > 0) (Counter(skip + n, take), Vector.empty) else (Counter(skip, take + n), items)
     keys match {
       case _ if skip == 0 && take == 0 =>
         println(s"ITERATIONS $iterations")
         currentNodes.asRight[ReadParams[F]].pure[F]
-      case Nil =>
+      case Seq() =>
         println(s"ITERATIONS $iterations")
         currentNodes.asRight[ReadParams[F]].pure[F]
       case key +: keysRest =>
@@ -79,56 +79,56 @@ object RSpaceExporter {
             (none, path)
           }
           // Extract child nodes
-          children = extractRefs(trie, key, offset)
+          children                    = extractRefs(trie, key, offset)
+          (childLeafs, childNotLeafs) = children.partition(_.isLeaf)
           (counter, collected) = if (isHeadPath && !isSelectedNode) {
             // Prefix path selected, continue traverse
-            getCounter(0, Seq.empty)
+            getCounter(0, Vector.empty)
           } else if (isSelectedNode) {
             // Selected node in the path, keep it and continue traverse
-            getCounter(-1, Seq(key))
+            getCounter(-1, Vector(key))
           } else if (path.nonEmpty) {
             // Path non empty, continue traverse
-            getCounter(0, Seq.empty)
+            getCounter(0, Vector.empty)
           } else {
             // Add child nodes to result history
-            val childLeafs = children.filter(_.isLeaf)
             getCounter(-1, currentNodes ++ childLeafs :+ key)
           }
           // Tries left to process
-          remainingKeys = children.filterNot(_.isLeaf) ++ keysRest
+          remainingKeys = childNotLeafs ++ keysRest
         } yield (remainingKeys, pathRest, counter, collected, iterations + 1).asLeft
     }
   }
 
   private def extractRefs(
-      t: Trie,
+      trie: Trie,
       node: TrieNode[Blake2b256Hash],
       offset: Option[Byte]
-  ): Seq[TrieNode[Blake2b256Hash]] =
-    t match {
-      case EmptyTrie => Seq.empty
+  ): Vector[TrieNode[Blake2b256Hash]] =
+    trie match {
+      case EmptyTrie => Vector.empty
       // Collects key for cold store
       case Skip(_, LeafPointer(hash)) =>
-        Seq(TrieNode(hash, isLeaf = true, node.path))
+        Vector(TrieNode(hash, isLeaf = true, node.path))
       // Collects child reference
       case Skip(_, NodePointer(hash)) =>
-        Seq(TrieNode(hash, isLeaf = false, node.path))
+        Vector(TrieNode(hash, isLeaf = false, node.path))
       case PointerBlock(childs) =>
         // Collects hashes of child tries
         val itemsIndexed = childs.zipWithIndex
         // Filter by offset / repositioning for the starting path
-        val items = if (offset.nonEmpty) itemsIndexed.dropWhile {
-          case (_, i) => (offset.get & 0xff) > i
-        } else itemsIndexed
+        val items = offset.fold(itemsIndexed)(
+          offsetVal => itemsIndexed.dropWhile { case (_, i) => (offsetVal & 0xff) > i }
+        )
         items.flatMap {
           case (SkipPointer(hash), idx) =>
-            Seq(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
+            Vector(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
           case (NodePointer(hash), idx) =>
-            Seq(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
+            Vector(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
           case (LeafPointer(hash), idx) =>
-            Seq(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
+            Vector(TrieNode(hash, isLeaf = false, node.path :+ (node.hash, idx.toByte.some)))
           case _ =>
-            Seq.empty
+            Vector.empty
         }
     }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/state/exporters/RSpaceExporterDisk.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/exporters/RSpaceExporterDisk.scala
@@ -44,7 +44,7 @@ object RSpaceExporterDisk {
               time("COMPLETE LMDB VALUES WRITE")(dataStore.put(partialValuesList))
             )
 
-        _ = println(s"LAST PATH: ${inputHistory.lastPath.map { case (x, y) => (x, toHex(y)) }}")
+        _ = println(s"LAST PATH: ${inputHistory.lastPath map RSpaceExporter.pathPretty}")
 
         _ = println("")
 

--- a/rspace/src/main/scala/coop/rchain/rspace/state/syntax/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/syntax/package.scala
@@ -35,6 +35,16 @@ package object syntax {
     )(implicit m: Sync[F]): F[StoreItems[Blake2b256Hash, Value]] =
       RSpaceExporterItems.getData(exporter, startPath, skip, take, fromBuffer)
 
+    def getHistoryAndData[Value](
+        startPath: Seq[(Blake2b256Hash, Option[Byte])],
+        skip: Int,
+        take: Int,
+        fromBuffer: ByteBuffer => Value
+    )(
+        implicit m: Sync[F]
+    ): F[(StoreItems[Blake2b256Hash, Value], StoreItems[Blake2b256Hash, Value])] =
+      RSpaceExporterItems.getHistoryAndData(exporter, startPath, skip, take, fromBuffer)
+
     // Export to disk
 
     def writeToDisk(root: Blake2b256Hash, dirPath: Path, chunkSize: Int)(

--- a/rspace/src/main/scala/coop/rchain/rspace/util/Lib.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/Lib.scala
@@ -30,7 +30,4 @@ object Lib {
       m  = Duration.fromNanos(t1 - t0)
       _  = println(s">>> $tag elapsed: ${showTime(m)}")
     } yield a
-
-  def toHex(b: Option[Byte]) =
-    b.map(v => String.format("%02x", Integer.valueOf(v & 0xff))).getOrElse("--")
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/util/Lib.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/Lib.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rspace.util
 
 import cats.Monad
+import cats.effect.Sync
 import cats.syntax.all._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -21,15 +22,14 @@ object Lib {
     else s"${m / 1e6d} ms"
   }
 
-  def time[F[_]: Monad, A](tag: String)(block: => F[A]): F[A] = {
-    val t0 = System.nanoTime
+  def time[F[_]: Sync, A](tag: String)(block: => F[A]): F[A] =
     for {
+      t0 <- Sync[F].delay(System.nanoTime)
       a  <- block
       t1 = System.nanoTime
       m  = Duration.fromNanos(t1 - t0)
       _  = println(s">>> $tag elapsed: ${showTime(m)}")
     } yield a
-  }
 
   def toHex(b: Option[Byte]) =
     b.map(v => String.format("%02x", Integer.valueOf(v & 0xff))).getOrElse("--")


### PR DESCRIPTION
## Overview
This PR fixes trie traversal to use Vector instead of Seq to speed up concatenation which was reason for slowdown with larger number of traversed records.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
