### PR TITLE
Upgrade of scalapb, netty and grpc-java libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,7 @@ lazy val casper = (project in file("casper"))
     shared       % "compile->compile;test->test",
     graphz,
     crypto,
-    models   % "compile->compile;test->test",
+    models % "compile->compile;test->test",
     rspace,
     rholang % "compile->compile;test->test"
   )
@@ -196,9 +196,9 @@ lazy val comm = (project in file("comm"))
       guava
     ),
     PB.targets in Compile := Seq(
-      PB.gens.java                              -> (sourceManaged in Compile).value,
-      scalapb.gen(javaConversions = true)       -> (sourceManaged in Compile).value,
-      grpcmonix.generators.GrpcMonixGenerator() -> (sourceManaged in Compile).value
+      PB.gens.java                                      -> (sourceManaged in Compile).value,
+      scalapb.gen(javaConversions = true, grpc = false) -> (sourceManaged in Compile).value,
+      grpcmonix.generators.gen()                        -> (sourceManaged in Compile).value
     )
   )
   .dependsOn(shared % "compile->compile;test->test", crypto, models)
@@ -234,10 +234,8 @@ lazy val models = (project in file("models"))
       scalapbRuntimegGrpc
     ),
     PB.targets in Compile := Seq(
-      coop.rchain.scalapb.StacksafeScalapbGenerator
-        .gen(flatPackage = true) -> (sourceManaged in Compile).value,
-      grpcmonix.generators
-        .GrpcMonixGenerator(flatPackage = true) -> (sourceManaged in Compile).value
+      coop.rchain.scalapb.gen(flatPackage = true, grpc = false) -> (sourceManaged in Compile).value,
+      grpcmonix.generators.gen()                                -> (sourceManaged in Compile).value
     )
   )
   .dependsOn(shared % "compile->compile;test->test", rspace)
@@ -271,9 +269,10 @@ lazy val node = (project in file("node"))
         pureconfig
       ),
     PB.targets in Compile := Seq(
-      PB.gens.java                              -> (sourceManaged in Compile).value / "protobuf",
-      scalapb.gen(javaConversions = true)       -> (sourceManaged in Compile).value / "protobuf",
-      grpcmonix.generators.GrpcMonixGenerator() -> (sourceManaged in Compile).value / "protobuf"
+      PB.gens.java -> (sourceManaged in Compile).value / "protobuf",
+      scalapb
+        .gen(javaConversions = true, grpc = false) -> (sourceManaged in Compile).value / "protobuf",
+      grpcmonix.generators.gen()                   -> (sourceManaged in Compile).value / "protobuf"
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "coop.rchain.node",

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -171,7 +171,7 @@ object GrpcTransportReceiver {
     val server = NettyServerBuilder
       .forPort(port)
       .executor(scheduler)
-      .maxMessageSize(maxMessageSize)
+      .maxInboundMessageSize(maxMessageSize)
       .sslContext(serverSslContext)
       .addService(RoutingGrpcMonix.bindService(service, scheduler))
       .intercept(new SslSessionServerInterceptor(networkId))

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -17,6 +17,7 @@ option (scalapb.options) = {
   flat_package: true
   single_file: true
   preamble: "sealed trait CasperMessageProto"
+  preserve_unknown_fields: false
 };
 
 message HasBlockRequestProto {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package casper;
 
 import "CasperMessage.proto";
-import "google/protobuf/empty.proto";
 
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:
@@ -20,6 +19,7 @@ option (scalapb.options) = {
   flat_package: true
   single_file: true
   preamble: "sealed trait ReportEventProto"
+  preserve_unknown_fields: false
 };
 
 message FindDeployQuery {

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -19,6 +19,7 @@ option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol.deploy.v1"
   flat_package: true
   single_file: true
+  preserve_unknown_fields: false
 };
 
 // Use `doDeploy` to queue deployments of Rholang code and then

--- a/models/src/main/protobuf/ProposeServiceCommon.proto
+++ b/models/src/main/protobuf/ProposeServiceCommon.proto
@@ -12,6 +12,7 @@ option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"
   flat_package: true
   single_file: true
+  preserve_unknown_fields: false
 };
 
 message PrintUnmatchedSendsQuery {

--- a/models/src/main/protobuf/ProposeServiceV1.proto
+++ b/models/src/main/protobuf/ProposeServiceV1.proto
@@ -15,6 +15,7 @@ option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol.propose.v1"
   flat_package: true
   single_file: true
+  preserve_unknown_fields: false
 };
 
 service ProposeService {

--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -17,6 +17,7 @@ option (scalapb.options) = {
   import: "coop.rchain.models.BitSetBytesMapper.bitSetBytesMapper"
   import: "coop.rchain.models.ParSetTypeMapper.parSetESetTypeMapper"
   import: "coop.rchain.models.ParMapTypeMapper.parMapEMapTypeMapper"
+  preserve_unknown_fields: false
 };
 
 /**

--- a/models/src/main/protobuf/ServiceError.proto
+++ b/models/src/main/protobuf/ServiceError.proto
@@ -9,6 +9,7 @@ import "scalapb/scalapb.proto";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol"
+  preserve_unknown_fields: false
 };
 
 message ServiceError {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -7,11 +7,11 @@ package routing;
 // make a scalapb directory in this file's location and place it inside
 
 import "scalapb/scalapb.proto";
-import "CasperMessage.proto";
 
 option (scalapb.options) = {
   package_name: "coop.rchain.comm.protocol.routing"
   flat_package: true
+  preserve_unknown_fields: false
 };
 
 message Node {

--- a/models/src/main/scala/coop/rchain/casper/protocol/PacketTypeTag.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/PacketTypeTag.scala
@@ -92,7 +92,7 @@ trait FromPacket[Tag <: PacketTypeTag] {
 }
 
 object FromPacket {
-  def protoImpl[Tag <: PacketTypeTag, A <: GeneratedMessage with Message[A]](
+  def protoImpl[Tag <: PacketTypeTag, A <: GeneratedMessage](
       implicit companion: GeneratedMessageCompanion[A],
       witness0: ValueOf[Tag]
   ): FromPacket[Tag] { type To = A } = new FromPacket[Tag] {
@@ -118,7 +118,7 @@ object ToPacket {
     override val witness                             = witness0
     protected override def content(a: A): ByteString = a.toByteString
   }
-  implicit def protoSerde[Tag0 <: PacketTypeTag, A0 <: GeneratedMessage with Message[A0]](
+  implicit def protoSerde[Tag0 <: PacketTypeTag, A0 <: GeneratedMessage](
       implicit de: FromPacket[Tag0] { type To = A0 }
   ): ToPacket[A0] { type Tag = Tag0 } = protoMessageImpl[A0, Tag0](de.witness)
 }

--- a/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
+++ b/models/src/main/scala/coop/rchain/models/StacksafeMessage.scala
@@ -1,9 +1,9 @@
 package coop.rchain.models
+
 import cats.effect.Sync
 import com.google.protobuf.CodedInputStream
-import scalapb.Message
 
-trait StacksafeMessage[A] extends scalapb.GeneratedMessage with Message[A] {
+trait StacksafeMessage[A] extends scalapb.GeneratedMessage {
 
   def serializedSizeM: Memo[Int]
 

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -39,7 +39,7 @@ package object api {
       NettyServerBuilder
         .forAddress(new InetSocketAddress(host, port))
         .executor(grpcExecutor)
-        .maxMessageSize(maxMessageSize)
+        .maxInboundMessageSize(maxMessageSize)
         .addService(
           ReplGrpcMonix.bindService(replGrpcService, grpcExecutor)
         )
@@ -79,7 +79,7 @@ package object api {
       NettyServerBuilder
         .forAddress(new InetSocketAddress(host, port))
         .executor(grpcExecutor)
-        .maxMessageSize(maxMessageSize)
+        .maxInboundMessageSize(maxMessageSize)
         .addService(
           DeployServiceV1GrpcMonix
             .bindService(deployGrpcService, grpcExecutor)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,8 @@ object Dependencies {
   val slf4jVersion      = "1.7.25"
 
   // format: off
-  val bouncyProvCastle    = "org.bouncycastle"           % "bcprov-jdk15on"             % "1.66"
-  val bouncyPkixCastle    = "org.bouncycastle"           % "bcpkix-jdk15on"             % "1.66"
+  val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.66"
+  val bouncyPkixCastle    = "org.bouncycastle"            % "bcpkix-jdk15on"            % "1.66"
   val catsCore            = "org.typelevel"              %% "cats-core"                 % catsVersion
   val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
   val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"
@@ -23,13 +23,14 @@ object Dependencies {
   val catsEffectLawsTest  = "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion % "test"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
+  val catsRetry           = "com.github.cb372"           %% "cats-retry"                % "2.0.0"
   val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.12"
-  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
   val circeLiteral        = "io.circe"                   %% "circe-literal"             % circeVersion
   val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
+  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
   val guava               = "com.google.guava"            % "guava"                     % "24.1.1-jre"
   val hasher              = "com.roundeights"            %% "hasher"                    % "1.2.0"
@@ -40,6 +41,7 @@ object Dependencies {
   val jaxb                = "javax.xml.bind"              % "jaxb-api"                  % "2.3.1"
   val jline               = ("org.scala-lang"             % "jline"                     % "2.10.7")
     .exclude("org.fusesource.jansi", "jansi")
+  val julToSlf4j          = "org.slf4j"                   % "jul-to-slf4j"              % slf4jVersion
   // see https://jitpack.io/#rchain/kalium
   val kalium              = "com.github.rchain"           % "kalium"                    % "0.8.1"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
@@ -51,8 +53,11 @@ object Dependencies {
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
+  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
+  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
   val monix               = "io.monix"                   %% "monix"                     % "3.3.0"
+  val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"
@@ -73,17 +78,12 @@ object Dependencies {
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.10.3"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "0.8.0"
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.20"
-  val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
-  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
-  val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.4"
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
-  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
+  val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
-  val julToSlf4j          = "org.slf4j"                   % "jul-to-slf4j"              % slf4jVersion
+  val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.4"
   // format: on
-  val pureconfig          = "com.github.pureconfig"       %% "pureconfig"               % "0.14.0"
-  val catsRetry          ="com.github.cb372"             %% "cats-retry"               % "2.0.0"
 
   val overrides = Seq(
     catsCore,
@@ -95,7 +95,7 @@ object Dependencies {
     scalacheck,
     disciplineCore,
     //overrides for transitive dependencies (we don't use them directly, hence no val-s)
-    "com.typesafe"             % "config"                 % "1.4.0",
+    "com.typesafe"             % "config"                  % "1.4.0",
     "org.typelevel"            %% "machinist"              % "0.6.5",
     "org.typelevel"            %% "catalysts-platform"     % "0.6",
     "com.lihaoyi"              %% "sourcecode"             % "0.1.4",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,6 +32,7 @@ object Dependencies {
   val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
   val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
+  val fs2Core             = "co.fs2"                     %% "fs2-core"                  % "2.4.4"
   val guava               = "com.google.guava"            % "guava"                     % "24.1.1-jre"
   val hasher              = "com.roundeights"            %% "hasher"                    % "1.2.0"
   val http4sBlazeClient   = "org.http4s"                 %% "http4s-blaze-client"       % http4sVersion
@@ -69,10 +70,10 @@ object Dependencies {
   val scalapbRuntimegGrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
   val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
   val grpcServices        = "io.grpc"                     % "grpc-services"             % scalapb.compiler.Version.grpcJavaVersion
-  val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.10.Final"
-  val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.10.Final" classifier osClassifier
-  val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.10.Final" classifier "linux-x86_64"
-  val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.10.Final" classifier "linux-x86_64-fedora"
+  val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.31.Final"
+  val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier osClassifier
+  val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier "linux-x86_64"
+  val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier "linux-x86_64-fedora"
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.10.3"
@@ -89,20 +90,29 @@ object Dependencies {
     catsCore,
     catsEffect,
     catsLawsTest,
-    shapeless,
-    guava,
-    scodecBits,
-    scalacheck,
     disciplineCore,
+    fs2Core,
+    guava,
+    scalacheck,
+    scodecBits,
+    shapeless,
+    // Added to resolve conflicts in scalapb plugin v0.10.8
+    "org.codehaus.mojo"      % "animal-sniffer-annotations" % "1.18",
+    "com.google.protobuf"    % "protobuf-java"              % "3.12.0",
+    "org.scala-lang.modules" %% "scala-collection-compat"   % "2.2.0",
+    // Strange version conflict, it requires the same version but in square brackets (range?).
+    // e.g. io.grpc:grpc-core:1.30.2 ([1.30.2] wanted)
+    // https://stackoverflow.com/questions/59423185/strange-versions-conflict-in-sbt-strict-mode
+    "io.grpc"  % "grpc-api"          % "1.30.2",
+    "io.grpc"  % "grpc-core"         % "1.30.2",
+    "io.netty" % "netty-codec-http2" % "4.1.48.Final",
     //overrides for transitive dependencies (we don't use them directly, hence no val-s)
-    "com.typesafe"             % "config"                  % "1.4.0",
-    "org.typelevel"            %% "machinist"              % "0.6.5",
-    "org.typelevel"            %% "catalysts-platform"     % "0.6",
-    "com.lihaoyi"              %% "sourcecode"             % "0.1.4",
-    "org.scala-lang.modules"   %% "scala-xml"              % "1.1.0",
+    "com.github.jnr"           % "jnr-ffi"                 % "2.1.15",
+    "com.google.errorprone"    % "error_prone_annotations" % "2.3.4",
     "com.google.code.findbugs" % "jsr305"                  % "3.0.2",
-    "com.google.errorprone"    % "error_prone_annotations" % "2.1.2",
-    "com.github.jnr"           % "jnr-ffi"                 % "2.1.7"
+    "com.lihaoyi"              %% "sourcecode"             % "0.2.1",
+    "org.scala-lang.modules"   %% "scala-xml"              % "1.3.0",
+    "com.typesafe"             % "config"                  % "1.4.0"
   )
 
   private val kindProjector = compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.23")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
+
 addSbtPlugin("com.typesafe.sbt"       % "sbt-license-report"   % "1.2.0")
 addSbtPlugin("org.wartremover"        % "sbt-wartremover"      % "2.4.10")
 addSbtPlugin("org.scalameta"          % "sbt-scalafmt"         % "2.0.1")

--- a/rholang/project/build.properties
+++ b/rholang/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13


### PR DESCRIPTION
## Overview
Upgrade `scalapb` library to latest version. Because of defined custom plugins for types and gRPC services transition is more complicated because scalapb 0.7.4 API changed together with Google protobuf definitions.

NOTE 1: Unfortunately OOM error is not resolved with this update https://github.com/rchain/rchain/issues/3180#issuecomment-725343150.

NOTE 2:
First time (and only) run on CI produced _Unable to consume results of system deploy_ error for 3 tests in MultiParentCasperMergeSpec.
  - handle multi-parent blocks correctly
  - handle multi-parent blocks correctly when they operate on stdout
  - not conflict on registry lookups

I don't have explanation why that happened but I also don't see how changes in this PR can be related. Error can also means conflict in merging blocks when executing system deploy (?).
https://github.com/rchain/rchain/runs/1381054008

```
coop.rchain.casper.util.rholang.SystemDeployPlatformFailure$ConsumeFailed$: Platform failure: Unable to consume results of system deploy
	at coop.rchain.casper.util.rholang.SystemDeployPlatformFailure$ConsumeFailed$.<clinit>(SystemDeployFailure.scala)
	at coop.rchain.casper.util.rholang.RuntimeManagerImpl.$anonfun$replaySystemDeployInternal$4(RuntimeManager.scala:261)
	at scala.util.Either.flatMap(Either.scala:341)
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
