### PR TITLE
rename toCodec to toSizeHeadCodec 

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/ReportMemStore.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ReportMemStore.scala
@@ -84,18 +84,24 @@ object ReportMemStore {
       .by(uint2)
       .subcaseP(0)({
         case n: ReportingProduce[C, A] @unchecked => n
-      })(codecReportingProduce(serializeC.toCodec, serializeA.toCodec))
+      })(codecReportingProduce(serializeC.toSizeHeadCodec, serializeA.toSizeHeadCodec))
       .subcaseP(1) {
         case n: ReportingConsume[C, P, K] @unchecked => n
-      }(codecReportingConsume(serializeC.toCodec, serializeP.toCodec, serializeK.toCodec))
+      }(
+        codecReportingConsume(
+          serializeC.toSizeHeadCodec,
+          serializeP.toSizeHeadCodec,
+          serializeK.toSizeHeadCodec
+        )
+      )
       .subcaseP(2) {
         case n: ReportingComm[C, P, A, K] @unchecked => n
       }(
         codecReportingComm(
-          serializeC.toCodec,
-          serializeP.toCodec,
-          serializeA.toCodec,
-          serializeK.toCodec
+          serializeC.toSizeHeadCodec,
+          serializeP.toSizeHeadCodec,
+          serializeA.toSizeHeadCodec,
+          serializeK.toSizeHeadCodec
         )
       )
 

--- a/casper/src/main/scala/coop/rchain/casper/ReportingCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ReportingCasper.scala
@@ -107,7 +107,7 @@ object ReportingCasper {
       store: ReportMemStore[F]
   )(implicit scheduler: ExecutionContext): ReportingCasper[F] =
     new ReportingCasper[F] {
-      val codecK                                                     = serializeTaggedContinuation.toCodec
+      val codecK                                                     = serializeTaggedContinuation.toSizeHeadCodec
       implicit val m: RSpaceMatch[F, BindPattern, ListParWithRandom] = matchListPar[F]
       implicit val source                                            = Metrics.Source(CasperMetricsSource, "report-replay")
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -225,7 +225,7 @@ class RSpace[F[_], C, P, A, K](
       changes     <- storeAtom.get().changes()
       nextHistory <- historyRepositoryAtom.get().checkpoint(changes.toList)
       _           = historyRepositoryAtom.set(nextHistory)
-      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+      _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       log         = eventLog.take()
       _           = eventLog.put(Seq.empty)
       _           = produceCounter.take()
@@ -280,7 +280,7 @@ object RSpace {
       setup                  <- setUp[F, C, P, A, K](v2Dir, mapSize, Branch.MASTER)
       (historyReader, store) = setup
       space                  = new RSpace[F, C, P, A, K](historyReader, AtomicAny(store), Branch.MASTER)
-      replayStore            <- HotStore.empty(historyReader)(sk.toCodec, concurrent)
+      replayStore            <- HotStore.empty(historyReader)(sk.toSizeHeadCodec, concurrent)
       replay = new ReplayRSpace[F, C, P, A, K](
         historyReader,
         AtomicAny(replayStore),
@@ -328,10 +328,10 @@ object RSpace {
   ): F[(HistoryRepository[F, C, P, A, K], HotStore[F, C, P, A, K])] = {
 
     import coop.rchain.rspace.history._
-    implicit val cc = sc.toCodec
-    implicit val cp = sp.toCodec
-    implicit val ca = sa.toCodec
-    implicit val ck = sk.toCodec
+    implicit val cc = sc.toSizeHeadCodec
+    implicit val cp = sp.toSizeHeadCodec
+    implicit val ca = sa.toSizeHeadCodec
+    implicit val ck = sk.toSizeHeadCodec
 
     val coldStore    = StoreConfig(dataDir.resolve("cold"), mapSize)
     val historyStore = StoreConfig(dataDir.resolve("history"), mapSize)

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -66,7 +66,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       )
       .toMap
 
-  implicit val codecC = serializeC.toCodec
+  implicit val codecC = serializeC.toSizeHeadCodec
   val syncF: Sync[F]  = Concurrent[F]
 
   private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF(MetricsSource)
@@ -325,7 +325,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       _           = eventLog.put(Seq.empty)
       _           = produceCounter.take()
       _           = produceCounter.put(Map.empty.withDefaultValue(0))
-      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+      _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       _           <- restoreInstalls()
     } yield ()
   }
@@ -352,7 +352,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
 
   override def revertToSoftCheckpoint(checkpoint: SoftCheckpoint[C, P, A, K]): F[Unit] =
     spanF.trace(revertSoftCheckpointSpanLabel) {
-      implicit val ck: Codec[K] = serializeK.toCodec
+      implicit val ck: Codec[K] = serializeK.toSizeHeadCodec
       val history               = historyRepositoryAtom.get()
       for {
         hotStore <- HotStore.from(checkpoint.cacheSnapshot.cache, history)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -251,7 +251,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
       changes     <- storeAtom.get().changes()
       nextHistory <- historyRepositoryAtom.get().checkpoint(changes.toList)
       _           = historyRepositoryAtom.set(nextHistory)
-      _           <- createNewHotStore(nextHistory)(serializeK.toCodec)
+      _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       _           <- restoreInstalls()
     } yield (Checkpoint(nextHistory.history.root, Seq.empty))
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -156,7 +156,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
   override def createCheckpoint(): F[Checkpoint] = syncF.defer {
     val historyRepository = historyRepositoryAtom.get()
     for {
-      _ <- createNewHotStore(historyRepository)(serializeK.toCodec)
+      _ <- createNewHotStore(historyRepository)(serializeK.toSizeHeadCodec)
       _ <- restoreInstalls()
       _ = softReport.update(_ => Seq.empty[ReportingEvent])
       _ = report.update(_ => Seq.empty[Seq[ReportingEvent]])

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -94,5 +94,5 @@ package object util {
       Try.apply(new String(bytes.toArray, StandardCharsets.UTF_8)).toEither
   }
 
-  val stringCodec: Codec[String] = stringSerialize.toCodec
+  val stringCodec: Codec[String] = stringSerialize.toSizeHeadCodec
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -1313,7 +1313,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
       hotStore = {
         implicit val hr = history
         implicit val c  = cache
-        implicit val ck = stringClosureSerialize.toCodec
+        implicit val ck = stringClosureSerialize.toSizeHeadCodec
         HotStore.inMem[Task, String, Pattern, String, StringsCaptor]
       }
       res <- f(cache, history, hotStore)
@@ -1336,7 +1336,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
       hotStore = {
         implicit val hr = history
         implicit val c  = cache
-        implicit val ck = stringClosureSerialize.toCodec
+        implicit val ck = stringClosureSerialize.toSizeHeadCodec
         HotStore.inMem[Task, String, Pattern, String, StringsCaptor]
       }
       res <- f(hotStore)

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1300,10 +1300,10 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
       storeConfig("roots")
     )
 
-    implicit val cc = sc.toCodec
-    implicit val cp = sp.toCodec
-    implicit val ca = sa.toCodec
-    implicit val ck = sk.toCodec
+    implicit val cc = sc.toSizeHeadCodec
+    implicit val cp = sp.toSizeHeadCodec
+    implicit val ca = sa.toSizeHeadCodec
+    implicit val ck = sk.toSizeHeadCodec
 
     (for {
       historyRepository <- HistoryRepositoryInstances.lmdbRepository[Task, C, P, A, K](config)

--- a/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
@@ -18,7 +18,7 @@ class SerializeTests extends FlatSpec with Matchers with Checkers with Configura
   "A String" should "round trip through a derived codec" in {
 
     val propRoundTripCodec: Prop = Prop.forAll { (str: String) =>
-      roundTripCodec(str)(stringSerialize.toCodec)
+      roundTripCodec(str)(stringSerialize.toSizeHeadCodec)
         .map((value: DecodeResult[String]) => value.value == str)
         .getOrElse(default = false)
     }
@@ -29,7 +29,7 @@ class SerializeTests extends FlatSpec with Matchers with Checkers with Configura
   "A Pattern" should "round trip through a derived codec" in {
 
     val propRoundTripCodec: Prop = Prop.forAll { (pat: Pattern) =>
-      roundTripCodec(pat)(patternSerialize.toCodec)
+      roundTripCodec(pat)(patternSerialize.toSizeHeadCodec)
         .map((value: DecodeResult[Pattern]) => value.value == pat)
         .getOrElse(default = false)
     }

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -27,8 +27,8 @@ trait StorageActionsTests[F[_]]
   implicit val serializeString: Serialize[String] = coop.rchain.rspace.util.stringSerialize
 
   implicit val codecString: Codec[String]   = coop.rchain.rspace.util.stringCodec
-  implicit val codecP: Codec[Pattern]       = implicitly[Serialize[Pattern]].toCodec
-  implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
+  implicit val codecP: Codec[Pattern]       = implicitly[Serialize[Pattern]].toSizeHeadCodec
+  implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toSizeHeadCodec
 
   "produce" should
     "persist a piece of data in the store" in fixture { (store, _, space) =>

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -270,11 +270,13 @@ trait StorageExamplesTests[F[_]]
 abstract class InMemoryHotStoreStorageExamplesTestsBase[F[_]]
     extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor] {
 
-  implicit val channelCodec: Codec[Channel] = AddressBookExample.implicits.serializeChannel.toCodec
-  implicit val patternCodec: Codec[Pattern] = AddressBookExample.implicits.serializePattern.toCodec
-  implicit val entryCodec: Codec[Entry]     = AddressBookExample.implicits.serializeInfo.toCodec
+  implicit val channelCodec: Codec[Channel] =
+    AddressBookExample.implicits.serializeChannel.toSizeHeadCodec
+  implicit val patternCodec: Codec[Pattern] =
+    AddressBookExample.implicits.serializePattern.toSizeHeadCodec
+  implicit val entryCodec: Codec[Entry] = AddressBookExample.implicits.serializeInfo.toSizeHeadCodec
   implicit val entryCaptorCodec: Codec[EntriesCaptor] =
-    AddressBookExample.implicits.serializeEntriesCaptor.toCodec
+    AddressBookExample.implicits.serializeEntriesCaptor.toSizeHeadCodec
 
   override def fixture[R](f: (ST, AtST, T) => F[R]): R = {
     val creator: (HR, ST, Branch) => F[(ST, AtST, T)] =

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -135,10 +135,11 @@ abstract class InMemoryHotStoreTestsBase[F[_]]
     extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
     with BeforeAndAfterAll {
 
-  implicit val patternCodec: Codec[Pattern] = StringExamples.implicits.patternSerialize.toCodec
-  implicit val stringCodec: Codec[String]   = StringExamples.implicits.stringSerialize.toCodec
+  implicit val patternCodec: Codec[Pattern] =
+    StringExamples.implicits.patternSerialize.toSizeHeadCodec
+  implicit val stringCodec: Codec[String] = StringExamples.implicits.stringSerialize.toSizeHeadCodec
   implicit val stringCaptorCodec: Codec[StringsCaptor] =
-    StringExamples.implicits.stringClosureSerialize.toCodec
+    StringExamples.implicits.stringClosureSerialize.toSizeHeadCodec
 
   override def fixture[S](f: (ST, AtST, T) => F[S]): S = {
     val creator: (HR, ST, Branch) => F[(ST, AtST, T)] =

--- a/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
@@ -23,8 +23,8 @@ class EncodingSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyCh
 
   implicit val codecContinuation: Codec[WaitingContinuation[Pattern, StringsCaptor]] =
     codecWaitingContinuation(
-      implicits.patternSerialize.toCodec,
-      implicits.stringClosureSerialize.toCodec
+      implicits.patternSerialize.toSizeHeadCodec,
+      implicits.stringClosureSerialize.toSizeHeadCodec
     )
 
   "Datum list encode" should "return same hash for different orderings of each datum" in forAll {

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -90,9 +90,9 @@ abstract class HistoryRepositoryGenerativeDefinition
     with OptionValues
     with GeneratorDrivenPropertyChecks {
 
-  implicit val codecString: Codec[String]   = implicitly[Serialize[String]].toCodec
-  implicit val codecP: Codec[Pattern]       = implicitly[Serialize[Pattern]].toCodec
-  implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toCodec
+  implicit val codecString: Codec[String]   = implicitly[Serialize[String]].toSizeHeadCodec
+  implicit val codecP: Codec[Pattern]       = implicitly[Serialize[Pattern]].toSizeHeadCodec
+  implicit val codecK: Codec[StringsCaptor] = implicitly[Serialize[StringsCaptor]].toSizeHeadCodec
 
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 

--- a/shared/src/main/scala/coop/rchain/shared/Serialize.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Serialize.scala
@@ -35,7 +35,7 @@ object Serialize {
 
   implicit class RichSerialize[A](private val instance: Serialize[A]) extends AnyVal {
 
-    def toCodec: Codec[A] = new Codec[A] {
+    def toSizeHeadCodec: Codec[A] = new Codec[A] {
 
       private val sizeCodec = int64
 


### PR DESCRIPTION
## Overview
This is related to the discussion https://github.com/rchain/rchain/issues/3126#issuecomment-708108701

But this is **not a FIX** for that. Just a pr to rename the method `toCodec` to `toSizeHeadCodec` which would make more sense and it should help distinguish two codec while reading the codes.

I jumped into this encoding trap several times. I think this can help a little bit.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
