### PR TITLE
Enable protocol client timeout

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
@@ -22,7 +22,7 @@ class RunningHandleHasBlockRequestSpec extends FunSpec with BeforeAndAfterEach w
 
   val local: PeerNode = peerNode("src", 40400)
   val networkId       = "nid"
-  val conf            = RPConf(local, networkId, null, null, 0, null)
+  val conf            = RPConf(local, networkId, None, 100, null)
 
   private def endpoint(port: Int): Endpoint = Endpoint("host", port, port)
   private def peerNode(name: String, port: Int): PeerNode =

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
@@ -52,7 +52,7 @@ class RunningHandleHasBlockSpec extends FunSpec with BeforeAndAfterEach with Mat
   val hb   = HasBlock(hash)
 
   val networkId = "nid"
-  val conf      = RPConf(local, networkId, null, null, 0, null)
+  val conf      = RPConf(local, networkId, None, 100, null)
 
   private def endpoint(port: Int): Endpoint = Endpoint("host", port, port)
   private def peerNode(name: String, port: Int): PeerNode =

--- a/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
@@ -52,7 +52,7 @@ class BlockRetrieverRequesAllSpec extends FunSpec with BeforeAndAfterEach with M
   implicit val blockRetriever = BlockRetriever.of[Task]
 
   val networkId = "nid"
-  val conf      = RPConf(local, networkId, null, null, 0, null)
+  val conf      = RPConf(local, networkId, None, 100, null)
 
   private def toBlockRequest(protocol: Protocol): BlockRequest =
     BlockRequest.from(convert[PacketTypeTag.BlockRequest.type](toPacket(protocol).right.get).get)

--- a/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/RPConf.scala
@@ -8,7 +8,6 @@ final case class RPConf(
     local: PeerNode,
     networkId: String,
     bootstrap: Option[PeerNode],
-    defaultTimeout: FiniteDuration,
     maxNumOfConnections: Int,
     clearConnections: ClearConnectionsConf
 )

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportClient.scala
@@ -44,12 +44,11 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
     maxMessageSize: Int,
     packetChunkSize: Int,
     clientQueueSize: Int,
+    networkTimeout: FiniteDuration = 5.seconds,
     channelsMap: Ref[F, Map[PeerNode, Deferred[F, BufferedGrpcStreamChannel[F]]]],
     ioScheduler: Scheduler
 )(implicit scheduler: Scheduler)
     extends TransportLayer[F] {
-
-  val DefaultSendTimeout: FiniteDuration = 5.seconds
 
   implicit val metricsSource: Metrics.Source =
     Metrics.Source(CommMetricsSource, "rp.transport")
@@ -138,7 +137,7 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
     } yield result).attempt.map(_.fold(e => Left(protocolException(e)), identity))
 
   def send(peer: PeerNode, msg: Protocol): F[CommErr[Unit]] =
-    withClient(peer, DefaultSendTimeout)(GrpcTransport.send(_, peer, msg))
+    withClient(peer, networkTimeout)(GrpcTransport.send(_, peer, msg))
 
   def broadcast(peers: Seq[PeerNode], msg: Protocol): F[Seq[CommErr[Unit]]] = {
     import cats.instances.list._
@@ -162,7 +161,7 @@ class GrpcTransportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
   ): F[Unit] = {
 
     def timeout(packet: Packet): FiniteDuration =
-      Math.max(packet.content.size().toLong * 5, DefaultSendTimeout.toMicros).micros
+      Math.max(packet.content.size().toLong * 5, networkTimeout.toMicros).micros
 
     PacketOps.restore[F](key, cache) >>= {
       case Right(packet) =>

--- a/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
@@ -140,7 +140,6 @@ class ClearConnectionsSpec
     new ConstApplicativeAsk(
       RPConf(
         clearConnections = ClearConnectionsConf(numOfConnectionsPinged),
-        defaultTimeout = 1.milli,
         local = peer("src"),
         networkId = networkId,
         bootstrap = None,

--- a/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
@@ -26,7 +26,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
   implicit val time              = new LogicalTime[Effect]
   implicit val metric            = new Metrics.MetricsNOP[Id]
   implicit val nodeDiscovery     = new NodeDiscoveryStub[Effect]()
-  implicit val rpConf            = conf(defaultTimeout = deftimeout)
+  implicit val rpConf            = conf()
 
   var willConnectSuccessfully       = List.empty[PeerNode]
   var connectCalled: List[PeerNode] = List.empty[PeerNode]
@@ -112,13 +112,11 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
 
   private def conf(
       maxNumOfConnections: Int = 5,
-      numOfConnectionsPinged: Int = 5,
-      defaultTimeout: FiniteDuration
+      numOfConnectionsPinged: Int = 5
   ): RPConfAsk[Id] =
     new ConstApplicativeAsk(
       RPConf(
         clearConnections = ClearConnectionsConf(numOfConnectionsPinged),
-        defaultTimeout = defaultTimeout,
         local = peer("src"),
         networkId = "test",
         bootstrap = None,

--- a/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TcpTransportLayerSpec.scala
@@ -34,6 +34,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
   val maxMessageSize: Int        = 256 * 1024
   val maxStreamMessageSize: Long = 1024 * 1024 * 200
 
+  import scala.concurrent.duration._
   def createTransportLayer(
       env: TcpTlsEnvironment
   ): Task[TransportLayer[Task]] =
@@ -45,6 +46,7 @@ class TcpTransportLayerSpec extends TransportLayerSpec[Task, TcpTlsEnvironment] 
         maxMessageSize,
         maxMessageSize,
         100,
+        5.seconds,
         Ref.unsafe[Task, Map[PeerNode, Deferred[Task, BufferedGrpcStreamChannel[Task]]]](Map.empty),
         scheduler
       )

--- a/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/EffectsTestInstances.scala
@@ -56,7 +56,7 @@ object EffectsTestInstances {
       clearConnections: ClearConnectionsConf = ClearConnectionsConf(1)
   ) =
     new ConstApplicativeAsk[F, RPConf](
-      RPConf(local, networkId, Some(local), defaultTimeout, 20, clearConnections)
+      RPConf(local, networkId, Some(local), 20, clearConnections)
     )
 
   class TransportLayerStub[F[_]: Sync: Applicative] extends TransportLayer[F] {

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -57,6 +57,7 @@ package object effects {
       keyPath: Path,
       maxMessageSize: Int,
       packetChunkSize: Int,
+      networkTimeout: FiniteDuration,
       ioScheduler: Scheduler
   )(implicit scheduler: Scheduler): F[TransportLayer[F]] =
     Ref.of[F, Map[PeerNode, Deferred[F, BufferedGrpcStreamChannel[F]]]](Map()) map { channels =>
@@ -69,6 +70,7 @@ package object effects {
         maxMessageSize,
         packetChunkSize,
         clientQueueSize = 100,
+        networkTimeout,
         channels,
         ioScheduler
       ): TransportLayer[F]

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -99,6 +99,7 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
             nodeConf.tls.keyPath,
             nodeConf.protocolClient.grpcMaxRecvMessageSize.toInt,
             nodeConf.protocolClient.grpcStreamChunkSize.toInt,
+            nodeConf.protocolClient.networkTimeout,
             grpcScheduler
           )
       }
@@ -237,7 +238,6 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
       local,
       nodeConf.protocolClient.networkId,
       bootstrapNode,
-      nodeConf.protocolClient.networkTimeout,
       nodeConf.protocolClient.batchMaxConnections,
       ClearConnectionsConf(nodeConf.peersDiscovery.heartbeatBatchSize)
     )


### PR DESCRIPTION
Current configuration contains timeout for protocol client, but it is used not in client instantiated but in kademlia client and RPConf class. 

This PR removes field from RPConf as it is not used anywhere and adds timeout to GrpcTransportClient constructor. So both kademlia client and protocol client share the same timeout variable.