### PR TITLE
Fix generation of bonds and wallets file

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -27,8 +27,8 @@ final case class CasperConf(
 
 final case class GenesisBlockData(
     genesisDataDir: Path,
-    bondsFile: Option[String],
-    walletsFile: Option[String],
+    bondsFile: String,
+    walletsFile: String,
     bondMinimum: Long,
     bondMaximum: Long,
     epochLength: Int,

--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -59,10 +59,10 @@ object ApproveBlockProtocol {
     )
 
   def of[F[_]: Sync: Concurrent: RaiseIOError: CommUtil: Log: EventLog: Time: Metrics: RuntimeManager: LastApprovedBlock](
-      maybeBondsPath: Option[String],
+      bondsPath: String,
       autogenShardSize: Int,
       genesisPath: Path,
-      maybeVaultsPath: Option[String],
+      vaultsPath: String,
       minimumBond: Long,
       maximumBond: Long,
       epochLength: Int,
@@ -78,12 +78,10 @@ object ApproveBlockProtocol {
       now       <- Time[F].currentMillis
       timestamp = deployTimestamp.getOrElse(now)
 
-      vaults <- VaultParser.parse[F](maybeVaultsPath, genesisPath.resolve("wallets.txt"))
+      vaults <- VaultParser.parse[F](vaultsPath)
       bonds <- BondsParser.parse[F](
-                maybeBondsPath,
-                genesisPath.resolve("bonds.txt"),
-                autogenShardSize,
-                genesisPath
+                bondsPath,
+                autogenShardSize
               )
 
       genesisBlock <- if (bonds.size <= requiredSigs)

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -145,17 +145,11 @@ object CasperLaunch {
           timestamp <- conf.genesisBlockData.deployTimestamp.fold(Time[F].currentMillis)(_.pure[F])
           bonds <- BondsParser.parse[F](
                     conf.genesisBlockData.bondsFile,
-                    conf.genesisBlockData.genesisDataDir.resolve("bonds.txt"),
-                    conf.genesisCeremony.autogenShardSize,
-                    conf.genesisBlockData.genesisDataDir
+                    conf.genesisCeremony.autogenShardSize
                   )
 
           validatorId <- ValidatorIdentity.fromPrivateKeyWithLogging[F](conf.validatorPrivateKey)
-          vaults <- VaultParser.parse(
-                     conf.genesisBlockData.walletsFile
-                       .map(Paths.get(_))
-                       .getOrElse(conf.genesisBlockData.genesisDataDir.resolve("wallets.txt"))
-                   )
+          vaults      <- VaultParser.parse(conf.genesisBlockData.walletsFile)
           bap <- BlockApproverProtocol.of(
                   validatorId.get,
                   timestamp,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -78,14 +78,14 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
           _ <- fromInputFiles()(runtimeManager, genesisPath, log, time)
           _ = log.warns.count(
             _.contains(
-              "Bonds file was not specified and default bonds file does not exist. Falling back on generating random validators."
+              "Creating file with random bonds"
             )
           ) should be(1)
-        } yield log.infos.count(_.contains("Created validator")) should be(autogenShardSize)
+        } yield log.infos.count(_.contains("Bond generated")) should be(autogenShardSize)
     }
   )
 
-  it should "fail with error when bonds file does not exist" in taskTest(
+  it should "tell when bonds file does not exist" in taskTest(
     withGenResources {
       (
           runtimeManager: RuntimeManager[Task],
@@ -100,9 +100,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
                              log,
                              time
                            ).attempt
-        } yield genesisAttempt.left.value.getMessage should be(
-          "Specified bonds file not/a/real/file does not exist"
-        )
+        } yield log.warns.exists(_.contains("BONDS FILE NOT FOUND"))
     }
   )
 
@@ -128,7 +126,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
                              time
                            ).attempt
         } yield genesisAttempt.left.value.getMessage should include(
-          "misformatted.txt cannot be parsed"
+          "FAILED PARSING BONDS FILE"
         )
     }
   )
@@ -152,7 +150,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
                       time
                     )
           bonds = ProtoUtil.bonds(genesis)
-          _     = log.infos.length should be(2)
+          _     = log.infos.length should be(3)
           result = validators
             .map {
               case (v, i) => Bond(ByteString.copyFrom(Base16.unsafeDecode(v)), i.toLong)
@@ -238,12 +236,12 @@ object GenesisTest {
   ): Task[BlockMessage] =
     for {
       timestamp <- deployTimestamp.fold(Time[Task].currentMillis)(x => x.pure[Task])
-      vaults    <- VaultParser.parse[Task](maybeVaultsPath, genesisPath.resolve("wallets.txt"))
+      vaults <- VaultParser.parse[Task](
+                 maybeVaultsPath.getOrElse(genesisPath + "/wallets.txt")
+               )
       bonds <- BondsParser.parse[Task](
-                maybeBondsPath,
-                genesisPath.resolve("bonds.txt"),
-                autogenShardSize,
-                genesisPath
+                maybeBondsPath.getOrElse(genesisPath + "/bonds.txt"),
+                autogenShardSize
               )
       validators = bonds.toSeq.map(Validator.tupled)
       genesisBlock <- createGenesisBlock(

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -214,8 +214,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         ),
         genesisBlockData = GenesisBlockData(
           genesisDataDir = Paths.get("/var/lib/rnode/genesis"),
-          bondsFile = Some("/var/lib/rnode/genesis/bonds1.txt"),
-          walletsFile = Some("/var/lib/rnode/genesis/wallets1.txt"),
+          bondsFile = "/var/lib/rnode/genesis/bonds1.txt",
+          walletsFile = "/var/lib/rnode/genesis/wallets1.txt",
           bondMaximum = 111111,
           bondMinimum = 111111,
           epochLength = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -124,8 +124,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         ),
         genesisBlockData = GenesisBlockData(
           genesisDataDir = Paths.get("/var/lib/rnode/genesis"),
-          bondsFile = Some("/var/lib/rnode/genesis/bonds.txt"),
-          walletsFile = Some("/var/lib/rnode/genesis/wallets.txt"),
+          bondsFile = "/var/lib/rnode/genesis/bonds.txt",
+          walletsFile = "/var/lib/rnode/genesis/wallets.txt",
           bondMaximum = 9223372036854775807L,
           bondMinimum = 1,
           epochLength = 10000,


### PR DESCRIPTION
Some old PR refactoring config https://github.com/rchain/rchain/commit/e2bbe2f5a28996916d23565b2d3a3bbaac9e7187 broken autogeneration of bonds file and made node require wallets file without any fallback.

This PR fixes user experience.

**The rule for bonds:** if no bonds file at path specified (or default `genesis_path/bonds.txt` if nothing specified) does not exist - node will generate one for user. If bonds file exists but is empty node will report error and exit.
**The rule for wallets:** if no wallets file - node reports that genesis won't have any genesis vault. No exception possibly thrown. Empty wallets file is allowed.

closes https://github.com/rchain/rchain/issues/3008