### PR TITLE
Update scalactic and scalatest to 3.3.0-SNAP2 in Dependencies.scala

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "1.1.5"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.14.3"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.8" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.3.0-SNAP2" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -74,7 +74,7 @@ object Dependencies {
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.31.Final" classifier "linux-x86_64-fedora"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.3.0-SNAP2" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.10.3"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "0.8.0"


### PR DESCRIPTION
## Overview
Update scalactic and scalatest to 3.3.0-SNAP2 in Dependencies.scala





### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
