### PR TITLE
cats 2.2.0 from 2.1.1 in Dependencies.scala

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -1,19 +1,17 @@
 package coop.rchain.casper
 
-import cats.Applicative
+import cats.{Applicative, Id}
 import cats.effect.Sync
 import cats.syntax.applicative._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.option._
-import com.google.protobuf.{ByteString, Int32Value, StringValue}
-import coop.rchain.casper.protocol.{BlockMessage, Body, Header, Signature}
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{BlockMessage, Signature}
 import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.casper.util.ProtoUtil.{hashByteArrays, hashSignedBlock}
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.{Secp256k1, SignaturesAlg}
 import coop.rchain.crypto.{PrivateKey, PublicKey}
-import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.{EnvVars, Log, LogSource}
 
 final case class ValidatorIdentity(
@@ -50,7 +48,7 @@ object ValidatorIdentity {
   private val RNodeValidatorPasswordEnvVar  = "RNODE_VALIDATOR_PASSWORD"
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
-  def apply[F[_]: Applicative](
+  def apply(
       privateKey: PrivateKey
   ): ValidatorIdentity = {
     val publicKey = Secp256k1.toPublic(privateKey)

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -224,7 +224,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
         block            <- node.createBlock(basicDeployData)
         dag              <- node.blockDagStorage.getRepresentation
         (sk, pk)         = Secp256k1.newKeyPair
-        validatorId      = ValidatorIdentity[Effect](sk)
+        validatorId      = ValidatorIdentity(sk)
         sender           = ByteString.copyFrom(pk.bytes)
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
@@ -558,7 +558,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
       for {
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-        block = ValidatorIdentity[Effect](defaultValidatorSks(1)).signBlock(
+        block = ValidatorIdentity(defaultValidatorSks(1)).signBlock(
           blockThatPointsToInvalidBlock
         )
       } yield block

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -106,7 +106,7 @@ class ValidateTest
       sender           = ByteString.copyFrom(pk.bytes)
       latestMessageOpt <- dag.latestMessage(sender)
       seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-      result           = ValidatorIdentity[Task](sk).signBlock(block.copy(seqNum = seqNum))
+      result           = ValidatorIdentity(sk).signBlock(block.copy(seqNum = seqNum))
     } yield result
   }
 
@@ -545,7 +545,7 @@ class ValidateTest
         sender           = ByteString.copyFrom(pk.bytes)
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-        signedBlock = ValidatorIdentity[Task](sk).signBlock(
+        signedBlock = ValidatorIdentity(sk).signBlock(
           block.withBlockNumber(17).copy(seqNum = 1)
         )
         _ <- Validate.blockSummary[Task](
@@ -754,7 +754,7 @@ class ValidateTest
         sender           = ByteString.copyFrom(pk.bytes)
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-        genesis = ValidatorIdentity[Task](sk)
+        genesis = ValidatorIdentity(sk)
           .signBlock(context.genesisBlock.copy(seqNum = seqNum))
         _ <- Validate.formatOfFields[Task](genesis) shouldBeF true
         _ <- Validate.formatOfFields[Task](genesis.copy(blockHash = ByteString.EMPTY)) shouldBeF false
@@ -779,7 +779,7 @@ class ValidateTest
         dag              <- blockDagStorage.getRepresentation
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-        genesis = ValidatorIdentity[Task](sk)
+        genesis = ValidatorIdentity(sk)
           .signBlock(context.genesisBlock.copy(seqNum = seqNum))
         _ <- Validate.blockHash[Task](genesis) shouldBeF Right(Valid)
         result <- Validate.blockHash[Task](
@@ -796,7 +796,7 @@ class ValidateTest
       dag              <- blockDagStorage.getRepresentation
       latestMessageOpt <- dag.latestMessage(sender)
       seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-      genesis = ValidatorIdentity[Task](sk).signBlock(
+      genesis = ValidatorIdentity(sk).signBlock(
         context.genesisBlock.copy(seqNum = seqNum)
       )
       _      <- Validate.version[Task](genesis, -1) shouldBeF false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.9"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "2.1.1"
+  val catsVersion       = "2.2.0"
   val catsEffectVersion = "2.2.0"
   val catsMtlVersion    = "0.7.1"
   val slf4jVersion      = "1.7.25"
@@ -23,7 +23,7 @@ object Dependencies {
   val catsEffectLawsTest  = "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion % "test"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
-  val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.11"
+  val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.12"
   val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/IndexMapChain.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/IndexMapChain.scala
@@ -1,5 +1,7 @@
 package coop.rchain.rholang.interpreter.compiler
 
+import cats.syntax.all._
+
 /**
   *
   * A structure for keeping track of bound variables. Every time we go under a binding construct
@@ -13,14 +15,11 @@ final case class IndexMapChain[T](chain: Vector[DeBruijnIndexMap[T]]) {
 
   def get(name: String): Option[IndexContext[T]] = chain.head.get(name)
 
-  def find(name: String): Option[(IndexContext[T], Int)] = {
-    import cats.implicits.catsStdInstancesForVector
-    import cats.Foldable.ops.toAllFoldableOps
+  def find(name: String): Option[(IndexContext[T], Int)] =
     chain.zipWithIndex.collectFirstSome {
       case (indexMap, depth) =>
         indexMap.get(name).map((_, depth))
     }
-  }
 
   def put(binding: IdContext[T]): IndexMapChain[T] =
     IndexMapChain(chain.updated(0, chain(0).put(binding)))


### PR DESCRIPTION
cats update to 2.2.0 from 2.1.1 in Dependencies.scala, Also cats-tagless-macros update from 0.11 to 0.12



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
