### PR TITLE
[WIP] Enable attestation messages

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/ProposeResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/ProposeResult.scala
@@ -55,9 +55,11 @@ object ProposeResult {
 }
 
 trait BlockCreatorResult
-case object NoNewDeploys                             extends BlockCreatorResult with ProposeFailure
-final case class Created(blockMessage: BlockMessage) extends BlockCreatorResult
+case object NoNewDeploys                                        extends BlockCreatorResult with ProposeFailure
+final case class Created(blockMessage: BlockMessage)            extends BlockCreatorResult
+final case class CreatedAttestation(blockMessage: BlockMessage) extends BlockCreatorResult
 object BlockCreatorResult {
-  def noNewDeploys: BlockCreatorResult             = NoNewDeploys
-  def created(b: BlockMessage): BlockCreatorResult = Created(b)
+  def noNewDeploys: BlockCreatorResult                        = NoNewDeploys
+  def created(b: BlockMessage): BlockCreatorResult            = Created(b)
+  def createdAttestation(b: BlockMessage): BlockCreatorResult = CreatedAttestation(b)
 }

--- a/casper/src/main/scala/coop/rchain/casper/package.scala
+++ b/casper/src/main/scala/coop/rchain/casper/package.scala
@@ -1,6 +1,8 @@
 package coop.rchain
 
+import com.google.protobuf.ByteString
 import coop.rchain.casper.blocks.proposer.ProposerResult
+import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.comm.CommUtilSyntax
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
@@ -23,6 +25,13 @@ package object casper {
       with AllSyntaxComm
       with AllSyntaxBlockStorage
       with RhoRuntimeSyntax
+
+  /** If block message is attestation.
+    * Attestation confirms post state hashes of justifications and does not introduce any state change */
+  def isAttestationMessage(b: BlockMessage) =
+    b.body.state.preStateHash == ByteString.EMPTY &&
+      b.body.state.postStateHash == ByteString.EMPTY &&
+      b.body.deploys.isEmpty
 }
 
 // Casper syntax


### PR DESCRIPTION
## Overview
This is WIP that might go to RCHIP, but for sake of clarity and to expose ideas in the code, it's a draft PR for now.

The suggestion is to make block message(BM) be presented in two flavours: attestation message (AM) and state transition message (STM). 
Both of them are exposed as block message on the wire, but having a bit different field content. So no hard fork is required, and casper message logic is preserved.

**Why this is needed?** _To not execute Rholang just for Casper needs when no state changes are required. So to achieve much faster finality._ 

**Impact:** this is not backward compatible change. 

**Formal difference:** 
- STM has preStateHash and postStateHash and they are not equal, so there is some state transition: whether this is some user deploy or system deploy 
- AM has preStateHash and postStateHash equal empty byte string. 
The purpose of AM is to serve as an approval for Casper that does not introduce any state change, so decoupled from Rholang. Attestation message is issued according to synchrony constraint if no user deploys are there to create state transition, and validator is not forced to make state change with some system deploy (e.g. issue CloseBlock deploy to make epoch change or other state change that is tied to particular block height). NOTE: slashing is not such change (look into point 7 below).

Below influence of introducing such messsage is outlined.

1. **Latest messages**: remains the same, all block messages (both STM and AM) are accounted

2. **Synchrony constraint**: Only state transition messages are accounted for synchrony constraint. 
When checking the constraint, node have to find by traversing through self justification first one which is which is STM (`lsjSTM`) and check if `lsjSTM` is not in the view of latest self-proposed message.
So nothing changes except requirement to optionally traverse several blocks n the past through self justification.

3. **Justifications**: both STM and AM can be a justification. Block as a justification unit remains the same. 
The difference here is that AM is defined by its justifications, so it virtually has multiple blockHashes. If some new STM uses multiple AM as justifications, parents used for computing pre state hash are join of justifications of parent AMs. If AM has AMs in its justification, process continues recursively - traverse justifications until all paths led to some STM.
This process exposes difference between STM and AM and decoupling Casper from global state. Only STMs matter for the global state. 

4. **Last Finalised Block**: AM cannot be LFB, if new LFB found is AM, pick the most recent STM ancestor.

5. **Main parent**: nothing changing, when creating STM, node have to compute preStateHash and find bonds map, so pick main parent according to stake of message creator. AM can be main parent. Only problem that is visible for now is odd way of computing bonds map that involves reading bonds map of main parent. https://github.com/rchain/rchain/blob/61726ac897b55c1326d637ae715333153d9cdbda/casper/src/main/scala/coop/rchain/casper/safety/CliqueOracle.scala#L134-L150

6. **Merging**: as AM does not introduce state change it does not require knowledge about merged pre state. Only when STM is created, it should find as per `3.` parents to merge.

7. **Slashing**: ~~currently invalid messages are accounted when computing fault tolerance, so local view does not matter network wise. The only thing validator can do is try to put slashing deploy in its each new block (and possibly die brave on that hill if majority disagrees) once it sees invalid block and still sees offender bonded. So slash deploy is just put in the next STM according to normal network operation.~~ If node sees invalid block, it cannot create attestation over it, as it incurs an agreement. So when slashing is required, STM is created.  

8. **Epoch change**: closeBlock should not be triggered in AM, as it should not changes state and does not have preState computed. Therefore, if block number is epoch change block, but no user deploys are available to put in a block, STM with only close block should be created. NOTE: this is the only case when AM becomes STM, when there are slashing deploys put in a block - node still proceeds with AM, as it is free to issue slashing deploy at any time

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
