### PR TITLE
Limit recursion depth in stack safe tests

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -34,10 +34,16 @@ object StackSafetySpec extends Assertions {
       } catch {
         case _: StackOverflowError => i
       }
+
     println("About to find max recursion depth for this test run")
+
     val maxDepth = count(0)
-    println(s"Max recursion depth is $maxDepth")
-    maxDepth
+    println(s"Calculated max recursion depth is $maxDepth")
+
+    // Because of OOM errors on CI depth recursion is limited
+    val maxDepthLimited = Math.min(1500, maxDepth)
+    println(s"Used recursion depth is limited to $maxDepthLimited")
+    maxDepthLimited
   }
 
   //this wrapper allows the test suite to continue with other tests after a SOE is spotted
@@ -95,8 +101,7 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
     checkAll(hugeBinOp(" ++ ", "[1]"))
   }
 
-  //Fixme - sometimes fails with OOM in Github actions. To not disturb, ignored temporarily
-  ignore should "handle a huge nested list" in {
+  it should "handle a huge nested list" in {
     checkAll(hugeNested("[", "", "]"))
   }
 


### PR DESCRIPTION
## Overview
This PR is to prevent Out of Memory errors on CI when executing stack safe tests.
Different processors can support different stack size, in which case detected depth is can be too high and execution of stack safe tests can be too long or use too much memory.
Limiting recursion depth ensures that on CI we don't exceed available resources.

We need to create separate performance part of the tests which can be executed only when necessary and not on each change.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
