### PR TITLE
wartremover to 2.4.13 in plugins.sbt

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.23")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 addSbtPlugin("com.typesafe.sbt"       % "sbt-license-report"   % "1.2.0")
-addSbtPlugin("org.wartremover"        % "sbt-wartremover"      % "2.4.10")
+addSbtPlugin("org.wartremover"        % "sbt-wartremover"      % "2.4.13")
 addSbtPlugin("org.scalameta"          % "sbt-scalafmt"         % "2.0.1")
 addSbtPlugin("com.eed3si9n"           % "sbt-assembly"         % "0.14.9")
 addSbtPlugin("org.scoverage"          % "sbt-scoverage"        % "1.6.1")


### PR DESCRIPTION
## Overview
update wartremover to 2.4.13 from 2.4.10 in plugins.sbt




### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
