### PR TITLE
Make Justification regression work with LFS

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -663,7 +663,6 @@ class ValidateTest
                   dag   <- blockDagStorage.getRepresentation
                   result <- Validate.justificationRegressions[Task](
                              block,
-                             b0,
                              dag
                            )
                 } yield result == Right(Valid)
@@ -681,7 +680,6 @@ class ValidateTest
         dag <- blockDagStorage.getRepresentation
         _ <- Validate.justificationRegressions[Task](
               blockWithJustificationRegression,
-              b0,
               dag
             ) shouldBeF Left(JustificationRegression)
         result = log.warns.size shouldBe 1
@@ -715,7 +713,6 @@ class ValidateTest
         dag <- blockDagStorage.getRepresentation
         _ <- Validate.justificationRegressions[Task](
               blockWithInvalidJustification,
-              b0,
               dag
             ) shouldBeF Right(Valid)
       } yield ()


### PR DESCRIPTION
Testing of LFS revealed (unexpectedly) possible flaw in justification regression detector.

JR detector can be broken when validator bonds and does not propose blocks.

More info in related issue

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
