### PR TITLE
Refactor dagstore insert, allow reverse order adding

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/ByteStringKVStoreSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/ByteStringKVStoreSyntax.scala
@@ -1,0 +1,32 @@
+package coop.rchain.blockstorage
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.models.Validator.Validator
+import coop.rchain.store.KeyValueTypedStore
+import coop.rchain.shared.syntax._
+
+trait ByteStringKVStoreSyntax {
+  implicit final def blockStorageSyntaxByteStringKVTypedStore[F[_], V](
+      store: KeyValueTypedStore[F, Validator, V]
+  ): ByteStringKVStoreOps[F, V] = new ByteStringKVStoreOps[F, V](store)
+}
+
+final case class ByteStringKVInconsistencyError(message: String) extends Exception(message)
+
+final class ByteStringKVStoreOps[F[_], V](
+    // KeyValueTypedStore extensions / syntax
+    private val store: KeyValueTypedStore[F, Validator, V]
+) extends AnyVal {
+  def getUnsafe(key: Validator)(
+      implicit f: Sync[F],
+      line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing
+  ): F[V] = {
+    def source = s"${file.value}:${line.value} ${enclosing.value}"
+    def errMsg = s"ByteStringKVStore is missing key ${PrettyPrinter.buildString(key)}\n $source"
+    store.get(key) >>= (_.liftTo(ByteStringKVInconsistencyError(errMsg)))
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -10,6 +10,7 @@ import coop.rchain.blockstorage.dag.BlockMetadataStore.BlockMetadataStore
 import coop.rchain.blockstorage.dag.EquivocationTrackerStore.EquivocationTrackerStore
 import coop.rchain.blockstorage.dag.codecs._
 import coop.rchain.blockstorage.util.BlockMessageUtil._
+import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.Metrics.Source
@@ -19,6 +20,7 @@ import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
 import coop.rchain.shared.syntax._
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.shared.{Log, LogSource}
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
 
@@ -133,57 +135,100 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
   def insert(
       block: BlockMessage,
       invalid: Boolean
-  ): F[BlockDagRepresentation[F]] =
-    lock.withPermit(
+  ): F[BlockDagRepresentation[F]] = {
+    import cats.instances.list._
+    import cats.instances.option._
+    import coop.rchain.catscontrib.Catscontrib.ToBooleanF
+
+    // Empty sender is valid for genesis
+    val senderIsEmpty          = block.sender == ByteString.EMPTY
+    val senderHasInvalidFormat = (block.sender.size() != Validator.Length) && !senderIsEmpty
+    val sendersNewLM           = (block.sender, block.blockHash)
+
+    val logAlreadyStored =
+      Log[F].warn(s"Block ${PrettyPrinter.buildString(block, short = true)} is already stored.")
+
+    val logEmptySender =
+      Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty")
+
+    def shouldAddAsLatest: F[Boolean] =
+      // Do not add LM for empty senders
+      (!senderIsEmpty).pure[F] &&^
+        // Add LM either if there is no one for sender, or if sequence number advances
+        (latestMessagesIndex.contains(block.sender).not ||^
+          latestMessagesIndex
+          // Try get sender's latest message
+            .get(block.sender)
+            // Get metadata from index
+            .flatMap(_.traverse(blockMetadataIndex.getUnsafe))
+            // Check if seq number is greater that existing
+            .map(_.map(block.seqNum >= _.seqNum))
+            // Evaluate option and result
+            .map(_.contains(true)))
+
+    def newLatestMessages: F[Map[Validator, BlockHash]] = {
+      val newlyBondedSet = bonds(block)
+        .map(_.validator)
+        .toSet
+        .diff(block.justifications.map(_.validator).toSet)
       for {
-        alreadyStored <- blockMetadataIndex.contains(block.blockHash)
-        _ <- if (alreadyStored) {
-              Log[F].warn(s"Block ${Base16.encode(block.blockHash.toByteArray)} is already stored")
-            } else {
-              val blockMetadata = BlockMetadata.fromBlock(block, invalid)
-              assert(block.blockHash.size == BlockHash.Length)
-              for {
-                _ <- if (invalid) invalidBlocksIndex.put(blockMetadata.blockHash, blockMetadata)
-                    else ().pure[F]
-                //Block which contains newly bonded validators will not
-                //have those validators in its justification
-                newValidators = bonds(block)
-                  .map(_.validator)
-                  .toSet
-                  .diff(block.justifications.map(_.validator).toSet)
-                newValidatorsLatestMessages = newValidators.map(v => (v, block.blockHash))
-                newValidatorsWithSenderLatestMessages <- if (block.sender.isEmpty) {
-                                                          // Ignore empty sender for special cases such as genesis block
-                                                          Log[F].warn(
-                                                            s"Block ${Base16.encode(block.blockHash.toByteArray)} sender is empty"
-                                                          ) >> newValidatorsLatestMessages.pure[F]
-                                                        } else if (block.sender
-                                                                     .size() == Validator.Length) {
-                                                          (newValidatorsLatestMessages + (
-                                                            (
-                                                              block.sender,
-                                                              block.blockHash
-                                                            )
-                                                          )).pure[F]
-                                                        } else {
-                                                          Sync[F].raiseError[Set[
-                                                            (ByteString, ByteString)
-                                                          ]](
-                                                            BlockSenderIsMalformed(block)
-                                                          )
-                                                        }
-                deployHashes = deployData(block).map(_.sig).toList
-                // Add deploys to deploy index storage
-                _ <- deployIndex.put(deployHashes.map(_ -> block.blockHash))
-                // Add/update validators latest messages
-                _ <- latestMessagesIndex.put(newValidatorsWithSenderLatestMessages.toList)
-                // Add block metadata
-                _ <- blockMetadataIndex.add(blockMetadata)
-              } yield ()
-            }
-        dag <- representation
-      } yield dag
+        // This filter is required to enable adding blocks backward from higher height to lower
+        newlyBondedUnseen <- newlyBondedSet.toList.filterA(
+                              lm => latestMessagesIndex.contains(lm).not
+                            )
+        newlyBondedLMs = newlyBondedUnseen.map(v => (v, block.blockHash)).toMap
+
+      } yield newlyBondedLMs
+    }
+
+    def doInsert: F[Unit] = {
+      val blockMetadata      = BlockMetadata.fromBlock(block, invalid)
+      val blockHashIsInvalid = !(block.blockHash.size == BlockHash.Length)
+
+      for {
+        // Basic validation of input hash values
+        _ <- BlockSenderIsMalformed(block).raiseError[F, Unit].whenA(senderHasInvalidFormat)
+        // TODO: should we have special error type for block hash error also?
+        //  Should this be checked before calling insert? Is DAG storage responsible for that?
+        _ <- new Exception(
+              s"Block hash (${PrettyPrinter.buildString(block.blockHash)}) is not correct length."
+            ).raiseError[F, Unit]
+              .whenA(blockHashIsInvalid)
+
+        _ <- logEmptySender.whenA(senderIsEmpty)
+
+        // Add block metadata
+        _ <- blockMetadataIndex.add(blockMetadata)
+
+        // Add deploys to deploy index storage
+        deployHashes = deployData(block).map(_.sig).toList
+        _            <- deployIndex.put(deployHashes.map(_ -> block.blockHash))
+
+        // Update invalid index
+        _ <- invalidBlocksIndex.put(blockMetadata.blockHash, blockMetadata).whenA(invalid)
+
+        // Resolve if block should be added as the latest message for the block sender
+        newLatestFromSender <- (senderIsEmpty.pure[F].not &&^ shouldAddAsLatest)
+                                .ifM(
+                                  Map(sendersNewLM).pure[F],
+                                  Map.empty[Validator, BlockHash].pure[F]
+                                )
+
+        // Add/update validators latest messages
+        newLatestFromNewValidators <- newLatestMessages
+
+        // All new latest messages to add
+        newLatestToAdd = newLatestFromNewValidators ++ newLatestFromSender
+
+        // Add latest messages to DB
+        _ <- latestMessagesIndex.put(newLatestToAdd.toList)
+      } yield ()
+    }
+
+    lock.withPermit(
+      blockMetadataIndex.contains(block.blockHash).ifM(logAlreadyStored, doInsert) >> representation
     )
+  }
 
   override def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A] =
     lock.withPermit(f(KeyValueStoreEquivocationsTracker))

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain
 
-import coop.rchain.blockstorage.BlockStoreSyntax
+import coop.rchain.blockstorage.{BlockStoreSyntax, ByteStringKVStoreSyntax}
 import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
 import coop.rchain.metrics.Metrics
 
@@ -13,4 +13,7 @@ package object blockstorage {
 }
 
 // Block storage syntax
-trait AllSyntaxBlockStorage extends BlockStoreSyntax with BlockDagRepresentationSyntax
+trait AllSyntaxBlockStorage
+    extends BlockStoreSyntax
+    with BlockDagRepresentationSyntax
+    with ByteStringKVStoreSyntax


### PR DESCRIPTION
This fixes some flaws in bockDAG insert method, that are required for LFS.
1. do not update latest message if seqNum goes backwards
2. do not update latest message for newly bonded validators if blocks are added in reverse order.
3. Refactor


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
