### PR TITLE
Fix requesting blocks and state chunks

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -146,10 +146,10 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     val sendersNewLM           = (block.sender, block.blockHash)
 
     val logAlreadyStored =
-      Log[F].warn(s"${PrettyPrinter.buildString(block, short = true)} is already stored.")
+      Log[F].warn(s"Block ${PrettyPrinter.buildString(block, short = true)} is already stored.")
 
     val logEmptySender =
-      Log[F].warn(s"${PrettyPrinter.buildString(block, short = true)} sender is empty")
+      Log[F].warn(s"Block ${PrettyPrinter.buildString(block, short = true)} sender is empty.")
 
     // Add LM either if there is no existing message for the sender, or if sequence number advances
     // - assumes block sender is not valid hash

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -59,7 +59,6 @@ trait Casper[F[_]] {
   def getGenesis: F[BlockMessage]
   def getValidator: F[Option[PublicKey]]
   def getVersion: F[Long]
-  def getDeployLifespan: F[Int]
 
   def getBlocksInProcessing: F[Set[BlockHash]]
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -282,7 +282,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
                 validatorIdentity,
                 shardId,
                 version,
-                deployLifespanBlocks,
+                deployLifespan,
                 runtimeManager
               )
           }
@@ -342,7 +342,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
   ): F[(ValidBlockProcessing, BlockDagRepresentation[F])] = {
     val validationStatus: EitherT[F, BlockError, ValidBlock] =
       for {
-        _ <- EitherT(Validate.blockSummary(b, approvedBlock, dag, shardId, deployLifespanBlocks))
+        _ <- EitherT(Validate.blockSummary(b, approvedBlock, dag, shardId, deployLifespan))
         _ <- EitherT.liftF(Span[F].mark("post-validation-block-summary"))
         _ <- EitherT(
               InterpreterUtil
@@ -536,8 +536,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
 
 object MultiParentCasperImpl {
 
-  // TODO: Extract hardcoded deployLifespanBlocks from shard config
-  val deployLifespanBlocks = 50
+  // TODO: Extract hardcoded deployLifespan from shard config
+  // Size of deploy safety range.
+  // Validators will try to put deploy in a block only for next `deployLifespan` blocks.
+  // Required to enable protection from re-submitting duplicate deploys
+  val deployLifespan = 50
 
   def addedEvent(block: BlockMessage): RChainEvent = {
     val (blockHash, parents, justifications, deployIds, creator, seqNum) = blockEvent(block)

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -210,8 +210,8 @@ class Initializing[F[_]
         .filter(v => slashedValidators.contains(v.validator))
         .map(_.latestBlockHash)
         .toSet
-      // Add sorted DAG in reverse order (from approved block)
-      _ <- sortedHashes.flatMap(_._2).toList.reverse.traverse_ { hash =>
+      // Add sorted DAG in order from oldest to approved block
+      _ <- sortedHashes.flatMap(_._2).toList.traverse_ { hash =>
             for {
               block <- BlockStore[F].getUnsafe(hash)
               // if sender has stake 0 in approved block, this means that sender has been slashed and block is invalid

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -131,9 +131,6 @@ class Initializing[F[_]
                 case _                => (false, false)
               }
 
-      // HACK: Wait for master transition to Running
-      _ <- Time[F].sleep(3.seconds).whenA(start)
-
       _ <- handleApprovedBlock.whenA(start)
     } yield ()
   }

--- a/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
@@ -138,7 +138,7 @@ object LastFinalizedStateBlockRequester {
 
           // Mark block as finished
           blockNumber           = ProtoUtil.blockNumber(block)
-          blockNumberOpt        = if (useAsMinHeight) blockNumber.some else none
+          blockNumberOpt        = if (useAsMinHeight) (blockNumber - 1).some else none
           minBlockNumberForDeps <- st.modify(_.done(block.blockHash, blockNumberOpt))
 
           // Minimum block number to request

--- a/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
@@ -96,7 +96,7 @@ object LastFinalizedStateBlockRequester {
 
     val block                           = approvedBlock.candidate.block
     val approvedBlockNumber             = ProtoUtil.blockNumber(block)
-    val minBlockNumberForDeployLifespan = approvedBlockNumber - MultiParentCasperImpl.deployLifespanBlocks
+    val minBlockNumberForDeployLifespan = approvedBlockNumber - MultiParentCasperImpl.deployLifespan
 
     // Active validators as per approved block state
     // - for approved state to be complete it is required to have block from each of them

--- a/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
@@ -98,7 +98,7 @@ object LastFinalizedStateBlockRequester {
 
     // Active validators as per approved block state
     // - for approved state to be complete it is required to have block from each of them
-    val validators = ProtoUtil.bonds(block).filter(_.stake > 0).map(_.validator).toSet[Validator]
+    val validators = ProtoUtil.bonds(block).map(_.validator).toSet[Validator]
 
     def createStream(
         st: SignallingRef[F, ST[BlockHash, Validator]],

--- a/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LastFinalizedStateBlockRequester.scala
@@ -1,22 +1,21 @@
 package coop.rchain.casper.engine
 
 import cats.effect.Concurrent
-import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.ValidBlock.Valid
-import coop.rchain.casper.{PrettyPrinter, Validate}
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage}
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.comm.CommUtil
+import coop.rchain.casper.{MultiParentCasperImpl, PrettyPrinter, Validate}
 import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.{Log, Time}
-import fs2.Stream
 import fs2.concurrent.{Queue, SignallingRef}
+import fs2.{Pipe, Stream}
 
 import scala.concurrent.duration._
 
@@ -31,38 +30,54 @@ object LastFinalizedStateBlockRequester {
   /**
     * State to control processing of requests
     */
-  final case class ST[Key](private val d: Map[Key, ReqStatus]) {
+  final case class ST[Key, Sender](
+      private val d: Map[Key, ReqStatus] = Map[Key, ReqStatus](),
+      senders: Set[Sender] = Set[Sender](),
+      lowerBound: Long = Long.MaxValue
+  ) {
     // Adds new keys to Init state, ready for processing. Existing keys are skipped.
-    def add(keys: Set[Key]): ST[Key] = ST(d ++ keys.filterNot(d.contains).map((_, Init)))
+    def add(keys: Set[Key]): ST[Key, Sender] =
+      this.copy(d ++ keys.filterNot(d.contains).map((_, Init)))
 
     // Get next keys not already requested or
     //  in case of resend together with Requested.
     // Returns updated state with requested keys.
-    def getNext(resend: Boolean): (ST[Key], Seq[Key]) = {
+    def getNext(resend: Boolean): (ST[Key, Sender], Seq[Key]) = {
       val requested = d
         .filter { case (_, v) => v == Init || (resend && v == Requested) }
         .mapValues(_ => Requested)
-      ST(d ++ requested) -> requested.keysIterator.toSeq
+      this.copy(d ++ requested) -> requested.keysIterator.toSeq
     }
 
     // Confirm key is Received if it was Requested.
     // Returns updated state with the flag if it was Requested.
-    def received(k: Key): (ST[Key], Boolean) = {
+    def received(k: Key): (ST[Key, Sender], Boolean) = {
       val isRequested = d.get(k).contains(Requested)
       val newSt       = if (isRequested) d + ((k, Received)) else d
-      ST(newSt) -> isRequested
+      this.copy(newSt) -> isRequested
     }
 
-    // Mark key as finished (Done).
-    def done(k: Key): ST[Key] = ST(d + ((k, Done)))
+    // Mark key as finished (Done) with optionally set minimum lower bound.
+    def done(k: Key, height: Option[Long]): (ST[Key, Sender], Long) = {
+      val newLowest = height.fold(lowerBound)(Math.min(_, lowerBound))
+      val newSt     = d + ((k, Done))
+      this.copy(newSt, lowerBound = newLowest) -> newLowest
+    }
 
     // Returns flag if all keys are marked as finished (Done).
     def isFinished: Boolean = !d.exists { case (_, v) => v != Done }
+
+    // Track when senders list will be empty
+    def hasSender(sender: Sender): (ST[Key, Sender], Boolean) = {
+      val newSenders = senders - sender
+      this.copy(senders = newSenders) -> (senders != newSenders)
+    }
   }
 
   object ST {
     // Create requests state with initial keys.
-    def apply[Key](initial: Seq[Key]): ST[Key] = ST[Key](d = initial.map((_, Init)).toMap)
+    def apply[Key, V](initial: Seq[Key], senders: Set[V]): ST[Key, V] =
+      ST[Key, V](d = initial.map((_, Init)).toMap, senders)
   }
 
   /**
@@ -77,18 +92,79 @@ object LastFinalizedStateBlockRequester {
       responseQueue: Queue[F, BlockMessage]
   ): F[Stream[F, Boolean]] = {
 
+    val block                           = approvedBlock.candidate.block
+    val approvedBlockNumber             = ProtoUtil.blockNumber(block)
+    val minBlockNumberForDeployLifespan = approvedBlockNumber - MultiParentCasperImpl.deployLifespanBlocks
+
+    // Active validators as per approved block state
+    // - for approved state to be complete it is required to have block from each of them
+    val validators = ProtoUtil.bonds(block).filter(_.stake > 0).map(_.validator).toSet[Validator]
+
     def createStream(
-        d: SignallingRef[F, ST[BlockHash]],
-        requestQueue: Queue[F, Boolean],
-        validatorsRequired: Ref[F, Set[Validator]]
+        st: SignallingRef[F, ST[BlockHash, Validator]],
+        requestQueue: Queue[F, Boolean]
     ): Stream[F, Boolean] = {
 
       def broadcastStreams(ids: Seq[BlockHash]) = {
         // Create broadcast requests to peers
         val broadcastRequests = ids.map(x => Stream.eval(CommUtil[F].broadcastRequestForBlock(x)))
-        // Create stream if requests
+        // Create stream of requests
         Stream(broadcastRequests: _*)
       }
+
+      /**
+        * Validate and save block. Checking justifications from last finalized block gives us proof
+        *  for all ancestor blocks.
+        */
+      def validateAndSaveBlock(block: BlockMessage) =
+        for {
+          isBlockHashValid_ <- Validate.blockHash(block).map(_ == Right(Valid))
+          // TODO: validate zero genesis correctly
+          isBlockHashValid = block.body.state.blockNumber == 0 || isBlockHashValid_
+
+          // Log invalid block
+          invalidBlockMsg = s"Received ${PrettyPrinter.buildString(block)} with invalid hash. Ignored block."
+          _               <- Log[F].warn(invalidBlockMsg).whenA(!isBlockHashValid)
+
+          _ <- saveBlock(block).whenA(isBlockHashValid)
+        } yield ()
+
+      def saveBlock(block: BlockMessage) =
+        for {
+          // Block is latest message from bonded validator
+          // - we need all child blocks of this block
+          // - it must be used to calculate minimum block height
+          useAsMinHeight <- st.modify(_.hasSender(block.sender))
+
+          // Mark block as finished
+          blockNumber           = ProtoUtil.blockNumber(block)
+          blockNumberOpt        = if (useAsMinHeight) blockNumber.some else none
+          minBlockNumberForDeps <- st.modify(_.done(block.blockHash, blockNumberOpt))
+
+          // Minimum block number to request
+          minBlockNumber = Math.min(minBlockNumberForDeps, minBlockNumberForDeployLifespan)
+
+          // Is block number accepted
+          isBlockNumberAccepted = blockNumber >= minBlockNumber
+
+          // Save block to the store
+          alreadySaved <- BlockStore[F].contains(block.blockHash)
+          _ <- BlockStore[F]
+                .put(block.blockHash, block)
+                .whenA(isBlockNumberAccepted && !alreadySaved)
+
+          _ <- Log[F]
+                .info(s"New minimum block height re-calculated $minBlockNumberForDeps.")
+                .whenA(useAsMinHeight)
+
+          // Update dependencies for requesting
+          requestDependencies = getBlockDependencies(block) >>= (
+              deps => st.update(_.add(deps.toSet))
+          )
+          _ <- requestDependencies.whenA(isBlockNumberAccepted)
+        } yield ()
+
+      import cats.instances.list._
 
       /**
         * Request stream is pulling new block hashes ready for broadcast requests.
@@ -98,13 +174,22 @@ object LastFinalizedStateBlockRequester {
         resend <- requestQueue.dequeue
 
         // Check if stream is finished (no more requests)
-        isEnd <- Stream.eval(d.get.map(_.isFinished))
+        isEnd <- Stream.eval(st.get.map(_.isFinished))
 
-        // Take next set of items to request
-        ids <- Stream.eval(d.modify(_.getNext(resend)))
+        // Take next set of items to request (w/o duplicates)
+        hashes <- Stream.eval(st.modify(_.getNext(resend)))
+
+        // Check existing blocks
+        existingHashes <- Stream.eval(hashes.toList.filterA(BlockStore[F].contains))
+
+        // Missing blocks not already in the block store
+        missingBlocks = hashes.diff(existingHashes)
+
+        _ <- Stream.eval(st.update(_.add(missingBlocks.toSet)))
 
         // Send all requests in parallel
-        _ <- broadcastStreams(ids).parJoinUnbounded.whenA(!isEnd && ids.nonEmpty)
+        _ <- broadcastStreams(missingBlocks).parJoinUnbounded
+              .whenA(!isEnd && missingBlocks.nonEmpty)
       } yield isEnd
 
       /**
@@ -115,58 +200,17 @@ object LastFinalizedStateBlockRequester {
         block <- responseQueue.dequeue
 
         // Mark block as received
-        isReceived <- Stream.eval(d.modify(_.received(block.blockHash)))
-
-        allValidatorsSeen <- Stream.eval(validatorsRequired.modify[Boolean] { currSet =>
-                              val newSet = currSet - block.sender
-                              (newSet, newSet.isEmpty)
-                            })
-
-        inDeployLifeSpanRage = ProtoUtil.blockNumber(block) > ProtoUtil.blockNumber(
-          approvedBlock.candidate.block
-          // TODO extract this number from shard config
-        ) - 50
-        // Add block parents for requesting
-        _ <- Stream
-              .eval {
-                for {
-                  deps <- getBlockDependencies(block)
-                  _    <- d.update(_.add(deps.toSet))
-                } yield ()
-              }
-              .whenA(isReceived && (inDeployLifeSpanRage || !allValidatorsSeen))
-
-        /**
-          * Validate block hash. Checking justifications from last finalized block gives us proof
-          *  for all ancestor blocks.
-          */
-        isBlockHashValid_ <- Stream.eval(Validate.blockHash(block).map(_ == Right(Valid)))
-        // TODO: validate zero genesis correctly
-        isBlockHashValid = block.body.state.blockNumber == 0 || isBlockHashValid_
-        warnInvalidBlock = Log[F].warn(
-          s"Received ${PrettyPrinter.buildString(block)} with invalid hash. Ignored block."
-        )
-        // Log invalid block
-        _ <- Stream.eval(warnInvalidBlock).whenA(isReceived && !isBlockHashValid)
+        isReceived <- Stream.eval(st.modify(_.received(block.blockHash)))
 
         // Save block to DAG store
-        _ <- Stream
-              .eval(
-                for {
-                  // Save block to the store
-                  _ <- BlockStore[F].put(block.blockHash, block)
-                  // Mark block as finished
-                  _ <- d.update(_.done(block.blockHash))
-                } yield ()
-              )
-              .whenA(isReceived && isBlockHashValid)
+        _ <- Stream.eval(validateAndSaveBlock(block)).whenA(isReceived)
 
         // Trigger request queue (without resend of already requested)
         _ <- Stream.eval(requestQueue.enqueue1(false))
       } yield ()
 
       /**
-        * Timeout to resend block requests if response is not received
+        * Timeout to resend block requests if response is not received.
         */
       val timeoutDuration = 30.seconds
       val timeoutMsg      = s"No block responses for $timeoutDuration. Requests resent."
@@ -176,13 +220,14 @@ object LastFinalizedStateBlockRequester {
       )
       // Switch to resend if response is not triggered after timeout
       // - response message reset timeout by canceling previous stream
-      val timeoutResendStream = responseStream.switchMap(_ => resendStream.repeat)
+      def withTimeout: Pipe[F, Boolean, Boolean] =
+        in => in concurrently in.switchMap(_ => resendStream)
 
       /**
         * Final result! Concurrently pulling requests and handling responses
         *  with resend timeout if response is not received.
         */
-      requestStream.takeWhile(!_) concurrently responseStream concurrently timeoutResendStream
+      requestStream.takeWhile(!_).broadcastThrough(withTimeout) concurrently responseStream
     }
 
     def getBlockDependencies(block: BlockMessage) = {
@@ -191,26 +236,20 @@ object LastFinalizedStateBlockRequester {
     }
 
     for {
+      // Requester state, fill with validators for required latest messages
+      st <- SignallingRef[F, ST[BlockHash, Validator]](
+             ST(Seq(block.blockHash), senders = validators)
+           )
 
-      // Start block hashes
-      dependenciesHashes <- getBlockDependencies(approvedBlock.candidate.block)
-      // Requester state
-      st <- SignallingRef[F, ST[BlockHash]](ST(dependenciesHashes))
       // Block requests queue
       requestQueue <- Queue.unbounded[F, Boolean]
-
-      // active validators as per approved block state
-      // for approved state to be complete it is required to have block from each of them
-      abValidators = approvedBlock.candidate.block.body.state.bonds
-        .filter(_.stake > 0)
-        .map(_.validator)
-      validatorsRequired <- Ref.of[F, Set[Validator]](abValidators.toSet)
 
       // Light the fire! / Starts the first request for block
       // - `true` if requested blocks should be re-requested
       _ <- requestQueue.enqueue1(false)
+
       // Create block receiver stream
-    } yield createStream(st, requestQueue, validatorsRequired)
+    } yield createStream(st, requestQueue)
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -261,6 +261,5 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   override def dagContains(hash: BlockHash): F[Boolean]    = underlying.dagContains(hash)
   override def bufferContains(hash: BlockHash): F[Boolean] = underlying.bufferContains(hash)
   override def getVersion: F[Long]                         = underlying.getVersion
-  override def getDeployLifespan: F[Int]                   = underlying.getDeployLifespan
   override def getBlocksInProcessing: F[Set[BlockHash]]    = underlying.getBlocksInProcessing
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/TransportLayerSyntax.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/TransportLayerSyntax.scala
@@ -47,7 +47,7 @@ final class TransportLayerOps[F[_]: Monad: RPConfAsk](
       message: Msg
   ): F[Unit] = streamToPeer(peer, ToPacket(message))
 
-  def sendToBootstrap(message: Packet): F[Unit] =
+  def sendToBootstrap[Msg: ToPacket](message: Msg): F[Unit] =
     for {
       maybeBootstrap <- RPConfAsk[F].reader(_.bootstrap)
       bootstrap      = maybeBootstrap.get

--- a/models/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
+++ b/models/src/main/scala/coop/rchain/casper/PrettyPrinter.scala
@@ -20,7 +20,9 @@ object PrettyPrinter {
   // TODO shouldn header.parentsHashList be nonempty list?
   private def buildString(b: BlockMessage, short: Boolean): String =
     b.header.parentsHashList.headOption
-      .fold(s"Block ${buildString(b.blockHash)} with empty parents (supposedly genesis)")(
+      .fold(
+        s"Block #${b.body.state.blockNumber} (${buildString(b.blockHash)}) with empty parents (supposedly genesis)"
+      )(
         mainParent =>
           if (short) {
             s"#${b.body.state.blockNumber} (${buildString(b.blockHash)})"


### PR DESCRIPTION
## Overview
This PR fixes and improves how block and state requester manage internal state to track received and saved items. Part of that is timeout stream which in previous solution was dequeueing twice so now Pipe is used instead to broadcast from the queue.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
