### PR TITLE
Monix 3.2.2+55-9adf112c-SNAPSHOT with async stack trace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ lazy val projectSettings = Seq(
     Resolver.sonatypeRepo("snapshots"),
     "jitpack" at "https://jitpack.io"
   ),
+  // TODO: added because of monix snapshot dependency
+  updateOptions := updateOptions.value.withLatestSnapshots(false),
   wartremoverExcluded += sourceManaged.value,
   wartremoverErrors in (Compile, compile) ++= Warts.allBut(
     // those we want

--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
@@ -4,11 +4,10 @@ import java.util
 
 import scala.collection.mutable
 import scala.math.ceil
-
 import monix.execution.internal.atomic.UnsafeAccess
-import org.jctools.queues._
-import org.jctools.queues.MessagePassingQueue.Consumer
-import org.jctools.queues.atomic.MpscAtomicArrayQueue
+import monix.execution.internal.jctools.queues._
+import monix.execution.internal.jctools.queues.MessagePassingQueue.Consumer
+import monix.execution.internal.jctools.queues.atomic.MpscAtomicArrayQueue
 
 /**
   * This code has been copied from the Monix codebase because unfortunately

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
-  val monix               = "io.monix"                   %% "monix"                     % "3.2.2"
+  val monix               = "io.monix"                   %% "monix"                     % "3.2.2+55-9adf112c-SNAPSHOT"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"


### PR DESCRIPTION
## Overview
This is test PR with monix `3.2.2+55-9adf112c-SNAPSHOT` with async stack trace.

Docker image: `tgrospic/rnode:v0.9.25.6-monix`.