### PR TITLE
Propose on start (for --autopropose)

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -46,6 +46,7 @@ object CasperLaunch {
   (
       blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],
       blocksInProcessing: Ref[F, Set[BlockHash]],
+      proposeFOpt: Option[ProposeFunction[F]],
       conf: CasperConf,
       trimState: Boolean,
       disableStateExporter: Boolean
@@ -149,6 +150,8 @@ object CasperLaunch {
           init = for {
             _ <- askPeersForForkChoiceTips
             _ <- sendBufferPendantsToCasper(casper)
+            // try to propose (async way) if proposer is defined
+            _ <- proposeFOpt.traverse(p => p(casper, true))
           } yield ()
           _ <- Engine
                 .transitionToRunning[F](

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -342,6 +342,7 @@ object Setup {
         CasperLaunch.of[F](
           blockProcessorQueue,
           blockProcessorStateRef,
+          if (conf.autopropose) triggerProposeFOpt else none[ProposeFunction[F]],
           conf.casper,
           !conf.protocolClient.disableLfs,
           conf.protocolServer.disableStateExporter


### PR DESCRIPTION
## Overview
When validator is connected to existing network, it should try to create block after Casper is initialised and it found peers, so operator does not have to manually issue propose.

This is just a usability improvement. 