### PR TITLE
Fix synchrony constraint calculation when latest block is older than approved

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
@@ -8,14 +8,16 @@ import coop.rchain.casper.protocol.{BlockMessage, Justification}
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.metrics.Span
+import coop.rchain.models.BlockMetadata
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.Log
 
-final class SynchronyConstraintChecker[F[_]: Sync: BlockStore: Log](
+final class SynchronyConstraintChecker[F[_]: Sync: BlockStore: Estimator: Log: Span](
     synchronyConstraintThreshold: Double
 ) {
   private def calculateSeenSendersSince(
-      lastProposed: BlockMessage,
+      lastProposed: BlockMetadata,
       dag: BlockDagRepresentation[F]
   ): F[Set[Validator]] =
     for {
@@ -35,40 +37,59 @@ final class SynchronyConstraintChecker[F[_]: Sync: BlockStore: Log](
   def check(
       dag: BlockDagRepresentation[F],
       runtimeManager: RuntimeManager[F],
-      genesis: BlockMessage,
+      approvedBlock: BlockMessage,
       validator: Validator
   ): F[Boolean] =
     dag.latestMessageHash(validator).flatMap {
-      case Some(lastProposedBlockHash) if lastProposedBlockHash == genesis.blockHash =>
-        // The node has not proposed any block yet and hence allowed to propose once
-        true.pure[F]
       case Some(lastProposedBlockHash) =>
         for {
-          lastProposedBlock <- BlockStore[F].getUnsafe(lastProposedBlockHash)
-          // Guaranteed to be present since last proposed block was present
-          seenSenders            <- calculateSeenSendersSince(lastProposedBlock, dag)
-          lastProposedTuplespace = ProtoUtil.postStateHash(lastProposedBlock)
-          bonds                  <- runtimeManager.computeBonds(lastProposedTuplespace)
-          activeValidators       <- runtimeManager.getActiveValidators(lastProposedTuplespace)
-          validatorWeightMap = bonds
-            .filter(b => activeValidators.contains(b.validator))
-            .map(b => b.validator -> b.stake)
-            .toMap
-          sendersWeight = seenSenders.toList.flatMap(s => validatorWeightMap.get(s)).sum
-          // This method can be called on readonly node or not active validator.
-          // So map validator -> stake might not have key associated with the node,
-          // that's why we need `getOrElse`
-          otherValidatorsWeight = validatorWeightMap.values.sum - validatorWeightMap
-            .getOrElse(validator, 0L)
-          // If there is no other active validators, do not put any constraint (value = 1)
-          synchronyConstraintValue = if (otherValidatorsWeight == 0) 1
-          else
-            sendersWeight.toDouble / otherValidatorsWeight
-          _ <- Log[F].info(
-                s"Seen ${seenSenders.size} senders with weight $sendersWeight out of total $otherValidatorsWeight " +
-                  s"(${synchronyConstraintValue} out of $synchronyConstraintThreshold needed)"
-              )
-        } yield synchronyConstraintValue >= synchronyConstraintThreshold
+          lastProposedBlockMeta <- dag.lookupUnsafe(lastProposedBlockHash)
+
+          checkConstraint = for {
+            // Estimate parent blocks for proposing block
+            tipHashes             <- Estimator[F].tips(dag, approvedBlock)
+            estimatedParentBlocks <- EstimatorHelper.chooseNonConflicting(tipHashes, dag)
+
+            // Get main parent of the main parent block
+            mainParentOpt  = estimatedParentBlocks.headOption
+            mainParentMeta <- mainParentOpt.liftTo[F](new Exception(s"Parent blocks not found.}"))
+
+            // Loading the whole block is only needed to get post-state hash
+            mainParentBlock     <- BlockStore[F].getUnsafe(mainParentMeta.blockHash)
+            mainParentStateHash = ProtoUtil.postStateHash(mainParentBlock)
+
+            // Get bonds map from PoS
+            // NOTE: It would be useful to have active validators cached in the block in the same way as bonds.
+            activeValidators <- runtimeManager.getActiveValidators(mainParentStateHash)
+
+            // Validators weight map filtered by active validators only.
+            validatorWeightMap = lastProposedBlockMeta.weightMap.filter {
+              case (validator, _) => activeValidators.contains(validator)
+            }
+            // Guaranteed to be present since last proposed block was present
+            seenSenders   <- calculateSeenSendersSince(lastProposedBlockMeta, dag)
+            sendersWeight = seenSenders.toList.flatMap(validatorWeightMap.get).sum
+
+            // This method can be called on readonly node or not active validator.
+            // So map validator -> stake might not have key associated with the node,
+            // that's why we need `getOrElse`
+            validatorOwnStake     = validatorWeightMap.getOrElse(validator, 0L)
+            otherValidatorsWeight = validatorWeightMap.values.sum - validatorOwnStake
+
+            // If there is no other active validators, do not put any constraint (value = 1)
+            synchronyConstraintValue = if (otherValidatorsWeight == 0) 1
+            else sendersWeight.toDouble / otherValidatorsWeight
+
+            _ <- Log[F].info(
+                  s"Seen ${seenSenders.size} senders with weight $sendersWeight out of total $otherValidatorsWeight " +
+                    s"(${synchronyConstraintValue} out of $synchronyConstraintThreshold needed)"
+                )
+          } yield synchronyConstraintValue >= synchronyConstraintThreshold
+
+          // If validator's latest block is genesis, it's not proposed any block yet and hence allowed to propose once.
+          latestBlockIsGenesis = lastProposedBlockMeta.blockNum == 0
+          allowedToPropose     <- if (latestBlockIsGenesis) true.pure[F] else checkConstraint
+        } yield allowedToPropose
       case None =>
         Sync[F].raiseError[Boolean](
           new IllegalStateException("Validator does not have a latest message")
@@ -80,7 +101,7 @@ object SynchronyConstraintChecker {
   def apply[F[_]](implicit ev: SynchronyConstraintChecker[F]): SynchronyConstraintChecker[F] =
     ev
 
-  def apply[F[_]: Sync: BlockStore: Log](
+  def apply[F[_]: Sync: BlockStore: Estimator: Log: Span](
       synchronyConstraintThreshold: Double
   ): SynchronyConstraintChecker[F] =
     new SynchronyConstraintChecker[F](synchronyConstraintThreshold)

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -219,6 +219,7 @@ object CasperLaunch {
                 // TODO peer should be able to request approved blocks on different heights
                 // from genesis to the most recent one (default)
                 CommUtil[F].requestApprovedBlock(trimState),
+                trimState,
                 enableStateExporter
               )
         } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -493,8 +493,8 @@ class Running[F[_]
       if (enableStateExporter) {
         logRequest *> handleStateItemsMessageRequest(peer, startPath, skip, take)
       } else {
-        Log[F].debug(
-          s"Received StoreItemsMessage from ${peer} but the node is configured to not respond to StoreItemsMessage."
+        Log[F].info(
+          s"Received StoreItemsMessage request but the node is configured to not respond to StoreItemsMessage, from ${peer}."
         )
       }
     case _ => noop

--- a/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/CreateBlockAPITest.scala
@@ -66,6 +66,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with EitherValues {
     implicit val metricsEff: Metrics[Effect] = new metrics.Metrics.MetricsNOP[Effect]
     implicit val logEff                      = new LogStub[Effect]
     implicit val spanEff                     = NoopSpan[Effect]
+    implicit val estimator                   = Estimator[Task](Estimator.UnlimitedParents, None)
     implicit val time = new Time[Task] {
       private val timer                               = Task.timer
       def currentMillis: Task[Long]                   = timer.clock.realTime(MILLISECONDS)
@@ -148,6 +149,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with EitherValues {
           val engine                        = new EngineWithCasper[Task](n1.casperEff)
           implicit val blockStore           = n1.blockStore
           implicit val lastFinalizedStorage = n1.lastFinalizedStorage
+          implicit val estimator            = Estimator[Task](Estimator.UnlimitedParents, None)
           implicit val synchronyConstraintChecker =
             SynchronyConstraintChecker[Effect](syncConstraintThreshold)
           implicit val lastFinalizedHeightConstraintChecker =
@@ -180,6 +182,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with EitherValues {
           val engine                        = new EngineWithCasper[Task](n1.casperEff)
           implicit val blockStore           = n1.blockStore
           implicit val lastFinalizedStorage = n1.lastFinalizedStorage
+          implicit val estimator            = Estimator[Task](Estimator.UnlimitedParents, None)
           implicit val synchronyConstraintChecker =
             SynchronyConstraintChecker[Effect](syncConstraintThreshold)
           implicit val lastFinalizedHeightConstraintChecker =
@@ -211,6 +214,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with EitherValues {
           val engine                        = new EngineWithCasper[Task](n1.casperEff)
           implicit val blockStore           = n1.blockStore
           implicit val lastFinalizedStorage = n1.lastFinalizedStorage
+          implicit val estimator            = Estimator[Task](Estimator.UnlimitedParents, None)
           implicit val synchronyConstraintChecker =
             SynchronyConstraintChecker[Effect](syncConstraintThreshold)
           implicit val lastFinalizedHeightConstraintChecker =

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -141,10 +141,10 @@ object Setup {
       ): Task[Float] = Task.pure(1.0f)
     }
     implicit val lastFinalizedBlockCalculator = LastFinalizedBlockCalculator[Task](0f)
+    implicit val estimator                    = Estimator[Task](Estimator.UnlimitedParents, None)
     implicit val synchronyConstraintChecker   = SynchronyConstraintChecker[Task](0d)
     implicit val lastFinalizedConstraintChecker =
       LastFinalizedHeightConstraintChecker[Task](Long.MaxValue)
-    implicit val estimator      = Estimator[Task](Estimator.UnlimitedParents, None)
     implicit val blockRetriever = BlockRetriever.of[Task]
 
     implicit val kvsManager = InMemoryStoreManager[Task]

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -81,11 +81,11 @@ class TestNode[F[_]](
   implicit val transportLayerEff            = tle
   implicit val cliqueOracleEffect           = SafetyOracle.cliqueOracle[F]
   implicit val lastFinalizedBlockCalculator = LastFinalizedBlockCalculator[F](0f)
+  implicit val estimator                    = Estimator[F](maxNumberOfParents, maxParentDepth)
   implicit val synchronyConstraintChecker =
     SynchronyConstraintChecker[F](synchronyConstraintThreshold)
   implicit val lastFinalizedHeightConstraintChecker =
     LastFinalizedHeightConstraintChecker[F](Long.MaxValue)
-  implicit val estimator = Estimator[F](maxNumberOfParents, maxParentDepth)
   implicit val rpConfAsk = createRPConfAsk[F](local)
   implicit val eventBus  = EventPublisher.noop[F]
 

--- a/integration-tests/resources/logback.xml
+++ b/integration-tests/resources/logback.xml
@@ -17,8 +17,8 @@
   </appender>
 
   <logger name="coop.rchain.shared.EventLogger" level="OFF" />
+  <logger name="coop.rchain.rspace" level="info" />
   <logger name="io.opencensus" level="OFF" />
-  <logger name="coop.rchain.rspace" level="warn" />
   <logger name="org.http4s" level="warn" />
   <logger name="io.netty" level="warn" />
   <logger name="io.grpc" level="warn" />

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -813,8 +813,14 @@ object NodeRuntime {
           conf.casper.faultToleranceThreshold
         )
       }
+      estimator = {
+        implicit val sp = span
+        Estimator[F](conf.casper.maxNumberOfParents, conf.casper.maxParentDepth)
+      }
       synchronyConstraintChecker = {
         implicit val bs = blockStore
+        implicit val es = estimator
+        implicit val sp = span
         SynchronyConstraintChecker[F](
           conf.casper.synchronyConstraintThreshold
         )
@@ -825,10 +831,6 @@ object NodeRuntime {
         LastFinalizedHeightConstraintChecker[F](
           conf.casper.heightConstraintThreshold
         )
-      }
-      estimator = {
-        implicit val sp = span
-        Estimator[F](conf.casper.maxNumberOfParents, conf.casper.maxParentDepth)
       }
       evalRuntime <- {
         implicit val s  = rspaceScheduler


### PR DESCRIPTION
## Overview
When validator propose a block it must satisfy synchrony constraint which depends on reading active validators from tuple space. When LFS state is downloaded and validator latest block is older then approved block, we don't have tuple state for that block. This PR adds this detection and allow validator to propose.

Another small fix to Engine initialization. The bug manifested when LFS node received the state, LFS exporter was not enabled although the flag was set.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
