### PR TITLE
Upgrade to Monix3.2.2 and catsEffect2.2.0

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/ReportingCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ReportingCasper.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper
 
 import cats.data.EitherT
-import cats.effect.concurrent.{MVar, Ref}
+import cats.effect.concurrent.{MVar, MVar2, Ref}
 import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.implicits._
 import cats.{Monad, Parallel}
@@ -260,7 +260,7 @@ object ReportingCasper {
     */
   class ReportingRuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
       val emptyStateHash: StateHash,
-      runtimeContainer: MVar[F, ReportingRuntime[F]]
+      runtimeContainer: MVar2[F, ReportingRuntime[F]]
   ) {
     import coop.rchain.models.rholang.{implicits => toPar}
     private val systemDeployConsumeAllPattern =

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.util.rholang
 
 import cats.Applicative
 import cats.data.{EitherT, WriterT}
-import cats.effect.concurrent.MVar
+import cats.effect.concurrent.{MVar, MVar2}
 import cats.effect.{Sync, _}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
@@ -83,7 +83,7 @@ trait RuntimeManager[F[_]] {
 
 class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
     val emptyStateHash: StateHash,
-    runtimeContainer: MVar[F, Runtime[F]]
+    runtimeContainer: MVar2[F, Runtime[F]]
 ) extends RuntimeManager[F] {
   import coop.rchain.models.rholang.{implicits => toPar}
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -52,7 +52,7 @@ trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>
       runtime                <- Resources.mkRuntimeManagerAt[Task](paths.rspaceDir)()
     } yield (blockStore, indexedBlockDagStorage, runtime)
 
-    resource.use[R] { case (b, d, r) => f(b)(d)(r) }.unsafeRunSync
+    resource.use[Task, R] { case (b, d, r) => f(b)(d)(r) }.unsafeRunSync
   }
 
   def withStorage[R](f: BlockStore[Task] => IndexedBlockDagStorage[Task] => Task[R]): R = {

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -137,13 +137,13 @@ class GrpcTransportClient(
     withClient(peer, DefaultSendTimeout)(GrpcTransport.send(peer, msg))
 
   def broadcast(peers: Seq[PeerNode], msg: Protocol): Task[Seq[CommErr[Unit]]] =
-    Task.gatherUnordered(peers.map(send(_, msg)))
+    Task.parSequenceUnordered(peers.map(send(_, msg)))
 
   def stream(peer: PeerNode, blob: Blob): Task[Unit] =
     getChannel(peer).flatMap(_.buffer.enque(blob))
 
   def stream(peers: Seq[PeerNode], blob: Blob): Task[Unit] =
-    Task.gatherUnordered(peers.map(stream(_, blob))).void
+    Task.parSequenceUnordered(peers.map(stream(_, blob))).void
 
   private def streamBlobFile(
       path: Path,

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -2,9 +2,7 @@ package coop.rchain.comm.transport
 
 import java.nio.file._
 
-import cats.effect.concurrent.{Deferred, Ref}
-
-import scala.concurrent.duration.Duration
+import cats.effect.concurrent.{Deferred, MVar, Ref}
 import coop.rchain.comm._
 import coop.rchain.comm.rp.Connect.RPConfAsk
 import coop.rchain.crypto.codec.Base16
@@ -12,11 +10,11 @@ import coop.rchain.crypto.util.{CertificateHelper, CertificatePrinter}
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared.Log
-import io.grpc.ManagedChannel
-import monix.catnap.MVar
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
+
+import scala.concurrent.duration.Duration
 
 class TcpTransportLayerSpec
     extends TransportLayerSpec[Task, TcpTlsEnvironment]
@@ -68,7 +66,7 @@ class TcpTransportLayerSpec
   def extract[A](fa: Task[A]): A = fa.runSyncUnsafe(Duration.Inf)
 
   def createDispatcherCallback: Task[DispatcherCallback[Task]] =
-    MVar.empty[Task, Unit]().map(new DispatcherCallback(_))
+    MVar.empty[Task, Unit].map(new DispatcherCallback(_))
 
   def createTransportLayerServer(env: TcpTlsEnvironment): Task[TransportLayerServer[Task]] =
     Task.delay {

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 
 import cats._
 import cats.effect.Timer
-import cats.effect.concurrent.MVar
+import cats.effect.concurrent.MVar2
 import cats.implicits._
 
 import coop.rchain.catscontrib.ski._
@@ -219,7 +219,7 @@ trait Environment {
   def port: Int
 }
 
-final class DispatcherCallback[F[_]: Functor](state: MVar[F, Unit]) {
+final class DispatcherCallback[F[_]: Functor](state: MVar2[F, Unit]) {
   def notifyThatDispatched(): F[Unit] = state.tryPut(()).void
   def waitUntilDispatched(): F[Unit]  = state.take
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.4"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "2.1.0"
-  val catsEffectVersion = "2.0.0"
-  val catsMtlVersion    = "0.7.0"
+  val catsVersion       = "2.1.1"
+  val catsEffectVersion = "2.2.0"
+  val catsMtlVersion    = "0.7.1"
   val slf4jVersion      = "1.7.25"
 
   // format: off
@@ -24,7 +24,7 @@ object Dependencies {
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
   val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.11"
-  val disciplineCore      = "org.typelevel"                                    %% "discipline-core"           % "1.0.2"
+  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
-  val monix               = "io.monix"                   %% "monix"                     % "3.1.0"
+  val monix               = "io.monix"                   %% "monix"                     % "3.2.2"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -19,7 +19,7 @@ class TwoStepLockTest extends FlatSpec with Matchers {
     val t3   = acquireLock(lock, List("a", "b"), List("w1", "w2"), { a = a + 5 })
     val t4   = acquireLock(lock, List("a", "b"), List("w1", "w2"), { a = a - 8 })
 
-    val r = Task.gatherUnordered(List(t1, t2, t3, t4))
+    val r = Task.parSequenceUnordered(List(t1, t2, t3, t4))
     r.unsafeRunSync
   }
 


### PR DESCRIPTION
## Overview
Change Dependencies.scala to update monix version to 3.2.2
Change Task.gatherUnordered (deprecated) to Task.parSequenceUnordered necessary for upgrade to monix 3.2.2 in GrpcTransportClient.scala and TwoStepLockTest.scala

To achieve benefits identified in https://github.com/rchain/rchain/issues/3142

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
