### PR TITLE
remove cross compile to scala2.11 in build.sbt to allow newer dependencies that do not support scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val coverageSettings = Seq(
 )
 
 lazy val compilerSettings = CompilerSettings.options ++ Seq(
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+  crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.1")
 )
 
 // Before starting sbt export YOURKIT_AGENT set to the profiling agent appropriate

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val coverageSettings = Seq(
 )
 
 lazy val compilerSettings = CompilerSettings.options ++ Seq(
-  crossScalaVersions := Seq(scalaVersion.value, "2.13.1")
+  crossScalaVersions := Seq(scalaVersion.value)
 )
 
 // Before starting sbt export YOURKIT_AGENT set to the profiling agent appropriate

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val coverageSettings = Seq(
 )
 
 lazy val compilerSettings = CompilerSettings.options ++ Seq(
-  crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.1")
+  crossScalaVersions := Seq(scalaVersion.value, "2.13.1")
 )
 
 // Before starting sbt export YOURKIT_AGENT set to the profiling agent appropriate


### PR DESCRIPTION
## Overview
remove crosscompile for scala2.11 in build.sbt to allow update to latest plugins and dependencies that do not support scala 2.11





### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
