### PR TITLE
Add dev option to put dummy deploy in each block

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala
@@ -25,7 +25,7 @@ import coop.rchain.shared.{Cell, Log, Time}
 import coop.rchain.casper.util.rholang.SystemDeployUtil
 
 final class BlockCreator[F[_]: Sync: Log: Time: BlockStore: Estimator: DeployStorage: Metrics](
-    dummyDeployerPrivateKey: Option[PrivateKey]
+    dummyDeployerPrivateKey: Option[PrivateKey] = None
 ) {
   private[this] val CreateBlockMetricsSource =
     Metrics.Source(CasperMetricsSource, "create-block")

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -102,7 +102,7 @@ sealed abstract class MultiParentCasperInstances {
     Metrics.Source(CasperMetricsSource, "casper")
   private[this] val genesisLabel = Metrics.Source(MetricsSource, "genesis")
 
-  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockRetriever](
+  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockRetriever: BlockCreator](
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
       shardId: String,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -32,7 +32,7 @@ import coop.rchain.casper.engine.BlockRetriever
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.Signed
 
-class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: CommUtil: EventPublisher: Estimator: DeployStorage: BlockRetriever](
+class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: CommUtil: EventPublisher: Estimator: DeployStorage: BlockRetriever: BlockCreator](
     validatorId: Option[ValidatorIdentity],
     approvedBlock: BlockMessage,
     postGenesisStateHash: StateHash,
@@ -319,7 +319,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
       case Some(validatorIdentity) =>
         BlockDagStorage[F].getRepresentation
           .flatMap { dag =>
-            BlockCreator
+            BlockCreator[F]
               .createBlock(
                 dag,
                 approvedBlock,

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -30,7 +30,7 @@ trait CasperLaunch[F[_]] {
 
 object CasperLaunch {
 
-  def of[F[_]: Parallel: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: LastFinalizedStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage](
+  def of[F[_]: Parallel: LastApprovedBlock: Metrics: Span: BlockStore: CommUtil: ConnectionsCell: TransportLayer: RPConfAsk: SafetyOracle: LastFinalizedBlockCalculator: Concurrent: Time: Log: EventLog: BlockDagStorage: LastFinalizedStorage: EngineCell: EnvVars: RaiseIOError: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockCreator](
       conf: CasperConf
   ): CasperLaunch[F] = new CasperLaunch[F] {
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -97,7 +97,7 @@ object Engine {
 
     } yield ()
 
-  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage](
+  def transitionToInitializing[F[_]: Concurrent: Metrics: Span: Monad: EngineCell: Log: EventLog: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockCreator](
       shardId: String,
       finalizationRate: Int,
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -41,7 +41,7 @@ class GenesisCeremonyMaster[F[_]: Sync: BlockStore: CommUtil: TransportLayer: RP
 
 object GenesisCeremonyMaster {
   import Engine._
-  def waitingForApprovedBlockLoop[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: BlockRetriever: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage](
+  def waitingForApprovedBlockLoop[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: BlockRetriever: BlockStore: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockCreator](
       shardId: String,
       finalizationRate: Int,
       validatorId: Option[ValidatorIdentity]

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -21,7 +21,7 @@ import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.models.BlockHash.BlockHash
 
-class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage](
+class GenesisValidator[F[_]: Sync: Metrics: Span: Concurrent: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: BlockRetriever: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockCreator](
     validatorId: ValidatorIdentity,
     shardId: String,
     finalizationRate: Int,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -28,7 +28,7 @@ import scala.language.higherKinds
   * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
   * `F[None]` to all other message types.
     **/
-class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: BlockRetriever: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage](
+class Initializing[F[_]: Sync: Metrics: Span: Concurrent: BlockStore: CommUtil: TransportLayer: ConnectionsCell: RPConfAsk: BlockRetriever: Log: EventLog: Time: SafetyOracle: LastFinalizedBlockCalculator: LastApprovedBlock: BlockDagStorage: LastFinalizedStorage: EngineCell: RuntimeManager: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockCreator](
     shardId: String,
     finalizationRate: Int,
     validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
@@ -28,7 +28,8 @@ object ConstructDeploy {
       timestamp: Long,
       phloLimit: Long = 90000,
       phloPrice: Long = 1L,
-      sec: PrivateKey = defaultSec
+      sec: PrivateKey = defaultSec,
+      validAfterBlockNumber: Long = 0L
   ): Signed[DeployData] = {
     val data =
       DeployData(
@@ -36,7 +37,7 @@ object ConstructDeploy {
         timestamp = timestamp,
         phloLimit = phloLimit,
         phloPrice = phloPrice,
-        validAfterBlockNumber = 0L
+        validAfterBlockNumber = validAfterBlockNumber
       )
 
     Signed(data, Secp256k1, sec)

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -144,6 +144,7 @@ object Setup {
     implicit val casperBuffer = CasperBufferKeyValueStorage
       .create[Task]
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
+    implicit val blockCreator = new BlockCreator[Task]
   }
   private def endpoint(port: Int): Endpoint = Endpoint("host", port, port)
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -119,6 +119,8 @@ class TestNode[F[_]](
 
   val blocksInProcessing = Ref.unsafe[F, Set[BlockHash]](Set.empty)
 
+  implicit val blockCreator = new BlockCreator[F]
+
   implicit val casperEff = new MultiParentCasperImpl[F](
     validatorId,
     genesis,

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -5,7 +5,6 @@
 # 3. `required-signatures` = 0
 # for node to be able to create and approve genesis block if its not available
 standalone = false
-dev-mode = false
 
 protocol-server {
   # ID of the RChain network.
@@ -333,4 +332,11 @@ metrics {
   influxdb-udp = false
   zipkin = false
   sigar = false
+}
+
+dev-mode = false
+
+dev {
+  # If set, on each propose node will add dummy deploy signed by this key.
+  # deployer-private-key =
 }

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -35,6 +35,8 @@ import coop.rchain.comm.discovery._
 import coop.rchain.comm.rp._
 import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell, RPConfAsk, RPConfState}
 import coop.rchain.comm.transport._
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.grpc.Server
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
@@ -846,6 +848,18 @@ object NodeRuntime {
       engineCell   <- EngineCell.init[F]
       envVars      = EnvVars.envVars[F]
       raiseIOError = IOError.raiseIOErrorThroughSync[F]
+
+      blockCreator = {
+        implicit val bs         = blockStore
+        implicit val es         = estimator
+        implicit val ds         = deployStorage
+        val dummyDeployerKeyOpt = conf.dev.deployerPrivateKey
+        val dummyDeployerKey =
+          if (dummyDeployerKeyOpt.isEmpty) None
+          else PrivateKey(Base16.decode(dummyDeployerKeyOpt.get).get).some
+        new BlockCreator[F](dummyDeployerKey)
+      }
+
       casperLaunch = {
         implicit val bs     = blockStore
         implicit val bd     = blockDagStorage
@@ -868,6 +882,7 @@ object NodeRuntime {
         implicit val es     = estimator
         implicit val ds     = deployStorage
         implicit val cbs    = casperBufferStorage
+        implicit val bc     = blockCreator
 
         CasperLaunch.of[F](conf.casper)
       }

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -101,8 +101,19 @@ object Configuration {
         ConfigFactory.empty()
     val kamonConf = kamonDefaultConfig.withFallback(ConfigFactory.load("kamon.conf"))
 
-    (nodeConf, profile, configFile, kamonConf)
+    val nodeConf_ = checkDevMode(nodeConf)
+
+    (nodeConf_, profile, configFile, kamonConf)
   }
+
+  def checkDevMode(nodeConf: NodeConf): NodeConf =
+    if (nodeConf.devMode) {
+      nodeConf
+    } else {
+      if (nodeConf.dev.deployerPrivateKey.nonEmpty)
+        System.out.println("Node is not in dev mode, ignoring --deployer-private-key")
+      nodeConf.copy(dev = DevConf(deployerPrivateKey = None))
+    }
 
   final case class Profile(name: String, dataDir: (Path, String))
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -22,7 +22,6 @@ object ConfigMapper {
       val run = options.run
       val add = addToMap()
       add("standalone", run.standalone)
-      add("dev-mode", run.devMode)
       add("protocol-server.network-id", run.networkId)
       add("protocol-server.dynamic-ip", run.dynamicIp)
       add("protocol-server.no-upnp", run.noUpnp)
@@ -117,6 +116,10 @@ object ConfigMapper {
       add("metrics.influxdb-udp", run.influxdbUdp)
       add("metrics.zipkin", run.zipkin)
       add("metrics.sigar", run.sigar)
+
+      add("dev-mode", run.devMode)
+      add("dev.deployer-private-key", run.deployerPrivateKey)
+
       //TODO remove
       //add(keys.KnownValidatorsFile, run.knownValidators
     }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -167,10 +167,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Start a stand-alone node."
     )
 
-    val devMode = opt[Flag](
-      descr = "Enable all developer tools."
-    )
-
     val bootstrap = opt[PeerNode](
       short = 'b',
       descr = "Address of RNode to bootstrap from when connecting to a network."
@@ -529,6 +525,14 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Timestamp for the deploys."
     )
 
+    // Dev mode options
+    val devMode = opt[Flag](
+      descr = "Enable all developer tools."
+    )
+
+    val deployerPrivateKey = opt[String](
+      descr = "Private key for dummy deploys."
+    )
   }
   addSubcommand(run)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -16,7 +16,6 @@ import pureconfig.generic.auto._
 
 final case class NodeConf(
     standalone: Boolean,
-    devMode: Boolean,
     protocolServer: ProtocolServer,
     protocolClient: ProtocolClient,
     peersDiscovery: PeersDiscovery,
@@ -25,6 +24,8 @@ final case class NodeConf(
     storage: Storage,
     casper: CasperConf,
     metrics: Metrics,
+    devMode: Boolean,
+    dev: DevConf,
     // This field is dynamic and computed according to profile and is not used directly in client code.
     // But it is required in the model because of how Pureconfig works and how config file is structured (there are
     // references to this key in `defaults.conf`).
@@ -96,6 +97,10 @@ final case class Metrics(
     influxdbUdp: Boolean,
     zipkin: Boolean,
     sigar: Boolean
+)
+
+final case class DevConf(
+    deployerPrivateKey: Option[String]
 )
 
 sealed trait Command

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -7,6 +7,7 @@ import coop.rchain.casper.{CasperConf, GenesisBlockData, GenesisCeremonyConf, Ro
 import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.node.configuration.{
   ApiServer,
+  DevConf,
   Metrics,
   NodeConf,
   PeersDiscovery,
@@ -28,7 +29,6 @@ class ConfigMapperSpec extends FunSuite with Matchers {
       Seq(
         "run",
         "--standalone",
-        "--dev-mode",
         "--host localhost",
         "--bootstrap rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404",
         "--network-id testnet",
@@ -106,7 +106,9 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--influxdb",
         "--influxdb-udp",
         "--zipkin",
-        "--sigar"
+        "--sigar",
+        "--dev-mode",
+        "--deployer-private-key somerandonmprivatekey"
       ).mkString(" ")
 
     val options = Options(args.split(' '))
@@ -141,7 +143,6 @@ class ConfigMapperSpec extends FunSuite with Matchers {
     val expectedConfig = NodeConf(
       defaultDataDir = "/var/lib/rnode",
       standalone = true,
-      devMode = true,
       protocolServer = ProtocolServer(
         networkId = "testnet",
         host = Some("localhost"),
@@ -251,7 +252,9 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         influxdbUdp = true,
         zipkin = true,
         sigar = true
-      )
+      ),
+      devMode = true,
+      dev = DevConf(deployerPrivateKey = Some("somerandonmprivatekey"))
     )
     config shouldEqual expectedConfig
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -10,6 +10,7 @@ import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.node.configuration.{
   ApiServer,
+  DevConf,
   Metrics,
   NodeConf,
   PeersDiscovery,
@@ -50,7 +51,6 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
     val expectedConfig = NodeConf(
       defaultDataDir = "/var/lib/rnode",
       standalone = false,
-      devMode = false,
       protocolServer = ProtocolServer(
         networkId = "testnet",
         host = None,
@@ -160,6 +160,10 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         influxdbUdp = false,
         zipkin = false,
         sigar = false
+      ),
+      devMode = false,
+      dev = DevConf(
+        deployerPrivateKey = None
       )
     )
     config shouldEqual expectedConfig


### PR DESCRIPTION
Attempts for initial testing of block merge with shard config enabled revealed one pain point - it is hard to make predictable block creation from outside. Basically what is needed is make node try to issue block after each new block added (obeying sync constraint). With outside API its quite a pain, taking into account that deployer should have non zero balance, and external tool should know when blocks are added.

So dev option is suggested - to add dummy deploy to a block sighed with preconfigured secret key.
This should make testing much easier.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
