### PR TITLE
Per block dag view

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -20,6 +20,7 @@ import coop.rchain.models.EquivocationRecord.SequenceNumber
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
 import coop.rchain.shared.syntax._
+import coop.rchain.models.syntax._
 import coop.rchain.shared.{Log, LogSource}
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
 import fs2.Stream
@@ -65,127 +66,75 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
 
     /**
       * Truncate full DAG according to some view, defined by latest messages.
-      *
-      * Please see example below: `-` here denote message that are not seen by target view.
-      * Target latest messages are A B C D E. G - genesis
-      *
-      * Computing of excess messages can be divided into 3 parts:
-      * 1. high excess - messages that has height above highest target latest message. This is done simply by
-      * splitting height map.
-      * 2. lmRange excess, which are messages inside the range of target latest messages, but not seen yet by
-      * the view (are higher then some target latest message from the same sender).
-      * This requires reading metadata which is more costly then 1.
-      * 3. unseen senders excess (low excess) - Please note that the first column is full of `-`, which means target
-      * message sender is ignoring this validator, but this particular node adds these
-      * messages for some reason. It does not seem like a impossible scenario, and makes truncating logic a
-      * bit more complex.
-      *
-      *   - - -   -
-      *     -       _____  ^             high excess              ^
-      *     B   -          v                                      v
-      *     *   D E
-      *     * C                        lmRange excess
-      * - - *   *
-      * - A * * * * _____  ^                                      ^
-      * -   *   *          v   unseenSendersExcess (low excess)   v
-      * -   * * * *
-      * - * *   *
-      *     G
-      *
       */
     override def truncate(
-        targetLatestMessages: Map[Validator, BlockHash]
+        targetLatestMessages: Map[Validator, BlockHash],
+        findLfb: Map[Validator, BlockHash] => F[BlockHash]
     ): F[BlockDagRepresentation[F]] = {
-      final case class HeightView(
-          height: Long,
-          excess: Iterator[ByteString],
-          inView: Iterator[ByteString]
-      )
-      for {
-        lmMetas <- targetLatestMessages.values.toStream.traverse(this.lookupUnsafe)
-        (highestHeight, lowestHeight, lmPerValidatorHeight) = lmMetas.foldLeft(
-          (0L, Long.MaxValue, Map.empty[ByteString, Long])
-        ) {
-          case ((curHH, curLH, curLVH), meta) =>
-            val newHH  = Math.max(curHH, meta.blockNum)
-            val newLH  = Math.min(curLH, meta.blockNum)
-            val newLVH = curLVH.updated(meta.sender, meta.blockNum)
-            (newHH, newLH, newLVH)
-        }
-        // messages higher then highest latest message are outside the view
-        (highExcess, withoutHighExcess) = heightMap.partition { case (h, _) => h > highestHeight }
+      val lmAll                     = this.latestMessagesMap.values.toSet
+      val lmSeen                    = targetLatestMessages.values.toSet
+      val targetEqualLatestView     = lmAll == lmSeen
+      val knownSenders              = this.latestMessagesMap.keySet
+      val seenSenders               = targetLatestMessages.keySet
+      val unknownSender             = targetLatestMessages.keysIterator.find(!knownSenders.contains(_))
+      def noSenderMsg(v: Validator) = s"Error when truncating the DAG: sender ${v.show} unknown."
 
-        // messages inside range of latest message heights might contain new messages from validator that are not seen yet
-        lmRangeViews <- heightMap
-                         .range(lowestHeight, highestHeight + 1)
-                         .toStream
-                         .traverse {
-                           case (h, messages) =>
-                             for {
-                               lms <- messages.toStream
-                                       .traverse(this.lookupUnsafe)
-                                       .map(_.map(m => (m.blockHash, m.sender)))
-                               (inView, excess) = lms.partition {
-                                 case (_, sender) =>
-                                   // remove message if target view is not aware of validator,
-                                   // or latest message in full view is newer then target
-                                   val senderSeen = lmPerValidatorHeight.contains(sender)
-                                   senderSeen && h <= lmPerValidatorHeight(sender)
-                               }
-                               r = HeightView(
-                                 h,
-                                 excess = excess.map { case (hash, _) => hash }.toIterator,
-                                 inView = inView.map { case (hash, _) => hash }.toIterator
-                               )
-                             } yield r
+      val doTruncate = for {
+        lfb             <- findLfb(targetLatestMessages)
+        latestFinalized <- this.latestFinalized(lfb, seenSenders).map(_.valuesIterator.toSet)
+        // for all known latest messages, collect all self justifications until first finalized message found
+        toAdjust <- Stream
+                     .fromIterator(lmAll.iterator)
+                     .flatMap(
+                       this
+                       // message + all self justifications
+                         .fromSenderBelowWith(_, m => (m.blockHash, m.blockNum))
+                         // take while first finalized message is found
+                         .takeWhile {
+                           case (hash, _) => !latestFinalized.contains(hash)
                          }
-                         .map(_.toSet)
-        excessMessages = lmRangeViews.flatMap(_.excess) ++ highExcess.values.flatten
+                         .mapAccumulate(init = false) {
+                           case (childIsSeen, (hash, height)) =>
+                             val seen = childIsSeen || lmSeen.contains(hash)
+                             (seen, (hash, height))
+                         }
+                     )
+                     .compile
+                     .toList
 
-        // check clause 3
-        fullLMMetas <- this.latestMessages
-        // senders that are in the full dag but not seen by view that is being created
-        unseenSenders = fullLMMetas.filter { case (_, meta) => meta.blockNum != 0 }.keySet diff targetLatestMessages.keySet
-        unseenSendersExcess <- Stream
-                              // gather all messages of unseen validators
-                                .fromIterator(unseenSenders.toIterator)
-                                .map(fullLMMetas(_).blockHash)
-                                .flatMap { h =>
-                                  Stream(h) ++ this.selfJustificationChain(h).map(_.latestBlockHash)
-                                }
-                                // if message is already removed no need to process it again
-                                .filterNot(excessMessages.contains)
-                                .evalMap(this.lookupUnsafe)
-                                // the lowest message in the DAG is always genesis - never remove genesis
-                                .filterNot(_.blockNum == heightMap.keySet.min)
-                                .map(meta => meta.blockNum -> meta.blockHash)
-                                // accumulate messages into low excess map
-                                .mapAccumulate(Map.empty[Long, Set[BlockHash]]) {
-                                  case (acc, (height, hash)) =>
-                                    val newVal = acc.getOrElse(height, Set.empty[BlockHash]) + hash
-                                    (acc.updated(height, newVal), hash)
-                                }
-                                .map { case (acc, _) => acc }
-                                .compile
-                                .last
-                                .map(_.getOrElse(Map.empty))
+        (u, r) = toAdjust.partition { case (seen, _) => seen }
+
+        toUnfinalize = u.map { case (_, (hash, height)) => (hash, height) }
+        toRemove     = r.map { case (_, (hash, height)) => (hash, height) }
+
+        excessSet       = toRemove.map { case (hash, _)     => hash }.toSet
+        nonFinalizedSet = toUnfinalize.map { case (hash, _) => hash }.toSet
+
         // new truncated values
-        truncatedDagSet     = this.dagSet diff excessMessages diff unseenSendersExcess.values.flatten.toSet
+        truncatedDagSet     = this.dagSet diff excessSet
         truncatedInvalidSet = this.invalidBlocksSet.filter(m => dagSet.contains(m.blockHash))
-        withoutRangeExcess = lmRangeViews.foldLeft(withoutHighExcess)(
-          (acc, heightView) => acc.updated(heightView.height, heightView.inView.toSet)
-        )
-        truncatedHeightMap = unseenSendersExcess.foldLeft(withoutRangeExcess) {
-          case (acc, (height, excess)) => acc.updated(height, acc(height) -- excess)
+        truncatedHeightMap = toRemove.foldLeft(this.heightMap) {
+          case (acc, (hash, height)) => acc.updated(height, acc(height) - hash)
         }
+        truncatedFinalizesSet = finalizedBlocksSet diff excessSet diff nonFinalizedSet
 
         view = this.copy(
+          lastFinalizedBlockHash = lfb,
+          finalizedBlocksSet = truncatedFinalizesSet,
           dagSet = truncatedDagSet,
           latestMessagesMap = targetLatestMessages,
           heightMap = truncatedHeightMap,
           invalidBlocksSet = truncatedInvalidSet
         )
-      } yield view
+
+      } yield view.asInstanceOf[BlockDagRepresentation[F]]
+
+      unknownSender match {
+        case None =>
+          if (targetEqualLatestView) this.asInstanceOf[BlockDagRepresentation[F]].pure
+          else doTruncate
+        case Some(v) => new Exception(noSenderMsg(v)).raiseError[F, BlockDagRepresentation[F]]
+      }
     }
 
     override def lastFinalizedBlock: BlockHash = lastFinalizedBlockHash
@@ -224,6 +173,9 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
 
     def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
       deployIndex.get(deployId)
+
+    override def nonFinalizedSet: Set[BlockHash] =
+      dagSet diff finalizedBlocksSet
   }
 
   private object KeyValueStoreEquivocationsTracker extends EquivocationsTracker[F] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -71,15 +71,11 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
         targetLatestMessages: Map[Validator, BlockHash],
         findLfb: Map[Validator, BlockHash] => F[BlockHash]
     ): F[BlockDagRepresentation[F]] = {
-      val lmAll                     = this.latestMessagesMap.values.toSet
-      val lmSeen                    = targetLatestMessages.values.toSet
-      val targetEqualLatestView     = lmAll == lmSeen
-      val knownSenders              = this.latestMessagesMap.keySet
-      val seenSenders               = targetLatestMessages.keySet
-      val unknownSender             = targetLatestMessages.keysIterator.find(!knownSenders.contains(_))
-      def noSenderMsg(v: Validator) = s"Error when truncating the DAG: sender ${v.show} unknown."
+      val lmAll       = this.latestMessagesMap.values.toSet
+      val lmSeen      = targetLatestMessages.values.toSet
+      val seenSenders = targetLatestMessages.keySet
 
-      val doTruncate = for {
+      for {
         lfb             <- findLfb(targetLatestMessages)
         latestFinalized <- this.latestFinalized(lfb, seenSenders).map(_.valuesIterator.toSet)
         // for all known latest messages, collect all self justifications until first finalized message found
@@ -126,15 +122,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
           heightMap = truncatedHeightMap,
           invalidBlocksSet = truncatedInvalidSet
         )
-
-      } yield view.asInstanceOf[BlockDagRepresentation[F]]
-
-      unknownSender match {
-        case None =>
-          if (targetEqualLatestView) this.asInstanceOf[BlockDagRepresentation[F]].pure
-          else doTruncate
-        case Some(v) => new Exception(noSenderMsg(v)).raiseError[F, BlockDagRepresentation[F]]
-      }
+      } yield view
     }
 
     override def lastFinalizedBlock: BlockHash = lastFinalizedBlockHash

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -90,17 +90,16 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
           Stream
             .unfoldLoopEval(lmAll.toVector) { messages =>
               for {
-                metas                    <- messages.traverse(this.lookupUnsafe).map(_.filterNot(finalized))
-                (toUnfinalize, toRemove) = metas.partition(seen)
+                metas <- messages.traverse(this.lookupUnsafe).map(_.filterNot(finalized))
+                out   = metas.map(m => (m, !seen(m)))
 
                 parents = metas.flatMap(_.parents).distinct
                 next    = parents.nonEmpty.guard[Option].as(parents)
-                out     = toRemove.map((_, true)) ++ toUnfinalize.map((_, false))
               } yield (Stream.emits(out.toList), next)
             }
             .flatten
             .fold((Map.empty[Long, Set[BlockHash]], Map.empty[Long, Set[BlockHash]], childMap)) {
-              case ((removeAcc, unfinalizeAcc, childMap), (m, shouldRemove)) =>
+              case ((removeAcc, unfinalizeAcc, childMapAcc), (m, shouldRemove)) =>
                 val height = m.blockNum
                 if (shouldRemove)
                   (
@@ -108,15 +107,15 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
                     unfinalizeAcc,
                     // Remove from children map key for message, adjust keys for parents.
                     // As some parent might be already removed by previous iterations, use filter.
-                    m.parents.filter(childMap.contains).foldLeft(childMap - m.blockHash) { (a, p) =>
-                      a + (p -> (a(p) - m.blockHash))
+                    m.parents.filter(childMapAcc.contains).foldLeft(childMapAcc - m.blockHash) {
+                      case (a, p) => a + (p -> (a(p) - m.blockHash))
                     }
                   )
                 else
                   (
                     removeAcc,
                     unfinalizeAcc + (height -> (unfinalizeAcc.getOrElse(height, Set()) + m.blockHash)),
-                    childMap
+                    childMapAcc
                   )
             }
             .compile
@@ -132,7 +131,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
         truncatedDagSet     = this.dagSet diff excessSet
         truncatedInvalidSet = this.invalidBlocksSet.filter(m => dagSet.contains(m.blockHash))
         truncatedHeightMap = toRemove.foldLeft(this.heightMap) {
-          case (acc, (height, hashes)) => acc.updated(height, acc(height) -- hashes)
+          case (acc, (height, hashes)) => acc.updated(height, acc(height) diff hashes)
         }
         truncatedFinalizesSet = finalizedBlocksSet diff excessSet diff nonFinalizedSet
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -125,12 +125,12 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
                                lms <- messages.toStream
                                        .traverse(this.lookupUnsafe)
                                        .map(_.map(m => (m.blockHash, m.sender)))
-                               (excess, inView) = lms.partition {
+                               (inView, excess) = lms.partition {
                                  case (_, sender) =>
                                    // remove message if target view is not aware of validator,
                                    // or latest message in full view is newer then target
                                    val senderSeen = lmPerValidatorHeight.contains(sender)
-                                   senderSeen && h > lmPerValidatorHeight(sender)
+                                   senderSeen && h <= lmPerValidatorHeight(sender)
                                }
                                r = HeightView(
                                  h,

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -160,11 +160,11 @@ final class BlockDagRepresentationOps[F[_]](
       .compile
       .to(Set)
 
-  def ancestors(blockHash: BlockHash, filterF: BlockHash => F[Boolean])(
+  def ancestors(start: List[BlockHash], filterF: BlockHash => F[Boolean])(
       implicit sync: Sync[F]
   ): F[Set[BlockHash]] =
     Stream
-      .unfoldEval(List(blockHash)) { lvl =>
+      .unfoldEval(start) { lvl =>
         val parents = lvl
           .traverse(lookupUnsafe)
           .flatMap(_.flatMap(_.parents).distinct.filterA(filterF))
@@ -177,5 +177,5 @@ final class BlockDagRepresentationOps[F[_]](
   def withAncestors(blockHash: BlockHash, filterF: BlockHash => F[Boolean])(
       implicit sync: Sync[F]
   ): F[Set[BlockHash]] =
-    ancestors(blockHash, filterF).map(_ + blockHash)
+    ancestors(List(blockHash), filterF).map(_ + blockHash)
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -98,6 +98,18 @@ final class BlockDagRepresentationOps[F[_]](
           .map(_.map(next => (next, next.latestBlockHash)))
     )
 
+  def fromSenderBelowWith[A](start: BlockHash, proj: BlockMetadata => A)(
+      implicit sync: Sync[F]
+  ): Stream[F, A] =
+    Stream.unfoldLoopEval(start)(
+      message =>
+        lookupUnsafe(message)
+          .map { meta =>
+            val selfJustification = meta.justifications.find(_.validator == meta.sender)
+            (proj(meta), selfJustification.map(_.latestBlockHash))
+          }
+    )
+
   def selfJustification(h: BlockHash)(implicit sync: Sync[F]): F[Option[Justification]] =
     selfJustificationChain(h).head.compile.last
 
@@ -133,20 +145,7 @@ final class BlockDagRepresentationOps[F[_]](
     dag.lookup(item).map(_.map(v => v.parents)) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
   }
 
-  def nonFinalizedBlocks(implicit sync: Sync[F]): F[Set[BlockHash]] =
-    for {
-      tips <- latestMessages.map(_.values.map(_.blockHash).toList)
-      r <- Stream
-            .unfoldLoopEval(tips) { lvl =>
-              for {
-                out  <- lvl.filterA(dag.isFinalized(_).not)
-                next <- out.traverse(dag.lookup(_).map(_.map(_.parents))).map(_.flatten.flatten)
-              } yield (out, next.nonEmpty.guard[Option].as(next))
-            }
-            .flatMap(Stream.emits)
-            .compile
-            .to(Set)
-    } yield r
+  def nonFinalizedBlocks(implicit sync: Sync[F]): F[Set[BlockHash]] = dag.nonFinalizedSet.pure
 
   def descendants(blockHash: BlockHash)(implicit sync: Sync[F]): F[Set[BlockHash]] =
     Stream
@@ -178,4 +177,29 @@ final class BlockDagRepresentationOps[F[_]](
       implicit sync: Sync[F]
   ): F[Set[BlockHash]] =
     ancestors(List(blockHash), filterF).map(_ + blockHash)
+
+  def latestFinalized(lfb: BlockHash, targetSenders: Set[Validator])(
+      implicit sync: Sync[F]
+  ): F[Map[Validator, BlockHash]] =
+    Stream
+      .unfoldLoopEval((List(lfb), Map.empty[Validator, BlockHash])) {
+        case (lvl, acc) =>
+          for {
+            metas <- lvl.traverse(this.lookupUnsafe).map(_.distinct)
+            newAcc = metas.foldLeft(acc)(
+              (a, m) =>
+                if (a.contains(m.sender)) a
+                else
+                  a.updated(m.sender, m.blockHash)
+            )
+            done = newAcc.keySet == targetSenders
+            next = if (done) none[(List[BlockHash], Map[Validator, BlockHash])]
+            else {
+              val parents = metas.flatMap(_.parents).distinct
+              parents.nonEmpty.guard[Option].as((parents, newAcc))
+            }
+          } yield (newAcc, next)
+      }
+      .compile
+      .lastOrError
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -98,18 +98,6 @@ final class BlockDagRepresentationOps[F[_]](
           .map(_.map(next => (next, next.latestBlockHash)))
     )
 
-  def fromSenderBelowWith[A](start: BlockHash, proj: BlockMetadata => A)(
-      implicit sync: Sync[F]
-  ): Stream[F, A] =
-    Stream.unfoldLoopEval(start)(
-      message =>
-        lookupUnsafe(message)
-          .map { meta =>
-            val selfJustification = meta.justifications.find(_.validator == meta.sender)
-            (proj(meta), selfJustification.map(_.latestBlockHash))
-          }
-    )
-
   def selfJustification(h: BlockHash)(implicit sync: Sync[F]): F[Option[Justification]] =
     selfJustificationChain(h).head.compile.last
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -44,8 +44,10 @@ trait BlockDagRepresentation[F[_]] {
   // DAG representation has to have finalized block, or it does not make sense
   def lastFinalizedBlock: BlockHash
   def isFinalized(blockHash: BlockHash): F[Boolean]
+  def nonFinalizedSet: Set[BlockHash]
   def truncate(
-      latestMessages: Map[Validator, BlockHash]
+      latestMessages: Map[Validator, BlockHash],
+      findLfb: Map[Validator, BlockHash] => F[BlockHash]
   ): F[BlockDagRepresentation[F]]
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -44,6 +44,9 @@ trait BlockDagRepresentation[F[_]] {
   // DAG representation has to have finalized block, or it does not make sense
   def lastFinalizedBlock: BlockHash
   def isFinalized(blockHash: BlockHash): F[Boolean]
+  def truncate(
+      latestMessages: Map[Validator, BlockHash]
+  ): F[BlockDagRepresentation[F]]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
@@ -4,7 +4,7 @@ import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.syntax._
-import coop.rchain.casper.PrettyPrinter
+import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
@@ -13,6 +13,7 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.blockImplicits._
 import coop.rchain.models.{BlockMetadata, EquivocationRecord}
 import coop.rchain.shared
+import coop.rchain.shared.syntax._
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 
@@ -336,6 +337,129 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         // all finalized should be in set supplied for finalization effect
         effects <- effectsRef.get
         _       = effects shouldBe Set(b1, b2, b3).map(_.blockHash)
+      } yield ()
+    }
+
+  /**
+    * Assuming recreating view of target block T.
+    * Bi are seen, 0i not seen, but already in the most recent view.
+    * All Os should be removed.
+    *
+    * O2 and O3 are high excess
+    * O1 is range excess
+    * O4 is unseenSender excess - some validator bonded in genesis has been waiting for a while before creating new block.
+    *   And created on top of genesis without referencing all new messages.
+    *
+    *   03
+    *   02     T
+    *   L1 01 L2
+    *      L0
+    *   B0 B1 B2 O4
+    * G
+    */
+  "truncate" should "remove all excess messages" in
+    withDagStorage { storage =>
+      def randomValidator: ByteString =
+        ByteString.copyFrom(Array.fill(65)((scala.util.Random.nextInt(256) - 128).toByte))
+      // v0, v1, v2 are bonded in genesis, v4 is bonded later in late message
+      val Seq(v0, v1, v2, v3) = (1 to 4).map(_ => randomValidator)
+      val g = genesis.copy(
+        body = genesis.body.copy(
+          state = genesis.body.state
+            .copy(bonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)))
+        )
+      )
+
+      for {
+        _ <- storage.insert(g, false, true)
+        Seq(b0, b1, b2) = Seq(v0, v1, v2).map { v =>
+          getRandomBlock(
+            setParentsHashList = List(g.blockHash).some,
+            setJustifications = List(v0, v1, v2, v3).map(Justification(_, g.blockHash)).some,
+            setBlockNumber = 1L.some,
+            setValidator = v.some,
+            setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+          )
+        }
+        l0 = getRandomBlock(
+          setParentsHashList = List(b0, b1, b2).map(_.blockHash).some,
+          setJustifications = List(
+            Justification(v0, b0.blockHash),
+            Justification(v1, b1.blockHash),
+            Justification(v2, b2.blockHash),
+            Justification(v3, g.blockHash)
+          ).some,
+          setBlockNumber = 2L.some,
+          setValidator = v1.some,
+          setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+        )
+        Seq(l1, o1, l2) = Seq(v0, v1, v2).map { v =>
+          getRandomBlock(
+            setParentsHashList = List(l0.blockHash).some,
+            setJustifications = List(
+              Justification(v0, b0.blockHash),
+              Justification(v1, l0.blockHash),
+              Justification(v2, b2.blockHash),
+              Justification(v3, g.blockHash)
+            ).some,
+            setBlockNumber = 3L.some,
+            setValidator = v.some,
+            setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+          )
+        }
+        o2 = getRandomBlock(
+          setParentsHashList = List(l1, o1, l2).map(_.blockHash).some,
+          setBlockNumber = 4L.some,
+          setJustifications = List(
+            Justification(v0, l1.blockHash),
+            Justification(v1, o1.blockHash),
+            Justification(v2, l2.blockHash),
+            Justification(v3, g.blockHash)
+          ).some,
+          setValidator = v0.some,
+          setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+        )
+        o3 = getRandomBlock(
+          setParentsHashList = List(o2.blockHash).some,
+          setJustifications = List(
+            Justification(v0, o2.blockHash),
+            Justification(v1, o1.blockHash),
+            Justification(v2, l2.blockHash),
+            Justification(v3, g.blockHash)
+          ).some,
+          setBlockNumber = 5L.some,
+          setValidator = v0.some,
+          setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+        )
+        // o4 is late and building on top of genesis. So it is below range of target latest messages
+        // and should be deleted
+        o4 = getRandomBlock(
+          setParentsHashList = List(g.blockHash).some,
+          setJustifications = List(v0, v1, v2, v3).map(Justification(_, g.blockHash)).some,
+          setBlockNumber = 1L.some,
+          setValidator = v3.some,
+          setBonds = List(Bond(v0, 1), Bond(v1, 1), Bond(v2, 1), Bond(v3, 1)).some
+        )
+        fullDag <- List(b0, b1, b2, l0, l1, o1, l2, o2, o3, o4)
+                    .traverse(storage.insert(_, false))
+                    .map(_.last)
+        excess = Vector(o1, o2, o3, o4).map(_.blockHash)
+        inView = Vector(b0, b1, b2, l0, l1, l2, g).map(_.blockHash)
+
+        // all blocks should be present in full DAG
+        _ <- (excess ++ inView).findM(fullDag.contains(_).not) shouldBeF None
+
+        tDag <- fullDag.truncate(
+                 List(
+                   (v0, l1.blockHash),
+                   (v1, l0.blockHash),
+                   (v2, l2.blockHash)
+                 ).toMap
+               )
+        // all these should be absent in truncated DAG
+        _ <- excess.findM(tDag.contains) shouldBeF None
+        // all these should be present in truncated DAG
+        _ <- inView.findM(tDag.contains(_).not) shouldBeF None
       } yield ()
     }
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
@@ -4,6 +4,7 @@ import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.PrettyPrinter
 import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
@@ -449,12 +450,16 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         // all blocks should be present in full DAG
         _ <- (excess ++ inView).findM(fullDag.contains(_).not) shouldBeF None
 
+        findLfb = (_: Map[Validator, BlockHash]) => genesis.blockHash.pure[Task]
+
         tDag <- fullDag.truncate(
                  List(
                    (v0, l1.blockHash),
                    (v1, l0.blockHash),
-                   (v2, l2.blockHash)
-                 ).toMap
+                   (v2, l2.blockHash),
+                   (v3, genesis.blockHash)
+                 ).toMap,
+                 findLfb
                )
         // all these should be absent in truncated DAG
         _ <- excess.findM(tDag.contains) shouldBeF None

--- a/casper/src/main/scala/coop/rchain/casper/BlockDagRepresentationSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockDagRepresentationSyntax.scala
@@ -1,0 +1,33 @@
+package coop.rchain.casper
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.finality.Finalizer
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+
+trait BlockDagRepresentationSyntax {
+  implicit final def casperSyntaxBlockDagRepresentation[F[_]](
+      dag: BlockDagRepresentation[F]
+  ): BlockDagRepresentationOps[F] = new BlockDagRepresentationOps[F](dag)
+}
+
+final class BlockDagRepresentationOps[F[_]](private val dag: BlockDagRepresentation[F])
+    extends AnyVal {
+
+  /** find last finalized block, given set of latest messages. Use maxDepth put a constraint on search scope. */
+  def findLastFinalizedBlock(
+      latestMessagesView: Map[Validator, BlockHash],
+      faultToleranceThreshold: Float,
+      lowestHeight: Long = 0
+  )(implicit syncF: Sync[F]): F[Option[BlockHash]] =
+    latestMessagesView.toStream
+      .traverse { case (v, h) => dag.lookupUnsafe(h).map((v, _)) }
+      .map(_.toMap)
+      .flatMap(
+        Finalizer
+          .findLastFinalizedBlock(dag, _, faultToleranceThreshold, lowestHeight)
+      )
+}

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -48,7 +48,7 @@ object DeployError {
 }
 
 trait Casper[F[_]] {
-  def getSnapshot: F[CasperSnapshot[F]]
+  def getSnapshot(targetBlockOpt: Option[BlockMessage] = None): F[CasperSnapshot[F]]
   def contains(hash: BlockHash): F[Boolean]
   def dagContains(hash: BlockHash): F[Boolean]
   def bufferContains(hash: BlockHash): F[Boolean]

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -93,8 +93,6 @@ object MultiParentCasper extends MultiParentCasperInstances {
 final case class CasperSnapshot[F[_]](
     dag: BlockDagRepresentation[F],
     lastFinalizedBlock: BlockHash,
-    lca: BlockHash,
-    tips: IndexedSeq[BlockHash],
     parents: List[BlockMessage],
     justifications: Set[Justification],
     invalidBlocks: Map[Validator, BlockHash],

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -187,7 +187,7 @@ class MultiParentCasperImpl[F[_]
   override def getSnapshot(targetMessageOpt: Option[BlockMessage]): F[CasperSnapshot[F]] = {
     import cats.instances.list._
 
-    def getOnChainState(b: BlockMessage): F[OnChainCasperState] =
+    def computeOnChainState(b: BlockMessage): F[OnChainCasperState] =
       for {
         av <- RuntimeManager[F].getActiveValidators(b.body.state.postStateHash)
         // bonds are available in block message, but please remember this is just a cache, source of truth is RSpace.
@@ -195,43 +195,97 @@ class MultiParentCasperImpl[F[_]
         shardConfig = casperShardConf
       } yield OnChainCasperState(shardConfig, bm.map(v => v.validator -> v.stake).toMap, av)
 
+    // parents do not include invalid latest messages and share the same bonds map
+    def computeParents(dag: BlockDagRepresentation[F]): F[List[BlockMessage]] =
+      for {
+        r         <- Estimator[F].tips(dag, approvedBlock)
+        (_, tips) = (r.lca, r.tips)
+
+        /**
+          * Before block merge, `EstimatorHelper.chooseNonConflicting` were used to filter parents, as we could not
+          * have conflicting parents. With introducing block merge, all parents that share the same bonds map
+          * should be parents. Parents that have different bond maps are only one that cannot be merged in any way.
+          */
+        // For now main parent bonds map taken as a reference, but might be we want to pick a subset with equal
+        // bond maps that has biggest cumulative stake.
+        blocks  <- tips.toList.traverse(BlockStore[F].getUnsafe)
+        parents = blocks.filter(b => b.body.state.bonds == blocks.head.body.state.bonds)
+      } yield parents
+
+    /**
+      * Justifications might include invalid latest messages and should be bonded in parents
+      * We ensure that only the justifications given in the block are those
+      * which are bonded validators in the chosen parent. This is safe because
+      * any latest message not from a bonded validator will not change the
+      * final fork-choice.
+      */
+    def computeJustifications(
+        dag: BlockDagRepresentation[F],
+        onChainState: OnChainCasperState
+    ): F[Map[Validator, BlockHash]] =
+      dag.latestMessageHashes.map(_.filterKeys(onChainState.bondsMap.keySet.contains(_)))
+
     for {
-      dag         <- BlockDagStorage[F].getRepresentation
-      r           <- Estimator[F].tips(dag, approvedBlock)
-      (lca, tips) = (r.lca, r.tips)
+      // the most recent view on the DAG, includes everything node seen so far
+      fullDag <- BlockDagStorage[F].getRepresentation
 
-      /**
-        * Before block merge, `EstimatorHelper.chooseNonConflicting` were used to filter parents, as we could not
-        * have conflicting parents. With introducing block merge, all parents that share the same bonds map
-        * should be parents. Parents that have different bond maps are only one that cannot be merged in any way.
-        */
-      parents <- for {
-                  // For now main parent bonds map taken as a reference, but might be we want to pick a subset with equal
-                  // bond maps that has biggest cumulative stake.
-                  blocks  <- tips.toList.traverse(BlockStore[F].getUnsafe)
-                  parents = blocks.filter(b => b.body.state.bonds == blocks.head.body.state.bonds)
-                } yield parents
-      onChainState <- getOnChainState(parents.head)
-
-      /**
-        * We ensure that only the justifications given in the block are those
-        * which are bonded validators in the chosen parent. This is safe because
-        * any latest message not from a bonded validator will not change the
-        * final fork-choice.
-        */
-      justifications <- {
+      getBlockView = (m: BlockMessage) =>
         for {
-          lms <- dag.latestMessages
-          r = lms.toList
-            .map {
-              case (validator, blockMetadata) => Justification(validator, blockMetadata.blockHash)
-            }
-            .filter(j => onChainState.bondsMap.keySet.contains(j.validator))
-        } yield r.toSet
-      }
-      parentMetas <- parents.traverse(b => dag.lookupUnsafe(b.blockHash))
-      maxBlockNum = ProtoUtil.maxBlockNumberMetadata(parentMetas)
-      maxSeqNums  <- dag.latestMessages.map(m => m.map { case (k, v) => k -> v.seqNum })
+          p       <- m.header.parentsHashList.traverse(BlockStore[F].getUnsafe)
+          s       <- computeOnChainState(p.head)
+          j       = m.justifications.map { case Justification(v, h) => (v, h) }.toMap
+          dagView <- fullDag.truncate(j)
+          // compute LFB for the view
+          minNum       <- p.map(_.blockHash).traverse(fullDag.lookupUnsafe).map(_.map(_.blockNum).min)
+          lowestHeight = minNum - Finalizer.MaxSearchDepth // lowest height puts a constraint on search area
+          lfb <- fullDag
+                  .findLastFinalizedBlock(
+                    latestMessagesView = j,
+                    faultToleranceThreshold = casperShardConf.faultToleranceThreshold,
+                    lowestHeight = lowestHeight
+                  )
+                  .flatMap { lfbOpt =>
+                    // if approved block is in search range - return it.
+                    // This is required because genesis has fault tolerance less then max value so wont be finalized for
+                    // all thresholds.
+                    // Also in future approved block restored from LFS might be finalized with fault tolerance less then current
+                    // fault tolerance from shard config
+
+                    val approvedBlockIsInRange = fullDag
+                      .lookupUnsafe(approvedBlock.blockHash)
+                      .map(_.blockNum)
+                      .map(_ >= lowestHeight)
+
+                    val notFoundF = approvedBlockIsInRange.ifM(
+                      approvedBlock.blockHash.pure[F], {
+                        val lfbNotFoundErrMsg = s"No last finalized block found when creating casper snapshot for " +
+                          s"${targetMessageOpt.map(PrettyPrinter.buildString(_)).getOrElse("the most recent view")}."
+                        new Exception(lfbNotFoundErrMsg).raiseError[F, BlockHash]
+                      }
+                    )
+                    lfbOpt.map(_.pure[F]).getOrElse(notFoundF)
+                  }
+        } yield (dagView, lfb, p, s, j)
+
+      getLatestView = for {
+        p <- computeParents(fullDag)
+        s <- computeOnChainState(p.head)
+        j <- computeJustifications(fullDag, s)
+        // LFB can be read from storage which is updated after each new block processed
+        lfb = fullDag.lastFinalizedBlock
+      } yield (fullDag, lfb, p, s, j)
+
+      // if target message supplied, create dag view, otherwise get the most recent view
+      view                                              <- targetMessageOpt.map(getBlockView).getOrElse(getLatestView)
+      (dag, lfb, parents, onChainState, justifications) = view
+
+      parentMetas <- parents.map(_.blockHash).traverse(dag.lookupUnsafe)
+      maxBlockNum = parentMetas.map(_.blockNum).max
+      maxSeqNums <- justifications.toList
+                     .traverse {
+                       case (v, h) => dag.lookupUnsafe(h).map((v -> _.seqNum))
+                     }
+                     .map(_.toMap)
       deploysInScope <- {
         val currentBlockNumber  = maxBlockNum + 1
         val earliestBlockNumber = currentBlockNumber - onChainState.shardConf.deployLifespan
@@ -255,14 +309,11 @@ class MultiParentCasperImpl[F[_]
         } yield result
       }
       invalidBlocks <- dag.invalidBlocksMap
-      lfb           = dag.lastFinalizedBlock
     } yield CasperSnapshot(
       dag,
       lfb,
-      lca,
-      tips,
       parents,
-      justifications,
+      justifications.map { case (v, h) => Justification(v, h) }.toSet,
       invalidBlocks,
       deploysInScope,
       maxBlockNum,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -236,9 +236,9 @@ class MultiParentCasperImpl[F[_]
           j       = m.justifications.map { case Justification(v, h) => (v, h) }.toMap
           dagView <- fullDag.truncate(j)
           // compute LFB for the view
-          minNum       <- p.map(_.blockHash).traverse(fullDag.lookupUnsafe).map(_.map(_.blockNum).min)
+          minNum       <- p.map(_.blockHash).traverse(dagView.lookupUnsafe).map(_.map(_.blockNum).min)
           lowestHeight = minNum - Finalizer.MaxSearchDepth // lowest height puts a constraint on search area
-          lfb <- fullDag
+          lfb <- dagView
                   .findLastFinalizedBlock(
                     latestMessagesView = j,
                     faultToleranceThreshold = casperShardConf.faultToleranceThreshold,
@@ -251,7 +251,7 @@ class MultiParentCasperImpl[F[_]
                     // Also in future approved block restored from LFS might be finalized with fault tolerance less then current
                     // fault tolerance from shard config
 
-                    val approvedBlockIsInRange = fullDag
+                    val approvedBlockIsInRange = dagView
                       .lookupUnsafe(approvedBlock.blockHash)
                       .map(_.blockNum)
                       .map(_ >= lowestHeight)

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -184,7 +184,7 @@ class MultiParentCasperImpl[F[_]
     } yield ()
   }
 
-  override def getSnapshot: F[CasperSnapshot[F]] = {
+  override def getSnapshot(targetMessageOpt: Option[BlockMessage]): F[CasperSnapshot[F]] = {
     import cats.instances.list._
 
     def getOnChainState(b: BlockMessage): F[OnChainCasperState] =

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -231,53 +231,56 @@ class MultiParentCasperImpl[F[_]
 
       getBlockView = (m: BlockMessage) =>
         for {
-          p       <- m.header.parentsHashList.traverse(BlockStore[F].getUnsafe)
-          s       <- computeOnChainState(p.head)
-          j       = m.justifications.map { case Justification(v, h) => (v, h) }.toMap
-          dagView <- fullDag.truncate(j)
-          // compute LFB for the view
-          minNum       <- p.map(_.blockHash).traverse(dagView.lookupUnsafe).map(_.map(_.blockNum).min)
-          lowestHeight = minNum - Finalizer.MaxSearchDepth // lowest height puts a constraint on search area
-          lfb <- dagView
-                  .findLastFinalizedBlock(
-                    latestMessagesView = j,
-                    faultToleranceThreshold = casperShardConf.faultToleranceThreshold,
-                    lowestHeight = lowestHeight
-                  )
-                  .flatMap { lfbOpt =>
-                    // if approved block is in search range - return it.
-                    // This is required because genesis has fault tolerance less then max value so wont be finalized for
-                    // all thresholds.
-                    // Also in future approved block restored from LFS might be finalized with fault tolerance less then current
-                    // fault tolerance from shard config
+          p <- m.header.parentsHashList.traverse(BlockStore[F].getUnsafe)
+          s <- computeOnChainState(p.head)
+          j = m.justifications.map { case Justification(v, h) => (v, h) }.toMap
 
-                    val approvedBlockIsInRange = dagView
-                      .lookupUnsafe(approvedBlock.blockHash)
-                      .map(_.blockNum)
-                      .map(_ >= lowestHeight)
+          findLfb = (latestMessages: Map[Validator, BlockHash]) =>
+            for {
+              minNum       <- p.map(_.blockHash).traverse(fullDag.lookupUnsafe).map(_.map(_.blockNum).min)
+              lowestHeight = minNum - Finalizer.MaxSearchDepth // lowest height puts a constraint on search area
 
-                    val notFoundF = approvedBlockIsInRange.ifM(
-                      approvedBlock.blockHash.pure[F], {
-                        val lfbNotFoundErrMsg = s"No last finalized block found when creating casper snapshot for " +
-                          s"${targetMessageOpt.map(PrettyPrinter.buildString(_)).getOrElse("the most recent view")}."
-                        new Exception(lfbNotFoundErrMsg).raiseError[F, BlockHash]
+              lfb <- fullDag
+                      .findLastFinalizedBlock(
+                        latestMessagesView = latestMessages,
+                        faultToleranceThreshold = casperShardConf.faultToleranceThreshold,
+                        lowestHeight = lowestHeight
+                      )
+                      .flatMap { lfbOpt =>
+                        // if approved block is in search range - return it.
+                        // This is required because genesis has fault tolerance less then max value so wont be finalized for
+                        // all thresholds.
+                        // Also in future approved block restored from LFS might be finalized with fault tolerance less then current
+                        // fault tolerance from shard config
+
+                        val approvedBlockIsInRange = fullDag
+                          .lookupUnsafe(approvedBlock.blockHash)
+                          .map(_.blockNum)
+                          .map(_ >= lowestHeight)
+
+                        val notFoundF = approvedBlockIsInRange.ifM(
+                          approvedBlock.blockHash.pure[F], {
+                            val lfbNotFoundErrMsg = s"No last finalized block found when creating casper snapshot for " +
+                              s"${targetMessageOpt.map(PrettyPrinter.buildString(_)).getOrElse("the most recent view")}."
+                            new Exception(lfbNotFoundErrMsg).raiseError[F, BlockHash]
+                          }
+                        )
+                        lfbOpt.map(_.pure[F]).getOrElse(notFoundF)
                       }
-                    )
-                    lfbOpt.map(_.pure[F]).getOrElse(notFoundF)
-                  }
-        } yield (dagView, lfb, p, s, j)
+            } yield lfb
+          dagView <- fullDag.truncate(j, findLfb)
+        } yield (dagView, p, s, j)
 
       getLatestView = for {
         p <- computeParents(fullDag)
         s <- computeOnChainState(p.head)
         j <- computeJustifications(fullDag, s)
-        // LFB can be read from storage which is updated after each new block processed
-        lfb = fullDag.lastFinalizedBlock
-      } yield (fullDag, lfb, p, s, j)
+      } yield (fullDag, p, s, j)
 
       // if target message supplied, create dag view, otherwise get the most recent view
-      view                                              <- targetMessageOpt.map(getBlockView).getOrElse(getLatestView)
-      (dag, lfb, parents, onChainState, justifications) = view
+      view                                         <- targetMessageOpt.map(getBlockView).getOrElse(getLatestView)
+      (dag, parents, onChainState, justifications) = view
+      lfb                                          = dag.lastFinalizedBlock
 
       parentMetas <- parents.map(_.blockHash).traverse(dag.lookupUnsafe)
       maxBlockNum = parentMetas.map(_.blockNum).max

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockProcessor.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockProcessor.scala
@@ -30,7 +30,7 @@ class BlockProcessor[F[_]: Concurrent](
     requestMissingDependencies: Set[BlockHash] => F[Unit],
     ackProcessed: (BlockMessage) => F[Unit],
     // Casper state to validate block against
-    getCasperSnapshot: Casper[F] => F[CasperSnapshot[F]],
+    getCasperSnapshot: (Casper[F], BlockMessage) => F[CasperSnapshot[F]],
     validateBlock: (Casper[F], CasperSnapshot[F], BlockMessage) => F[ValidBlockProcessing],
     effValidBlock: (Casper[F], BlockMessage) => F[BlockDagRepresentation[F]],
     effInvalidVBlock: (
@@ -94,7 +94,7 @@ class BlockProcessor[F[_]: Concurrent](
       s: Option[CasperSnapshot[F]] = None
   ): F[ValidBlockProcessing] =
     for {
-      cs     <- if (s.isDefined) s.get.pure[F] else getCasperSnapshot(c)
+      cs     <- if (s.isDefined) s.get.pure[F] else getCasperSnapshot(c, b)
       status <- validateBlock(c, cs, b)
       _ <- status
             .map(s => effValidBlock(c, b))
@@ -125,7 +125,7 @@ object BlockProcessor {
 
     val storeBlock = (b: BlockMessage) => BlockStore[F].put(b)
 
-    val getCasperStateSnapshot = (c: Casper[F]) => c.getSnapshot
+    val getCasperStateSnapshot = (c: Casper[F], b: BlockMessage) => c.getSnapshot(b.some)
 
     val getNonValidatedDependencies = (c: Casper[F], b: BlockMessage) => {
       import cats.instances.list._

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -166,7 +166,7 @@ object Proposer {
       validatorIdentity: ValidatorIdentity,
       dummyDeployOpt: Option[(PrivateKey, String)] = None
   )(implicit runtimeManager: RuntimeManager[F]): Proposer[F] = {
-    val getCasperSnapshotSnapshot = (c: Casper[F]) => c.getSnapshot
+    val getCasperSnapshot = (c: Casper[F]) => c.getSnapshot()
 
     val createBlock = (s: CasperSnapshot[F], validatorIdentity: ValidatorIdentity) =>
       BlockCreator.create(s, validatorIdentity, dummyDeployOpt)
@@ -208,7 +208,7 @@ object Proposer {
         EventPublisher[F].publish(MultiParentCasperImpl.createdEvent(b))
 
     new Proposer(
-      getCasperSnapshotSnapshot,
+      getCasperSnapshot,
       checkValidatorIsActive,
       checkEnoughBaseStake,
       checkLastFinalizedHeightConstraint,

--- a/casper/src/main/scala/coop/rchain/casper/finality/Finalizer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/finality/Finalizer.scala
@@ -39,6 +39,8 @@ import fs2.Stream
   */
 object Finalizer {
 
+  val MaxSearchDepth = 100L
+
   private type WeightMap = Map[Validator, Long]
 
   /** Message that is agreed on + weight of this agreement. */
@@ -85,63 +87,78 @@ object Finalizer {
   }
 
   /**
-    * Find the highest finalized message.
+    * The goal here is to create stream of agreements breadth first, so on each step agreements by all
+    * validator are recorded, and only after that next level of main parents is visited.
+    * @param dag dependency DAG
+    * @param agreeingMessages - messages to compute ageements for
+    * @param lowestHeight - height at which DAG traversal shall be stopped, this height is emitted last
+    * @return Stream of agreements passed down from agreeing messages through main parent chains according to
+    *         dependency DAG. Starts with agreements of message on themselves.
+    */
+  private def agreementsStream[F[_]: Sync](
+      dag: BlockDagRepresentation[F],
+      agreeingMessages: Map[Validator, BlockMetadata],
+      lowestHeight: Long
+  ): Stream[F, MessageAgreement] = {
+    // sort latest messages by agreeing validator to ensure random ordering does not change output
+    val sortedLatestMessages = agreeingMessages.toList.sortBy { case (v, _) => v }
+    Stream
+      .unfoldLoopEval(sortedLatestMessages) { layer =>
+        // output current visits
+        val out = layer
+        // proceed to main parents
+        val nextF = layer
+          .traverse {
+            case (v, message) =>
+              message.parents.headOption.traverse(dag.lookupUnsafe).map { messageMainParent =>
+                (v, messageMainParent)
+              }
+          }
+          // filter out empty results when no main parent and those out of scope
+          .map(_.collect { case (v, Some(meta)) if meta.blockNum >= lowestHeight => (v, meta) })
+
+        nextF.map(next => (out, next.nonEmpty.guard[Option].as(next)))
+      }
+      .evalMap(_.traverse {
+        // map visits to message agreements: validator v agrees on message m
+        case (v, m) =>
+          messageWeightMapF(m, dag).map { messageWeightMap =>
+            recordAgreement(messageWeightMap, v).map { agreement =>
+              MessageAgreement(m, messageWeightMap, Map(agreement))
+            }
+          }
+      })
+      // collect successful agreements (by bonded validators as per message agreed on)
+      .map(_.collect { case Some(v) => v })
+      // flatten in a single stream
+      .map(Stream.emits(_))
+      .flatten
+  }
+
+  /**
+    * Finalize dag: find the last finalized message, invoke all finalization related effects.
     * Scope of the search is constrained by the lowest height (height of current last finalized message).
     */
-  def run[F[_]: Concurrent: Metrics: Log: Span](
+  def run[F[_]: Sync](
       dag: BlockDagRepresentation[F],
       faultToleranceThreshold: Float,
       currLFBHeight: Long,
       newLfbFoundEffect: BlockHash => F[Unit]
-  ): F[Option[BlockHash]] = {
+  ): F[Option[BlockHash]] =
+    dag.latestMessages
+      .flatMap(findLastFinalizedBlock(dag, _, faultToleranceThreshold, currLFBHeight + 1))
+      .flatMap(_.traverseTap(newLfbFoundEffect))
 
-    /**
-      * Stream of agreements passed down from all latest messages to main parents.
-      * Starts with agreements of latest message on themselves.
-      *
-      * The goal here is to create stream of agreements breadth first, so on each step agreements by all
-      * validator are recorded, and only after that next level of main parents is visited.
-      */
-    val mkAgreementsStream: F[Stream[F, MessageAgreement]] =
-      dag.latestMessages.map { lms =>
-        // sort latest messages by agreeing validator to ensure random ordering does not change output
-        val sortedLatestMessages = lms.toList.sortBy { case (v, _) => v }
-        Stream
-          .unfoldLoopEval(sortedLatestMessages) { layer =>
-            // output current visits
-            val out = layer
-            // proceed to main parents
-            val nextF = layer
-              .traverse {
-                case (v, message) =>
-                  message.parents.headOption.traverse(dag.lookupUnsafe).map { messageMainParent =>
-                    (v, messageMainParent)
-                  }
-              }
-              // filter out empty results when no main parent and those out of scope
-              .map(_.collect { case (v, Some(meta)) if meta.blockNum > currLFBHeight => (v, meta) })
-
-            nextF.map(next => (out, next.nonEmpty.guard[Option].as(next)))
-          }
-          .evalMap(_.traverse {
-            // map visits to message agreements: validator v agrees on message m
-            case (v, m) =>
-              messageWeightMapF(m, dag).map { messageWeightMap =>
-                recordAgreement(messageWeightMap, v).map { agreement =>
-                  MessageAgreement(m, messageWeightMap, Map(agreement))
-                }
-              }
-          })
-          // collect successful agreements (by bonded validators as per message agreed on)
-          .map(_.collect { case Some(v) => v })
-          // flatten in a single stream
-          .map(Stream.emits(_))
-          .flatten
-      }
-
-    mkAgreementsStream.flatMap {
-      // while recording each agreement in agreements map
-      _.mapAccumulate(Map.empty[BlockMetadata, WeightMap]) {
+  /** Find last finalized block given latest messages and dependency DAG. Search is constrained by lowest height. */
+  def findLastFinalizedBlock[F[_]: Sync](
+      dag: BlockDagRepresentation[F],
+      latestMessagesView: Map[Validator, BlockMetadata],
+      faultToleranceThreshold: Float,
+      lowestHeight: Long
+  ): F[Option[BlockHash]] =
+    // while recording each agreement in agreements map
+    agreementsStream(dag, latestMessagesView, lowestHeight)
+      .mapAccumulate(Map.empty[BlockMetadata, WeightMap]) {
         case (acc, MessageAgreement(message, messageWeightMap, stakeAgreed)) =>
           val curVal = acc.getOrElse(message, Map.empty)
           require(
@@ -152,35 +169,31 @@ object Finalizer {
           (acc.updated(message, newVal), (message, messageWeightMap))
       }
       // output only target message of current agreement
-        .map {
-          case (fullAgreementsMap, (message, messageWeightMap)) =>
-            (message, messageWeightMap, fullAgreementsMap(message))
-        }
-        // filter only messages that cannot be orphaned
-        .filter {
-          case (_, messageWeightMap, agreeingWeightMap) =>
-            cannotBeOrphaned(messageWeightMap, agreeingWeightMap)
-        }
-        // compute fault tolerance
-        .evalMap {
-          case (message, messageWeightMap, agreeingWeightMap) =>
-            CliqueOracle
-              .computeOutput[F](
-                targetMsg = message.blockHash,
-                messageWeightMap = messageWeightMap,
-                agreeingWeightMap = agreeingWeightMap,
-                dag = dag
-              )
-              .map((message, _))
-        }
-        // first candidate that meets finalization criteria is new LFB
-        .filter { case (_, faultTolerance) => faultTolerance > faultToleranceThreshold }
-        .head
-        .map { case (lfb, _) => lfb.blockHash }
-        // execute finalization effect
-        .evalTap(newLfbFoundEffect)
-        .compile
-        .last
-    }
-  }
+      .map {
+        case (fullAgreementsMap, (message, messageWeightMap)) =>
+          (message, messageWeightMap, fullAgreementsMap(message))
+      }
+      // filter only messages that cannot be orphaned
+      .filter {
+        case (_, messageWeightMap, agreeingWeightMap) =>
+          cannotBeOrphaned(messageWeightMap, agreeingWeightMap)
+      }
+      // compute fault tolerance
+      .evalMap {
+        case (message, messageWeightMap, agreeingWeightMap) =>
+          CliqueOracle
+            .computeOutput[F](
+              targetMsg = message.blockHash,
+              messageWeightMap = messageWeightMap,
+              agreeingWeightMap = agreeingWeightMap,
+              dag = dag
+            )
+            .map((message, _))
+      }
+      // first candidate that meets finalization criteria is new LFB
+      .filter { case (_, faultTolerance) => faultTolerance > faultToleranceThreshold }
+      .head
+      .map { case (lfb, _) => lfb.blockHash }
+      .compile
+      .last
 }

--- a/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
@@ -27,10 +27,10 @@ object DagMerger {
       rejectionCostF: DeployChainIndex => Long
   ): F[(Blake2b256Hash, Seq[ByteString])] =
     for {
-      // all not finalized blocks (conflict set)
-      nonFinalisedBlocks <- dag.nonFinalizedBlocks
       // blocks that see last finalized state
       actualBlocks <- dag.descendants(lfb)
+      // all not finalized blocks (conflict set)
+      nonFinalisedBlocks = dag.nonFinalizedSet
       // blocks that does not see last finalized state
       lateBlocks = nonFinalisedBlocks diff actualBlocks
 

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -23,6 +23,7 @@ package object casper {
       with AllSyntaxComm
       with AllSyntaxBlockStorage
       with RhoRuntimeSyntax
+      with BlockDagRepresentationSyntax
 }
 
 // Casper syntax

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -34,7 +34,7 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
 
   implicit val timeEff = new LogicalTime[Effect]
 
-  val genesis = buildGenesis()
+  val genesis = buildGenesis(buildGenesisParametersWithRandom(validatorsNum = 5))
 
   //put a new casper instance at the start of each
   //test since we cannot reset it
@@ -556,6 +556,53 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
           blockThatPointsToInvalidBlock
         )
       } yield block
+    }
+  }
+
+  it should "replay block using truncated dag view as per block's justifications" in effectTest {
+    TestNode.networkEff(genesis, networkSize = 5).use {
+      case nodes @ n0 +: n1 +: n2 +: n3 +: n4 +: _ =>
+        for {
+          deploys <- (genesis.validatorPks zip genesis.genesisVaultsSks).zipWithIndex.toList
+                      .traverse {
+                        case ((_, payerSk), i) => {
+                          ConstructDeploy.basicDeployData[Effect](i, payerSk)
+                        }
+                      }
+          //b0
+          b0 <- n0.createBlockUnsafe(deploys.head)
+          _  <- nodes.toList.traverse(_.processBlock(b0))
+          _  = b0.header.parentsHashList.size shouldBe 1
+          //   b1 b2
+          //b0
+          b1 <- n1.createBlockUnsafe(deploys(1))
+          b2 <- n2.createBlockUnsafe(deploys(2))
+          _  <- nodes.toList.traverse(_.processBlock(b1))
+          _  <- nodes.toList.traverse(_.processBlock(b2))
+          _  = b1.header.parentsHashList.size shouldBe 1
+          _  = b2.header.parentsHashList.size shouldBe 1
+          //         b3 b4
+          //   b1 b2
+          //b0
+          b3 <- n3.createBlockUnsafe(deploys(3))
+          b4 <- n4.createBlockUnsafe(deploys(4))
+          _  = (b3.body.state.preStateHash == b4.body.state.preStateHash) shouldBe true
+          _  <- nodes.toList.traverse(_.processBlock(b3))
+          // after b3 processed by all blocks, b4 processing should not be influenced by b3 (b3 should not be used as parent)
+          _ <- nodes.toList.traverse(_.processBlock(b4))
+          // these are merge blocks that will be inside merge scope gor b5
+          _ = b3.header.parentsHashList.size shouldBe 2
+          _ = b4.header.parentsHashList.size shouldBe 2
+          //b5
+          //         b3 b4 - two merge blocks
+          //   b1 b2
+          //b0
+          d  <- ConstructDeploy.basicDeployData[Effect](0, genesis.genesisVaultsSks.head)
+          b5 <- n0.createBlockUnsafe(d)
+          _  <- nodes.toList.traverse(_.processBlock(b5))
+          // goal of the test is to ensure that v5 is created succesfully
+          _ = b5.header.parentsHashList.size shouldBe 2
+        } yield ()
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
@@ -60,7 +60,7 @@ class SingleParentCasperSpec extends FlatSpec with Matchers with Inspectors {
 
           validateResult <- {
             import n1._
-            n1.casperEff.getSnapshot >>=
+            n1.casperEff.getSnapshot(Some(dualParentB3)) >>=
               (snap => Validate.parents(dualParentB3, n1.genesis, snap))
           }
         } yield validateResult shouldBe BlockStatus.invalidParents.asLeft[ValidBlock]

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -52,8 +52,6 @@ class ValidateTest
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
-      ByteString.EMPTY,
-      IndexedSeq.empty,
       List.empty,
       Set.empty,
       Map.empty,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -37,8 +37,6 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
-      ByteString.EMPTY,
-      IndexedSeq.empty,
       List.empty,
       Set.empty,
       Map.empty,

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -37,8 +37,6 @@ object BlockGenerator {
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
-      ByteString.EMPTY,
-      IndexedSeq.empty,
       List.empty,
       Set.empty,
       Map.empty,

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -50,7 +50,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
       _ <- Sync[F].delay(store.update(b.get.blockHash, b.get))
     } yield BlockStatus.valid.asRight
 
-  override def getSnapshot: F[CasperSnapshot[F]] = ???
+  override def getSnapshot(b: Option[BlockMessage]): F[CasperSnapshot[F]] = ???
   override def validate(
       b: BlockMessage,
       s: CasperSnapshot[F]

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -231,7 +231,7 @@ case class TestNode[F[_]: Timer](
   def createBlock(deployDatums: Signed[DeployData]*): F[BlockCreatorResult] =
     for {
       _                 <- deployDatums.toList.traverse(casperEff.deploy)
-      cs                <- casperEff.getSnapshot
+      cs                <- casperEff.getSnapshot()
       vid               <- casperEff.getValidator
       createBlockResult <- BlockCreator.create(cs, vid.get)
     } yield createBlockResult
@@ -240,7 +240,7 @@ case class TestNode[F[_]: Timer](
   def createBlockUnsafe(deployDatums: Signed[DeployData]*): F[BlockMessage] =
     for {
       _                 <- deployDatums.toList.traverse(casperEff.deploy)
-      cs                <- casperEff.getSnapshot
+      cs                <- casperEff.getSnapshot()
       vid               <- casperEff.getValidator
       createBlockResult <- BlockCreator.create(cs, vid.get)
       block <- createBlockResult match {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -59,8 +59,6 @@ class InterpreterUtilTest
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
-      ByteString.EMPTY,
-      IndexedSeq.empty,
       List.empty,
       Set.empty,
       Map.empty,

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -115,12 +115,14 @@ object Resources {
       override def children(vertex: BlockHash): F[Option[Set[BlockHash]]] = ???
 
       override def lastFinalizedBlock: BlockHash = ???
+
+      override def truncate(
+          latestMessages: Map[Validator, BlockHash]
+      ): F[BlockDagRepresentation[F]] = ???
     }
     CasperSnapshot[F](
       dummyRepresentation,
       ByteString.EMPTY,
-      ByteString.EMPTY,
-      IndexedSeq.empty,
       List.empty,
       Set.empty,
       Map.empty,

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -116,8 +116,11 @@ object Resources {
 
       override def lastFinalizedBlock: BlockHash = ???
 
+      override def nonFinalizedSet: Set[BlockHash] = ???
+
       override def truncate(
-          latestMessages: Map[Validator, BlockHash]
+          latestMessages: Map[Validator, BlockHash],
+          findLfb: Map[Validator, BlockHash] => F[BlockHash]
       ): F[BlockDagRepresentation[F]] = ???
     }
     CasperSnapshot[F](

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -6,17 +6,21 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.{BlockDagKeyValueStorage, BlockDagStorage}
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.merging.{BlockIndex, DagMerger}
-import coop.rchain.casper.protocol.{ProcessedDeploy, ProcessedSystemDeploy}
+import coop.rchain.casper.protocol.{BlockMessage, Bond, ProcessedDeploy, ProcessedSystemDeploy}
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang.costacc.CloseBlockDeploy
 import coop.rchain.casper.util.rholang.{Resources, RuntimeManager, SystemDeployUtil}
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
+import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator
 import coop.rchain.models.Validator.Validator
+import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
+import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.shared.{Log, Time}
@@ -41,6 +45,30 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
     rm  <- Resource.liftF(Resources.mkRuntimeManagerAt[Task](kvm))
   } yield rm
 
+  def txRho(payer: String, payee: String) =
+    s"""
+       |new
+       |  rl(`rho:registry:lookup`), stdout(`rho:io:stdout`),  revVaultCh, log
+       |in {
+       |  rl!(`rho:rchain:revVault`, *revVaultCh) |
+       |  for (@(_, revVault) <- revVaultCh) {
+       |    match ("${payer}", "${payee}", 50) {
+       |      (from, to, amount) => {
+       |        new vaultCh, revVaultKeyCh, deployerId(`rho:rchain:deployerId`) in {
+       |          @revVault!("findOrCreate", from, *vaultCh) |
+       |          @revVault!("deployerAuthKey", *deployerId, *revVaultKeyCh) |
+       |          for (@(true, vault) <- vaultCh; key <- revVaultKeyCh) {
+       |            new resultCh in {
+       |              stdout!("TX from ${payer} to ${payee} succeed.")|
+       |              @vault!("transfer", to, amount, *key, *resultCh) 
+       |            }
+       |          }
+       |        }
+       |      }
+       |    }
+       |  }
+       |}""".stripMargin
+
   def makeTxAndCommitState(
       runtimeManager: RuntimeManager[Task],
       baseState: StateHash,
@@ -48,9 +76,20 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
       validator: PublicKey,
       seqNum: Int = 0,
       blockNum: Long = 0
-  ): Task[(StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])] =
+  ): Task[(StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])] = {
+    val payerAddr = RevAddress.fromPublicKey(Secp256k1.toPublic(payerKey)).get.address.toBase58
+    // random address for recipient
+    val payeeAddr =
+      RevAddress
+        .fromDeployerId(Array.fill(Validator.Length)((scala.util.Random.nextInt(256) - 128).toByte))
+        .get
+        .address
+        .toBase58
     for {
-      txDeploy    <- ConstructDeploy.sourceDeployNowF("Nil", sec = payerKey)
+      txDeploy <- ConstructDeploy.sourceDeployNowF(
+                   txRho(payerAddr, payeeAddr),
+                   sec = payerKey
+                 )
       userDeploys = txDeploy :: Nil
       systemDeploys = CloseBlockDeploy(
         SystemDeployUtil
@@ -73,11 +112,16 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
             invalidBlocks
           )
     } yield r
+  }
 
-  def mkStatesSteams(preStateHash: StateHash, seqNum: Int, blockNum: Long)(
+  def mkBlocksSteams(preStateHash: StateHash, seqNum: Int, blockNum: Long)(
       implicit runtimeManager: RuntimeManager[Task]
-  ) =
-    (genesisContext.validatorPks zip genesisContext.genesisVaultsSks).map {
+  ) = {
+    val pksWithSingleConflict = {
+      val a = genesisContext.genesisVaultsSks.last
+      genesisContext.genesisVaultsSks.dropRight(2) ++ List(a, a)
+    }
+    (genesisContext.validatorPks zip pksWithSingleConflict).map {
       case (validatorPk, payerSk) =>
         Stream
           .eval(
@@ -90,23 +134,39 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
               blockNum
             )
           )
+          .map { s =>
+            getRandomBlock(
+              setPreStateHash = preStateHash.some,
+              setPostStateHash = s._1.some,
+              setDeploys = s._2.some,
+              setBlockNumber = blockNum.some,
+              setSeqNumber = seqNum.some,
+              setValidator = ByteString.copyFrom(validatorPk.bytes).some,
+              setBonds = genesisContext.validatorKeyPairs
+                .map(_._2)
+                .map(pk => Bond(ByteString.copyFrom(pk.bytes), 1))
+                .toList
+                .some
+            )
+          }
     }.toList
+  }
 
-  def mkState(stateHash: StateHash, seqNum: Int, blockNum: Long, n: Int)(
+  def mkBlocks(stateHash: StateHash, seqNum: Int, blockNum: Long, n: Int)(
       implicit runtimeManager: RuntimeManager[Task]
   ) =
-    mkStatesSteams(stateHash, seqNum, blockNum).get(n.toLong).get.compile.lastOrError
+    mkBlocksSteams(stateHash, seqNum, blockNum).get(n.toLong).get.compile.lastOrError
 
-  def mkHeadState(stateHash: StateHash, seqNum: Int, blockNum: Long)(
+  def mkHeadBlock(stateHash: StateHash, seqNum: Int, blockNum: Long)(
       implicit runtimeManager: RuntimeManager[Task]
   ) =
-    mkStatesSteams(stateHash, seqNum, blockNum).head.compile.lastOrError
+    mkBlocksSteams(stateHash, seqNum, blockNum).head.compile.lastOrError
 
-  def mkTailStates(stateHash: StateHash, seqNum: Int, blockNum: Long)(
+  def mkTailBlocks(stateHash: StateHash, seqNum: Int, blockNum: Long)(
       implicit runtimeManager: RuntimeManager[Task]
   ) =
     Stream
-      .emits(mkStatesSteams(stateHash, seqNum, blockNum).tail)
+      .emits(mkBlocksSteams(stateHash, seqNum, blockNum).tail)
       .parJoinUnbounded
       .compile
       .toList
@@ -332,50 +392,35 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
 //    getRejectedBlocksAtTheTop(template)
 //  }
 
-  "multiple 1 block branches" should "be merged" in effectTest {
+  "merging with leader" should "work" in effectTest {
     runtimeManagerResource.use { runtimeManager =>
       {
         implicit val rm: RuntimeManager[Task] = runtimeManager
         implicit val concurrent               = Concurrent[Task]
         implicit val metrics                  = new Metrics.MetricsNOP
-        val genesisPostStateHash              = genesis.body.state.postStateHash
         import coop.rchain.models.blockImplicits._
 
-        // simulates 0.99 sync threshold - first validator create state, then all other create on top of that/
-        // merge state of resulting blocks returned
+        // simulates 0.99 sync threshold
         def mkLayer(
-            startPreStateHash: StateHash,
-            n: Int,
+            baseBlock: BlockMessage,
             dagStore: BlockDagStorage[Task]
-        ): Task[StateHash] =
-          for {
-            // create state on first validator
-            b <- mkHeadState(startPreStateHash, n * 2 + 1, (n * 2 + 1).toLong)
-            base = getRandomBlock(
-              setPostStateHash = b._1.some,
-              setPreStateHash = startPreStateHash.some,
-              setParentsHashList = List().some,
-              setDeploys = b._2.some
-            )
-            _ <- dagStore.insert(base, false, approved = true)
+        ): Task[BlockMessage] = {
 
-            // create children an all other
-            baseChildren <- mkTailStates(b._1, n * 2 + 2, (n * 2 + 2).toLong)
-            mergingBlocks = baseChildren.map(
-              s =>
-                getRandomBlock(
-                  setPostStateHash = s._1.some,
-                  setPreStateHash = b._1.some,
-                  setParentsHashList = List(base.blockHash).some,
-                  setDeploys = s._2.some
-                )
+          val baseState        = baseBlock.body.state.postStateHash
+          val seqNum           = baseBlock.seqNum + 1
+          val mergingBlocksNum = (baseBlock.seqNum * 2 + 1).toLong
+          val nexBaseBlockNum  = (baseBlock.seqNum * 2 + 2).toLong
+
+          for {
+            // create children blocks
+            r <- mkTailBlocks(baseState, seqNum, mergingBlocksNum)
+            mergingBlocks = r.map(
+              b => b.copy(header = b.header.copy(parentsHashList = List(baseBlock.blockHash)))
             )
             _ <- mergingBlocks.traverse(dagStore.insert(_, false))
 
-            s = s"merging ${mergingBlocks.size} children into ${PrettyPrinter.buildString(startPreStateHash)}"
-            _ = println(s)
-
-            indices <- (base +: mergingBlocks)
+            // merge children blocks
+            indices <- (baseBlock +: mergingBlocks)
                         .traverse(
                           b =>
                             BlockIndex(
@@ -388,29 +433,42 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
                             ).map((b.blockHash -> _))
                         )
                         .map(_.toMap)
-
-            _   <- dagStore.recordDirectlyFinalized(base.blockHash, _ => ().pure[Task])
             dag <- dagStore.getRepresentation
-            // merge children to get next preStateHash
             v <- DagMerger.merge[Task](
                   dag,
-                  base.blockHash,
-                  Blake2b256Hash.fromByteString(base.body.state.postStateHash),
+                  baseBlock.blockHash,
+                  Blake2b256Hash.fromByteString(baseState),
                   indices(_).deployChains.pure,
                   runtimeManager.getHistoryRepo,
                   DagMerger.costOptimalRejectionAlg
                 )
             (postState, rejectedDeploys) = v
-            nextPreStateHash             = ByteString.copyFrom(postState.bytes.toArray)
-            _                            = assert(rejectedDeploys.size == 0)
-            _                            = assert(nextPreStateHash != base.body.state.postStateHash)
-            _                            = println(s"merge result ${PrettyPrinter.buildString(nextPreStateHash)}")
-          } yield nextPreStateHash
+            mergedState                  = ByteString.copyFrom(postState.bytes.toArray)
+            _                            = assert(rejectedDeploys.size == 1)
+            _                            = assert(mergedState != baseBlock.body.state.postStateHash)
+
+            // create next base block (merge block)
+            r <- mkHeadBlock(mergedState, seqNum, nexBaseBlockNum)
+            nextBaseBlock = r.copy(
+              header = r.header.copy(parentsHashList = mergingBlocks.map(_.blockHash))
+            )
+            _ <- dagStore.insert(nextBaseBlock, false)
+            _ <- dagStore.recordDirectlyFinalized(nextBaseBlock.blockHash, _ => ().pure[Task])
+          } yield nextBaseBlock
+        }
 
         val kvm = new InMemoryStoreManager
         for {
           dagStore <- BlockDagKeyValueStorage.create[Task](kvm)
-          _        <- mkLayer(genesisPostStateHash, 0, dagStore)
+          _        <- dagStore.insert(genesis, false, true)
+          _ <- ((genesis, 0)).tailRecM {
+                case (start, layerNum) =>
+                  if (layerNum < 4)
+                    mkLayer(start, dagStore).map(
+                      post => (post, layerNum + 1).asLeft[BlockMessage]
+                    )
+                  else (start).asRight[(BlockMessage, Int)].pure
+              }
         } yield ()
       }
     }


### PR DESCRIPTION
## Overview
When concurrent block processing is enabled in the network, local view of the validating node might be different then view of block creator (there might be more messages processed). Therefore to be able to validate blocks, Casper view should be reconstructed according to justifications of a block being validated.
Details described in Issue https://github.com/rchain/rchain/issues/3350.

### Notes
This branch is running well against 0.67 sync constraint, but very quickly fails with well known "Bug found: refund failed" when multiple blocks from the same validator are in merging scope. So further testing is blocked until merging if REV balances is implemented.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
