### PR TITLE
Optimization for in-memory block metadata store initialization

### DIFF
--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStore.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStore.scala
@@ -9,5 +9,12 @@ trait KeyValueTypedStore[F[_], K, V] {
 
   def contains(keys: Seq[K]): F[Seq[Boolean]]
 
+  /**
+    * Efficient way to iterate and filter the whole KV store
+    *
+    * @param pf Partial function to project and filter values
+    */
+  def collect[T](pf: PartialFunction[(K, () => V), T]): F[Seq[T]]
+
   def toMap: F[Map[K, V]]
 }


### PR DESCRIPTION
## Overview
This PR creates memory efficient iterator for KV store. It's used to initialize in-memory block metadata representation when node starts.

## Results
The first half of the graph is related to block metadata initialization.

Before
![image](https://user-images.githubusercontent.com/5306205/108035932-dbea2700-7037-11eb-9023-7fc56086b909.png)

After
![image](https://user-images.githubusercontent.com/5306205/108036302-574bd880-7038-11eb-8fef-027c75b638c4.png)

### Reported resuls by @gsj5 on main net node.

The very first restart on current 0.10.0 version took ~4 minutes. Because LMDB uses disk cache, subsequent restarts are much faster.

| State/Version  | 0.10.0   | w/ optimization
|:-              |:-        |:-
| Full           | 89 sec   | 28 sec
| Trimmed (LFS)  | 20 sec   | 12 sec

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
