### PR TITLE
Fix CI release with latest tag

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       VERSION: ${{ env.VERSION }}
       BRANCH: ${{ env.BRANCH }}
+      DEV_LATEST_TAG: ${{ env.DEV_LATEST_TAG }}
     steps:
       - name: Clone Repository
         uses: actions/checkout@v1
@@ -56,7 +57,12 @@ jobs:
           version="`git describe --tags --always`"
           echo "VERSION=$version" >> $GITHUB_ENV
 
+          # Find latest tag on dev branch
+          dev_latest_tag="`git describe --tags --abbrev=0 origin/dev`"
+          echo "DEV_LATEST_TAG=$dev_latest_tag" >> $GITHUB_ENV
+
           # Find related HEAD branch
+          branch=""
           if [[ $GITHUB_REF =~ ^refs/tags/ ]]; then
             # Tag related to multiple branches leaves empty branch variable
             raw_branch=$(git branch -r --contains ${{ github.ref }})
@@ -387,6 +393,7 @@ jobs:
           # Output from build_base job
           VERSION: ${{ needs.build_base.outputs.VERSION }}
           BRANCH: ${{ needs.build_base.outputs.BRANCH }}
+          DEV_LATEST_TAG: ${{ needs.build_base.outputs.DEV_LATEST_TAG }}
         shell: bash
         run: |
           set -eu -o pipefail
@@ -424,8 +431,8 @@ jobs:
           docker tag coop.rchain/rnode:latest $img_version
           docker push $img_version
 
-          # Tag Docker image as latest if dev branch is tagged
-          if [[ $GITHUB_REF =~ ^refs/tags/ ]] && [[ $BRANCH =~ ^dev$ ]]; then
+          # Tag Docker image as latest if tag is the latest on dev branch
+          if [[ $GITHUB_REF =~ ^refs/tags/ ]] && [[ $DEV_LATEST_TAG =~ $VERSION ]]; then
             docker tag coop.rchain/rnode:latest $img_latest
             docker push $img_latest
           fi


### PR DESCRIPTION
## Overview
This PR is addition to #3330 to fix creating Docker image with latest tag. Only when _version_ matches latest tag on dev branch Docker image with _latest_ tag will be created.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
