### PR TITLE
Refactor event log to be Vector instead of Seq (List)

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
@@ -77,6 +77,6 @@ object ConstructDeploy {
       id: Int
   ): F[ProcessedDeploy] =
     basicDeployData[F](id).map(
-      deploy => ProcessedDeploy(deploy = deploy, cost = PCost(0L), List.empty, false)
+      deploy => ProcessedDeploy(deploy = deploy, cost = PCost(0L), Vector.empty, false)
     )
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -447,7 +447,7 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
             .copy(systemDeployError = Some(errorMsg))
       }
       .run // run the computation and produce the logs
-      .map { case (accLog, pd) => pd.copy(deployLog = accLog.toList) }
+      .map { case (accLog, pd) => pd.copy(deployLog = accLog) }
   }
 
   private def processDeploy(runtime: Runtime[F])(
@@ -462,7 +462,7 @@ class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log](
       deployResult = ProcessedDeploy(
         deploy,
         Cost.toProto(cost),
-        checkpoint.log.map(EventConverter.toCasperEvent).toList,
+        checkpoint.log.map(EventConverter.toCasperEvent),
         errors.nonEmpty
       )
       _ <- if (errors.nonEmpty) runtime.space.revertToSoftCheckpoint(fallback)

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/SystemDeployResult.scala
@@ -34,7 +34,7 @@ object SystemDeployPlayResult {
   ): SystemDeployPlayResult[A] =
     PlaySucceeded(
       stateHash,
-      ProcessedSystemDeploy.Succeeded(log.toList, systemDeployData),
+      ProcessedSystemDeploy.Succeeded(log.toVector, systemDeployData),
       result
     )
 
@@ -48,7 +48,7 @@ object SystemDeployPlayResult {
       log: Seq[Event],
       systemDeployError: SystemDeployError
   ): SystemDeployPlayResult[A] =
-    PlayFailed(ProcessedSystemDeploy.Failed(log.toList, systemDeployError.errorMsg))
+    PlayFailed(ProcessedSystemDeploy.Failed(log.toVector, systemDeployError.errorMsg))
 
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -390,7 +390,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
               ProcessedDeploy(
                 deploy = d,
                 cost = PCost(0L),
-                List.empty,
+                Vector.empty,
                 isFailed = false
               )
           )

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorHelperTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorHelperTest.scala
@@ -102,12 +102,12 @@ class EstimatorHelperTest
     implicit blockStore => implicit blockDagStorage =>
       testConflict[Task] { deploy =>
         deploy.copy(
-          deployLog = List(
+          deployLog = Vector(
             produce(ByteString.copyFromUtf8(channelsHash))
           )
         )
       } { deploy =>
-        deploy.copy(deployLog = List(consume(ByteString.copyFromUtf8(channelsHash))))
+        deploy.copy(deployLog = Vector(consume(ByteString.copyFromUtf8(channelsHash))))
       }
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -212,7 +212,7 @@ class InterpreterUtilTest
 
   def prepareDeploys(v: Vector[String], c: PCost) = {
     val genesisDeploys = v.map(ConstructDeploy.sourceDeployNow(_))
-    genesisDeploys.map(d => ProcessedDeploy(d, c, List.empty, false))
+    genesisDeploys.map(d => ProcessedDeploy(d, c, Vector.empty, false))
   }
 
   it should "merge histories in case of multiple parents with complex contract" in withGenesis(
@@ -353,7 +353,7 @@ class InterpreterUtilTest
     implicit blockStore => implicit blockDagStorage =>
       val deploys = Vector("@1!(1)").map(ConstructDeploy.sourceDeployNow(_))
       val processedDeploys =
-        deploys.map(d => ProcessedDeploy(d, PCost(1L), List.empty, false))
+        deploys.map(d => ProcessedDeploy(d, PCost(1L), Vector.empty, false))
       val invalidHash = ByteString.EMPTY
       mkRuntimeManager("interpreter-util-test").use { runtimeManager =>
         for {

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -79,6 +79,15 @@ object EqualM extends EqualMDerivation {
     }
 
   }
+  implicit def vectorEqual[A: EqualM]: EqualM[Vector[A]] = new EqualM[Vector[A]] {
+
+    override def equal[F[_]: Sync](self: Vector[A], other: Vector[A]): F[Boolean] = {
+      val pairs = self.toStream.zip(other)
+      Sync[F].delay(self.length == other.length) &&^
+        pairs.forallM(tupled(EqualM[A].equal[F]))
+    }
+
+  }
 
   implicit def arrayEqual[A: EqualM]: EqualM[Array[A]] = new EqualM[Array[A]] {
 

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -83,15 +83,12 @@ object HashM extends HashMDerivation {
 
     override def hash[F[_]: Sync](value: Seq[A]): F[Int] =
       value.toList.traverse(HashM[A].hash[F]).map(_.hashCode)
-      
 
   }
   implicit def vectorHash[A: HashM]: HashM[Vector[A]] = new HashM[Vector[A]] {
 
     override def hash[F[_]: Sync](value: Vector[A]): F[Int] =
-      for {
-        hashes <- value.toVector.traverse(HashM[A].hash[F])
-      } yield hashes.hashCode()
+      value.traverse(HashM[A].hash[F]).map(_.hashCode)
 
   }
 

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -82,18 +82,15 @@ object HashM extends HashMDerivation {
   implicit def seqHash[A: HashM]: HashM[Seq[A]] = new HashM[Seq[A]] {
 
     override def hash[F[_]: Sync](value: Seq[A]): F[Int] =
-      for {
-        hashes <- value.toList.traverse(HashM[A].hash[F])
-      } yield hashes.hashCode()
+      value.toList.traverse(HashM[A].hash[F]).map(_.hashCode)
+      
 
   }
 
   implicit def arrayHash[A: HashM]: HashM[Array[A]] = new HashM[Array[A]] {
 
     override def hash[F[_]: Sync](value: Array[A]): F[Int] =
-      for {
-        hashes <- value.toList.traverse(HashM[A].hash[F])
-      } yield hashes.hashCode()
+      value.toList.traverse(HashM[A].hash[F]).map(_.hashCode)
 
   }
 

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -86,6 +86,14 @@ object HashM extends HashMDerivation {
       
 
   }
+  implicit def vectorHash[A: HashM]: HashM[Vector[A]] = new HashM[Vector[A]] {
+
+    override def hash[F[_]: Sync](value: Vector[A]): F[Int] =
+      for {
+        hashes <- value.toVector.traverse(HashM[A].hash[F])
+      } yield hashes.hashCode()
+
+  }
 
   implicit def arrayHash[A: HashM]: HashM[Array[A]] = new HashM[Array[A]] {
 

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -69,7 +69,7 @@ object blockImplicits {
     } yield ProcessedDeploy(
       deploy = deployData,
       cost = PCost(0L),
-      deployLog = List.empty,
+      deployLog = Vector.empty,
       isFailed = false
     )
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -227,7 +227,7 @@ class RSpace[F[_], C, P, A, K](
       _           = historyRepositoryAtom.set(nextHistory)
       _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       log         = eventLog.take()
-      _           = eventLog.put(Seq.empty)
+      _           = eventLog.put(Vector.empty)
       _           = produceCounter.take()
       _           = produceCounter.put(Map.empty.withDefaultValue(0))
       _           <- restoreInstalls()

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -55,7 +55,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
   def assertF(predicate: Boolean, errorMsg: => String): F[Unit] =
     Sync[F].raiseError(new IllegalStateException(errorMsg)).unlessA(predicate)
 
-  protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Seq.empty)
+  protected[this] val eventLog: SyncVar[EventLog] = create[EventLog](Vector.empty)
   protected[this] val produceCounter: SyncVar[Map[Produce, Int]] =
     create[Map[Produce, Int]](Map.empty.withDefaultValue(0))
 
@@ -322,7 +322,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       nextHistory <- historyRepositoryAtom.get().reset(root)
       _           = historyRepositoryAtom.set(nextHistory)
       _           = eventLog.take()
-      _           = eventLog.put(Seq.empty)
+      _           = eventLog.put(Vector.empty)
       _           = produceCounter.take()
       _           = produceCounter.put(Map.empty.withDefaultValue(0))
       _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
@@ -345,7 +345,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
     for {
       cache    <- storeAtom.get().snapshot()
       log      = eventLog.take()
-      _        = eventLog.put(Seq.empty)
+      _        = eventLog.put(Vector.empty)
       pCounter = produceCounter.take()
       _        = produceCounter.put(Map.empty.withDefaultValue(0))
     } yield SoftCheckpoint[C, P, A, K](cache, log, pCounter)

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -253,7 +253,7 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
       _           = historyRepositoryAtom.set(nextHistory)
       _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       _           <- restoreInstalls()
-    } yield (Checkpoint(nextHistory.history.root, Seq.empty))
+    } yield (Checkpoint(nextHistory.history.root, Vector.empty))
   }
 
   override def clear(): F[Unit] = syncF.delay { replayData.clear() } >> super.clear()

--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -160,7 +160,7 @@ class ReportingRspace[F[_]: Sync, C, P, A, K](
       _ <- restoreInstalls()
       _ = softReport.update(_ => Seq.empty[ReportingEvent])
       _ = report.update(_ => Seq.empty[Seq[ReportingEvent]])
-    } yield (Checkpoint(historyRepository.history.root, Seq.empty))
+    } yield (Checkpoint(historyRepository.history.root, Vector.empty))
   }
 
   override def createSoftCheckpoint(): F[SoftCheckpoint[C, P, A, K]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/package.scala
@@ -4,7 +4,7 @@ import coop.rchain.rspace.internal.MultisetMultiMap
 
 package object trace {
 
-  type Log = Seq[Event]
+  type Log = Vector[Event]
 
   type ReplayData = MultisetMultiMap[IOEvent, COMM]
 }


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

Addresses  #3287. Makes event log a Vector rather than a Seq. Fixes related issues with this change. Targeted toward improving performance.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
