### PR TITLE
Block store (approved block) implementation with KeyValueStore

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -327,26 +327,4 @@ object FileLMDBIndexBlockStore {
     } yield result
   }
 
-  def create[F[_]: Monad: Concurrent: Sync: Log: Metrics](
-      config: Config
-  ): F[StorageErr[BlockStore[F]]] =
-    for {
-      notExists <- Sync[F].delay(Files.notExists(config.indexPath))
-      _         <- if (notExists) Sync[F].delay(Files.createDirectories(config.indexPath)) else ().pure[F]
-      env <- Sync[F].delay {
-              val flags = if (config.noTls) List(EnvFlags.MDB_NOTLS) else List.empty
-              Env
-                .create(PROXY_SAFE)
-                .setMapSize(config.mapSize)
-                .setMaxDbs(config.maxDbs)
-                .setMaxReaders(config.maxReaders)
-                .open(config.indexPath.toFile, flags: _*)
-            }
-      result <- create[F](
-                 env,
-                 config.storagePath,
-                 config.approvedBlockPath,
-                 config.checkpointsDirPath
-               )
-    } yield result
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/KeyValueBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/KeyValueBlockStore.scala
@@ -1,0 +1,161 @@
+package coop.rchain.blockstorage
+
+import java.nio.ByteBuffer
+
+import cats.effect.Sync
+import cats.syntax.all._
+import com.google.protobuf.{ByteString, CodedInputStream}
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.protocol._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.ByteStringOps.RichByteString
+import coop.rchain.shared.ByteVectorOps.RichByteVector
+import coop.rchain.shared.Compression
+import coop.rchain.shared.syntax._
+import coop.rchain.store.{KeyValueStore, KeyValueStoreManager}
+import net.jpountz.lz4.{LZ4CompressorWithLength, LZ4DecompressorWithLength}
+import scodec.bits.ByteVector
+
+class KeyValueBlockStore[F[_]: Sync](
+    private val store: KeyValueStore[F],
+    private val storeApprovedBlock: KeyValueStore[F]
+) extends BlockStore[F] {
+  import KeyValueBlockStore._
+
+  private def errorBlock(hash: BlockHash)(cause: String) = BlockStoreFatalError(
+    s"Block decoding error, hash ${PrettyPrinter.buildString(hash)}. Cause: $cause"
+  )
+
+  override def get(blockHash: BlockHash): F[Option[BlockMessage]] = {
+    import cats.instances.option._
+    for {
+      // Optional serialized block from the store
+      bytes <- store.get1(blockHash.toDirectByteBuffer, ByteVector(_))
+      // Decode protobuf message / throws if fail
+      proto <- bytes.map(_.toArray).traverse(bytesToBlockProto[F])
+      block <- proto.traverse(BlockMessage.from(_).leftMap(errorBlock(blockHash)).liftTo[F])
+    } yield block
+  }
+
+  override def find(p: BlockHash => Boolean, n: Int): F[Seq[(BlockHash, BlockMessage)]] = {
+    import cats.instances.list._
+    for {
+      filteredIndex <- store.iterate { iterator =>
+                        iterator
+                          .map { case (k, v) => (ByteString.copyFrom(k), v) }
+                          .withFilter { case (key, _) => p(key) }
+                          // Decode value only for filtered elements
+                          .map { case (k, v) => (k, ByteVector(v)) }
+                          // Return only the first n results / stop iteration
+                          .take(n)
+                          .toList
+                      }
+
+      result <- filteredIndex.traverse {
+                 case (hash, bytes) =>
+                   // Convert bytes to proto object, it's fatal error if fails
+                   bytesToBlockProto(bytes.toArray) map
+                     BlockMessage.from flatMap
+                     (_.leftMap(errorBlock(hash)).liftTo[F]) map
+                     ((hash, _))
+               }
+    } yield result
+  }
+
+  override def put(data: => (BlockHash, BlockMessage)): F[Unit] = Sync[F].defer {
+    def toBuffer(b: BlockMessage) = blockProtoToBuffer(b.toProto)
+    val (hash, block)             = data
+    val keyBuffer                 = hash.toDirectByteBuffer
+    store.put1(keyBuffer, block, toBuffer)
+  }
+
+  // ApprovedBlock store
+
+  private def errorApprovedBlock(cause: String) = BlockStoreFatalError(
+    s"Approved block decoding error. Cause: $cause"
+  )
+
+  override def getApprovedBlock: F[Option[ApprovedBlock]] = {
+    import cats.instances.option._
+    for {
+      // Optional block message from the store
+      proto <- storeApprovedBlock.get1(
+                ByteVector(approvedBlockKey).toDirectByteBuffer,
+                bufferToApprovedBlockProto
+              )
+      // Decode protobuf message / throw if fail
+      block <- proto.traverse(ApprovedBlock.from(_).leftMap(errorApprovedBlock).liftTo[F])
+    } yield block
+  }
+
+  override def putApprovedBlock(block: ApprovedBlock): F[Unit] = Sync[F].defer {
+    def toBuffer(b: ApprovedBlock) = b.toProto.toByteString.toDirectByteBuffer
+    val keyBuffer                  = ByteVector(approvedBlockKey).toDirectByteBuffer
+    storeApprovedBlock.put1(keyBuffer, block, toBuffer)
+  }
+
+  // Resource management is done in KV manager
+  override def close(): F[Unit] = ().pure[F]
+
+  // Not used
+  override def checkpoint(): F[Unit] = ???
+  override def clear(): F[Unit]      = ???
+}
+
+object KeyValueBlockStore {
+  def apply[F[_]: Sync](
+      store: KeyValueStore[F],
+      storeApprovedBlock: KeyValueStore[F]
+  ): F[BlockStore[F]] = Sync[F].delay(new KeyValueBlockStore[F](store, storeApprovedBlock))
+
+  // TODO: move this to `node` project where is implementation of KV manager
+  def apply[F[_]: Sync: KeyValueStoreManager](): F[BlockStore[F]] =
+    for {
+      store              <- KeyValueStoreManager[F].store("blocks")
+      storeApprovedBlock <- KeyValueStoreManager[F].store("blocks-approved")
+      blockStore         <- KeyValueBlockStore(store, storeApprovedBlock)
+    } yield blockStore
+
+  /**
+    * This is fatal error from which Block Store can not be recovered.
+    */
+  final case class BlockStoreFatalError(message: String) extends Exception(message)
+
+  // We store only one approved block so its key is constant.
+  val approvedBlockKey = Array[Byte](42)
+
+  // Encoding BlockMessage
+
+  def bytesToBlockProto[F[_]: Sync](bytes: Array[Byte]): F[BlockMessageProto] =
+    decompressBytes[F](bytes) map BlockMessageProto.parseFrom
+
+  def blockProtoToBytes(blockProto: BlockMessageProto): Array[Byte] =
+    compressBytes(blockProto.toByteArray)
+
+  private def blockProtoToBuffer(blockProto: BlockMessageProto): ByteBuffer = {
+    val bytes              = blockProtoToBytes(blockProto)
+    val buffer: ByteBuffer = ByteBuffer.allocateDirect(bytes.length)
+    buffer.put(bytes).flip
+  }
+
+  // Encoding ApprovedBlock
+
+  private def bufferToApprovedBlockProto(buff: ByteBuffer): ApprovedBlockProto = {
+    val inputStream = CodedInputStream.newInstance(buff)
+    ApprovedBlockProto.parseFrom(inputStream)
+  }
+
+  // Compression
+
+  val compressor = new LZ4CompressorWithLength(Compression.factory.fastCompressor())
+  // val compressor = new LZ4CompressorWithLength(factory.highCompressor(17)) // Max compression
+  val decompressor = new LZ4DecompressorWithLength(Compression.factory.fastDecompressor())
+
+  def compressBytes(bytes: Array[Byte]): Array[Byte] = compressor.compress(bytes)
+
+  def decompressBytes[F[_]: Sync](bytes: Array[Byte]): F[Array[Byte]] =
+    Sync[F].delay(decompressor.decompress(bytes)).handleErrorWith { ex =>
+      new Exception("Decompress of block failed.", ex).raiseError
+    }
+
+}

--- a/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
+++ b/block-storage/src/main/scala/org/lmdbjava/TxnOps.scala
@@ -1,7 +1,0 @@
-package org.lmdbjava
-import org.lmdbjava.Library.LIB
-
-object TxnOps {
-  def manuallyAbortTxn[T](txn: Txn[T]) =
-    LIB.mdb_txn_reset(txn.pointer())
-}

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/KeyValueBlockStoreSpec.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/KeyValueBlockStoreSpec.scala
@@ -1,0 +1,262 @@
+package coop.rchain.blockstorage
+
+import java.nio.ByteBuffer
+
+import cats.effect.Sync
+import cats.instances.tuple._
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{
+  ApprovedBlock,
+  ApprovedBlockCandidate,
+  BlockMessage,
+  BlockMessageProto
+}
+import coop.rchain.models.blockImplicits.{blockElementGen, blockElementsGen}
+import coop.rchain.shared.ByteStringOps.RichByteString
+import coop.rchain.shared.ByteVectorOps.RichByteVector
+import coop.rchain.store.KeyValueStore
+import monix.eval.Task
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class KeyValueBlockStoreSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+
+  class KV[F[_]: Sync](
+      getResult: Option[ByteString],
+      iterateMap: Map[ByteString, ByteString] = Map()
+  ) extends KeyValueStore[F] {
+    import scala.collection.mutable
+
+    val inputKeys = mutable.MutableList[ByteString]()
+
+    val inputPut = mutable.MutableList[ByteString]()
+
+    override def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]] =
+      Sync[F].delay {
+        inputKeys ++= keys.map(ByteString.copyFrom)
+
+        Seq(getResult.map(_.asReadOnlyByteBuffer).map(fromBuffer))
+      }
+
+    override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit] =
+      Sync[F].delay {
+        inputKeys ++= kvPairs.map(_._1).map(ByteString.copyFrom)
+
+        inputPut ++= kvPairs.map(_.map(toBuffer andThen ByteString.copyFrom)).map(_._2)
+      }
+
+    override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => T): F[T] = Sync[F].delay {
+      val iterBuffer = iterateMap.map {
+        case (k, v) => (k.toDirectByteBuffer, v.toDirectByteBuffer)
+      }
+      f(iterBuffer.iterator)
+    }
+
+    // Delete should not be used, block store can only add data.
+    override def delete(keys: Seq[ByteBuffer]): F[Int] = ???
+  }
+
+  def notImplementedKV[F[_]]: KeyValueStore[F] = new KeyValueStore[F] {
+    override def get[T](keys: Seq[ByteBuffer], fromBuffer: ByteBuffer => T): F[Seq[Option[T]]] = ???
+    override def put[T](kvPairs: Seq[(ByteBuffer, T)], toBuffer: T => ByteBuffer): F[Unit]     = ???
+    override def delete(keys: Seq[ByteBuffer]): F[Int]                                         = ???
+    override def iterate[T](f: Iterator[(ByteBuffer, ByteBuffer)] => T): F[T]                  = ???
+  }
+
+  implicit val scheduler = monix.execution.Scheduler.global
+
+  import KeyValueBlockStore._
+  import coop.rchain.shared.ByteStringOps._
+
+  val blockProtoToByteString = blockProtoToBytes _ andThen ByteString.copyFrom
+
+  /**
+    * Block store tests.
+    */
+  "Block store" should "get data from underlying key-value store" in {
+    forAll(blockElementGen(), arbitrary[String]) { (block, keyString) =>
+      // Testing block serialized
+      val blockBytes = blockProtoToByteString(block.toProto)
+
+      // Underlying key-value store
+      val kv = new KV[Task](blockBytes.some)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(kv, notImplementedKV)
+
+      // Key to request from block store
+      val key = ByteString.copyFromUtf8(keyString)
+
+      // Test block store GET operation
+      val result = bs.get(key).runSyncUnsafe()
+
+      // Requested key should match
+      kv.inputKeys shouldBe Seq(key)
+
+      // Result should be testing block
+      result shouldBe block.some
+    }
+  }
+
+  it should "not get data if not exists in underlying key-value store" in {
+    forAll(arbitrary[String]) { keyString =>
+      // Underlying key-value store
+      val kv = new KV[Task](none)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(kv, notImplementedKV)
+
+      // Key to request from block store
+      val key = ByteString.copyFromUtf8(keyString)
+
+      // Test block store GET operation
+      val result = bs.get(key).runSyncUnsafe()
+
+      // Result should be none
+      result shouldBe none
+    }
+  }
+
+  it should "put data to underlying key-value store" in {
+    forAll(blockElementGen()) { block =>
+      // Testing block serialized
+      val blockBytes = blockProtoToByteString(block.toProto)
+
+      // Underlying key-value store
+      val kv = new KV[Task](blockBytes.some)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(kv, notImplementedKV)
+
+      // Test block store PUT operation
+      bs.put(block).runSyncUnsafe()
+
+      // Block hash should match the key
+      kv.inputKeys shouldBe Seq(block.blockHash)
+
+      // Result should be testing block
+      kv.inputPut shouldBe Seq(blockBytes)
+    }
+  }
+
+  it should "iterate over data in underlying key-value store" in {
+    forAll(blockElementsGen, sizeRange(25)) { blocks =>
+      def toBufferKV(block: BlockMessage) = {
+        val key   = block.blockHash
+        val value = ByteString.copyFrom(blockProtoToBytes(block.toProto))
+        (key, (value, block))
+      }
+
+      // Testing state
+      val blocksBytesMap: Map[ByteString, (ByteString, BlockMessage)] = blocks.map(toBufferKV).toMap
+      val bytesMap: Map[ByteString, ByteString]                       = blocksBytesMap.map(_.map(_._1))
+      val blocksMap: Map[ByteString, BlockMessage]                    = blocksBytesMap.map(_.map(_._2))
+
+      // Underlying key-value store
+      val kv = new KV[Task](none, bytesMap)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(kv, notImplementedKV)
+
+      if (blocks.nonEmpty) {
+        // Pick one key to search for
+        val searchKey = blocksMap.head._1
+
+        // Find block with that key
+        val result = bs.find(_ == searchKey).runSyncUnsafe()
+
+        // Result should be key/block pair
+        result shouldBe Seq((searchKey, blocksMap(searchKey)))
+
+        // Find no blocks for non existing key
+        val resultEmpty = bs.find(_ == ByteString.EMPTY).runSyncUnsafe()
+
+        // Result should be empty
+        resultEmpty shouldBe Seq.empty
+
+        // Find multiple blocks
+        val resultMulti = bs.find(blocksBytesMap.keySet(_)).runSyncUnsafe()
+
+        // Result should be all testing blocks
+        resultMulti.toSet shouldBe blocksMap.toSet
+      } else {
+        // Find no blocks for empty store
+        val result = bs.find(_ == ByteString.EMPTY).runSyncUnsafe()
+
+        // Result should be empty
+        result shouldBe Seq.empty
+      }
+    }
+  }
+
+  /**
+    * Approved block store
+    */
+  def toApprovedBlock(block: BlockMessage): ApprovedBlock = {
+    val candidate = ApprovedBlockCandidate(block, requiredSigs = 0)
+    ApprovedBlock(candidate, sigs = List())
+  }
+
+  it should "get approved block from underlying key-value store" in {
+    forAll(blockElementGen()) { block =>
+      // Testing block serialized
+      val approvedBlock   = toApprovedBlock(block)
+      val blockByteBuffer = approvedBlock.toProto.toByteString
+
+      // Underlying key-value store
+      val kv = new KV[Task](blockByteBuffer.some)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(notImplementedKV, kv)
+
+      // Test block store GET approved block operation
+      val result = bs.getApprovedBlock.runSyncUnsafe()
+
+      // Requested key should match
+      kv.inputKeys shouldBe Seq(ByteString.copyFrom(approvedBlockKey))
+
+      // Result should be testing block
+      result shouldBe approvedBlock.some
+    }
+  }
+
+  it should "not get approved block if not exists in underlying key-value store" in {
+    // Underlying key-value store
+    val kv = new KV[Task](none)
+
+    // Block store under testing
+    val bs = new KeyValueBlockStore(notImplementedKV, kv)
+
+    // Test block store GET approved block operation
+    val result = bs.getApprovedBlock.runSyncUnsafe()
+
+    // Result should be none
+    result shouldBe none
+  }
+
+  it should "put approved block to underlying key-value store" in {
+    forAll(blockElementGen()) { block =>
+      // Testing block serialized
+      val approvedBlock = toApprovedBlock(block)
+      val blockBytes    = approvedBlock.toProto.toByteString
+
+      // Underlying key-value store
+      val kv = new KV[Task](blockBytes.some)
+
+      // Block store under testing
+      val bs = new KeyValueBlockStore(notImplementedKV, kv)
+
+      // Test block store PUT approved block operation
+      bs.putApprovedBlock(approvedBlock).runSyncUnsafe()
+
+      // Block hash should match the key
+      kv.inputKeys shouldBe Seq(ByteString.copyFrom(approvedBlockKey))
+
+      // Result should be testing block
+      kv.inputPut shouldBe Seq(blockBytes)
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -451,7 +451,6 @@ lazy val blockStorage = (project in file("block-storage"))
     name := "block-storage",
     version := "0.0.1-SNAPSHOT",
     libraryDependencies ++= commonDependencies ++ protobufLibDependencies ++ Seq(
-      lmdbjava,
       catsCore,
       catsEffect,
       catsMtl

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
@@ -48,8 +48,10 @@ class ManyValidatorsTest
 
     val testProgram = runtimeManagerResource.use { implicit runtimeManager =>
       for {
-        blockStore             <- BlockDagStorageTestFixture.createBlockStorage[Task](blockStoreDir)
-        blockDagStorage        <- BlockDagStorageTestFixture.createBlockDagStorage(blockDagStorageDir)
+        blockStore <- BlockDagStorageTestFixture.createBlockStorage[Task](blockStoreDir)
+        blockDagStorage <- BlockDagStorageTestFixture.createBlockDagStorage[Task](
+                            blockDagStorageDir
+                          )
         indexedBlockDagStorage <- IndexedBlockDagStorage.create(blockDagStorage)
         genesis <- createGenesis[Task](bonds = bonds)(
                     Monad[Task],
@@ -69,7 +71,9 @@ class ManyValidatorsTest
                 initialLatestMessages
               )
             }
-        newBlockDagStorage        <- BlockDagStorageTestFixture.createBlockDagStorage(blockDagStorageDir)
+        newBlockDagStorage <- BlockDagStorageTestFixture.createBlockDagStorage[Task](
+                               blockDagStorageDir
+                             )
         newIndexedBlockDagStorage <- IndexedBlockDagStorage.create(newBlockDagStorage)
         dag                       <- newIndexedBlockDagStorage.getRepresentation
         tips                      <- Estimator[Task].tips(dag, genesis)

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -433,23 +433,6 @@ object TestNode {
     } yield node
   }
 
-  def makeBlockDagFileStorageConfig(blockDagDir: Path) =
-    BlockDagFileStorage.Config(
-      blockDagDir.resolve("latest-messages-data"),
-      blockDagDir.resolve("latest-messages-crc"),
-      blockDagDir.resolve("block-metadata-data"),
-      blockDagDir.resolve("block-metadata-crc"),
-      blockDagDir.resolve("equivocations-tracker-data"),
-      blockDagDir.resolve("equivocations-tracker-crc"),
-      blockDagDir.resolve("invalid-blocks-data"),
-      blockDagDir.resolve("invalid-blocks-crc"),
-      blockDagDir.resolve("block-hashes-by-deploy-data"),
-      blockDagDir.resolve("block-hashes-by-deploy-crc"),
-      blockDagDir.resolve("checkpoints"),
-      blockDagDir.resolve("block-number-index"),
-      mapSize
-    )
-
   private def peerNode(name: String, port: Int): PeerNode =
     PeerNode(NodeIdentifier(name.getBytes), endpoint(port))
 

--- a/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueStoreSyntax.scala
@@ -1,6 +1,10 @@
 package coop.rchain.store
 
+import java.nio.ByteBuffer
+
+import cats.Functor
 import cats.effect.Sync
+import cats.syntax.all._
 import scodec.Codec
 
 trait KeyValueStoreSyntax {
@@ -12,6 +16,23 @@ final class KeyValueStoreOps[F[_]](
     // KeyValueStore extensions / syntax
     private val store: KeyValueStore[F]
 ) extends AnyVal {
+  // Suffix `1` because overload is not resolved and also because it gets one record
+
+  def get1[T](key: ByteBuffer, fromBuffer: ByteBuffer => T)(implicit f: Functor[F]): F[Option[T]] =
+    store.get(Seq(key), fromBuffer).map(_.head)
+
+  def put1[T](key: ByteBuffer, value: T, toBuffer: T => ByteBuffer): F[Unit] =
+    store.put(Seq((key, value)), toBuffer)
+
+  def delete1(key: ByteBuffer)(implicit f: Functor[F]): F[Boolean] =
+    store.delete(Seq(key)).map(_ == 1)
+
+  def contains(keys: Seq[ByteBuffer])(implicit f: Functor[F]): F[Seq[Boolean]] =
+    store.get(keys, _ => ()).map(_.map(_.nonEmpty))
+
+  def contains(key: ByteBuffer)(implicit f: Functor[F]): F[Boolean] =
+    contains(Seq(key)).map(_.head)
+
   // From key-value store, with serializers for K and V, typed store can be created
   def toTypedStore[K, V](kCodec: Codec[K], vCodec: Codec[V])(
       implicit s: Sync[F]


### PR DESCRIPTION
## Overview
This PR introduces replacement implementation for file based blocks database which is not reliable for corruption and restricted in concurrent access for write but also read.

This implementation is based on abstract [KeyValueStore](https://github.com/rchain/rchain/blob/a8cb29eff84/shared/src/main/scala/coop/rchain/store/KeyValueStore.scala) interface which is not tied to specific binary storage layer restricted for concurrency access.
In addition it adds compression to binary data which shows more then double reduction in file size.

We have KV store implemented with LMDB which means that blocks (and approved block) will be stored in LMDB. Performanse on LMDB is much better so even with added compression overall speed is increased. :rocket:

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
