### PR TITLE
openssl to 1.1.1h in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val node = (project in file("node"))
     /* Debian */
     debianPackageDependencies in Debian ++= Seq(
       "openjdk-11-jre-headless",
-      "openssl(>= 1.1.1h) | openssl(>= 1.1.1h)", //ubuntu & debian
+      "openssl(>= 1.0.2g) | openssl(>= 1.1.1h)", //ubuntu & debian
       "bash (>= 2.05a-11)"
     ),
     /* Redhat */

--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val node = (project in file("node"))
     /* Debian */
     debianPackageDependencies in Debian ++= Seq(
       "openjdk-11-jre-headless",
-      "openssl(>= 1.1.1h) | openssl(>= 1.1.1d)", //ubuntu & debian
+      "openssl(>= 1.1.1h) | openssl(>= 1.1.1h)", //ubuntu & debian
       "bash (>= 2.05a-11)"
     ),
     /* Redhat */

--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val node = (project in file("node"))
     /* Debian */
     debianPackageDependencies in Debian ++= Seq(
       "openjdk-11-jre-headless",
-      "openssl(>= 1.0.2g) | openssl(>= 1.1.0f)", //ubuntu & debian
+      "openssl(>= 1.1.1h) | openssl(>= 1.1.1h)", //ubuntu & debian
       "bash (>= 2.05a-11)"
     ),
     /* Redhat */

--- a/build.sbt
+++ b/build.sbt
@@ -359,7 +359,7 @@ lazy val node = (project in file("node"))
     /* Debian */
     debianPackageDependencies in Debian ++= Seq(
       "openjdk-11-jre-headless",
-      "openssl(>= 1.1.1h) | openssl(>= 1.1.1h)", //ubuntu & debian
+      "openssl(>= 1.1.1h) | openssl(>= 1.1.1d)", //ubuntu & debian
       "bash (>= 2.05a-11)"
     ),
     /* Redhat */


### PR DESCRIPTION
## Overview
Update openssl to 1.1.1h in build.sbt from 1.0.2g and 1.1.0f respectively


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
