### PR TITLE
Re-enable shutdown hook

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/discovery/package.scala
+++ b/comm/src/main/scala/coop/rchain/comm/discovery/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain.comm
 
-import cats.effect.Sync
+import cats.effect.Concurrent
 import com.google.protobuf.ByteString
 import coop.rchain.grpc.{GrpcServer, Server}
 import coop.rchain.metrics.Metrics
@@ -12,12 +12,12 @@ package object discovery {
   val DiscoveryMetricsSource: Metrics.Source =
     Metrics.Source(CommMetricsSource, "discovery.kademlia")
 
-  def acquireKademliaRPCServer[F[_]: Monixable: Sync](
+  def acquireKademliaRPCServer[F[_]: Monixable: Concurrent](
       networkId: String,
       port: Int,
       pingHandler: PeerNode => F[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => F[Seq[PeerNode]]
-  )(implicit scheduler: Scheduler): F[Server[F]] =
+  )(implicit scheduler: Scheduler): Server[F] =
     GrpcServer[F](
       NettyServerBuilder
         .forPort(port)

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportServer.scala
@@ -1,11 +1,7 @@
 package coop.rchain.comm.transport
 
-import java.io.ByteArrayInputStream
-import java.nio.file.Path
-import java.util.concurrent.atomic.AtomicReference
-
 import cats.effect.concurrent.{Deferred, Ref}
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Concurrent, ExitCode, Resource, Sync}
 import cats.syntax.all._
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.comm.protocol.routing.Protocol
@@ -20,6 +16,9 @@ import io.grpc.netty.GrpcSslContexts
 import io.netty.handler.ssl._
 import monix.execution.{Cancelable, Scheduler}
 
+import java.io.ByteArrayInputStream
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
 import scala.collection.concurrent.TrieMap
 import scala.io.Source
 import scala.util.{Left, Right}

--- a/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
@@ -13,6 +13,7 @@ import coop.rchain.shared.Log
 
 import monix.eval.Task
 import monix.execution.Scheduler
+import cats.syntax.all._
 
 class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
 
@@ -47,7 +48,8 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
       env: GrpcEnvironment,
       pingHandler: PeerNode => Task[Unit],
       lookupHandler: (PeerNode, Array[Byte]) => Task[Seq[PeerNode]]
-  ): Task[Server[Task]] = acquireKademliaRPCServer(networkId, env.port, pingHandler, lookupHandler)
+  ): Task[Server[Task]] =
+    acquireKademliaRPCServer(networkId, env.port, pingHandler, lookupHandler).pure[Task]
 }
 
 case class GrpcEnvironment(

--- a/node/src/main/scala/coop/rchain/node/api/package.scala
+++ b/node/src/main/scala/coop/rchain/node/api/package.scala
@@ -2,7 +2,7 @@ package coop.rchain.node
 
 import java.net.InetSocketAddress
 
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Concurrent
 import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
 import coop.rchain.casper.protocol.propose.v1.ProposeServiceV1GrpcMonix
 import coop.rchain.grpc.{GrpcServer, Server}
@@ -16,7 +16,7 @@ import scala.concurrent.duration.FiniteDuration
 
 package object api {
 
-  def acquireInternalServer[F[_]: Sync](
+  def acquireInternalServer[F[_]: Concurrent](
       host: String,
       port: Int,
       grpcExecutor: Scheduler,
@@ -30,7 +30,7 @@ package object api {
       maxConnectionIdle: FiniteDuration,
       maxConnectionAge: FiniteDuration,
       maxConnectionAgeGrace: FiniteDuration
-  ): F[Server[F]] =
+  ): Server[F] =
     GrpcServer[F](
       NettyServerBuilder
         .forAddress(new InetSocketAddress(host, port))
@@ -70,7 +70,7 @@ package object api {
       maxConnectionIdle: FiniteDuration,
       maxConnectionAge: FiniteDuration,
       maxConnectionAgeGrace: FiniteDuration
-  ): F[Server[F]] =
+  ): Server[F] =
     GrpcServer[F](
       NettyServerBuilder
         .forAddress(new InetSocketAddress(host, port))

--- a/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/fs2/Fs2StreamSyntax.scala
@@ -1,10 +1,11 @@
 package coop.rchain.fs2
 
-import cats.effect.Concurrent
+import cats.effect.{Concurrent, ExitCode}
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import coop.rchain.shared.Time
 import fs2.Stream
+import fs2.concurrent.SignallingRef
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{DurationInt, FiniteDuration}

--- a/shared/src/main/scala/coop/rchain/grpc/GrpcServer.scala
+++ b/shared/src/main/scala/coop/rchain/grpc/GrpcServer.scala
@@ -1,11 +1,13 @@
 package coop.rchain.grpc
 
+import cats.effect.concurrent.Ref
+
 import java.util.concurrent.TimeUnit
-
-import cats.effect.Sync
+import cats.effect.{Concurrent, ExitCode, Resource, Sync}
 import cats.syntax.all._
-
+import fs2.Stream
 import coop.rchain.catscontrib.ski.kp
+import fs2.concurrent.{Signal, SignallingRef}
 
 trait Server[F[_]] {
   def start: F[Unit]
@@ -13,7 +15,7 @@ trait Server[F[_]] {
   def port: Int
 }
 
-class GrpcServer[F[_]: Sync](server: io.grpc.Server) extends Server[F] {
+class GrpcServer[F[_]: Concurrent](server: io.grpc.Server) extends Server[F] {
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def start: F[Unit] = Sync[F].delay(server.start())
 
@@ -34,6 +36,6 @@ class GrpcServer[F[_]: Sync](server: io.grpc.Server) extends Server[F] {
 }
 
 object GrpcServer {
-  def apply[F[_]: Sync](server: io.grpc.Server): F[Server[F]] =
-    Sync[F].delay(new GrpcServer[F](server))
+  def apply[F[_]: Concurrent](server: io.grpc.Server): Server[F] =
+    new GrpcServer[F](server)
 }


### PR DESCRIPTION
In https://github.com/rchain/rchain/commit/deff62b18fa82bb85079fee28389c3179f0ee81e when splitting Runtime into smaller pieces shutdown hook has been disabled. This PR enables it back.
What should be cleaned up is 1) store manager, 2) deploy storage, as it is still outside of store manager 3) Kamon reporters. 4) API servers 5) block store