### PR TITLE
Clique oracle rewrite

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -97,8 +97,8 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
       deployIndex.get(deployId)
 
-    override def parents(vertex: BlockHash): F[Option[Set[BlockHash]]] =
-      lookup(vertex).map(_.map(_.parents.toSet))
+    override def parents(vertex: BlockHash): F[Option[Seq[BlockHash]]] =
+      lookup(vertex).map(_.map(_.parents))
   }
 
   private object KeyValueStoreEquivocationsTracker extends EquivocationsTracker[F] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -3,8 +3,6 @@ package coop.rchain.blockstorage.dag
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import coop.rchain.casper.PrettyPrinter
-import coop.rchain.casper.protocol.Justification
-import coop.rchain.dag.Casper
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockMetadata
 import coop.rchain.models.Validator.Validator
@@ -113,19 +111,4 @@ final class BlockDagRepresentationOps[F[_]: Sync](
       ib <- dag.invalidBlocks
       r  = ib.map(block => (block.blockHash, block.sender)).toMap
     } yield r
-
-  def getCasperJustificationsUnsafe(
-      blockHash: BlockHash
-  ): F[Set[Casper.Justification[BlockHash, Validator]]] =
-    lookupUnsafe(blockHash).map(
-      _.justifications.map {
-        case Justification(validator, latestBlockHash) =>
-          Casper.Justification(latestBlockHash, validator)
-      }.toSet
-    )
-
-  def toCasperJustificationUnsafe(
-      blockHash: BlockHash
-  ): F[Casper.Justification[BlockHash, Validator]] =
-    lookupUnsafe(blockHash).map(m => Casper.Justification(m.blockHash, m.sender))
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/InMemBlockDagStorage.scala
@@ -75,8 +75,8 @@ final class InMemBlockDagStorage[F[_]: Concurrent: Sync: Log](
     def invalidBlocks: F[Set[BlockMetadata]] =
       invalidBlocksSet.pure[F]
 
-    override def parents(vertex: BlockHash): F[Option[Set[BlockHash]]] =
-      lookup(vertex).map(_.map(_.parents.toSet))
+    override def parents(vertex: BlockHash): F[Option[Seq[BlockHash]]] =
+      lookup(vertex).map(_.map(_.parents))
   }
 
   object InMemEquivocationsTracker extends EquivocationsTracker[F] {

--- a/casper/src/main/scala/coop/rchain/casper/BlockDagRepresentationSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockDagRepresentationSyntax.scala
@@ -1,0 +1,37 @@
+package coop.rchain.casper
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.protocol.Justification
+import coop.rchain.casper.safety.CliqueOracle
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+
+trait BlockDagRepresentationSyntax {
+  implicit final def casperSyntaxBlockDagRepresentation[F[_]](
+      dag: BlockDagRepresentation[F]
+  ): BlockDagRepresentationOps[F] = new BlockDagRepresentationOps[F](dag)
+}
+
+final class BlockDagRepresentationOps[F[_]](
+    private val dag: BlockDagRepresentation[F]
+) extends AnyVal {
+  def getCasperJustificationsUnsafe(
+      blockHash: BlockHash
+  )(implicit sync: Sync[F]): F[Set[CliqueOracle.Justification[BlockHash, Validator]]] =
+    dag
+      .lookupUnsafe(blockHash)
+      .map(
+        _.justifications.map {
+          case Justification(validator, latestBlockHash) =>
+            CliqueOracle.Justification(latestBlockHash, validator)
+        }.toSet
+      )
+
+  def toCasperJustificationUnsafe(
+      blockHash: BlockHash
+  )(implicit sync: Sync[F]): F[CliqueOracle.Justification[BlockHash, Validator]] =
+    dag.lookupUnsafe(blockHash).map(m => CliqueOracle.Justification(m.blockHash, m.sender))
+}

--- a/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/coop/rchain/casper/EquivocationDetector.scala
@@ -345,7 +345,7 @@ object EquivocationDetector {
         )
     }
 
-  private def findCreatorJustificationAncestorWithSeqNum[F[_]: Monad](
+  private def findCreatorJustificationAncestorWithSeqNum[F[_]: Sync](
       blockDag: BlockDagRepresentation[F],
       b: BlockMessage,
       seqNum: SequenceNumber

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -41,6 +41,7 @@ import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.dag.DagOps
 import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.models.syntax._
 
 class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: LastFinalizedBlockCalculator: BlockStore: BlockDagStorage: LastFinalizedStorage: CommUtil: EventPublisher: Estimator: DeployStorage: BlockRetriever](
     validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -20,6 +20,7 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.{Log, StreamT}
+import coop.rchain.casper.syntax._
 
 /*
  * Implementation inspired by Ethereum's CBC casper simulator's clique oracle implementation.

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -6,10 +6,12 @@ import cats.instances.list._
 import coop.rchain.catscontrib._
 import Catscontrib._
 import cats.data.OptionT
-import cats.effect.Sync
+import cats.effect.{Concurrent, Sync}
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.Justification
+import coop.rchain.casper.safety.CliqueOracle
+import coop.rchain.casper.safety.CliqueOracle.normalizedFaultTolerance
 import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.{Clique, ProtoUtil}
 import coop.rchain.dag.DagOps
@@ -55,177 +57,29 @@ trait SafetyOracle[F[_]] {
 }
 
 object SafetyOracle extends SafetyOracleInstances {
+  val MIN_FAULT_TOLERANCE: Float                                 = -1f
+  val MAX_FAULT_TOLERANCE: Float                                 = 1f
   def apply[F[_]](implicit ev: SafetyOracle[F]): SafetyOracle[F] = ev
 }
 
 sealed abstract class SafetyOracleInstances {
-  def cliqueOracle[F[_]: Sync: Log: Metrics: Span]: SafetyOracle[F] =
-    new SafetyOracle[F] {
-      private val SafetyOracleMetricsSource: Metrics.Source =
-        Metrics.Source(CasperMetricsSource, "safety-oracle")
+  def cliqueOracle[F[_]: Concurrent: Log: Metrics: Span]: SafetyOracle[F] = new SafetyOracle[F] {
+    override def normalizedFaultTolerance(
+        blockDag: BlockDagRepresentation[F],
+        candidateBlockHash: BlockHash
+    ): F[Float] = {
+      import coop.rchain.blockstorage.syntax._
+      import coop.rchain.models.BlockHash._
 
-      /**
-        * To have a maximum clique of half the total weight,
-        * you need at least twice the weight of the agreeingValidatorToWeight to be greater than the total weight.
-        * If that is false, we don't need to compute agreementGraphMaxCliqueWeight
-        * as we know the value is going to be below 0 and thus useless for finalization.
-        */
-      def normalizedFaultTolerance(
-          blockDag: BlockDagRepresentation[F],
-          candidateBlockHash: BlockHash
-      ): F[Float] = Span[F].trace(SafetyOracleMetricsSource) {
-        for {
-          _ <- Log[F].debug(
-                s"Calculating faultTolearance of block ${PrettyPrinter.buildString(candidateBlockHash)} "
-              )
-          maybeCandidateMetadata <- blockDag.lookup(candidateBlockHash)
-          faultTolerance <- maybeCandidateMetadata match {
-                             case Some(candidateMetadata) =>
-                               for {
-                                 totalWeight <- computeTotalWeight(blockDag, candidateMetadata)
-                                 _           <- Span[F].mark("total-weight")
-                                 agreeingValidatorToWeight <- computeAgreeingValidatorToWeight(
-                                                               blockDag,
-                                                               candidateMetadata
-                                                             )
-                                 _ <- Span[F].mark("agreeing-validator-to-weight")
-                                 maxCliqueWeight <- if (2L * agreeingValidatorToWeight.values.sum < totalWeight) {
-                                                     0L.pure[F]
-                                                   } else {
-                                                     agreementGraphMaxCliqueWeight(
-                                                       blockDag,
-                                                       candidateMetadata,
-                                                       agreeingValidatorToWeight
-                                                     )
-                                                   }
-                                 _ <- Span[F].mark("max-clique-weight")
-
-                                 faultTolerance = 2 * maxCliqueWeight - totalWeight
-                               } yield faultTolerance.toFloat / totalWeight
-                             // if the node can to find the block, it would return -1 and regard that block as orphaned
-                             case None =>
-                               Log[F].info(
-                                 s"calculate faultTolerance blockHash ${PrettyPrinter.buildString(candidateBlockHash)} failed because it can not be found in store."
-                               ) >> (-1L).toFloat
-                                 .pure[F]
-                           }
-        } yield faultTolerance
-      }
-
-      private def computeTotalWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Long] =
-        computeMainParentWeightMap(blockDag, candidateMetadata).map(weightMapTotal)
-
-      private def computeAgreeingValidatorToWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Map[Validator, Long]] =
-        for {
-          weights <- computeMainParentWeightMap(blockDag, candidateMetadata)
-          agreeingWeights <- weights.toList.traverse {
-                              case (validator, stake) =>
-                                blockDag.latestMessageHash(validator).flatMap {
-                                  case Some(latestMessageHash) =>
-                                    computeCompatibility(
-                                      blockDag,
-                                      candidateMetadata,
-                                      latestMessageHash
-                                    ).map { isCompatible =>
-                                      if (isCompatible) {
-                                        Some((validator, stake))
-                                      } else {
-                                        none[(Validator, Long)]
-                                      }
-                                    }
-                                  case None =>
-                                    none[(Validator, Long)].pure[F]
-                                }
-                            }
-        } yield agreeingWeights.flatten.toMap
-
-      private def computeMainParentWeightMap(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata
-      ): F[Map[BlockHash, Long]] =
-        candidateMetadata.parents.headOption match {
-          case Some(parent) =>
-            blockDag.lookup(parent).map(_.fold(candidateMetadata.weightMap)(_.weightMap))
-          case None => candidateMetadata.weightMap.pure[F]
-        }
-
-      private def agreementGraphMaxCliqueWeight(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata,
-          agreeingValidatorToWeight: Map[Validator, Long]
-      ): F[Long] = {
-        def filterChildren(block: BlockMetadata, validator: Validator): F[StreamT[F, BlockHash]] =
-          blockDag.latestMessageHash(validator).flatMap {
-            case Some(latestByValidatorHash) =>
-              val creatorJustificationOrGenesis = block.justifications
-                .find(_.validator == block.sender)
-                .fold(block.blockHash)(_.latestBlockHash)
-              DagOps
-                .bfTraverseF[F, BlockHash](List(latestByValidatorHash)) { blockHash =>
-                  ProtoUtil.getCreatorJustificationAsListUntilGoalInMemory(
-                    blockDag,
-                    blockHash,
-                    b => b == creatorJustificationOrGenesis
-                  )
-                }
-                .pure[F]
-            case None => StreamT.empty[F, BlockHash].pure[F]
-          }
-
-        def neverEventuallySeeDisagreement(
-            first: Validator,
-            second: Validator
-        ): F[Boolean] =
-          (for {
-            firstLatestBlock <- OptionT(blockDag.latestMessage(first))
-            secondLatestOfFirstLatestHash <- OptionT.fromOption[F](
-                                              firstLatestBlock.justifications
-                                                .find {
-                                                  case Justification(validator, _) =>
-                                                    validator == second
-                                                }
-                                                .map(_.latestBlockHash)
-                                            )
-            secondLatestOfFirstLatest <- OptionT(blockDag.lookup(secondLatestOfFirstLatestHash))
-            potentialDisagreements <- OptionT.liftF(
-                                       filterChildren(secondLatestOfFirstLatest, second)
-                                     )
-            // TODO: Implement forallM on StreamT
-            result <- OptionT.liftF(potentialDisagreements.toList.flatMap(_.forallM {
-                       potentialDisagreement =>
-                         computeCompatibility(blockDag, candidateMetadata, potentialDisagreement)
-                     }))
-          } yield result).fold(false)(identity)
-
-        def computeAgreementGraphEdges: F[List[(Validator, Validator)]] =
-          (for {
-            x <- agreeingValidatorToWeight.keys
-            y <- agreeingValidatorToWeight.keys
-            if x.toString > y.toString // TODO: Order ByteString
-          } yield (x, y)).toList.filterA {
-            case (first: Validator, second: Validator) =>
-              neverEventuallySeeDisagreement(first, second) &&^ neverEventuallySeeDisagreement(
-                second,
-                first
-              )
-          }
-
-        computeAgreementGraphEdges.map { edges =>
-          Clique.findMaximumCliqueByWeight[Validator](edges, agreeingValidatorToWeight)
-        }
-      }
-
-      private def computeCompatibility(
-          blockDag: BlockDagRepresentation[F],
-          candidateMetadata: BlockMetadata,
-          targetBlockHash: BlockHash
-      ): F[Boolean] =
-        isInMainChain(blockDag, candidateMetadata, targetBlockHash)
+      CliqueOracle.normalizedFaultTolerance(
+        candidateBlockHash,
+        blockDag,
+        (h: BlockHash) => blockDag.lookupUnsafe(h).map(_.weightMap),
+        (h: BlockHash) => blockDag.lookupUnsafe(h).map(_.blockNum),
+        (v: Validator) => blockDag.latestMessageHashUnsafe(v),
+        blockDag.toCasperJustificationUnsafe,
+        blockDag.getCasperJustificationsUnsafe
+      )
     }
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/SafetyOracle.scala
@@ -1,26 +1,14 @@
 package coop.rchain.casper
 
-import cats.Monad
+import cats.effect.Concurrent
 import cats.syntax.all._
-import cats.instances.list._
-import coop.rchain.catscontrib._
-import Catscontrib._
-import cats.data.OptionT
-import cats.effect.{Concurrent, Sync}
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
-import coop.rchain.blockstorage.syntax._
-import coop.rchain.casper.protocol.Justification
 import coop.rchain.casper.safety.CliqueOracle
-import coop.rchain.casper.safety.CliqueOracle.normalizedFaultTolerance
-import coop.rchain.casper.util.ProtoUtil._
-import coop.rchain.casper.util.{Clique, ProtoUtil}
-import coop.rchain.dag.DagOps
-import coop.rchain.models.BlockMetadata
+import coop.rchain.casper.syntax._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
-import coop.rchain.shared.{Log, StreamT}
-import coop.rchain.casper.syntax._
+import coop.rchain.shared.Log
 
 /*
  * Implementation inspired by Ethereum's CBC casper simulator's clique oracle implementation.
@@ -70,7 +58,7 @@ sealed abstract class SafetyOracleInstances {
         candidateBlockHash: BlockHash
     ): F[Float] = {
       import coop.rchain.blockstorage.syntax._
-      import coop.rchain.models.BlockHash._
+      import coop.rchain.models.syntax._
 
       CliqueOracle.normalizedFaultTolerance(
         candidateBlockHash,

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -24,7 +24,8 @@ import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.graphz._
 import coop.rchain.metrics.{Metrics, Span}
-import coop.rchain.models.BlockHash.{BlockHash, _}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.syntax._
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.models.{BlockMetadata, Par}

--- a/casper/src/main/scala/coop/rchain/casper/blocks/merger/CasperMergingDagReader.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/merger/CasperMergingDagReader.scala
@@ -31,12 +31,12 @@ final class CasperMergingDagReader[F[_]: Concurrent: BlockStore](
           )
     }
 
-  override def parents(vertex: MergingVertex): F[Option[Set[MergingVertex]]] =
+  override def parents(vertex: MergingVertex): F[Option[Seq[MergingVertex]]] =
     hashDAGReader.parents(vertex.blockHash).flatMap {
-      case None => none[Set[MergingVertex]].pure[F]
+      case None => none[Seq[MergingVertex]].pure[F]
       case Some(children) =>
         BlockStore[F]
-          .getUnsafe(children.toSeq)
+          .getUnsafe(children)
           .compile
           .toList
           .map(
@@ -48,7 +48,7 @@ final class CasperMergingDagReader[F[_]: Concurrent: BlockStore](
                   b.body.state.preStateHash,
                   b.body.deploys.toSet
                 )
-            ).toSet.some
+            ).some
           )
     }
 }

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -23,6 +23,7 @@ package object casper {
       with AllSyntaxComm
       with AllSyntaxBlockStorage
       with RhoRuntimeSyntax
+      with BlockDagRepresentationSyntax
 }
 
 // Casper syntax

--- a/casper/src/main/scala/coop/rchain/casper/safety/CliqueOracle.scala
+++ b/casper/src/main/scala/coop/rchain/casper/safety/CliqueOracle.scala
@@ -1,0 +1,180 @@
+package coop.rchain.casper.safety
+
+import cats.Show
+import cats.data.OptionT
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.casper.util.{Clique, ProtoUtil}
+import coop.rchain.dag.{Casper, DagOps, DagReader}
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.shared.Log
+import coop.rchain.shared.syntax._
+import coop.rchain.metrics.implicits._
+import fs2.Stream
+
+import scala.reflect.ClassTag
+
+object CliqueOracle {
+  // map of validator id to stake bonded
+  type WeightMap[V] = Map[V, Long]
+
+  implicit val baseMetricsSource: Source = coop.rchain.casper.CasperMetricsSource
+
+  private def computeMaxCliqueWeight[F[_]: Concurrent: Span, M, V: ClassTag](
+      target: M,
+      dag: DagReader[F, M],
+      agreeingWeightMap: WeightMap[V],
+      agreeingLatestMessages: Map[V, M],
+      toJustificationF: M => F[Casper.Justification[M, V]],
+      justificationsF: M => F[Set[Casper.Justification[M, V]]],
+      heightF: M => F[Long]
+  )(implicit show: Show[M]): F[Long] = Span[F].traceI("compute-max-clique-weight") {
+
+    /**
+      * Prerequisite for this is that latest messages from a and b both are in main chain with target message
+      *
+      *     a    b
+      *     *    *  <- lmB
+      *      \   *
+      *       \  *
+      *        \ *
+      *         \*
+      *          *  <- lmAjB
+      *
+      * 1. get justification of validator b as per latest message of a (lmAjB)
+      * 2. check if any self justifications between latest message of b (lmB) and lmAjB are NOT in main chain
+      *    with target message. If one found - this is a source of disagreement.
+      * */
+    def neverEventuallySeeDisagreement(a: V, b: V): F[Boolean] = {
+      val noDisagreement = for {
+        // latest messages of validators matched
+        lmA <- OptionT.fromOption(agreeingLatestMessages.get(a))
+        lmB <- OptionT.fromOption(agreeingLatestMessages.get(b))
+        // message of `b` used as a justification by latest message of `a`
+        lmAjB <- OptionT(justificationsF(lmA).map(_.find(j => j.creator == b)))
+
+        disagreements = for {
+          // self justification of lmAjB or lmAjB itself. Used as a stopper for traversal
+          // TODO not completely clear why try to use self justification and not just message itself
+          stopper <- justificationsF(lmAjB.message).map(
+                      _.find(_.creator == lmAjB.creator)
+                        .getOrElse(lmAjB)
+                        .message
+                    )
+          selfJustificationsChain = DagOps
+            .bfTraverseF[F, M](List(lmB)) { jFromB =>
+              ProtoUtil
+                .getCreatorJustification(
+                  jFromB,
+                  (b: M) => b == stopper,
+                  toJustificationF,
+                  justificationsF
+                )
+                .map(_.map(List(_)).getOrElse(List.empty))
+            }
+          // find if any of traversed selfJustifications is NOT in main chain with target
+          r <- selfJustificationsChain
+                .filterF(dag.isInMainChain(_, target, heightF).not)
+                .flatMap(_.toList)
+        } yield r
+
+        r <- OptionT.liftF(disagreements.map(_.isEmpty))
+
+      } yield r
+
+      noDisagreement.getOrElse(false)
+    }
+
+    /** across combination of validators compute pairs that do not have disagreement */
+    def computeAgreeingValidatorPairs: F[List[(V, V)]] = {
+      val pairs = agreeingWeightMap.keys.toArray.combinations(2).map { case Array(a, b) => (a, b) }
+
+      Stream
+        .fromIterator(pairs)
+        .evalFilterAsyncProcBounded {
+          case (a, b) =>
+            neverEventuallySeeDisagreement(a, b) &&^ neverEventuallySeeDisagreement(b, a)
+        }
+        .compile
+        .toList
+    }
+
+    computeAgreeingValidatorPairs.map { edges =>
+      Clique.findMaximumCliqueByWeight[V](edges, agreeingWeightMap)
+    }
+  }
+
+  def normalizedFaultTolerance[F[_]: Concurrent: Log: Metrics: Span, M, V: ClassTag](
+      target: M,
+      dag: DagReader[F, M],
+      getWeightMapF: M => F[WeightMap[V]],
+      heightF: M => F[Long],
+      latestMessageF: V => F[M],
+      toJustificationF: M => F[Casper.Justification[M, V]],
+      getJustificationsF: M => F[Set[Casper.Justification[M, V]]]
+  )(implicit show: Show[M]): F[Float] = {
+    val nonExistingMessage =
+      Log[F].error(s"Fault tolerance for non existing message ${target.show} requested.").as(-1f)
+
+    val compute = for {
+      // weight map of main parent (fallbacks to message itself if no parents)
+      fullWeightMap <- {
+        dag
+          .mainParent(target)
+          .map {
+            case Some(mainParent) => mainParent
+            case None             => target
+          }
+      }.flatMap(getWeightMapF)
+      // stake that agrees on a target message
+      agreeingWeightMap <- fs2.Stream
+                            .emits(fullWeightMap.toList)
+                            .evalFilterAsyncProcBounded {
+                              case (validator, _) =>
+                                for {
+                                  lm <- latestMessageF(validator)
+                                  r <- dag.isInMainChain(
+                                        lm,
+                                        target,
+                                        heightF
+                                      )
+                                } yield r
+                            }
+                            .compile
+                            .toList
+                            .map(_.toMap)
+      agreeingStake = agreeingWeightMap.values.sum
+      // total stake
+      totalStake = fullWeightMap.values.sum
+      _ <- new ArithmeticException("Long overflow when computing total stake").raiseError
+            .whenA(totalStake < 0)
+      // latest messages of agreeing validators
+      agreeingLatestMessages <- agreeingWeightMap.keys.toList
+                                 .traverse { k =>
+                                   for {
+                                     lm <- latestMessageF(k)
+                                   } yield (k, lm)
+                                 }
+                                 .map(_.toMap)
+      r <- computeOutput[F, M, V](
+            target,
+            dag,
+            totalStake,
+            agreeingWeightMap,
+            agreeingLatestMessages,
+            toJustificationF,
+            getJustificationsF,
+            heightF
+          )
+    } yield r
+
+    dag
+      .contains(target)
+      .ifM(
+        Log[F].debug(s"Calculating fault tolerance for ${target.show}.") >>
+          Span[F].traceI("normalized-fault-tolerance")(compute),
+        nonExistingMessage
+      )
+  }
+}

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -19,6 +19,7 @@ import coop.rchain.dag.DagOps
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models._
+import coop.rchain.models.syntax._
 import coop.rchain.rholang.interpreter.DeployParameters
 import coop.rchain.shared.syntax._
 
@@ -35,7 +36,6 @@ object ProtoUtil {
       candidateMetadata: BlockMetadata,
       targetBlockHash: BlockHash
   ): F[Boolean] = {
-    import BlockHash._
     val heightF: BlockHash => F[Long] = h => dag.lookupUnsafe(h).map(_.blockNum)
     dag.isInMainChain(targetBlockHash, candidateMetadata.blockHash, heightF)
   }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/PreChargeDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/PreChargeDeploy.scala
@@ -12,7 +12,7 @@ final class PreChargeDeploy(chargeAmount: Long, pk: PublicKey, rand: Blake2b512R
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/RefundDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/RefundDeploy.scala
@@ -10,7 +10,7 @@ final class RefundDeploy(refundAmount: Long, rand: Blake2b512Random) extends Sys
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
@@ -13,11 +13,12 @@ final case class SlashDeploy(
     initialRand: Blake2b512Random
 ) extends SystemDeploy(initialRand) {
   import coop.rchain.models._
+  import coop.rchain.models.syntax._
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
   import record._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -11,7 +11,6 @@ import coop.rchain.casper.engine.EngineCell._
 import coop.rchain.casper.engine._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
 import coop.rchain.casper.protocol._
-import coop.rchain.casper.safety.CliqueOracle
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
@@ -24,6 +23,7 @@ import coop.rchain.shared.{Cell, Log}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import coop.rchain.models.syntax._
 
 import scala.collection.immutable.HashMap
 
@@ -76,7 +76,7 @@ class BlockQueryResponseAPITest
         effects                                  <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
         spanEff                                  = NoopSpan[Task]()
         (logEff, engineCell, cliqueOracleEffect) = effects
-        hash                                     = BlockHashOps(secondBlock.blockHash).base16String
+        hash                                     = secondBlock.blockHash.base16String
         blockQueryResponse <- BlockAPI.getBlock[Task](hash)(
                                Sync[Task],
                                engineCell,
@@ -92,11 +92,11 @@ class BlockQueryResponseAPITest
             )
             blockInfo.blockInfo match {
               case Some(b) =>
-                b.blockHash should be(BlockHashOps(secondBlock.blockHash).base16String)
-                b.sender should be(BlockHashOps(secondBlock.sender).base16String)
+                b.blockHash should be(secondBlock.blockHash.base16String)
+                b.sender should be(secondBlock.sender.base16String)
                 b.blockSize should be(secondBlock.toProto.serializedSize.toString)
                 b.seqNum should be(secondBlock.toProto.seqNum)
-                b.sig should be(BlockHashOps(secondBlock.sig).base16String)
+                b.sig should be(secondBlock.sig.base16String)
                 b.sigAlgorithm should be(secondBlock.sigAlgorithm)
                 b.shardId should be(secondBlock.toProto.shardId)
                 b.extraBytes should be(secondBlock.toProto.extraBytes)
@@ -104,14 +104,14 @@ class BlockQueryResponseAPITest
                 b.timestamp should be(secondBlock.header.timestamp)
                 b.headerExtraBytes should be(secondBlock.header.extraBytes)
                 b.parentsHashList should be(
-                  secondBlock.header.parentsHashList.map(BlockHashOps(_).base16String)
+                  secondBlock.header.parentsHashList.map(_.base16String)
                 )
                 b.blockNumber should be(secondBlock.body.state.blockNumber)
                 b.preStateHash should be(
-                  BlockHashOps(secondBlock.body.state.preStateHash).base16String
+                  secondBlock.body.state.preStateHash.base16String
                 )
                 b.postStateHash should be(
-                  BlockHashOps(secondBlock.body.state.postStateHash).base16String
+                  secondBlock.body.state.postStateHash.base16String
                 )
                 b.bodyExtraBytes should be(secondBlock.body.extraBytes)
                 b.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))
@@ -214,11 +214,11 @@ class BlockQueryResponseAPITest
                              )
         _ = inside(blockQueryResponse) {
           case Right(blockInfo) =>
-            blockInfo.blockHash should be(BlockHashOps(secondBlock.toProto.blockHash).base16String)
-            blockInfo.sender should be(BlockHashOps(secondBlock.toProto.sender).base16String)
+            blockInfo.blockHash should be(secondBlock.toProto.blockHash.base16String)
+            blockInfo.sender should be(secondBlock.toProto.sender.base16String)
             blockInfo.blockSize should be(secondBlock.toProto.serializedSize.toString)
             blockInfo.seqNum should be(secondBlock.toProto.seqNum)
-            blockInfo.sig should be(BlockHashOps(secondBlock.sig).base16String)
+            blockInfo.sig should be(secondBlock.sig.base16String)
             blockInfo.sigAlgorithm should be(secondBlock.sigAlgorithm)
             blockInfo.shardId should be(secondBlock.toProto.shardId)
             blockInfo.extraBytes should be(secondBlock.toProto.extraBytes)
@@ -226,14 +226,14 @@ class BlockQueryResponseAPITest
             blockInfo.timestamp should be(secondBlock.header.timestamp)
             blockInfo.headerExtraBytes should be(secondBlock.header.extraBytes)
             blockInfo.parentsHashList should be(
-              secondBlock.header.parentsHashList.map(BlockHashOps(_).base16String)
+              secondBlock.header.parentsHashList.map(_.base16String)
             )
             blockInfo.blockNumber should be(secondBlock.body.state.blockNumber)
             blockInfo.preStateHash should be(
-              BlockHashOps(secondBlock.body.state.preStateHash).base16String
+              secondBlock.body.state.preStateHash.base16String
             )
             blockInfo.postStateHash should be(
-              BlockHashOps(secondBlock.body.state.postStateHash).base16String
+              secondBlock.body.state.postStateHash.base16String
             )
             blockInfo.bodyExtraBytes should be(secondBlock.body.extraBytes)
             blockInfo.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.api
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Concurrent, Resource, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
@@ -286,7 +286,7 @@ class BlockQueryResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metricsEff, spanEff)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metricsEff, spanEff)
       } yield (logEff, engineCell, cliqueOracleEffect)
     }
 
@@ -307,7 +307,7 @@ class BlockQueryResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metricsEff, spanEff)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metricsEff, spanEff)
       } yield (logEff, engineCell, cliqueOracleEffect)
     }
 }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -11,6 +11,7 @@ import coop.rchain.casper.engine.EngineCell._
 import coop.rchain.casper.engine._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.safety.CliqueOracle
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
@@ -63,7 +64,7 @@ class BlockQueryResponseAPITest
       setBonds = List(bondsValidator).some
     )
 
-  val faultTolerance = -1f
+  val faultTolerance = SafetyOracle.MIN_FAULT_TOLERANCE
 
   val deployCostList: List[String] = randomDeploys.map(PrettyPrinter.buildString)
 

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -59,10 +59,11 @@ class BlockQueryResponseAPITest
       setValidator = sender.some,
       setDeploys = randomDeploys.some,
       setJustifications = List(Justification(bondsValidator.validator, genesisBlock.blockHash)).some,
+      setParentsHashList = List(genesisBlock.blockHash).some,
       setBonds = List(bondsValidator).some
     )
 
-  val faultTolerance = 1f
+  val faultTolerance = -1f
 
   val deployCostList: List[String] = randomDeploys.map(PrettyPrinter.buildString)
 

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.api
 
 import scala.collection.immutable.HashMap
-import cats.effect.{Resource, Sync}
+import cats.effect.{Concurrent, Resource, Sync}
 import coop.rchain.casper._
 import coop.rchain.casper.engine._
 import EngineCell._
@@ -113,7 +113,7 @@ class BlocksResponseAPITest
           engine     = new EngineWithCasper[Task](casperEffect)
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.showMainChain[Task](10, maxBlockLimit)(
                              Sync[Task],
                              engineCell,
@@ -141,7 +141,7 @@ class BlocksResponseAPITest
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           logEff     = new LogStub[Task]
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.getBlocks[Task](10, maxBlockLimit)(
                              Sync[Task],
                              engineCell,
@@ -168,7 +168,7 @@ class BlocksResponseAPITest
         engine     = new EngineWithCasper[Task](casperEffect)
         engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
         cliqueOracleEffect = SafetyOracle
-          .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+          .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
         blocksResponse <- BlockAPI.getBlocks[Task](2, maxBlockLimit)(
                            Sync[Task],
                            engineCell,
@@ -196,7 +196,7 @@ class BlocksResponseAPITest
           engine     = new EngineWithCasper[Task](casperEffect)
           engineCell <- Cell.mvarCell[Task, Engine[Task]](engine)
           cliqueOracleEffect = SafetyOracle
-            .cliqueOracle[Task](Sync[Task], logEff, metrics, span)
+            .cliqueOracle[Task](Concurrent[Task], logEff, metrics, span)
           blocksResponse <- BlockAPI.getBlocksByHeights[Task](2, 5, maxBlockLimit)(
                              Sync[Task],
                              engineCell,

--- a/casper/src/test/scala/coop/rchain/casper/batch1/StateMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/StateMergerSpec.scala
@@ -153,7 +153,7 @@ class StateMergerSpec extends FlatSpec with Matchers with Inspectors with Mergea
             lfbNode   = MergingNode(baseIndex, isFinalized = true, baseCheckpoint.root)
 
             childMap   = ListMap(lfbNode -> Set(rightNode, leftNode))
-            parentsMap = ListMap(rightNode -> Set(lfbNode), leftNode -> Set(lfbNode))
+            parentsMap = ListMap(rightNode -> Seq(lfbNode), leftNode -> Seq(lfbNode))
             dag        = new InMemDAG[Task, MergingNode](childMap, parentsMap)
 
             mergedState <- DagMerger.merge[Task, MergingNode](

--- a/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/CliqueOracleTest.scala
@@ -46,6 +46,18 @@ class CliqueOracleTest
     )
 
   // See [[/docs/casper/images/cbc-casper_ping_pong_diagram.png]]
+  /**
+    *       *     b8
+    *       |
+    *   *   *     b6 b7
+    *   | /
+    *   *   *     b4 b5
+    *   | /
+    *   *   *     b2 b3
+    *    \ /
+    *     *
+    *   c2 c1
+    */
   it should "detect finality as appropriate" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       val v1     = generateValidator("Validator One")

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -146,7 +146,7 @@ object Resources {
 
       override def children(vertex: BlockHash): F[Option[Set[BlockHash]]] = ???
 
-      override def parents(vertex: BlockHash): F[Option[Set[BlockHash]]] = ???
+      override def parents(vertex: BlockHash): F[Option[Seq[BlockHash]]] = ???
     }
     CasperSnapshot[F](
       dummyRepresentation,

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,22 +1,9 @@
 package coop.rchain.models
 
-import cats.Show
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.codec.Base16
 
 object BlockHash {
   type BlockHash = ByteString
 
   val Length = 32
-  implicit class BlockHashOps(bs: BlockHash) {
-    def base16String: String = Base16.encode(bs.toByteArray)
-  }
-
-  implicit def ordering: Ordering[BlockHash] =
-    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
-
-  implicit val show = new Show[BlockHash] {
-    def show(blockHash: BlockHash): String =
-      Base16.encode(blockHash.toByteArray).take(10)
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,5 +1,6 @@
 package coop.rchain.models
 
+import cats.Show
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.codec.Base16
 
@@ -9,5 +10,13 @@ object BlockHash {
   val Length = 32
   implicit class BlockHashOps(bs: BlockHash) {
     def base16String: String = Base16.encode(bs.toByteArray)
+  }
+
+  implicit def ordering: Ordering[BlockHash] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[BlockHash] {
+    def show(blockHash: BlockHash): String =
+      Base16.encode(blockHash.toByteArray).take(10)
   }
 }

--- a/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
+++ b/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
@@ -1,0 +1,24 @@
+package coop.rchain.models
+
+import cats.Show
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.codec.Base16
+
+trait ByteStringSyntax {
+  implicit final def modelsSyntaxByteString(bs: ByteString): ByteStringOps =
+    new ByteStringOps(bs)
+
+  implicit def ordering: Ordering[ByteString] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[ByteString] {
+    def show(validator: ByteString): String = validator.base16String
+  }
+}
+
+final class ByteStringOps(
+    // ByteString extensions / syntax
+    private val bs: ByteString
+) extends AnyVal {
+  def base16String: String = Base16.encode(bs.toByteArray)
+}

--- a/models/src/main/scala/coop/rchain/models/Validator.scala
+++ b/models/src/main/scala/coop/rchain/models/Validator.scala
@@ -1,9 +1,19 @@
 package coop.rchain.models
 
+import cats.Show
 import com.google.protobuf.ByteString
+import coop.rchain.crypto.codec.Base16
 
 object Validator {
   type Validator = ByteString
 
   val Length = 65
+
+  implicit def ordering: Ordering[Validator] =
+    Ordering.by((b: Validator) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[Validator] {
+    def show(validator: Validator): String =
+      Base16.encode(validator.toByteArray).take(10)
+  }
 }

--- a/models/src/main/scala/coop/rchain/models/Validator.scala
+++ b/models/src/main/scala/coop/rchain/models/Validator.scala
@@ -1,19 +1,9 @@
 package coop.rchain.models
 
-import cats.Show
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.codec.Base16
 
 object Validator {
   type Validator = ByteString
 
   val Length = 65
-
-  implicit def ordering: Ordering[Validator] =
-    Ordering.by((b: Validator) => b.toByteArray.toIterable)
-
-  implicit val show = new Show[Validator] {
-    def show(validator: Validator): String =
-      Base16.encode(validator.toByteArray).take(10)
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/block/StateHash.scala
+++ b/models/src/main/scala/coop/rchain/models/block/StateHash.scala
@@ -1,22 +1,9 @@
 package coop.rchain.models.block
 
-import cats.Show
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.codec.Base16
 
 object StateHash {
   type StateHash = ByteString
 
   val Length = 32
-  implicit class StateHashOps(bs: StateHash) {
-    def base16String: String = Base16.encode(bs.toByteArray)
-  }
-
-  implicit def ordering: Ordering[StateHash] =
-    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
-
-  implicit val show = new Show[StateHash] {
-    def show(validator: StateHash): String =
-      Base16.encode(validator.toByteArray).take(10)
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/block/StateHash.scala
+++ b/models/src/main/scala/coop/rchain/models/block/StateHash.scala
@@ -1,5 +1,6 @@
 package coop.rchain.models.block
 
+import cats.Show
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.codec.Base16
 
@@ -9,5 +10,13 @@ object StateHash {
   val Length = 32
   implicit class StateHashOps(bs: StateHash) {
     def base16String: String = Base16.encode(bs.toByteArray)
+  }
+
+  implicit def ordering: Ordering[StateHash] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[StateHash] {
+    def show(validator: StateHash): String =
+      Base16.encode(validator.toByteArray).take(10)
   }
 }

--- a/models/src/main/scala/coop/rchain/models/package.scala
+++ b/models/src/main/scala/coop/rchain/models/package.scala
@@ -1,0 +1,11 @@
+package coop.rchain
+
+import coop.rchain.models.ByteStringSyntax
+
+package object models {
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxModels
+}
+
+// Models syntax
+trait AllSyntaxModels extends ByteStringSyntax

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -35,7 +35,7 @@ object blockImplicits {
   val bondGen: Gen[Bond] = for {
     byteArray <- listOfN(Validator.Length, arbitrary[Byte])
     validator = ByteString.copyFrom(byteArray.toArray)
-    stake     <- arbitrary[Long]
+    stake     <- Gen.chooseNum(1L, 1024L)
   } yield Bond(validator, stake)
 
   val justificationGen: Gen[Justification] = for {

--- a/node/src/main/scala/coop/rchain/node/web/ReportingRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/ReportingRoutes.scala
@@ -18,6 +18,7 @@ import org.http4s.{HttpRoutes, QueryParamDecoder}
 import coop.rchain.rspace.ReportingTransformer
 import coop.rchain.rholang.interpreter.{PrettyPrinter => RhoPrinter}
 import org.http4s.circe.jsonEncoderOf
+import coop.rchain.models.syntax._
 
 object ReportingRoutes {
 

--- a/shared/src/main/scala/coop/rchain/dag/Casper.scala
+++ b/shared/src/main/scala/coop/rchain/dag/Casper.scala
@@ -1,5 +1,0 @@
-package coop.rchain.dag
-
-object Casper {
-  final case class Justification[M, V](message: M, creator: V)
-}

--- a/shared/src/main/scala/coop/rchain/dag/Casper.scala
+++ b/shared/src/main/scala/coop/rchain/dag/Casper.scala
@@ -1,0 +1,5 @@
+package coop.rchain.dag
+
+object Casper {
+  final case class Justification[M, V](message: M, creator: V)
+}

--- a/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
@@ -19,13 +19,9 @@ final class DagReaderOps[F[_], A](
 
   def parentsUnsafe(item: A)(
       implicit sync: Sync[F],
-      line: sourcecode.Line,
-      file: sourcecode.File,
-      enclosing: sourcecode.Enclosing,
       show: Show[A]
   ): F[Seq[A]] = {
-    def source = s"${file.value}:${line.value} ${enclosing.value}"
-    def errMsg = s"Parents lookup failed: DAG is missing ${item.show}\n at $source"
+    def errMsg = s"Parents lookup failed: DAG is missing ${item.show}"
     dag.parents(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
   }
 
@@ -37,13 +33,9 @@ final class DagReaderOps[F[_], A](
 
   def mainParentUnsafe(item: A)(
       implicit sync: Sync[F],
-      line: sourcecode.Line,
-      file: sourcecode.File,
-      enclosing: sourcecode.Enclosing,
       show: Show[A]
   ): F[A] = {
-    def source = s"${file.value}:${line.value} ${enclosing.value}"
-    def errMsg = s"Unsafe call for parents for block with no parents: ${item.show}\n at $source"
+    def errMsg = s"Unsafe call for parents for block with no parents: ${item.show}"
     mainParent(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
   }
 

--- a/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
@@ -1,0 +1,67 @@
+package coop.rchain.dag
+
+import cats.Show
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.dag.DagOps.bfTraverseF
+import coop.rchain.shared.syntax._
+import fs2.Stream
+
+trait DagReaderSyntax {
+  implicit final def syntaxDagReader[F[_], A](
+      dag: DagReader[F, A]
+  ): DagReaderOps[F, A] = new DagReaderOps[F, A](dag)
+}
+
+final class DagReaderOps[F[_], A](
+    private val dag: DagReader[F, A]
+) extends AnyVal {
+
+  def parentsUnsafe(item: A)(
+      implicit sync: Sync[F],
+      line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      show: Show[A]
+  ): F[Seq[A]] = {
+    def source = s"${file.value}:${line.value} ${enclosing.value}"
+    def errMsg = s"Parents lookup failed: DAG is missing ${item.show}\n at $source"
+    dag.parents(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
+  }
+
+  def contains(item: A)(implicit sync: Sync[F]): F[Boolean] =
+    dag.parents(item).map(_.isDefined) ||^ dag.children(item).map(_.isDefined)
+
+  def mainParent(item: A)(implicit sync: Sync[F]): F[Option[A]] =
+    dag.parents(item).map(_.flatMap(_.headOption))
+
+  def mainParentUnsafe(item: A)(
+      implicit sync: Sync[F],
+      line: sourcecode.Line,
+      file: sourcecode.File,
+      enclosing: sourcecode.Enclosing,
+      show: Show[A]
+  ): F[A] = {
+    def source = s"${file.value}:${line.value} ${enclosing.value}"
+    def errMsg = s"Unsafe call for parents for block with no parents: ${item.show}\n at $source"
+    mainParent(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
+  }
+
+  def isInMainChain(
+      descendant: A,
+      ancestor: A,
+      height: A => F[Long]
+  )(implicit sync: Sync[F], show: Show[A]): F[Boolean] =
+    descendant.tailRecM { d =>
+      if (d == ancestor) true.asRight[A].pure[F]
+      else
+        for {
+          dHeight <- height(d)
+          aHeight <- height(ancestor)
+          r <- if (dHeight <= aHeight)
+                false.asRight[A].pure[F]
+              else
+                mainParentUnsafe(d).map(_.asLeft[Boolean])
+        } yield r
+    }
+}

--- a/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/dag/DagReaderSyntax.scala
@@ -1,11 +1,9 @@
 package coop.rchain.dag
 
-import cats.Show
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Sync
 import cats.syntax.all._
-import coop.rchain.dag.DagOps.bfTraverseF
+import cats.{Monad, Show}
 import coop.rchain.shared.syntax._
-import fs2.Stream
 
 trait DagReaderSyntax {
   implicit final def syntaxDagReader[F[_], A](
@@ -25,10 +23,10 @@ final class DagReaderOps[F[_], A](
     dag.parents(item) >>= (_.liftTo(DagReader.VertexDoesNotExist(errMsg)))
   }
 
-  def contains(item: A)(implicit sync: Sync[F]): F[Boolean] =
+  def contains(item: A)(implicit monad: Monad[F]): F[Boolean] =
     dag.parents(item).map(_.isDefined) ||^ dag.children(item).map(_.isDefined)
 
-  def mainParent(item: A)(implicit sync: Sync[F]): F[Option[A]] =
+  def mainParent(item: A)(implicit monad: Monad[F]): F[Option[A]] =
     dag.parents(item).map(_.flatMap(_.headOption))
 
   def mainParentUnsafe(item: A)(

--- a/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
@@ -84,4 +84,10 @@ class Fs2StreamOps[F[_], A](
     */
   def parEvalMapUnorderedProcBounded[F2[x] >: F[x]: Concurrent, B](f: A => F2[B]): Stream[F2, B] =
     stream.parEvalMapUnordered[F2, B](availableProcessors)(f)
+
+  /**
+    * Variant of [[Stream.evalFilterAsync]] with parallelism bound to number of processors.
+    */
+  def evalFilterAsyncProcBounded[F2[x] >: F[x]: Concurrent, B](f: A => F2[Boolean]): Stream[F2, A] =
+    stream.evalFilterAsync[F2](availableProcessors)(f)
 }

--- a/shared/src/main/scala/coop/rchain/shared/package.scala
+++ b/shared/src/main/scala/coop/rchain/shared/package.scala
@@ -1,6 +1,8 @@
 package coop.rchain
 
+import coop.rchain.dag.DagReaderSyntax
 import coop.rchain.fs2.Fs2StreamSyntax
+import coop.rchain.metrics.MetricsSyntax
 import coop.rchain.monix.MonixableSyntax
 import coop.rchain.store.{KeyValueStoreManagerSyntax, KeyValueStoreSyntax, KeyValueTypedStoreSyntax}
 
@@ -18,3 +20,5 @@ trait AllSyntaxShared
     with KeyValueStoreManagerSyntax
     with MonixableSyntax
     with Fs2StreamSyntax
+    with catscontrib.ToBooleanF
+    with DagReaderSyntax


### PR DESCRIPTION
This is straight replacement for <https://github.com/rchain/rchain/pull/3379> as it has been closed  by bors and base `block-merge` branch has been deleted, so PR cannot be reopened.

This PR is an effort to refactor clique oracle to enable new finalizer. 

New clique oracle is a drop-in replacement for old one written in abstract way. Main purpose is to have clear code and path towards new finalizer. No test are changed (except one) which should give confidence about correct implementation.

The next step is #3366 which should use only `computeOutput` public function from new oracle.