### PR TITLE
RCHAIN-3952 - fix for LMDB read operation

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
@@ -48,10 +48,8 @@ object StoreInstances {
       dbi   <- Sync[F].delay { env.openDbi("db", MDB_CREATE) }
       store = LMDBStore(env, dbi)
     } yield new Store[F] {
-      override def get(key: Blake2b256Hash): F[Option[BitVector]] = {
-        val directKey = key.bytes.toDirectByteBuffer
-        get(directKey).map(v => v.map(BitVector(_)))
-      }
+      override def get(key: Blake2b256Hash): F[Option[BitVector]] =
+        get(Seq(key), BitVector(_)).map(_.head)
 
       override def put(key: Blake2b256Hash, value: BitVector): F[Unit] = {
         val directKey   = key.bytes.toDirectByteBuffer

--- a/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
@@ -18,6 +18,11 @@ trait Store[F[_]] {
   def get(key: ByteBuffer): F[Option[ByteBuffer]]
   def put(key: ByteBuffer, value: ByteBuffer): F[Unit]
   def put(data: Seq[(Blake2b256Hash, BitVector)]): F[Unit]
+
+  // Multiple keys (for exporter/importer)
+  def get[T](keys: Seq[Blake2b256Hash], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]]
+  def put[T](keys: Seq[(Blake2b256Hash, T)], toBuffer: T => ByteBuffer): F[Unit]
+
   def close(): F[Unit]
 }
 
@@ -56,6 +61,11 @@ object StoreInstances {
 
       override def get(key: ByteBuffer): F[Option[ByteBuffer]] = store.get(key)
 
+      override def get[T](
+          keys: Seq[Blake2b256Hash],
+          fromBuffer: ByteBuffer => T
+      ): F[Seq[Option[T]]] = store.get[T](keys.map(_.bytes.toDirectByteBuffer), fromBuffer)
+
       override def put(key: ByteBuffer, value: ByteBuffer): F[Unit] = store.put(key, value)
 
       @SuppressWarnings(Array("org.wartremover.warts.Throw"))
@@ -80,6 +90,14 @@ object StoreInstances {
         store.withWriteTxnF { txn =>
           byteBuffers.foreach { case (key, value) => putIfAbsent(txn, key, value) }
         }
+      }
+
+      override def put[T](
+          data: Seq[(Blake2b256Hash, T)],
+          toBuffer: T => ByteBuffer
+      ): F[Unit] = {
+        val rawData = data.map { case (k, v) => (k.bytes.toDirectByteBuffer, v) }
+        store.put(rawData, toBuffer)
       }
 
       override def close(): F[Unit] = store.close()


### PR DESCRIPTION
## Overview
This PR fixes long standing bug which was occurring very rarely when HistoryStore was reading data.

This fix is to convert ByteBuffer returned from LMDB get operation before transaction is closed.

Also in this PR are additional methods on LMDBStore to get and put multiple records in one transaction which will be needed later for last finalized state feature.

### JIRA issue
https://rchain.atlassian.net/browse/RCHAIN-3952

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
