### PR TITLE
Fix LFS block requester tests

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
@@ -90,7 +90,7 @@ class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2Stream
       requestTimeout: FiniteDuration
   )(test: Mock[F] => F[Unit]): F[Unit] = {
 
-    // Approved block has initial root hash of the state
+    // Approved block has initial latest messages
     val approvedBlock = createApprovedBlock(startBlock)
 
     // Approved block is already saved in block storage
@@ -274,7 +274,6 @@ class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2Stream
       _ <- receiveBlock(b8)
 
       // Only valid block should be saved
-      //      _ = eff.puts shouldBe asMap(b7)
       puts <- savedBlocks.take(1).compile.to(Map)
       _    = puts shouldBe asMap(b8)
 
@@ -306,11 +305,11 @@ class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2Stream
   it should "request and save all blocks" in dagFromBlock(b9) { mock =>
     import mock._
     for {
-      // Staring block with dependencies should be requested
+      // Staring block dependencies should be requested
       reqs <- sentRequests.take(1).compile.to(List)
       _    = reqs.sorted shouldBe List(hash8)
 
-      // Receive starting block and its dependencies (latest blocks)
+      // Receive starting block dependencies (latest blocks)
       _ <- receiveBlock(b8)
 
       // Dependencies of b8 should be in requests also
@@ -340,7 +339,7 @@ class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2Stream
       puts <- savedBlocks.take(2).compile.to(Map)
       _    = puts shouldBe asMap(b6, b3)
 
-      // Receive block b3
+      // Receive blocks b4 and b1
       _ <- receiveBlock(b4, b1)
 
       // All blocks should be requested

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
@@ -1,26 +1,24 @@
 package coop.rchain.casper.engine
 
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Concurrent
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.engine.LfsBlockRequester.ST
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.TestTime
+import coop.rchain.casper.util.scalatest.Fs2StreamMatchers
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.blockImplicits
-import coop.rchain.shared.{Log, SyncVarOps, Time}
+import coop.rchain.shared.{Log, Time}
 import fs2.Stream
 import fs2.concurrent.Queue
 import monix.eval.Task
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
-class LfsBlockRequesterEffectsSpec
-    extends FlatSpec
-    with Matchers
-    with GeneratorDrivenPropertyChecks {
+class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2StreamMatchers {
 
   def mkHash(s: String) = ByteString.copyFromUtf8(s)
 
@@ -61,96 +59,87 @@ class LfsBlockRequesterEffectsSpec
   val b2 = getBlock(hash2, number = 2, Seq())
   val b1 = getBlock(hash1, number = 1, Seq())
 
-  trait Effects[F[_]] {
-    def requestForBlock(hash: BlockHash): F[Unit]
-    def containsBlockInStore(hash: BlockHash): F[Boolean]
-    def getBlock(hash: BlockHash): F[BlockMessage]
-    def putBlockToStore(hash: BlockHash, b: BlockMessage): F[Unit]
-    def validateBlock(b: BlockMessage): F[Boolean]
-  }
+  implicit val ordBytes = Ordering.by((_: ByteString).toByteArray.toIterable).reverse
 
-  case class EffectsImpl[F[_]: Sync](
-      var requests: List[BlockHash],
-      var puts: Map[BlockHash, BlockMessage],
-      var invalids: Set[BlockHash]
-  ) extends Effects[F] {
-    val lock = SyncVarOps.create(this)
+  case class TestST(blocks: Map[BlockHash, BlockMessage], invalid: Set[BlockHash])
 
-    // Helper for multi-thread safe update of the state
-    def atomically[A](operation: => A): F[A] =
-      Sync[F].delay {
-        lock.take()
-        val result = operation
-        lock.put(this)
-        result
-      }
+  trait Mock[F[_]] {
+    // Fill response queue - simulate receiving block from external source
+    def receiveBlock(blocks: BlockMessage*): F[Unit]
 
-    implicit val ordBytes = Ordering.by((_: ByteString).toByteArray.toIterable)
+    // Observed requests
+    val sentRequests: Stream[F, BlockHash]
 
-    override def requestForBlock(hash: BlockHash): F[Unit] =
-      atomically(requests = (requests :+ hash).sorted.reverse).void
+    // Observed saved blocks
+    val savedBlocks: Stream[F, (BlockHash, BlockMessage)]
 
-    override def containsBlockInStore(hash: BlockHash): F[Boolean] =
-      atomically(puts.contains(hash))
+    // Test state
+    val setup: Ref[F, TestST]
 
-    override def getBlock(hash: BlockHash): F[BlockMessage] =
-      atomically(puts(hash))
-
-    override def putBlockToStore(hash: BlockHash, b: BlockMessage): F[Unit] =
-      atomically(puts = puts + ((hash, b))).void
-
-    override def validateBlock(b: BlockMessage): F[Boolean] =
-      atomically(!invalids(b.blockHash))
-  }
-
-  trait SUT[F[_], Eff] {
     // Processing stream
     val stream: Stream[F, ST[BlockHash]]
-    // Fill response queue - simulate receiving blocks from external source
-    def receive(bs: BlockMessage*): F[Unit]
-    // Observed effects (sent requests, saved blocks, ...)
-    val eff: Eff
   }
 
-  def createSut[F[_]: Concurrent: Time: Log, Eff <: Effects[F]](
+  /**
+    * Creates test setup
+    *
+    * @param test test definition
+    */
+  def createMock[F[_]: Concurrent: Time: Log](
       startBlock: BlockMessage,
-      effects: Eff,
       requestTimeout: FiniteDuration
-  )(test: SUT[F, Eff] => F[Unit]): F[Unit] = {
-    import cats.instances.list._
+  )(test: Mock[F] => F[Unit]): F[Unit] = {
 
+    // Approved block has initial root hash of the state
     val approvedBlock = createApprovedBlock(startBlock)
+
+    // Approved block is already saved in block storage
+    val savedBlocks = Map(startBlock.blockHash -> startBlock)
+
     for {
+      testState <- Ref.of[F, TestST](TestST(blocks = savedBlocks, invalid = Set()))
+
       // Queue for received blocks
       responseQueue <- Queue.unbounded[F, BlockMessage]
+
+      // Queue for requested block hashes
+      requestQueue <- Queue.unbounded[F, BlockHash]
+
+      // Queue for saved blocks
+      savedBlocksQueue <- Queue.unbounded[F, (BlockHash, BlockMessage)]
+
       // Queue for processing the internal state (ST)
-      requestStream <- LfsBlockRequester.stream(
-                        approvedBlock,
-                        responseQueue,
-                        initialMinimumHeight = 0,
-                        effects.requestForBlock,
-                        requestTimeout,
-                        effects.containsBlockInStore,
-                        effects.getBlock,
-                        effects.putBlockToStore,
-                        effects.validateBlock
-                      )
+      processingStream <- LfsBlockRequester.stream(
+                           approvedBlock,
+                           responseQueue,
+                           initialMinimumHeight = 0,
+                           requestQueue.enqueue1,
+                           requestTimeout,
+                           hash => testState.get.map(_.blocks.contains(hash)),
+                           hash => testState.get.map(_.blocks(hash)),
+                           savedBlocksQueue.enqueue1(_, _),
+                           block => testState.get.map(!_.invalid.contains(block.blockHash))
+                         )
 
-      receiveBlocks = (bs: List[BlockMessage]) => {
-        bs.traverse_(responseQueue.enqueue1(_) >> requestStream.take(1).compile.drain)
-      }
+      mock = new Mock[F] {
+        override def receiveBlock(blocks: BlockMessage*): F[Unit] =
+          responseQueue.enqueue(Stream.emits(blocks)).compile.drain
 
-      sut = new SUT[F, Eff] {
-        override val stream: Stream[F, ST[BlockHash]]    = requestStream
-        override def receive(bs: BlockMessage*): F[Unit] = receiveBlocks(bs.toList)
-        override val eff: Eff                            = effects
+        override val sentRequests: Stream[F, BlockHash] =
+          Stream.eval(requestQueue.dequeue1).repeat
+        override val savedBlocks: Stream[F, (BlockHash, BlockMessage)] =
+          Stream.eval(savedBlocksQueue.dequeue1).repeat
+
+        override val setup: Ref[F, TestST] = testState
+
+        override val stream: Stream[F, ST[BlockHash]] = processingStream
       }
 
       // Take one element from the stream, processed the first signal on start
-      _ <- requestStream.take(1).compile.drain
+      _ <- processingStream.take(1).compile.drain
 
-      // Execute test function
-      _ <- test(sut)
+      // Execute test function together with processing stream
+      _ <- test(mock)
     } yield ()
   }
 
@@ -168,149 +157,210 @@ class LfsBlockRequesterEffectsSpec
     * @param requestTimeout request resend timeout
     * @param test test specification
     */
-  def dagFromBlock(startBlock: BlockMessage, requestTimeout: FiniteDuration = 10.days)(
-      test: SUT[Task, EffectsImpl[Task]] => Task[Unit]
-  ): Unit =
-    createSut[Task, EffectsImpl[Task]](
-      startBlock,
-      EffectsImpl[Task](Nil, Map(), Set()),
-      requestTimeout
-    )(test).runSyncUnsafe(timeout = 10.seconds)
+  def dagFromBlock(
+      startBlock: BlockMessage,
+      runProcessingStream: Boolean = true,
+      requestTimeout: FiniteDuration = 10.days
+  )(test: Mock[Task] => Task[Unit]): Unit =
+    createMock[Task](startBlock, requestTimeout) { mock =>
+      if (!runProcessingStream) test(mock)
+      else (Stream.eval(test(mock)) concurrently mock.stream).compile.drain
+    }.runSyncUnsafe(timeout = 3.seconds)
 
   def asMap(bs: BlockMessage*): Map[BlockHash, BlockMessage] = bs.map(b => (b.blockHash, b)).toMap
 
-  it should "send requests for dependencies" in dagFromBlock(b8) { sut =>
-    import sut._
+  it should "send requests for dependencies" in dagFromBlock(b8) { mock =>
+    import mock._
     for {
       // Receive of parent should create requests for justifications (dependencies)
-      _ <- receive(b8)
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash7, hash5)
 
-      _ = eff.requests shouldBe List(hash8, hash7, hash5)
+      // No other requests should be sent
+      _ = sentRequests should notEmit
     } yield ()
   }
 
-  it should "first request dependencies from starting block" in dagFromBlock(b8) { sut =>
-    import sut._
+  it should "not request saved blocks" in dagFromBlock(b8) { mock =>
+    import mock._
     for {
-      // Receive of starting block
-      _ <- receive(b8)
+      // Receive of parent should create requests for justifications (dependencies)
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash7, hash5)
 
+      // No other requests should be sent
+      _ = sentRequests should notEmit
+
+      // Dependent block is already saved
+      _ <- setup.update(x => x.copy(blocks = x.blocks ++ asMap(b6)))
+
+      _ <- receiveBlock(b7, b5)
+
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash4, hash3)
+
+      // No other requests should be sent
+      _ = sentRequests should notEmit
+    } yield ()
+  }
+
+  it should "first request dependencies only from starting block" in dagFromBlock(b8) { mock =>
+    import mock._
+    for {
       // Requested dependencies from starting blocks
-      _ = eff.requests shouldBe List(hash8, hash7, hash5)
-      _ = eff.requests = Nil
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash7, hash5)
 
       // Receive only one dependency
-      _ <- receive(b7)
+      _ <- receiveBlock(b7)
 
       // No new requests until all dependencies received
-      _ = eff.requests shouldBe Nil
+      _ = sentRequests should notEmit
 
       // Receive the last dependency (the last of latest blocks)
-      _ <- receive(b5)
+      _ <- receiveBlock(b5)
 
       // All dependencies should be requested
-      _ = eff.requests shouldBe List(hash6, hash3)
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash6, hash3)
     } yield ()
   }
 
-  it should "save received blocks if requested" in dagFromBlock(b9) { sut =>
-    import sut._
+  it should "save received blocks if requested" in dagFromBlock(b9) { mock =>
+    import mock._
     for {
-      // Receive first block (with dependencies)
-      _ <- receive(b9, b8)
+      // Receive first block dependencies
+      _ <- receiveBlock(b8)
+
+      // Received blocks should be saved
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b8)
+
+      // Wait for requests to be sent
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash8, hash7)
 
       // Receive one dependency
-      _ <- receive(b7)
+      _ <- receiveBlock(b7)
 
       // Both blocks should be saved
-      _ = eff.puts shouldBe asMap(b9, b8, b7)
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b7)
+
+      // No other blocks should be saved
+      _ = savedBlocks should notEmit
     } yield ()
   }
 
-  it should "skip received invalid blocks" in dagFromBlock(b9) { sut =>
-    import sut._
-    for {
-      // Receive first block (with dependencies)
-      _ <- receive(b9, b8)
-      _ = eff.requests = Nil
-      _ = eff.puts = Map()
-
-      // Set invalid blocks
-      _ = eff.invalids = Set(hash5)
-
-      // Receive dependencies
-      _ <- receive(b7, b5)
-
-      // Only valid block should be saved
-      _ = eff.puts shouldBe asMap(b7)
-
-      // Only dependencies from valid block should requested
-      _ = eff.requests shouldBe List(hash6)
-    } yield ()
-  }
-
-  it should "drop all blocks not requested" in dagFromBlock(b9) { sut =>
-    import sut._
+  it should "drop all blocks not requested" in dagFromBlock(b9) { mock =>
+    import mock._
     for {
       // Receive blocks not requested
-      _ <- receive(b7, b6, b5, b4, b3, b2, b1)
+      _ <- receiveBlock(b7, b6, b5, b4, b3, b2, b1)
 
       // It should contain only request for the first block
-      _ = eff.requests shouldBe List(hash9, hash8)
-      // Nothing should be saved
-      _ = eff.puts shouldBe Map()
+      reqs <- sentRequests.take(1).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash8)
+
+      // Nothing else should be saved
+      _ = savedBlocks should notEmit
     } yield ()
   }
 
-  it should "request and save all blocks" in dagFromBlock(b9) { sut =>
-    import sut._
-    // Staring block with dependencies should be requested
-    eff.requests shouldBe List(hash9, hash8)
-    eff.requests = Nil
+  it should "skip received invalid blocks" in dagFromBlock(b9) { mock =>
+    import mock._
     for {
+      // Receive first block dependencies
+      _ <- receiveBlock(b8)
+
+      // Only valid block should be saved
+      //      _ = eff.puts shouldBe asMap(b7)
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b8)
+
+      // No other blocks should be saved
+      _ = savedBlocks should notEmit
+
+      // Set invalid blocks
+      _ <- setup.update(_.copy(invalid = Set(hash5)))
+
+      // Receive dependencies
+      _ <- receiveBlock(b7, b5)
+
+      // Only valid block should be saved
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b7)
+
+      // No other blocks should be saved
+      _ = savedBlocks should notEmit
+
+      // Only dependencies from valid block should requested
+      reqs <- sentRequests.take(4).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash8, hash7, hash6, hash5)
+
+      // No other requests should be sent
+      _ = sentRequests should notEmit
+    } yield ()
+  }
+
+  it should "request and save all blocks" in dagFromBlock(b9) { mock =>
+    import mock._
+    for {
+      // Staring block with dependencies should be requested
+      reqs <- sentRequests.take(1).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash8)
+
       // Receive starting block and its dependencies (latest blocks)
-      _ <- receive(b9, b8)
+      _ <- receiveBlock(b8)
 
       // Dependencies of b8 should be in requests also
-      _ = eff.requests shouldBe List(hash7, hash5)
-      _ = eff.requests = Nil
-      // Starting block and its dependencies should be saved
-      _ = eff.puts shouldBe asMap(b9, b8)
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash7, hash5)
+      // Starting block dependencies should be saved
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b8)
 
       // Receive blocks b7 and b5
-      _ <- receive(b7, b5)
+      _ <- receiveBlock(b7, b5)
 
       // All blocks should be requested
-      _ = eff.requests shouldBe List(hash6, hash3)
-      _ = eff.requests = Nil
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash6, hash3)
       // Received blocks should be saved
-      _ = eff.puts shouldBe asMap(b9, b8, b7, b5)
+      puts <- savedBlocks.take(2).compile.to(Map)
+      _    = puts shouldBe asMap(b7, b5)
 
       // Receive blocks b6, b5 and b3
-      _ <- receive(b6, b5, b3)
+      _ <- receiveBlock(b6, b5, b3)
 
       // All blocks should be requested
-      _ = eff.requests shouldBe List(hash4, hash1)
-      _ = eff.requests = Nil
+      reqs <- sentRequests.take(2).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash4, hash1)
       // All blocks should be saved
-      _ = eff.puts shouldBe asMap(b9, b8, b7, b6, b5, b3)
+      puts <- savedBlocks.take(2).compile.to(Map)
+      _    = puts shouldBe asMap(b6, b3)
 
       // Receive block b3
-      _ <- receive(b4, b1)
+      _ <- receiveBlock(b4, b1)
 
       // All blocks should be requested
-      _ = eff.requests shouldBe List(hash2)
-      _ = eff.requests = Nil
+      reqs <- sentRequests.take(1).compile.to(List)
+      _    = reqs.sorted shouldBe List(hash2)
       // All blocks should be saved
-      _ = eff.puts shouldBe asMap(b9, b8, b7, b6, b5, b4, b3, b1)
+      puts <- savedBlocks.take(2).compile.to(Map)
+      _    = puts shouldBe asMap(b4, b1)
 
       // Receive block b2
-      _ <- receive(b2)
+      _ <- receiveBlock(b2)
 
-      // All blocks should be requested
-      _ = eff.requests shouldBe Nil
+      // All blocks should already be be requested, no new requests
+      _ = sentRequests should notEmit
       // All blocks should be saved
-      _ = eff.puts shouldBe asMap(b9, b8, b7, b6, b5, b4, b3, b2, b1)
+      puts <- savedBlocks.take(1).compile.to(Map)
+      _    = puts shouldBe asMap(b2)
+
+      // Nothing else should be saved
+      _ = savedBlocks should notEmit
     } yield ()
   }
 
@@ -323,16 +373,24 @@ class LfsBlockRequesterEffectsSpec
     *  Other testing instances of Time are the same as in normal node execution (using Task.timer).
     *  https://github.com/rchain/rchain/issues/3001
     */
-  it should "re-send request after timeout" in dagFromBlock(b9, requestTimeout = 200.millis) {
-    sut =>
-      import sut._
-      for {
-        // Wait for timeout to expire
-        _ <- stream.compile.drain.timeout(300.millis).onErrorHandle(_ => ())
+  it should "re-send request after timeout" in dagFromBlock(
+    b9,
+    runProcessingStream = false,
+    requestTimeout = 200.millis
+  ) { mock =>
+    import mock._
+    for {
+      // Wait for timeout to expire
+      _ <- stream.compile.drain.timeout(300.millis).onErrorHandle(_ => ())
 
-        // Request should be repeated
-        _ = eff.requests shouldBe List(hash9, hash9, hash8, hash8)
-      } yield ()
+      // Wait for two requests
+      reqs <- sentRequests.take(2).compile.toList
+
+      // Both requests should be repeated by resend
+      _ = reqs.sorted shouldBe List(hash8, hash8).sorted
+
+      // No other requests should be sent
+      _ = sentRequests should notEmit
+    } yield ()
   }
-
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/scalatest/Fs2StreamMatchers.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/scalatest/Fs2StreamMatchers.scala
@@ -1,0 +1,35 @@
+package coop.rchain.casper.util.scalatest
+
+import fs2.Stream
+import monix.eval.Task
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import java.util.concurrent.TimeoutException
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+trait Fs2StreamMatchers {
+
+  /**
+    * Checks if Stream will not produce any more elements == stream is empty
+    *
+    * @param timeout duration to wait for new elements
+    */
+  class EmptyMatcher[A](timeout: FiniteDuration) extends Matcher[Stream[Task, A]] {
+    import monix.execution.Scheduler.Implicits.global
+
+    def apply(left: Stream[Task, A]) = {
+      val res = left.take(1).timeout(timeout).compile.toList.attempt.runSyncUnsafe()
+
+      val isEmpty = res.isLeft && res.left.get.isInstanceOf[TimeoutException]
+
+      val onFail    = if (!isEmpty) s"Stream is not empty, emitted: ${res.right.get}" else ""
+      val onSuccess = s"Stream is empty"
+
+      MatchResult(isEmpty, onFail, onSuccess)
+    }
+  }
+
+  def notEmit = new EmptyMatcher[Any](250.millis)
+
+  def notEmit(timeout: FiniteDuration) = new EmptyMatcher[Any](timeout)
+}


### PR DESCRIPTION
## Overview

This PR fixes occasional error on CI when running tests for LFS blocks requester. Tests are now implemented in the same way as LFS state requester tests, using fs2 streams for mocking.

Helper ScalaTest metcher is added to check for empty streams.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
