### PR TITLE
Print approved block when node starts

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -100,9 +100,10 @@ object Engine {
       validatorId: Option[ValidatorIdentity],
       init: F[Unit],
       disableStateExporter: Boolean
-  ): F[Unit] =
+  ): F[Unit] = {
+    val approvedBlockInfo = PrettyPrinter.buildString(approvedBlock.candidate.block, short = true)
     for {
-      _ <- Log[F].info("Making a transition to Running state.")
+      _ <- Log[F].info(s"Making a transition to Running state. Approved $approvedBlockInfo")
       _ <- EventLog[F].publish(
             shared.Event.EnteredRunningState(
               PrettyPrinter.buildStringNoLimit(approvedBlock.candidate.block.blockHash)
@@ -120,6 +121,7 @@ object Engine {
       _ <- EngineCell[F].set(running)
 
     } yield ()
+  }
 
   // format: off
   def transitionToInitializing[F[_]


### PR DESCRIPTION
## Overview
This PR adds approved block info to log message when node starts.

```
20:15:49.494 [INFO] [node-runner-57] [c.r.casper.engine.Engine$] - Making a transition to Running state. Approved Block #123 (aa5d0837b9...)
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
