### PR TITLE
Validate block even if it is in blockstore

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -127,13 +127,12 @@ object Running {
                       if (r.doIgnore) {
                         logIgnore(r.status) >> false.pure[F]
                       } else {
-                        hasBlock.ifM(
-                          logAlreadyInStore >> ackReceive >> true.pure[F],
-                          validateBlockF(blockMessage, peer).ifM(
-                            saveBlock >> logOkSaved >> ackReceive >> true
-                              .pure[F],
-                            logBadDropped >> false.pure[F]
-                          )
+                        validateBlockF(blockMessage, peer).ifM(
+                          hasBlock.ifM(
+                            logAlreadyInStore >> ackReceive >> true.pure[F],
+                            saveBlock >> logOkSaved >> ackReceive >> true.pure[F]
+                          ),
+                          logBadDropped >> false.pure[F]
                         )
                       }
                     })


### PR DESCRIPTION
This PR adjusts how Running engine handles BlockMessage. Check for block validity is being put before check for block availability in blockstore. For more info see issue attached.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
