### PR TITLE
Update build.sbt with fixed Java version

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,8 +1,8 @@
 ## Building and running
 
-Pre-release versions of the RChain software are now available. We plan to launch the full platform in Q1 of 2019.
-
 __Note__ Successfully building from source requires attending to all of the prerequisites shown below. When users experience errors, it is typically related to failure to assure all prerequisites are met. Work is in progress to improve this experience.
+
+Setup using _nix_ can be found in the [nix](./nix) directory.
 
 ### Prerequisites
 * Java Development Kit (JDK), version 10. We recommend using the OpenJDK

--- a/build.sbt
+++ b/build.sbt
@@ -196,9 +196,8 @@ lazy val comm = (project in file("comm"))
       guava
     ),
     PB.targets in Compile := Seq(
-      PB.gens.java                                      -> (sourceManaged in Compile).value,
-      scalapb.gen(javaConversions = true, grpc = false) -> (sourceManaged in Compile).value,
-      grpcmonix.generators.gen()                        -> (sourceManaged in Compile).value
+      scalapb.gen(grpc = false)  -> (sourceManaged in Compile).value,
+      grpcmonix.generators.gen() -> (sourceManaged in Compile).value
     )
   )
   .dependsOn(shared % "compile->compile;test->test", crypto, models)
@@ -268,10 +267,8 @@ lazy val node = (project in file("node"))
         pureconfig
       ),
     PB.targets in Compile := Seq(
-      PB.gens.java -> (sourceManaged in Compile).value / "protobuf",
-      scalapb
-        .gen(javaConversions = true, grpc = false) -> (sourceManaged in Compile).value / "protobuf",
-      grpcmonix.generators.gen()                   -> (sourceManaged in Compile).value / "protobuf"
+      scalapb.gen(grpc = false)  -> (sourceManaged in Compile).value / "protobuf",
+      grpcmonix.generators.gen() -> (sourceManaged in Compile).value / "protobuf"
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "coop.rchain.node",

--- a/build.sbt
+++ b/build.sbt
@@ -486,7 +486,6 @@ lazy val rspace = (project in file("rspace"))
       ScmInfo(url("https://github.com/rchain/rchain"), "git@github.com:rchain/rchain.git")
     ),
     git.remoteRepo := scmInfo.value.get.connection,
-    useGpg := true,
     pomIncludeRepository := { _ =>
       false
     },

--- a/build.sbt
+++ b/build.sbt
@@ -59,10 +59,7 @@ lazy val projectSettings = Seq(
   dependencyOverrides ++= Seq(
     "io.kamon" %% "kamon-core" % kamonVersion
   ),
-  javacOptions ++= (sys.env.get("JAVAC_VERSION") match {
-    case None    => Seq()
-    case Some(v) => Seq("-source", v, "-target", v)
-  }),
+  javacOptions ++= Seq("-source", "11", "-target", "11"),
   Test / fork := true,
   Test / parallelExecution := false,
   Test / testForkedParallel := false,

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,128 @@
+# RChain project setup/build using *nix*
+
+This document describes developer setup and build commands for RChain project using _nix_ package manager to install additional tools.
+
+**Note:** _default.nix_ file in this directory is not part of this document.
+
+## Java 11
+
+```sh
+sudo update-alternatives --config java
+
+# If necessary install Java 11 version
+sudo apt install default-jdk
+```
+
+## Nix
+
+Install Nix https://nixos.org/download.html
+
+```sh
+curl -L https://nixos.org/nix/install | sh
+```
+
+Test `nix` installation
+
+```sh
+# Install example Hello World program
+nix-env -i hello
+
+# Execute hello program
+hello
+# Hello, world!
+
+# Unistall Hello World program
+nix-env -e hello
+```
+
+## sbt
+
+Install Scala build tool `sbt`
+
+```sh
+sudo apt install sbt
+```
+
+## BNFC
+
+Install `jflex` and `bnfc` with *nix*
+
+```sh
+# Install BNFC and jflex with nix
+# - jflex v1.7.0 with ghc 8.6.5
+nix-env -i jflex -iA haskellPackages.BNFC --file https://github.com/NixOS/nixpkgs-channels/archive/nixos-20.03.tar.gz
+
+# Uninstall
+nix-env -e jflex BNFC
+
+# Install in case of error (Ubuntu)
+sudo apt-get install libgmp3-dev
+```
+
+## RNode build
+
+```sh
+# Regenerate parser from bnfc (./rholang/src/main/java)
+# - Java code not part of _target_ folder
+sbt bnfc:generate
+
+# Compile
+sbt compile
+
+# Compile with tests
+sbt test:compile
+
+# Compile and create local executable
+# path: rchain/node/target/universal/stage/bin/rnode
+sbt stage
+
+# Compile Docker image
+sbt docker:publishLocal
+
+# Clean project (except bnfc generated Java code)
+sbt clean
+
+# Clean bnfc generated Java code
+sbt bnfc:clean
+```
+
+### `sbt`  interactive mode
+
+```sh
+# Enter sbt interactive mode
+sbt
+
+# sbt interactive commands
+# sbt:rchain>
+
+# Regenerate parser from bnfc (./rholang/src/main/java)
+# - Java code not part of _target_ folder
+bnfc:generate
+
+# Compile
+compile
+
+# Compile with tests
+test:compile
+
+# Compile and create local executable
+# path: rchain/node/target/universal/stage/bin/rnode
+stage
+
+# Compile Docker image
+docker:publishLocal
+
+# Clean project (except bnfc generated Java code)
+clean
+
+# Clean bnfc generated Java code
+bnfc:clean
+```
+
+### Reset Git repository to a clean state
+
+**WARNING: this will remove all non-versioned files from your local repository folder**
+
+```sh
+git clean -fdx
+```


### PR DESCRIPTION
## Overview
This PR changes build.sbt with fixed Java version 11 to correctly support sbt import of the project in IntelliJ Idea IDE.

It also removes obsolete _useGpg_ option.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
