### PR TITLE
Repairing bundle error message

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
@@ -165,7 +165,7 @@ class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2Stream
     createMock[Task](startBlock, requestTimeout) { mock =>
       if (!runProcessingStream) test(mock)
       else (Stream.eval(test(mock)) concurrently mock.stream).compile.drain
-    }.runSyncUnsafe(timeout = 3.seconds)
+    }.runSyncUnsafe(timeout = 10.seconds)
 
   def asMap(bs: BlockMessage*): Map[BlockHash, BlockMessage] = bs.map(b => (b.blockHash, b)).toMap
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PBundleNormalizer.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PBundleNormalizer.scala
@@ -28,13 +28,20 @@ object PBundleNormalizer {
     def error(targetResult: ProcVisitOutputs): F[ProcVisitOutputs] = {
       val errMsg = {
         def at(variable: String, sourcePosition: SourcePosition): String =
-          variable + " line: " + sourcePosition.row + ", column: " + sourcePosition.column
+          s"$variable at $sourcePosition"
         val wildcardsPositions = targetResult.knownFree.wildcards.map(at("", _))
         val freeVarsPositions = targetResult.knownFree.levelBindings.map {
           case (n, LevelContext(_, _, sourcePosition)) => at(s"`$n`", sourcePosition)
         }
-        wildcardsPositions.mkString(" Wildcards at positions: ", ", ", ".") ++
-          freeVarsPositions.mkString(" Free variables at positions: ", ", ", ".")
+        val errMsgWildcards =
+          if (wildcardsPositions.nonEmpty)
+            wildcardsPositions.mkString(" Wildcards positions ", ", ", ".")
+          else ""
+        val errMsgFreeVars =
+          if (freeVarsPositions.nonEmpty)
+            freeVarsPositions.mkString(" Free variables positions ", ", ", ".")
+          else ""
+        errMsgWildcards + errMsgFreeVars
       }
       Sync[F].raiseError(
         UnexpectedBundleContent(


### PR DESCRIPTION
## Overview
Repairing small bug in "bundle" error message.
### Notes
The syntax for displaying the message was violated. There is a conclusion  "at line x: column y"  For correct display in VScode, "at x:y" is required (where x - row, y - column).


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
