### PR TITLE
Fix peek conflict detection

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -40,7 +40,6 @@ object DeployChainIndex {
                        channelsStore = historyRepository,
                        historyRepository.getSerializeC
                      )
-
     } yield DeployChainIndex(
       deploysWithCost,
       preStateHash,

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -29,7 +29,7 @@ import scala.collection.Seq
 
 class MergingBranchMergerSpec extends FlatSpec with Matchers {
 
-  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 5)
+  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 50)
   val genesis                    = genesisContext.genesisBlock
   implicit val logEff            = Log.log[Task]
   implicit val timeF: Time[Task] = new LogicalTime[Task]

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -29,7 +29,7 @@ import scala.collection.Seq
 
 class MergingBranchMergerSpec extends FlatSpec with Matchers {
 
-  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 50)
+  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 5)
   val genesis                    = genesisContext.genesisBlock
   implicit val logEff            = Log.log[Task]
   implicit val timeF: Time[Task] = new LogicalTime[Task]

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/MergingLogic.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/MergingLogic.scala
@@ -70,7 +70,7 @@ object MergingLogic {
 
   /** produce created inside event log */
   def producesCreated(e: EventLogIndex): Set[Produce] =
-    (e.producesLinear ++ e.producesPersistent) diff e.producesCopiedByPeek
+    (e.producesLinear ++ e.producesPersistent) diff e.producesExistingInPreState
 
   /** consume created inside event log */
   def consumesCreated(e: EventLogIndex): Set[Consume] =
@@ -78,7 +78,7 @@ object MergingLogic {
 
   /** produces that are created inside event log and not destroyed via COMM inside event log */
   def producesCreatedAndNotDestroyed(e: EventLogIndex): Set[Produce] =
-    ((e.producesLinear diff e.producesConsumed) ++ e.producesPersistent) diff e.producesCopiedByPeek
+    ((e.producesLinear diff e.producesConsumed) ++ e.producesPersistent) diff e.producesExistingInPreState
 
   /** consumes that are created inside event log and not destroyed via COMM inside event log */
   def consumesCreatedAndNotDestroyed(e: EventLogIndex): Set[Consume] =
@@ -103,6 +103,6 @@ object MergingLogic {
   /** if produce is copied by peek in one index and originated in another - it is considered as created in aggregate*/
   def combineProducesCopiedByPeek(x: EventLogIndex, y: EventLogIndex): Set[Produce] =
     Seq(x, y)
-      .map(_.producesCopiedByPeek)
+      .map(_.producesExistingInPreState)
       .reduce(_ ++ _) diff Seq(x, y).map(producesCreated).reduce(_ ++ _)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/package.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/package.scala
@@ -48,7 +48,11 @@ package object merger {
       }
     }
     // each rejection option is defined by decision not to reject a key in rejection map
-    conflictMap.keySet.map(k => process(conflictMap(k), Set.empty, reject = true))
+    conflictMap
+    // only keys that have conflicts associated should be examined
+      .filter { case (_, conflicts) => conflicts.nonEmpty }
+      .keySet
+      .map(k => process(conflictMap(k), Set.empty, reject = true))
   }
 
   def computeRelatedSets[A](items: Set[A], relation: (A, A) => Boolean): Set[Set[A]] =


### PR DESCRIPTION
## Overview
Due to this bug https://github.com/rchain/rchain/pull/3445 (issue https://github.com/rchain/rchain/issues/3349#issuecomment-863916745) peek cannot be reliably detected by COMM event itself, so we have to examine **all** produces (including inside COMM log) for existence in pre state, and adjust set of consumed produces accordingly

### Notes
Closes https://github.com/rchain/rchain/issues/3349, but still the problem of not having peek exposed in COMM event log remains active. It's not clear whether it can be fixed without hard fork. But also we want peek to be atomic which should cover this issue as well https://github.com/rchain/rchain/issues/3268. So no new issue is created.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
