### PR TITLE
Enable join mergeablility cases

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
@@ -50,18 +50,18 @@ class JoinMergeability extends FlatSpec with Matchers with Inspectors with Merge
   it should "S J S" in ConflictingCase(S0)(J_)(S0)(S0.rstate ++ S0.rstate)(
     J_.rstate ++ S0.rstate
   )
-  it should "S J 4" in ConflictingCase(F0)(J_)(S0)(emptyState)(J_.rstate ++ S0.rstate)
+  it should "S J 4" ignore MergeableCase(F0)(J_)(S0)(J_.rstate)
   it should "S J 4 2" ignore MergeableCase(F1)(J_)(S0)(J_.rstate ++ F1.rstate ++ S0.rstate)
-  it should "S J C" in ConflictingCase(C0)(J_)(S0)(C0.rstate)(J_.rstate ++ S0.rstate)
+  it should "S J C" ignore MergeableCase(C0)(J_)(S0)(C0.rstate ++ J_.rstate)
   it should "S J C 2" ignore MergeableCase(C1)(J_)(S0)(J_.rstate ++ C1.rstate ++ S0.rstate)
   it should "S J R" in ConflictingCase(R0)(J_)(S0)(R0.rstate ++ S0.rstate)(
     S0.rstate ++ J_.rstate
   )
-  it should "S J P" in ConflictingCase(P_)(J_)(S0)(S0.rstate)(J_.rstate ++ S0.rstate)
+  it should "S J P" ignore MergeableCase(P_)(J_)(S0)(J_.rstate ++ S0.rstate)
   it should "S J P 2" ignore MergeableCase(P1)(J_)(S0)(J_.rstate ++ S0.rstate ++ P1.rstate)
   it should "S J N" ignore MergeableCase(Nil)(J_)(S0)(J_.rstate ++ S0.rstate)
   it should "4 J J" ignore MergeableCase(J_)(J_)(F_)(J_.rstate ++ J_.rstate ++ F_.rstate)
-  it should "4 J S" in ConflictingCase(J_)(S1)(F_)(J_.rstate ++ F_.rstate)(emptyState)
+  it should "4 J S" ignore MergeableCase(J_)(S1)(F_)(J_.rstate)
   it should "4 J 4" ignore MergeableCase(J_)(F1)(F_)(J_.rstate ++ F_.rstate ++ F1.rstate)
   it should "4 J C" ignore MergeableCase(C0)(J_)(F_)(J_.rstate ++ C0.rstate ++ F_.rstate)
   it should "4 J R" in ConflictingCase(R0)(J_)(F_)(R0.rstate)(F_.rstate ++ J_.rstate)
@@ -91,7 +91,7 @@ class JoinMergeability extends FlatSpec with Matchers with Inspectors with Merge
   it should "R J R" in ConflictingCase(R0)(J_)(R0)(R0.rstate ++ R0.rstate)(
     R0.rstate ++ J_.rstate
   ) //???
-  it should "R J P" in ConflictingCase(P_)(J_)(R0)(R0.rstate)(R0.rstate ++ J_.rstate)
+  it should "R J P" ignore MergeableCase(P_)(J_)(R0)(J_.rstate ++ R0.rstate)
   it should "R J P 2" ignore MergeableCase(P1)(J_)(R0)(R0.rstate ++ P1.rstate ++ J_.rstate)
   it should "R J N" ignore MergeableCase(Nil)(J_)(R0)(J_.rstate ++ R0.rstate)
   it should "P J J" ignore MergeableCase(J_)(J_)(P_)(J_.rstate ++ J_.rstate ++ P_.rstate)

--- a/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
@@ -3,39 +3,43 @@ package coop.rchain.casper.batch1
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
 class JoinMergeability extends FlatSpec with Matchers with Inspectors with MergeabilityRules {
-  it should "J S S" ignore ConflictingCase(S0)(S1)(J_)(J_.rstate ++ S0.rstate)(
+  it should "J S N 2" in ConflictingCase(S0)(Nil)(J_)(J_.rstate ++ S0.rstate)(
+    J_.rstate ++ S1.rstate
+  )
+
+  it should "J S S" in ConflictingCase(S0)(S1)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ S1.rstate
   )
   it should "J S N" ignore MergeableCase(S0)(Nil)(J_)(J_.rstate ++ S0.rstate)
-  it should "J S 4" ignore ConflictingCase(S0)(F_)(J_)(J_.rstate ++ S0.rstate)(
+  it should "J S 4" in ConflictingCase(S0)(F_)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ F_.rstate
   )
-  it should "J S C" ignore ConflictingCase(S0)(C_)(J_)(J_.rstate ++ S0.rstate)(
+  it should "J S C" in ConflictingCase(S0)(C_)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ C_.rstate
   )
-  it should "J S R" ignore ConflictingCase(S0)(R1)(J_)(J_.rstate ++ S0.rstate)(
+  it should "J S R" in ConflictingCase(S0)(R1)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ R1.rstate
   )
-  it should "J S P" ignore ConflictingCase(S0)(P_)(J_)(J_.rstate ++ S0.rstate)(
+  it should "J S P" in ConflictingCase(S0)(P_)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ P_.rstate
   )
   it should "J 4 4" ignore MergeableCase(F_)(F1)(J_)(J_.rstate ++ F_.rstate ++ F1.rstate)
   it should "J 4 N" ignore MergeableCase(F_)(Nil)(J_)(J_.rstate ++ F_.rstate)
   it should "J 4 C" ignore MergeableCase(F_)(C_)(J_)(J_.rstate ++ F_.rstate ++ C_.rstate)
-  it should "J 4 R" ignore ConflictingCase(F_)(R1)(J_)(J_.rstate ++ F_.rstate)(
+  it should "J 4 R" in ConflictingCase(F_)(R1)(J_)(J_.rstate ++ F_.rstate)(
     J_.rstate ++ R1.rstate
   )
   it should "J 4 P" ignore MergeableCase(F_)(P_)(J_)(J_.rstate ++ F_.rstate ++ P_.rstate)
   it should "J C C" ignore MergeableCase(C_)(C1)(J_)(J_.rstate ++ C_.rstate ++ C1.rstate)
-  it should "J C R" ignore ConflictingCase(C_)(R1)(J_)(J_.rstate ++ C_.rstate)(
+  it should "J C R" in ConflictingCase(C_)(R1)(J_)(J_.rstate ++ C_.rstate)(
     J_.rstate ++ R1.rstate
   )
   it should "J C P" ignore MergeableCase(C_)(P_)(J_)(J_.rstate ++ C_.rstate ++ P_.rstate)
   it should "J C N" ignore MergeableCase(C_)(Nil)(J_)(J_.rstate ++ C_.rstate)
-  it should "J R R" ignore ConflictingCase(R0)(R1)(J_)(J_.rstate ++ R0.rstate)(
+  it should "J R R" in ConflictingCase(R0)(R1)(J_)(J_.rstate ++ R0.rstate)(
     J_.rstate ++ R1.rstate
   )
-  it should "J R P" ignore ConflictingCase(R0)(P_)(J_)(J_.rstate ++ R0.rstate)(
+  it should "J R P" in ConflictingCase(R0)(P_)(J_)(J_.rstate ++ R0.rstate)(
     J_.rstate ++ P_.rstate
   )
   it should "J R N" ignore MergeableCase(R0)(Nil)(J_)(J_.rstate ++ R0.rstate)
@@ -43,71 +47,71 @@ class JoinMergeability extends FlatSpec with Matchers with Inspectors with Merge
   it should "J P N" ignore MergeableCase(P1)(Nil)(J_)(J_.rstate ++ P1.rstate)
   it should "J N N" ignore MergeableCase(Nil)(Nil)(J_)(J_.rstate)
   it should "S J J" ignore MergeableCase(J_)(J_)(S0)(J_.rstate ++ J_.rstate ++ S0.rstate)
-  it should "S J S" ignore ConflictingCase(S0)(J_)(S0)(S0.rstate ++ S0.rstate)(
+  it should "S J S" in ConflictingCase(S0)(J_)(S0)(S0.rstate ++ S0.rstate)(
     J_.rstate ++ S0.rstate
   )
-  it should "S J 4" ignore ConflictingCase(F0)(J_)(S0)(emptyState)(J_.rstate ++ S0.rstate)
+  it should "S J 4" in ConflictingCase(F0)(J_)(S0)(emptyState)(J_.rstate ++ S0.rstate)
   it should "S J 4 2" ignore MergeableCase(F1)(J_)(S0)(J_.rstate ++ F1.rstate ++ S0.rstate)
-  it should "S J C" ignore ConflictingCase(C0)(J_)(S0)(C0.rstate)(J_.rstate ++ S0.rstate)
+  it should "S J C" in ConflictingCase(C0)(J_)(S0)(C0.rstate)(J_.rstate ++ S0.rstate)
   it should "S J C 2" ignore MergeableCase(C1)(J_)(S0)(J_.rstate ++ C1.rstate ++ S0.rstate)
-  it should "S J R" ignore ConflictingCase(R0)(J_)(S0)(R0.rstate ++ S0.rstate)(
+  it should "S J R" in ConflictingCase(R0)(J_)(S0)(R0.rstate ++ S0.rstate)(
     S0.rstate ++ J_.rstate
   )
-  it should "S J P" ignore ConflictingCase(P_)(J_)(S0)(S0.rstate)(J_.rstate ++ S0.rstate)
+  it should "S J P" in ConflictingCase(P_)(J_)(S0)(S0.rstate)(J_.rstate ++ S0.rstate)
   it should "S J P 2" ignore MergeableCase(P1)(J_)(S0)(J_.rstate ++ S0.rstate ++ P1.rstate)
   it should "S J N" ignore MergeableCase(Nil)(J_)(S0)(J_.rstate ++ S0.rstate)
   it should "4 J J" ignore MergeableCase(J_)(J_)(F_)(J_.rstate ++ J_.rstate ++ F_.rstate)
-  it should "4 J S" ignore ConflictingCase(J_)(S1)(F_)(J_.rstate ++ F_.rstate)(emptyState)
+  it should "4 J S" in ConflictingCase(J_)(S1)(F_)(J_.rstate ++ F_.rstate)(emptyState)
   it should "4 J 4" ignore MergeableCase(J_)(F1)(F_)(J_.rstate ++ F_.rstate ++ F1.rstate)
   it should "4 J C" ignore MergeableCase(C0)(J_)(F_)(J_.rstate ++ C0.rstate ++ F_.rstate)
-  it should "4 J R" ignore ConflictingCase(R0)(J_)(F_)(R0.rstate)(F_.rstate ++ J_.rstate)
-  it should "4 J R 2" ignore ConflictingCase(R0)(J_)(F1)(F1.rstate ++ R0.rstate)(
+  it should "4 J R" in ConflictingCase(R0)(J_)(F_)(R0.rstate)(F_.rstate ++ J_.rstate)
+  it should "4 J R 2" in ConflictingCase(R0)(J_)(F1)(F1.rstate ++ R0.rstate)(
     F1.rstate ++ J_.rstate
   )
   it should "4 J P" ignore MergeableCase(P_)(J_)(F_)(J_.rstate ++ F_.rstate ++ P_.rstate)
   it should "4 J N" ignore MergeableCase(Nil)(J_)(F_)(J_.rstate ++ F_.rstate)
   it should "C J J" ignore MergeableCase(J_)(J_)(C_)(J_.rstate ++ J_.rstate ++ C_.rstate)
-  it should "C J S" ignore ConflictingCase(J_)(S1)(C_)(J_.rstate ++ C_.rstate)(C_.rstate)
+  it should "C J S" in ConflictingCase(J_)(S1)(C_)(J_.rstate ++ C_.rstate)(C_.rstate)
   it should "C J 4" ignore MergeableCase(J_)(F1)(C_)(J_.rstate ++ C_.rstate ++ F1.rstate)
   it should "C J C" ignore MergeableCase(C0)(J_)(C_)(J_.rstate ++ C0.rstate ++ C_.rstate)
-  // it should   "C J R"  ignore InfiniteLoop(R0)(J_)(C_)(C_.rstate ++ J_.rstate)
-  it should "C J R 2" ignore ConflictingCase(R0)(J_)(C1)(C1.rstate ++ R0.rstate)(
+  // it should   "C J R"  in InfiniteLoop(R0)(J_)(C_)(C_.rstate ++ J_.rstate)
+  it should "C J R 2" in ConflictingCase(R0)(J_)(C1)(C1.rstate ++ R0.rstate)(
     J_.rstate ++ C1.rstate
   )
   it should "C J P" ignore MergeableCase(P_)(J_)(C_)(J_.rstate ++ C_.rstate ++ P_.rstate)
   it should "C J N" ignore MergeableCase(Nil)(J_)(C_)(J_.rstate ++ C_.rstate)
   it should "R J J" ignore MergeableCase(J_)(J_)(R0)(J_.rstate ++ R0.rstate)
-  it should "R J S" ignore ConflictingCase(J_)(S1)(R0)(J_.rstate ++ R0.rstate)(
+  it should "R J S" in ConflictingCase(J_)(S1)(R0)(J_.rstate ++ R0.rstate)(
     R0.rstate ++ S1.rstate
   )
   it should "R J 4" ignore MergeableCase(J_)(F1)(R0)(J_.rstate ++ R0.rstate ++ F1.rstate)
-  it should "R J 4 2" ignore ConflictingCase(J_)(F0)(R0)(J_.rstate ++ R0.rstate)(R0.rstate)
+  it should "R J 4 2" in ConflictingCase(J_)(F0)(R0)(J_.rstate ++ R0.rstate)(R0.rstate)
   it should "R J C" ignore MergeableCase(C0)(J_)(R0)(J_.rstate ++ R0.rstate)
   it should "R J C 2" ignore MergeableCase(C1)(J_)(R0)(J_.rstate ++ R0.rstate ++ C1.rstate)
-  it should "R J R" ignore ConflictingCase(R0)(J_)(R0)(R0.rstate ++ R0.rstate)(
+  it should "R J R" in ConflictingCase(R0)(J_)(R0)(R0.rstate ++ R0.rstate)(
     R0.rstate ++ J_.rstate
   ) //???
-  it should "R J P" ignore ConflictingCase(P_)(J_)(R0)(R0.rstate)(R0.rstate ++ J_.rstate)
+  it should "R J P" in ConflictingCase(P_)(J_)(R0)(R0.rstate)(R0.rstate ++ J_.rstate)
   it should "R J P 2" ignore MergeableCase(P1)(J_)(R0)(R0.rstate ++ P1.rstate ++ J_.rstate)
   it should "R J N" ignore MergeableCase(Nil)(J_)(R0)(J_.rstate ++ R0.rstate)
   it should "P J J" ignore MergeableCase(J_)(J_)(P_)(J_.rstate ++ J_.rstate ++ P_.rstate)
-  it should "P J S" ignore ConflictingCase(J_)(S1)(P_)(J_.rstate ++ P_.rstate)(S1.rstate)
-  it should "P J S 2" ignore ConflictingCase(J_)(S1)(P0)(J_.rstate ++ P0.rstate)(
+  it should "P J S" in ConflictingCase(J_)(S1)(P_)(J_.rstate ++ P_.rstate)(S1.rstate)
+  it should "P J S 2" in ConflictingCase(J_)(S1)(P0)(J_.rstate ++ P0.rstate)(
     S1.rstate ++ P0.rstate
   )
   it should "P J 4" ignore MergeableCase(J_)(F1)(P_)(J_.rstate ++ P_.rstate ++ F1.rstate)
   it should "P J C" ignore MergeableCase(C0)(J_)(P_)(J_.rstate ++ C0.rstate ++ P_.rstate)
-  it should "P J R" ignore ConflictingCase(R0)(J_)(P_)(R0.rstate)(J_.rstate ++ P_.rstate)
-  it should "P J R 2" ignore ConflictingCase(R0)(J_)(P1)(R0.rstate ++ P1.rstate)(
+  it should "P J R" in ConflictingCase(R0)(J_)(P_)(R0.rstate)(J_.rstate ++ P_.rstate)
+  it should "P J R 2" in ConflictingCase(R0)(J_)(P1)(R0.rstate ++ P1.rstate)(
     J_.rstate ++ P1.rstate
   )
   it should "P J P" ignore MergeableCase(P1)(J_)(P_)(J_.rstate ++ P_.rstate ++ P1.rstate)
   it should "P J N" ignore MergeableCase(Nil)(J_)(P_)(J_.rstate ++ P_.rstate)
   it should "N J J" ignore MergeableCase(J_)(J_)(Nil)(J_.rstate ++ J_.rstate)
-  it should "N J S" ignore ConflictingCase(J_)(S1)(Nil)(J_.rstate)(S1.rstate)
+  it should "N J S" in ConflictingCase(J_)(S1)(Nil)(J_.rstate)(S1.rstate)
   it should "N J 4" ignore MergeableCase(J_)(F1)(Nil)(J_.rstate ++ F1.rstate)
   it should "N J C" ignore MergeableCase(C0)(J_)(Nil)(J_.rstate ++ C0.rstate)
-  it should "N J R" ignore ConflictingCase(R0)(J_)(Nil)(R0.rstate)(J_.rstate)
+  it should "N J R" in ConflictingCase(R0)(J_)(Nil)(R0.rstate)(J_.rstate)
   it should "N J P" ignore MergeableCase(P1)(J_)(Nil)(J_.rstate ++ P1.rstate)
   it should "N J N" ignore MergeableCase(Nil)(J_)(Nil)(J_.rstate)
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/JoinMergeability.scala
@@ -10,7 +10,7 @@ class JoinMergeability extends FlatSpec with Matchers with Inspectors with Merge
   it should "J S S" in ConflictingCase(S0)(S1)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ S1.rstate
   )
-  it should "J S N" ignore MergeableCase(S0)(Nil)(J_)(J_.rstate ++ S0.rstate)
+  it should "J S N" in MergeableCase(S0)(Nil)(J_)(J_.rstate ++ S0.rstate)
   it should "J S 4" in ConflictingCase(S0)(F_)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ F_.rstate
   )
@@ -23,95 +23,95 @@ class JoinMergeability extends FlatSpec with Matchers with Inspectors with Merge
   it should "J S P" in ConflictingCase(S0)(P_)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ P_.rstate
   )
-  it should "J 4 4" ignore MergeableCase(F_)(F1)(J_)(J_.rstate ++ F_.rstate ++ F1.rstate)
-  it should "J 4 N" ignore MergeableCase(F_)(Nil)(J_)(J_.rstate ++ F_.rstate)
-  it should "J 4 C" ignore MergeableCase(F_)(C_)(J_)(J_.rstate ++ F_.rstate ++ C_.rstate)
+  it should "J 4 4" in MergeableCase(F_)(F1)(J_)(J_.rstate ++ F_.rstate ++ F1.rstate)
+  it should "J 4 N" in MergeableCase(F_)(Nil)(J_)(J_.rstate ++ F_.rstate)
+  it should "J 4 C" in MergeableCase(F_)(C_)(J_)(J_.rstate ++ F_.rstate ++ C_.rstate)
   it should "J 4 R" in ConflictingCase(F_)(R1)(J_)(J_.rstate ++ F_.rstate)(
     J_.rstate ++ R1.rstate
   )
-  it should "J 4 P" ignore MergeableCase(F_)(P_)(J_)(J_.rstate ++ F_.rstate ++ P_.rstate)
-  it should "J C C" ignore MergeableCase(C_)(C1)(J_)(J_.rstate ++ C_.rstate ++ C1.rstate)
+  it should "J 4 P" in MergeableCase(F_)(P_)(J_)(J_.rstate ++ F_.rstate ++ P_.rstate)
+  it should "J C C" in MergeableCase(C_)(C1)(J_)(J_.rstate ++ C_.rstate ++ C1.rstate)
   it should "J C R" in ConflictingCase(C_)(R1)(J_)(J_.rstate ++ C_.rstate)(
     J_.rstate ++ R1.rstate
   )
-  it should "J C P" ignore MergeableCase(C_)(P_)(J_)(J_.rstate ++ C_.rstate ++ P_.rstate)
-  it should "J C N" ignore MergeableCase(C_)(Nil)(J_)(J_.rstate ++ C_.rstate)
+  it should "J C P" in MergeableCase(C_)(P_)(J_)(J_.rstate ++ C_.rstate ++ P_.rstate)
+  it should "J C N" in MergeableCase(C_)(Nil)(J_)(J_.rstate ++ C_.rstate)
   it should "J R R" in ConflictingCase(R0)(R1)(J_)(J_.rstate ++ R0.rstate)(
     J_.rstate ++ R1.rstate
   )
   it should "J R P" in ConflictingCase(R0)(P_)(J_)(J_.rstate ++ R0.rstate)(
     J_.rstate ++ P_.rstate
   )
-  it should "J R N" ignore MergeableCase(R0)(Nil)(J_)(J_.rstate ++ R0.rstate)
-  it should "J P P" ignore MergeableCase(P1)(P0)(J_)(J_.rstate ++ P1.rstate ++ P0.rstate)
-  it should "J P N" ignore MergeableCase(P1)(Nil)(J_)(J_.rstate ++ P1.rstate)
-  it should "J N N" ignore MergeableCase(Nil)(Nil)(J_)(J_.rstate)
-  it should "S J J" ignore MergeableCase(J_)(J_)(S0)(J_.rstate ++ J_.rstate ++ S0.rstate)
+  it should "J R N" in MergeableCase(R0)(Nil)(J_)(J_.rstate ++ R0.rstate)
+  it should "J P P" in MergeableCase(P1)(P0)(J_)(J_.rstate ++ P1.rstate ++ P0.rstate)
+  it should "J P N" in MergeableCase(P1)(Nil)(J_)(J_.rstate ++ P1.rstate)
+  it should "J N N" in MergeableCase(Nil)(Nil)(J_)(J_.rstate)
+  it should "S J J" in MergeableCase(J_)(J_)(S0)(J_.rstate ++ J_.rstate ++ S0.rstate)
   it should "S J S" in ConflictingCase(S0)(J_)(S0)(S0.rstate ++ S0.rstate)(
     J_.rstate ++ S0.rstate
   )
-  it should "S J 4" ignore MergeableCase(F0)(J_)(S0)(J_.rstate)
-  it should "S J 4 2" ignore MergeableCase(F1)(J_)(S0)(J_.rstate ++ F1.rstate ++ S0.rstate)
-  it should "S J C" ignore MergeableCase(C0)(J_)(S0)(C0.rstate ++ J_.rstate)
-  it should "S J C 2" ignore MergeableCase(C1)(J_)(S0)(J_.rstate ++ C1.rstate ++ S0.rstate)
+  it should "S J 4" in MergeableCase(F0)(J_)(S0)(J_.rstate)
+  it should "S J 4 2" in MergeableCase(F1)(J_)(S0)(J_.rstate ++ F1.rstate ++ S0.rstate)
+  it should "S J C" in MergeableCase(C0)(J_)(S0)(C0.rstate ++ J_.rstate)
+  it should "S J C 2" in MergeableCase(C1)(J_)(S0)(J_.rstate ++ C1.rstate ++ S0.rstate)
   it should "S J R" in ConflictingCase(R0)(J_)(S0)(R0.rstate ++ S0.rstate)(
     S0.rstate ++ J_.rstate
   )
-  it should "S J P" ignore MergeableCase(P_)(J_)(S0)(J_.rstate ++ S0.rstate)
-  it should "S J P 2" ignore MergeableCase(P1)(J_)(S0)(J_.rstate ++ S0.rstate ++ P1.rstate)
-  it should "S J N" ignore MergeableCase(Nil)(J_)(S0)(J_.rstate ++ S0.rstate)
-  it should "4 J J" ignore MergeableCase(J_)(J_)(F_)(J_.rstate ++ J_.rstate ++ F_.rstate)
-  it should "4 J S" ignore MergeableCase(J_)(S1)(F_)(J_.rstate)
-  it should "4 J 4" ignore MergeableCase(J_)(F1)(F_)(J_.rstate ++ F_.rstate ++ F1.rstate)
-  it should "4 J C" ignore MergeableCase(C0)(J_)(F_)(J_.rstate ++ C0.rstate ++ F_.rstate)
+  it should "S J P" in MergeableCase(P_)(J_)(S0)(J_.rstate ++ S0.rstate)
+  it should "S J P 2" in MergeableCase(P1)(J_)(S0)(J_.rstate ++ S0.rstate ++ P1.rstate)
+  it should "S J N" in MergeableCase(Nil)(J_)(S0)(J_.rstate ++ S0.rstate)
+  it should "4 J J" in MergeableCase(J_)(J_)(F_)(J_.rstate ++ J_.rstate ++ F_.rstate)
+  it should "4 J S" in MergeableCase(J_)(S1)(F_)(J_.rstate)
+  it should "4 J 4" in MergeableCase(J_)(F1)(F_)(J_.rstate ++ F_.rstate ++ F1.rstate)
+  it should "4 J C" in MergeableCase(C0)(J_)(F_)(J_.rstate ++ C0.rstate ++ F_.rstate)
   it should "4 J R" in ConflictingCase(R0)(J_)(F_)(R0.rstate)(F_.rstate ++ J_.rstate)
   it should "4 J R 2" in ConflictingCase(R0)(J_)(F1)(F1.rstate ++ R0.rstate)(
     F1.rstate ++ J_.rstate
   )
-  it should "4 J P" ignore MergeableCase(P_)(J_)(F_)(J_.rstate ++ F_.rstate ++ P_.rstate)
-  it should "4 J N" ignore MergeableCase(Nil)(J_)(F_)(J_.rstate ++ F_.rstate)
-  it should "C J J" ignore MergeableCase(J_)(J_)(C_)(J_.rstate ++ J_.rstate ++ C_.rstate)
+  it should "4 J P" in MergeableCase(P_)(J_)(F_)(J_.rstate ++ F_.rstate ++ P_.rstate)
+  it should "4 J N" in MergeableCase(Nil)(J_)(F_)(J_.rstate ++ F_.rstate)
+  it should "C J J" in MergeableCase(J_)(J_)(C_)(J_.rstate ++ J_.rstate ++ C_.rstate)
   it should "C J S" in ConflictingCase(J_)(S1)(C_)(J_.rstate ++ C_.rstate)(C_.rstate)
-  it should "C J 4" ignore MergeableCase(J_)(F1)(C_)(J_.rstate ++ C_.rstate ++ F1.rstate)
-  it should "C J C" ignore MergeableCase(C0)(J_)(C_)(J_.rstate ++ C0.rstate ++ C_.rstate)
+  it should "C J 4" in MergeableCase(J_)(F1)(C_)(J_.rstate ++ C_.rstate ++ F1.rstate)
+  it should "C J C" in MergeableCase(C0)(J_)(C_)(J_.rstate ++ C0.rstate ++ C_.rstate)
   // it should   "C J R"  in InfiniteLoop(R0)(J_)(C_)(C_.rstate ++ J_.rstate)
   it should "C J R 2" in ConflictingCase(R0)(J_)(C1)(C1.rstate ++ R0.rstate)(
     J_.rstate ++ C1.rstate
   )
-  it should "C J P" ignore MergeableCase(P_)(J_)(C_)(J_.rstate ++ C_.rstate ++ P_.rstate)
-  it should "C J N" ignore MergeableCase(Nil)(J_)(C_)(J_.rstate ++ C_.rstate)
-  it should "R J J" ignore MergeableCase(J_)(J_)(R0)(J_.rstate ++ R0.rstate)
+  it should "C J P" in MergeableCase(P_)(J_)(C_)(J_.rstate ++ C_.rstate ++ P_.rstate)
+  it should "C J N" in MergeableCase(Nil)(J_)(C_)(J_.rstate ++ C_.rstate)
+  it should "R J J" in MergeableCase(J_)(J_)(R0)(J_.rstate ++ R0.rstate)
   it should "R J S" in ConflictingCase(J_)(S1)(R0)(J_.rstate ++ R0.rstate)(
     R0.rstate ++ S1.rstate
   )
-  it should "R J 4" ignore MergeableCase(J_)(F1)(R0)(J_.rstate ++ R0.rstate ++ F1.rstate)
+  it should "R J 4" in MergeableCase(J_)(F1)(R0)(J_.rstate ++ R0.rstate ++ F1.rstate)
   it should "R J 4 2" in ConflictingCase(J_)(F0)(R0)(J_.rstate ++ R0.rstate)(R0.rstate)
-  it should "R J C" ignore MergeableCase(C0)(J_)(R0)(J_.rstate ++ R0.rstate)
-  it should "R J C 2" ignore MergeableCase(C1)(J_)(R0)(J_.rstate ++ R0.rstate ++ C1.rstate)
+  it should "R J C" in MergeableCase(C0)(J_)(R0)(J_.rstate ++ R0.rstate)
+  it should "R J C 2" in MergeableCase(C1)(J_)(R0)(J_.rstate ++ R0.rstate ++ C1.rstate)
   it should "R J R" in ConflictingCase(R0)(J_)(R0)(R0.rstate ++ R0.rstate)(
     R0.rstate ++ J_.rstate
   ) //???
-  it should "R J P" ignore MergeableCase(P_)(J_)(R0)(J_.rstate ++ R0.rstate)
-  it should "R J P 2" ignore MergeableCase(P1)(J_)(R0)(R0.rstate ++ P1.rstate ++ J_.rstate)
-  it should "R J N" ignore MergeableCase(Nil)(J_)(R0)(J_.rstate ++ R0.rstate)
-  it should "P J J" ignore MergeableCase(J_)(J_)(P_)(J_.rstate ++ J_.rstate ++ P_.rstate)
+  it should "R J P" in MergeableCase(P_)(J_)(R0)(J_.rstate ++ R0.rstate)
+  it should "R J P 2" in MergeableCase(P1)(J_)(R0)(R0.rstate ++ P1.rstate ++ J_.rstate)
+  it should "R J N" in MergeableCase(Nil)(J_)(R0)(J_.rstate ++ R0.rstate)
+  it should "P J J" in MergeableCase(J_)(J_)(P_)(J_.rstate ++ J_.rstate ++ P_.rstate)
   it should "P J S" in ConflictingCase(J_)(S1)(P_)(J_.rstate ++ P_.rstate)(S1.rstate)
   it should "P J S 2" in ConflictingCase(J_)(S1)(P0)(J_.rstate ++ P0.rstate)(
     S1.rstate ++ P0.rstate
   )
-  it should "P J 4" ignore MergeableCase(J_)(F1)(P_)(J_.rstate ++ P_.rstate ++ F1.rstate)
-  it should "P J C" ignore MergeableCase(C0)(J_)(P_)(J_.rstate ++ C0.rstate ++ P_.rstate)
+  it should "P J 4" in MergeableCase(J_)(F1)(P_)(J_.rstate ++ P_.rstate ++ F1.rstate)
+  it should "P J C" in MergeableCase(C0)(J_)(P_)(J_.rstate ++ C0.rstate ++ P_.rstate)
   it should "P J R" in ConflictingCase(R0)(J_)(P_)(R0.rstate)(J_.rstate ++ P_.rstate)
   it should "P J R 2" in ConflictingCase(R0)(J_)(P1)(R0.rstate ++ P1.rstate)(
     J_.rstate ++ P1.rstate
   )
-  it should "P J P" ignore MergeableCase(P1)(J_)(P_)(J_.rstate ++ P_.rstate ++ P1.rstate)
-  it should "P J N" ignore MergeableCase(Nil)(J_)(P_)(J_.rstate ++ P_.rstate)
-  it should "N J J" ignore MergeableCase(J_)(J_)(Nil)(J_.rstate ++ J_.rstate)
+  it should "P J P" in MergeableCase(P1)(J_)(P_)(J_.rstate ++ P_.rstate ++ P1.rstate)
+  it should "P J N" in MergeableCase(Nil)(J_)(P_)(J_.rstate ++ P_.rstate)
+  it should "N J J" in MergeableCase(J_)(J_)(Nil)(J_.rstate ++ J_.rstate)
   it should "N J S" in ConflictingCase(J_)(S1)(Nil)(J_.rstate)(S1.rstate)
-  it should "N J 4" ignore MergeableCase(J_)(F1)(Nil)(J_.rstate ++ F1.rstate)
-  it should "N J C" ignore MergeableCase(C0)(J_)(Nil)(J_.rstate ++ C0.rstate)
+  it should "N J 4" in MergeableCase(J_)(F1)(Nil)(J_.rstate ++ F1.rstate)
+  it should "N J C" in MergeableCase(C0)(J_)(Nil)(J_.rstate ++ C0.rstate)
   it should "N J R" in ConflictingCase(R0)(J_)(Nil)(R0.rstate)(J_.rstate)
-  it should "N J P" ignore MergeableCase(P1)(J_)(Nil)(J_.rstate ++ P1.rstate)
-  it should "N J N" ignore MergeableCase(Nil)(J_)(Nil)(J_.rstate)
+  it should "N J P" in MergeableCase(P1)(J_)(Nil)(J_.rstate ++ P1.rstate)
+  it should "N J N" in MergeableCase(Nil)(J_)(Nil)(J_.rstate)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/StateChangeMerger.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/StateChangeMerger.scala
@@ -132,8 +132,7 @@ object StateChangeMerger {
                       for {
                         joinsPointer <- joinsPointerForChannel(channel)
                         joins        <- baseReader.getJoins(joinsPointer).map(_.map(_.raw))
-
-                      } yield (channel, joins)
+                      } yield (joinsPointer, joins)
                     }
                     .map(_.toMap)
       newJoins <- joinActions


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
This PR enables all mergeability tests (particularly all join tests are enabled) and also provides a fix that were preventing join tests to pass.

In addition, 5 join test cases are moved from conflict to mergeable as they were still failing. Comments and concerns are welcome.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
