### PR TITLE
Cleaning up block processing logic

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -38,6 +38,7 @@ trait BlockDagRepresentation[F[_]] {
       startBlockNumber: Long,
       maybeEndBlockNumber: Option[Long]
   ): F[Vector[Vector[BlockHash]]]
+  def equivocationHashes: Set[BlockHash]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -1,34 +1,37 @@
 package coop.rchain.casper
 
+import coop.rchain.models.BlockHash
+import coop.rchain.models.BlockHash.BlockHash
+
 sealed trait BlockStatus
 object BlockStatus {
-  def valid: ValidBlock                    = ValidBlock.Valid
-  def processed: BlockError                = BlockError.Processed
-  def casperIsBusy: BlockError             = BlockError.CasperIsBusy
-  def exception(ex: Throwable): BlockError = BlockError.BlockException(ex)
-  def admissibleEquivocation: BlockError   = InvalidBlock.AdmissibleEquivocation
-  def ignorableEquivocation: BlockError    = InvalidBlock.IgnorableEquivocation
-  def missingBlocks: BlockError            = InvalidBlock.MissingBlocks
-  def invalidFormat: BlockError            = InvalidBlock.InvalidFormat
-  def invalidSignature: BlockError         = InvalidBlock.InvalidSignature
-  def invalidSender: BlockError            = InvalidBlock.InvalidSender
-  def invalidVersion: BlockError           = InvalidBlock.InvalidVersion
-  def invalidTimestamp: BlockError         = InvalidBlock.InvalidTimestamp
-  def deployNotSigned: BlockError          = InvalidBlock.DeployNotSigned
-  def invalidBlockNumber: BlockError       = InvalidBlock.InvalidBlockNumber
-  def invalidRepeatDeploy: BlockError      = InvalidBlock.InvalidRepeatDeploy
-  def invalidParents: BlockError           = InvalidBlock.InvalidParents
-  def invalidFollows: BlockError           = InvalidBlock.InvalidFollows
-  def invalidSequenceNumber: BlockError    = InvalidBlock.InvalidSequenceNumber
-  def invalidShardId: BlockError           = InvalidBlock.InvalidShardId
-  def justificationRegression: BlockError  = InvalidBlock.JustificationRegression
-  def neglectedInvalidBlock: BlockError    = InvalidBlock.NeglectedInvalidBlock
-  def neglectedEquivocation: BlockError    = InvalidBlock.NeglectedEquivocation
-  def invalidTransaction: BlockError       = InvalidBlock.InvalidTransaction
-  def invalidBondsCache: BlockError        = InvalidBlock.InvalidBondsCache
-  def invalidBlockHash: BlockError         = InvalidBlock.InvalidBlockHash
-  def containsExpiredDeploy: BlockError    = InvalidBlock.ContainsExpiredDeploy
-  def containsFutureDeploy: BlockError     = InvalidBlock.ContainsFutureDeploy
+  def valid: ValidBlock                                  = ValidBlock.Valid
+  def processed: BlockError                              = BlockError.Processed
+  def casperIsBusy: BlockError                           = BlockError.CasperIsBusy
+  def exception(ex: Throwable): BlockError               = BlockError.BlockException(ex)
+  def admissibleEquivocation: BlockError                 = InvalidBlock.AdmissibleEquivocation
+  def ignorableEquivocation: BlockError                  = InvalidBlock.IgnorableEquivocation
+  def missingBlocks(missing: Set[BlockHash]): BlockError = InvalidBlock.MissingBlocks(missing)
+  def invalidFormat: BlockError                          = InvalidBlock.InvalidFormat
+  def invalidSignature: BlockError                       = InvalidBlock.InvalidSignature
+  def invalidSender: BlockError                          = InvalidBlock.InvalidSender
+  def invalidVersion: BlockError                         = InvalidBlock.InvalidVersion
+  def invalidTimestamp: BlockError                       = InvalidBlock.InvalidTimestamp
+  def deployNotSigned: BlockError                        = InvalidBlock.DeployNotSigned
+  def invalidBlockNumber: BlockError                     = InvalidBlock.InvalidBlockNumber
+  def invalidRepeatDeploy: BlockError                    = InvalidBlock.InvalidRepeatDeploy
+  def invalidParents: BlockError                         = InvalidBlock.InvalidParents
+  def invalidFollows: BlockError                         = InvalidBlock.InvalidFollows
+  def invalidSequenceNumber: BlockError                  = InvalidBlock.InvalidSequenceNumber
+  def invalidShardId: BlockError                         = InvalidBlock.InvalidShardId
+  def justificationRegression: BlockError                = InvalidBlock.JustificationRegression
+  def neglectedInvalidBlock: BlockError                  = InvalidBlock.NeglectedInvalidBlock
+  def neglectedEquivocation: BlockError                  = InvalidBlock.NeglectedEquivocation
+  def invalidTransaction: BlockError                     = InvalidBlock.InvalidTransaction
+  def invalidBondsCache: BlockError                      = InvalidBlock.InvalidBondsCache
+  def invalidBlockHash: BlockError                       = InvalidBlock.InvalidBlockHash
+  def containsExpiredDeploy: BlockError                  = InvalidBlock.ContainsExpiredDeploy
+  def containsFutureDeploy: BlockError                   = InvalidBlock.ContainsFutureDeploy
 
   def isInDag(blockStatus: BlockStatus): Boolean =
     blockStatus match {
@@ -59,8 +62,8 @@ object InvalidBlock {
   // For now we won't eagerly slash equivocations that we can just ignore,
   // as we aren't forced to add it to our view as a dependency.
   // TODO: The above will become a DOS vector if we don't fix.
-  case object IgnorableEquivocation extends InvalidBlock
-  case object MissingBlocks         extends InvalidBlock
+  case object IgnorableEquivocation                       extends InvalidBlock
+  final case class MissingBlocks(missing: Set[BlockHash]) extends InvalidBlock
 
   case object InvalidFormat    extends InvalidBlock
   case object InvalidSignature extends InvalidBlock

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -62,8 +62,10 @@ object InvalidBlock {
   // For now we won't eagerly slash equivocations that we can just ignore,
   // as we aren't forced to add it to our view as a dependency.
   // TODO: The above will become a DOS vector if we don't fix.
-  case object IgnorableEquivocation                       extends InvalidBlock
-  final case class MissingBlocks(missing: Set[BlockHash]) extends InvalidBlock
+  case object IgnorableEquivocation extends InvalidBlock
+  final case class MissingBlocks(missing: Set[BlockHash]) extends InvalidBlock {
+    override def toString: String = "MissingBlocks"
+  }
 
   case object InvalidFormat    extends InvalidBlock
   case object InvalidSignature extends InvalidBlock

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -5,33 +5,34 @@ import coop.rchain.models.BlockHash.BlockHash
 
 sealed trait BlockStatus
 object BlockStatus {
-  def valid: ValidBlock                                  = ValidBlock.Valid
-  def processed: BlockError                              = BlockError.Processed
-  def casperIsBusy: BlockError                           = BlockError.CasperIsBusy
-  def exception(ex: Throwable): BlockError               = BlockError.BlockException(ex)
-  def admissibleEquivocation: BlockError                 = InvalidBlock.AdmissibleEquivocation
-  def ignorableEquivocation: BlockError                  = InvalidBlock.IgnorableEquivocation
-  def missingBlocks(missing: Set[BlockHash]): BlockError = InvalidBlock.MissingBlocks(missing)
-  def invalidFormat: BlockError                          = InvalidBlock.InvalidFormat
-  def invalidSignature: BlockError                       = InvalidBlock.InvalidSignature
-  def invalidSender: BlockError                          = InvalidBlock.InvalidSender
-  def invalidVersion: BlockError                         = InvalidBlock.InvalidVersion
-  def invalidTimestamp: BlockError                       = InvalidBlock.InvalidTimestamp
-  def deployNotSigned: BlockError                        = InvalidBlock.DeployNotSigned
-  def invalidBlockNumber: BlockError                     = InvalidBlock.InvalidBlockNumber
-  def invalidRepeatDeploy: BlockError                    = InvalidBlock.InvalidRepeatDeploy
-  def invalidParents: BlockError                         = InvalidBlock.InvalidParents
-  def invalidFollows: BlockError                         = InvalidBlock.InvalidFollows
-  def invalidSequenceNumber: BlockError                  = InvalidBlock.InvalidSequenceNumber
-  def invalidShardId: BlockError                         = InvalidBlock.InvalidShardId
-  def justificationRegression: BlockError                = InvalidBlock.JustificationRegression
-  def neglectedInvalidBlock: BlockError                  = InvalidBlock.NeglectedInvalidBlock
-  def neglectedEquivocation: BlockError                  = InvalidBlock.NeglectedEquivocation
-  def invalidTransaction: BlockError                     = InvalidBlock.InvalidTransaction
-  def invalidBondsCache: BlockError                      = InvalidBlock.InvalidBondsCache
-  def invalidBlockHash: BlockError                       = InvalidBlock.InvalidBlockHash
-  def containsExpiredDeploy: BlockError                  = InvalidBlock.ContainsExpiredDeploy
-  def containsFutureDeploy: BlockError                   = InvalidBlock.ContainsFutureDeploy
+  def valid: ValidBlock                    = ValidBlock.Valid
+  def processed: BlockError                = BlockError.Processed
+  def casperIsBusy: BlockError             = BlockError.CasperIsBusy
+  def exception(ex: Throwable): BlockError = BlockError.BlockException(ex)
+  def admissibleEquivocation: BlockError   = InvalidBlock.AdmissibleEquivocation
+  def ignorableEquivocation: BlockError    = InvalidBlock.IgnorableEquivocation
+  def missingBlocks(missing: Set[BlockHash], equivocating: Set[BlockHash]): BlockError =
+    InvalidBlock.MissingBlocks(missing, equivocating)
+  def invalidFormat: BlockError           = InvalidBlock.InvalidFormat
+  def invalidSignature: BlockError        = InvalidBlock.InvalidSignature
+  def invalidSender: BlockError           = InvalidBlock.InvalidSender
+  def invalidVersion: BlockError          = InvalidBlock.InvalidVersion
+  def invalidTimestamp: BlockError        = InvalidBlock.InvalidTimestamp
+  def deployNotSigned: BlockError         = InvalidBlock.DeployNotSigned
+  def invalidBlockNumber: BlockError      = InvalidBlock.InvalidBlockNumber
+  def invalidRepeatDeploy: BlockError     = InvalidBlock.InvalidRepeatDeploy
+  def invalidParents: BlockError          = InvalidBlock.InvalidParents
+  def invalidFollows: BlockError          = InvalidBlock.InvalidFollows
+  def invalidSequenceNumber: BlockError   = InvalidBlock.InvalidSequenceNumber
+  def invalidShardId: BlockError          = InvalidBlock.InvalidShardId
+  def justificationRegression: BlockError = InvalidBlock.JustificationRegression
+  def neglectedInvalidBlock: BlockError   = InvalidBlock.NeglectedInvalidBlock
+  def neglectedEquivocation: BlockError   = InvalidBlock.NeglectedEquivocation
+  def invalidTransaction: BlockError      = InvalidBlock.InvalidTransaction
+  def invalidBondsCache: BlockError       = InvalidBlock.InvalidBondsCache
+  def invalidBlockHash: BlockError        = InvalidBlock.InvalidBlockHash
+  def containsExpiredDeploy: BlockError   = InvalidBlock.ContainsExpiredDeploy
+  def containsFutureDeploy: BlockError    = InvalidBlock.ContainsFutureDeploy
 
   def isInDag(blockStatus: BlockStatus): Boolean =
     blockStatus match {
@@ -63,7 +64,8 @@ object InvalidBlock {
   // as we aren't forced to add it to our view as a dependency.
   // TODO: The above will become a DOS vector if we don't fix.
   case object IgnorableEquivocation extends InvalidBlock
-  final case class MissingBlocks(missing: Set[BlockHash]) extends InvalidBlock {
+  final case class MissingBlocks(missing: Set[BlockHash], equivocating: Set[BlockHash])
+      extends InvalidBlock {
     override def toString: String = "MissingBlocks"
   }
 

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -25,6 +25,8 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared._
 
+import scala.collection.immutable.Queue
+
 sealed trait DeployError
 final case class ParsingError(details: String)          extends DeployError
 final case object MissingUser                           extends DeployError
@@ -47,7 +49,7 @@ object DeployError {
   }
 }
 
-final case class BlockProcessingState(enqueued: Set[BlockHash], processing: Set[BlockHash])
+final case class BlockProcessingState(enqueued: Queue[BlockHash], processing: Set[BlockHash])
 
 trait Casper[F[_]] {
   def addBlockFromStore(b: BlockHash, allowAddFromBuffer: Boolean = false): F[ValidBlockProcessing]
@@ -142,7 +144,7 @@ sealed abstract class MultiParentCasperInstances {
                                }
         blockProcessingLock <- MetricsSemaphore.single[F]
         blockProcessingState <- Ref.of[F, BlockProcessingState](
-                                 BlockProcessingState(Set.empty, Set.empty)
+                                 BlockProcessingState(Queue.empty, Set.empty)
                                )
       } yield {
         new MultiParentCasperImpl(

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -21,6 +21,7 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.blockImplicits.getRandomBlock
 import monix.eval.Task
 
+import scala.collection.immutable.Queue
 import scala.collection.mutable.{Map => MutableMap}
 
 class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
@@ -58,7 +59,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
     } yield BlockStatus.valid.asRight
 
   def getBlockProcessingState: F[BlockProcessingState] =
-    BlockProcessingState(Set.empty[BlockHash], Set.empty[BlockHash]).pure[F]
+    BlockProcessingState(Queue.empty[BlockHash], Set.empty[BlockHash]).pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -44,6 +44,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.Assertions
 
+import scala.collection.immutable.Queue
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
 class TestNode[F[_]](
@@ -118,7 +119,7 @@ class TestNode[F[_]](
   implicit val blockRetriever: BlockRetriever[F] = BlockRetriever.of[F]
 
   val blockProcessingState =
-    Ref.unsafe[F, BlockProcessingState](BlockProcessingState(Set.empty, Set.empty))
+    Ref.unsafe[F, BlockProcessingState](BlockProcessingState(Queue.empty, Set.empty))
 
   implicit val casperEff = new MultiParentCasperImpl[F](
     validatorId,


### PR DESCRIPTION
There is two filter cases missing in dependencies set construction - it should not include blocks that are being processed by Casper at the moment or enqueued to Casper.

This PR turned into some bigger attempt to refactor, bugfix and improve how block processing is handled.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
