### PR TITLE
Update Kamon dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,8 +14,8 @@ object Dependencies {
   val slf4jVersion      = "1.7.25"
 
   // format: off
-  val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.67"
-  val bouncyPkixCastle    = "org.bouncycastle"            % "bcpkix-jdk15on"            % "1.67"
+  val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.68"
+  val bouncyPkixCastle    = "org.bouncycastle"            % "bcpkix-jdk15on"            % "1.68"
   val catsCore            = "org.typelevel"              %% "cats-core"                 % catsVersion
   val catsLawsTest        = "org.typelevel"              %% "cats-laws"                 % catsVersion % "test"
   val catsLawsTestkitTest = "org.typelevel"              %% "cats-testkit"              % catsVersion % "test"
@@ -54,7 +54,7 @@ object Dependencies {
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
-  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "5.3"
+  val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
   val monix               = "io.monix"                   %% "monix"                     % "3.3.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,7 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.1"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val circeVersion      = "0.13.0"
   val enumeratumVersion = "1.5.13"
   val http4sVersion     = "0.21.9"
-  val kamonVersion      = "1.1.5"
+  val kamonVersion      = "2.1.9"
   val catsVersion       = "2.2.0"
   val catsEffectVersion = "2.2.0"
   val catsMtlVersion    = "0.7.1"
@@ -46,10 +46,10 @@ object Dependencies {
   // see https://jitpack.io/#rchain/kalium
   val kalium              = "com.github.rchain"           % "kalium"                    % "0.8.1"
   val kamonCore           = "io.kamon"                   %% "kamon-core"                % kamonVersion
-  val kamonSystemMetrics  = "io.kamon"                   %% "kamon-system-metrics"      % "1.0.1"
-  val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % "1.1.2"
-  val kamonInfluxDb       = "io.kamon"                   %% "kamon-influxdb"            % "1.0.2"
-  val kamonZipkin         = "io.kamon"                   %% "kamon-zipkin"              % "1.0.0"
+  val kamonSystemMetrics  = "io.kamon"                   %% "kamon-system-metrics"      % kamonVersion
+  val kamonPrometheus     = "io.kamon"                   %% "kamon-prometheus"          % kamonVersion
+  val kamonInfluxDb       = "io.kamon"                   %% "kamon-influxdb"            % kamonVersion
+  val kamonZipkin         = "io.kamon"                   %% "kamon-zipkin"              % kamonVersion
   val lightningj          = ("org.lightningj"             % "lightningj"                % "0.5.2-Beta")
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
   val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
@@ -96,6 +96,9 @@ object Dependencies {
     scalacheck,
     scodecBits,
     shapeless,
+    //added to resolve conflicts with kamon
+    slf4j,
+    "com.squareup.okhttp3" % "okhttp" % "3.12.1",
     // Added to resolve conflicts in scalapb plugin v0.10.8
     "org.codehaus.mojo"      % "animal-sniffer-annotations" % "1.18",
     "com.google.protobuf"    % "protobuf-java"              % "3.12.0",

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/errors.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.compiler.SourcePosition
-import net.logstash.logback.encoder.org.apache.commons.lang.exception.ExceptionUtils
+import net.logstash.logback.encoder.org.apache.commons.lang3.exception.ExceptionUtils
 
 object errors {
 
@@ -107,7 +107,7 @@ object errors {
       interpreterErrors: Vector[InterpreterError],
       errors: Vector[Throwable]
   ) extends InterpreterError(
-        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getFullStackTrace).mkString}"
+        s"Error: Aggregate Error\n${(interpreterErrors ++ errors).map(ExceptionUtils.getStackTrace).mkString}"
       )
 
   // Current implementation of SpaceMatcher (extractDataCandidates) causes unmatched comms


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Kamon was recently refactored such that all kamon dependencies now share the same version. This PR updates all kamon dependencies to the latest version [x.x.x -> 2.1.9] and adds the necessary overrides to facilitate the update. 

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
