### PR TITLE
monix to 3.3.0 in dependencies.scala

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/buffer/ConcurrentQueue.scala
@@ -4,11 +4,14 @@ import java.util
 
 import scala.collection.mutable
 import scala.math.ceil
-
 import monix.execution.internal.atomic.UnsafeAccess
-import org.jctools.queues._
-import org.jctools.queues.MessagePassingQueue.Consumer
-import org.jctools.queues.atomic.MpscAtomicArrayQueue
+import monix.execution.internal.jctools.queues.MessagePassingQueue.Consumer
+import monix.execution.internal.jctools.queues.atomic.MpscAtomicArrayQueue
+import monix.execution.internal.jctools.queues.{
+  MessagePassingQueue,
+  MpscArrayQueue,
+  MpscChunkedArrayQueue
+}
 
 /**
   * This code has been copied from the Monix codebase because unfortunately

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.5.1"
-  val monix               = "io.monix"                   %% "monix"                     % "3.2.2"
+  val monix               = "io.monix"                   %% "monix"                     % "3.3.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"


### PR DESCRIPTION
## Overview
Update monix to 3.3.0 from 3.2.2 in Dependencies.scala



### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
