### PR TITLE
Add autopropose option

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -88,11 +88,11 @@ object BlockCreator {
         } yield slashingDeploys
 
       def prepareDummyDeploy(blockNumber: Long): Seq[Signed[DeployData]] = dummyDeployOpt match {
-        case Some(d) =>
+        case Some((privateKey, term)) =>
           Seq(
             ConstructDeploy.sourceDeployNow(
-              source = d._2,
-              sec = d._1,
+              source = term,
+              sec = privateKey,
               vabn = blockNumber - 1
             )
           )

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -14,6 +14,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.PrivateKey
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.shared.{EventPublisher, Log, Time}
 import fs2.Stream
@@ -114,12 +115,13 @@ object Proposer {
     /* Comm */        : CommUtil: BlockRetriever
   ] // format: on
   (
-      validatorIdentity: ValidatorIdentity
+      validatorIdentity: ValidatorIdentity,
+      dummyDeployOpt: Option[(PrivateKey, String)] = None
   )(implicit runtimeManager: RuntimeManager[F]): Proposer[F] = {
     val getCasperSnapshotSnapshot = (c: Casper[F]) => c.getSnapshot
 
     val createBlock = (s: CasperSnapshot[F], validatorIdentity: ValidatorIdentity) =>
-      BlockCreator.create(s, validatorIdentity)
+      BlockCreator.create(s, validatorIdentity, dummyDeployOpt)
 
     val validateBlock = (casper: Casper[F], s: CasperSnapshot[F], b: BlockMessage) =>
       casper.validate(b, s.dag)

--- a/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
@@ -28,7 +28,8 @@ object ConstructDeploy {
       timestamp: Long,
       phloLimit: Long = 90000,
       phloPrice: Long = 1L,
-      sec: PrivateKey = defaultSec
+      sec: PrivateKey = defaultSec,
+      vabn: Long = 0
   ): Signed[DeployData] = {
     val data =
       DeployData(
@@ -36,7 +37,7 @@ object ConstructDeploy {
         timestamp = timestamp,
         phloLimit = phloLimit,
         phloPrice = phloPrice,
-        validAfterBlockNumber = 0L
+        validAfterBlockNumber = vabn
       )
 
     Signed(data, Secp256k1, sec)
@@ -44,18 +45,22 @@ object ConstructDeploy {
 
   def sourceDeployNow(
       source: String,
-      sec: PrivateKey = defaultSec
+      sec: PrivateKey = defaultSec,
+      vabn: Long = 0
   ): Signed[DeployData] =
-    sourceDeploy(source = source, timestamp = System.currentTimeMillis(), sec = sec)
+    sourceDeploy(source = source, timestamp = System.currentTimeMillis(), sec = sec, vabn = vabn)
 
   def sourceDeployNowF[F[_]: Time: Functor](
       source: String,
       phloLimit: Long = 1000000,
       phloPrice: Long = 1L,
-      sec: PrivateKey = defaultSec
+      sec: PrivateKey = defaultSec,
+      vabn: Long = 0
   ): F[Signed[DeployData]] =
     Time[F].currentMillis
-      .map(sourceDeploy(source, _, phloLimit = phloLimit, phloPrice = phloPrice, sec = sec))
+      .map(
+        sourceDeploy(source, _, phloLimit = phloLimit, phloPrice = phloPrice, sec = sec, vabn: Long)
+      )
 
   // TODO: replace usages with basicSendDeployData
   def basicDeployData[F[_]: Monad: Time](

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -5,6 +5,7 @@
 # 3. `required-signatures` = 0
 # for node to be able to create and approve genesis block if its not available
 standalone = false
+autopropose = false
 dev-mode = false
 
 protocol-server {
@@ -127,7 +128,7 @@ api-server {
   # Port for HTTP API
   port-http = 40403
 
-    # Port for admin HTTP API
+  # Port for admin HTTP API
   port-admin-http = 40405
 
   # Some of API methods are loading blocks into memory, which can lead to memory exhaustion.

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -6,7 +6,6 @@
 # for node to be able to create and approve genesis block if its not available
 standalone = false
 autopropose = false
-dev-mode = false
 
 protocol-server {
   # ID of the RChain network.

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -343,3 +343,10 @@ metrics {
   zipkin = false
   sigar = false
 }
+
+dev-mode = false
+
+dev {
+  # If set, on each propose node will add dummy deploy signed by this key.
+  # deployer-private-key =
+}

--- a/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/NodeRuntime.scala
@@ -434,7 +434,9 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
       blockProcessorStream = BlockProcessorInstance.create(
         incomingBlocksQueue,
         blockProcessor,
-        blockProcessingState
+        blockProcessingState,
+        proposeRequestsQueue,
+        nodeConf.autopropose
       )
 
       proposerStream = if (proposer.isDefined)

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -101,8 +101,20 @@ object Configuration {
         ConfigFactory.empty()
     val kamonConf = kamonDefaultConfig.withFallback(ConfigFactory.load("kamon.conf"))
 
-    (nodeConf, profile, configFile, kamonConf)
+    val nodeConf_ = checkDevMode(nodeConf)
+
+    (nodeConf_, profile, configFile, kamonConf)
+
   }
+
+  def checkDevMode(nodeConf: NodeConf): NodeConf =
+    if (nodeConf.devMode) {
+      nodeConf
+    } else {
+      if (nodeConf.dev.deployerPrivateKey.nonEmpty)
+        System.out.println("Node is not in dev mode, ignoring --deployer-private-key")
+      nodeConf.copy(dev = DevConf(deployerPrivateKey = None))
+    }
 
   final case class Profile(name: String, dataDir: (Path, String))
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -22,6 +22,7 @@ object ConfigMapper {
       val run = options.run
       val add = addToMap()
       add("standalone", run.standalone)
+      add("autopropose", run.autopropose)
       add("protocol-server.network-id", run.networkId)
       add("protocol-server.dynamic-ip", run.dynamicIp)
       add("protocol-server.no-upnp", run.noUpnp)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -22,7 +22,6 @@ object ConfigMapper {
       val run = options.run
       val add = addToMap()
       add("standalone", run.standalone)
-      add("dev-mode", run.devMode)
       add("protocol-server.network-id", run.networkId)
       add("protocol-server.dynamic-ip", run.dynamicIp)
       add("protocol-server.no-upnp", run.noUpnp)
@@ -122,6 +121,10 @@ object ConfigMapper {
       add("metrics.influxdb-udp", run.influxdbUdp)
       add("metrics.zipkin", run.zipkin)
       add("metrics.sigar", run.sigar)
+
+      add("dev-mode", run.devMode)
+      add("dev.deployer-private-key", run.deployerPrivateKey)
+
       //TODO remove
       //add(keys.KnownValidatorsFile, run.knownValidators
     }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -177,7 +177,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     )
 
     val autopropose = opt[Flag](
-      descr = "make node automatically trying to propose block after each new block added"
+      descr =
+        "Make node automatically trying to propose block after new block added or new deploy received."
     )
 
     val noUpnp = opt[Flag](

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -176,6 +176,10 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "ID of the RChain network to connect to."
     )
 
+    val autopropose = opt[Flag](
+      descr = "make node automatically trying to propose block after each new block added"
+    )
+
     val noUpnp = opt[Flag](
       descr = "Use this flag to disable UPnP."
     )

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -167,10 +167,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Start a stand-alone node."
     )
 
-    val devMode = opt[Flag](
-      descr = "Enable all developer tools."
-    )
-
     val bootstrap = opt[PeerNode](
       short = 'b',
       descr = "Address of RNode to bootstrap from when connecting to a network."
@@ -535,6 +531,15 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     // TODO remove
     val deployTimestamp = opt[Long](
       descr = "Timestamp for the deploys."
+    )
+
+    // Dev mode options
+    val devMode = opt[Flag](
+      descr = "Enable all developer tools."
+    )
+
+    val deployerPrivateKey = opt[String](
+      descr = "Private key for dummy deploys."
     )
 
   }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -16,7 +16,6 @@ import pureconfig.generic.auto._
 
 final case class NodeConf(
     standalone: Boolean,
-    devMode: Boolean,
     protocolServer: ProtocolServer,
     protocolClient: ProtocolClient,
     peersDiscovery: PeersDiscovery,
@@ -25,6 +24,8 @@ final case class NodeConf(
     storage: Storage,
     casper: CasperConf,
     metrics: Metrics,
+    devMode: Boolean,
+    dev: DevConf,
     // This field is dynamic and computed according to profile and is not used directly in client code.
     // But it is required in the model because of how Pureconfig works and how config file is structured (there are
     // references to this key in `defaults.conf`).
@@ -98,6 +99,10 @@ final case class Metrics(
     influxdbUdp: Boolean,
     zipkin: Boolean,
     sigar: Boolean
+)
+
+final case class DevConf(
+    deployerPrivateKey: Option[String]
 )
 
 sealed trait Command

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -16,6 +16,7 @@ import pureconfig.generic.auto._
 
 final case class NodeConf(
     standalone: Boolean,
+    autopropose: Boolean,
     protocolServer: ProtocolServer,
     protocolClient: ProtocolClient,
     peersDiscovery: PeersDiscovery,

--- a/node/src/main/scala/coop/rchain/node/instances/ProposerInstance.scala
+++ b/node/src/main/scala/coop/rchain/node/instances/ProposerInstance.scala
@@ -29,6 +29,8 @@ object ProposerInstance {
       .eval(for {
         lock    <- Semaphore[F](1)
         trigger <- MVar[F].of(())
+        // initial position for propose trigger - inactive
+        _ <- trigger.take
       } yield (lock, trigger))
       .flatMap {
         case (lock, trigger) =>

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -7,6 +7,7 @@ import coop.rchain.casper.{CasperConf, GenesisBlockData, GenesisCeremonyConf, Ro
 import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.node.configuration.{
   ApiServer,
+  DevConf,
   Metrics,
   NodeConf,
   PeersDiscovery,
@@ -255,7 +256,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         influxdbUdp = true,
         zipkin = true,
         sigar = true
-      )
+      ),
+      dev = DevConf(deployerPrivateKey = None)
     )
     config shouldEqual expectedConfig
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -144,6 +144,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
     val expectedConfig = NodeConf(
       defaultDataDir = "/var/lib/rnode",
       standalone = true,
+      autopropose = false,
       devMode = true,
       protocolServer = ProtocolServer(
         networkId = "testnet",

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -10,6 +10,7 @@ import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.node.configuration.{
   ApiServer,
+  DevConf,
   Metrics,
   NodeConf,
   PeersDiscovery,
@@ -162,7 +163,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         influxdbUdp = false,
         zipkin = false,
         sigar = false
-      )
+      ),
+      dev = DevConf(deployerPrivateKey = None)
     )
     config shouldEqual expectedConfig
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -51,6 +51,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
     val expectedConfig = NodeConf(
       defaultDataDir = "/var/lib/rnode",
       standalone = false,
+      autopropose = false,
       devMode = false,
       protocolServer = ProtocolServer(
         networkId = "testnet",


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

This PR intention is to make development and testing easier.

1.  Add `--deployer-private-key $key` CLI/config option. 
When set, with node in development mode (`--dev-mode` flag is set), makes node to put `Nil` deploy signed by this key into each block created. This makes it possible to just call `rnode propose` and make node issue a block without requirement to make a deploy first.
NOTE: corresponding private key has to be funded (e.g. through wallets file in genesis block).

2.  Add `--autopropose` CLI/config flag. When set, node makes attempt to propose after each new block added. 
NOTE: this does not guarantee block will be issued. If some propose constraint is not met (e.g. synchrony constraint), propose fails.

3.  Make node attempting to propose after each new deploy when `--autopropose` is set

Overall, after this PR it should be easy to seed network with a single propose command and then block creation should be automatic, according to propose constraints. Later this propose constraints will be read from on-chain shard config.