### PR TITLE
Migrate file-based blockstore to key-value implementation

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/FileLMDBIndexBlockStore.scala
@@ -2,7 +2,6 @@ package coop.rchain.blockstorage
 
 import java.nio.ByteBuffer
 import java.nio.file._
-
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
@@ -24,11 +23,14 @@ import coop.rchain.lmdb.LMDBStore
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.rspace.Context
 import coop.rchain.shared.ByteStringOps._
 import coop.rchain.shared.{AtomicMonadState, Log}
 import monix.execution.atomic.AtomicAny
 import org.lmdbjava.DbiFlags.MDB_CREATE
 import org.lmdbjava.ByteBufferProxy.PROXY_SAFE
+import fs2._
+import monix.eval.Task
 import org.lmdbjava._
 
 import scala.util.matching.Regex
@@ -137,6 +139,26 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
                    readBlockMessage(indexEntry)
                      .map(block => List(blockHash -> BlockMessage.from(block).right.get)) // TODO FIX-ME
                })
+    } yield result
+
+  def iterateStream: F[Stream[F, BlockMessage]] =
+    for {
+      indexes <- index.iterate { iterator =>
+                  Stream.chunk(
+                    Chunk.iterable(
+                      iterator
+                        .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
+                        .map {
+                          case (key, value) => (key, IndexEntry.load(value))
+                        }
+                        .toIterable
+                    )
+                  )
+                }
+      result = indexes.evalMap {
+        case (_, indexEntry) =>
+          readBlockMessage(indexEntry).map(b => BlockMessage.from(b).right.get)
+      }
     } yield result
 
   // Default implementation will use `get` to load the whole block so
@@ -286,6 +308,16 @@ object FileLMDBIndexBlockStore {
       blockStoreDataDir.resolve("approved-block"),
       blockStoreDataDir.resolve("checkpoints")
     )
+
+  def create[F[_]: Concurrent: Sync: Log: Metrics](
+      blockStoreDataDir: Path
+  ): F[BlockStore[F]] = {
+    val blockstoreEnv = Context.env(blockStoreDataDir, 1024L * 1024L * 1024L)
+    for {
+      blockStore <- create(blockstoreEnv, blockStoreDataDir)
+                     .map(_.right.get)
+    } yield blockStore
+  }
 
   def create[F[_]: Monad: Concurrent: Sync: Log: Metrics](
       env: Env[ByteBuffer],

--- a/build.sbt
+++ b/build.sbt
@@ -278,6 +278,7 @@ lazy val node = (project in file("node"))
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "coop.rchain.node",
+    mainClass in Compile := Some("coop.rchain.node.Main"),
     mainClass in assembly := Some("coop.rchain.node.Main"),
     assemblyMergeStrategy in assembly := {
       case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first

--- a/node/src/main/scala/coop/rchain/node/BlockStoreMigrate.scala
+++ b/node/src/main/scala/coop/rchain/node/BlockStoreMigrate.scala
@@ -1,0 +1,58 @@
+package coop.rchain.node
+
+import coop.rchain.blockstorage.{FileLMDBIndexBlockStore, KeyValueBlockStore}
+import coop.rchain.casper.storage.RNodeKeyValueStoreManager
+import coop.rchain.metrics.Metrics
+import coop.rchain.rspace.Context
+import coop.rchain.shared.Log
+import coop.rchain.shared.syntax._
+import monix.eval.Task
+import org.rogach.scallop.ScallopConf
+import monix.execution.Scheduler.Implicits.global
+
+import java.nio.file.Path
+
+final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val width = 120
+  helpWidth(width)
+  printedName = "migrate-blockstore"
+
+  val originalBlockStore = opt[Path](
+    descr = "original block store directory",
+    required = true
+  )
+
+  val targetDataDir = opt[Path](
+    descr = "Output block store directory",
+    required = true
+  )
+
+  verify()
+
+}
+object BlockStoreMigrate {
+  def main(args: Array[String]): Unit = {
+    val options            = Options(args)
+    val originalBlockStore = options.originalBlockStore()
+    val targetDataDir      = options.targetDataDir()
+    implicit val log       = effects.log
+    implicit val metrics   = new Metrics.MetricsNOP[Task]
+
+    val t = for {
+      casperStoreManager <- RNodeKeyValueStoreManager[Task](targetDataDir)
+      blockKVStore       <- KeyValueBlockStore[Task](casperStoreManager)
+
+      blockFileStorage <- FileLMDBIndexBlockStore.create[Task](originalBlockStore)
+      _                <- log.info("Migrating file based block store to key value store.")
+      dataStream       <- blockFileStorage.asInstanceOf[FileLMDBIndexBlockStore[Task]].iterateStream
+      operation        = dataStream.parEvalMapUnorderedProcBounded(b => blockKVStore.put(b))
+      _                <- operation.compile.drain
+      _                <- log.info("Migrating file based block store to key value store done.")
+      approvedBlock    <- blockFileStorage.getApprovedBlock.map(_.get)
+      _                <- blockKVStore.putApprovedBlock(approvedBlock)
+      _                <- log.info("Migration on approved block is done.")
+
+    } yield ()
+    t.runSyncUnsafe()
+  }
+}


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
1. implement a `iterateStream` in blockstore
2. implement migration binary 

Steps to migrate the old database:
```
$ mv $RNODE_DATA_DIR/blockstore $RNODE_DATA_DIR/blockstore-old
$ docker run -v $RNODE_DATA_DIR:/var/lib/rnode --entrypoint /opt/docker/bin/block-store-migrate coop.rchain/rnode:$VERSION --original-block-store /var/lib/rnode/blockstore-old --target-data-dir /var/lib/rnode
```


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
