### PR TITLE
Fix score for binary data, different ByteString should not be equal

### DIFF
--- a/casper/src/test/resources/PoSTest.rho
+++ b/casper/src/test/resources/PoSTest.rho
@@ -706,13 +706,14 @@ match (
           contract closeBlock(ackCh) = {
             new ackCh0, activeValidatorsCh, setBlockData(`rho:test:block:data:set`), blockDataSet in {
               @PoS!("closeBlock", sysAuthToken, *ackCh0) |
-              @PoS!("getActiveValidators", *activeValidatorsCh) |
-              for (@ack              <- ackCh0;
-                   @activeValidators <- activeValidatorsCh) {
-                // For testing we need one of the active validators to be the block sender
-                setBlockData!("sender", activeValidators.nth(0), *blockDataSet) |
-                for (_ <- blockDataSet) {
-                  ackCh!(ack)
+              for (@ack              <- ackCh0) {
+                @PoS!("getActiveValidators", *activeValidatorsCh) |
+                for (@activeValidators <- activeValidatorsCh){
+                  // For testing we need one of the active validators to be the block sender
+                  setBlockData!("sender", activeValidators.nth(0), *blockDataSet) |
+                  for (_ <- blockDataSet) {
+                    ackCh!(ack)
+                  }
                 }
               }
             }
@@ -793,7 +794,7 @@ match (
                       @PoS!("refundDeploy", refundAmt, sysAuthToken, *refundCh) |
                       for (@(true, _) <- chargeCh;
                            @(true, _) <- refundCh) {
-                        match activeValidators.nth(1) {
+                        match activeValidators.nth(3) {
                           slashedValidator => {
                             computeHash!(slashedValidator, *hashCh) |
                             for (@hash <- hashCh) {

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -259,7 +259,7 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
       case gs: GString => ScoredTerm(e, Node(Score.STRING, Leaf(gs.value))).pure[F]
       case gu: GUri    => ScoredTerm(e, Node(Score.URI, Leaf(gu.value))).pure[F]
       case GByteArray(ba) =>
-        ScoredTerm(e, Node(Score.EBYTEARR, Leaf(ba.toStringUtf8))).pure[F]
+        ScoredTerm(e, Node(Score.EBYTEARR, Leaf(ba))).pure[F]
       //TODO get rid of Empty nodes in Protobuf unless they represent sth indeed optional
       case Empty =>
         ScoredTerm(e, Node(Score.ABSENT)).pure[F]

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -1,5 +1,7 @@
 package coop.rchain.models.rholang
 
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
@@ -113,6 +115,14 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     checkScoreEquality[Receive]
     checkScoreEquality[Send]
     checkScoreEquality[Var]
+  }
+  it should "score in different ByteString should be unequal" in {
+    // ci failing case https://github.com/rchain/rchain/runs/2268175723
+    // a is Expr(GByteArray(<ByteString@65e14bdc size=1 contents="\200">))
+    // b is Expr(GByteArray(<ByteString@2f125f4b size=1 contents="\331">))
+    val a = Expr(GByteArray(ByteString.copyFrom(Base16.unsafeDecode("80"))))
+    val b = Expr(GByteArray(ByteString.copyFrom(Base16.unsafeDecode("d9"))))
+    assert(sort(a).score != sort(b).score)
   }
   it should "sort so that unequal New have unequal scores" in {
     val new1 = New(


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
https://discord.com/channels/391435113415573504/417429638642532363/828667175140982815

fix failing test case in https://github.com/rchain/rchain/runs/2268175723
```
2021-04-05T07:34:33.3160040Z [info] - should sort so that unequal terms have unequal scores and the other way around *** FAILED *** (2 seconds, 158 milliseconds)
2021-04-05T07:34:33.3167230Z [info]   TestFailedException was thrown during property evaluation.
2021-04-05T07:34:33.3175460Z [info]     Message: Node(List(Leaf(ScoreAtom(IntAtom(116))), Leaf(ScoreAtom(StringAtom(�))))) equaled Node(List(Leaf(ScoreAtom(IntAtom(116))), Leaf(ScoreAtom(StringAtom(�)))))
2021-04-05T07:34:33.3183342Z [info]     Location: (SortTest.scala:100)
2021-04-05T07:34:33.3189985Z [info]     Occurred when passed generated values (
2021-04-05T07:34:33.3196766Z [info]       arg0 = List(Expr(GByteArray(<ByteString@65e14bdc size=1 contents="\200">)), Expr(GByteArray(<ByteString@2f125f4b size=1 contents="\331">))) // 3 shrinks
2021-04-05T07:34:33.3203504Z [info]     )
```

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
