### PR TITLE
Store finalized blockHash in mem

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -211,6 +211,11 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
 
     def invalidBlocks: F[Set[BlockMetadata]] =
       invalidBlocksSet.pure[F]
+
+    // blockDag file doesn't support this now because we will get rid of file storage in the future
+    // and we already got migration from file storage to key value store
+    def isFinalized(blockHash: BlockHash): F[Boolean] =
+      Sync[F].raiseError(new Exception("File storage doesn't support isFinalize api."))
   }
 
   private object FileEquivocationsTracker extends EquivocationsTracker[F] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagFileStorage.scala
@@ -357,6 +357,11 @@ final class BlockDagFileStorage[F[_]: Concurrent: Sync: Log: RaiseIOError] priva
         _ <- blockNumberIndex.close
       } yield ()
     )
+
+  // blockDag file doesn't support this now because we will get rid of file storage in the future
+  // and we already got migration from file storage to key value store
+  def addFinalizedBlockHash(blockHash: BlockHash): F[Unit] =
+    Sync[F].raiseError(new Exception("File dag storage doesn't support addFinalizedBlockHash api."))
 }
 
 object BlockDagFileStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -244,7 +244,8 @@ object BlockDagKeyValueStorage {
       equivocationsDb: KeyValueTypedStore[F, (Validator, SequenceNumber), Set[BlockHash]],
       latestMessages: KeyValueTypedStore[F, Validator, BlockHash],
       invalidBlocks: KeyValueTypedStore[F, BlockHash, BlockMetadata],
-      deploys: KeyValueTypedStore[F, DeployId, BlockHash]
+      deploys: KeyValueTypedStore[F, DeployId, BlockHash],
+      lastFinalizedBlock: KeyValueTypedStore[F, Int, BlockHash]
   )
 
   private def createStores[F[_]: Concurrent: KeyValueStoreManager: Log: Metrics] =
@@ -282,6 +283,13 @@ object BlockDagKeyValueStorage {
                         codecDeployId,
                         codecBlockHash
                       )
+
+      // last finalized block
+      lastFinalizedBlockDb <- KeyValueStoreManager[F].database[Int, BlockHash](
+                               "last-finalized-block",
+                               codecSeqNum,
+                               codecBlockHash
+                             )
     } yield DagStores(
       blockMetadataStore,
       blockMetadataDb,
@@ -289,7 +297,8 @@ object BlockDagKeyValueStorage {
       equivocationTrackerDb,
       latestMessagesDb,
       invalidBlocksDb,
-      deployIndexDb
+      deployIndexDb,
+      lastFinalizedBlockDb
     )
 
   def create[F[_]: Concurrent: KeyValueStoreManager: Log: Metrics]: F[BlockDagStorage[F]] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -39,6 +39,7 @@ trait BlockDagRepresentation[F[_]] {
       startBlockNumber: Long,
       maybeEndBlockNumber: Option[Long]
   ): F[Vector[Vector[BlockHash]]]
+  def isFinalized(blockHash: BlockHash): F[Boolean]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -16,6 +16,7 @@ trait BlockDagStorage[F[_]] {
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
   def checkpoint(): F[Unit]
   def close(): F[Unit]
+  def addFinalizedBlockHash(blockHash: BlockHash): F[Unit]
 }
 
 object BlockDagStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -55,6 +55,9 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
       topoSortVector.slice(startBlockNumber.toInt, endBlockNumber.toInt + 1).pure[F]
     }
 
+    def isFinalized(blockHash: BlockHash): F[Boolean] =
+      finalizedBlocksRef.get.map(_.contains(blockHash))
+
     def latestBlockNumber: F[Long] = (topoSortVector.length - 1L).pure[F]
 
     def latestMessageHash(validator: Validator): F[Option[BlockHash]] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorage.scala
@@ -33,9 +33,9 @@ class LastFinalizedFileStorage[F[_]: Sync: RaiseIOError] private (
       } yield ()
     )
 
-  override def get(genesis: BlockMessage): F[BlockHash] =
+  override def get(): F[Option[BlockHash]] =
     lock.withPermit(
-      lastFinalizedBlockHashState.read.map(_.getOrElse(genesis.blockHash))
+      lastFinalizedBlockHashState.read
     )
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
@@ -1,0 +1,46 @@
+package coop.rchain.blockstorage.finality
+
+import java.nio.file.Path
+
+import cats.syntax.all._
+import cats.effect.{Concurrent, Sync}
+import coop.rchain.blockstorage.dag.codecs.{codecBlockHash, codecSeqNum}
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.shared.Log
+import coop.rchain.store.{KeyValueStore, KeyValueTypedStore}
+import coop.rchain.shared.syntax._
+import coop.rchain.blockstorage.syntax._
+
+class LastFinalizedKeyValueStorage[F[_]: Sync] private (
+    lastFinalizedBlockDb: KeyValueTypedStore[F, Int, BlockHash]
+) extends LastFinalizedStorage[F] {
+  val fixedKey = 1
+  override def put(blockHash: BlockHash): F[Unit] =
+    lastFinalizedBlockDb.put(Seq((fixedKey, blockHash)))
+
+  override def get(): F[Option[BlockHash]] =
+    lastFinalizedBlockDb.get(fixedKey)
+}
+
+object LastFinalizedKeyValueStorage {
+  def apply[F[_]: Sync](
+      lastFinalizedBlockDb: KeyValueTypedStore[F, Int, BlockHash]
+  ): LastFinalizedKeyValueStorage[F] = new LastFinalizedKeyValueStorage(lastFinalizedBlockDb)
+
+  def apply[F[_]: Sync](keyValueStore: KeyValueStore[F]): LastFinalizedKeyValueStorage[F] =
+    apply(keyValueStore.toTypedStore(codecSeqNum, codecBlockHash))
+
+  def importFromFileStorage[F[_]: Concurrent: Log: Metrics](
+      oldLastFinalizedPath: Path,
+      lastFinalizedBlockDb: LastFinalizedKeyValueStorage[F]
+  ): F[Unit] =
+    for {
+      _                       <- Log[F].warn(s"Starting Last Finalized Block migration, loading existing data.")
+      oldLastFinalizedStorage <- LastFinalizedFileStorage.make[F](oldLastFinalizedPath)
+      lastFinalizedBlock      <- oldLastFinalizedStorage.getUnSafe
+      _                       <- Log[F].warn(s"Last Finalized Block is $lastFinalizedBlock .")
+      _                       <- lastFinalizedBlockDb.put(lastFinalizedBlock)
+      _                       <- Log[F].warn(s"Migrate Last Finalized Block done.")
+    } yield ()
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
@@ -14,8 +14,8 @@ class LastFinalizedMemoryStorage[F[_]: Functor](
   override def put(blockHash: BlockHash): F[Unit] =
     lastFinalizedBlockHashState.set(blockHash.some)
 
-  override def get(genesis: BlockMessage): F[BlockHash] =
-    lastFinalizedBlockHashState.read.map(_.getOrElse(genesis.blockHash))
+  override def get(): F[Option[BlockHash]] =
+    lastFinalizedBlockHashState.read
 }
 
 object LastFinalizedMemoryStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
@@ -5,7 +5,7 @@ import coop.rchain.models.BlockHash.BlockHash
 
 trait LastFinalizedStorage[F[_]] {
   def put(blockHash: BlockHash): F[Unit]
-  def get(genesis: BlockMessage): F[BlockHash]
+  def get(): F[Option[BlockHash]]
 }
 
 object LastFinalizedStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorageSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorageSyntax.scala
@@ -1,0 +1,22 @@
+package coop.rchain.blockstorage.finality
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockHash.BlockHash
+
+trait LastFinalizedStorageSyntax {
+  implicit final def blockStorageSyntaxLastFinalizedStorage[F[_]: Sync](
+      store: LastFinalizedStorage[F]
+  ): LastFinalizedStorageOps[F] = new LastFinalizedStorageOps[F](store)
+}
+
+object LastFinalizedBlockNotFound extends Exception
+
+final class LastFinalizedStorageOps[F[_]: Sync](
+    private val store: LastFinalizedStorage[F]
+) {
+  def getOrElse(blockHash: BlockHash): F[BlockHash] = store.get().map(_.getOrElse(blockHash))
+
+  def getUnSafe: F[BlockHash] = store.get() >>= (_.liftTo(LastFinalizedBlockNotFound))
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -2,6 +2,7 @@ package coop.rchain
 
 import coop.rchain.blockstorage.{BlockStoreSyntax, ByteStringKVStoreSyntax}
 import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
+import coop.rchain.blockstorage.finality.LastFinalizedStorageSyntax
 import coop.rchain.metrics.Metrics
 
 package object blockstorage {
@@ -17,3 +18,4 @@ trait AllSyntaxBlockStorage
     extends BlockStoreSyntax
     with BlockDagRepresentationSyntax
     with ByteStringKVStoreSyntax
+    with LastFinalizedStorageSyntax

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/finality/LastFinalizedFileStorageTest.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import cats.effect.Sync
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.blockstorage.util.io._
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.models.blockImplicits._
 import coop.rchain.shared.scalatestcontrib._
@@ -40,7 +41,7 @@ class LastFinalizedFileStorageTest
   "Last finalized file storage" should "return genesis on empty state" in {
     forAll(blockElementGen()) { genesis =>
       withLfbStorage {
-        _.get(genesis) shouldBeF genesis.blockHash
+        _.getOrElse(genesis.blockHash) shouldBeF genesis.blockHash
       }
     }
   }
@@ -52,7 +53,7 @@ class LastFinalizedFileStorageTest
           lfbStorage1 <- LastFinalizedFileStorage.make[Task](lfbStorageFile)
           _           <- lfbStorage1.put(blockHash)
           lfbStorage2 <- LastFinalizedFileStorage.make[Task](lfbStorageFile)
-          _           <- lfbStorage2.get(genesis) shouldBeF blockHash
+          _           <- lfbStorage2.getOrElse(genesis.blockHash) shouldBeF blockHash
         } yield ()
       }
     }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -58,7 +58,7 @@ trait Casper[F[_]] {
   def deploy(d: Signed[DeployData]): F[Either[DeployError, DeployId]]
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]]
   def createBlock: F[CreateBlockStatus]
-  def getGenesis: F[BlockMessage]
+  def getApprovedBlock: F[BlockMessage]
   def getValidator: F[Option[PublicKey]]
   def getVersion: F[Long]
   def getDeployLifespan: F[Int]

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedBlockCalculator.scala
@@ -19,7 +19,8 @@ final class LastFinalizedBlockCalculator[F[_]: Sync: Log: Concurrent: BlockStore
       maybeFinalizedChild <- childrenHashes.findM(isGreaterThanFaultToleranceThreshold(dag, _))
       newFinalizedBlock <- maybeFinalizedChild match {
                             case Some(finalizedChild) =>
-                              removeDeploysInFinalizedBlock(finalizedChild) >> run(
+                              removeDeploysInFinalizedBlock(finalizedChild) >> BlockDagStorage[F]
+                                .addFinalizedBlockHash(finalizedChild) >> run(
                                 dag,
                                 finalizedChild
                               )

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
@@ -21,7 +21,7 @@ final class LastFinalizedHeightConstraintChecker[F[_]: Sync: LastFinalizedStorag
       validator: Validator
   ): F[Boolean] =
     for {
-      lastFinalizedBlockHash <- LastFinalizedStorage[F].get(genesis)
+      lastFinalizedBlockHash <- LastFinalizedStorage[F].getOrElse(genesis.blockHash)
       lastFinalizedBlock     <- dag.lookupUnsafe(lastFinalizedBlockHash)
       latestMessageOpt       <- dag.latestMessage(validator)
       result <- latestMessageOpt match {

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -64,8 +64,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
 
   def getVersion: F[Long] = version.pure[F]
 
-  //TODO rename to getApprovedBlock
-  def getGenesis: F[BlockMessage] = approvedBlock.pure[F]
+  def getApprovedBlock: F[BlockMessage] = approvedBlock.pure[F]
 
   def getValidator: F[Option[PublicKey]] = validatorId.map(_.publicKey).pure[F]
 
@@ -124,7 +123,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
   override def approvedBlockStateComplete: F[Boolean] = {
     import cats.instances.list._
     for {
-      approvedBlock  <- getGenesis
+      approvedBlock  <- getApprovedBlock
       abHasLowHeight = ProtoUtil.blockNumber(approvedBlock) < expirationThreshold
 
       // active validators as per approved block state

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -4,7 +4,6 @@ import cats.Applicative
 import cats.data.EitherT
 import cats.effect.{Concurrent, Sync}
 import cats.effect.concurrent.{Ref, Semaphore}
-import cats.effect.syntax.bracket
 import cats.syntax.all._
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
@@ -24,7 +23,6 @@ import coop.rchain.models.BlockHash._
 import coop.rchain.models.{EquivocationRecord, NormalizerEnv}
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared._
-import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.finality.LastFinalizedStorage
@@ -358,7 +356,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
   def lastFinalizedBlock: F[BlockMessage] =
     for {
       dag                    <- blockDag
-      lastFinalizedBlockHash <- LastFinalizedStorage[F].get(approvedBlock)
+      lastFinalizedBlockHash <- LastFinalizedStorage[F].getOrElse(approvedBlock.blockHash)
       updatedLastFinalizedBlockHash <- LastFinalizedBlockCalculator[F]
                                         .run(dag, lastFinalizedBlockHash)
       _ <- LastFinalizedStorage[F].put(updatedLastFinalizedBlockHash)

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -108,7 +108,7 @@ object BlockAPI {
                 maybeValidator  <- casper.getValidator
                 validatorPubKey <- maybeValidator.fold(validatorCheckFailed)(_.pure[F])
                 validator       = ByteString.copyFrom(validatorPubKey.bytes)
-                genesis         <- casper.getGenesis
+                genesis         <- casper.getApprovedBlock
                 dag             <- casper.blockDag
                 runtimeManager  <- casper.getRuntimeManager
                 checkSynchronyConstraint = SynchronyConstraintChecker[F]

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -775,38 +775,10 @@ object BlockAPI {
       _.withCasper[ApiErr[Boolean]](
         implicit casper =>
           for {
-            lastFinalizedBlock <- casper.lastFinalizedBlock
-            lastFinalizedBlockMetadata = BlockMetadata
-              .fromBlock(lastFinalizedBlock, invalid = false)
-            dag                   <- casper.blockDag
-            givenBlockHash        = ProtoUtil.stringToByteString(hash)
-            givenBlockMetadataOpt <- dag.lookup(givenBlockHash)
-            result <- givenBlockMetadataOpt match {
-                       case None =>
-                         s"Could not find block with hash $hash"
-                           .asLeft[Boolean]
-                           .pure[F]
-                       case Some(givenBlockMetadata) => {
-                         // TODO this is temporary solution to not calculate fault tolerance for old blocks which is costly
-                         val oldBlock =
-                           dag.latestBlockNumber.map(_ - givenBlockMetadata.blockNum).map(_ > 100)
-                         val isInvalid           = dag.lookup(givenBlockMetadata.blockHash).map(_.get.invalid)
-                         val oldBlockIsFinalized = isInvalid.map(if (_) false else true)
-                         oldBlock.ifM(
-                           oldBlockIsFinalized.map(_.asRight[Error]),
-                           DagOperations
-                             .bfTraverseF(List(lastFinalizedBlockMetadata)) { b =>
-                               b.parents.traverse(dag.lookup).map { parentOpts =>
-                                 parentOpts.flatten.distinct
-                                   .filter(_.blockNum >= givenBlockMetadata.blockNum)
-                               }
-                             }
-                             .contains(givenBlockMetadata)
-                             .map(_.asRight[Error])
-                         )
-                       }
-                     }
-          } yield result,
+            dag            <- casper.blockDag
+            givenBlockHash = ProtoUtil.stringToByteString(hash)
+            result         <- dag.isFinalized(givenBlockHash)
+          } yield result.asRight[Error],
         Log[F].warn(errorMessage).as(s"Error: $errorMessage".asLeft)
       )
     )

--- a/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/storage/RNodeKeyValueStoreManager.scala
@@ -48,6 +48,7 @@ private final case class RNodeKeyValueStoreManager[F[_]: Concurrent: Log](
     ("latest-messages", dagStorageEnvConfig),
     ("invalid-blocks", dagStorageEnvConfig),
     ("deploy-index", dagStorageEnvConfig),
+    ("last-finalized-block", dagStorageEnvConfig),
     // Reporting (trace) cache
     ("reporting-cache", reportingEnvConfig),
     // CasperBuffer

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -247,7 +247,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def fetchDependencies: F[Unit]              = underlying.fetchDependencies
   def approvedBlockStateComplete: F[Boolean]  = underlying.approvedBlockStateComplete
 
-  def getGenesis: F[BlockMessage]        = underlying.getGenesis
+  def getApprovedBlock: F[BlockMessage]  = underlying.getApprovedBlock
   def getValidator: F[Option[PublicKey]] = underlying.getValidator
   override def createBlock: F[CreateBlockStatus] =
     for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -46,7 +46,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def lastFinalizedBlock: F[BlockMessage]                             = getRandomBlock().pure[F]
   def getRuntimeManager: F[RuntimeManager[F]]                         = runtimeManager.pure[F]
   def fetchDependencies: F[Unit]                                      = ().pure[F]
-  def getGenesis: F[BlockMessage]                                     = getRandomBlock().pure[F]
+  def getApprovedBlock: F[BlockMessage]                               = getRandomBlock().pure[F]
   def getValidator: F[Option[PublicKey]]                              = none.pure[F]
   def getVersion: F[Long]                                             = 1L.pure[F]
   def getDeployLifespan: F[Int]                                       = Int.MaxValue.pure[F]

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -774,7 +774,19 @@ object NodeRuntime {
         // Start block storage
         if (oldBlockStoreExists) oldStorage else KeyValueBlockStore()
       }
-
+      // Last finalized Block storage
+      lastFinalizedStorage <- {
+        for {
+          lastFinalizedBlockDb   <- casperStoreManager.store("last-finalized-block")
+          lastFinalizedIsEmpty   = lastFinalizedBlockDb.iterate(_.isEmpty)
+          oldLastFinalizedExists = Sync[F].delay(Files.exists(lastFinalizedPath))
+          shouldMigrate          <- lastFinalizedIsEmpty &&^ oldLastFinalizedExists
+          lastFinalizedStore     = LastFinalizedKeyValueStorage(lastFinalizedBlockDb)
+          _ <- LastFinalizedKeyValueStorage
+                .importFromFileStorage(lastFinalizedPath, lastFinalizedStore)
+                .whenA(shouldMigrate)
+        } yield lastFinalizedStore
+      }
       // Block DAG storage
       blockDagStorage <- {
         implicit val kvm = casperStoreManager
@@ -793,18 +805,6 @@ object NodeRuntime {
       casperBufferStorage <- {
         implicit val kvm = casperStoreManager
         CasperBufferKeyValueStorage.create[F]
-      }
-      lastFinalizedStorage <- {
-        for {
-          lastFinalizedBlockDb   <- casperStoreManager.store("last-finalized-block")
-          lastFinalizedIsEmpty   = lastFinalizedBlockDb.iterate(_.isEmpty)
-          oldLastFinalizedExists = Sync[F].delay(Files.exists(lastFinalizedPath))
-          shouldMigrate          <- lastFinalizedIsEmpty &&^ oldLastFinalizedExists
-          lastFinalizedStore     = LastFinalizedKeyValueStorage(lastFinalizedBlockDb)
-          _ <- LastFinalizedKeyValueStorage
-                .importFromFileStorage(lastFinalizedPath, lastFinalizedStore)
-                .whenA(shouldMigrate)
-        } yield lastFinalizedStore
       }
       deployStorageAllocation               <- LMDBDeployStorage.make[F](deployStorageConfig).allocated
       (deployStorage, deployStorageCleanup) = deployStorageAllocation


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Another solution for https://github.com/rchain/rchain/pull/3255

1. rename getGenesis in Casper.scala to getApprovedBlock
2. change get in LastFinalizedStorage and add LastFinalizedStorageSyntax
3. introduce LastFinalizedKeyValueStorage
4. introduce finalized blockHas set in BlockMetadataStore
5. add isFinalized api in BlockDagRepresentation
6. new isFinalized BlockAPI implementation

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
