### PR TITLE
Update Dependencies.scala for scodec-bits to 1.1.20 from 1.1.18

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.10.3"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "0.8.0"
-  val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.18"
+  val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.20"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,7 +82,7 @@ object Dependencies {
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
   val julToSlf4j          = "org.slf4j"                   % "jul-to-slf4j"              % slf4jVersion
   // format: on
-  val pureconfig          = "com.github.pureconfig"       %% "pureconfig"               % "0.13.0"
+  val pureconfig          = "com.github.pureconfig"       %% "pureconfig"               % "0.14.0"
   val catsRetry          ="com.github.cb372"             %% "cats-retry"               % "2.0.0"
 
   val overrides = Seq(


### PR DESCRIPTION
## Overview
Update Dependencies.scala for scodec-bitsto 1.1.20 from 1.1.18




### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
