### PR TITLE
Syntax for bytestring based models

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -15,13 +15,13 @@ import coop.rchain.casper.util.ProtoUtil._
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.casper.util.rholang._
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
-import coop.rchain.catscontrib.BooleanF._
 import coop.rchain.catscontrib.Catscontrib.ToBooleanF
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.metrics.implicits._
 import coop.rchain.models.BlockHash._
 import coop.rchain.models.{BlockMetadata, EquivocationRecord, NormalizerEnv}
 import coop.rchain.models.Validator.Validator
+import coop.rchain.models.syntax._
 import coop.rchain.shared._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.deploy.DeployStorage

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -24,7 +24,8 @@ import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.graphz._
 import coop.rchain.metrics.{Metrics, Span}
-import coop.rchain.models.BlockHash.{BlockHash, _}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.syntax._
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits.mkProtobufInstance
 import coop.rchain.models.{BlockMetadata, Par}

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/PreChargeDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/PreChargeDeploy.scala
@@ -12,7 +12,7 @@ final class PreChargeDeploy(chargeAmount: Long, pk: PublicKey, rand: Blake2b512R
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/RefundDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/RefundDeploy.scala
@@ -10,7 +10,7 @@ final class RefundDeploy(refundAmount: Long, rand: Blake2b512Random) extends Sys
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/costacc/SlashDeploy.scala
@@ -13,11 +13,12 @@ final case class SlashDeploy(
     initialRand: Blake2b512Random
 ) extends SystemDeploy(initialRand) {
   import coop.rchain.models._
+  import coop.rchain.models.syntax._
   import Expr.ExprInstance._
   import rholang.{implicits => toPar}
   import shapeless._
   import record._
-  import syntax.singleton._
+  import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])
   type Result = Unit

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -23,6 +23,7 @@ import coop.rchain.shared.{Cell, Log}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import coop.rchain.models.syntax._
 
 import scala.collection.immutable.HashMap
 
@@ -74,7 +75,7 @@ class BlockQueryResponseAPITest
         effects                                  <- effectsForSimpleCasperSetup(blockStore, blockDagStorage)
         spanEff                                  = NoopSpan[Task]()
         (logEff, engineCell, cliqueOracleEffect) = effects
-        hash                                     = BlockHashOps(secondBlock.blockHash).base16String
+        hash                                     = secondBlock.blockHash.base16String
         blockQueryResponse <- BlockAPI.getBlock[Task](hash)(
                                Sync[Task],
                                engineCell,
@@ -90,11 +91,11 @@ class BlockQueryResponseAPITest
             )
             blockInfo.blockInfo match {
               case Some(b) =>
-                b.blockHash should be(BlockHashOps(secondBlock.blockHash).base16String)
-                b.sender should be(BlockHashOps(secondBlock.sender).base16String)
+                b.blockHash should be(secondBlock.blockHash.base16String)
+                b.sender should be(secondBlock.sender.base16String)
                 b.blockSize should be(secondBlock.toProto.serializedSize.toString)
                 b.seqNum should be(secondBlock.toProto.seqNum)
-                b.sig should be(BlockHashOps(secondBlock.sig).base16String)
+                b.sig should be(secondBlock.sig.base16String)
                 b.sigAlgorithm should be(secondBlock.sigAlgorithm)
                 b.shardId should be(secondBlock.toProto.shardId)
                 b.extraBytes should be(secondBlock.toProto.extraBytes)
@@ -102,14 +103,14 @@ class BlockQueryResponseAPITest
                 b.timestamp should be(secondBlock.header.timestamp)
                 b.headerExtraBytes should be(secondBlock.header.extraBytes)
                 b.parentsHashList should be(
-                  secondBlock.header.parentsHashList.map(BlockHashOps(_).base16String)
+                  secondBlock.header.parentsHashList.map(_.base16String)
                 )
                 b.blockNumber should be(secondBlock.body.state.blockNumber)
                 b.preStateHash should be(
-                  BlockHashOps(secondBlock.body.state.preStateHash).base16String
+                  secondBlock.body.state.preStateHash.base16String
                 )
                 b.postStateHash should be(
-                  BlockHashOps(secondBlock.body.state.postStateHash).base16String
+                  secondBlock.body.state.postStateHash.base16String
                 )
                 b.bodyExtraBytes should be(secondBlock.body.extraBytes)
                 b.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))
@@ -212,11 +213,11 @@ class BlockQueryResponseAPITest
                              )
         _ = inside(blockQueryResponse) {
           case Right(blockInfo) =>
-            blockInfo.blockHash should be(BlockHashOps(secondBlock.toProto.blockHash).base16String)
-            blockInfo.sender should be(BlockHashOps(secondBlock.toProto.sender).base16String)
+            blockInfo.blockHash should be(secondBlock.toProto.blockHash.base16String)
+            blockInfo.sender should be(secondBlock.toProto.sender.base16String)
             blockInfo.blockSize should be(secondBlock.toProto.serializedSize.toString)
             blockInfo.seqNum should be(secondBlock.toProto.seqNum)
-            blockInfo.sig should be(BlockHashOps(secondBlock.sig).base16String)
+            blockInfo.sig should be(secondBlock.sig.base16String)
             blockInfo.sigAlgorithm should be(secondBlock.sigAlgorithm)
             blockInfo.shardId should be(secondBlock.toProto.shardId)
             blockInfo.extraBytes should be(secondBlock.toProto.extraBytes)
@@ -224,14 +225,14 @@ class BlockQueryResponseAPITest
             blockInfo.timestamp should be(secondBlock.header.timestamp)
             blockInfo.headerExtraBytes should be(secondBlock.header.extraBytes)
             blockInfo.parentsHashList should be(
-              secondBlock.header.parentsHashList.map(BlockHashOps(_).base16String)
+              secondBlock.header.parentsHashList.map(_.base16String)
             )
             blockInfo.blockNumber should be(secondBlock.body.state.blockNumber)
             blockInfo.preStateHash should be(
-              BlockHashOps(secondBlock.body.state.preStateHash).base16String
+              secondBlock.body.state.preStateHash.base16String
             )
             blockInfo.postStateHash should be(
-              BlockHashOps(secondBlock.body.state.postStateHash).base16String
+              secondBlock.body.state.postStateHash.base16String
             )
             blockInfo.bodyExtraBytes should be(secondBlock.body.extraBytes)
             blockInfo.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))

--- a/models/src/main/scala/coop/rchain/models/BlockHash.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockHash.scala
@@ -1,13 +1,9 @@
 package coop.rchain.models
 
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.codec.Base16
 
 object BlockHash {
   type BlockHash = ByteString
 
   val Length = 32
-  implicit class BlockHashOps(bs: BlockHash) {
-    def base16String: String = Base16.encode(bs.toByteArray)
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
+++ b/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
@@ -1,0 +1,24 @@
+package coop.rchain.models
+
+import cats.Show
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.codec.Base16
+
+trait ByteStringSyntax {
+  implicit final def modelsSyntaxByteString(bs: ByteString): ByteStringOps =
+    new ByteStringOps(bs)
+
+  implicit def ordering: Ordering[ByteString] =
+    Ordering.by((b: ByteString) => b.toByteArray.toIterable)
+
+  implicit val show = new Show[ByteString] {
+    def show(validator: ByteString): String = validator.base16String
+  }
+}
+
+final class ByteStringOps(
+    // ByteString extensions / syntax
+    private val bs: ByteString
+) extends AnyVal {
+  def base16String: String = Base16.encode(bs.toByteArray)
+}

--- a/models/src/main/scala/coop/rchain/models/block/StateHash.scala
+++ b/models/src/main/scala/coop/rchain/models/block/StateHash.scala
@@ -1,13 +1,9 @@
 package coop.rchain.models.block
 
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.codec.Base16
 
 object StateHash {
   type StateHash = ByteString
 
   val Length = 32
-  implicit class StateHashOps(bs: StateHash) {
-    def base16String: String = Base16.encode(bs.toByteArray)
-  }
 }

--- a/models/src/main/scala/coop/rchain/models/package.scala
+++ b/models/src/main/scala/coop/rchain/models/package.scala
@@ -1,0 +1,11 @@
+package coop.rchain
+
+import coop.rchain.models.ByteStringSyntax
+
+package object models {
+  // Importing syntax object means using all extensions in the project
+  object syntax extends AllSyntaxModels
+}
+
+// Models syntax
+trait AllSyntaxModels extends ByteStringSyntax

--- a/node/src/main/scala/coop/rchain/node/web/ReportingRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/ReportingRoutes.scala
@@ -18,6 +18,7 @@ import org.http4s.{HttpRoutes, QueryParamDecoder}
 import coop.rchain.rspace.ReportingTransformer
 import coop.rchain.rholang.interpreter.{PrettyPrinter => RhoPrinter}
 import org.http4s.circe.jsonEncoderOf
+import coop.rchain.models.syntax._
 
 object ReportingRoutes {
 

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/instances/EventLogIndexConflictDetector.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/instances/EventLogIndexConflictDetector.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace.merger.instances
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import coop.rchain.catscontrib.Catscontrib._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.internal.Datum
 import coop.rchain.rspace.merger.EventLogIndex

--- a/shared/src/main/scala/coop/rchain/shared/package.scala
+++ b/shared/src/main/scala/coop/rchain/shared/package.scala
@@ -18,3 +18,4 @@ trait AllSyntaxShared
     with KeyValueStoreManagerSyntax
     with MonixableSyntax
     with Fs2StreamSyntax
+    with catscontrib.ToBooleanF


### PR DESCRIPTION
This PR unifies syntax for bytestring based models (Validator, StateHash, BlockHash). This is some work from deploymerge branch which belongs to dev.