### PR TITLE
Enable parallel runtimes

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -1,6 +1,6 @@
 package coop.rchain.blockstorage.dag
 
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.models.BlockHash.BlockHash
@@ -36,6 +36,33 @@ final class BlockDagRepresentationOps[F[_]: Sync](
     def source = s"${file.value}:${line.value} ${enclosing.value}"
     def errMsg = s"DAG storage is missing hash ${PrettyPrinter.buildString(hash)}\n  $source"
     dag.lookup(hash) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
+  }
+
+  def lookupUnsafe(hashes: Seq[BlockHash])(
+      implicit line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      concurrent: Concurrent[F]
+  ): F[List[BlockMetadata]] = {
+    val streams = hashes.map(h => fs2.Stream.eval(lookupUnsafe(h)))
+    fs2.Stream.emits(streams).parJoinUnbounded.compile.toList
+  }
+
+  def childrensMetas(hashes: Seq[BlockHash])(
+      implicit line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      concurrent: Concurrent[F]
+  ): F[List[BlockMetadata]] = {
+
+    val childStream = fs2.Stream.emits(hashes).flatMap { h =>
+      fs2.Stream
+        .eval(dag.children(h).map(_.getOrElse(Set.empty)))
+        .flatMap(xs => fs2.Stream.fromIterator(xs.iterator))
+        .parEvalMapUnordered(100)(lookupUnsafe)
+    }
+    childStream.compile.toList
+
   }
 
   def latestMessage(validator: Validator): F[Option[BlockMetadata]] = {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -129,10 +129,10 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       playSystemDeploy: S,
       replaySystemDeploy: S
   )(resultAssertion: S#Result => Boolean): Task[StateHash] =
-    runtimeManager.withRuntimeLock(
+    runtimeManager.withRuntime(
       runtime => runtime.setBlockData(BlockData(0, 0, genesisContext.validatorPks.head, 0))
     ) >>
-      runtimeManager.withReplayRuntimeLock(
+      runtimeManager.withReplayRuntime(
         runtime => runtime.setBlockData(BlockData(0, 0, genesisContext.validatorPks.head, 0))
       ) >>
       runtimeManager.playSystemDeploy(startState)(playSystemDeploy).attempt >>= {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/RuntimeManagerTest.scala
@@ -6,6 +6,7 @@ import cats.{Functor, Id}
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.ProcessedSystemDeploy.Failed
 import coop.rchain.casper.protocol.{DeployData, ProcessedDeploy}
+import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang.SystemDeployPlayResult.{PlayFailed, PlaySucceeded}
 import coop.rchain.casper.util.rholang.SystemDeployReplayResult.{ReplayFailed, ReplaySucceeded}
@@ -17,7 +18,6 @@ import coop.rchain.casper.util.rholang.costacc.{
 }
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
 import coop.rchain.catscontrib.effect.implicits._
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.Signed
@@ -130,39 +130,53 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       replaySystemDeploy: S
   )(resultAssertion: S#Result => Boolean): Task[StateHash] =
     runtimeManager.withRuntime(
-      runtime => runtime.setBlockData(BlockData(0, 0, genesisContext.validatorPks.head, 0))
-    ) >>
-      runtimeManager.withReplayRuntime(
-        runtime => runtime.setBlockData(BlockData(0, 0, genesisContext.validatorPks.head, 0))
-      ) >>
-      runtimeManager.playSystemDeploy(startState)(playSystemDeploy).attempt >>= {
-      case Right(PlaySucceeded(finalPlayStateHash, processedSystemDeploy, playResult)) =>
-        assert(resultAssertion(playResult))
-        runtimeManager
-          .replaySystemDeploy(startState)(replaySystemDeploy, processedSystemDeploy)
-          .attempt
-          .map {
-            case Right(Right(systemDeployReplayResult)) =>
-              systemDeployReplayResult match {
-                case ReplaySucceeded(finalReplayStateHash, replayResult) =>
-                  assert(finalPlayStateHash == finalReplayStateHash)
-                  assert(playResult == replayResult)
-                  finalReplayStateHash
-                case ReplayFailed(systemDeployError) =>
-                  fail(
-                    s"Unexpected user error during replay: ${systemDeployError.errorMessage}"
+      runtime =>
+        for {
+          _ <- runtime.setBlockData(BlockData(0, 0, genesisContext.validatorPks.head, 0))
+          r <- runtime.playSystemDeploy(startState)(playSystemDeploy).attempt >>= {
+                case Right(PlaySucceeded(finalPlayStateHash, processedSystemDeploy, playResult)) =>
+                  assert(resultAssertion(playResult))
+                  runtimeManager.withReplayRuntime(
+                    runtime =>
+                      for {
+                        _ <- runtime.setBlockData(
+                              BlockData(0, 0, genesisContext.validatorPks.head, 0)
+                            )
+                        r <- runtime
+                              .replaySystemDeploy(startState)(
+                                replaySystemDeploy,
+                                processedSystemDeploy
+                              )
+                              .attempt
+                              .map {
+                                case Right(Right(systemDeployReplayResult)) =>
+                                  systemDeployReplayResult match {
+                                    case ReplaySucceeded(finalReplayStateHash, replayResult) =>
+                                      assert(finalPlayStateHash == finalReplayStateHash)
+                                      assert(playResult == replayResult)
+                                      finalReplayStateHash
+                                    case ReplayFailed(systemDeployError) =>
+                                      fail(
+                                        s"Unexpected user error during replay: ${systemDeployError.errorMessage}"
+                                      )
+                                  }
+                                case Right(Left(replayFailure)) =>
+                                  fail(s"Unexpected replay failure: $replayFailure")
+                                case Left(throwable) =>
+                                  fail(
+                                    s"Unexpected system error during replay: ${throwable.getMessage}"
+                                  )
+                              }
+                      } yield r
                   )
+
+                case Right(PlayFailed(Failed(_, errorMsg))) =>
+                  fail(s"Unexpected user error during play: $errorMsg")
+                case Left(throwable) =>
+                  fail(s"Unexpected system error during play: ${throwable.getMessage}")
               }
-            case Right(Left(replayFailure)) =>
-              fail(s"Unexpected replay failure: $replayFailure")
-            case Left(throwable) =>
-              fail(s"Unexpected system error during replay: ${throwable.getMessage}")
-          }
-      case Right(PlayFailed(Failed(_, errorMsg))) =>
-        fail(s"Unexpected user error during play: $errorMsg")
-      case Left(throwable) =>
-        fail(s"Unexpected system error during play: ${throwable.getMessage}")
-    }
+        } yield r
+    )
 
   "PreChargeDeploy" should "reduce user account balance by the correct amount" in effectTest {
     runtimeManagerResource.use { runtimeManager =>

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoRuntime.scala
@@ -18,7 +18,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.RholangMetricsSource
-import coop.rchain.rholang.interpreter.RhoRuntime.{RhoISpace, RhoReplayISpace}
+import coop.rchain.rholang.interpreter.RhoRuntime.{RhoISpace, RhoReplayISpace, RhoTuplespace}
 import coop.rchain.rholang.interpreter.SystemProcesses._
 import coop.rchain.rholang.interpreter.accounting.{_cost, Cost, CostAccounting, HasCost}
 import coop.rchain.rholang.interpreter.registry.RegistryBootstrap
@@ -140,6 +140,8 @@ trait RhoRuntime[F[_]] extends HasCost[F] {
     * Currently this is only for debug info mostly.
     */
   def getHotChanges: F[Map[Seq[Par], Row[BindPattern, ListParWithRandom, TaggedContinuation]]]
+
+  def getRSpace: RhoTuplespace[F]
 }
 
 trait ReplayRhoRuntime[F[_]] extends RhoRuntime[F] {
@@ -225,6 +227,8 @@ class RhoRuntimeImpl[F[_]: Sync](
       )
     invalidBlocksParam.setParams(invalidBlocksPar)
   }
+
+  override def getRSpace: RhoTuplespace[F] = space
 }
 
 class ReplayRhoRuntimeImpl[F[_]: Sync](
@@ -238,6 +242,8 @@ class ReplayRhoRuntimeImpl[F[_]: Sync](
   override def checkReplayData: F[Unit] = space.checkReplayData()
 
   override def rig(log: trace.Log): F[Unit] = space.rig(log)
+
+  override def getRSpace: RhoTuplespace[F] = space
 }
 
 object ReplayRhoRuntime {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -232,6 +232,16 @@ class RSpace[F[_], C, P, A, K](
       _           = produceCounter.put(Map.empty.withDefaultValue(0))
       _           <- restoreInstalls()
     } yield Checkpoint(nextHistory.history.root, log)
+
+  def spawn: F[ISpace[F, C, P, A, K]] = {
+    val historyRep  = historyRepositoryAtom.get()
+    implicit val ck = serializeK.toSizeHeadCodec
+    for {
+      nextHistory <- historyRep.reset(historyRep.history.root)
+      hotStore    <- HotStore.empty(nextHistory)
+      _           <- restoreInstalls()
+    } yield new RSpace[F, C, P, A, K](nextHistory, AtomicAny(hotStore), branch)
+  }
 }
 
 object RSpace {

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -239,8 +239,9 @@ class RSpace[F[_], C, P, A, K](
     for {
       nextHistory <- historyRep.reset(historyRep.history.root)
       hotStore    <- HotStore.empty(nextHistory)
-      _           <- restoreInstalls()
-    } yield new RSpace[F, C, P, A, K](nextHistory, AtomicAny(hotStore), branch)
+      r           = new RSpace[F, C, P, A, K](nextHistory, AtomicAny(hotStore), branch)
+      _           <- r.restoreInstalls()
+    } yield r
   }
 }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -175,7 +175,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
           store.removeDatum(candidateChannel, dataIndex).unlessA(persistData)
       }
 
-  protected[this] def restoreInstalls(): F[Unit] =
+  def restoreInstalls(): F[Unit] =
     /*spanF.trace(restoreInstallsSpanLabel)*/
     installs.get.toList
       .traverse {

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -319,10 +319,11 @@ class ReplayRSpace[F[_]: Sync, C, P, A, K](
     val historyRep  = historyRepositoryAtom.get()
     implicit val ck = serializeK.toSizeHeadCodec
     for {
-      nextHistory <- historyRep.reset(historyRep.history.root)
-      hotStore    <- HotStore.empty(nextHistory)
-      _           <- restoreInstalls()
-    } yield new ReplayRSpace[F, C, P, A, K](nextHistory, AtomicAny(hotStore), branch)
+      newHR <- historyRep.reset(historyRep.history.root)
+      newHS <- HotStore.empty(newHR)
+      r     = new ReplayRSpace[F, C, P, A, K](newHR, AtomicAny(newHS), branch)
+      _     <- r.restoreInstalls()
+    } yield r
   }
 }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryInstances.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryInstances.scala
@@ -557,7 +557,8 @@ object HistoryInstances {
 
     override def close(): F[Unit] = historyStore.close()
 
-    override def reset(root: Blake2b256Hash): History[F] = this.copy(root = root)
+    override def reset(root: Blake2b256Hash): History[F] =
+      this.copy(root = root, historyStore = CachingHistoryStore(historyStore.historyStore))
 
   }
 


### PR DESCRIPTION
This PR enables parallel Runtimes to be constructed, which is a requirement for block merge.

This is a very simple minimal working fix, heavy refactoring of RSpace/ReplayRspace/RSpaceOps still needed.

The commit with adding syntax is not related to this, but as this PR is an attempt to split the huge https://github.com/rchain/rchain/pull/3238, it is small enough, so I decided to make it accompany the parallel runtimes commit.