### PR TITLE
Fix memory leak in RSpace

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -68,7 +68,7 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
   implicit val codecC = serializeC.toSizeHeadCodec
   val syncF: Sync[F]  = Concurrent[F]
 
-  private val lockF: TwoStepLock[F, Blake2b256Hash] = new ConcurrentTwoStepLockF(MetricsSource)
+  private val lockF = new ConcurrentTwoStepLockF[F, Blake2b256Hash](MetricsSource)
 
   //private[this] val installSpanLabel         = Metrics.Source(MetricsSource, "install")
   //private[this] val restoreInstallsSpanLabel = Metrics.Source(MetricsSource, "restore-installs")
@@ -326,6 +326,10 @@ abstract class RSpaceOps[F[_]: Concurrent: Metrics, C, P, A, K](
       _           = produceCounter.put(Map.empty.withDefaultValue(0))
       _           <- createNewHotStore(nextHistory)(serializeK.toSizeHeadCodec)
       _           <- restoreInstalls()
+
+      // TODO: temp fix to release Semaphores inside TwoStepLock
+      //  Adjust when runtime changes got in, create instance on spawn runtime.
+      _ <- lockF.cleanUp
     } yield ()
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/concurrent/TwoStepLock.scala
@@ -1,8 +1,7 @@
 package coop.rchain.rspace.concurrent
 
-import cats.implicits._
 import cats.effect.Concurrent
-
+import cats.syntax.all._
 import coop.rchain.metrics.Metrics
 
 trait TwoStepLock[F[_], K] {
@@ -27,4 +26,10 @@ class ConcurrentTwoStepLockF[F[_]: Concurrent: Metrics, K](ms: Metrics.Source)
         res   <- phaseB.acquire(keysB)(thunk)
       } yield res
     }
+
+  def cleanUp: F[Unit] =
+    for {
+      _ <- phaseA.cleanUp
+      _ <- phaseB.cleanUp
+    } yield ()
 }


### PR DESCRIPTION
## Overview
This PR adds clean up method to multi lock used in RSpace so it can be called on each reset in RSpace.

Testing on main net observer node shows stable memory after more then 20 running hours.

![rspace-mem-leak-fix](https://user-images.githubusercontent.com/5306205/111513754-69ad5500-8751-11eb-8e86-893f50085266.png)


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
