### PR TITLE
Rename the generated bnfc to ast instead of Syntax based on the discussion #3193 (comment)

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
@@ -4,7 +4,7 @@ import cats.Monoid
 import cats.implicits._
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.helper.TestRhoRuntime.rhoRuntimeEff
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.{BindPattern, Expr, ListParWithRandom, Par, TaggedContinuation}

--- a/project/BNFC.scala
+++ b/project/BNFC.scala
@@ -92,7 +92,7 @@ object BNFC {
         // format: off
         javaSource     := (javaSource in Compile).value,
         scalaSource    := (javaSource in Compile).value,
-        bnfcNamespace  := "coop.rchain.rholang.parser",
+        bnfcNamespace  := "coop.rchain.rholang.ast",
         bnfcGrammarDir := baseDirectory.value / "src" / "main" / "bnfc",
         bnfcOutputDir  := (javaSource in Compile).value,
         bnfcDocDir     := baseDirectory.value / "doc" / "bnfc",

--- a/project/BNFC.scala
+++ b/project/BNFC.scala
@@ -92,7 +92,7 @@ object BNFC {
         // format: off
         javaSource     := (javaSource in Compile).value,
         scalaSource    := (javaSource in Compile).value,
-        bnfcNamespace  := "coop.rchain.rholang.syntax",
+        bnfcNamespace  := "coop.rchain.rholang.parser",
         bnfcGrammarDir := baseDirectory.value / "src" / "main" / "bnfc",
         bnfcOutputDir  := (javaSource in Compile).value,
         bnfcDocDir     := baseDirectory.value / "doc" / "bnfc",

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -15,7 +15,7 @@ import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.compiler.ParBuilder
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Resources
 import monix.eval.{Coeval, Task}
 import monix.execution.{CancelableFuture, Scheduler}

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
@@ -9,8 +9,8 @@ import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.errors._
-import coop.rchain.rholang.parser.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.parser.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.ast.rholang_mercury.{parser, Yylex}
 
 trait ParBuilder[F[_]] {
   def buildNormalizedTerm(source: String, normalizerEnv: Map[String, Par]): F[Par]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
@@ -9,8 +9,8 @@ import coop.rchain.models.Par
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.rholang.sorter.Sortable
 import coop.rchain.rholang.interpreter.errors._
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
-import coop.rchain.rholang.syntax.rholang_mercury.{parser, Yylex}
+import coop.rchain.rholang.parser.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.parser.rholang_mercury.{parser, Yylex}
 
 trait ParBuilder[F[_]] {
   def buildNormalizedTerm(source: String, normalizerEnv: Map[String, Par]): F[Par]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalize.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.errors._
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{
+import coop.rchain.rholang.parser.rholang_mercury.Absyn.{
   Bundle => AbsynBundle,
   Ground => AbsynGround,
   KeyValuePair => AbsynKeyValuePair,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalize.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalize.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.errors._
-import coop.rchain.rholang.parser.rholang_mercury.Absyn.{
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
   Bundle => AbsynBundle,
   Ground => AbsynGround,
   KeyValuePair => AbsynKeyValuePair,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/package.scala
@@ -1,14 +1,11 @@
 package coop.rchain.rholang
 
 import cats.effect.Bracket
-import coop.rchain.rholang.interpreter.RhoRuntimeSyntax
 
 package object interpreter {
 
   type _error[F[_]] = Bracket[F, Throwable]
 
   def _error[F[_]](implicit ev: _error[F]): _error[F] = ev
-  object syntax extends AllSyntaxRholang
 
 }
-trait AllSyntaxRholang extends RhoRuntimeSyntax

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/storage/StoragePrinter.scala
@@ -11,7 +11,7 @@ import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoISpace
 import coop.rchain.rholang.interpreter.accounting.Cost
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.interpreter.{PrettyPrinter, RhoRuntime}
 import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
 import coop.rchain.rspace.trace.{Consume, Produce}

--- a/rholang/src/main/scala/coop/rchain/rholang/package.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/package.scala
@@ -1,7 +1,11 @@
 package coop.rchain
 
 import coop.rchain.metrics.Metrics
+import coop.rchain.rholang.interpreter.RhoRuntimeSyntax
 
 package object rholang {
   val RholangMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "rholang")
+  object syntax extends AllSyntaxRholang
+
 }
+trait AllSyntaxRholang extends RhoRuntimeSyntax

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -8,7 +8,7 @@ import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.interpreter.{EvaluateResult, Interpreter, RhoRuntime}
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGen.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGen.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang
 import cats.Invariant
 import cats.data.NonEmptyList
-import coop.rchain.rholang.parser.rholang_mercury.Absyn._
+import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.Shrink._

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGen.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGen.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rholang
 import cats.Invariant
 import cats.data.NonEmptyList
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
+import coop.rchain.rholang.parser.rholang_mercury.Absyn._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalacheck.Shrink._

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -2,8 +2,8 @@ package coop.rchain.rholang
 
 import coop.rchain.models.PrettyPrinted
 import coop.rchain.rholang.interpreter.ParBuilderUtil
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
-import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
+import coop.rchain.rholang.parser.rholang_mercury.Absyn._
+import coop.rchain.rholang.parser.rholang_mercury.PrettyPrinter
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -2,8 +2,8 @@ package coop.rchain.rholang
 
 import coop.rchain.models.PrettyPrinted
 import coop.rchain.rholang.interpreter.ParBuilderUtil
-import coop.rchain.rholang.parser.rholang_mercury.Absyn._
-import coop.rchain.rholang.parser.rholang_mercury.PrettyPrinter
+import coop.rchain.rholang.ast.rholang_mercury.Absyn._
+import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -9,7 +9,7 @@ import coop.rchain.models.serialization.implicits._
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.StackSafetySpec.findMaxRecursionDepth
 import coop.rchain.rholang.interpreter.{Interpreter, InterpreterUtil, ParBuilderUtil, PrettyPrinter}
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.{Log, Serialize}
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global

--- a/rholang/src/test/scala/coop/rchain/rholang/StoragePrinterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StoragePrinterSpec.scala
@@ -6,7 +6,7 @@ import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.interpreter.{Interpreter, InterpreterUtil}
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpreterUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpreterUtil.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import cats.effect.Sync
 import cats.implicits._
 import coop.rchain.models.Par
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import org.scalatest.Matchers._
 
 object InterpreterUtil {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import java.io.StringReader
 
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{
+import coop.rchain.rholang.parser.rholang_mercury.Absyn.{
   Bundle => AbsynBundle,
   Ground => AbsynGround,
   KeyValuePair => AbsynKeyValuePair,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/NormalizeTest.scala
@@ -2,7 +2,7 @@ package coop.rchain.rholang.interpreter
 
 import java.io.StringReader
 
-import coop.rchain.rholang.parser.rholang_mercury.Absyn.{
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
   Bundle => AbsynBundle,
   Ground => AbsynGround,
   KeyValuePair => AbsynKeyValuePair,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -5,7 +5,7 @@ import java.io.{Reader, StringReader}
 import cats.effect.Sync
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.compiler.ParBuilder
-import coop.rchain.rholang.parser.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.Proc
 import monix.eval.Coeval
 
 object ParBuilderUtil {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -5,7 +5,7 @@ import java.io.{Reader, StringReader}
 import cats.effect.Sync
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.compiler.ParBuilder
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.Proc
+import coop.rchain.rholang.parser.rholang_mercury.Absyn.Proc
 import monix.eval.Coeval
 
 object ParBuilderUtil {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -19,7 +19,7 @@ import coop.rchain.rholang.interpreter.compiler.{
   SourcePosition,
   VarSort
 }
-import coop.rchain.rholang.parser.rholang_mercury.Absyn._
+import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import monix.eval.Coeval
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -19,7 +19,7 @@ import coop.rchain.rholang.interpreter.compiler.{
   SourcePosition,
   VarSort
 }
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn._
+import coop.rchain.rholang.parser.rholang_mercury.Absyn._
 import monix.eval.Coeval
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rholang.Resources.mkRuntime
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -8,8 +8,8 @@ import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models._
 import coop.rchain.rholang.Resources._
 import coop.rchain.rholang.interpreter.{PrettyPrinter => PP, _}
-import coop.rchain.rholang.syntax.rholang_mercury.Absyn.{PPar, Proc}
-import coop.rchain.rholang.syntax.rholang_mercury.PrettyPrinter
+import coop.rchain.rholang.parser.rholang_mercury.Absyn.{PPar, Proc}
+import coop.rchain.rholang.parser.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.interpreter.syntax._
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.shared.Log

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -10,7 +10,7 @@ import coop.rchain.rholang.Resources._
 import coop.rchain.rholang.interpreter.{PrettyPrinter => PP, _}
 import coop.rchain.rholang.ast.rholang_mercury.Absyn.{PPar, Proc}
 import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -8,8 +8,8 @@ import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models._
 import coop.rchain.rholang.Resources._
 import coop.rchain.rholang.interpreter.{PrettyPrinter => PP, _}
-import coop.rchain.rholang.parser.rholang_mercury.Absyn.{PPar, Proc}
-import coop.rchain.rholang.parser.rholang_mercury.PrettyPrinter
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.{PPar, Proc}
+import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
 import coop.rchain.rholang.interpreter.syntax._
 import coop.rchain.rholang.{GenTools, ProcGen}
 import coop.rchain.shared.Log

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -10,7 +10,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rholang.Resources
 import coop.rchain.rholang.interpreter.{EvaluateResult, RhoRuntime}
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.rholang.interpreter.accounting.utils._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rspace.Checkpoint

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -6,7 +6,7 @@ import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.rholang.interpreter.{EvaluateResult, Interpreter, InterpreterUtil}
-import coop.rchain.rholang.interpreter.syntax._
+import coop.rchain.rholang.syntax._
 import coop.rchain.shared.{Log, Resources}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Renames bnfc generated files from package syntax to ast to improve clarity. 
Described in #3001 and #3193 

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
