### PR TITLE
update dependencies scala-uri to 3.0.0, catsversion to 2.2.0, cats-tagless-macros to 0.12, discipline-core to 1.1.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.4"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "2.1.1"
+  val catsVersion       = "2.2.0"
   val catsEffectVersion = "2.2.0"
   val catsMtlVersion    = "0.7.1"
   val slf4jVersion      = "1.7.25"
@@ -23,8 +23,8 @@ object Dependencies {
   val catsEffectLawsTest  = "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion % "test"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
-  val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.11"
-  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.0.3"
+  val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.12"
+  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.1.2"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
@@ -54,7 +54,7 @@ object Dependencies {
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
   val monix               = "io.monix"                   %% "monix"                     % "3.2.2"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
-  val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
+  val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"


### PR DESCRIPTION

## Overview
Update dependencies scala-uri to 3.0.0, catsversion to 2.2.0, cats-tagless-macros to 0.12, discipline-core to 1.1.2,



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
