### PR TITLE
Updating asm, kind projector, guava, magnolia, nettyBoringSSL, scodec-cats & kryo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -507,7 +507,7 @@ lazy val rspaceBench = (project in file("rspace-bench"))
   .settings(
     commonSettings,
     libraryDependencies ++= commonDependencies,
-    libraryDependencies += "com.esotericsoftware" % "kryo" % "4.0.2",
+    libraryDependencies += "com.esotericsoftware" % "kryo" % "5.0.3",
     dependencyOverrides ++= Seq(
       "org.ow2.asm" % "asm" % "5.0.4"
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -509,7 +509,7 @@ lazy val rspaceBench = (project in file("rspace-bench"))
     libraryDependencies ++= commonDependencies,
     libraryDependencies += "com.esotericsoftware" % "kryo" % "5.0.3",
     dependencyOverrides ++= Seq(
-      "org.ow2.asm" % "asm" % "5.0.4"
+      "org.ow2.asm" % "asm" % "9.0"
     ),
     sourceDirectory in Jmh := (sourceDirectory in Test).value,
     classDirectory in Jmh := (classDirectory in Test).value,

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -367,8 +367,8 @@ sealed trait SystemDeployData
 
 final case class SlashSystemDeployData(invalidBlockHash: BlockHash, issuerPublicKey: PublicKey)
     extends SystemDeployData
-object CloseBlockSystemDeployData extends SystemDeployData
-object Empty                      extends SystemDeployData
+case object CloseBlockSystemDeployData extends SystemDeployData
+case object Empty                      extends SystemDeployData
 
 object SystemDeployData {
   val empty: SystemDeployData = Empty

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.9" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -74,7 +74,7 @@ object Dependencies {
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.9" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,9 +71,9 @@ object Dependencies {
   val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
   val grpcServices        = "io.grpc"                     % "grpc-services"             % scalapb.compiler.Version.grpcJavaVersion
   val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.36.Final"
-  val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier osClassifier
-  val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier "linux-x86_64"
-  val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier "linux-x86_64-fedora"
+  val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier osClassifier
+  val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
+  val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
@@ -98,7 +98,7 @@ object Dependencies {
     shapeless,
     // Added to resolve conflicts with kamon, cats, http4s
     slf4j,
-    "org.typelevel"          % "jawn-parser_2.12"         % "1.0.0",
+    "org.typelevel" % "jawn-parser_2.12" % "1.0.0",
     // Added to resolve conflicts in scalapb plugin v0.10.8
     "org.codehaus.mojo"      % "animal-sniffer-annotations" % "1.18",
     "com.google.protobuf"    % "protobuf-java"              % "3.12.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.3" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -74,10 +74,10 @@ object Dependencies {
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.3" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
-  val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M2"
+  val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.23"
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.3" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.9" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -74,7 +74,7 @@ object Dependencies {
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.3" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.9" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
-  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.8"
+  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.17.0"
   val monix               = "io.monix"                   %% "monix"                     % "3.3.0"
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.1.3"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
   val fs2Core             = "co.fs2"                     %% "fs2-core"                  % "2.5.0"
-  val guava               = "com.google.guava"            % "guava"                     % "30.0-jre"
+  val guava               = "com.google.guava"            % "guava"                     % "30.1-jre"
   val hasher              = "com.roundeights"            %% "hasher"                    % "1.2.0"
   val http4sBlazeClient   = "org.http4s"                 %% "http4s-blaze-client"       % http4sVersion
   val http4sBlazeServer   = "org.http4s"                 %% "http4s-blaze-server"       % http4sVersion
@@ -56,7 +56,7 @@ object Dependencies {
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
-  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.0"
+  val magnolia            = "com.propensive"             %% "magnolia"                  % "0.12.8"
   val monix               = "io.monix"                   %% "monix"                     % "3.3.0"
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.2"
@@ -70,7 +70,7 @@ object Dependencies {
   val scalapbRuntimegGrpc = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"      % scalapb.compiler.Version.scalapbVersion
   val grpcNetty           = "io.grpc"                     % "grpc-netty"                % scalapb.compiler.Version.grpcJavaVersion
   val grpcServices        = "io.grpc"                     % "grpc-services"             % scalapb.compiler.Version.grpcJavaVersion
-  val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.34.Final"
+  val nettyBoringSsl      = "io.netty"                    % "netty-tcnative-boringssl-static" % "2.0.36.Final"
   val nettyTcnative       = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier osClassifier
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.34.Final" classifier "linux-x86_64-fedora"
@@ -118,7 +118,7 @@ object Dependencies {
     "com.typesafe"             % "config"                  % "1.4.0"
   )
 
-  private val kindProjector = compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0")
+  private val kindProjector = compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
   private val macroParadise = compilerPlugin(
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full

--- a/rspace-bench/src/test/scala/coop/rchain/models/KryoSerializers.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/models/KryoSerializers.scala
@@ -28,7 +28,7 @@ class DefaultSerializer[T](implicit tag: ClassTag[T]) extends Serializer[T] {
   override def read(
       kryo: Kryo,
       input: Input,
-      `type`: Class[T]
+      `type`: Class[_ <: T]
   ): T = defaultSerializer(kryo).read(kryo, input, `type`)
 
 }
@@ -41,7 +41,7 @@ object KryoSerializers {
     override def write(kryo: Kryo, output: Output, parMap: ParMap): Unit =
       kryo.writeObject(output, parMapToEMap(parMap))
 
-    override def read(kryo: Kryo, input: Input, `type`: Class[ParMap]): ParMap =
+    override def read(kryo: Kryo, input: Input, `type`: Class[_ <: ParMap]): ParMap =
       emapToParMap(kryo.readObject(input, classOf[EMap]))
   }
 
@@ -51,7 +51,7 @@ object KryoSerializers {
     override def write(kryo: Kryo, output: Output, parSet: ParSet): Unit =
       kryo.writeObject(output, parSetToESet(parSet))
 
-    override def read(kryo: Kryo, input: Input, `type`: Class[ParSet]): ParSet =
+    override def read(kryo: Kryo, input: Input, `type`: Class[_ <: ParSet]): ParSet =
       esetToParSet(kryo.readObject(input, classOf[ESet]))
   }
 
@@ -60,7 +60,7 @@ object KryoSerializers {
       override def read(
           kryo: Kryo,
           input: Input,
-          `type`: Class[T]
+          `type`: Class[_ <: T]
       ): T = {
         val read = super.read(kryo, input, `type`)
         if (thunk(read))


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Changelog
Kind projector [0.10.0 -> 0.10.3]
guava [30.0-> 30.1]
magnolia [0.12.0 -> 0.17.0]
nettyBoringSSL [2.0.34 -> 2.0.36]
Kryo [4.0.2 -> 5.0.3]
ASM [5.0.4 -> 9.0]
Scalactic [3.0.5 -> 3.0.5] Attempted update to 3.0.9 and 3.2.3 gives errors, to be tackled in a separate PR
ScalaTest [3.0.5 -> 3.0.5] Attempted update to 3.0.9 and 3.2.3 gives errors, to be tackled in a separate PR
scodec-cats [1.1.0-M2 -> 1.1.0-M4]

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
