### PR TITLE
Do not ask for dependencies for approved block child

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -110,6 +110,7 @@ class Initializing[F[_]
               )
             )
 
+        _ <- BlockStore[F].putApprovedBlock(approvedBlock)
         _ <- LastApprovedBlock[F].set(approvedBlock)
 
         // Update last finalized block with received block hash


### PR DESCRIPTION
As we made ensuring that everything needed for approved state - a task for Initialising engine, we should remove this check from Running and do not request dependencies for approved block children.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
