### PR TITLE
Transport layer in-memory cache

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -165,7 +165,7 @@ class TestNode[F[_]](
       Created(block)    = createBlockResult
     } yield block
 
-  def receive(): F[Unit] = tls.receive(p => handle[F](p), kp(().pure[F])).void
+  def receive(): F[Unit] = tls.handleReceive(p => handle[F](p), kp(().pure[F])).void
 
   val maxSyncAttempts = 10
   def syncWith(nodes: Seq[TestNode[F]]): F[Unit] = {

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/TransportLayerTestImpl.scala
@@ -84,7 +84,7 @@ class TransportLayerTestImpl[F[_]: Monad]()(
 class TransportLayerServerTestImpl[F[_]: Monad](identity: PeerNode)(
     implicit val testNetworkF: TestNetwork[F]
 ) extends TransportLayerServer[F] {
-  def receive(
+  def handleReceive(
       dispatch: Protocol => F[CommunicationResponse],
       handleStreamed: Blob => F[Unit]
   ): F[Cancelable] =

--- a/comm/src/main/scala/coop/rchain/comm/errors.scala
+++ b/comm/src/main/scala/coop/rchain/comm/errors.scala
@@ -34,7 +34,7 @@ final case class UnexpectedMessage(msgStr: String)                  extends Comm
 final case object SenderNotAvailable                                extends CommError
 final case class PongNotReceivedForPing(peer: PeerNode)             extends CommError
 final case class UnableToStorePacket(packet: Packet, th: Throwable) extends CommError
-final case class UnableToRestorePacket(path: Path, th: Throwable)   extends CommError
+final case class UnableToRestorePacket(key: String, th: Throwable)  extends CommError
 // TODO add Show instance
 
 object CommError {
@@ -62,7 +62,7 @@ object CommError {
   def timeout: CommError                                   = TimeOut
   def unableToStorePacket(packet: Packet, th: Throwable): CommError =
     UnableToStorePacket(packet, th)
-  def unableToRestorePacket(path: Path, th: Throwable) = UnableToRestorePacket(path, th)
+  def unableToRestorePacket(key: String, th: Throwable) = UnableToRestorePacket(key, th)
 
   def errorMessage(ce: CommError): String =
     ce match {

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -1,7 +1,6 @@
 package coop.rchain.comm.transport
 
 import java.io.ByteArrayInputStream
-import java.nio.file.Path
 
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.syntax.all._
@@ -16,7 +15,6 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.monix.Monixable
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
-import coop.rchain.shared.PathOps.PathDelete
 import io.grpc.ManagedChannel
 import io.grpc.netty._
 import io.netty.handler.ssl.SslContext
@@ -24,6 +22,7 @@ import monix.eval.Task
 import monix.execution.Ack.Continue
 import monix.execution.{Cancelable, CancelableFuture, Scheduler}
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util._
 
@@ -44,7 +43,6 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
     key: String,
     maxMessageSize: Int,
     packetChunkSize: Int,
-    tempFolder: Path,
     clientQueueSize: Int,
     channelsMap: Ref[F, Map[PeerNode, Deferred[F, BufferedGrpcStreamChannel[F]]]],
     ioScheduler: Scheduler
@@ -58,6 +56,9 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
 
   private def certInputStream = new ByteArrayInputStream(cert.getBytes())
   private def keyInputStream  = new ByteArrayInputStream(key.getBytes())
+
+  // Cache to store received partial data (streaming packets)
+  private val cache = TrieMap[String, Array[Byte]]()
 
   private val clientSslContextTask: F[SslContext] =
     Sync[F]
@@ -86,12 +87,12 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
         .intercept(new SslSessionClientInterceptor(networkId))
         .overrideAuthority(peer.id.toString)
         .build()
-      buffer = new StreamObservable[F](peer, clientQueueSize, tempFolder)
+      buffer = new StreamObservable[F](peer, clientQueueSize, cache)
 
       buferSubscriber = buffer.subscribe(
         sMsg =>
-          streamBlobFile(sMsg.path, peer, sMsg.sender)
-            .guarantee(sMsg.path.deleteSingleFile[F])
+          streamBlobFile(sMsg.key, peer, sMsg.sender)
+            .guarantee(Sync[F].delay(cache.remove(sMsg.key)).void)
             .toTask
             .runToFuture >> Continue.pure[CancelableFuture]
       )
@@ -163,7 +164,7 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
     def timeout(packet: Packet): FiniteDuration =
       Math.max(packet.content.size().toLong * 5, DefaultSendTimeout.toMicros).micros
 
-    PacketOps.restore[F](path) >>= {
+    PacketOps.restore[F](key, cache) >>= {
       case Right(packet) =>
         Log[F].debug(
           s"Attempting to stream packet to $peer with timeout: ${timeout(packet).toMillis}ms"
@@ -175,10 +176,10 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
               Log[F].debug(
                 s"Error while streaming packet to $peer (timeout: ${timeout(packet).toMillis}ms): ${error.message}"
               )
-            case Right(_) => Log[F].debug(s"Streamed packet $path to $peer")
+            case Right(_) => Log[F].debug(s"Streamed packet $key to $peer")
           }
       case Left(error) =>
-        Log[F].error(s"Error while streaming packet $path to $peer: ${error.message}")
+        Log[F].error(s"Error while streaming packet $key to $peer: ${error.message}")
     }
   }
 }

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -155,7 +155,7 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
   }
 
   private def streamBlobFile(
-      path: Path,
+      key: String,
       peer: PeerNode,
       sender: PeerNode
   ): F[Unit] = {

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -38,8 +38,7 @@ object GrpcTransportReceiver {
       buffersMap: Ref[F, Map[PeerNode, Deferred[F, MessageBuffers]]],
       messageHandlers: MessageHandlers[F],
       parallelism: Int,
-      cache: TrieMap[String, Array[Byte]],
-      ioScheduler: Scheduler
+      cache: TrieMap[String, Array[Byte]]
   )(implicit mainScheduler: Scheduler): F[Cancelable] = {
 
     val service = new RoutingGrpcMonix.TransportLayer {
@@ -53,8 +52,8 @@ object GrpcTransportReceiver {
 
       private def getBuffers(peer: PeerNode): F[MessageBuffers] = {
         def createBuffers: MessageBuffers = {
-          val tellBuffer = buffer.LimitedBufferObservable.dropNew[Send](64)(ioScheduler)
-          val blobBuffer = buffer.LimitedBufferObservable.dropNew[StreamMessage](8)(ioScheduler)
+          val tellBuffer = buffer.LimitedBufferObservable.dropNew[Send](64)
+          val blobBuffer = buffer.LimitedBufferObservable.dropNew[StreamMessage](8)
           // TODO cancel queues when peer is lost
           val tellCancellable = tellBuffer
             .mapParallelUnordered(parallelism)(messageHandlers._1(_).toTask)

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -38,8 +38,7 @@ class GrpcTransportServer[F[_]: Monixable: Concurrent: RPConfAsk: Log: Metrics](
     key: String,
     maxMessageSize: Int,
     maxStreamMessageSize: Long,
-    parallelism: Int,
-    ioScheduler: Scheduler
+    parallelism: Int
 )(implicit mainScheduler: Scheduler)
     extends TransportLayerServer[F] {
   private def certInputStream = new ByteArrayInputStream(cert.getBytes())
@@ -97,8 +96,7 @@ class GrpcTransportServer[F[_]: Monixable: Concurrent: RPConfAsk: Log: Metrics](
                    messageBuffers,
                    (dispatchSend, dispatchBlob),
                    parallelism = parallelism,
-                   cache,
-                   ioScheduler
+                   cache
                  )
     } yield receiver
   }
@@ -112,8 +110,7 @@ object GrpcTransportServer {
       keyPath: Path,
       maxMessageSize: Int,
       maxStreamMessageSize: Long,
-      parallelism: Int,
-      ioScheduler: Scheduler
+      parallelism: Int
   )(implicit mainScheduler: Scheduler): TransportServer[F] = {
     val cert = Resources.withResource(Source.fromFile(certPath.toFile))(_.mkString)
     val key  = Resources.withResource(Source.fromFile(keyPath.toFile))(_.mkString)
@@ -125,8 +122,7 @@ object GrpcTransportServer {
         key,
         maxMessageSize,
         maxStreamMessageSize,
-        parallelism,
-        ioScheduler
+        parallelism
       )
     )
   }

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -24,7 +24,7 @@ import scala.io.Source
 import scala.util.{Left, Right}
 
 trait TransportLayerServer[F[_]] {
-  def receive(
+  def handleReceive(
       dispatch: Protocol => F[CommunicationResponse],
       handleStreamed: Blob => F[Unit]
   ): F[Cancelable]
@@ -63,7 +63,7 @@ class GrpcTransportServer[F[_]: Monixable: Concurrent: RPConfAsk: Log: Metrics](
         case Left(t)           => Sync[F].raiseError[SslContext](t)
       }
 
-  def receive(
+  def handleReceive(
       dispatch: Protocol => F[CommunicationResponse],
       handleStreamed: Blob => F[Unit]
   ): F[Cancelable] = {
@@ -143,7 +143,7 @@ class TransportServer[F[_]: Monixable: Concurrent](server: GrpcTransportServer[F
       case Some(_) => ().pure[F]
       case _ =>
         server
-          .receive(dispatch, handleStreamed)
+          .handleReceive(dispatch, handleStreamed)
           .toTask
           .foreachL { cancelable =>
             ref

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -40,8 +40,7 @@ final case class Streamed(
     header: Option[Header] = None,
     readSoFar: Long = 0,
     circuit: Circuit = Closed,
-    path: Path,
-    fos: FileOutputStream
+    key: String
 )
 
 object StreamHandler {

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamObservable.scala
@@ -1,20 +1,23 @@
 package coop.rchain.comm.transport
 
-import java.nio.file._
-
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.comm.PeerNode
 import coop.rchain.comm.transport.PacketOps._
 import coop.rchain.shared.Log
-import coop.rchain.shared.PathOps._
 import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
 
-final case class Stream(path: Path, sender: PeerNode)
+import scala.collection.concurrent.TrieMap
 
-class StreamObservable[F[_]: Sync: Log](peer: PeerNode, bufferSize: Int, folder: Path)(
+final case class Stream(key: String, sender: PeerNode)
+
+class StreamObservable[F[_]: Sync: Log](
+    peer: PeerNode,
+    bufferSize: Int,
+    cache: TrieMap[String, Array[Byte]]
+)(
     implicit scheduler: Scheduler
 ) extends Observable[Stream] {
 
@@ -27,20 +30,20 @@ class StreamObservable[F[_]: Sync: Log](peer: PeerNode, bufferSize: Int, folder:
         s"Pushing message to $peer stream message queue."
       )
 
-    val storeBlob: F[Option[Path]] =
-      blob.packet.store[F](folder) >>= {
+    val storeBlob: F[Option[String]] =
+      blob.packet.store[F](cache) >>= {
         case Right(file) => file.some.pure[F]
         case Left(e)     => Log[F].error(e.message) >> none.pure[F]
       }
 
-    def push(file: Path): F[Boolean] =
-      Sync[F].delay(subject.pushNext(Stream(file, blob.sender)))
+    def push(key: String): F[Boolean] =
+      Sync[F].delay(subject.pushNext(Stream(key, blob.sender)))
 
-    def propose(file: Path): F[Unit] = {
+    def propose(key: String): F[Unit] = {
       val processError = Log[F].warn(
         s"Client stream message queue for $peer is full (${bufferSize} items). Dropping message.)"
-      ) >> file.deleteSingleFile[F]
-      push(file) >>= (pushSucceed => processError.unlessA(pushSucceed))
+      ) >> Sync[F].delay(cache.remove(key))
+      push(key) >>= (pushSucceed => processError.unlessA(pushSucceed))
     }
 
     logStreamInformation >> storeBlob >>= (_.fold(().pure[F])(propose))

--- a/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/messages.scala
@@ -1,17 +1,16 @@
 package coop.rchain.comm.transport
 
-import java.nio.file.Path
-import java.util.concurrent.atomic.AtomicBoolean
-import coop.rchain.comm.protocol.routing.Protocol
-import monix.execution.Callback
 import coop.rchain.comm.PeerNode
+import coop.rchain.comm.protocol.routing.Protocol
 
 trait ServerMessage
+
 final case class Send(msg: Protocol) extends ServerMessage
+
 final case class StreamMessage(
     sender: PeerNode,
     typeId: String,
-    path: Path,
+    key: String,
     compressed: Boolean,
     contentLength: Int
 ) extends ServerMessage

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -80,7 +80,8 @@ class TcpTransportLayerSpec
         maxMessageSize,
         maxStreamMessageSize,
         tempFolder,
-        4
+        4,
+        scheduler
       )
     }
 }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -1,7 +1,5 @@
 package coop.rchain.comm.transport
 
-import java.nio.file._
-
 import cats.effect.concurrent.{Deferred, MVar, Ref}
 import coop.rchain.comm._
 import coop.rchain.comm.rp.Connect.RPConfAsk
@@ -12,25 +10,14 @@ import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.scalatest._
 
 import scala.concurrent.duration.Duration
 
-class TcpTransportLayerSpec
-    extends TransportLayerSpec[Task, TcpTlsEnvironment]
-    with BeforeAndAfterEach {
+class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] {
 
   implicit val log: Log[Task]         = new Log.NOPLog[Task]
   implicit val scheduler: Scheduler   = Scheduler.Implicits.global
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP
-
-  var tempFolder: Path = null
-
-  override def beforeEach(): Unit =
-    tempFolder = Files.createTempDirectory("rchain-")
-
-  override def afterEach(): Unit =
-    tempFolder.toFile.delete()
 
   def createEnvironment(port: Int): Task[TcpTlsEnvironment] =
     Task.delay {
@@ -57,7 +44,6 @@ class TcpTransportLayerSpec
         env.key,
         maxMessageSize,
         maxMessageSize,
-        tempFolder,
         100,
         Ref.unsafe[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel[Task]]]](Map.empty),
         scheduler
@@ -79,7 +65,6 @@ class TcpTransportLayerSpec
         env.key,
         maxMessageSize,
         maxStreamMessageSize,
-        tempFolder,
         4,
         scheduler
       )

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -65,8 +65,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
         env.key,
         maxMessageSize,
         maxStreamMessageSize,
-        4,
-        scheduler
+        4
       )
     }
 }

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerRuntime.scala
@@ -82,7 +82,7 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
             local     = e1.peer
             remote    = e2.peer
             cb        <- createDispatcherCallback
-            server <- remoteTls.receive(
+            server <- remoteTls.handleReceive(
                        protocolDispatcher.dispatch(remote, cb),
                        streamDispatcher.dispatch(remote, cb)
                      )
@@ -163,11 +163,11 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
             cbl        <- createDispatcherCallback
             cb1        <- createDispatcherCallback
             cb2        <- createDispatcherCallback
-            server1 <- remoteTls1.receive(
+            server1 <- remoteTls1.handleReceive(
                         protocolDispatcher.dispatch(remote1, cb1),
                         streamDispatcher.dispatch(remote1, cb1)
                       )
-            server2 <- remoteTls2.receive(
+            server2 <- remoteTls2.handleReceive(
                         protocolDispatcher.dispatch(remote2, cb2),
                         streamDispatcher.dispatch(remote2, cb2)
                       )

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -45,7 +45,7 @@ object Main {
     // Should always be passed as implicit dependency.
     // All other schedulers should be explicit.
     implicit val scheduler: Scheduler = Scheduler.computation(
-      Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
+      Math.max(java.lang.Runtime.getRuntime.availableProcessors() * 4, 2),
       "node-runner",
       reporter = UncaughtExceptionLogger
     )

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -521,7 +521,8 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
                               nodeConf.protocolServer.grpcMaxRecvMessageSize.toInt,
                               nodeConf.protocolServer.grpcMaxRecvStreamMessageSize,
                               nodeConf.storage.dataDir.resolve("tmp").resolve("comm"),
-                              nodeConf.protocolServer.maxMessageConsumers
+                              nodeConf.protocolServer.maxMessageConsumers,
+                              grpcScheduler
                             )
                           )
 

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -2,13 +2,13 @@ package coop.rchain.node
 
 import java.nio.file.{Files, Path}
 
-import cats.{~>, Parallel}
 import cats.data.ReaderT
 import cats.effect._
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.syntax.all._
 import cats.mtl._
 import cats.syntax.all._
+import cats.{~>, Parallel}
 import com.typesafe.config.Config
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferKeyValueStorage
@@ -55,7 +55,6 @@ import coop.rchain.node.web._
 import coop.rchain.p2p.effects._
 import coop.rchain.rholang.interpreter.Runtime
 import coop.rchain.rspace.Context
-import coop.rchain.shared.PathOps._
 import coop.rchain.shared._
 import coop.rchain.shared.syntax._
 import coop.rchain.store.KeyValueStoreManager
@@ -111,15 +110,8 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
                 )
 
       // 3. create instances of typeclasses
-      metrics       = diagnostics.effects.metrics[F]
-      time          = effects.time[F]
-      commTmpFolder = nodeConf.storage.dataDir.resolve("tmp").resolve("comm")
-      _ <- commTmpFolder.toFile
-            .exists()
-            .fold(
-              commTmpFolder.deleteDirectory[F](),
-              ().pure[F]
-            )
+      metrics = diagnostics.effects.metrics[F]
+      time    = effects.time[F]
 
       transport <- {
         implicit val s = scheduler
@@ -132,7 +124,6 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
             nodeConf.tls.keyPath,
             nodeConf.protocolClient.grpcMaxRecvMessageSize.toInt,
             nodeConf.protocolClient.grpcStreamChunkSize.toInt,
-            commTmpFolder,
             grpcScheduler
           )
       }
@@ -398,11 +389,13 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
       _ <- Log[F].info(
             s"Kademlia RPC server started at $host:${servers.kademliaRPCServer.port}"
           )
+
       _ <- servers.transportServer
             .start(
               HandleMessages.handle[F](_),
               blob => packetHandler.handlePacket(blob.sender, blob.packet)
             )
+
       address = local.toAddress
       _       <- Log[F].info(s"Listening for traffic on $address.")
       _       <- EventLog[F].publish(Event.NodeStarted(address))
@@ -520,7 +513,6 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
                               nodeConf.tls.keyPath,
                               nodeConf.protocolServer.grpcMaxRecvMessageSize.toInt,
                               nodeConf.protocolServer.grpcMaxRecvStreamMessageSize,
-                              nodeConf.storage.dataDir.resolve("tmp").resolve("comm"),
                               nodeConf.protocolServer.maxMessageConsumers,
                               grpcScheduler
                             )

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -513,8 +513,7 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
                               nodeConf.tls.keyPath,
                               nodeConf.protocolServer.grpcMaxRecvMessageSize.toInt,
                               nodeConf.protocolServer.grpcMaxRecvStreamMessageSize,
-                              nodeConf.protocolServer.maxMessageConsumers,
-                              grpcScheduler
+                              nodeConf.protocolServer.maxMessageConsumers
                             )
                           )
 

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -4,18 +4,14 @@ import java.nio.file.Path
 
 import cats.data.ReaderT
 import cats.effect.concurrent.{Deferred, Ref}
-
-import scala.concurrent.duration._
-import scala.io.Source
-import scala.tools.jline.console._
 import cats.effect.{Concurrent, Sync, Timer}
 import cats.mtl._
-import cats.implicits._
+import cats.syntax.all._
 import cats.{Applicative, Monad, Parallel}
 import coop.rchain.comm._
 import coop.rchain.comm.discovery._
-import coop.rchain.comm.rp._
 import coop.rchain.comm.rp.Connect._
+import coop.rchain.comm.rp._
 import coop.rchain.comm.transport._
 import coop.rchain.metrics.Metrics
 import coop.rchain.monix.Monixable
@@ -23,6 +19,10 @@ import coop.rchain.shared._
 import monix.eval._
 import monix.execution._
 import monix.execution.atomic.AtomicAny
+
+import scala.concurrent.duration._
+import scala.io.Source
+import scala.tools.jline.console._
 
 package object effects {
 
@@ -57,7 +57,6 @@ package object effects {
       keyPath: Path,
       maxMessageSize: Int,
       packetChunkSize: Int,
-      folder: Path,
       ioScheduler: Scheduler
   )(implicit scheduler: Scheduler): F[TransportLayer[F]] =
     Ref.of[F, Map[PeerNode, Deferred[F, BufferedGrpcStreamChannel[F]]]](Map()) map { channels =>
@@ -69,7 +68,6 @@ package object effects {
         key,
         maxMessageSize,
         packetChunkSize,
-        folder,
         clientQueueSize = 100,
         channels,
         ioScheduler

--- a/shared/src/main/scala/coop/rchain/shared/GracefulClose.scala
+++ b/shared/src/main/scala/coop/rchain/shared/GracefulClose.scala
@@ -1,9 +1,0 @@
-package coop.rchain.shared
-
-import cats.effect.Sync
-import cats.implicits._
-
-object GracefulClose {
-  def gracefullyClose[F[_]: Sync](closable: AutoCloseable): F[Either[Throwable, Unit]] =
-    Sync[F].delay(closable.close()).attempt
-}


### PR DESCRIPTION
## Overview
This PR fixes slow memory leak with direct buffer when transport layer receives stream of messages. The problem is described in the linked issue.

Another problem found in LFS testing is slowdown in processing of inbound queue. The fix is in gRPC receiver, fixed scheduler is replaced with main scheduler. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
