### PR TITLE
Add conversion of Set in WebAPI, additional types as Map keys

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -127,10 +127,11 @@ object WebApi {
   // Rholang terms interesting for translation to JSON
 
   sealed trait RhoExpr
-  // Nested expressions
+  // Nested expressions (Par, Tuple, List and Set are converted to JSON list)
   final case class ExprPar(data: List[RhoExpr])        extends RhoExpr
-  final case class ExprList(data: List[RhoExpr])       extends RhoExpr
   final case class ExprTuple(data: List[RhoExpr])      extends RhoExpr
+  final case class ExprList(data: List[RhoExpr])       extends RhoExpr
+  final case class ExprSet(data: List[RhoExpr])        extends RhoExpr
   final case class ExprMap(data: Map[String, RhoExpr]) extends RhoExpr
   // Terminal expressions (here is the data)
   final case class ExprBool(data: Boolean)  extends RhoExpr
@@ -264,6 +265,9 @@ object WebApi {
     // List
     else if (exp.exprInstance.isEListBody)
       ExprList(exp.getEListBody.ps.flatMap(exprFromParProto).toList).some
+    // Set
+    else if (exp.exprInstance.isESetBody)
+      ExprSet(exp.getESetBody.ps.flatMap(exprFromParProto).toList).some
     // Map
     else if (exp.exprInstance.isEMapBody) {
       val fields = for {
@@ -271,8 +275,17 @@ object WebApi {
         keyExpr <- exprFromParProto(k)
         key <- keyExpr match {
                 case ExprString(str) => str.some
-                case ExprBytes(str)  => str.some
-                case _               => none
+                case ExprInt(num)    => num.toString.some
+                case ExprBool(bool)  => bool.toString.some
+                case ExprUri(uri)    => uri.some
+                case ExprUnforg(unforg) =>
+                  unforg match {
+                    case UnforgPrivate(hex)  => hex.some
+                    case UnforgDeploy(hex)   => hex.some
+                    case UnforgDeployer(hex) => hex.some
+                  }
+                case ExprBytes(hex) => hex.some
+                case _              => none
               }
         value <- exprFromParProto(v)
       } yield (key, value)


### PR DESCRIPTION
## Overview
This PR adds conversion for Rholang `Set` to JSON in WebAPI. Already Par, Tuple and List, and now Set, are converted to JSN list.

Also type of keys in the Map are extended to primitive types `Int`, `Boolean` and `Uri`, converted to string representation and unforgeable names converted to hex string.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
