### PR TITLE
Fix LMDB database corruption on put operation

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/LmdbKeyValueStore.scala
@@ -64,13 +64,17 @@ final case class LmdbKeyValueStore[F[_]: Sync](
     }
 
   // PUT
-  override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
+  override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] = {
+    // Buffers for key and value created outside of transaction.
+    // Why this helps (or why corruption happens) is not clear but this code will prevent corruption of the database.
+    val byteBuffers = kvPairs.map { case (key, value) => (key, toBuffer(value)) }
     withWriteTxn { (txn, dbi) =>
-      kvPairs.foreach {
+      byteBuffers.foreach {
         case (key, value) =>
-          if (dbi.put(txn, key, toBuffer(value))) () else ()
+          if (dbi.put(txn, key, value)) () else ()
       }
     }
+  }
 
   // DELETE
   override def delete(keys: Seq[ByteBuffer]): F[Int] =

--- a/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
+++ b/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
@@ -69,17 +69,6 @@ final case class LMDBStore[F[_]: Sync](env: Env[ByteBuffer], dbi: Dbi[ByteBuffer
       }
     }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-  def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
-    withWriteTxnF { txn =>
-      kvPairs.foreach {
-        case (key, value) =>
-          if (!dbi.put(txn, key, toBuffer(value))) {
-            throw new RuntimeException("was not able to put data")
-          }
-      }
-    }
-
   def delete(keys: List[ByteBuffer]): F[Int] =
     withWriteTxnF { txn =>
       keys.foldLeft(0) { (deletedCount, key) =>


### PR DESCRIPTION
## Overview
When testing for LFS, import of Rholang state (history and cold store), sometimes results in corrupted LMDB database. The same bug is also seen on test net node reported in linked issue.
This PR introduces a fix that resolves the problem and testing many iterations does not shows corruption.
But it's also not clear why the problem occurs and why allocating byte buffer values before write solves the problem.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
