### PR TITLE
Add to log duration of block creation and replay

### DIFF
--- a/shared/src/main/scala/coop/rchain/shared/Stopwatch.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Stopwatch.scala
@@ -17,6 +17,14 @@ object Stopwatch {
       _  <- log(s"$tag [${showTime(m)}]")
     } yield a
 
+  def duration[F[_]: Sync, A](block: => F[A]): F[(A, String)] =
+    for {
+      t0 <- Sync[F].delay(System.nanoTime)
+      a  <- block
+      t1 = System.nanoTime
+      m  = Duration.fromNanos(t1 - t0)
+    } yield (a, showTime(m))
+
   def showTime(d: FiniteDuration): String = {
     val ns   = 1d
     val ms   = 1e6 * ns


### PR DESCRIPTION
## Overview
This PR adds additional log messages for the measured duration of block creation and replay.

```accesslog
18:20:32.944 [INFO] [node-runner-31] [c.r.c.b.p.BlockCreator$    ] - Block created: #5 (c77aaf817b...) [3.181517271 sec]
...
18:20:35.779 [INFO] [node-runner-57] [c.r.c.MultiParentCasperImpl] - Block replayed: #5 (c77aaf817b...) (Valid) [2.834514364 sec]
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
