### PR TITLE
Update Scalaversion to 2.12.10 and change /: in files to foldLeft to ensure compatibility with 2.12.10

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Compile
         run: |
-          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true"
+          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g"
           sbt update scalafmtCheckAll rholang/bnfc:generate compile
 
       - name: Pack Working Tree

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Compile
         run: |
-          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g"
+          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g -Xss1m"
           sbt update scalafmtCheckAll rholang/bnfc:generate compile
 
       - name: Pack Working Tree

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ Global / dependencyOverrides := Dependencies.overrides
 
 lazy val projectSettings = Seq(
   organization := "coop.rchain",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   version := "0.1.0-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnIndexMap.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnIndexMap.scala
@@ -13,7 +13,7 @@ class DebruijnIndexMap[T](val next: Int, val env: Map[String, (Int, T, Int, Int)
 
   // Returns the new map
   def newBindings(bindings: List[(String, T, Int, Int)]): DebruijnIndexMap[T] =
-    (this /: bindings)((map, binding) => map.newBinding(binding))
+    bindings.foldLeft(this)((map, binding) => map.newBinding(binding))
 
   // Returns the new map, and a list of the shadowed variables
   // Takes a **Level** map, because we use that to track the Free Variables.

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnLevelMap.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/DebruijnLevelMap.scala
@@ -30,7 +30,7 @@ class DebruijnLevelMap[T](
 
   // Returns the new map, and the first value assigned. Given that they're assigned contiguously
   def newBindings(bindings: List[(String, T, Int, Int)]): (DebruijnLevelMap[T], Int) = {
-    val newMap = (this /: bindings)((map, binding) => map.newBinding(binding)._1)
+    val newMap = bindings.foldLeft(this)((map, binding) => map.newBinding(binding)._1)
     (newMap, next)
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -116,7 +116,7 @@ final case class PrettyPrinter(
       case ESetBody(ParSet(pars, _, _, remainder)) =>
         pure("Set(") |+| buildSeq(pars.sortedPars) |+| buildRemainderString(remainder) |+| pure(")")
       case EMapBody(ParMap(ps, _, _, remainder)) =>
-        pure("{") |+| (pure("") /: ps.sortedList.zipWithIndex) {
+        pure("{") |+| ps.sortedList.zipWithIndex.foldLeft(pure("")) {
           case (string, (kv, i)) =>
             string |+| buildStringM(kv._1) |+| pure(" : ") |+| buildStringM(kv._2) |+| pure {
               if (i != ps.sortedList.size - 1) ", "
@@ -190,7 +190,7 @@ final case class PrettyPrinter(
         } |+| buildSeq(s.data) |+| pure(")")
 
       case r: Receive =>
-        val (totalFree, bindsString) = ((0, pure("")) /: r.binds.zipWithIndex) {
+        val (totalFree, bindsString) = r.binds.zipWithIndex.foldLeft((0, pure(""))) {
           case ((previousFree, string), (bind, i)) =>
             val bindString =
               this
@@ -241,7 +241,7 @@ final case class PrettyPrinter(
 
       case m: Match =>
         pure("match ") |+| buildStringM(m.target) |+| pure(" {\n") |+|
-          (pure("") /: m.cases.zipWithIndex) {
+          m.cases.zipWithIndex.foldLeft(pure("")) {
             case (string, (matchCase, i)) =>
               string |+| pure(indentStr * (indent + 1)) |+| buildMatchCase(matchCase, indent + 1) |+| pure {
                 if (i != m.cases.length - 1) "\n"
@@ -280,13 +280,13 @@ final case class PrettyPrinter(
               par.unforgeables,
               par.connectives
             )
-          ((false, pure("")) /: list) {
+          list.foldLeft((false, pure(""))) {
             // format: off
             case ((prevNonEmpty, string), items) =>
               if (items.nonEmpty) {
                 (true,
                  string |+| pure { if (prevNonEmpty) " |\n" + (indentStr * indent) else "" } |+|
-                   (pure("") /: items.zipWithIndex) {
+                    items.zipWithIndex.foldLeft(pure("")) {
                      case (_string, (_par, index)) =>
                        _string |+| buildStringM(_par, indent) |+| pure {
                          if (index != items.length - 1) " |\n" + (indentStr * indent) else ""
@@ -322,7 +322,7 @@ final case class PrettyPrinter(
       .mkString(", ")
 
   private def buildSeq[T <: GeneratedMessage](s: Seq[T]): Coeval[String] =
-    (pure("") /: s.zipWithIndex) {
+    s.zipWithIndex.foldLeft(pure("")) {
       case (string, (p, i)) =>
         string |+| buildStringM(p) |+| pure {
           if (i != s.length - 1) ", "
@@ -331,7 +331,7 @@ final case class PrettyPrinter(
     }
 
   private def buildPattern(patterns: Seq[Par]): Coeval[String] =
-    (pure("") /: patterns.zipWithIndex) {
+    patterns.zipWithIndex.foldLeft(pure("")) {
 
       case (string, (pattern, i)) =>
         string |+| buildChannelStringM(pattern) |+| pure {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -895,10 +895,10 @@ class IncrementTester extends FlatSpec with Matchers {
   val printer = PrettyPrinter()
 
   "Increment" should "increment the id prefix every 26 increments" in {
-    val id: String = ("a" /: (0 until 26)) { (s, _) =>
+    val id: String = (0 until 26).foldLeft("a") { (s, _) =>
       printer.increment(s)
     }
-    val _id: String = (id /: (0 until 26)) { (s, _) =>
+    val _id: String = (0 until 26).foldLeft(id) { (s, _) =>
       printer.increment(s)
     }
     id shouldBe "aa"
@@ -907,7 +907,7 @@ class IncrementTester extends FlatSpec with Matchers {
 
   "Increment and Rotate" should "" in {
 
-    val _printer: PrettyPrinter = (printer /: (0 until 52)) { (p, _) =>
+    val _printer: PrettyPrinter = (0 until 52).foldLeft(printer) { (p, _) =>
       p.copy(
         freeId = p.boundId,
         baseId = p.setBaseId()


### PR DESCRIPTION
## Overview
Update Scalaversion to 2.12.10 and change /: in files to foldLeft to ensure compatibility with 2.12.10



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
