### PR TITLE
Fix synchrony constraint to use main parent weight map

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SynchronyConstraintChecker.scala
@@ -63,7 +63,7 @@ final class SynchronyConstraintChecker[F[_]: Sync: BlockStore: Estimator: Log: S
             activeValidators <- runtimeManager.getActiveValidators(mainParentStateHash)
 
             // Validators weight map filtered by active validators only.
-            validatorWeightMap = lastProposedBlockMeta.weightMap.filter {
+            validatorWeightMap = mainParentMeta.weightMap.filter {
               case (validator, _) => activeValidators.contains(validator)
             }
             // Guaranteed to be present since last proposed block was present


### PR DESCRIPTION
## Overview
This is small fix related to PR #3269. Weight map should be used from main parent block and now validator's latest block.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
