### PR TITLE
FIXES BORS. Update bouncy castle [1.67 ->1.68], logstashLogback [5.3 -> 6.6], & scalacheck [1.15.1 -> 1.15.2]. Fixes errors related to logstash due to deprecated code. 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -426,51 +426,51 @@ jobs:
 
   # Merge into "trying" branch (bors try) does not trigger release_* jobs.
 
-  bors_try_success:
+  bors_success:
     name: bors build finished
     needs:
-      - run_unit_tests
-      - run_integration_tests
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
+      - release_docker_image
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/trying' || github.ref == 'refs/heads/staging') && success()"
     runs-on: ubuntu-latest
     steps:
       - run: true
-  
+    
 
   # IMPORTANT: 
   # bors_try_failure and bors_merge_failure are no longer needed due to an update to bors 
-  # <https://github.com/bors-ng/bors-ng/issues/1115> that considers skipped checks as failures.
+  # <https://github.com/bors-ng/bors-ng/issues/1115> that considers skipped checks that share 
+  # names (e.g. 'bors build finished') as failures.
 
 
-  bors_try_failure:
-    name: bors build finished
-    needs:
-      - run_unit_tests
-      - run_integration_tests
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: false
+  # bors_try_failure:
+  #   name: bors build finished
+  #   needs:
+  #     - run_unit_tests
+  #     - run_integration_tests
+  #   if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: false
 
   # Merge into "staging" branch (bors r+ ) triggers release_* jobs which depend
   # on run_*_tests jobs.
 
-  bors_merge_success:
-    name: bors build finished
-    needs:
-      - release_docker_image
-      #- release_packages
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
+  #bors_merge_success:
+  #  name: bors build finished
+  #  needs:
+  #    - release_docker_image
+  #    #- release_packages
+  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - run: true
 
-  bors_merge_failure:
-    name: bors build finished
-    needs:
-      - release_docker_image
-      #- release_packages
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: false
+  #bors_merge_failure:
+  #  name: bors build finished
+  #  needs:
+  #    - release_docker_image
+  #    #- release_packages
+  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - run: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -427,7 +427,7 @@ jobs:
   # Merge into "trying" branch (bors try) does not trigger release_* jobs.
 
   bors_try_success:
-    name: bors build finished
+    name: bors build finished, try successful
     needs:
       - run_unit_tests
       - run_integration_tests
@@ -455,7 +455,7 @@ jobs:
   # on run_*_tests jobs.
 
   bors_merge_success:
-    name: bors build finished
+    name: bors build finished, merge successful
     needs:
       - release_docker_image
       #- release_packages

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -426,39 +426,15 @@ jobs:
 
   # Merge into "trying" branch (bors try) does not trigger release_* jobs.
 
-  //replaces bors_try_success and bors_merge_success
-  end-success:
-    name: bors build finished
-    if: success()
+  bors_try_success:
+    name: bors build finished, try successful
+    needs:
+      - run_unit_tests
+      - run_integration_tests
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
     runs-on: ubuntu-latest
-    needs: 
-      - release_docker_image
-
     steps:
-      - name: Mark the job as successful
-        run: exit 0
-
-  //replaces bors_merge_failure and bors_try_failure
-  end-failure:
-    name: bors build finished
-    if: "!success()"
-    runs-on: ubuntu-latest
-    needs: 
-      - release_docker_image
-    steps:
-      - name: Mark the job as a failure
-        run: exit 1
-
-  
-  # bors_try_success:
-  #  name: bors build finished, try successful
-  #  needs:
-  #    - run_unit_tests
-  #    - run_integration_tests
-  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - run: true
+      - run: true
   
 
   # IMPORTANT: 
@@ -466,35 +442,35 @@ jobs:
   # <https://github.com/bors-ng/bors-ng/issues/1115> that considers skipped checks as failures.
 
 
-  # bors_try_failure:
-  #  name: bors build finished
-  #   needs:
-  #     - run_unit_tests
-  #     - run_integration_tests
-  #   if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #    - run: false
+  bors_try_failure:
+    name: bors build finished
+     needs:
+       - run_unit_tests
+       - run_integration_tests
+     if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
+     runs-on: ubuntu-latest
+     steps:
+      - run: false
 
   # Merge into "staging" branch (bors r+ ) triggers release_* jobs which depend
   # on run_*_tests jobs.
 
-  # bors_merge_success:
-  #  name: bors build finished, merge successful
-  #  needs:
-  #   - release_docker_image
-  #    #- release_packages
-  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - run: true
+  bors_merge_success:
+    name: bors build finished, merge successful
+    needs:
+     - release_docker_image
+      #- release_packages
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
 
-  # bors_merge_failure:
-  #   name: bors build finished
-  #   needs:
-  #     - release_docker_image
-  #     #- release_packages
-  #   if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: false
+  bors_merge_failure:
+    name: bors build finished
+    needs:
+      - release_docker_image
+      #- release_packages
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
+    runs-on: ubuntu-latest
+    steps:
+      - run: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -444,12 +444,12 @@ jobs:
 
   bors_try_failure:
     name: bors build finished
-     needs:
-       - run_unit_tests
-       - run_integration_tests
-     if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
-     runs-on: ubuntu-latest
-     steps:
+    needs:
+      - run_unit_tests
+      - run_integration_tests
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
+    runs-on: ubuntu-latest
+    steps:
       - run: false
 
   # Merge into "staging" branch (bors r+ ) triggers release_* jobs which depend
@@ -458,7 +458,7 @@ jobs:
   bors_merge_success:
     name: bors build finished
     needs:
-     - release_docker_image
+      - release_docker_image
       #- release_packages
     if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -426,15 +426,40 @@ jobs:
 
   # Merge into "trying" branch (bors try) does not trigger release_* jobs.
 
-  bors_try_success:
-    name: bors build finished, try successful
-    needs:
-      - run_unit_tests
-      - run_integration_tests
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
+  //replaces bors_try_success and bors_merge_success
+  end-success:
+    name: bors build finished
+    if: success()
     runs-on: ubuntu-latest
+    needs: 
+      - release_docker_image
+
     steps:
-      - run: true
+      - name: Mark the job as successful
+        run: exit 0
+
+  //replaces bors_merge_failure and bors_try_failure
+  end-failure:
+    name: bors build finished
+    if: "!success()"
+    runs-on: ubuntu-latest
+    needs: 
+      - release_docker_image
+    steps:
+      - name: Mark the job as a failure
+        run: exit 1
+
+  
+  # bors_try_success:
+  #  name: bors build finished, try successful
+  #  needs:
+  #    - run_unit_tests
+  #    - run_integration_tests
+  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && success()"
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - run: true
+  
 
   # IMPORTANT: 
   # bors_try_failure and bors_merge_failure are no longer needed due to an update to bors 
@@ -454,15 +479,15 @@ jobs:
   # Merge into "staging" branch (bors r+ ) triggers release_* jobs which depend
   # on run_*_tests jobs.
 
-  bors_merge_success:
-    name: bors build finished, merge successful
-    needs:
-      - release_docker_image
-      #- release_packages
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
+  # bors_merge_success:
+  #  name: bors build finished, merge successful
+  #  needs:
+  #   - release_docker_image
+  #    #- release_packages
+  #  if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && success()"
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - run: true
 
   # bors_merge_failure:
   #   name: bors build finished

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -427,7 +427,7 @@ jobs:
   # Merge into "trying" branch (bors try) does not trigger release_* jobs.
 
   bors_try_success:
-    name: bors build finished, try successful
+    name: bors build finished
     needs:
       - run_unit_tests
       - run_integration_tests
@@ -456,7 +456,7 @@ jobs:
   # on run_*_tests jobs.
 
   bors_merge_success:
-    name: bors build finished, merge successful
+    name: bors build finished
     needs:
      - release_docker_image
       #- release_packages

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -436,15 +436,20 @@ jobs:
     steps:
       - run: true
 
-  bors_try_failure:
-    name: bors build finished
-    needs:
-      - run_unit_tests
-      - run_integration_tests
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: false
+  # IMPORTANT: 
+  # bors_try_failure and bors_merge_failure are no longer needed due to an update to bors 
+  # <https://github.com/bors-ng/bors-ng/issues/1115> that considers skipped checks as failures.
+
+
+  # bors_try_failure:
+  #  name: bors build finished
+  #   needs:
+  #     - run_unit_tests
+  #     - run_integration_tests
+  #   if: "github.event_name == 'push' && github.ref == 'refs/heads/trying' && !success()"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #    - run: false
 
   # Merge into "staging" branch (bors r+ ) triggers release_* jobs which depend
   # on run_*_tests jobs.
@@ -459,12 +464,12 @@ jobs:
     steps:
       - run: true
 
-  bors_merge_failure:
-    name: bors build finished
-    needs:
-      - release_docker_image
-      #- release_packages
-    if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
-    runs-on: ubuntu-latest
-    steps:
-      - run: false
+  # bors_merge_failure:
+  #   name: bors build finished
+  #   needs:
+  #     - release_docker_image
+  #     #- release_packages
+  #   if: "github.event_name == 'push' && github.ref == 'refs/heads/staging' && !success()"
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,8 @@ object Dependencies {
   val slf4jVersion      = "1.7.25"
 
   // format: off
-  val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.67"
-  val bouncyPkixCastle    = "org.bouncycastle"            % "bcpkix-jdk15on"            % "1.67"
+  val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.68"
+  val bouncyPkixCastle    = "org.bouncycastle"            % "bcpkix-jdk15on"            % "1.68"
   val catsCore            = "org.typelevel"              %% "cats-core"                 % catsVersion
   val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
   val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"
@@ -54,7 +54,7 @@ object Dependencies {
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
-  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
+  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
   val monix               = "io.monix"                   %% "monix"                     % "3.3.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,7 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.1"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.compiler.SourcePosition
-import net.logstash.logback.encoder.org.apache.commons.lang.exception.ExceptionUtils
+import net.logstash.logback.encoder.org.apache.commons.lang3.exception.ExceptionUtils
 
 object errors {
 
@@ -107,7 +107,7 @@ object errors {
       interpreterErrors: Vector[InterpreterError],
       errors: Vector[Throwable]
   ) extends InterpreterError(
-        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getFullStackTrace).mkString}"
+        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getStackTrace).mkString}"
       )
 
   // Current implementation of SpaceMatcher (extractDataCandidates) causes unmatched comms


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Contains updates to 4 dependencies. Summarized in the commit. 
Updates scalacheck from 1.15.1 -> 1.15.2
Fixes errors in rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala by updating deprecated code. 
Fixes bors 

### Notes

Bors fix (README): bors_try_failure and bors_merge_failure are no longer needed due to an update to bors detailed at bors-ng/bors-ng#1115
This update considers skipped checks that share a name with other checks failures, so when bors_try_success, bors_try_failure, & bors_merge_failure (name: 'bors build finished') are skipped, bors fails, and the PR is prevented from merging. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
