### PR TITLE
Fix for state exporter flag to be able to disable export

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -95,7 +95,7 @@ object Engine {
       approvedBlock: ApprovedBlock,
       validatorId: Option[ValidatorIdentity],
       init: F[Unit],
-      enableStateExporter: Boolean
+      disableStateExporter: Boolean
   ): F[Unit] =
     for {
       _ <- Log[F].info("Making a transition to Running state.")
@@ -109,7 +109,7 @@ object Engine {
         approvedBlock,
         validatorId,
         init,
-        enableStateExporter
+        disableStateExporter
       )
       _ <- EngineCell[F].set(running)
 
@@ -130,7 +130,7 @@ object Engine {
       validatorId: Option[ValidatorIdentity],
       init: F[Unit],
       trimState: Boolean = false,
-      enableStateExporter: Boolean = false
+      disableStateExporter: Boolean = false
   ): F[Unit] =
     for {
       blockResponseQueue <- Queue.bounded[F, BlockMessage](50)
@@ -144,7 +144,7 @@ object Engine {
               blockResponseQueue,
               stateResponseQueue,
               trimState,
-              enableStateExporter
+              disableStateExporter
             )
           )
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -129,7 +129,7 @@ object Engine {
       finalizationRate: Int,
       validatorId: Option[ValidatorIdentity],
       init: F[Unit],
-      trimState: Boolean = false,
+      trimState: Boolean = true,
       disableStateExporter: Boolean = false
   ): F[Unit] =
     for {

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -56,7 +56,7 @@ object GenesisCeremonyMaster {
       shardId: String,
       finalizationRate: Int,
       validatorId: Option[ValidatorIdentity],
-      enableStateExporter: Boolean
+      disableStateExporter: Boolean
   ): F[Unit] =
     for {
       // This loop sleep can be short as it does not do anything except checking if there is last approved block available
@@ -68,7 +68,7 @@ object GenesisCeremonyMaster {
                    shardId,
                    finalizationRate,
                    validatorId,
-                   enableStateExporter
+                   disableStateExporter
                  )
                case Some(approvedBlock) =>
                  val ab = approvedBlock.candidate.block
@@ -87,7 +87,7 @@ object GenesisCeremonyMaster {
                            approvedBlock,
                            validatorId,
                            ().pure[F],
-                           enableStateExporter
+                           disableStateExporter
                          )
                    _ <- CommUtil[F].sendForkChoiceTipRequest
                  } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -53,7 +53,7 @@ class Initializing[F[_]
     blockMessageQueue: Queue[F, BlockMessage],
     tupleSpaceQueue: Queue[F, StoreItemsMessage],
     trimState: Boolean = false,
-    enableStateExporter: Boolean
+    disableStateExporter: Boolean
 ) extends Engine[F] {
 
   import Engine._
@@ -62,7 +62,7 @@ class Initializing[F[_]
 
   override def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = msg match {
     case ab: ApprovedBlock =>
-      onApprovedBlock(peer, ab, enableStateExporter)
+      onApprovedBlock(peer, ab, disableStateExporter)
     case br: ApprovedBlockRequest => sendNoApprovedBlockAvailable(peer, br.identifier)
     case na: NoApprovedBlockAvailable =>
       logNoApprovedBlockAvailable[F](na.nodeIdentifer) >>
@@ -86,7 +86,7 @@ class Initializing[F[_]
   private def onApprovedBlock(
       sender: PeerNode,
       approvedBlock: ApprovedBlock,
-      enableStateExporter: Boolean
+      disableStateExporter: Boolean
   ): F[Unit] = {
     val senderIsBootstrap = RPConfAsk[F].ask.map(_.bootstrap.exists(_ == sender))
 
@@ -281,7 +281,7 @@ class Initializing[F[_]
             approvedBlock,
             validatorId,
             ().pure,
-            enableStateExporter
+            disableStateExporter
           )
       _ <- CommUtil[F].sendForkChoiceTipRequest
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -52,7 +52,7 @@ class Initializing[F[_]
     theInit: F[Unit],
     blockMessageQueue: Queue[F, BlockMessage],
     tupleSpaceQueue: Queue[F, StoreItemsMessage],
-    trimState: Boolean = false,
+    trimState: Boolean = true,
     disableStateExporter: Boolean
 ) extends Engine[F] {
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -238,7 +238,7 @@ object LfsTupleSpaceRequester {
       st <- Ref.of[F, ST[StatePartPath]](ST(Seq(startRequest)))
 
       // Queue to trigger processing of requests. `True` to resend requests.
-      requestQueue <- Queue.bounded[F, Boolean](maxSize = 10)
+      requestQueue <- Queue.bounded[F, Boolean](maxSize = 2)
 
       // Light the fire! / Starts the first request for chunk of state
       // - `true` if requested chunks should be re-requested

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -263,9 +263,9 @@ object Running {
       peer: PeerNode,
       approvedBlock: ApprovedBlock
   ): F[Unit] =
-    Log[F].info(s"Received ApprovedBlockRequest from ${peer.endpoint.host}") >>
+    Log[F].info(s"Received ApprovedBlockRequest from ${peer}") >>
       TransportLayer[F].streamToPeer(peer, approvedBlock.toProto) >>
-      Log[F].info(s"ApprovedBlock sent to ${peer.endpoint.host}")
+      Log[F].info(s"ApprovedBlock sent to ${peer}")
 
   final case object LastFinalizedBlockNotFoundError
       extends Exception("Last finalized block not found in the block storage.")

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -314,7 +314,7 @@ class Running[F[_]
     approvedBlock: ApprovedBlock,
     validatorId: Option[ValidatorIdentity],
     theInit: F[Unit],
-    enableStateExporter: Boolean
+    disableStateExporter: Boolean
 ) extends Engine[F] {
 
   import Engine._
@@ -490,7 +490,7 @@ class Running[F[_]
       val logRequest = Log[F].info(
         s"Received request for store items, startPath: [$start], chunk: $take, skip: $skip, from: $peer"
       )
-      if (enableStateExporter) {
+      if (!disableStateExporter) {
         logRequest *> handleStateItemsMessageRequest(peer, startPath, skip, take)
       } else {
         Log[F].info(

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/CommUtil.scala
@@ -140,7 +140,7 @@ final class CommUtilOps[F[_]](
       Log[F].info(s"Requested fork tip from peers")
 
   def requestApprovedBlock(
-      trimState: Boolean = false
+      trimState: Boolean = true
   )(implicit m: Sync[F], r: RPConfAsk[F]): F[Unit] =
     for {
       maybeBootstrap <- RPConfAsk[F].reader(_.bootstrap)

--- a/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/GenesisCeremonyMasterSpec.scala
@@ -56,7 +56,7 @@ class GenesisCeremonyMasterSpec extends WordSpec {
             shardId,
             finalizationRate,
             Some(validatorId),
-            enableStateExporter = true
+            disableStateExporter = true
           )
           .startAndForget
           .runToFuture

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -53,7 +53,7 @@ class InitializingSpec extends WordSpec with BeforeAndAfterEach {
           blockResponseQueue,
           stateResponseQueue,
           trimState = false,
-          enableStateExporter = true
+          disableStateExporter = false
         )
 
       val approvedBlockCandidate = ApprovedBlockCandidate(block = genesis, requiredSigs = 0)

--- a/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/InitializingSpec.scala
@@ -52,7 +52,7 @@ class InitializingSpec extends WordSpec with BeforeAndAfterEach {
           theInit,
           blockResponseQueue,
           stateResponseQueue,
-          trimState = false,
+          trimState = true,
           disableStateExporter = false
         )
 

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -68,11 +68,11 @@ protocol-client {
   # sed 's/^04//' | keccak-256sum -x -l | tr -d ' -' | tail -c 41```
   bootstrap = "rnode://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404"
 
-  # Allow node starts from genesis block or Approved block
-  # If this is `true`,when a node without any data connecting to exist network, the node would starts from
-  # genesis block and validate blocks from scratch. Otherwise, the node would start from approved block which
-  # can save a lot of time of validating all the history blocks
-  trim-state = true
+  # Disable the node to start from Last Finalized State, instead it will start from genesis.
+  # If this is `true`, when a node without any data connecting to existing network, the node would start from
+  # genesis block and validate blocks from scratch. Otherwise, the node would start from last finalized block which
+  # can save a lot of time of validating all the history blocks.
+  disable-lfs = false
 
   # Number of connected peers picked randomly for broadcasting and streaming
   batch-max-connections = 20

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -53,7 +53,7 @@ protocol-server {
   max-message-consumers = 400
 
   # whether a node could export the state to other nodes
-  enable-state-exporter = true
+  disable-state-exporter = false
 }
 
 protocol-client {

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -45,7 +45,7 @@ object Main {
     // Should always be passed as implicit dependency.
     // All other schedulers should be explicit.
     implicit val scheduler: Scheduler = Scheduler.computation(
-      Math.max(java.lang.Runtime.getRuntime.availableProcessors() * 4, 2),
+      Math.max(java.lang.Runtime.getRuntime.availableProcessors, 2),
       "node-runner",
       reporter = UncaughtExceptionLogger
     )

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -913,7 +913,7 @@ object NodeRuntime {
         CasperLaunch.of[F](
           conf.casper,
           conf.protocolClient.trimState,
-          conf.protocolServer.enableStateExporter
+          conf.protocolServer.disableStateExporter
         )
       }
       packetHandler = {

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -912,7 +912,7 @@ object NodeRuntime {
 
         CasperLaunch.of[F](
           conf.casper,
-          conf.protocolClient.trimState,
+          !conf.protocolClient.disableLfs,
           conf.protocolServer.disableStateExporter
         )
       }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -58,7 +58,7 @@ object ConfigMapper {
         run.protocolGrpcMaxRecvMessageSize
       )
       add("protocol-client.grpc-stream-chunk-size", run.protocolGrpcStreamChunkSize)
-      add("protocol-client.trim-state", run.trimState)
+      add("protocol-client.disable-lfs", run.disableLfs)
 
       add("storage.data-dir", run.dataDir)
       add("storage.lmdb-map-size-rspace", run.lmdbMapSizeRspace)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -31,8 +31,8 @@ object ConfigMapper {
       add("protocol-server.use-random-ports", run.useRandomPorts)
       add("protocol-server.allow-private-addresses", run.allowPrivateAddresses)
       add(
-        "protocol-server.enable-state-exporter",
-        run.enableStateExporter
+        "protocol-server.disable-state-exporter",
+        run.disableStateExporter
       )
       add(
         "protocol-server.grpc-max-recv-message-size",

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -194,8 +194,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         "in `<genesis-path>/<public_key>.sk`" +
         "This param specifies number of validator identites to generate."
     )
-    val trimState = opt[Flag](
-      descr = "Node would start from approved block state."
+    val disableLfs = opt[Flag](
+      descr =
+        "Disable the node to start from Last Finalized State, instead it will start from genesis."
     )
 
     val host = opt[String](

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -210,8 +210,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Allow connections to peers with private network addresses."
     )
 
-    val enableStateExporter = opt[Flag](
-      descr = "Allow the node to export the state."
+    val disableStateExporter = opt[Flag](
+      descr = "Disable the node respond to export state requests."
     )
 
     val networkTimeout = opt[FiniteDuration](

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -46,7 +46,7 @@ final case class ProtocolServer(
     grpcMaxRecvMessageSize: Long,
     grpcMaxRecvStreamMessageSize: Long,
     maxMessageConsumers: Int,
-    enableStateExporter: Boolean
+    disableStateExporter: Boolean
 )
 
 final case class ProtocolClient(

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -52,7 +52,7 @@ final case class ProtocolServer(
 final case class ProtocolClient(
     networkId: String,
     bootstrap: PeerNode,
-    trimState: Boolean,
+    disableLfs: Boolean,
     batchMaxConnections: Int,
     networkTimeout: FiniteDuration,
     grpcMaxRecvMessageSize: Long,

--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -16,7 +16,7 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.CORS
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 package object web {
   // TODO: Temp until web API is refactored with one effect type.
@@ -78,7 +78,7 @@ package object web {
       adminHttpServerFiber <- BlazeServerBuilder[F](scheduler)
                                .bindHttp(httpPort, host)
                                .withHttpApp(Router(baseRoutes.toList: _*).orNotFound)
-                               .withResponseHeaderTimeout(connectionIdleTimeout)
+                               .withResponseHeaderTimeout(connectionIdleTimeout - 1.second)
                                .withIdleTimeout(connectionIdleTimeout)
                                .resource
                                .use(_ => Async[F].never[Unit])

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -103,7 +103,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--approve-interval 111111seconds",
         "--approve-duration 111111seconds",
         "--genesis-validator",
-        "--trim-state",
+        "--disable-lfs",
         "--prometheus",
         "--influxdb",
         "--influxdb-udp",
@@ -165,7 +165,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           )
           .right
           .get,
-        trimState = true,
+        disableLfs = true,
         batchMaxConnections = 111111,
         networkTimeout = 111111.seconds,
         grpcMaxRecvMessageSize = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -49,7 +49,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         "--protocol-grpc-stream-chunk-size 111111",
         "--protocol-max-connections 111111",
         "--protocol-max-message-consumers 111111",
-        "--enable-state-exporter",
+        "--disable-state-exporter",
         //other vars?
         "--tls-certificate-path /var/lib/rnode/node.certificate.pem",
         "--tls-key-path /var/lib/rnode/node.key.pem",
@@ -155,7 +155,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         grpcMaxRecvMessageSize = 111111,
         grpcMaxRecvStreamMessageSize = 111111,
         maxMessageConsumers = 111111,
-        enableStateExporter = true
+        disableStateExporter = true
       ),
       protocolClient = ProtocolClient(
         networkId = "testnet",

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -72,7 +72,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           )
           .right
           .get,
-        trimState = true,
+        disableLfs = false,
         batchMaxConnections = 20,
         networkTimeout = 5.seconds,
         grpcMaxRecvMessageSize = 262144,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -62,7 +62,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         grpcMaxRecvMessageSize = 262144,
         grpcMaxRecvStreamMessageSize = 268435456,
         maxMessageConsumers = 400,
-        enableStateExporter = true
+        disableStateExporter = false
       ),
       protocolClient = ProtocolClient(
         networkId = "testnet",


### PR DESCRIPTION
## Overview
Boolean CLI options can only be set without parameters which sets flag to _true_. This means if default value is _true_ it cannot be turned off.
This PR changes option from `enable-state-exporter` to `disable-state-exporter` with default value `false` which enables state exporter.

Also parallelism in LFS block requester is bounded to available processor number. More testing with LFS didn't show that larger value gives better result although LMDB operations are synchronous.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
