### PR TITLE
Fix LMDB get operation to safely use returned buffer

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -115,7 +115,7 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
   override def get(blockHash: BlockHash): F[Option[BlockMessage]] =
     lock.withPermit(
       for {
-        indexEntryBytesOpt     <- index.get(blockHash.toDirectByteBuffer)
+        indexEntryBytesOpt     <- index.get_WARNING(blockHash.toDirectByteBuffer)
         indexEntryOpt          = indexEntryBytesOpt.map(IndexEntry.load)
         maybeBlockMessageProto <- indexEntryOpt.traverse(readBlockMessage)
       } yield maybeBlockMessageProto >>= (bmp => BlockMessage.from(bmp).toOption)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -65,7 +65,7 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
 
   private[this] def getBlockNumber(blockHash: BlockHash): F[Option[Long]] =
     for {
-      blockNumberBytesOpt <- blockNumberIndex.get(blockHash.toDirectByteBuffer)
+      blockNumberBytesOpt <- blockNumberIndex.get_WARNING(blockHash.toDirectByteBuffer)
     } yield blockNumberBytesOpt.map(_.getLong)
 
   private[this] def putBlockNumber(blockHash: BlockHash, blockNumber: Long): F[Unit] =

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RootsStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RootsStore.scala
@@ -26,16 +26,9 @@ object RootsStoreInstances {
 
     override def currentRoot(): F[Option[Blake2b256Hash]] =
       for {
-        byteBuf <- store.get(currentRootName)
-        maybeDecoded <- byteBuf
-                         .map(
-                           bytes =>
-                             Blake2b256Hash.codecBlake2b256Hash
-                               .decode(BitVector(bytes))
-                               .get
-                         )
-                         .sequence
-        maybeHash = maybeDecoded.map(_.value)
+        bytes        <- store.get(currentRootName)
+        maybeDecoded <- bytes.map(Blake2b256Hash.codecBlake2b256Hash.decode(_).get).sequence
+        maybeHash    = maybeDecoded.map(_.value)
       } yield (maybeHash)
 
     override def validateRoot(key: Blake2b256Hash): F[Option[Blake2b256Hash]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/Store.scala
@@ -3,20 +3,20 @@ package coop.rchain.rspace.history
 import java.nio.ByteBuffer
 import java.nio.file.Path
 
-import cats.implicits._
 import cats.effect.Sync
+import cats.implicits._
 import coop.rchain.lmdb.LMDBStore
-import coop.rchain.shared.ByteVectorOps.RichByteVector
 import coop.rchain.rspace.Blake2b256Hash
-import org.lmdbjava.DbiFlags.MDB_CREATE
+import coop.rchain.shared.ByteVectorOps.RichByteVector
 import org.lmdbjava.ByteBufferProxy.PROXY_SAFE
+import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.{Env, EnvFlags, Txn}
 import scodec.bits.BitVector
 
 trait Store[F[_]] {
   def get(key: Blake2b256Hash): F[Option[BitVector]]
   def put(key: Blake2b256Hash, value: BitVector): F[Unit]
-  def get(key: ByteBuffer): F[Option[ByteBuffer]]
+  def get(key: ByteBuffer): F[Option[BitVector]]
   def put(key: ByteBuffer, value: ByteBuffer): F[Unit]
   def put(data: Seq[(Blake2b256Hash, BitVector)]): F[Unit]
 
@@ -58,7 +58,7 @@ object StoreInstances {
         put(directKey, directValue)
       }
 
-      override def get(key: ByteBuffer): F[Option[ByteBuffer]] = store.get(key)
+      override def get(key: ByteBuffer): F[Option[BitVector]] = store.get(key)
 
       override def get[T](
           keys: Seq[Blake2b256Hash],

--- a/rspace/src/main/scala/coop/rchain/rspace/history/StoreFactory.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/StoreFactory.scala
@@ -16,16 +16,14 @@ object StoreFactory {
       store <- KeyValueStoreManager[F].store(dbName)
     } yield new Store[F] {
 
-      override def get(key: ByteBuffer): F[Option[ByteBuffer]] =
-        store.get(Seq(key), identity).map(_.head)
+      override def get(key: ByteBuffer): F[Option[BitVector]] =
+        store.get(Seq(key), BitVector(_)).map(_.head)
 
       override def put(key: ByteBuffer, value: ByteBuffer): F[Unit] =
         store.put[ByteBuffer](Seq((key, value)), identity)
 
-      override def get(key: Blake2b256Hash): F[Option[BitVector]] = {
-        val directKey = key.bytes.toDirectByteBuffer
-        get(directKey).map(v => v.map(BitVector(_)))
-      }
+      override def get(key: Blake2b256Hash): F[Option[BitVector]] =
+        get(key.bytes.toDirectByteBuffer)
 
       override def get[T](
           keys: Seq[Blake2b256Hash],

--- a/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
+++ b/shared/src/main/scala/coop/rchain/lmdb/LMDBStore.scala
@@ -2,10 +2,10 @@ package coop.rchain.lmdb
 
 import java.nio.ByteBuffer
 
-import cats.implicits._
 import cats.effect.Sync
 import coop.rchain.shared.Resources.withResource
 import org.lmdbjava.{CursorIterable, Dbi, Env, Txn}
+import scodec.bits.BitVector
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
@@ -37,10 +37,16 @@ final case class LMDBStore[F[_]: Sync](env: Env[ByteBuffer], dbi: Dbi[ByteBuffer
       withTxn(env.txnWrite)(f)
     }
 
-  def get(key: ByteBuffer): F[Option[ByteBuffer]] =
+  def get(key: ByteBuffer): F[Option[BitVector]] =
     withReadTxnF { txn =>
-      dbi.get(txn, key)
-    }.map(v => Option(v))
+      Option(dbi.get(txn, key)).map(BitVector(_))
+    }
+
+  // TODO: Remove this method. Returned byte buffer is deallocated after transaction is closed which can cause corrupted read.
+  def get_WARNING(key: ByteBuffer): F[Option[ByteBuffer]] =
+    withReadTxnF { txn =>
+      Option(dbi.get(txn, key))
+    }
 
   def get[V](key: Seq[ByteBuffer], fromBuffer: ByteBuffer => V): F[Seq[Option[V]]] =
     withReadTxnF { txn =>


### PR DESCRIPTION
## Overview
This PR adds additional fixes for LMDB get operation follows PR #3121. Returned byte buffer is deallocated when LMDB transaction is closed so any use after can cause corrupted value.

LMDB `get` - ByteBuffer is returned
https://github.com/lmdbjava/lmdbjava/blob/25fe08a/src/main/java/org/lmdbjava/Dbi.java#L240
On transaction _close_, close is also called on `KeyVal` and value buffer is deallocated
https://github.com/lmdbjava/lmdbjava/blob/25fe08af/src/main/java/org/lmdbjava/KeyVal.java#L68

### JIRA issue
https://rchain.atlassian.net/browse/RCHAIN-3952

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
