### PR TITLE
Tests for LFS block requester

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -9,6 +9,7 @@ import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
+import coop.rchain.casper.ValidBlock.Valid
 import coop.rchain.casper._
 import coop.rchain.casper.engine.EngineCell._
 import coop.rchain.casper.protocol._
@@ -140,7 +141,11 @@ class Initializing[F[_]
       // Request all blocks for Last Finalized State
       blockRequestStream <- LastFinalizedStateBlockRequester.stream(
                              approvedBlock,
-                             blockMessageQueue
+                             blockMessageQueue,
+                             CommUtil[F].broadcastRequestForBlock,
+                             BlockStore[F].contains,
+                             BlockStore[F].put,
+                             block => Validate.blockHash(block).map(_ == Right(Valid))
                            )
 
       // Request tuple space state for Last Finalized State

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -99,7 +99,7 @@ class InitializingSpec extends WordSpec with BeforeAndAfterEach {
         _ <- EngineCell[Task].set(initializingEngine)
 
         // Send responses with some delay because `Initializing.handle` is blocking until LFS is not received.
-        _ <- Concurrent[Task].start(Task.sleep(1.second) >> enqueueResponses)
+        _ <- Concurrent[Task].start(Task.sleep(5.second) >> enqueueResponses)
 
         // Handle approved block (it's blocking until responses are received)
         _ <- initializingEngine.handle(local, approvedBlock)

--- a/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterEffectsSpec.scala
@@ -1,0 +1,259 @@
+package coop.rchain.casper.engine
+
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.TestTime
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.blockImplicits
+import coop.rchain.shared.{Log, SyncVarOps, Time}
+import fs2.Stream
+import fs2.concurrent.Queue
+import monix.eval.Task
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class LFSBlockRequesterEffectsSpec
+    extends FlatSpec
+    with Matchers
+    with GeneratorDrivenPropertyChecks {
+
+  def mkHash(bs: Byte*) = ByteString.copyFrom(bs.toArray)
+
+  def getBlock(hash: BlockHash, number: Long, latestMessages: Seq[BlockHash]) = {
+    val justifications                     = latestMessages.map(Justification(ByteString.EMPTY, _))
+    val hashFun: BlockMessage => BlockHash = _ => hash
+    blockImplicits.getRandomBlock(
+      hashF = hashFun.some,
+      setBlockNumber = number.some,
+      setJustifications = justifications.some,
+      // Parents must be set also to prevent auto generation
+      setParentsHashList = justifications.map(_.latestBlockHash).some
+    )
+  }
+
+  def createApprovedBlock(block: BlockMessage): ApprovedBlock = {
+    val candidate = ApprovedBlockCandidate(block, requiredSigs = 0)
+    ApprovedBlock(candidate, Nil)
+  }
+
+  val hash9 = mkHash(90)
+  val hash8 = mkHash(80)
+  val hash7 = mkHash(70)
+  val hash6 = mkHash(60)
+  val hash5 = mkHash(50)
+  val hash4 = mkHash(40)
+  val hash3 = mkHash(30)
+  val hash2 = mkHash(20)
+  val hash1 = mkHash(10)
+
+  val b9 = getBlock(hash9, number = 109, Seq(hash8, hash7))
+  val b8 = getBlock(hash8, number = 108, Seq(hash6, hash4))
+  val b7 = getBlock(hash7, number = 107, Seq(hash5))
+  val b6 = getBlock(hash6, number = 106, Seq(hash4))
+  val b5 = getBlock(hash5, number = 75, Seq(hash3))
+  val b4 = getBlock(hash4, number = 34, Seq(hash2))
+  val b3 = getBlock(hash3, number = 23, Seq(hash1))
+  val b2 = getBlock(hash2, number = 2, Seq())
+  val b1 = getBlock(hash1, number = 1, Seq())
+
+  trait Effects[F[_]] {
+    def requestForBlock(hash: BlockHash): F[Unit]
+    def containsBlockInStore(hash: BlockHash): F[Boolean]
+    def putBlockToStore(hash: BlockHash, b: BlockMessage): F[Unit]
+    def validateBlock(b: BlockMessage): F[Boolean]
+  }
+
+  case class EffectsImpl[F[_]: Sync](
+      var requests: List[BlockHash],
+      var puts: Map[BlockHash, BlockMessage],
+      var invalids: Set[BlockHash]
+  ) extends Effects[F] {
+    val lock = SyncVarOps.create(this)
+
+    // Helper for multi-thread safe update of the state
+    def atomically[A](operation: => A): F[A] =
+      Sync[F].delay {
+        lock.take()
+        val result = operation
+        lock.put(this)
+        result
+      }
+
+    override def requestForBlock(hash: BlockHash): F[Unit] =
+      atomically(requests = requests :+ hash).void
+
+    override def containsBlockInStore(hash: BlockHash): F[Boolean] =
+      atomically(puts.contains(hash))
+
+    override def putBlockToStore(hash: BlockHash, b: BlockMessage): F[Unit] =
+      atomically(puts = puts + ((hash, b))).void
+
+    override def validateBlock(b: BlockMessage): F[Boolean] =
+      atomically(!invalids(b.blockHash))
+  }
+
+  trait SUT[F[_], Eff] {
+    // Processing stream
+    val stream: Stream[F, Boolean]
+    // Fill response queue - simulate receiving blocks from external source
+    def receive(bs: BlockMessage*): F[Unit]
+    // Observed effects (sent requests, saved blocks, ...)
+    val eff: Eff
+  }
+
+  def createSut[F[_]: Concurrent: Time: Log, Eff <: Effects[F]](
+      startBlock: BlockMessage,
+      effects: Eff
+  )(test: SUT[F, Eff] => F[Unit]): F[Unit] = {
+    import cats.instances.list._
+
+    val approvedBlock = createApprovedBlock(startBlock)
+    for {
+      // Queue for received blocks
+      responseQueue <- Queue.unbounded[F, BlockMessage]
+      // Queue for processing the internal state (ST)
+      requestStream <- LastFinalizedStateBlockRequester.stream(
+                        approvedBlock,
+                        responseQueue,
+                        effects.requestForBlock,
+                        effects.containsBlockInStore,
+                        effects.putBlockToStore,
+                        effects.validateBlock
+                      )
+
+      receiveBlocks = (bs: List[BlockMessage]) => {
+        bs.traverse_(responseQueue.enqueue1(_) >> requestStream.take(1).compile.drain)
+      }
+
+      sut = new SUT[F, Eff] {
+        override val stream: Stream[F, Boolean]          = requestStream
+        override def receive(bs: BlockMessage*): F[Unit] = receiveBlocks(bs.toList)
+        override val eff: Eff                            = effects
+      }
+
+      // Take one element from the stream, processed the first signal on start
+      _ <- requestStream.take(1).compile.drain
+
+      // Execute test function
+      _ <- test(sut)
+    } yield ()
+  }
+
+  implicit val logEff: Log[Task]   = Log.log[Task]
+  implicit val timeEff: Time[Task] = TestTime.instance
+
+  import monix.execution.Scheduler.Implicits.global
+
+  def dagFromBlock(startBlock: BlockMessage)(f: SUT[Task, EffectsImpl[Task]] => Task[Unit]): Unit =
+    createSut[Task, EffectsImpl[Task]](startBlock, EffectsImpl[Task](Nil, Map(), Set()))(f)
+      .runSyncUnsafe(20000.seconds)
+
+  def asMap(bs: BlockMessage*): Map[BlockHash, BlockMessage] = bs.map(b => (b.blockHash, b)).toMap
+
+  it should "send requests for dependencies" in dagFromBlock(b9) { sut =>
+    import sut._
+    for {
+      // Receive of parent should create requests for justifications
+      _ <- receive(b9)
+
+      _ = eff.requests shouldBe List(hash9, hash8, hash7)
+    } yield ()
+  }
+
+  it should "save received blocks if requested" in dagFromBlock(b9) { sut =>
+    import sut._
+    for {
+      // Receive first block
+      _ <- receive(b9)
+
+      // Receive one dependency
+      _ <- receive(b8)
+
+      // Both blocks should be saved
+      _ = eff.puts shouldBe asMap(b9, b8)
+    } yield ()
+  }
+
+  it should "skip received invalid blocks" in dagFromBlock(b9) { sut =>
+    import sut._
+    for {
+      // Receive first block
+      _ <- receive(b9)
+      _ = eff.requests = Nil
+      _ = eff.puts = Map()
+
+      // Set invalid blocks
+      _ = eff.invalids = Set(hash8)
+
+      // Receive dependencies
+      _ <- receive(b8, b7)
+
+      // Only valid block should be saved
+      _ = eff.puts shouldBe asMap(b7)
+
+      // Only dependencies from valid block should requested
+      _ = eff.requests shouldBe List(hash5)
+    } yield ()
+  }
+
+  it should "drop all blocks not requested" in dagFromBlock(b9) { sut =>
+    import sut._
+    for {
+      // Receive blocks not requested
+      _ <- receive(b8, b7, b6, b5, b4, b3, b2, b1)
+
+      // It should contain only request for the first block
+      _ = eff.requests shouldBe List(hash9)
+      // Nothing should be saved
+      _ = eff.puts shouldBe Map()
+    } yield ()
+  }
+
+  it should "request and save all blocks" in dagFromBlock(b9) { sut =>
+    import sut._
+    // First block should be requested
+    eff.requests shouldBe List(hash9)
+    eff.requests = Nil
+    for {
+      // Receive block b9
+      _ <- receive(b9)
+
+      // Dependencies of b9 should be in requests also
+      _ = eff.requests.toSet shouldBe Set(hash8, hash7)
+      _ = eff.requests = Nil
+      // Approved block should be saved
+      _ = eff.puts shouldBe asMap(b9)
+
+      // Receive blocks b8 and b7
+      _ <- receive(b8, b7)
+
+      // All blocks should be requested
+      _ = eff.requests.toSet shouldBe Set(hash6, hash5, hash4)
+      _ = eff.requests = Nil
+      // Received blocks should be saved
+      _ = eff.puts shouldBe asMap(b9, b8, b7)
+
+      // Receive blocks b6, b5 and b4
+      _ <- receive(b6, b5, b4)
+
+      // All blocks should be requested
+      _ = eff.requests.toSet shouldBe Set(hash3)
+      _ = eff.requests = Nil
+      // All blocks should be saved
+      _ = eff.puts shouldBe asMap(b9, b8, b7, b6, b5)
+
+      // Receive block b3
+      _ <- receive(b3)
+
+      // All blocks should be requested
+      _ = eff.requests shouldBe Nil
+      // All blocks should be saved
+      _ = eff.puts shouldBe asMap(b9, b8, b7, b6, b5)
+    } yield ()
+  }
+
+}

--- a/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterStateSpec.scala
@@ -1,0 +1,130 @@
+package coop.rchain.casper.engine
+
+import cats.syntax.all._
+import coop.rchain.casper.engine.LastFinalizedStateBlockRequester.ST
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class LFSBlockRequesterStateSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  "getNext" should "return empty list when called again" in {
+    val st = ST(Seq(10))
+
+    // Calling next should produce initial set
+    val (st1, ids1) = st.getNext(resend = false)
+
+    ids1 shouldBe Seq(10)
+
+    // Calling next again should NOT return new items
+    val (st2, ids2) = st1.getNext(resend = false)
+
+    ids2 shouldBe Seq()
+
+    st1 shouldBe st2
+  }
+
+  "getNext" should "return new items after add" in {
+    val st = ST(Seq(10))
+
+    // Add new items
+    val st2 = st.add(Set(9, 8))
+
+    // Calling next should return new items
+    val (_, ids2) = st2.getNext(resend = false)
+
+    ids2 shouldBe Seq(10, 9, 8)
+  }
+
+  "received" should "return true for requested and false for unknown" in {
+    val st = ST(Seq(10))
+
+    // Mark next as requested
+    val (st1, _) = st.getNext(resend = false)
+
+    // Received requested item
+    val (_, isReceivedTrue) = st1.received(10)
+
+    isReceivedTrue shouldBe true
+
+    // Received unknown item
+    val (_, isReceivedFalse) = st1.received(100)
+
+    isReceivedFalse shouldBe false
+  }
+
+  "admitLatest" should "return found and empty if exists in latest" in {
+    val st = ST(Seq(10), latest = Set[Int](10))
+
+    // Admit message, check if latest and remove it
+    // - returns if latest is found and if latest set is empty
+    val (_, (isFound, isEmpty)) = st.admitLatest(10)
+
+    isFound shouldBe true
+    isEmpty shouldBe true
+  }
+
+  "admitLatest called again" should "return not found" in {
+    val st = ST(Seq(10), latest = Set[Int](10))
+
+    val (st1, _) = st.admitLatest(10)
+
+    val (_, (isFound, isEmpty)) = st1.admitLatest(10)
+
+    isFound shouldBe false
+    isEmpty shouldBe true
+  }
+
+  "done" should "return minimum height if supplied" in {
+    val st = ST(Seq(10), latest = Set[Int](10))
+
+    val (_, minHeight) = st.done(10, height = 1000L.some)
+
+    minHeight shouldBe 1000L
+  }
+
+  "done" should "return existing minimum height if not supplied" in {
+    val st = ST(Seq(10), latest = Set[Int](5))
+
+    val (_, minHeight) = st.done(10, none)
+
+    minHeight shouldBe Long.MaxValue
+  }
+
+  "done" should "make state finished" in {
+    val st = ST(Seq(10))
+
+    val (st1, _) = st.done(10, none)
+
+    st1.isFinished shouldBe true
+  }
+
+  "from start to finish" should "receive one item" in {
+    val st = ST(Seq(10), latest = Set[Int](10))
+
+    // Calling next should produce initial set
+    val (st1, ids1) = st.getNext(resend = false)
+
+    ids1 shouldBe Seq(10)
+
+    // Calling next again should NOT return new items
+    val (st2, ids2) = st1.getNext(resend = false)
+
+    ids2 shouldBe Seq()
+
+    // It should not be finished until all items are Done
+    st2.isFinished shouldBe false
+
+    // Received first item
+    val (st3, isReceived) = st2.received(10)
+
+    isReceived shouldBe true
+
+    val (st4, _) = st3.done(10, none)
+
+    val (st5, _) = st4.admitLatest(10)
+
+    // Return finished when all items as Done
+    st5.isFinished shouldBe true
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR contains initial set of tests for receiver of blocks for Last Finalized State. Tests are separated in two pieces, tests for internal state and effects (network requests and block store operations).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
