### PR TITLE
Fix for HTTP idle timeout, header timeout must be less than idle

### DIFF
--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -16,7 +16,7 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.CORS
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 package object web {
   // TODO: Temp until web API is refactored with one effect type.
@@ -56,6 +56,7 @@ package object web {
       httpServerFiber <- BlazeServerBuilder[F](scheduler)
                           .bindHttp(httpPort, host)
                           .withHttpApp(Router(allRoutes.toList: _*).orNotFound)
+                          .withResponseHeaderTimeout(connectionIdleTimeout - 1.second)
                           .withIdleTimeout(connectionIdleTimeout)
                           .resource
                           .use(_ => Async[F].never[Unit])
@@ -78,7 +79,7 @@ package object web {
       adminHttpServerFiber <- BlazeServerBuilder[F](scheduler)
                                .bindHttp(httpPort, host)
                                .withHttpApp(Router(baseRoutes.toList: _*).orNotFound)
-                               .withResponseHeaderTimeout(connectionIdleTimeout)
+                               .withResponseHeaderTimeout(connectionIdleTimeout - 1.second)
                                .withIdleTimeout(connectionIdleTimeout)
                                .resource
                                .use(_ => Async[F].never[Unit])


### PR DESCRIPTION
## Overview
Timeout for HTTP idle connection must be set to higher value than request header timeout.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
