### PR TITLE
Print user deploy errors to log (play/replay/reporting)

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -305,8 +305,9 @@ class MultiParentCasperImpl[F[_]: Sync: Concurrent: Log: Time: SafetyOracle: Las
       (valResult, elapsed) = r
       _ <- valResult
             .map { status =>
-              val blockInfo = PrettyPrinter.buildString(b, short = true)
-              Log[F].info(s"Block replayed: $blockInfo ($status) [$elapsed]")
+              val blockInfo   = PrettyPrinter.buildString(b, short = true)
+              val deployCount = b.body.deploys.size
+              Log[F].info(s"Block replayed: $blockInfo (${deployCount}d) ($status) [$elapsed]")
             }
             .getOrElse(().pure[F])
     } yield valResult

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -164,8 +164,9 @@ object BlockCreator {
         (blockStatus, elapsed) = r
         _ <- blockStatus match {
               case Created(block) =>
-                val blockInfo = PrettyPrinter.buildString(block, short = true)
-                Log[F].info(s"Block created: $blockInfo [$elapsed]")
+                val blockInfo   = PrettyPrinter.buildString(block, short = true)
+                val deployCount = block.body.deploys.size
+                Log[F].info(s"Block created: $blockInfo (${deployCount}d) [$elapsed]")
               case _ => ().pure[F]
             }
       } yield blockStatus

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -28,6 +28,7 @@ import coop.rchain.casper.blocks.merger.{
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.rholang.interpreter.compiler.ParBuilder
+import coop.rchain.rholang.interpreter.errors.InterpreterError
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.store.{KeyValueCache, LazyAdHocKeyValueCache, NoOpKeyValueCache}
 import monix.eval.Coeval
@@ -191,6 +192,18 @@ object InterpreterUtil {
             .as(none[StateHash].asRight[BlockError])
         }
     }
+
+  /**
+    * Temporary solution to print user deploy errors to Log so we can have
+    * at least some way to debug user errors.
+    */
+  def printDeployErrors[F[_]: Sync: Log](
+      deploySig: ByteString,
+      errors: Seq[InterpreterError]
+  ): F[Unit] = Sync[F].defer {
+    val deployInfo = PrettyPrinter.buildStringSig(deploySig)
+    Log[F].info(s"Deploy ($deployInfo) errors: ${errors.mkString(", ")}")
+  }
 
   def computeDeploysCheckpoint[F[_]: Concurrent: BlockStore: Log: Metrics](
       parents: Seq[BlockMessage],


### PR DESCRIPTION
## Overview
This PR adds printing of user errors that can happen when node is processing deploys, in block creation (play), block replay and reporting.

Example of user error when number is expected instead of supplied string.
```
11:09:30.092 [INFO] [node-runner-50] [c.r.c.u.r.InterpreterUtil] - Deploy (3045022100c9e647f7d7...8e13bb92d48f825f9054) errors: coop.rchain.rholang.interpreter.errors$ReduceError: Unexpected compare: Expr(GString(wrong number)) vs. Expr(GInt(0))
```

Also it adds deploy count to existing log message for block creation and replay.

Example of deploy count message with 3 deploys.
```
11:16:03.494 [INFO] [node-runner-30] [c.r.c.b.p.BlockCreator] - Block created: #23 (38185f570f...) (3d) [4.567020221 sec]

11:16:07.630 [INFO] [node-runner-39] [c.r.c.MultiParentCasperImpl] - Block replayed: #23 (38185f570f...) (3d) (Valid) [4.135097106 sec]
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
