### PR TITLE
Clique oracle rewrite

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -97,8 +97,8 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
       deployIndex.get(deployId)
 
-    override def parents(vertex: BlockHash): F[Option[Set[BlockHash]]] =
-      lookup(vertex).map(_.map(_.parents.toSet))
+    override def parents(vertex: BlockHash): F[Option[Seq[BlockHash]]] =
+      lookup(vertex).map(_.map(_.parents))
   }
 
   private object KeyValueStoreEquivocationsTracker extends EquivocationsTracker[F] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -75,8 +75,8 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
     def invalidBlocks: F[Set[BlockMetadata]] =
       invalidBlocksSet.pure[F]
 
-    override def parents(vertex: BlockHash): F[Option[Set[BlockHash]]] =
-      lookup(vertex).map(_.map(_.parents.toSet))
+    override def parents(vertex: BlockHash): F[Option[Seq[BlockHash]]] =
+      lookup(vertex).map(_.map(_.parents))
   }
 
   object InMemEquivocationsTracker extends EquivocationsTracker[F] {

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -345,7 +345,7 @@ object EquivocationDetector {
         )
     }
 
-  private def findCreatorJustificationAncestorWithSeqNum[F[_]: Monad](
+  private def findCreatorJustificationAncestorWithSeqNum[F[_]: Sync](
       blockDag: BlockDagRepresentation[F],
       b: BlockMessage,
       seqNum: SequenceNumber

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -6,10 +6,12 @@ import cats.instances.list._
 import coop.rchain.catscontrib._
 import Catscontrib._
 import cats.data.OptionT
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.Justification
+import coop.rchain.casper.safety.CliqueOracle
+import coop.rchain.casper.safety.CliqueOracle.normalizedFaultTolerance
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, ProtoUtil}
 import coop.rchain.dag.DagOps
@@ -55,177 +57,29 @@ trait SafetyOracle[F[_]] {
 }
 
 object SafetyOracle extends SafetyOracleInstances {
+  val MIN_FAULT_TOLERANCE: Float                                 = -1f
+  val MAX_FAULT_TOLERANCE: Float                                 = 1f
   def apply[F[_]](implicit ev: SafetyOracle[F]): SafetyOracle[F] = ev
 }
 
 sealed abstract class SafetyOracleInstances {
-  def cliqueOracle[F[_]: Sync: Log: Metrics: Span]: SafetyOracle[F] =
-    new SafetyOracle[F] {
-      private val SafetyOracleMetricsSource: Metrics.Source =
-        Metrics.Source(CasperMetricsSource, "safety-oracle")
+  def cliqueOracle[F[_]: Concurrent: Log: Metrics: Span]: SafetyOracle[F] = new SafetyOracle[F] {
+    override def normalizedFaultTolerance(
+        blockDag: BlockDagRepresentation[F],
+        candidateBlockHash: BlockHash
+    ): F[Float] = {
+      import coop.rchain.blockstorage.syntax._
+      import coop.rchain.models.BlockHash._
 
-      /**
-        * To have a maximum clique of half the total weight,
-        * you need at least twice the weight of the agreeingValidatorToWeight to be greater than the total weight.
-        * If that is false, we don't need to compute agreementGraphMaxCliqueWeight
-        * as we know the value is going to be below 0 and thus useless for finalization.
-        */
-      def normalizedFaultTolerance(
-          blockDag: BlockDagRepresentation[F],
-          candidateBlockHash: BlockHash
-      ): F[Float] = Span[F].trace(SafetyOracleMetricsSource) {
-        for {
-          _ <- Log[F].debug(
-                s"Calculating faultTolearance of block ${PrettyPrinter.buildString(candidateBlockHash)} "
-              )
-          maybeCandidateMetadata <- blockDag.lookup(candidateBlockHash)
-          faultTolerance <- maybeCandidateMetadata match {
-                             case Some(candidateMetadata) =>
-                               for {
-                                 totalWeight <- computeTotalWeight(blockDag, candidateMetadata)
-                                 _           <- Span[F].mark("total-weight")
-                                 agreeingValidatorToWeight <- computeAgreeingValidatorToWeight(
-                                                               blockDag,
-                                                               candidateMetadata
-                                                             )
-                                 _ <- Span[F].mark("agreeing-validator-to-weight")
-                                 maxCliqueWeight <- if (2L * agreeingValidatorToWeight.values.sum < totalWeight) {
-                                                     0L.pure[F]
-                                                   } else {
-                                                     agreementGraphMaxCliqueWeight(
-                                                       blockDag,
-                                                       candidateMetadata,
-                                                       agreeingValidatorToWeight
-                                                     )
-                                                   }
-                                 _ <- Span[F].mark("max-clique-weight")
-
-                                 faultTolerance = 2 * maxCliqueWeight - totalWeight
-                               } yield faultTolerance.toFloat / totalWeight
-                             // if the node can to find the block, it would return -1 and regard that block as orphaned
-                             case None =>
-                               Log[F].info(
-                                 s"calculate faultTolerance blockHash ${PrettyPrinter.buildString(candidateBlockHash)} failed because it can not be found in store."
-                               ) >> (-1L).toFloat
-                                 .pure[F]
-                           }
-        } yield faultTolerance
-      }
-
-      private def computeTotalWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Long] =
-        computeMainParentWeightMap(blockDag, candidateMetadata).map(weightMapTotal)
-
-      private def computeAgreeingValidatorToWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Map[Validator, Long]] =
-        for {
-          weights <- computeMainParentWeightMap(blockDag, candidateMetadata)
-          agreeingWeights <- weights.toList.traverse {
-                              case (validator, stake) =>
-                                blockDag.latestMessageHash(validator).flatMap {
-                                  case Some(latestMessageHash) =>
-                                    computeCompatibility(
-                                      blockDag,
-                                      candidateMetadata,
-                                      latestMessageHash
-                                    ).map { isCompatible =>
-                                      if (isCompatible) {
-                                        Some((validator, stake))
-                                      } else {
-                                        none[(Validator, Long)]
-                                      }
-                                    }
-                                  case None =>
-                                    none[(Validator, Long)].pure[F]
-                                }
-                            }
-        } yield agreeingWeights.flatten.toMap
-
-      private def computeMainParentWeightMap(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Map[BlockHash, Long]] =
-        candidateMetadata.parents.headOption match {
-          case Some(parent) =>
-            blockDag.lookup(parent).map(_.fold(candidateMetadata.weightMap)(_.weightMap))
-          case None => candidateMetadata.weightMap.pure[F]
-        }
-
-      private def agreementGraphMaxCliqueWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata,
-          agreeingValidatorToWeight: Map[Validator, Long]
-      ): F[Long] = {
-        def filterChildren(block: BlockMetadata, validator: Validator): F[StreamT[F, BlockHash]] =
-          blockDag.latestMessageHash(validator).flatMap {
-            case Some(latestByValidatorHash) =>
-              val creatorJustificationOrGenesis = block.justifications
-                .find(_.validator == block.sender)
-                .fold(block.blockHash)(_.latestBlockHash)
-              DagOps
-                .bfTraverseF[F, BlockHash](List(latestByValidatorHash)) { blockHash =>
-                  ProtoUtil.getCreatorJustificationAsListUntilGoalInMemory(
-                    blockDag,
-                    blockHash,
-                    b => b == creatorJustificationOrGenesis
-                  )
-                }
-                .pure[F]
-            case None => StreamT.empty[F, BlockHash].pure[F]
-          }
-
-        def neverEventuallySeeDisagreement(
-            first: Validator,
-            second: Validator
-        ): F[Boolean] =
-          (for {
-            firstLatestBlock <- OptionT(blockDag.latestMessage(first))
-            secondLatestOfFirstLatestHash <- OptionT.fromOption[F](
-                                              firstLatestBlock.justifications
-                                                .find {
-                                                  case Justification(validator, _) =>
-                                                    validator == second
-                                                }
-                                                .map(_.latestBlockHash)
-                                            )
-            secondLatestOfFirstLatest <- OptionT(blockDag.lookup(secondLatestOfFirstLatestHash))
-            potentialDisagreements <- OptionT.liftF(
-                                       filterChildren(secondLatestOfFirstLatest, second)
-                                     )
-            // TODO: Implement forallM on StreamT
-            result <- OptionT.liftF(potentialDisagreements.toList.flatMap(_.forallM {
-                       potentialDisagreement =>
-                         computeCompatibility(blockDag, candidateMetadata, potentialDisagreement)
-                     }))
-          } yield result).fold(false)(identity)
-
-        def computeAgreementGraphEdges: F[List[(Validator, Validator)]] =
-          (for {
-            x <- agreeingValidatorToWeight.keys
-            y <- agreeingValidatorToWeight.keys
-            if x.toString > y.toString // TODO: Order ByteString
-          } yield (x, y)).toList.filterA {
-            case (first: Validator, second: Validator) =>
-              neverEventuallySeeDisagreement(first, second) &&^ neverEventuallySeeDisagreement(
-                second,
-                first
-              )
-          }
-
-        computeAgreementGraphEdges.map { edges =>
-          Clique.findMaximumCliqueByWeight[Validator](edges, agreeingValidatorToWeight)
-        }
-      }
-
-      private def computeCompatibility(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata,
-          targetBlockHash: BlockHash
-      ): F[Boolean] =
-        isInMainChain(blockDag, candidateMetadata, targetBlockHash)
+      CliqueOracle.normalizedFaultTolerance(
+        candidateBlockHash,
+        blockDag,
+        (h: BlockHash) => blockDag.lookupUnsafe(h).map(_.weightMap),
+        (h: BlockHash) => blockDag.lookupUnsafe(h).map(_.blockNum),
+        (v: Validator) => blockDag.latestMessageHashUnsafe(v),
+        blockDag.toCasperJustificationUnsafe,
+        blockDag.getCasperJustificationsUnsafe
+      )
     }
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/blocks/merger/CasperMergingDagReader.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/merger/CasperMergingDagReader.scala
@@ -31,12 +31,12 @@ final class CasperMergingDagReader[F[_]: Concurrent: BlockStore](
           )
     }
 
-  override def parents(vertex: MergingVertex): F[Option[Set[MergingVertex]]] =
+  override def parents(vertex: MergingVertex): F[Option[Seq[MergingVertex]]] =
     hashDAGReader.parents(vertex.blockHash).flatMap {
-      case None => none[Set[MergingVertex]].pure[F]
+      case None => none[Seq[MergingVertex]].pure[F]
       case Some(children) =>
         BlockStore[F]
-          .getUnsafe(children.toSeq)
+          .getUnsafe(children)
           .compile
           .toList
           .map(
@@ -48,7 +48,7 @@ final class CasperMergingDagReader[F[_]: Concurrent: BlockStore](
                   b.body.state.preStateHash,
                   b.body.deploys.toSet
                 )
-            ).toSet.some
+            ).some
           )
     }
 }

--- a/casper/src/main/scala/coop/rchain/casper/safety/CliqueOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/safety/CliqueOracle.scala
@@ -1,0 +1,181 @@
+package coop.rchain.casper.safety
+
+import cats.Show
+import cats.data.OptionT
+import cats.effect.Concurrent
+import cats.syntax.all._
+import coop.rchain.casper.util.{Clique, ProtoUtil}
+import coop.rchain.dag.{Casper, DagOps, DagReader}
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.shared.Log
+import coop.rchain.shared.syntax._
+import coop.rchain.metrics.implicits._
+import fs2.Stream
+
+import scala.reflect.ClassTag
+
+object CliqueOracle {
+  // map of validator id to stake bonded
+  type WeightMap[V] = Map[V, Long]
+
+  implicit val baseMetricsSource: Source = coop.rchain.casper.CasperMetricsSource
+
+  private def computeMaxCliqueWeight[F[_]: Concurrent: Span, M, V: ClassTag](
+      target: M,
+      dag: DagReader[F, M],
+      agreeingWeightMap: WeightMap[V],
+      agreeingLatestMessages: Map[V, M],
+      toJustificationF: M => F[Casper.Justification[M, V]],
+      justificationsF: M => F[Set[Casper.Justification[M, V]]],
+      heightF: M => F[Long]
+  )(implicit show: Show[M]): F[Long] = Span[F].traceI("compute-max-clique-weight") {
+
+    /**
+      * Prerequisite for this is that latest messages from a and b both are in main chain with target message
+      *
+      *     a    b
+      *     *    *  <- lmB
+      *      \   *
+      *       \  *
+      *        \ *
+      *         \*
+      *          *  <- lmAjB
+      *
+      * 1. get justification of validator b as per latest message of a (lmAjB)
+      * 2. check if any self justifications between latest message of b (lmB) and lmAjB are NOT in main chain
+      *    with target message. If one found - this is a source of disagreement.
+      * */
+    def neverEventuallySeeDisagreement(a: V, b: V): F[Boolean] =
+      (for {
+        // latest messages of validators matched
+        lmA <- OptionT.fromOption(agreeingLatestMessages.get(a))
+        lmB <- OptionT.fromOption(agreeingLatestMessages.get(b))
+        // message of `b` used as a justification by latest message of `a`
+        lmAjB <- OptionT(justificationsF(lmA).map(_.find(j => j.creator == b)))
+
+        disagreements = for {
+          // self justification of lmAjB or lmAjB itself. Used as a stopper for traversal
+          // TODO not completely clear why try to use self justification and not just message itself
+          stopper <- justificationsF(lmAjB.message).map(
+                      _.find(_.creator == lmAjB.creator)
+                        .getOrElse(lmAjB)
+                        .message
+                    )
+          selfJustificationsChain = DagOps
+            .bfTraverseF[F, M](List(lmB)) { jFromB =>
+              ProtoUtil
+                .getCreatorJustification(
+                  jFromB,
+                  (b: M) => b == stopper,
+                  toJustificationF,
+                  justificationsF
+                )
+                .map(_.map(List(_)).getOrElse(List.empty))
+            }
+          // find if any of traversed selfJustifications is NOT in main chain with target
+          r <- selfJustificationsChain
+                .filterF(dag.isInMainChain(_, target, heightF).not)
+                .flatMap(_.toList)
+        } yield r
+
+        r <- OptionT.liftF(disagreements.map(_.isEmpty))
+
+      } yield r).fold(false)(identity)
+
+    /** across combination of validators compute pairs that do not have disagreement */
+    def computeAgreeingValidatorPairs: F[List[(V, V)]] = {
+      val pairs = agreeingWeightMap.keys.toArray.combinations(2).map { case Array(a, b) => (a, b) }
+
+      Stream
+        .fromIterator(pairs)
+        .evalFilterAsyncProcBounded {
+          case (a, b) =>
+            neverEventuallySeeDisagreement(a, b) &&^ neverEventuallySeeDisagreement(b, a)
+        }
+        .compile
+        .toList
+    }
+
+    computeAgreeingValidatorPairs.map { edges =>
+      Clique.findMaximumCliqueByWeight[V](edges, agreeingWeightMap)
+    }
+  }
+
+  def normalizedFaultTolerance[F[_]: Concurrent: Log: Metrics: Span, M, V: ClassTag](
+      target: M,
+      dag: DagReader[F, M],
+      getWeightMapF: M => F[WeightMap[V]],
+      heightF: M => F[Long],
+      latestMessageF: V => F[M],
+      toJustificationF: M => F[Casper.Justification[M, V]],
+      getJustificationsF: M => F[Set[Casper.Justification[M, V]]]
+  )(implicit show: Show[M]): F[Float] = {
+    val nonExistingMessage =
+      Log[F].error(s"Fault tolerance for non existing message ${target.show} requested.").as(-1f)
+
+    val compute = Span[F].traceI("normalized-fault-tolerance") {
+      for {
+        // weight map of main parent (fallbacks to message itself if no parents)
+        fullWeightMap <- {
+          dag
+            .mainParent(target)
+            .map {
+              case Some(mainParent) => mainParent
+              case None             => target
+            }
+        }.flatMap(getWeightMapF)
+        // stake that agrees on a target message
+        agreeingWeightMap <- fs2.Stream
+                              .emits(fullWeightMap.toList)
+                              .evalFilterAsyncProcBounded {
+                                case (validator, _) =>
+                                  for {
+                                    lm <- latestMessageF(validator)
+                                    r <- dag.isInMainChain(
+                                          lm,
+                                          target,
+                                          heightF
+                                        )
+                                  } yield r
+                              }
+                              .compile
+                              .toList
+                              .map(_.toMap)
+        agreeingStake = agreeingWeightMap.values.sum
+        // total stake
+        totalStake = fullWeightMap.values.sum
+        // latest messages of agreeing validators
+        agreeingLatestMessages <- agreeingWeightMap.keys.toList
+                                   .traverse { k =>
+                                     for {
+                                       lm <- latestMessageF(k)
+                                     } yield (k, lm)
+                                   }
+                                   .map(_.toMap)
+        // compute fault tolerance
+        faultToleranceF = computeMaxCliqueWeight[F, M, V](
+          target,
+          dag,
+          agreeingWeightMap,
+          agreeingLatestMessages,
+          toJustificationF,
+          getJustificationsF,
+          heightF
+        ).map(
+          mqw => (mqw * 2 - totalStake).toFloat / totalStake
+        )
+        // if less then half of stake agrees on message - it can be orphaned
+        r <- if (2L * agreeingStake < totalStake) (-1f).pure[F]
+            else faultToleranceF
+      } yield r
+    }
+
+    dag
+      .contains(target)
+      .ifM(
+        Log[F].debug(s"Calculating fault tolerance for ${target.show}.") >> compute,
+        nonExistingMessage
+      )
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.api
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Concurrent, Resource, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
@@ -286,7 +286,7 @@ class BlockQueryResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metricsEff, spanEff)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metricsEff, spanEff)
       } yield (logEff, engineCell, cliqueOracleEffect)
     }
 
@@ -307,7 +307,7 @@ class BlockQueryResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metricsEff, spanEff)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metricsEff, spanEff)
       } yield (logEff, engineCell, cliqueOracleEffect)
     }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -59,10 +59,11 @@ class BlockQueryResponseAPITest
       setValidator = sender.some,
       setDeploys = randomDeploys.some,
       setJustifications = List(Justification(bondsValidator.validator, genesisBlock.blockHash)).some,
+      setParentsHashList = List(genesisBlock.blockHash).some,
       setBonds = List(bondsValidator).some
     )
 
-  val faultTolerance = 1f
+  val faultTolerance = -1f
 
   val deployCostList: List[String] = randomDeploys.map(PrettyPrinter.buildString)
 

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.api
 
 import scala.collection.immutable.HashMap
-import cats.effect.{Resource, Sync}
+import cats.effect.{Concurrent, Resource, Sync}
 import coop.rchain.casper._
 import coop.rchain.casper.engine._
 import EngineCell._
@@ -113,7 +113,7 @@ class BlocksResponseAPITest
           engine     = new EngineWithCasper[Task](casperEffect)
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.showMainChain[Task](10, maxBlockLimit)(
                              Sync[Task],
                              engineCell,
@@ -141,7 +141,7 @@ class BlocksResponseAPITest
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           logEff     = new LogStub[Task]
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.getBlocks[Task](10, maxBlockLimit)(
                              Sync[Task],
                              engineCell,
@@ -168,7 +168,7 @@ class BlocksResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
         blocksResponse <- BlockAPI.getBlocks[Task](2, maxBlockLimit)(
                            Sync[Task],
                            engineCell,
@@ -196,7 +196,7 @@ class BlocksResponseAPITest
           engine     = new EngineWithCasper[Task](casperEffect)
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.getBlocksByHeights[Task](2, 5, maxBlockLimit)(
                              Sync[Task],
                              engineCell,

--- a/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
@@ -46,6 +46,18 @@ class CliqueOracleTest
     )
 
   // See [[/docs/casper/images/cbc-casper_ping_pong_diagram.png]]
+  /**
+    *       *     b8
+    *       |
+    *   *   *     b6 b7
+    *   | /
+    *   *   *     b4 b5
+    *   | /
+    *   *   *     b2 b3
+    *    \ /
+    *     *
+    *   c2 c1
+    */
   it should "detect finality as appropriate" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       val v1     = generateValidator("Validator One")

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,5 +1,6 @@
 package coop.rchain.models
 
+import cats.Show
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.codec.Base16
 
@@ -9,5 +10,13 @@ object BlockHash {
   val Length = 32
   implicit class BlockHashOps(bs: BlockHash) {
     def base16String: String = Base16.encode(bs.toByteArray)
+  }
+
+  implicit def ordering: Ordering[BlockHash] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[BlockHash] {
+    def show(blockHash: BlockHash): String =
+      Base16.encode(blockHash.toByteArray).take(10)
   }
 }

--- a/models/src/main/scala/coop/rchain/models/Validator.scala
+++ b/models/src/main/scala/coop/rchain/models/Validator.scala
@@ -1,9 +1,19 @@
 package coop.rchain.models
 
+import cats.Show
 import com.google.protobuf.ByteString
+import coop.rchain.crypto.codec.Base16
 
 object Validator {
   type Validator = ByteString
 
   val Length = 65
+
+  implicit def ordering: Ordering[Validator] =
+    Ordering.by((b: Validator) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[Validator] {
+    def show(validator: Validator): String =
+      Base16.encode(validator.toByteArray).take(10)
+  }
 }

--- a/models/src/main/scala/coop/rchain/models/block/StateHash.scala
+++ b/models/src/main/scala/coop/rchain/models/block/StateHash.scala
@@ -1,5 +1,6 @@
 package coop.rchain.models.block
 
+import cats.Show
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.codec.Base16
 
@@ -9,5 +10,13 @@ object StateHash {
   val Length = 32
   implicit class StateHashOps(bs: StateHash) {
     def base16String: String = Base16.encode(bs.toByteArray)
+  }
+
+  implicit def ordering: Ordering[StateHash] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[StateHash] {
+    def show(validator: StateHash): String =
+      Base16.encode(validator.toByteArray).take(10)
   }
 }

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -35,7 +35,7 @@ object blockImplicits {
   val bondGen: Gen[Bond] = for {
     byteArray <- listOfN(Validator.Length, arbitrary[Byte])
     validator = ByteString.copyFrom(byteArray.toArray)
-    stake     <- arbitrary[Long]
+    stake     <- Gen.chooseNum(1L, 1024L)
   } yield Bond(validator, stake)
 
   val justificationGen: Gen[Justification] = for {

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/instances/EventLogIndexConflictDetector.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/instances/EventLogIndexConflictDetector.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace.merger.instances
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.rspace.Blake2b256Hash
 import coop.rchain.rspace.internal.Datum
 import coop.rchain.rspace.merger.EventLogIndex

--- a/shared/src/main/scala/coop/rchain/dag/Casper.scala
+++ b/shared/src/main/scala/coop/rchain/dag/Casper.scala
@@ -1,0 +1,5 @@
+package coop.rchain.dag
+
+object Casper {
+  final case class Justification[M, V](message: M, creator: V)
+}

--- a/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
@@ -1,0 +1,68 @@
+package coop.rchain.dag
+
+import cats.Show
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.dag.DagOps.bfTraverseF
+import coop.rchain.shared.syntax._
+import fs2.Stream
+
+trait DagReaderSyntax {
+  implicit final def syntaxDagReader[F[_], A](
+      dag: DagReader[F, A]
+  ): DagReaderOps[F, A] = new DagReaderOps[F, A](dag)
+}
+
+final class DagReaderOps[F[_], A](
+    private val dag: DagReader[F, A]
+) extends AnyVal {
+
+  def parentsUnsafe(item: A)(
+      implicit sync: Sync[F],
+      line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      show: Show[A]
+  ): F[Seq[A]] = {
+    def source = s"${file.value}:${line.value} ${enclosing.value}"
+    def errMsg = s"Parents lookup failed: DAG is missing ${item.show}\n at $source"
+    dag.parents(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
+  }
+
+  def contains(item: A)(implicit sync: Sync[F]): F[Boolean] =
+    dag.parents(item).map(_.isDefined) ||^ dag.children(item).map(_.isDefined)
+
+  def mainParent(item: A)(implicit sync: Sync[F]): F[Option[A]] =
+    dag.parents(item).map(_.flatMap(_.headOption))
+
+  def mainParentUnsafe(item: A)(
+      implicit sync: Sync[F],
+      line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      show: Show[A]
+  ): F[A] = {
+    def source = s"${file.value}:${line.value} ${enclosing.value}"
+    def errMsg = s"Unsafe call for parents for block with no parents: ${item.show}\n at $source"
+    mainParent(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
+  }
+
+  def isInMainChain(
+      descendant: A,
+      ancestor: A,
+      height: A => F[Long]
+  )(implicit sync: Sync[F], show: Show[A]): F[Boolean] =
+    descendant.tailRecM(
+      d =>
+        if (d == ancestor) true.asRight[A].pure[F]
+        else
+          for {
+            dHeight <- height(d)
+            aHeight <- height(ancestor)
+            r <- if (dHeight <= aHeight)
+                  false.asRight[A].pure[F]
+                else
+                  mainParentUnsafe(d).map(_.asLeft[Boolean])
+          } yield r
+    )
+}

--- a/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
@@ -84,4 +84,10 @@ class Fs2StreamOps[F[_], A](
     */
   def parEvalMapUnorderedProcBounded[F2[x] >: F[x]: Concurrent, B](f: A => F2[B]): Stream[F2, B] =
     stream.parEvalMapUnordered[F2, B](availableProcessors)(f)
+
+  /**
+    * Variant of [[Stream.evalFilterAsync]] with parallelism bound to number of processors.
+    */
+  def evalFilterAsyncProcBounded[F2[x] >: F[x]: Concurrent, B](f: A => F2[Boolean]): Stream[F2, A] =
+    stream.evalFilterAsync[F2](availableProcessors)(f)
 }

--- a/shared/src/main/scala/coop/rchain/shared/package.scala
+++ b/shared/src/main/scala/coop/rchain/shared/package.scala
@@ -1,6 +1,8 @@
 package coop.rchain
 
+import coop.rchain.dag.DagReaderSyntax
 import coop.rchain.fs2.Fs2StreamSyntax
+import coop.rchain.metrics.MetricsSyntax
 import coop.rchain.monix.MonixableSyntax
 import coop.rchain.store.{KeyValueStoreManagerSyntax, KeyValueStoreSyntax, KeyValueTypedStoreSyntax}
 
@@ -18,3 +20,5 @@ trait AllSyntaxShared
     with KeyValueStoreManagerSyntax
     with MonixableSyntax
     with Fs2StreamSyntax
+    with catscontrib.ToBooleanF
+    with DagReaderSyntax


### PR DESCRIPTION
This PR is first in a series aiming to enable leaderless merging.

New clique oracle is a drop-in replacement for old one written in abstract way. Main purpose is to have clear code and path towards new finalizer. No test are changed (except one) which should give confidence about correct implementation. 

The next step is https://github.com/rchain/rchain/pull/3366 which should use only `computeMaxCliqueWeight` public function from new oracle.