### PR TITLE
Updates to http4s, cats, catsRetry, catsEffect, fs2Core, scodec-bits, & disciplineCore

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
   val catsEffectLawsTest  = "org.typelevel"              %% "cats-effect-laws"          % catsEffectVersion % "test"
   val catsMtl             = "org.typelevel"              %% "cats-mtl-core"             % catsMtlVersion
   val catsMtlLawsTest     = "org.typelevel"              %% "cats-mtl-laws"             % catsMtlVersion % "test"
-  val catsRetry           = "com.github.cb372"           %% "cats-retry"                % "2.0.0"
+  val catsRetry           = "com.github.cb372"           %% "cats-retry"                % "2.1.0"
   val catsTagless         = "org.typelevel"              %% "cats-tagless-macros"       % "0.12"
   val circeCore           = "io.circe"                   %% "circe-core"                % circeVersion
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % circeVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
 
   val circeVersion      = "0.13.0"
   val enumeratumVersion = "1.5.13"
-  val http4sVersion     = "0.21.9"
+  val http4sVersion     = "0.21.15"
   val kamonVersion      = "1.1.5"
-  val catsVersion       = "2.2.0"
-  val catsEffectVersion = "2.2.0"
+  val catsVersion       = "2.3.1"
+  val catsEffectVersion = "2.3.1"
   val catsMtlVersion    = "0.7.1"
   val slf4jVersion      = "1.7.25"
 
@@ -30,9 +30,9 @@ object Dependencies {
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
   val circeLiteral        = "io.circe"                   %% "circe-literal"             % circeVersion
   val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
-  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.1.2"
+  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.1.3"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
-  val fs2Core             = "co.fs2"                     %% "fs2-core"                  % "2.4.4"
+  val fs2Core             = "co.fs2"                     %% "fs2-core"                  % "2.5.0"
   val guava               = "com.google.guava"            % "guava"                     % "30.0-jre"
   val hasher              = "com.roundeights"            %% "hasher"                    % "1.2.0"
   val http4sBlazeClient   = "org.http4s"                 %% "http4s-blaze-client"       % http4sVersion
@@ -78,7 +78,7 @@ object Dependencies {
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M2"
-  val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.21"
+  val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.23"
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
@@ -96,6 +96,9 @@ object Dependencies {
     scalacheck,
     scodecBits,
     shapeless,
+    // Added to resolve conflicts with kamon, cats, http4s
+    slf4j,
+    "org.typelevel"          % "jawn-parser_2.12"         % "1.0.0",
     // Added to resolve conflicts in scalapb plugin v0.10.8
     "org.codehaus.mojo"      % "animal-sniffer-annotations" % "1.18",
     "com.google.protobuf"    % "protobuf-java"              % "3.12.0",


### PR DESCRIPTION
Changelog:

disciplineCore [1.1.2 -> 1.1.3]
fs2Core [2.4.4 -> 2.5.0]
Updating http4s [0.21.9 -> 0.21.15]
cats-core, cats-laws, cats-testkit, cats-effect, cats-effect-laws [2.2.0 -> 2.3.1]
cats-retry [2.0.0 -> 2.1.0]
scodec-bits [1.1.21 -> 1.1.23]


## Overview
<!-- What this PR does, and why it's needed -->


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
