### PR TITLE
RSpace and Rholang project cleanup

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -1,13 +1,10 @@
 package coop.rchain.models.rholang
 
+import com.google.protobuf.ByteString
 import coop.rchain.models.Connective.ConnectiveInstance
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.Var.VarInstance
-import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
-import coop.rchain.models._
-import com.google.protobuf.ByteString
 import coop.rchain.models.GUnforgeable.UnfInstance
 import coop.rchain.models.GUnforgeable.UnfInstance.{
   GDeployIdBody,
@@ -15,6 +12,9 @@ import coop.rchain.models.GUnforgeable.UnfInstance.{
   GPrivateBody,
   GSysAuthTokenBody
 }
+import coop.rchain.models.Var.VarInstance
+import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
+import coop.rchain.models._
 
 import scala.collection.immutable.{BitSet, Vector}
 
@@ -252,17 +252,14 @@ object implicits {
     def prepend(n: New): Par =
       p.copy(
         news = n +: p.news,
-        locallyFree =
-          p.locallyFree | n.locallyFree,
+        locallyFree = p.locallyFree | n.locallyFree,
         connectiveUsed = p.connectiveUsed || n.connectiveUsed
       )
     def prepend(e: Expr, depth: Int): Par =
       p.copy(
         exprs = e +: p.exprs,
-        locallyFree = p.locallyFree | ExprLocallyFree
-          .locallyFree(e, depth),
-        connectiveUsed = p.connectiveUsed || ExprLocallyFree
-          .connectiveUsed(e)
+        locallyFree = p.locallyFree | ExprLocallyFree.locallyFree(e, depth),
+        connectiveUsed = p.connectiveUsed || ExprLocallyFree.connectiveUsed(e)
       )
     def prepend(m: Match): Par =
       p.copy(
@@ -297,7 +294,7 @@ object implicits {
 
     def singleBundle(): Option[Bundle] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.unforgeables.isEmpty && p.connectives.isEmpty) {
-        p.bundles.toList match {
+        p.bundles match {
           case Seq(single) => Some(single)
           case _           => None
         }
@@ -307,7 +304,7 @@ object implicits {
 
     def singleUnforgeable(): Option[GUnforgeable] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.bundles.isEmpty && p.connectives.isEmpty) {
-        p.unforgeables.toList match {
+        p.unforgeables match {
           case Seq(single) => Some(single)
           case _           => None
         }
@@ -317,7 +314,7 @@ object implicits {
 
     def singleDeployId(): Option[GDeployId] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.bundles.isEmpty && p.connectives.isEmpty) {
-        p.unforgeables.toList match {
+        p.unforgeables match {
           case Seq(GUnforgeable(GDeployIdBody(single))) => Some(single)
           case _                                        => None
         }
@@ -327,7 +324,7 @@ object implicits {
 
     def singleDeployerId(): Option[GDeployerId] =
       if (p.sends.isEmpty && p.receives.isEmpty && p.news.isEmpty && p.exprs.isEmpty && p.matches.isEmpty && p.bundles.isEmpty && p.connectives.isEmpty) {
-        p.unforgeables.toList match {
+        p.unforgeables match {
           case Seq(GUnforgeable(GDeployerIdBody(single))) => Some(single)
           case _                                          => None
         }
@@ -342,7 +339,7 @@ object implicits {
         None
       }
 
-    def ++(that: Par) =
+    def ++(that: Par): Par =
       Par(
         that.sends ++ p.sends,
         that.receives ++ p.receives,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/ContractCall.scala
@@ -1,12 +1,11 @@
 package coop.rchain.rholang.interpreter
 
 import cats.effect.{Concurrent, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Span
 import coop.rchain.models.{ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoTuplespace
-import coop.rchain.rspace.util.unpackCont
 
 /**
   * This is a tool for unapplying the messages sent to the system contracts.
@@ -45,7 +44,7 @@ class ContractCall[F[_]: Concurrent: Span](
       _ <- produceResult.fold(Sync[F].unit) {
             case (cont, channels) =>
               dispatcher.dispatch(
-                unpackCont(cont),
+                cont.continuation,
                 channels.map(_.matchedDatum)
               )
           }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Env.scala
@@ -14,7 +14,7 @@ final case class Env[A] private (envMap: Map[Int, A], level: Int, shift: Int) {
 }
 
 object Env {
-  def apply[A]() = new Env[A](Map.empty[Int, A], 0, 0)
+  def apply[A]() = new Env[A](Map.empty[Int, A], level = 0, shift = 0)
 
   def makeEnv[A](k: A*): Env[A] = k.foldLeft(Env[A]())((acc, newVal) => acc.put(newVal))
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -58,7 +58,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
     * @param chan  The channel on which data is being sent.
     * @param data  The par objects holding the processes being sent.
     * @param persistent  True if the write should remain in the tuplespace indefinitely.
-    * @return  An optional continuation resulting from a match in the tuplespace.
     */
   private def produce(
       chan: Par,
@@ -79,8 +78,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
     * @param binds  A Seq of pattern, channel pairs. Each pattern is a Seq[Par].
     *               The Seq is for arity matching, and each term in the Seq is a name pattern.
     * @param body  A Par object which will be run in the envirnoment resulting from the match.
-    * @return  An optional continuation resulting from a match. The body of the continuation
-    *          will be @param body if the continuation is not None.
     */
   private def consume(
       binds: Seq[(BindPattern, Par)],
@@ -155,7 +152,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
       implicit env: Env[Par],
       rand: Blake2b512Random
   ): M[Unit] = {
-    // for lack of a better type...
     val terms: Seq[GeneratedMessage] = Seq(
       par.sends,
       par.receives,
@@ -247,7 +243,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
     *    correctly used as a key in the tuple space.
     * 3. Evaluate any top level expressions in the data being sent.
     * 4. Call produce
-    * 5. If produce returned a continuation, evaluate it.
     *
     * @param send An output process
     * @param env An execution context
@@ -387,9 +382,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
   /**
     * Adds neu.bindCount new GPrivate from UUID's to the environment and then
     * proceeds to evaluate the body.
-    *
-    * @param neu
-    * @return
     */
   // TODO: Eliminate variable shadowing
   private def eval(
@@ -1043,7 +1035,6 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
               )
             )
           ).pure[M]
-        //TODO(mateusz.gorski): think whether cost accounting for addition should be dependend on the operands
         case other => MethodNotDefined("add", other.typ).raiseError[M, Expr]
       }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -955,9 +955,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("union", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("union", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr  <- evalSingleExpr(p)
         otherExpr <- evalSingleExpr(args.head)
         result    <- union(baseExpr, otherExpr)
@@ -983,9 +983,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("diff", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("diff", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr  <- evalSingleExpr(p)
         otherExpr <- evalSingleExpr(args.head)
         result    <- diff(baseExpr, otherExpr)
@@ -1012,9 +1012,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("add", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("add", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
         _        <- charge[M](ADD_COST)
@@ -1054,9 +1054,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("delete", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("delete", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
         _        <- charge[M](REMOVE_COST) //TODO(mateusz.gorski): think whether deletion of an element from the collection should dependent on the collection type/size
@@ -1077,9 +1077,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("contains", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("contains", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         element  <- evalExpr(args.head)
         _        <- charge[M](LOOKUP_COST)
@@ -1098,9 +1098,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("get", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("get", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         _        <- charge[M](LOOKUP_COST)
@@ -1119,9 +1119,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 2)
-              MethodArgumentNumberMismatch("getOrElse", 2, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("getOrElse", 2, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 2)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         default  <- evalExpr(args(1))
@@ -1141,9 +1141,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 2)
-              MethodArgumentNumberMismatch("set", 2, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("set", 2, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 2)
         baseExpr <- evalSingleExpr(p)
         key      <- evalExpr(args.head)
         value    <- evalExpr(args(1))
@@ -1164,9 +1164,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("keys", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("keys", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         _        <- charge[M](KEYS_METHOD_COST)
         result   <- keys(baseExpr)
@@ -1189,9 +1189,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("size", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("size", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- size(baseExpr)
         _        <- charge[M](sizeMethodCost(result._1))
@@ -1214,9 +1214,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("length", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("length", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         _        <- charge[M](LENGTH_METHOD_COST)
         result   <- length(baseExpr)
@@ -1239,9 +1239,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 2)
-              MethodArgumentNumberMismatch("slice", 2, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("slice", 2, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 2)
         baseExpr   <- evalSingleExpr(p)
         fromArgRaw <- evalToLong(args.head)
         fromArg    <- restrictToInt(fromArgRaw)
@@ -1263,9 +1263,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.length != 1)
-              MethodArgumentNumberMismatch("take", 1, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("take", 1, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.length != 1)
         baseExpr <- evalSingleExpr(p)
         nArgRaw  <- evalToLong(args.head)
         nArg     <- restrictToInt(nArgRaw)
@@ -1300,9 +1300,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("toList", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("toList", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toList(baseExpr)
       } yield result
@@ -1337,9 +1337,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("toSet", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("toSet", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toSet(baseExpr)
       } yield result
@@ -1379,9 +1379,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- if (args.nonEmpty)
-              MethodArgumentNumberMismatch("toMap", 0, args.length).raiseError[M, Unit]
-            else ().pure[M]
+        _ <- MethodArgumentNumberMismatch("toMap", 0, args.length)
+              .raiseError[M, Unit]
+              .whenA(args.nonEmpty)
         baseExpr <- evalSingleExpr(p)
         result   <- toMap(baseExpr)
       } yield result

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -306,12 +306,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
     charge[M](VAR_EVAL_COST) >> {
       valproc.varInstance match {
         case BoundVar(level) =>
-          env.get(level) match {
-            case Some(par) =>
-              par.pure[M]
-            case None =>
-              ReduceError("Unbound variable: " + level + " in " + env.envMap).raiseError[M, Par]
-          }
+          env.get(level).liftTo[M](ReduceError("Unbound variable: " + level + " in " + env.envMap))
         case Wildcard(_) =>
           ReduceError("Unbound variable: attempting to evaluate a pattern").raiseError[M, Par]
         case FreeVar(_) =>
@@ -327,15 +322,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
   ): M[Unit] = {
 
     def addToEnv(env: Env[Par], freeMap: Map[Int, Par], freeCount: Int): Env[Par] =
-      Range(0, freeCount).foldLeft(env)(
-        (acc, e) =>
-          acc.put(
-            freeMap.get(e) match {
-              case Some(p) => p
-              case None    => Par()
-            }
-          )
-      )
+      Range(0, freeCount).foldLeft(env)((acc, e) => acc.put(freeMap.getOrElse(e, Par())))
 
     def firstMatch(target: Par, cases: Seq[MatchCase])(implicit env: Env[Par]): M[Unit] = {
       def firstMatchM(
@@ -393,7 +380,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
         )
 
       def addUrn(newEnv: Env[Par], urn: String): Either[InterpreterError, Env[Par]] =
-        if (urnMap.get(urn).isEmpty)
+        if (!urnMap.contains(urn))
           // If `urn` can't be found in `urnMap`, it must be referencing an injection
           neu.injections
             .get(urn)
@@ -409,15 +396,9 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
             }
             .getOrElse(normalizerBugFound(urn).asLeft[Env[Par]])
         else
-          urnMap.get(urn) match {
-            case Some(p) => newEnv.put(p).asRight[InterpreterError]
-            case None    => ReduceError(s"Unknown urn for new: $urn").asLeft[Env[Par]]
-          }
+          urnMap.get(urn).map(newEnv.put).toRight(left = ReduceError(s"Unknown urn for new: $urn"))
 
-      urns.toList.foldM(simpleNews)(addUrn) match {
-        case Right(tmpEnv) => tmpEnv.pure[M]
-        case Left(e)       => e.raiseError[M, Env[Par]]
-      }
+      urns.toList.foldM(simpleNews)(addUrn).fold(_.raiseError[M, Env[Par]], _.pure[M])
     }
 
     charge[M](newBindingsCost(neu.bindCount)) >>
@@ -455,11 +436,10 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
           _            <- charge[M](METHOD_CALL_COST)
           evaledTarget <- evalExpr(target)
           evaledArgs   <- arguments.toList.traverse(evalExpr)
-          resultPar <- methodTable.get(method) match {
-                        case None =>
-                          ReduceError("Unimplemented method: " + method).raiseError[M, Par]
-                        case Some(f) => f(evaledTarget, evaledArgs)
-                      }
+          resultPar <- methodTable
+                        .get(method)
+                        .liftTo[M](ReduceError("Unimplemented method: " + method))
+                        .flatMap(_(evaledTarget, evaledArgs))
         } yield resultPar
       }
       case _ => evalExprToExpr(expr).map(fromExpr(_)(identity))
@@ -786,11 +766,10 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
             _            <- charge[M](METHOD_CALL_COST)
             evaledTarget <- evalExpr(target)
             evaledArgs   <- arguments.toList.traverse(evalExpr)
-            resultPar <- methodTable.get(method) match {
-                          case None =>
-                            ReduceError("Unimplemented method: " + method).raiseError[M, Par]
-                          case Some(f) => f(evaledTarget, evaledArgs)
-                        }
+            resultPar <- methodTable
+                          .get(method)
+                          .liftTo[M](ReduceError("Unimplemented method: " + method))
+                          .flatMap(_(evaledTarget, evaledArgs))
             resultExpr <- evalSingleExpr(resultPar)
           } yield resultExpr
         case _ => ReduceError("Unimplemented expression: " + expr).raiseError[M, Expr]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1,8 +1,8 @@
 package coop.rchain.rholang.interpreter
 
 import cats.effect.Sync
-import cats.implicits._
-import cats.{Eval => _}
+import cats.syntax.all._
+import cats.{Parallel, Eval => _}
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.hash.Blake2b512Random
@@ -41,14 +41,10 @@ trait Reduce[M[_]] {
 
 }
 
-class DebruijnInterpreter[M[_]](
+class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
     space: RhoTuplespace[M],
     dispatcher: => RhoDispatch[M],
     urnMap: Map[String, Par]
-)(
-    implicit parallel: cats.Parallel[M],
-    syncM: Sync[M],
-    cost: _cost[M]
 ) extends Reduce[M] {
 
   type Application =
@@ -100,7 +96,7 @@ class DebruijnInterpreter[M[_]](
     ) >>= (continue(_, consume(binds, body, persistent, peek), persistent))
   }
 
-  private[this] def continue(res: Application, repeatOp: M[Unit], persistent: Boolean) =
+  private[this] def continue(res: Application, repeatOp: M[Unit], persistent: Boolean): M[Unit] =
     res match {
       case Some((continuation, dataList, _)) if persistent =>
         dispatchAndRun(continuation, dataList)(
@@ -112,27 +108,27 @@ class DebruijnInterpreter[M[_]](
         )
       case Some((continuation, dataList, _)) =>
         dispatch(continuation, dataList)
-      case None => syncM.unit
+      case None => Sync[M].unit
     }
 
   private[this] def dispatchAndRun(
       continuation: TaggedContinuation,
       dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
-  )(ops: M[Unit]*) =
+  )(ops: M[Unit]*): M[Unit] =
     // Collect errors from all parallel execution paths (pars)
     parTraverseSafe(dispatch(continuation, dataList) +: ops.toVector)(identity)
 
   private[this] def dispatch(
       continuation: TaggedContinuation,
       dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
-  ) = dispatcher.dispatch(
+  ): M[Unit] = dispatcher.dispatch(
     continuation,
     dataList.map(_._2)
   )
 
   private[this] def producePeeks(
       dataList: Seq[(Par, ListParWithRandom, ListParWithRandom, Boolean)]
-  ) =
+  ): Seq[M[Unit]] =
     dataList
       .withFilter {
         case (_, _, _, persist) => !persist
@@ -477,7 +473,7 @@ class DebruijnInterpreter[M[_]](
     }
 
   private def evalExprToExpr(expr: Expr)(implicit env: Env[Par]): M[Expr] = {
-    syncM.defer {
+    Sync[M].defer {
       def relop(
           p1: Par,
           p2: Par,
@@ -493,8 +489,7 @@ class DebruijnInterpreter[M[_]](
                      case (GInt(i1), GInt(i2))       => GBool(relopi(i1, i2)).pure[M]
                      case (GString(s1), GString(s2)) => GBool(relops(s1, s2)).pure[M]
                      case _ =>
-                       ReduceError("Unexpected compare: " + v1 + " vs. " + v2)
-                         .raiseError[M, GBool]
+                       ReduceError("Unexpected compare: " + v1 + " vs. " + v2).raiseError[M, GBool]
                    }
         } yield result
 
@@ -833,11 +828,11 @@ class DebruijnInterpreter[M[_]](
           v      <- evalSingleExpr(p)
           result <- v.exprInstance match {
                      case EListBody(EList(ps, _, _, _)) =>
-                       syncM.fromEither(localNth(ps, nth))
+                       Sync[M].fromEither(localNth(ps, nth))
                      case ETupleBody(ETuple(ps, _, _)) =>
-                       syncM.fromEither(localNth(ps, nth))
+                       Sync[M].fromEither(localNth(ps, nth))
                      case GByteArray(bs) =>
-                       syncM.fromEither(if (0 <= nth && nth < bs.size) {
+                       Sync[M].fromEither(if (0 <= nth && nth < bs.size) {
                          val b      = bs.byteAt(nth) & 0xff // convert to unsigned
                          val p: Par = Expr(GInt(b.toLong))
                          p.asRight[ReduceError]
@@ -865,7 +860,7 @@ class DebruijnInterpreter[M[_]](
           exprEvaled <- evalExpr(p)
           exprSubst  <- substituteAndCharge[Par, M](exprEvaled, 0, env)
           _          <- charge[M](toByteArrayCost(exprSubst))
-          ba         <- syncM.fromEither(serialize(exprSubst))
+          ba         <- Sync[M].fromEither(serialize(exprSubst))
         } yield Expr(GByteArray(ByteString.copyFrom(ba)))
       }
   }
@@ -1262,11 +1257,11 @@ class DebruijnInterpreter[M[_]](
     def slice(baseExpr: Expr, from: Int, until: Int): M[Par] =
       baseExpr.exprInstance match {
         case GString(string) =>
-          syncM.delay(GString(string.slice(from, until)))
+          Sync[M].delay(GString(string.slice(from, until)))
         case EListBody(EList(ps, locallyFree, connectiveUsed, remainder)) =>
-          syncM.delay(EList(ps.slice(from, until), locallyFree, connectiveUsed, remainder))
+          Sync[M].delay(EList(ps.slice(from, until), locallyFree, connectiveUsed, remainder))
         case GByteArray(bytes) =>
-          syncM.delay(GByteArray(bytes.substring(from, until)))
+          Sync[M].delay(GByteArray(bytes.substring(from, until)))
         case other =>
           MethodNotDefined("slice", other.typ).raiseError[M, Par]
       }
@@ -1290,7 +1285,7 @@ class DebruijnInterpreter[M[_]](
     def take(baseExpr: Expr, n: Int): M[Par] =
       baseExpr.exprInstance match {
         case EListBody(EList(ps, locallyFree, connectiveUsed, remainder)) =>
-          syncM.delay(EList(ps.take(n), locallyFree, connectiveUsed, remainder))
+          Sync[M].delay(EList(ps.take(n), locallyFree, connectiveUsed, remainder))
         case other =>
           MethodNotDefined("take", other.typ).raiseError[M, Par]
       }
@@ -1515,7 +1510,7 @@ class DebruijnInterpreter[M[_]](
       }
 
   private def restrictToInt(long: Long): M[Int] =
-    syncM.catchNonFatal(Math.toIntExact(long)).adaptError {
+    Sync[M].catchNonFatal(Math.toIntExact(long)).adaptError {
       case _: ArithmeticException => ReduceError(s"Integer overflow for value $long")
     }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
@@ -134,7 +134,7 @@ class ErrorHandlingParser(s: Yylex, sf: java_cup.runtime.SymbolFactory) extends 
   import java_cup.runtime.Symbol
 
   override def unrecovered_syntax_error(cur_token: Symbol): Unit =
-    throw new SyntaxError(
+    throw SyntaxError(
       cur_token match {
         case cs: ComplexSymbol =>
           s"syntax error(${cs.getName}): ${s
@@ -160,5 +160,5 @@ class ErrorHandlingParser(s: Yylex, sf: java_cup.runtime.SymbolFactory) extends 
   override def report_error(message: String, info: Object): Unit = ()
 
   override def report_fatal_error(message: String, info: Object): Unit =
-    throw new ParserError(message + info)
+    throw ParserError(message + info)
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
@@ -74,7 +74,7 @@ object ParBuilder {
                 case (name, LevelContext(_, _, sourcePosition)) => s"$name at $sourcePosition"
               }
               F.raiseError(
-                TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString("", ", ", ""))
+                TopLevelFreeVariablesNotAllowedError(topLevelFreeList.mkString(", "))
               )
             } else if (normalizedTerm.knownFree.connectives.nonEmpty) {
               def connectiveInstanceToString(conn: ConnectiveInstance): String =
@@ -88,14 +88,14 @@ object ParBuilder {
                   case (connType, sourcePosition) =>
                     s"${connectiveInstanceToString(connType)} at $sourcePosition"
                 }
-                .mkString("", ", ", "")
+                .mkString(", ")
               F.raiseError(TopLevelLogicalConnectivesNotAllowedError(connectives))
             } else {
               val topLevelWildcardList = normalizedTerm.knownFree.wildcards.map { sourcePosition =>
                 s"_ (wildcard) at $sourcePosition"
               }
               F.raiseError(
-                TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString("", ", ", ""))
+                TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString(", "))
               )
             }
           } else normalizedTerm.pure[F].map(_.par)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/ParBuilder.scala
@@ -98,7 +98,7 @@ object ParBuilder {
                 TopLevelWildcardsNotAllowedError(topLevelWildcardList.mkString(", "))
               )
             }
-          } else normalizedTerm.pure[F].map(_.par)
+          } else normalizedTerm.par.pure[F]
         }
 
     /**

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundNormalizeMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundNormalizeMatcher.scala
@@ -1,17 +1,18 @@
 package coop.rchain.rholang.interpreter.compiler.normalizer
 
-import cats.syntax.all._
 import cats.MonadError
+import cats.syntax.all._
 import coop.rchain.models.Expr
 import coop.rchain.models.Expr.ExprInstance.{GInt, GString, GUri}
-import coop.rchain.rholang.interpreter.errors.NormalizerError
 import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
   GroundBool,
   GroundInt,
   GroundString,
-  GroundUri
+  GroundUri,
+  Ground => AbsynGround
 }
-import coop.rchain.rholang.ast.rholang_mercury.Absyn.{Ground => AbsynGround}
+import coop.rchain.rholang.interpreter.errors.NormalizerError
+
 import scala.util.Try
 
 object GroundNormalizeMatcher {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PMethodNormalizer.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PMethodNormalizer.scala
@@ -1,14 +1,14 @@
 package coop.rchain.rholang.interpreter.compiler.normalizer.processes
 
-import cats.syntax.all._
 import cats.effect.Sync
-import coop.rchain.models.{EMethod, Par}
+import cats.syntax.all._
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.{EMethod, Par}
+import coop.rchain.rholang.ast.rholang_mercury.Absyn.PMethod
 import coop.rchain.rholang.interpreter.compiler.ProcNormalizeMatcher.normalizeMatch
 import coop.rchain.rholang.interpreter.compiler.{ProcVisitInputs, ProcVisitOutputs}
-import coop.rchain.rholang.ast.rholang_mercury.Absyn.PMethod
-import scala.collection.convert.ImplicitConversionsToScala._
 
+import scala.collection.convert.ImplicitConversionsToScala._
 import scala.collection.immutable.BitSet
 
 object PMethodNormalizer {
@@ -28,7 +28,7 @@ object PMethodNormalizer {
                      normalizeMatch[F](e, acc._2).map(
                        procMatchResult =>
                          (
-                           procMatchResult.par :: acc._1,
+                           procMatchResult.par +: acc._1,
                            ProcVisitInputs(Par(), input.env, procMatchResult.knownFree),
                            acc._3 | procMatchResult.par.locallyFree,
                            acc._4 || procMatchResult.par.connectiveUsed

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -16,8 +16,6 @@ trait Dispatch[M[_], A, K] {
 }
 
 object Dispatch {
-
-  // TODO: Make this function total
   def buildEnv(dataList: Seq[ListParWithRandom]): Env[Par] =
     Env.makeEnv(dataList.flatMap(_.pars): _*)
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -52,15 +52,10 @@ class RholangAndScalaDispatcher[M[_]] private (
 object RholangAndScalaDispatcher {
   type RhoDispatch[F[_]] = Dispatch[F, ListParWithRandom, TaggedContinuation]
 
-  def create[M[_], F[_]](
+  def create[M[_]: Sync: Parallel: _cost](
       tuplespace: RhoTuplespace[M],
       dispatchTable: => Map[Long, Seq[ListParWithRandom] => M[Unit]],
       urnMap: Map[String, Par]
-  )(
-      implicit
-      cost: _cost[M],
-      parallel: Parallel[M],
-      s: Sync[M]
   ): (Dispatch[M, ListParWithRandom, TaggedContinuation], Reduce[M]) = {
 
     implicit lazy val dispatcher: Dispatch[M, ListParWithRandom, TaggedContinuation] =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -125,7 +125,7 @@ class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEquals
 
       lazy val (_, reducer) =
         RholangAndScalaDispatcher
-          .create[Task, Task.Par](
+          .create[Task](
             pureRSpace,
             Map.empty,
             Map.empty

--- a/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/examples/AddressBookExample.scala
@@ -3,9 +3,9 @@ package coop.rchain.rspace.examples
 import cats.effect.{Concurrent, ContextShift}
 import cats.{Applicative, Id}
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
-import coop.rchain.rspace.{RSpace, _}
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
-import coop.rchain.rspace.util._
+import coop.rchain.rspace.util.{runKs, unpackOption, unpackSeq}
+import coop.rchain.rspace.{RSpace, _}
 import coop.rchain.shared.Language.ignore
 import coop.rchain.shared.{Log, Serialize}
 import coop.rchain.store.InMemoryStoreManager
@@ -226,7 +226,7 @@ object AddressBookExample {
     assert(pres2.nonEmpty)
     assert(pres3.isEmpty)
 
-    runKs(Seq(pres1, pres2))
+    runKs(unpackSeq(Seq(pres1, pres2)))
   }
 
   def exampleTwo(): Unit = {
@@ -267,7 +267,7 @@ object AddressBookExample {
     assert(cres2.isDefined)
     assert(cres3.isEmpty)
 
-    runKs(Seq(cres1, cres2))
+    runKs(unpackSeq(Seq(cres1, cres2)))
 
     Console.printf(space.toMap.toString())
   }

--- a/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/util/package.scala
@@ -8,17 +8,17 @@ import scala.util.Try
 
 package object util {
 
-  implicit def unpackSeq[C, P, K, R](
+  def unpackSeq[C, P, K, R](
       v: Seq[Option[(ContResult[C, P, K], Seq[Result[C, R]])]]
   ): Seq[Option[(K, Seq[R])]] =
     v.map(unpackOption)
 
-  implicit def unpackOption[C, P, K, R](
+  def unpackOption[C, P, K, R](
       v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
   ): Option[(K, Seq[R])] =
     v.map(unpackTuple)
 
-  implicit def unpackTuple[C, P, K, R](
+  def unpackTuple[C, P, K, R](
       v: (ContResult[C, P, K], Seq[Result[C, R]])
   ): (K, Seq[R]) =
     v match {
@@ -26,12 +26,12 @@ package object util {
         (continuation, data.map(_.matchedDatum))
     }
 
-  implicit def unpackOptionWithPeek[C, P, K, R](
+  def unpackOptionWithPeek[C, P, K, R](
       v: Option[(ContResult[C, P, K], Seq[Result[C, R]])]
   ): Option[(K, Seq[(C, R, R, Boolean)], Boolean)] =
     v.map(unpackTupleWithPeek)
 
-  implicit def unpackTupleWithPeek[C, P, K, R](
+  def unpackTupleWithPeek[C, P, K, R](
       v: (ContResult[C, P, K], Seq[Result[C, R]])
   ): (K, Seq[(C, R, R, Boolean)], Boolean) =
     v match {
@@ -42,8 +42,6 @@ package object util {
           peek
         )
     }
-
-  implicit def unpackCont[C, P, T](v: ContResult[C, P, T]): T = v.continuation
 
   /**
     * Extracts a continuation from a produce result

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -8,7 +8,7 @@ import coop.rchain.rspace.history.History._
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.test._
 import coop.rchain.rspace.trace.Consume
-import coop.rchain.rspace.util._
+import coop.rchain.rspace.util.{getK, runK, unpackOption}
 import coop.rchain.shared.Serialize
 import monix.eval.Task
 import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
@@ -139,8 +139,8 @@ trait StorageActionsTests[F[_]]
       c2            <- store.getContinuations(key)
       _             = c2 shouldBe Nil
       _             = r2 shouldBe defined
-      _             = runK(r2)
-      _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      _             = runK(unpackOption(r2))
+      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
     } yield ()
@@ -171,8 +171,8 @@ trait StorageActionsTests[F[_]]
       c2            <- store.getContinuations(key)
       _             = c2 shouldBe Nil
       _             = r2 shouldBe defined
-      _             = runK(r2)
-      _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      _             = runK(unpackOption(r2))
+      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
     } yield ()
@@ -201,8 +201,8 @@ trait StorageActionsTests[F[_]]
       c2            <- store.getContinuations(key)
       _             = c2 shouldBe Nil
       _             = r2 shouldBe defined
-      _             = runK(r2)
-      _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      _             = runK(unpackOption(r2))
+      _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions should have size 0
     } yield ()
@@ -230,8 +230,8 @@ trait StorageActionsTests[F[_]]
         c2            <- store.getContinuations(key)
         _             = c2 shouldBe Nil
         _             = r2 shouldBe defined
-        _             = runK(r2)
-        _             = getK(r2).results should contain theSameElementsAs List(List("datum"))
+        _             = runK(unpackOption(r2))
+        _             = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
         insertActions <- store.changes().map(collectActions[InsertAction])
         _             = insertActions should have size 0
       } yield ()
@@ -240,21 +240,27 @@ trait StorageActionsTests[F[_]]
   "producing three times then doing consuming three times" should "work" in fixture {
     (store, _, space) =>
       for {
-        r1            <- space.produce("ch1", "datum1", persist = false)
-        r2            <- space.produce("ch1", "datum2", persist = false)
-        r3            <- space.produce("ch1", "datum3", persist = false)
-        _             = r1 shouldBe None
-        _             = r2 shouldBe None
-        _             = r3 shouldBe None
-        r4            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _             = runK(r4)
-        _             = getK(r4).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
-        r5            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _             = runK(r5)
-        _             = getK(r5).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
-        r6            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
-        _             = runK(r6)
-        _             = getK(r6).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
+        r1 <- space.produce("ch1", "datum1", persist = false)
+        r2 <- space.produce("ch1", "datum2", persist = false)
+        r3 <- space.produce("ch1", "datum3", persist = false)
+        _  = r1 shouldBe None
+        _  = r2 shouldBe None
+        _  = r3 shouldBe None
+        r4 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+        _  = runK(unpackOption(r4))
+        _ = getK(r4).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
+        r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+        _  = runK(unpackOption(r5))
+        _ = getK(r5).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
+        r6 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
+        _  = runK(unpackOption(r6))
+        _ = getK(r6).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
         insertActions <- store.changes().map(collectActions[InsertAction])
         _             = insertActions shouldBe empty
       } yield ()
@@ -294,8 +300,10 @@ trait StorageActionsTests[F[_]]
       _  <- store.getData(produceKey2.head).map(_ shouldBe Nil)
       _  = r3 shouldBe defined
 
-      _             = runK(r3)
-      _             = getK(r3).results should contain theSameElementsAs List(List("datum1", "datum2"))
+      _ = runK(unpackOption(r3))
+      _ = getK(r3).continuation.results should contain theSameElementsAs List(
+        List("datum1", "datum2")
+      )
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
     } yield ()
@@ -344,8 +352,10 @@ trait StorageActionsTests[F[_]]
       _  = c4 shouldBe Nil
       _  = r4 shouldBe defined
 
-      _             = runK(r4)
-      _             = getK(r4).results should contain theSameElementsAs List(List("datum1", "datum2", "datum3"))
+      _ = runK(unpackOption(r4))
+      _ = getK(r4).continuation.results should contain theSameElementsAs List(
+        List("datum1", "datum2", "datum3")
+      )
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
     } yield ()
@@ -402,12 +412,18 @@ trait StorageActionsTests[F[_]]
           .map(unpackOption)
           .foreach(runK)
 
-        _             = getK(r1).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
-        _             = getK(r2).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
-        _             = getK(r3).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
-        _             = getK(r1).results shouldNot contain theSameElementsAs getK(r2).results
-        _             = getK(r1).results shouldNot contain theSameElementsAs getK(r3).results
-        _             = getK(r2).results shouldNot contain theSameElementsAs getK(r3).results
+        _ = getK(r1).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
+        _ = getK(r2).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
+        _ = getK(r3).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
+        _             = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r2).continuation.results
+        _             = getK(r1).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
+        _             = getK(r2).continuation.results shouldNot contain theSameElementsAs getK(r3).continuation.results
         insertActions <- store.changes().map(collectActions[InsertAction])
         _             = insertActions shouldBe empty
       } yield ()
@@ -447,9 +463,9 @@ trait StorageActionsTests[F[_]]
         .map(unpackOption)
         .foreach(runK)
 
-      _             = getK(r1).results shouldBe List(List("datum1"))
-      _             = getK(r2).results shouldBe List(List("datum2"))
-      _             = getK(r3).results shouldBe List(List("datum3"))
+      _             = getK(r1).continuation.results shouldBe List(List("datum1"))
+      _             = getK(r2).continuation.results shouldBe List(List("datum2"))
+      _             = getK(r3).continuation.results shouldBe List(List("datum3"))
       insertActions <- store.changes().map(collectActions[InsertAction])
     } yield (insertActions shouldBe empty)
   }
@@ -470,9 +486,11 @@ trait StorageActionsTests[F[_]]
       _ = r2 shouldBe None
       _ = r3 shouldBe defined
 
-      _ = runK(r3)
+      _ = runK(unpackOption(r3))
 
-      _             = getK(r3).results should contain theSameElementsAs List(List("datum1", "datum2"))
+      _ = getK(r3).continuation.results should contain theSameElementsAs List(
+        List("datum1", "datum2")
+      )
       insertActions <- store.changes().map(collectActions[InsertAction])
     } yield (insertActions shouldBe empty)
 
@@ -497,8 +515,8 @@ trait StorageActionsTests[F[_]]
       _ = r2 shouldBe None
       _ = r3 shouldBe defined
 
-      _             = runK(r3)
-      _             = getK(r3).results shouldBe List(List("datum1", "datum1"))
+      _             = runK(unpackOption(r3))
+      _             = getK(r3).continuation.results shouldBe List(List("datum1", "datum1"))
       insertActions <- store.changes().map(collectActions[InsertAction])
     } yield (insertActions shouldBe empty)
   }
@@ -537,8 +555,12 @@ trait StorageActionsTests[F[_]]
         .map(unpackOption)
         .foreach(runK)
 
-      _             = getK(r4).results should contain theSameElementsAs List(List("datum3", "datum4"))
-      _             = getK(r6).results should contain theSameElementsAs List(List("datum1", "datum2"))
+      _ = getK(r4).continuation.results should contain theSameElementsAs List(
+        List("datum3", "datum4")
+      )
+      _ = getK(r6).continuation.results should contain theSameElementsAs List(
+        List("datum1", "datum2")
+      )
       insertActions <- store.changes().map(collectActions[InsertAction])
     } yield (insertActions shouldBe empty)
 
@@ -601,8 +623,8 @@ trait StorageActionsTests[F[_]]
       d2 <- store.getData("ch2")
       _  = d2 shouldBe Nil
 
-      _             = getK(r3).results should contain theSameElementsAs List(List("datum1"))
-      _             = getK(r4).results should contain theSameElementsAs List(List("datum2"))
+      _             = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
+      _             = getK(r4).continuation.results should contain theSameElementsAs List(List("datum2"))
       insertActions <- store.changes().map(collectActions[InsertAction])
     } yield (insertActions shouldBe empty)
   }
@@ -631,9 +653,9 @@ trait StorageActionsTests[F[_]]
         _ = r3 shouldBe defined
         _ = r4 shouldBe None
 
-        _ = runK(r3)
+        _ = runK(unpackOption(r3))
 
-        _ = getK(r3).results should contain theSameElementsAs List(List("datum1"))
+        _ = getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
         //ensure that joins are cleaned-up after all
         _             <- store.getJoins("ch1").map(_ shouldBe List(List("ch1", "ch2")))
         _             <- store.getJoins("ch2").map(_ shouldBe List(List("ch1", "ch2")))
@@ -659,9 +681,9 @@ trait StorageActionsTests[F[_]]
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
 
-      _ = runK(r2)
+      _ = runK(unpackOption(r2))
 
-      _ = getK(r2).results should contain theSameElementsAs List(List("datum"))
+      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum"))
 
       // the data has been consumed, so the write will "stick"
       r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
@@ -687,8 +709,8 @@ trait StorageActionsTests[F[_]]
         insertActions <- store.changes().map(collectActions[InsertAction])
         _             = insertActions shouldBe empty
 
-        _ = runK(r2)
-        _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
+        _ = runK(unpackOption(r2))
+        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
         // All matching data has been consumed, so the write will "stick"
         r3 <- space.consume(key, List(Wildcard), new StringsCaptor, persist = true)
@@ -702,8 +724,8 @@ trait StorageActionsTests[F[_]]
         _  <- store.getData(key.head).map(_ shouldBe Nil)
         _  <- store.getContinuations(key).map(_ should not be empty)
 
-        _ = runK(r4)
-      } yield (getK(r4).results should contain theSameElementsAs List(List("datum2")))
+        _ = runK(unpackOption(r4))
+      } yield getK(r4).continuation.results should contain theSameElementsAs List(List("datum2"))
   }
 
   "doing a persistent consume and producing multiple times" should "work" in fixture {
@@ -719,19 +741,19 @@ trait StorageActionsTests[F[_]]
         _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
         _  = r2 shouldBe defined
 
-        _ = runK(r2)
-        _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
+        _ = runK(unpackOption(r2))
+        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
         r3 <- space.produce("ch1", "datum2", persist = false)
         _  <- store.getData("ch1").map(_ shouldBe Nil)
         _  <- store.getContinuations(List("ch1")).map(_ should not be empty)
 
         _ = r3 shouldBe defined
-        _ = runK(r3)
-      } yield (getK(r3).results should contain theSameElementsAs List(
+        _ = runK(unpackOption(r3))
+      } yield getK(r3).continuation.results should contain theSameElementsAs List(
         List("datum1"),
         List("datum2")
-      ))
+      )
   }
 
   "consuming and doing a persistient produce" should "work" in fixture { (store, _, space) =>
@@ -745,8 +767,8 @@ trait StorageActionsTests[F[_]]
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
 
-      _ = runK(r2)
-      _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
+      _ = runK(unpackOption(r2))
+      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
       // All matching continuations have been produced, so the write will "stick"
       r3 <- space.produce("ch1", "datum1", persist = true)
@@ -769,8 +791,8 @@ trait StorageActionsTests[F[_]]
         insertActions <- store.changes().map(collectActions[InsertAction])
         _             = insertActions shouldBe empty
 
-        _ = runK(r2)
-        _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
+        _ = runK(unpackOption(r2))
+        _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
         // All matching continuations have been produced, so the write will "stick"
         r3 <- space.produce("ch1", "datum1", persist = true)
@@ -783,8 +805,8 @@ trait StorageActionsTests[F[_]]
         _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
         _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
-        _ = runK(r4)
-      } yield (getK(r4).results should contain theSameElementsAs List(List("datum1")))
+        _ = runK(unpackOption(r4))
+      } yield getK(r4).continuation.results should contain theSameElementsAs List(List("datum1"))
   }
 
   "doing a persistent produce and consuming twice" should "work" in fixture { (store, _, space) =>
@@ -799,16 +821,16 @@ trait StorageActionsTests[F[_]]
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
       _  = r2 shouldBe defined
 
-      _ = runK(r2)
-      _ = getK(r2).results should contain theSameElementsAs List(List("datum1"))
+      _ = runK(unpackOption(r2))
+      _ = getK(r2).continuation.results should contain theSameElementsAs List(List("datum1"))
 
       r3 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = false)
       _  <- store.getData("ch1") map (_ shouldBe List(Datum.create("ch1", "datum1", true)))
       _  <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
 
       _ = r3 shouldBe defined
-      _ = runK(r3)
-    } yield (getK(r3).results should contain theSameElementsAs List(List("datum1")))
+      _ = runK(unpackOption(r3))
+    } yield getK(r3).continuation.results should contain theSameElementsAs List(List("datum1"))
   }
 
   "producing three times and doing a persistent consume" should "work" in fixture {
@@ -832,8 +854,10 @@ trait StorageActionsTests[F[_]]
         _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
         _ = r4 shouldBe defined
 
-        _ = runK(r4)
-        _ = getK(r4).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
+        _ = runK(unpackOption(r4))
+        _ = getK(r4).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
 
         // Matching data exists so the write will not "stick"
         r5 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
@@ -845,8 +869,10 @@ trait StorageActionsTests[F[_]]
         _ <- store.getContinuations(List("ch1")) map (_ shouldBe Nil)
         _ = r5 shouldBe defined
 
-        _ = runK(r5)
-        _ = getK(r5).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
+        _ = runK(unpackOption(r5))
+        _ = getK(r5).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
 
         // Matching data exists so the write will not "stick"
         r6            <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
@@ -854,8 +880,10 @@ trait StorageActionsTests[F[_]]
         _             = insertActions shouldBe empty
         _             = r6 shouldBe defined
 
-        _ = runK(r6)
-        _ = getK(r6).results should contain oneOf (List("datum1"), List("datum2"), List("datum3"))
+        _ = runK(unpackOption(r6))
+        _ = getK(r6).continuation.results should contain oneOf (List("datum1"), List("datum2"), List(
+          "datum3"
+        ))
 
         // All matching data has been consumed, so the write will "stick"
         r7 <- space.consume(List("ch1"), List(Wildcard), new StringsCaptor, persist = true)
@@ -880,8 +908,8 @@ trait StorageActionsTests[F[_]]
                persist = false
              )
         _ = r2 shouldBe defined
-        _ = runK(r2)
-      } yield (getK(r2).results should contain(List("datum", "datum")))
+        _ = runK(unpackOption(r2))
+      } yield getK(r2).continuation.results should contain(List("datum", "datum"))
   }
 
   "clear" should "reset to the same hash on multiple runs" in fixture { (store, _, space) =>
@@ -901,7 +929,7 @@ trait StorageActionsTests[F[_]]
       //the checkpointing mechanism should not interfere with the empty root
       checkpoint2 <- space.createCheckpoint()
       _           = checkpoint2.log shouldBe empty
-    } yield (checkpoint2.root shouldBe emptyCheckpoint.root)
+    } yield checkpoint2.root shouldBe emptyCheckpoint.root
   }
 
   "createCheckpoint on an empty store" should "return the expected hash" in fixture {
@@ -1000,7 +1028,7 @@ trait StorageActionsTests[F[_]]
       _   <- space.produce(channel, datum, persist = false)
       res <- Sync[F].attempt(space.install(key, patterns, new StringsCaptor))
       ex  = res.left.get
-    } yield (ex.getMessage shouldBe "Installing can be done only on startup")
+    } yield ex.getMessage shouldBe "Installing can be done only on startup"
   }
 
   "consuming with a list of patterns that is a different length than the list of channels" should
@@ -1013,7 +1041,7 @@ trait StorageActionsTests[F[_]]
       _             = err shouldBe an[IllegalArgumentException]
       _             = err.getMessage shouldBe "channels.length must equal patterns.length"
       insertActions <- store.changes().map(collectActions[InsertAction])
-    } yield (insertActions shouldBe empty)
+    } yield insertActions shouldBe empty
   }
 
   "createSoftCheckpoint" should "capture the current state of the store" in fixture {
@@ -1029,7 +1057,7 @@ trait StorageActionsTests[F[_]]
             channels,
             patterns,
             continuation,
-            false,
+            persist = false,
             SortedSet.empty
           )
       )
@@ -1060,7 +1088,7 @@ trait StorageActionsTests[F[_]]
         channels,
         patterns,
         continuation,
-        false,
+        persist = false,
         SortedSet.empty
       )
 
@@ -1097,7 +1125,7 @@ trait StorageActionsTests[F[_]]
           channels,
           patterns,
           continuation,
-          false
+          persistent = false
         )
       s2 <- space.createSoftCheckpoint()
       // assert that the event log has been cleared

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageExamplesTests.scala
@@ -1,19 +1,17 @@
 package coop.rchain.rspace
 
 import cats._
-import cats.implicits._
-import cats.syntax.parallel._
-import cats.instances.parallel._
+import cats.syntax.all._
 import coop.rchain.rspace.examples.AddressBookExample
 import coop.rchain.rspace.examples.AddressBookExample._
 import coop.rchain.rspace.examples.AddressBookExample.implicits._
-import coop.rchain.rspace.util._
 import coop.rchain.rspace.test._
+import coop.rchain.rspace.util.{getK, runK, unpackOption}
+import monix.eval.Task
+import monix.execution.atomic.AtomicAny
 import scodec.Codec
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import monix.eval.Task
-import monix.execution.atomic.AtomicAny
 
 trait StorageExamplesTests[F[_]]
     extends StorageTestsBase[F, Channel, Pattern, Entry, EntriesCaptor] {
@@ -33,8 +31,8 @@ trait StorageExamplesTests[F[_]]
       _             = r2 shouldBe None
       r3            <- space.produce(Channel("friends"), bob, persist = false)
       _             = r3 shouldBe defined
-      _             = runK(r3)
-      _             = getK(r3).results shouldBe List(List(bob, bob))
+      _             = runK(unpackOption(r3))
+      _             = getK(r3).continuation.results shouldBe List(List(bob, bob))
       insertActions <- store.changes().map(collectActions[InsertAction])
       _             = insertActions shouldBe empty
     } yield ()
@@ -55,8 +53,8 @@ trait StorageExamplesTests[F[_]]
                persist = false
              )
       _ = r3 shouldBe defined
-      _ = runK(r3)
-      _ = getK(r3).results shouldBe List(List(bob, bob))
+      _ = runK(unpackOption(r3))
+      _ = getK(r3).continuation.results shouldBe List(List(bob, bob))
     } yield (store.changes().map(_.isEmpty shouldBe true))
   }
 
@@ -81,8 +79,8 @@ trait StorageExamplesTests[F[_]]
       _  = r3 shouldBe None
       r4 <- space.produce(Channel("colleagues"), alice, persist = false)
       _  = r4 shouldBe defined
-      _  = runK(r4)
-      _  = getK(r4).results shouldBe List(List(alice, bob, bob))
+      _  = runK(unpackOption(r4))
+      _  = getK(r4).continuation.results shouldBe List(List(alice, bob, bob))
     } yield (store.changes().map(_.isEmpty shouldBe true))
 
   }
@@ -138,8 +136,8 @@ trait StorageExamplesTests[F[_]]
       _ = r9 shouldBe None
       _ = r10 shouldBe defined
 
-      _ = runK(r10)
-      _ = getK(r10).results shouldBe List(
+      _ = runK(unpackOption(r10))
+      _ = getK(r10).continuation.results shouldBe List(
         List(carol, carol, carol, carol, alice, alice, alice, bob, bob)
       )
 
@@ -198,8 +196,8 @@ trait StorageExamplesTests[F[_]]
               )
 
       _ = r10 shouldBe defined
-      _ = runK(r10)
-      _ = getK(r10).results shouldBe List(
+      _ = runK(unpackOption(r10))
+      _ = getK(r10).continuation.results shouldBe List(
         List(carol, carol, carol, carol, alice, alice, alice, bob, bob)
       )
     } yield (store.changes().map(_.isEmpty shouldBe true))
@@ -258,8 +256,8 @@ trait StorageExamplesTests[F[_]]
       _ = r9 shouldBe None
       _ = r10 shouldBe defined
 
-      _ = runK(r10)
-      _ = getK(r10).results shouldBe List(
+      _ = runK(unpackOption(r10))
+      _ = getK(r10).continuation.results shouldBe List(
         List(carol, alice, carol, bob, bob, carol, alice, alice, carol)
       )
     } yield (store.changes().map(_.isEmpty shouldBe true))


### PR DESCRIPTION
## Overview

The goal of this PR is to add more clarity to Rholang reducer and normalizer code. It removes implicit conversions of RSpace result types to be easier to understand.

**NOTE: It does not change any functionality.**

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
