### PR TITLE
Introduce MergingDeploysStatus with rejected flag

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -674,8 +674,8 @@ object BlockAPI {
       deployCount = block.body.deploys.length,
       faultTolerance = faultTolerance,
       justifications = block.justifications.map(ProtoUtil.justificationsToJustificationInfos),
-      rejectedDeploys = block.body.rejectedDeploys.map(
-        r => RejectedDeployInfo(PrettyPrinter.buildStringNoLimit(r.sig), r.rejected)
+      mergingDeployStatuses = block.body.mergingDeployStatuses.map(
+        r => MergingDeployStatusInfo(PrettyPrinter.buildStringNoLimit(r.sig), r.rejected)
       )
     )
 

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -674,9 +674,7 @@ object BlockAPI {
       deployCount = block.body.deploys.length,
       faultTolerance = faultTolerance,
       justifications = block.justifications.map(ProtoUtil.justificationsToJustificationInfos),
-      mergingDeployStatuses = block.body.mergingDeployStatuses.map(
-        r => MergingDeployStatusInfo(PrettyPrinter.buildStringNoLimit(r.sig), r.rejected)
-      )
+      mergingDeployStatuses = block.body.mergingDeployStatuses.map(MergingDeployStatus.toProto)
     )
 
   // Be careful to use this method , because it would iterate the whole indexes to find the matched one which would cause performance problem

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -675,7 +675,7 @@ object BlockAPI {
       faultTolerance = faultTolerance,
       justifications = block.justifications.map(ProtoUtil.justificationsToJustificationInfos),
       rejectedDeploys = block.body.rejectedDeploys.map(
-        r => RejectedDeployInfo(PrettyPrinter.buildStringNoLimit(r.sig))
+        r => RejectedDeployInfo(PrettyPrinter.buildStringNoLimit(r.sig), r.rejected)
       )
     )
 

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -131,7 +131,7 @@ object BlockCreator {
                   preStateHash,
                   postStateHash,
                   processedDeploys,
-                  rejectedDeploys,
+                  mergingDeploysStatus,
                   processedSystemDeploys
                 )             = checkpointData
                 newBonds      <- runtimeManager.computeBonds(postStateHash)
@@ -145,7 +145,7 @@ object BlockCreator {
                   preStateHash,
                   postStateHash,
                   processedDeploys,
-                  rejectedDeploys,
+                  mergingDeploysStatus,
                   processedSystemDeploys,
                   newBonds,
                   shardId,
@@ -167,7 +167,7 @@ object BlockCreator {
       preStateHash: StateHash,
       postStateHash: StateHash,
       deploys: Seq[ProcessedDeploy],
-      rejectedDeploys: Seq[ProcessedDeploy],
+      mergingDeploysStatus: Seq[ProcessedDeploy],
       systemDeploys: Seq[ProcessedSystemDeploy],
       bondsMap: Seq[Bond],
       shardId: String,
@@ -180,7 +180,7 @@ object BlockCreator {
         deploys.toList,
         // TODO check if the deploys are unrejected
         // https://github.com/rchain/rchain/issues/3372#issuecomment-815492081
-        rejectedDeploys.map(r => RejectedDeploy(r.deploy.sig, rejected = true)).toList,
+        mergingDeploysStatus.map(r => MergingDeployStatus(r.deploy.sig, rejected = true)).toList,
         systemDeploys.toList
       )
     val header = Header(parents.toList, blockData.timeStamp, version)

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -178,7 +178,9 @@ object BlockCreator {
       Body(
         state,
         deploys.toList,
-        rejectedDeploys.map(r => RejectedDeploy(r.deploy.sig)).toList,
+        // TODO check if the deploys are unrejected
+        // https://github.com/rchain/rchain/issues/3372#issuecomment-815492081
+        rejectedDeploys.map(r => RejectedDeploy(r.deploy.sig, rejected = true)).toList,
         systemDeploys.toList
       )
     val header = Header(parents.toList, blockData.timeStamp, version)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -96,7 +96,7 @@ object Genesis {
     val body = Body(
       state = state,
       deploys = sortedDeploys.toList,
-      rejectedDeploys = List.empty,
+      mergingDeployStatuses = List.empty,
       systemDeploys = List.empty
     )
     val version = 1L //FIXME make this part of Genesis, and pass it from upstream

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -84,13 +84,15 @@ object InterpreterUtil {
                            .buildString(incomingPreStateHash)}"
                        )
                        .as(none[StateHash].asRight[BlockError])
-                   } else if (rejectedDeployIds != block.body.rejectedDeploys.map(_.sig).toSet) {
+                   } else if (rejectedDeployIds != block.body.mergingDeployStatuses
+                                .map(_.sig)
+                                .toSet) {
                      Log[F]
                        .warn(
                          s"Computed rejected deploys " +
                            s"${rejectedDeployIds.map(r => PrettyPrinter.buildString(r._1) + s":${r._2}").mkString(",")} does not equal " +
                            s"block's rejected deploy " +
-                           s"${block.body.rejectedDeploys.map(_.sig).map(PrettyPrinter.buildString).mkString(",")}"
+                           s"${block.body.mergingDeployStatuses.map(_.sig).map(PrettyPrinter.buildString).mkString(",")}"
                        )
                        .as(InvalidRejectedDeploy.asLeft)
                    } else {

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -178,10 +178,10 @@ message BodyProto {
   repeated ProcessedDeployProto deploys      = 2;
   repeated ProcessedSystemDeployProto systemDeploys = 3;
   bytes                    extraBytes   = 4;
-  repeated RejectedDeployProto rejectedDeploys = 5;
+  repeated MergingDeployStatusProto mergingDeployStatuses = 5;
 }
 
-message RejectedDeployProto{
+message MergingDeployStatusProto{
   bytes sig = 1;
   bool  rejected = 2;
 }

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -183,6 +183,7 @@ message BodyProto {
 
 message RejectedDeployProto{
   bytes sig = 1;
+  bool  rejected = 2;
 }
 
 message JustificationProto {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -134,10 +134,10 @@ message LightBlockInfo {
   float faultTolerance = 19;
 
   repeated JustificationInfo justifications = 20;
-  repeated RejectedDeployInfo rejectedDeploys = 21;
+  repeated MergingDeployStatusInfo mergingDeployStatuses = 21;
 }
 
-message RejectedDeployInfo{
+message MergingDeployStatusInfo{
   string sig = 1;
   bool   rejected = 2;
 }

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -139,6 +139,7 @@ message LightBlockInfo {
 
 message RejectedDeployInfo{
   string sig = 1;
+  bool   rejected = 2;
 }
 
 // For node clients, see BlockMessage for actual Casper protocol Block representation

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -134,12 +134,7 @@ message LightBlockInfo {
   float faultTolerance = 19;
 
   repeated JustificationInfo justifications = 20;
-  repeated MergingDeployStatusInfo mergingDeployStatuses = 21;
-}
-
-message MergingDeployStatusInfo{
-  string sig = 1;
-  bool   rejected = 2;
+  repeated MergingDeployStatusProto mergingDeployStatuses = 21;
 }
 
 // For node clients, see BlockMessage for actual Casper protocol Block representation

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -241,23 +241,23 @@ object Header {
       .withExtraBytes(h.extraBytes)
 }
 
-final case class RejectedDeploy(
+final case class MergingDeployStatus(
     sig: ByteString,
     rejected: Boolean
 )
 
-object RejectedDeploy {
-  def from(r: RejectedDeployProto): Either[String, RejectedDeploy] =
-    Right(RejectedDeploy(r.sig, r.rejected))
+object MergingDeployStatus {
+  def from(r: MergingDeployStatusProto): Either[String, MergingDeployStatus] =
+    Right(MergingDeployStatus(r.sig, r.rejected))
 
-  def toProto(r: RejectedDeploy): RejectedDeployProto =
-    RejectedDeployProto().withSig(r.sig).withRejected(r.rejected)
+  def toProto(r: MergingDeployStatus): MergingDeployStatusProto =
+    MergingDeployStatusProto().withSig(r.sig).withRejected(r.rejected)
 }
 
 final case class Body(
     state: RChainState,
     deploys: List[ProcessedDeploy],
-    rejectedDeploys: List[RejectedDeploy],
+    mergingDeployStatuses: List[MergingDeployStatus],
     systemDeploys: List[ProcessedSystemDeploy],
     extraBytes: ByteString = ByteString.EMPTY
 ) {
@@ -267,17 +267,17 @@ final case class Body(
 object Body {
   def from(b: BodyProto): Either[String, Body] =
     for {
-      state           <- b.state.toRight("RChainState not available").map(RChainState.from)
-      deploys         <- b.deploys.toList.traverse(ProcessedDeploy.from)
-      systemDeploys   <- b.systemDeploys.toList.traverse(ProcessedSystemDeploy.from)
-      rejectedDeploys <- b.rejectedDeploys.toList.traverse(RejectedDeploy.from)
-    } yield Body(state, deploys, rejectedDeploys, systemDeploys, b.extraBytes)
+      state                 <- b.state.toRight("RChainState not available").map(RChainState.from)
+      deploys               <- b.deploys.toList.traverse(ProcessedDeploy.from)
+      systemDeploys         <- b.systemDeploys.toList.traverse(ProcessedSystemDeploy.from)
+      mergingDeployStatuses <- b.mergingDeployStatuses.toList.traverse(MergingDeployStatus.from)
+    } yield Body(state, deploys, mergingDeployStatuses, systemDeploys, b.extraBytes)
 
   def toProto(b: Body): BodyProto =
     BodyProto()
       .withState(RChainState.toProto(b.state))
       .withDeploys(b.deploys.map(ProcessedDeploy.toProto))
-      .withRejectedDeploys(b.rejectedDeploys.map(RejectedDeploy.toProto))
+      .withMergingDeployStatuses(b.mergingDeployStatuses.map(MergingDeployStatus.toProto))
       .withSystemDeploys(b.systemDeploys.map(ProcessedSystemDeploy.toProto))
       .withExtraBytes(b.extraBytes)
 

--- a/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
+++ b/models/src/main/scala/coop/rchain/casper/protocol/CasperMessage.scala
@@ -242,15 +242,16 @@ object Header {
 }
 
 final case class RejectedDeploy(
-    sig: ByteString
+    sig: ByteString,
+    rejected: Boolean
 )
 
 object RejectedDeploy {
   def from(r: RejectedDeployProto): Either[String, RejectedDeploy] =
-    Right(RejectedDeploy(r.sig))
+    Right(RejectedDeploy(r.sig, r.rejected))
 
   def toProto(r: RejectedDeploy): RejectedDeployProto =
-    RejectedDeployProto().withSig(r.sig)
+    RejectedDeployProto().withSig(r.sig).withRejected(r.rejected)
 }
 
 final case class Body(

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -175,7 +175,7 @@ object blockImplicits {
           ),
           deploys = deploys.toList,
           systemDeploys = List.empty,
-          rejectedDeploys = List.empty
+          mergingDeployStatuses = List.empty
         ),
         justifications = justifications.toList,
         sender = validator,

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -5,7 +5,6 @@ import cats.syntax.all._
 import cats.~>
 import com.google.protobuf.ByteString
 import coop.rchain.casper.PrettyPrinter
-import coop.rchain.casper.protocol.RejectedDeployInfo
 import coop.rchain.node.api.WebApi
 import coop.rchain.node.api.WebApi._
 import coop.rchain.shared.Log

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.protocol.{
   DeployInfo,
   JustificationInfo,
   LightBlockInfo,
-  RejectedDeployInfo
+  MergingDeployStatusInfo
 }
 import coop.rchain.crypto.codec._
 import coop.rchain.node.api.WebApi._
@@ -178,8 +178,8 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
   implicit val decodeJustificationInfo: Decoder[JustificationInfo] =
     deriveDecoder[JustificationInfo]
   implicit val decodeLightBlockInfo: Decoder[LightBlockInfo] = deriveDecoder[LightBlockInfo]
-  implicit val decodeRejectedDeployInfo: Decoder[RejectedDeployInfo] =
-    deriveDecoder[RejectedDeployInfo]
+  implicit val decodeMergingDeployStatusInfo: Decoder[MergingDeployStatusInfo] =
+    deriveDecoder[MergingDeployStatusInfo]
   implicit val decodeDeployInfo: Decoder[DeployInfo]             = deriveDecoder[DeployInfo]
   implicit val decodeBlockInfo: Decoder[BlockInfo]               = deriveDecoder[BlockInfo]
   implicit val decodeApiStatus: Decoder[ApiStatus]               = deriveDecoder[ApiStatus]

--- a/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
+++ b/node/src/test/scala/coop/rchain/node/web/WebApiRoutesTest.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.protocol.{
   DeployInfo,
   JustificationInfo,
   LightBlockInfo,
-  MergingDeployStatusInfo
+  MergingDeployStatusProto
 }
 import coop.rchain.crypto.codec._
 import coop.rchain.node.api.WebApi._
@@ -178,8 +178,8 @@ class WebApiRoutesTest extends FlatSpec with Matchers {
   implicit val decodeJustificationInfo: Decoder[JustificationInfo] =
     deriveDecoder[JustificationInfo]
   implicit val decodeLightBlockInfo: Decoder[LightBlockInfo] = deriveDecoder[LightBlockInfo]
-  implicit val decodeMergingDeployStatusInfo: Decoder[MergingDeployStatusInfo] =
-    deriveDecoder[MergingDeployStatusInfo]
+  implicit val decodeMergingDeployStatusProto: Decoder[MergingDeployStatusProto] =
+    deriveDecoder[MergingDeployStatusProto]
   implicit val decodeDeployInfo: Decoder[DeployInfo]             = deriveDecoder[DeployInfo]
   implicit val decodeBlockInfo: Decoder[BlockInfo]               = deriveDecoder[BlockInfo]
   implicit val decodeApiStatus: Decoder[ApiStatus]               = deriveDecoder[ApiStatus]


### PR DESCRIPTION
## Overview

This PR changes RejectedDeploy used in a block to be MergingDeploysStatus with rejected flag.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
