### PR TITLE
Disable oom test

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -95,7 +95,8 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
     checkAll(hugeBinOp(" ++ ", "[1]"))
   }
 
-  it should "handle a huge nested list" in {
+  //Fixme - sometimes fails with OOM in Github actions. To not disturb, ignored temporarily
+  ignore should "handle a huge nested list" in {
     checkAll(hugeNested("[", "", "]"))
   }
 


### PR DESCRIPTION
This particular tests fails frequently in Github Actions, recently it became more annoying. Might be something changed in GHA, but test is failing more often, to my observations. I'm not sure if this is related to any changes we made recently, I believe its not as we did not touch Rholang.

## Overview
<!-- What this PR does, and why it's needed -->


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
