### PR TITLE
Add leaderful propose script

### DIFF
--- a/node/src/main/resources/propose.conf
+++ b/node/src/main/resources/propose.conf
@@ -1,0 +1,33 @@
+leader = {
+    host = "localhost",
+    grpc-port = 40402,
+    http-port=40403,
+    propose-info= {
+        deploy-contract: "Nil",
+        phlo-limit: 100,
+        phlo-price: 1,
+        deploy-private-key: "34d969f43affa8e5c47900e6db475cb8ddd8520170ee73b2207c54014006ff2b"
+    }
+}
+followers = [
+    {host = "localhost",
+     grpc-port = 40302 ,
+     http-port=40403,
+     propose-info= {
+         deploy-contract: "Nil",
+         phlo-limit: 100,
+         phlo-price: 1,
+         deploy-private-key: "5438ac0bde91bb813c7b4b17f215cd6ad52b19e7bcbf1f7907adb1d69c8aa7b1"
+     }},
+     {host = "localhost",
+     grpc-port = 40202 ,
+     http-port=40403,
+     propose-info= {
+         deploy-contract: "Nil",
+         phlo-limit: 100,
+         phlo-price: 1,
+         deploy-private-key: "304b2893981c36122a687c1fd534628d6f1d4e9dd8f44569039ea762dae2d3e7"
+     }},
+]
+check-interval = 10s
+propose-interval = 1s

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -12,6 +12,7 @@ import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.{Secp256k1, SignaturesAlg}
 import coop.rchain.crypto.util.KeyUtil
 import coop.rchain.monix.Monixable
+import coop.rchain.node.api.client.{DeployRuntime, GrpcDeployService, GrpcProposeService}
 import coop.rchain.node.configuration.Configuration.Profile
 import coop.rchain.node.configuration._
 import coop.rchain.node.effects._

--- a/node/src/main/scala/coop/rchain/node/api/client/DeployRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/api/client/DeployRuntime.scala
@@ -1,31 +1,24 @@
-package coop.rchain.casper.util.comm
+package coop.rchain.node.api.client
 
-import java.nio.charset.Charset
-
-import scala.concurrent.duration._
-import scala.io.Source
-import scala.language.higherKinds
-import scala.util._
-import cats.{Functor, Id, Monad}
 import cats.data.EitherT
 import cats.effect.Sync
 import cats.implicits._
-import coop.rchain.casper.protocol._
-import coop.rchain.casper.util.ProtoUtil
-import coop.rchain.casper.util.comm.ListenAtName._
-import coop.rchain.catscontrib._
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.catscontrib.ski._
-import coop.rchain.models.Par
-import coop.rchain.shared.Time
-import coop.rchain.shared.ByteStringOps._
 import cats.syntax.either._
+import cats.{Functor, Id, Monad}
 import com.google.protobuf.ByteString
-import coop.rchain.crypto.{PrivateKey, PublicKey}
-import coop.rchain.crypto.codec.Base16
-import coop.rchain.crypto.hash.Blake2b256
+import coop.rchain.casper.protocol._
+import coop.rchain.casper.util.comm.ListenAtName._
+import coop.rchain.catscontrib.ski._
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.models.Par
+import coop.rchain.shared.ByteStringOps._
 import coop.rchain.shared.ThrowableOps._
+import coop.rchain.shared.Time
+
+import scala.io.Source
+import scala.language.higherKinds
+import scala.util._
 
 object DeployRuntime {
 

--- a/node/src/main/scala/coop/rchain/node/api/client/DeployService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/client/DeployService.scala
@@ -1,7 +1,4 @@
-package coop.rchain.casper.util.comm
-
-import java.io.Closeable
-import java.util.concurrent.TimeUnit
+package coop.rchain.node.api.client
 
 import cats.effect.Sync
 import cats.syntax.all._
@@ -13,6 +10,8 @@ import coop.rchain.monix.Monixable
 import coop.rchain.shared.syntax._
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
 import scala.util.Either
 
 trait DeployService[F[_]] {

--- a/node/src/main/scala/coop/rchain/node/api/client/ProposeService.scala
+++ b/node/src/main/scala/coop/rchain/node/api/client/ProposeService.scala
@@ -1,7 +1,4 @@
-package coop.rchain.casper.util.comm
-
-import java.io.Closeable
-import java.util.concurrent.TimeUnit
+package coop.rchain.node.api.client
 
 import cats.effect.Sync
 import coop.rchain.casper.protocol._
@@ -11,6 +8,8 @@ import coop.rchain.monix.Monixable
 import coop.rchain.shared.syntax._
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
 import scala.util.Either
 
 trait ProposeService[F[_]] {

--- a/node/src/main/scala/coop/rchain/node/proposescript/ProposeConfig.scala
+++ b/node/src/main/scala/coop/rchain/node/proposescript/ProposeConfig.scala
@@ -1,0 +1,132 @@
+package coop.rchain.node.proposescript
+
+import cats.syntax.all._
+import cats.effect.{Concurrent, Sync}
+import coop.rchain.monix.Monixable
+import coop.rchain.shared.Log
+import fs2.Stream
+import retry.{retryingOnFailures, RetryDetails, RetryPolicies, Sleep}
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class ProposeConfig(
+    leader: ValidatorProposeInfo,
+    followers: List[ValidatorProposeInfo],
+    checkInterval: FiniteDuration,
+    proposeInterval: FiniteDuration
+) {
+
+  def logWaitProposeInterval[F[_]: Log]: F[Unit] =
+    Log[F].info(s"Wait ${proposeInterval} seconds for proposing interval.")
+
+  def proposeInLeader[F[_]: Sync: Monixable: Log]: F[String] =
+    leader.deployAndProposeAsync
+      .flatTap(blockHash => leader.logValidatorProposedBlock(blockHash))
+
+  def checkLeaderBlockInFollower[F[_]: Concurrent: Monixable: Log](blockHash: String): F[Boolean] =
+    Stream
+      .emits(followers)
+      .parEvalMapUnordered[F, Boolean](followers.length)(
+        v =>
+          v.isContainBlock(blockHash).flatTap { isContain =>
+            v.logValidatorGotBlock(blockHash)
+              .whenA(isContain) >> v.logValidatorMissedBlock(blockHash).whenA(!isContain)
+          }
+      )
+      .forall(identity)
+      .compile
+      .last
+      .map(_.getOrElse(false))
+
+  def waitFollowersGotLeaderBlock[F[_]: Concurrent: Monixable: Log: Sleep](
+      blockHash: String
+  ): F[Boolean] = {
+    val retryPolicy = RetryPolicies.constantDelay(checkInterval)
+    def onFailure(failedValue: Boolean, details: RetryDetails): F[Unit] =
+      Log[F].info(
+        s"Retry check in ${checkInterval} because followers didn't get the block ${blockHash} from leader." +
+          s"Retry ${details.retriesSoFar} times so far, cumulate cumulativeDelay:${details.cumulativeDelay}, ${failedValue}."
+      )
+    retryingOnFailures[Boolean](
+      policy = retryPolicy,
+      wasSuccessful = identity,
+      onFailure = onFailure
+    ) {
+      checkLeaderBlockInFollower(blockHash)
+    }
+  }
+
+  def proposeInFollowers[F[_]: Concurrent: Monixable: Log]: F[List[String]] =
+    Stream
+      .emits(followers)
+      .parEvalMapUnordered[F, String](followers.length)(
+        v => v.deployAndProposeAsync.flatTap(blockHash => v.logValidatorProposedBlock(blockHash))
+      )
+      .compile
+      .toList
+
+  def checkFollowerBlocksInLeader[F[_]: Concurrent: Monixable: Log](
+      blockHashes: List[String]
+  ): F[Boolean] =
+    Stream
+      .emits(blockHashes)
+      .parEvalMapUnordered[F, Boolean](blockHashes.length)(
+        b =>
+          leader
+            .isContainBlock(b)
+            .flatTap { isContain =>
+              leader
+                .logValidatorGotBlock(b)
+                .whenA(isContain) >> leader.logValidatorMissedBlock(b).whenA(!isContain)
+            }
+      )
+      .forall(identity)
+      .compile
+      .last
+      .map(_.getOrElse(false))
+
+  def waitLeaderGotFollowerBlocks[F[_]: Concurrent: Monixable: Log: Sleep](
+      blocks: List[String]
+  ): F[Boolean] = {
+    val retryPolicy = RetryPolicies.constantDelay(checkInterval)
+    def onFailure(failedValue: Boolean, details: RetryDetails): F[Unit] =
+      Log[F].info(
+        s"Retry check in ${checkInterval} because leader didn't get the block from followers." +
+          s"Retry ${details.retriesSoFar} times so far, cumulate cumulativeDelay:${details.cumulativeDelay}, ${failedValue}."
+      )
+    retryingOnFailures[Boolean](
+      policy = retryPolicy,
+      wasSuccessful = identity,
+      onFailure = onFailure
+    ) {
+      checkFollowerBlocksInLeader(blocks)
+    }
+  }
+
+  def proposeRound[F[_]: Concurrent: Monixable: Log: Sleep]: F[Unit] =
+    for {
+      _                    <- logWaitProposeInterval
+      _                    <- Sleep[F].sleep(proposeInterval)
+      _                    <- Log[F].info(s"Going to propose in the leader ${leader.host}.")
+      proposeBlockInLeader <- proposeInLeader
+      _ <- Log[F].info(
+            s"Proposed successfully in the leader with new block ${proposeBlockInLeader} " +
+              s"and then waiting the followers got the block."
+          )
+      _ <- waitFollowersGotLeaderBlock(proposeBlockInLeader)
+      _ <- logWaitProposeInterval
+      _ <- Sleep[F].sleep(proposeInterval)
+      _ <- Log[F].info(
+            s"All followers got the newly proposed block ${proposeBlockInLeader} from leader."
+          )
+      proposeBlocksInFollowers <- proposeInFollowers
+      _ <- Log[F].info(
+            s"Proposed successfully among all the followers. " +
+              s"Then waiting the leader to receive all the new blocks ${proposeBlocksInFollowers}."
+          )
+      _ <- waitLeaderGotFollowerBlocks(proposeBlocksInFollowers)
+      _ <- Log[F].info(
+            "The leader successfully received all proposed blocks from followers."
+          )
+    } yield ()
+}

--- a/node/src/main/scala/coop/rchain/node/proposescript/ProposeMain.scala
+++ b/node/src/main/scala/coop/rchain/node/proposescript/ProposeMain.scala
@@ -1,0 +1,46 @@
+package coop.rchain.node.proposescript
+
+import cats.effect.ExitCode
+import coop.rchain.shared.Log
+import fs2.Stream
+import monix.eval.{Task, TaskApp}
+import org.rogach.scallop.ScallopConf
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+import java.nio.file.Path
+
+final case class ProposeScriptOptions(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val width = 120
+  helpWidth(width)
+  printedName = "propose-script"
+
+  val config = opt[Path](
+    descr = s"Target config file path",
+    required = true
+  )
+  verify()
+
+}
+object ProposeMain extends TaskApp {
+  override def run(args: List[String]): Task[ExitCode] = {
+    val options      = ProposeScriptOptions(args)
+    val configPath   = options.config()
+    val configSource = ConfigSource.file(configPath)
+    val configE      = configSource.load[ProposeConfig]
+    val config       = configE.right.get
+    implicit val log = Log.log[Task]
+
+    for {
+      _ <- log.info(s"Running propose script with config: ${config}")
+      _ <- Stream
+            .eval(
+              config.proposeRound.tapError(
+                e => log.error(s"Running propose script with config: ${config} with error ${e}")
+              )
+            )
+            .repeat
+            .compile
+            .drain
+    } yield ExitCode.Success
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/proposescript/ValidatorProposeInfo.scala
+++ b/node/src/main/scala/coop/rchain/node/proposescript/ValidatorProposeInfo.scala
@@ -1,0 +1,192 @@
+package coop.rchain.node.proposescript
+
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.casper.protocol.{
+  BlockInfo,
+  BlockQuery,
+  BlocksQuery,
+  DeployData,
+  LightBlockInfo,
+  ProposeQuery,
+  ProposeResultQuery
+}
+import coop.rchain.casper.protocol.deploy.v1.DeployServiceV1GrpcMonix
+import coop.rchain.casper.protocol.propose.v1.ProposeServiceV1GrpcMonix
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.{Secp256k1, Signed}
+import coop.rchain.monix.Monixable
+import coop.rchain.shared.Log
+import io.grpc.{ManagedChannel, ManagedChannelBuilder}
+import monix.eval.Task
+import coop.rchain.shared.syntax._
+
+final case class ProposeInfo(
+    deployContract: String,
+    phloLimit: Long,
+    phloPrice: Long,
+    deployPrivateKey: String
+)
+final case class ValidatorProposeInfo(
+    host: String,
+    grpcPort: Int,
+    httpPort: Int,
+    proposeInfo: ProposeInfo
+) {
+  private val ProposeSuccessRegex      = "Success! Block ([0-9a-f]+) created and added.".r
+  private val ProposeAsyncSuccessRegex = "Propose started \\(seqNum ([0-9]+)\\)".r
+
+  private val channel: ManagedChannel =
+    ManagedChannelBuilder
+      .forAddress(host, grpcPort)
+      .usePlaintext()
+      .build
+
+  private def deployStub  = DeployServiceV1GrpcMonix.stub(channel)
+  private def proposeStub = ProposeServiceV1GrpcMonix.stub(channel)
+
+  def getLatestBlocks[F[_]: Sync: Monixable](depth: Int = 1): F[List[LightBlockInfo]] =
+    deployStub
+      .getBlocks(BlocksQuery(depth = depth))
+      .mapEval(
+        resp =>
+          Task
+            .raiseError(
+              new Exception(s"Getting latest block from $host:$grpcPort failed with $resp.")
+            )
+            .whenA(resp.message.isError || resp.message.blockInfo.isEmpty)
+            .flatMap(_ => Task.pure(resp.message.blockInfo.get))
+      )
+      .toListL
+      .fromTask
+
+  def getBlock[F[_]: Sync: Monixable](blockHash: String): F[BlockInfo] =
+    deployStub
+      .getBlock(BlockQuery(hash = blockHash))
+      .fromTask
+      .flatTap(
+        blockResp =>
+          Sync[F]
+            .raiseError(
+              new Exception(
+                s"Getting block $blockHash from $host:$grpcPort failed with ${blockResp.message.error}."
+              )
+            )
+            .whenA(blockResp.message.isError || blockResp.message.blockInfo.isEmpty)
+      )
+      .map(_.message.blockInfo.get)
+
+  def deploy[F[_]: Sync: Monixable](validAfterBlockNumber: Long): F[String] = {
+    val timestamp = System.currentTimeMillis()
+    val d = DeployData(
+      term = proposeInfo.deployContract,
+      timestamp = timestamp,
+      phloPrice = proposeInfo.phloPrice,
+      phloLimit = proposeInfo.phloLimit,
+      validAfterBlockNumber = validAfterBlockNumber
+    )
+    val signedDeploy = Signed(
+      d,
+      Secp256k1,
+      PrivateKey(Base16.decode(proposeInfo.deployPrivateKey).get)
+    )
+    deployStub
+      .doDeploy(DeployData.toProto(signedDeploy))
+      .fromTask
+      .flatTap(
+        resp =>
+          Sync[F]
+            .raiseError(
+              new Exception(
+                s"Deploy on $host:$grpcPort failed on ${resp.message.error} with $signedDeploy"
+              )
+            )
+            .whenA(resp.message.isError || resp.message.result.isEmpty)
+      )
+      .map(_.message.result.get)
+  }
+
+  def propose[F[_]: Sync: Monixable](isAsync: Boolean): F[String] =
+    proposeStub
+      .propose(ProposeQuery(isAsync = isAsync))
+      .fromTask
+      .flatTap(
+        resp =>
+          Sync[F]
+            .raiseError(
+              new Exception(
+                s"Propose on $host:$grpcPort failed on ${resp.message.error} with isAsync = $isAsync"
+              )
+            )
+            .whenA(resp.message.isError || resp.message.result.isEmpty)
+      )
+      .map(_.message.result.get)
+
+  def proposeResult[F[_]: Sync: Monixable]: F[String] =
+    proposeStub
+      .proposeResult(ProposeResultQuery())
+      .fromTask
+      .flatTap(
+        proposeResResp =>
+          Sync[F]
+            .raiseError(
+              new Exception(
+                s"Getting propose result on $host:$grpcPort failed on ${proposeResResp.message.error}"
+              )
+            )
+            .whenA(proposeResResp.message.isError || proposeResResp.message.result.isEmpty)
+      )
+      .map(_.message.result.get)
+
+  def isContainBlock[F[_]: Sync: Monixable](blockHash: String): F[Boolean] =
+    getBlock(blockHash = blockHash).redeem(_ => false, _ => true)
+
+  private def deployAndPropose[F[_]: Sync: Monixable](isAsync: Boolean): F[String] =
+    getLatestBlocks()
+      .map(_.head)
+      .flatMap(latestBlock => deploy(latestBlock.blockNumber))
+      .flatMap(_ => propose(isAsync = isAsync))
+
+  def deployAndProposeAsync[F[_]: Sync: Monixable]: F[String] =
+    deployAndPropose(isAsync = true)
+      .flatTap {
+        case ProposeAsyncSuccessRegex(seqNum) => seqNum.pure
+        case failedResult =>
+          Sync[F].raiseError[String](
+            new Exception(s"Propose async failed with ${failedResult} on $host: $grpcPort")
+          )
+      }
+      .flatMap(_ => proposeResult)
+      .flatMap {
+        case ProposeSuccessRegex(blockHash) => blockHash.pure
+        case r =>
+          Sync[F].raiseError[String](
+            new Exception(
+              s"Getting async propose result failed with ${r} on $host: $grpcPort"
+            )
+          )
+      }
+
+  def deployAndProposeSync[F[_]: Sync: Monixable]: F[String] =
+    deployAndPropose(isAsync = false).flatMap {
+      case ProposeSuccessRegex(blockHash) => blockHash.pure
+      case proposeResult =>
+        Sync[F].raiseError[String](
+          new Exception(
+            s"Parsing propose result failed $proposeResult on $host:$grpcPort"
+          )
+        )
+    }
+
+  def logValidatorGotBlock[F[_]: Log](blockHash: String): F[Unit] =
+    Log[F].info(s"Validator ${host}:${grpcPort} got $blockHash.")
+
+  def logValidatorMissedBlock[F[_]: Log](blockHash: String): F[Unit] =
+    Log[F].info(s"Validator ${host}:${grpcPort} hasn't got $blockHash.")
+
+  def logValidatorProposedBlock[F[_]: Log](blockHash: String): F[Unit] =
+    Log[F].info(
+      s"Validator ${host}:${grpcPort} successfully proposed $blockHash."
+    )
+}


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

This pr is intended to add a new propose script in scala version while the [old propose script](https://github.com/rchain/rchain-testnet-node/blob/dev/scripts/propose_in_turn.py) is  not applicable in the new leader network.

The general workflow in propose script is like below

```
1.   propose in leader node
2. wait for all the followers getting the block from leader
3. propose in parallel among followers 
4. wait for the leader getting the blocks from leader
5. go into 1 and loop
 
```



### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
