### PR TITLE
Add manual rho types

### DIFF
--- a/models/src/main/scala/coop/rchain/models/manual/BindPattern.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/BindPattern.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+final case class BindPattern(
+    patterns: Seq[Par] = Seq.empty,
+    remainder: Option[Var] = None,
+    freeCount: Int = 0
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Bundle.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Bundle.scala
@@ -1,0 +1,18 @@
+package coop.rchain.models.manual
+
+/** *
+  * Nothing can be received from a (quoted) bundle with `readFlag = false`.
+  * Likeise nothing can be sent to a (quoted) bundle with `writeFlag = false`.
+  *
+  * If both flags are set to false, bundle allows only for equivalance check.
+  *
+  * @param writeFlag
+  *   flag indicating whether bundle is writeable
+  * @param readFlag
+  *   flag indicating whether bundle is readable
+  */
+final case class Bundle(
+    body: Par = Par.defaultInstance,
+    writeFlag: Boolean = false,
+    readFlag: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Connective.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Connective.scala
@@ -1,0 +1,33 @@
+package coop.rchain.models.manual
+
+import Connective._
+
+final case class Connective(
+    connectiveInstance: ConnectiveInstance = ConnectiveInstance.Empty
+)
+
+object Connective {
+  sealed trait ConnectiveInstance {
+    def connAndBody: Option[ConnectiveBody] = None
+    def connOrBody: Option[ConnectiveBody]  = None
+    def connNotBody: Option[Par]            = None
+    def varRefBody: Option[VarRef]          = None
+    def connBool: Option[Boolean]           = None
+    def connInt: Option[Boolean]            = None
+    def connString: Option[Boolean]         = None
+    def connUri: Option[Boolean]            = None
+    def connByteArray: Option[Boolean]      = None
+  }
+  object ConnectiveInstance {
+    case object Empty                                   extends ConnectiveInstance
+    final case class ConnAndBody(value: ConnectiveBody) extends ConnectiveInstance
+    final case class ConnOrBody(value: ConnectiveBody)  extends ConnectiveInstance
+    final case class ConnNotBody(value: Par)            extends ConnectiveInstance
+    final case class VarRefBody(value: VarRef)          extends ConnectiveInstance
+    final case class ConnBool(value: Boolean)           extends ConnectiveInstance
+    final case class ConnInt(value: Boolean)            extends ConnectiveInstance
+    final case class ConnString(value: Boolean)         extends ConnectiveInstance
+    final case class ConnUri(value: Boolean)            extends ConnectiveInstance
+    final case class ConnByteArray(value: Boolean)      extends ConnectiveInstance
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/manual/ConnectiveBody.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ConnectiveBody.scala
@@ -1,0 +1,5 @@
+package coop.rchain.models.manual
+
+final case class ConnectiveBody(
+    ps: Seq[Par] = Seq.empty
+)

--- a/models/src/main/scala/coop/rchain/models/manual/DeployId.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/DeployId.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+
+final case class DeployId(
+    sig: ByteString = ByteString.EMPTY
+)

--- a/models/src/main/scala/coop/rchain/models/manual/DeployerId.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/DeployerId.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+
+final case class DeployerId(
+    publicKey: ByteString = ByteString.EMPTY
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EAnd.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EAnd.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EAnd(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EDiv.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EDiv.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EDiv(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EEq.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EEq.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EEq(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EGt.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EGt.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EGt(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EGte.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EGte.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EGte(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EList.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EList.scala
@@ -1,0 +1,13 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+import com.google.protobuf.ByteString
+
+final case class EList(
+    ps: Seq[Par] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false,
+    remainder: Option[Var] = None
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ELt.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ELt.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class ELt(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ELte.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ELte.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class ELte(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMap.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMap.scala
@@ -1,0 +1,13 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+import com.google.protobuf.ByteString
+
+final case class EMap(
+    kvs: Seq[KeyValuePair] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false,
+    remainder: Option[Var] = None
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMatches.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMatches.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EMatches(
+    target: Par = Par.defaultInstance,
+    pattern: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMethod.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMethod.scala
@@ -1,0 +1,17 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+import com.google.protobuf.ByteString
+
+/** *
+  * `target.method(arguments)`
+  */
+final case class EMethod(
+    methodName: String = "",
+    target: Par = Par.defaultInstance,
+    arguments: Seq[Par] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMinus.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMinus.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EMinus(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMinusMinus.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMinusMinus.scala
@@ -1,0 +1,8 @@
+package coop.rchain.models.manual
+
+/** Set difference
+  */
+final case class EMinusMinus(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMod.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMod.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EMod(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EMult.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EMult.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EMult(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ENeg.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ENeg.scala
@@ -1,0 +1,5 @@
+package coop.rchain.models.manual
+
+final case class ENeg(
+    p: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ENeq.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ENeq.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class ENeq(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ENot.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ENot.scala
@@ -1,0 +1,5 @@
+package coop.rchain.models.manual
+
+final case class ENot(
+    p: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EOr.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EOr.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EOr(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EPercentPercent.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EPercentPercent.scala
@@ -1,0 +1,11 @@
+package coop.rchain.models.manual
+
+/** *
+  * String interpolation
+  *
+  * `"Hello, {name}" %% {"name": "Bob"}` denotes `"Hello, Bob"`
+  */
+final case class EPercentPercent(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EPlus.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EPlus.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class EPlus(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EPlusPlus.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EPlusPlus.scala
@@ -1,0 +1,8 @@
+package coop.rchain.models.manual
+
+/** Concatenation
+  */
+final case class EPlusPlus(
+    p1: Par = Par.defaultInstance,
+    p2: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ESet.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ESet.scala
@@ -1,0 +1,13 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+import com.google.protobuf.ByteString
+
+final case class ESet(
+    ps: Seq[Par] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false,
+    remainder: Option[Var] = None
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ETuple.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ETuple.scala
@@ -1,0 +1,12 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+import com.google.protobuf.ByteString
+
+final case class ETuple(
+    ps: Seq[Par] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/EVar.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/EVar.scala
@@ -1,0 +1,10 @@
+package coop.rchain.models.manual
+
+/** A variable used as a var should be bound in a process context, not a name
+  * context. For example:
+  * `for (&#64;x &lt;- c1; &#64;y &lt;- c2) { z!(x + y) }` is fine, but
+  * `for (x &lt;- c1; y &lt;- c2) { z!(x + y) }` should raise an error.
+  */
+final case class EVar(
+    v: Var = Var.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Expr.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Expr.scala
@@ -1,0 +1,81 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.ParSet
+import coop.rchain.models.ParMap
+import Expr._
+
+/** Any process may be an operand to an expression.
+  * Only processes equivalent to a ground process of compatible type will reduce.
+  */
+final case class Expr(
+    exprInstance: ExprInstance = ExprInstance.Empty
+)
+
+object Expr {
+  sealed trait ExprInstance {
+    def gBool: Option[Boolean]                       = None
+    def gInt: Option[Long]                           = None
+    def gString: Option[String]                      = None
+    def gUri: Option[String]                         = None
+    def gByteArray: Option[ByteString]               = None
+    def eNotBody: Option[ENot]                       = None
+    def eNegBody: Option[ENeg]                       = None
+    def eMultBody: Option[EMult]                     = None
+    def eDivBody: Option[EDiv]                       = None
+    def ePlusBody: Option[EPlus]                     = None
+    def eMinusBody: Option[EMinus]                   = None
+    def eLtBody: Option[ELt]                         = None
+    def eLteBody: Option[ELte]                       = None
+    def eGtBody: Option[EGt]                         = None
+    def eGteBody: Option[EGte]                       = None
+    def eEqBody: Option[EEq]                         = None
+    def eNeqBody: Option[ENeq]                       = None
+    def eAndBody: Option[EAnd]                       = None
+    def eOrBody: Option[EOr]                         = None
+    def eVarBody: Option[EVar]                       = None
+    def eListBody: Option[EList]                     = None
+    def eTupleBody: Option[ETuple]                   = None
+    def eSetBody: Option[ParSet]                     = None
+    def eMapBody: Option[ParMap]                     = None
+    def eMethodBody: Option[EMethod]                 = None
+    def eMatchesBody: Option[EMatches]               = None
+    def ePercentPercentBody: Option[EPercentPercent] = None
+    def ePlusPlusBody: Option[EPlusPlus]             = None
+    def eMinusMinusBody: Option[EMinusMinus]         = None
+    def eModBody: Option[EMod]                       = None
+  }
+  object ExprInstance {
+    case object Empty                                            extends ExprInstance
+    final case class GBool(value: Boolean)                       extends ExprInstance
+    final case class GInt(value: Long)                           extends ExprInstance
+    final case class GString(value: String)                      extends ExprInstance
+    final case class GUri(value: String)                         extends ExprInstance
+    final case class GByteArray(value: ByteString)               extends ExprInstance
+    final case class ENotBody(value: ENot)                       extends ExprInstance
+    final case class ENegBody(value: ENeg)                       extends ExprInstance
+    final case class EMultBody(value: EMult)                     extends ExprInstance
+    final case class EDivBody(value: EDiv)                       extends ExprInstance
+    final case class EPlusBody(value: EPlus)                     extends ExprInstance
+    final case class EMinusBody(value: EMinus)                   extends ExprInstance
+    final case class ELtBody(value: ELt)                         extends ExprInstance
+    final case class ELteBody(value: ELte)                       extends ExprInstance
+    final case class EGtBody(value: EGt)                         extends ExprInstance
+    final case class EGteBody(value: EGte)                       extends ExprInstance
+    final case class EEqBody(value: EEq)                         extends ExprInstance
+    final case class ENeqBody(value: ENeq)                       extends ExprInstance
+    final case class EAndBody(value: EAnd)                       extends ExprInstance
+    final case class EOrBody(value: EOr)                         extends ExprInstance
+    final case class EVarBody(value: EVar)                       extends ExprInstance
+    final case class EListBody(value: EList)                     extends ExprInstance
+    final case class ETupleBody(value: ETuple)                   extends ExprInstance
+    final case class ESetBody(value: ParSet)                     extends ExprInstance
+    final case class EMapBody(value: ParMap)                     extends ExprInstance
+    final case class EMethodBody(value: EMethod)                 extends ExprInstance
+    final case class EMatchesBody(value: EMatches)               extends ExprInstance
+    final case class EPercentPercentBody(value: EPercentPercent) extends ExprInstance
+    final case class EPlusPlusBody(value: EPlusPlus)             extends ExprInstance
+    final case class EMinusMinusBody(value: EMinusMinus)         extends ExprInstance
+    final case class EModBody(value: EMod)                       extends ExprInstance
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/manual/GDeployId.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/GDeployId.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+
+final case class GDeployId(
+    sig: ByteString = ByteString.EMPTY
+)

--- a/models/src/main/scala/coop/rchain/models/manual/GDeployerId.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/GDeployerId.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+
+final case class GDeployerId(
+    publicKey: ByteString = ByteString.EMPTY
+)

--- a/models/src/main/scala/coop/rchain/models/manual/GPrivate.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/GPrivate.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+
+final case class GPrivate(
+    id: ByteString = ByteString.EMPTY
+)

--- a/models/src/main/scala/coop/rchain/models/manual/GSysAuthToken.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/GSysAuthToken.scala
@@ -1,0 +1,3 @@
+package coop.rchain.models.manual
+
+final case class GSysAuthToken()

--- a/models/src/main/scala/coop/rchain/models/manual/GUnforgeable.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/GUnforgeable.scala
@@ -1,0 +1,24 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.manual.GUnforgeable.UnfInstance
+
+final case class GUnforgeable(
+    unfInstance: UnfInstance = UnfInstance.Empty
+)
+
+object GUnforgeable {
+  sealed trait UnfInstance {
+    def gPrivateBody: Option[GPrivate]           = None
+    def gDeployIdBody: Option[GDeployId]         = None
+    def gDeployerIdBody: Option[GDeployerId]     = None
+    def gSysAuthTokenBody: Option[GSysAuthToken] = None
+  }
+
+  object UnfInstance {
+    case object Empty                                        extends UnfInstance
+    final case class GPrivateBody(value: GPrivate)           extends UnfInstance
+    final case class GDeployIdBody(value: GDeployId)         extends UnfInstance
+    final case class GDeployerIdBody(value: GDeployerId)     extends UnfInstance
+    final case class GSysAuthTokenBody(value: GSysAuthToken) extends UnfInstance
+  }
+}

--- a/models/src/main/scala/coop/rchain/models/manual/KeyValuePair.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/KeyValuePair.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class KeyValuePair(
+    key: Par = Par.defaultInstance,
+    value: Par = Par.defaultInstance
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ListBindPatterns.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ListBindPatterns.scala
@@ -1,0 +1,5 @@
+package coop.rchain.models.manual
+
+final case class ListBindPatterns(
+    patterns: Seq[BindPattern] = Seq.empty
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ListParWithRandom.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ListParWithRandom.scala
@@ -1,0 +1,10 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.hash.Blake2b512Random
+
+final case class ListParWithRandom(
+    pars: Seq[Par] = Seq.empty,
+    randomState: Blake2b512Random = RhoTypesConst._typemapper_randomState
+      .toCustom(ByteString.EMPTY)
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Match.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Match.scala
@@ -1,0 +1,13 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.AlwaysEqual
+import scala.collection.immutable.BitSet
+
+final case class Match(
+    target: Par = Par.defaultInstance,
+    cases: Seq[MatchCase] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/MatchCase.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/MatchCase.scala
@@ -1,0 +1,7 @@
+package coop.rchain.models.manual
+
+final case class MatchCase(
+    pattern: Par = Par.defaultInstance,
+    source: Par = Par.defaultInstance,
+    freeCount: Int = 0
+)

--- a/models/src/main/scala/coop/rchain/models/manual/New.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/New.scala
@@ -1,0 +1,25 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.AlwaysEqual
+
+import scala.collection.immutable.BitSet
+
+/** Number of variables bound in the new statement.
+  * For normalized form, p should not contain solely another new.
+  * Also for normalized form, the first use should be level+0, next use level+1
+  * up to level+count for the last used variable.
+  *
+  * @param bindCount
+  *   Includes any uris listed below. This makes it easier to substitute or walk a term.
+  * @param uri
+  *   For normalization, uri-referenced variables come at the end, and in lexicographical order.
+  */
+final case class New(
+    bindCount: Int = 0,
+    p: Par = Par.defaultInstance,
+    uri: Seq[String] = Seq.empty,
+    injections: Map[String, Par] = Map.empty,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY)
+)

--- a/models/src/main/scala/coop/rchain/models/manual/PCost.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/PCost.scala
@@ -1,0 +1,8 @@
+package coop.rchain.models.manual
+
+/** *
+  * Cost of the performed operations.
+  */
+final case class PCost(
+    cost: Long = 0L
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Par.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Par.scala
@@ -1,0 +1,45 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.AlwaysEqual
+
+import scala.collection.immutable.BitSet
+
+/** *
+  * Rholang process
+  *
+  * For example, `&#64;0!(1) | &#64;2!(3) | for(x &lt;- &#64;0) { Nil }` has two sends
+  * and one receive.
+  *
+  * The Nil process is a `Par` with no sends, receives, etc.
+  *
+  * @param unforgeables
+  *   unforgeable names
+  */
+final case class Par(
+    sends: Seq[Send] = Seq.empty,
+    receives: Seq[Receive] = Seq.empty,
+    news: Seq[New] = Seq.empty,
+    exprs: Seq[Expr] = Seq.empty,
+    matches: Seq[Match] = Seq.empty,
+    unforgeables: Seq[GUnforgeable] = Seq.empty,
+    bundles: Seq[Bundle] = Seq.empty,
+    connectives: Seq[Connective] = Seq.empty,
+    locallyFree: AlwaysEqual[BitSet] = RhoTypesConst._typemapper_locallyFree
+      .toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)
+
+object Par {
+  lazy val defaultInstance: Par = Par(
+    sends = Seq.empty,
+    receives = Seq.empty,
+    news = Seq.empty,
+    exprs = Seq.empty,
+    matches = Seq.empty,
+    unforgeables = Seq.empty,
+    bundles = Seq.empty,
+    connectives = Seq.empty,
+    locallyFree = RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY)
+  )
+}

--- a/models/src/main/scala/coop/rchain/models/manual/ParWithRandom.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ParWithRandom.scala
@@ -1,0 +1,13 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.hash.Blake2b512Random
+
+/** *
+  * Rholang code along with the state of a split random number
+  * generator for generating new unforgeable names.
+  */
+final case class ParWithRandom(
+    body: Par = Par.defaultInstance,
+    randomState: Blake2b512Random = RhoTypesConst._typemapper_randomState.toCustom(ByteString.EMPTY)
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Receive.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Receive.scala
@@ -1,0 +1,24 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.AlwaysEqual
+
+import scala.collection.immutable.BitSet
+
+/** *
+  * A receive is written `for(binds) { body }`
+  * i.e. `for(patterns &lt;- source) { body }`
+  * or for a persistent recieve: `for(patterns &lt;= source) { body }`.
+  *
+  * It's an error for free Variable to occur more than once in a pattern.
+  */
+final case class Receive(
+    binds: Seq[ReceiveBind] = Seq.empty,
+    body: Par = Par.defaultInstance,
+    persistent: Boolean = false,
+    peek: Boolean = false,
+    bindCount: Int = 0,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/ReceiveBind.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/ReceiveBind.scala
@@ -1,0 +1,8 @@
+package coop.rchain.models.manual
+
+final case class ReceiveBind(
+    patterns: Seq[Par] = Seq.empty,
+    source: Par = Par.defaultInstance,
+    remainder: Option[Var] = None,
+    freeCount: Int = 0
+)

--- a/models/src/main/scala/coop/rchain/models/manual/RhoTypesConst.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/RhoTypesConst.scala
@@ -1,0 +1,16 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.models.AlwaysEqual
+import coop.rchain.models.BitSetBytesMapper.bitSetBytesMapper
+import scalapb.TypeMapper
+
+import scala.collection.immutable.BitSet
+
+object RhoTypesConst {
+  val _typemapper_locallyFree: TypeMapper[ByteString, AlwaysEqual[BitSet]] =
+    implicitly[TypeMapper[ByteString, AlwaysEqual[BitSet]]]
+  val _typemapper_randomState: TypeMapper[ByteString, Blake2b512Random] =
+    implicitly[TypeMapper[ByteString, Blake2b512Random]]
+}

--- a/models/src/main/scala/coop/rchain/models/manual/Send.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Send.scala
@@ -1,0 +1,20 @@
+package coop.rchain.models.manual
+
+import com.google.protobuf.ByteString
+import coop.rchain.models.AlwaysEqual
+
+import scala.collection.immutable.BitSet
+
+/** *
+  * A send is written `chan!(data)` or `chan!!(data)` for a persistent send.
+  *
+  * Upon send, all free variables in data are substituted with their values.
+  */
+final case class Send(
+    chan: Par = Par.defaultInstance,
+    data: Seq[Par] = Seq.empty,
+    persistent: Boolean = false,
+    locallyFree: AlwaysEqual[BitSet] =
+      RhoTypesConst._typemapper_locallyFree.toCustom(ByteString.EMPTY),
+    connectiveUsed: Boolean = false
+)

--- a/models/src/main/scala/coop/rchain/models/manual/TaggedContinuation.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/TaggedContinuation.scala
@@ -1,0 +1,10 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.TaggedContinuation.TaggedCont
+
+/** *
+  * Either rholang code or code built in to the interpreter.
+  */
+final case class TaggedContinuation(
+    taggedCont: TaggedCont = TaggedCont.Empty
+)

--- a/models/src/main/scala/coop/rchain/models/manual/Var.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/Var.scala
@@ -1,0 +1,18 @@
+package coop.rchain.models.manual
+
+import coop.rchain.models.Var.VarInstance
+
+/** While we use vars in both positions, when producing the normalized
+  * representation we need a discipline to track whether a var is a name or a
+  * process.
+  * These are DeBruijn levels
+  */
+final case class Var(
+    varInstance: VarInstance = VarInstance.Empty
+)
+
+object Var {
+  lazy val defaultInstance: Var = Var(
+    varInstance = VarInstance.Empty
+  )
+}

--- a/models/src/main/scala/coop/rchain/models/manual/VarRef.scala
+++ b/models/src/main/scala/coop/rchain/models/manual/VarRef.scala
@@ -1,0 +1,6 @@
+package coop.rchain.models.manual
+
+final case class VarRef(
+    index: Int = 0,
+    depth: Int = 0
+)


### PR DESCRIPTION
## Overview
This PR is a first step work [Replacement of Rholang protobuf types with Cap'n Proto](https://github.com/rchain/rchain/issues/3378).
Created a manual RhoTypes file structure. 

### Notes
This files based on autogenerated files: models/target/scala-2.12/src_managed/main/coop/rchain/models (generation from [RhoTypes.proto](https://github.com/rchain/rchain/blob/382576eb/models/src/main/protobuf/RhoTypes.proto)). The following changes have been made:
- Deleted methods, vars, and vals from the body of the classes.
- Saved default vals that's uses from initializations.
- Vals _typemapper_locallyFree and _typemapper_randomState moved to a new file [RhoTypesConst.scala](https://github.com/hilltracer/rchain/blob/2d7c6ab106fa810c9a99792c4451a4eeb4626154/models/src/main/scala/coop/rchain/models/manual/RhoTypesConst.scala).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
