### PR TITLE
Send all tips on fork choice request

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -84,13 +84,6 @@ object MultiParentCasper extends MultiParentCasperInstances {
   def apply[F[_]](implicit instance: MultiParentCasper[F]): MultiParentCasper[F] = instance
   def ignoreDoppelgangerCheck[F[_]: Applicative]: (BlockMessage, Validator) => F[Unit] =
     kp2(().pure)
-
-  def forkChoiceTip[F[_]: Sync](casper: MultiParentCasper[F]): F[BlockHash] =
-    for {
-      dag       <- casper.blockDag
-      tipHashes <- casper.estimator(dag)
-      tipHash   = tipHashes.head
-    } yield tipHash
 }
 
 /**


### PR DESCRIPTION
Currently there is only one message that gives information on latest blocks that some node seen - fork choice tip request. It is just tip that is a fork choice, so there is no way to see all tips. 

In multi parent environment, when node misses some block, e.g. due to network issues - it has no way to request this block because all requests for other nodes to give the latest view return only one tip, which is most probably not hash that has been missed.
 
This PR suggests to send all tips as a response for fork choice tip request.