### PR TITLE
Create height map when blocks are downloaded

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LFSBlockRequesterEffectsSpec.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper.engine
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
+import coop.rchain.casper.engine.LastFinalizedStateBlockRequester.ST
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.TestTime
 import coop.rchain.models.BlockHash.BlockHash
@@ -104,7 +105,7 @@ class LFSBlockRequesterEffectsSpec
 
   trait SUT[F[_], Eff] {
     // Processing stream
-    val stream: Stream[F, Boolean]
+    val stream: Stream[F, ST[BlockHash]]
     // Fill response queue - simulate receiving blocks from external source
     def receive(bs: BlockMessage*): F[Unit]
     // Observed effects (sent requests, saved blocks, ...)
@@ -140,7 +141,7 @@ class LFSBlockRequesterEffectsSpec
       }
 
       sut = new SUT[F, Eff] {
-        override val stream: Stream[F, Boolean]          = requestStream
+        override val stream: Stream[F, ST[BlockHash]]    = requestStream
         override def receive(bs: BlockMessage*): F[Unit] = receiveBlocks(bs.toList)
         override val eff: Eff                            = effects
       }


### PR DESCRIPTION
## Overview
This PR removes sorting step after blocks are downloaded for LFS. As a result block requester will create _height map_ which is used to add blocks to the DAG in correct order.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
