### PR TITLE
Internalise enqueued blocks set into Casper trait

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -71,6 +71,7 @@ trait Casper[F[_]] {
   def approvedBlockStateComplete: F[Boolean]
 
   def getBlocksInProcessing: F[Set[BlockHash]]
+  def getBlocksEnqueued: F[Set[BlockHash]]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F] {
@@ -140,6 +141,7 @@ sealed abstract class MultiParentCasperInstances {
                                }
         blockProcessingLock <- MetricsSemaphore.single[F]
         blocksInProcessing  <- Ref.of[F, Set[BlockHash]](Set.empty)
+        blocksEnqueued      <- Ref.of[F, Set[BlockHash]](Set.empty)
       } yield {
         new MultiParentCasperImpl(
           validatorId,
@@ -148,7 +150,8 @@ sealed abstract class MultiParentCasperInstances {
           shardId,
           finalizationRate,
           blockProcessingLock,
-          blocksInProcessing
+          blocksInProcessing,
+          blocksEnqueued
         )
       }
     }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -47,6 +47,8 @@ object DeployError {
   }
 }
 
+final case class BlockProcessingState(enqueued: Set[BlockHash], processing: Set[BlockHash])
+
 trait Casper[F[_]] {
   def addBlockFromStore(b: BlockHash, allowAddFromBuffer: Boolean = false): F[ValidBlockProcessing]
   def addBlock(b: BlockMessage, allowAddFromBuffer: Boolean = false): F[ValidBlockProcessing]
@@ -70,8 +72,7 @@ trait Casper[F[_]] {
     */
   def approvedBlockStateComplete: F[Boolean]
 
-  def getBlocksInProcessing: F[Set[BlockHash]]
-  def getBlocksEnqueued: F[Set[BlockHash]]
+  def getBlockProcessingState: F[BlockProcessingState]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F] {
@@ -140,8 +141,9 @@ sealed abstract class MultiParentCasperInstances {
                                  } yield postGenesisStateHash
                                }
         blockProcessingLock <- MetricsSemaphore.single[F]
-        blocksInProcessing  <- Ref.of[F, Set[BlockHash]](Set.empty)
-        blocksEnqueued      <- Ref.of[F, Set[BlockHash]](Set.empty)
+        blockProcessingState <- Ref.of[F, BlockProcessingState](
+                                 BlockProcessingState(Set.empty, Set.empty)
+                               )
       } yield {
         new MultiParentCasperImpl(
           validatorId,
@@ -150,8 +152,7 @@ sealed abstract class MultiParentCasperInstances {
           shardId,
           finalizationRate,
           blockProcessingLock,
-          blocksInProcessing,
-          blocksEnqueued
+          blockProcessingState
         )
       }
     }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -39,7 +39,8 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
     shardId: String,
     finalizationRate: Int,
     blockProcessingLock: Semaphore[F],
-    blocksInProcessing: Ref[F, Set[BlockHash]]
+    blocksInProcessing: Ref[F, Set[BlockHash]],
+    blocksEnqueued: Ref[F, Set[BlockHash]]
 )(
     implicit casperBuffer: CasperBufferStorage[F],
     metricsF: Metrics[F],
@@ -70,6 +71,13 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
   def getValidator: F[Option[PublicKey]] = validatorId.map(_.publicKey).pure[F]
 
   override def getBlocksInProcessing: F[Set[BlockHash]] = blocksInProcessing.get
+
+  /**
+    * Blocks that are received and
+    * have all dependencies filled, so not put in casperBuffer,
+    * but were not accepted by Casper, so processing is postponed
+    */
+  override def getBlocksEnqueued: F[Set[BlockHash]] = blocksEnqueued.get
 
   // Later this should replace addBlock, but for now one more method created, or there are too many tests to fix
   def addBlockFromStore(
@@ -176,6 +184,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
       addResult <- Sync[F].bracket(blockProcessingLock.tryAcquire) {
                     case true =>
                       for {
+                        _ <- blocksEnqueued.update(_ - b.blockHash)
                         _ <- blocksInProcessing.update(_ + b.blockHash)
                         _ <- Log[F].info(
                               s"Block ${PrettyPrinter.buildString(b, short = true)} got blockProcessingLock."
@@ -189,8 +198,10 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
                         .info(
                           s"Block ${PrettyPrinter.buildString(b, short = true)} " +
                             s"processing deferred as Casper is busy."
-                        )
-                        .as(BlockStatus.casperIsBusy.asLeft[ValidBlock])
+                        ) >>
+                        blocksEnqueued
+                          .update(_ + b.blockHash)
+                          .as(BlockStatus.casperIsBusy.asLeft[ValidBlock])
                   } {
                     case true =>
                       blockProcessingLock.release >>
@@ -277,12 +288,12 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
                                            .existsM(dagContains(_).not)
                           } yield !missingDep
                         }
-      enqueued <- BlockRetriever[F].getEnqueuedToCasper
+      enqueued <- getBlocksEnqueued
       all      = depFreePendants ++ enqueued
       _ <- Log[F].info(
             s"Blocks ready to be added: " +
               s"dependency free buffer pendants ${PrettyPrinter.buildString(depFreePendants)}, " +
-              s"enqueued to Casper ${PrettyPrinter.buildString(enqueued)}"
+              s"enqueued to Casper ${PrettyPrinter.buildString(enqueued.toList)}"
           )
     } yield all.headOption
   }

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -298,12 +298,12 @@ class Running[F[_]: Concurrent: BlockStore: CasperBufferStorage: BlockRetriever:
     for {
       // This long chain of ifM created to minimise computation for ignore check and provide
       // readable output for each ignore reason
-      received <- BlockRetriever[F].received(hash)
+      received <- BlockRetriever[F].isReceived(hash)
       r <- casper.getBlocksInProcessing
             .map(_.contains(hash))
             .ifM(
               IgnoreCasperMessageStatus(doIgnore = true, BlockIsInProcessing).pure[F],
-              BlockRetriever[F].getEnqueuedToCasper
+              casper.getBlocksEnqueued
                 .map(_.contains(hash))
                 .ifM(
                   IgnoreCasperMessageStatus(doIgnore = true, BlockIsWaitingForCasper).pure[F],

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -298,37 +298,32 @@ class Running[F[_]: Concurrent: BlockStore: CasperBufferStorage: BlockRetriever:
     for {
       // This long chain of ifM created to minimise computation for ignore check and provide
       // readable output for each ignore reason
-      received <- BlockRetriever[F].isReceived(hash)
-      r <- casper.getBlocksInProcessing
-            .map(_.contains(hash))
-            .ifM(
-              IgnoreCasperMessageStatus(doIgnore = true, BlockIsInProcessing).pure[F],
-              casper.getBlocksEnqueued
-                .map(_.contains(hash))
-                .ifM(
-                  IgnoreCasperMessageStatus(doIgnore = true, BlockIsWaitingForCasper).pure[F],
-                  CasperBufferStorage[F]
-                    .contains(hash)
+      received  <- BlockRetriever[F].isReceived(hash)
+      casperBPS <- casper.getBlockProcessingState
+      r <- if (casperBPS.processing.contains(hash))
+            IgnoreCasperMessageStatus(doIgnore = true, BlockIsInProcessing).pure[F]
+          else if (casperBPS.enqueued.contains(hash))
+            IgnoreCasperMessageStatus(doIgnore = true, BlockIsWaitingForCasper).pure[F]
+          else
+            CasperBufferStorage[F]
+              .contains(hash)
+              .ifM(
+                IgnoreCasperMessageStatus(doIgnore = true, BlockIsInCasperBuffer).pure[F],
+                casper.blockDag.flatMap(
+                  _.contains(hash)
                     .ifM(
-                      IgnoreCasperMessageStatus(doIgnore = true, BlockIsInCasperBuffer).pure[F],
-                      casper.blockDag.flatMap(
-                        _.contains(hash)
-                          .ifM(
-                            IgnoreCasperMessageStatus(doIgnore = true, BlockIsInDag).pure[F],
-                            // If none of the checks above is true, this means that
-                            // thread that received block did not execute Casper code yet.
-                            // So there is still possibility of `received` to be true, that's why
-                            // this check put in place. But the possibility is close to 0.
-                            if (received)
-                              IgnoreCasperMessageStatus(doIgnore = true, BlockIsReceived).pure[F]
-                            else
-                              IgnoreCasperMessageStatus(doIgnore = false, DoNotIgnore).pure[F]
-                          )
-                      )
+                      IgnoreCasperMessageStatus(doIgnore = true, BlockIsInDag).pure[F],
+                      // If none of the checks above is true, this means that
+                      // thread that received block did not execute Casper code yet.
+                      // So there is still possibility of `received` to be true, that's why
+                      // this check put in place. But the possibility is close to 0.
+                      if (received)
+                        IgnoreCasperMessageStatus(doIgnore = true, BlockIsReceived).pure[F]
+                      else
+                        IgnoreCasperMessageStatus(doIgnore = false, DoNotIgnore).pure[F]
                     )
                 )
-            )
-
+              )
     } yield r
 
   /**

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -257,12 +257,11 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   override def addBlockFromStore(
       b: BlockHash,
       allowAddFromBuffer: Boolean
-  ): F[ValidBlockProcessing]                               = underlying.addBlockFromStore(b, allowAddFromBuffer)
-  override def contains(hash: BlockHash): F[Boolean]       = underlying.contains(hash)
-  override def dagContains(hash: BlockHash): F[Boolean]    = underlying.dagContains(hash)
-  override def bufferContains(hash: BlockHash): F[Boolean] = underlying.bufferContains(hash)
-  override def getVersion: F[Long]                         = underlying.getVersion
-  override def getDeployLifespan: F[Int]                   = underlying.getDeployLifespan
-  override def getBlocksInProcessing: F[Set[BlockHash]]    = underlying.getBlocksInProcessing
-  override def getBlocksEnqueued: F[Set[BlockHash]]        = underlying.getBlocksEnqueued
+  ): F[ValidBlockProcessing]                                    = underlying.addBlockFromStore(b, allowAddFromBuffer)
+  override def contains(hash: BlockHash): F[Boolean]            = underlying.contains(hash)
+  override def dagContains(hash: BlockHash): F[Boolean]         = underlying.dagContains(hash)
+  override def bufferContains(hash: BlockHash): F[Boolean]      = underlying.bufferContains(hash)
+  override def getVersion: F[Long]                              = underlying.getVersion
+  override def getDeployLifespan: F[Int]                        = underlying.getDeployLifespan
+  override def getBlockProcessingState: F[BlockProcessingState] = underlying.getBlockProcessingState
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -264,4 +264,5 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   override def getVersion: F[Long]                         = underlying.getVersion
   override def getDeployLifespan: F[Int]                   = underlying.getDeployLifespan
   override def getBlocksInProcessing: F[Set[BlockHash]]    = underlying.getBlocksInProcessing
+  override def getBlocksEnqueued: F[Set[BlockHash]]        = underlying.getBlocksEnqueued
 }

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleBlockMessageSpec.scala
@@ -98,7 +98,7 @@ class RunningHandleBlockMessageSpec extends FunSpec with BeforeAndAfterEach with
           )
           .runSyncUnsafe()
         sentToCasper.contains(validBlock.blockHash) should be(true)
-        blockRetriever.received(validBlock.blockHash).unsafeRunSync should be(true)
+        blockRetriever.isReceived(validBlock.blockHash).unsafeRunSync should be(true)
       }
 
       it("should drop not valid messages") {

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -58,6 +58,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
     } yield BlockStatus.valid.asRight
 
   def getBlocksInProcessing: F[Set[BlockHash]] = Set.empty[BlockHash].pure[F]
+  def getBlocksEnqueued: F[Set[BlockHash]]     = Set.empty[BlockHash].pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -57,8 +57,8 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
       _ <- Sync[F].delay(store.update(b.get.blockHash, b.get))
     } yield BlockStatus.valid.asRight
 
-  def getBlocksInProcessing: F[Set[BlockHash]] = Set.empty[BlockHash].pure[F]
-  def getBlocksEnqueued: F[Set[BlockHash]]     = Set.empty[BlockHash].pure[F]
+  def getBlockProcessingState: F[BlockProcessingState] =
+    BlockProcessingState(Set.empty[BlockHash], Set.empty[BlockHash]).pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -117,8 +117,8 @@ class TestNode[F[_]](
   implicit val commUtil: CommUtil[F]             = CommUtil.of[F]
   implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]
 
-  val blocksInProcessing = Ref.unsafe[F, Set[BlockHash]](Set.empty)
-  val blocksEnqueued     = Ref.unsafe[F, Set[BlockHash]](Set.empty)
+  val blockProcessingState =
+    Ref.unsafe[F, BlockProcessingState](BlockProcessingState(Set.empty, Set.empty))
 
   implicit val casperEff = new MultiParentCasperImpl[F](
     validatorId,
@@ -127,8 +127,7 @@ class TestNode[F[_]](
     shardId,
     finalizationRate,
     blockProcessingLock,
-    blocksInProcessing,
-    blocksEnqueued
+    blockProcessingState
   )
 
   val engine                             = new Running(casperEff, approvedBlock, validatorId, ().pure[F])

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -118,6 +118,7 @@ class TestNode[F[_]](
   implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]
 
   val blocksInProcessing = Ref.unsafe[F, Set[BlockHash]](Set.empty)
+  val blocksEnqueued     = Ref.unsafe[F, Set[BlockHash]](Set.empty)
 
   implicit val casperEff = new MultiParentCasperImpl[F](
     validatorId,
@@ -126,7 +127,8 @@ class TestNode[F[_]](
     shardId,
     finalizationRate,
     blockProcessingLock,
-    blocksInProcessing
+    blocksInProcessing,
+    blocksEnqueued
   )
 
   val engine                             = new Running(casperEff, approvedBlock, validatorId, ().pure[F])


### PR DESCRIPTION
When new block A comes in, but Casper is busy processing another block, block A is put in queue and added later.
Currently node recognises enqueued blocks via BlockRetriever state. But sometimes this does not work, as it has been seen recently when integration test failed. Investigations had not led to any solution. So, this PR introduces more reliable way to have set of blocks enqueued as a structure internal to Casper. Which is better in logical sense as well.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
