### PR TITLE
enumeratum to 1.6.1 in Dependencies.scala

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val osClassifier: String = Detector.detect(Seq("fedora")).osClassifier
 
   val circeVersion      = "0.13.0"
-  val enumeratumVersion = "1.5.13"
+  val enumeratumVersion = "1.6.1"
   val http4sVersion     = "0.21.9"
   val kamonVersion      = "1.1.5"
   val catsVersion       = "2.2.0"


### PR DESCRIPTION
## Overview
Update enumeratum to 1.6.1 in Dependencies.scala





### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
