### PR TITLE
Fix signature verification for signing algorithm

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
@@ -2,9 +2,7 @@ package coop.rchain.casper.util
 
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.{DeployData, DeployDataProto}
-import coop.rchain.crypto.PrivateKey
-import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.signatures.{Ed25519, Secp256k1, Secp256k1Eth, SignaturesAlg, Signed}
+import coop.rchain.crypto.signatures._
 import org.scalatest.{FlatSpec, Matchers}
 
 class DeployValidationSpec extends FlatSpec with Matchers {
@@ -18,13 +16,8 @@ class DeployValidationSpec extends FlatSpec with Matchers {
       validAfterBlockNumber = 0L
     )
 
-    // TODO: fixed key is used because Secp256k1Eth sign/verify is unstable with some generated keys ???
-    // - check CertificateHelper.{encodeSignatureRStoDER, decodeSignatureDERtoRS}
-    val privKeyHex = "6a42f5941bdaec35fdfa93d735c04f58d5d51ca3529d9a2fe753b818f1fa32e1"
-    val privKey    = PrivateKey(Base16.unsafeDecode(privKeyHex))
-//    val (privKey, _) = alg.newKeyPair
-
-    val signed = Signed(deploy, alg, privKey)
+    val (privKey, _) = alg.newKeyPair
+    val signed       = Signed(deploy, alg, privKey)
     val deployProto = DeployDataProto()
       .withSigAlgorithm(alg.name)
       .withSig(signed.sig)

--- a/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/util/CertificateHelper.scala
@@ -156,7 +156,9 @@ object CertificateHelper {
   def decodeSignatureDERtoRS(signatureDER: Array[Byte]): Try[Array[Byte]] = {
     def toBytes(x: ASN1Encodable) = {
       val asn1 = x.toASN1Primitive.asInstanceOf[ASN1Integer]
-      BigIntegers.asUnsignedByteArray(asn1.getValue)
+      // IMPORTANT: Specifying length will left pad zeroes
+      val bytesLength = 32
+      BigIntegers.asUnsignedByteArray(bytesLength, asn1.getValue)
     }
 
     def convert: Array[Byte] = {


### PR DESCRIPTION
## Overview
This PR fixes false verification for Secp256k1 signature although signature should be valid. The problem was in rare cases when signature (RS coordinates) are less then 32 bytes in length, conversion was not padded with zeroes. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
