### PR TITLE
Send request for block message to single peer

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -142,7 +142,7 @@ class Initializing[F[_]
       blockRequestStream <- LastFinalizedStateBlockRequester.stream(
                              approvedBlock,
                              blockMessageQueue,
-                             CommUtil[F].broadcastRequestForBlock,
+                             hash => CommUtil[F].broadcastRequestForBlock(hash, 1.some),
                              BlockStore[F].contains,
                              BlockStore[F].put,
                              block => Validate.blockHash(block).map(_ == Right(Valid))

--- a/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/Connect.scala
@@ -29,9 +29,10 @@ object Connect {
   object ConnectionsCell {
     def apply[F[_]](implicit ev: ConnectionsCell[F]): ConnectionsCell[F] = ev
 
-    def random[F[_]: Monad: ConnectionsCell: RPConfAsk]: F[Connections] =
+    def random[F[_]: Monad: ConnectionsCell](
+        max: Int
+    ): F[Connections] =
       for {
-        max   <- RPConfAsk[F].reader(_.maxNumOfConnections)
         peers <- ConnectionsCell[F].read
       } yield Random.shuffle(peers).take(max)
   }


### PR DESCRIPTION
To not overload network with requests for blocks, block should be requested from a single peer.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
