### PR TITLE
Update LmdbJava library to latest version 0.8.1

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
@@ -83,7 +83,7 @@ final case class LmdbKeyValueStore[F[_]: Sync](
     withReadTxn { (txn, dbi) =>
       withResource(dbi.iterate(txn)) { iterator =>
         import scala.collection.JavaConverters._
-        f(iterator.asScala.map(c => (c.key, c.`val`)))
+        f(iterator.iterator.asScala.map(c => (c.key, c.`val`)))
       }
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,7 @@ object Dependencies {
   val kamonZipkin         = "io.kamon"                   %% "kamon-zipkin"              % "1.0.0"
   val lightningj          = ("org.lightningj"             % "lightningj"                % "0.5.2-Beta")
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
-  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.6.3"
+  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
   val monix               = "io.monix"                   %% "monix"                     % "3.1.0"

--- a/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
+++ b/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer
 import cats.implicits._
 import cats.effect.Sync
 import coop.rchain.shared.Resources.withResource
-import org.lmdbjava.{CursorIterator, Dbi, Env, Txn}
+import org.lmdbjava.{CursorIterable, Dbi, Env, Txn}
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -87,10 +87,10 @@ final case class LMDBStore[F[_]: Sync](env: Env[ByteBuffer], dbi: Dbi[ByteBuffer
       }
     }
 
-  def iterate[R](f: Iterator[CursorIterator.KeyVal[ByteBuffer]] => R): F[R] =
+  def iterate[R](f: Iterator[CursorIterable.KeyVal[ByteBuffer]] => R): F[R] =
     withReadTxnF { txn =>
       withResource(dbi.iterate(txn)) { iterator =>
-        f(iterator.asScala)
+        f(iterator.iterator.asScala)
       }
     }
 


### PR DESCRIPTION
## Overview
This PR updates LmdbJava to version 0.8.1.

Version 0.8.0 introduced breaking change how lmdb cursor (iterator) is used for reading data which caused small change in our code also https://github.com/lmdbjava/lmdbjava/issues/154.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
