### PR TITLE
Make Signed equals method count on signatures

### DIFF
--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Signed.scala
@@ -18,6 +18,13 @@ final case class Signed[A] private (
   // https://contributors.scala-lang.org/t/removing-copy-operation-from-case-classes-with-private-constructors/2605/2
   private def copy(): Unit = hack
   private def hack(): Unit = copy
+
+  override def hashCode(): Int = sig.hashCode()
+
+  override def equals(obj: Any): Boolean = obj match {
+    case s: Signed[A] => s.sig == this.sig
+    case _            => false
+  }
 }
 
 object Signed {


### PR DESCRIPTION
We issue InvalidRepeatDeploy based on duplicate signature. But we are filtering deploys seen in the past using object equality. 
https://github.com/rchain/rchain/blob/dac6dab1e7e21bbdd1b910a41adcdd591ba90349/casper/src/main/scala/coop/rchain/casper/BlockCreator.scala#L175
This PR overrides Signed class equal method to check if signatures are equal.