### PR TITLE
Make tips return lca as well

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -100,6 +100,8 @@ object MultiParentCasper extends MultiParentCasperInstances {
   */
 final case class CasperSnapshot[F[_]](
     dag: BlockDagRepresentation[F],
+    lastFinalizedBlock: BlockHash,
+    lca: BlockHash,
     tips: IndexedSeq[BlockHash],
     parents: List[BlockMessage],
     justifications: Set[Justification],

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -108,7 +108,7 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
     } yield deploy.sig
 
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
-    Estimator[F].tips(dag, approvedBlock)
+    Estimator[F].tips(dag, approvedBlock).map(_.tips)
 
   def lastFinalizedBlock: F[BlockMessage] =
     for {
@@ -175,8 +175,9 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
       } yield OnChainCasperState(shardConfig, bm.map(v => v.validator -> v.stake).toMap, av)
 
     for {
-      dag  <- BlockDagStorage[F].getRepresentation
-      tips <- Estimator[F].tips(dag, approvedBlock)
+      dag         <- BlockDagStorage[F].getRepresentation
+      r           <- Estimator[F].tips(dag, approvedBlock)
+      (lca, tips) = (r.lca, r.tips)
 
       /**
         * Before block merge, `EstimatorHelper.chooseNonConflicting` were used to filter parents, as we could not
@@ -233,8 +234,11 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
         } yield result
       }
       invalidBlocks <- dag.invalidBlocksMap
+      lfb           <- LastFinalizedStorage[F].getOrElse(approvedBlock.blockHash)
     } yield CasperSnapshot(
       dag,
+      lfb,
+      lca,
       tips,
       parents,
       justifications,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -470,7 +470,7 @@ object Validate {
 
     for {
       latestMessagesHashes <- ProtoUtil.toLatestMessageHashes(b.justifications).pure
-      tipHashes            <- Estimator[F].tips(dag, genesis, latestMessagesHashes)
+      tipHashes            <- Estimator[F].tips(dag, genesis, latestMessagesHashes).map(_.tips)
       computedParents      <- EstimatorHelper.chooseNonConflicting(tipHashes, dag)
       computedParentHashes = computedParents.map(_.blockHash)
       status <- if (parentHashes == computedParentHashes) {

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -107,7 +107,7 @@ class BlocksResponseAPITest
           tips    <- Estimator[Task].tips(dag, genesis)
           casperEffect <- NoOpsCasperEffect[Task](
                            HashMap.empty[BlockHash, BlockMessage],
-                           tips
+                           tips.tips
                          )
           logEff     = new LogStub[Task]
           engine     = new EngineWithCasper[Task](casperEffect)
@@ -135,7 +135,7 @@ class BlocksResponseAPITest
           tips       <- Estimator[Task].tips(dag, genesis)
           casperEffect <- NoOpsCasperEffect[Task](
                            HashMap.empty[BlockHash, BlockMessage],
-                           tips
+                           tips.tips
                          )
           engine     = new EngineWithCasper[Task](casperEffect)
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
@@ -162,7 +162,7 @@ class BlocksResponseAPITest
         tips       <- Estimator[Task].tips(dag, genesis)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
-                         tips
+                         tips.tips
                        )
         logEff     = new LogStub[Task]
         engine     = new EngineWithCasper[Task](casperEffect)
@@ -190,7 +190,7 @@ class BlocksResponseAPITest
           tips       <- Estimator[Task].tips(dag, genesis)
           casperEffect <- NoOpsCasperEffect[Task](
                            HashMap.empty[BlockHash, BlockMessage],
-                           tips
+                           tips.tips
                          )
           logEff     = new LogStub[Task]
           engine     = new EngineWithCasper[Task](casperEffect)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EstimatorTest.scala
@@ -87,7 +87,7 @@ class EstimatorTest
                        genesis,
                        Map.empty[Validator, BlockHash]
                      )
-      } yield forkchoice.head should be(genesis.blockHash)
+      } yield forkchoice.tips.head should be(genesis.blockHash)
   }
 
   // See https://docs.google.com/presentation/d/1znz01SF1ljriPzbMoFV0J127ryPglUYLFyhvsb-ftQk/edit?usp=sharing slide 29 for diagram
@@ -159,8 +159,8 @@ class EstimatorTest
                        genesis,
                        latestBlocks
                      )
-        _      = forkchoice.head should be(b6.blockHash)
-        result = forkchoice(1) should be(b8.blockHash)
+        _      = forkchoice.tips.head should be(b6.blockHash)
+        result = forkchoice.tips(1) should be(b8.blockHash)
       } yield result
   }
 
@@ -236,8 +236,8 @@ class EstimatorTest
                        genesis,
                        latestBlocks
                      )
-        _      = forkchoice.head should be(b8.blockHash)
-        result = forkchoice(1) should be(b7.blockHash)
+        _      = forkchoice.tips.head should be(b8.blockHash)
+        result = forkchoice.tips(1) should be(b7.blockHash)
       } yield result
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ManyValidatorsTest.scala
@@ -79,7 +79,7 @@ class ManyValidatorsTest
         tips                      <- Estimator[Task].tips(dag, genesis)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMessage],
-                         tips.toIndexedSeq
+                         tips.tips
                        )(Sync[Task], blockStore, newIndexedBlockDagStorage, runtimeManager)
         logEff             = new LogStub[Task]
         engine             = new EngineWithCasper[Task](casperEffect)

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -8,6 +8,7 @@ import cats.data.State
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.{Concurrent, Resource, Sync, Timer}
 import cats.implicits._
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.{BlockDagFileStorage, BlockDagStorage}
@@ -547,6 +548,8 @@ object TestNode {
                          dag <- BlockDagStorage[F].getRepresentation
                          dummyCasperSnapshot = CasperSnapshot(
                            dag,
+                           ByteString.EMPTY,
+                           ByteString.EMPTY,
                            IndexedSeq.empty,
                            List.empty,
                            Set.empty,


### PR DESCRIPTION
## Overview
Fork choice tips are ranked tips of the DAG. They do not make sense without knowing LCA, which were used to rank tips.
This PR package LCA next to tips returned by estimator.

This is useful for easier management of data and doing less work when preparing casper snapshot.
