### PR TITLE
Scalaversion2.12.11 and scalamacros-paradise 2.1.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Compile
         run: |
-          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g -Xss1m"
+          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g -Xss2m"
           sbt update scalafmtCheckAll rholang/bnfc:generate compile
 
       - name: Pack Working Tree

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ Global / dependencyOverrides := Dependencies.overrides
 
 lazy val projectSettings = Seq(
   organization := "coop.rchain",
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.12.11",
   version := "0.1.0-SNAPSHOT",
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
   private val kindProjector = compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10")
 
   private val macroParadise = compilerPlugin(
-    "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full
+    "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
   private val testing = Seq(scalactic, scalatest, scalacheck)


### PR DESCRIPTION
## Overview
Update scalaversion to 2.12.11 in build.sbt and org.scalamacros paradise to 2.1.1 in Dependencies.scala





### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
