### PR TITLE
Fix validators num in branch merge spec

### DIFF
--- a/casper/src/test/resources/logback-test.xml
+++ b/casper/src/test/resources/logback-test.xml
@@ -12,8 +12,10 @@
     <!--This is needed for RhoSpec tests output-->
     <logger name="coop.rchain.casper.helper.RhoLoggerContract" level="info"/>
     <logger name="coop.rchain.blockstorage" level="error"/>
+    <logger name="coop.rchain.rspace" level="error"/>
+    <logger name="coop.rchain.rspace.merger" level="debug"/>
 
-    <root level="warn">
+    <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -49,7 +49,7 @@ object GenesisBuilder {
   ): GenesisParameters = {
     // 4 default fixed validators, others are random generated
     val randomValidatorKeyPairs = (5 to validatorsNum).map(_ => Secp256k1.newKeyPair)
-    val (_, randomValidatorPks) = defaultValidatorKeyPairs.unzip
+    val (_, randomValidatorPks) = randomValidatorKeyPairs.unzip
     buildGenesisParameters(
       defaultValidatorKeyPairs ++ randomValidatorKeyPairs,
       bondsFunction(defaultValidatorPks ++ randomValidatorPks)

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -34,7 +34,8 @@ import scala.collection.Seq
 
 class MergingBranchMergerSpec extends FlatSpec with Matchers {
 
-  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 10)
+  val genesisParams              = GenesisBuilder.buildGenesisParametersWithRandom(validatorsNum = 40)
+  val genesisContext             = GenesisBuilder.buildGenesis(genesisParams)
   val genesis                    = genesisContext.genesisBlock
   implicit val logEff            = Log.log[Task]
   implicit val timeF: Time[Task] = new LogicalTime[Task]
@@ -377,7 +378,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
             // merge children to get next preStateHash
             v                                   <- CasperDagMerger.merge(mergingTips, base, dag, blockIndexCache)
             (nextPreStateHash, rejectedDeploys) = v
-            _                                   = assert(rejectedDeploys.size == 0)
+            _                                   = assert(rejectedDeploys.map(_.deploy.sig).isEmpty)
             _                                   = println(s"merge result ${PrettyPrinter.buildString(nextPreStateHash)}")
           } yield nextPreStateHash
 


### PR DESCRIPTION
## Overview
Branch merge test were always running with number of validators = 4 due to a bug. This PR enables arbitrary size of the network. This is required to reproduce https://github.com/rchain/rchain/issues/3349
Preferably use 40+ number of validators.

This should be along with merged with https://github.com/rchain/rchain/issues/3349 resolution