### PR TITLE
Remove debug logging in state requester

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -131,8 +131,9 @@ class Initializing[F[_]
 
       // Start only once, when state is true and approved block is valid
       start <- startRequester.modify {
-                case true if isValid => (false, true)
-                case _               => (false, false)
+                case true if isValid  => (false, true)
+                case true if !isValid => (true, false)
+                case _                => (false, false)
               }
 
       // HACK: Wait for master transition to Running


### PR DESCRIPTION
## Overview
Update for PR #3099 to remove debugging info printed to logs. It's printing the whole state in requester which is too much for main net state.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
